### PR TITLE
ORCH-0781: Re-arm Stripe web import gate

### DIFF
--- a/.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+++ b/.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
@@ -12,6 +12,8 @@ const allowedNativeImportFiles = new Set([
   "mingla-business/src/payments/stripePaymentSheet.native.ts",
 ]);
 const failures = [];
+const stripeReactNativeImportPattern =
+  /(?:import\s+["']@stripe\/stripe-react-native["']|from\s+["']@stripe\/stripe-react-native["']|require\(\s*["']@stripe\/stripe-react-native["']\s*\)|import\(\s*["']@stripe\/stripe-react-native["']\s*\))/;
 
 const walk = (directory) => {
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
@@ -24,14 +26,115 @@ const walk = (directory) => {
     if (!/\.(ts|tsx|js|jsx)$/.test(entry.name)) continue;
     const relativePath = path.relative(root, absolutePath);
     const source = fs.readFileSync(absolutePath, "utf8");
-    if (
-      /(?:from\s+["']@stripe\/stripe-react-native["']|require\(\s*["']@stripe\/stripe-react-native["']\s*\)|import\(\s*["']@stripe\/stripe-react-native["']\s*\))/.test(
-        source,
-      ) &&
-      !allowedNativeImportFiles.has(relativePath)
-    ) {
-      failures.push(relativePath);
+    if (stripeReactNativeImportPattern.test(source) && !allowedNativeImportFiles.has(relativePath)) {
+      failures.push(
+        `${relativePath} import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries`,
+      );
     }
+  }
+};
+
+const checkNpmWiring = () => {
+  const packageJsonPath = path.join(root, "mingla-business/package.json");
+  let packageJson;
+  try {
+    packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  } catch (error) {
+    failures.push(
+      `ORCH-0781 wiring: mingla-business/package.json npm wiring parse failed: ${error.message}`,
+    );
+    return;
+  }
+
+  const script = packageJson.scripts?.["test:orch-0778"];
+  if (typeof script !== "string" || !script.includes("orch-0778-web-stripe-native-import-gate.mjs")) {
+    failures.push(
+      `ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)`,
+    );
+  }
+};
+
+const getTopLevelBlock = (source, key) => {
+  const lines = source.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === `${key}:`);
+  if (start === -1) return "";
+
+  const block = [lines[start]];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^[^\s#][^:]*:\s*$/.test(line)) break;
+    if (/^[^\s#][^:]*:\s+/.test(line)) break;
+    block.push(line);
+  }
+  return block.join("\n");
+};
+
+const getIndentedChildBlock = (source, key, indent = 2) => {
+  const lines = source.split(/\r?\n/);
+  const childPattern = new RegExp(`^\\s{${indent}}${key}:\\s*$`);
+  const siblingPattern = new RegExp(`^\\s{${indent}}\\S[^:]*:\\s*`);
+  const start = lines.findIndex((line) => childPattern.test(line));
+  if (start === -1) return "";
+
+  const block = [lines[start]];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (siblingPattern.test(line)) break;
+    if (/^[^\s#]/.test(line)) break;
+    block.push(line);
+  }
+  return block.join("\n");
+};
+
+const branchBlockHas = (pushBlock, branchName) => {
+  const inlineBranches = pushBlock.match(/^\s{4}branches:\s*\[(?<branches>[^\]]*)\]\s*$/m);
+  if (inlineBranches?.groups?.branches) {
+    return inlineBranches.groups.branches
+      .split(",")
+      .map((branch) => branch.trim())
+      .includes(branchName);
+  }
+
+  const lines = pushBlock.split(/\r?\n/);
+  const branchesIndex = lines.findIndex((line) => /^\s{4}branches:\s*$/.test(line));
+  if (branchesIndex === -1) return false;
+
+  for (let index = branchesIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^\s{4}\S/.test(line)) break;
+    if (new RegExp(`^\\s{6}-\\s*${branchName}\\s*$`).test(line)) return true;
+  }
+  return false;
+};
+
+const checkWorkflowWiring = () => {
+  const workflowRelativePath = ".github/workflows/strict-grep-mingla-business.yml";
+  const workflowPath = path.join(root, workflowRelativePath);
+  let workflowSource;
+  try {
+    workflowSource = fs.readFileSync(workflowPath, "utf8");
+  } catch (error) {
+    failures.push(
+      `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml read failed: ${error.message} (CI wiring)`,
+    );
+    failures.push(
+      `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)`,
+    );
+    return;
+  }
+
+  if (!/^\s{2}orch-0778-web-stripe-native-import-gate:\s*$/m.test(workflowSource)) {
+    failures.push(
+      `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)`,
+    );
+  }
+
+  const onBlock = getTopLevelBlock(workflowSource, "on");
+  const pushBlock = getIndentedChildBlock(onBlock, "push", 2);
+  if (!pushBlock || !branchBlockHas(pushBlock, "main") || !branchBlockHas(pushBlock, "Seth")) {
+    failures.push(
+      `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)`,
+    );
   }
 };
 
@@ -39,10 +142,11 @@ for (const checkedRoot of checkedRoots) {
   walk(path.join(root, checkedRoot));
 }
 
+checkNpmWiring();
+checkWorkflowWiring();
+
 if (failures.length > 0) {
-  console.error(
-    "ORCH-0778 web Stripe native import gate failed. Move Stripe React Native imports behind a .native platform boundary:",
-  );
+  console.error("ORCH-0778 web Stripe native import gate failed.");
   for (const failure of failures) console.error(`- ${failure}`);
   process.exit(1);
 }

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -8,6 +8,13 @@ on:
       - "supabase/migrations/**"
       - ".github/scripts/strict-grep/**"
       - ".github/workflows/strict-grep-mingla-business.yml"
+  push:
+    branches: [main, Seth]
+    paths:
+      - "mingla-business/**"
+      - "supabase/migrations/**"
+      - ".github/scripts/strict-grep/**"
+      - ".github/workflows/strict-grep-mingla-business.yml"
 
 # Registry pattern (per DEC-101 D-17b-5):
 # Each invariant CI gate is its own modular Node.js script in
@@ -39,6 +46,7 @@ on:
 #   - I-PROPOSED-N (i-proposed-n-transitional-exit-condition.mjs) — TRANSITIONAL exit-condition lint (META-ORCH-0744)
 #   - I-PROPOSED-X (i-proposed-x-web-deprecation.mjs) — web-export deprecation parser (META-ORCH-0744)
 #   - ORCH-0776D (orch-0776d-cancelled-at-schema.mjs) — event cover video cancelled_at schema/code parity
+#   - ORCH-0778 (orch-0778-web-stripe-native-import-gate.mjs) — Stripe React Native imports stay behind .native payment boundaries (re-armed by ORCH-0781)
 #
 # Future gates to register (proposed but not yet implemented):
 #   - I-32 rank parity (Cycle 13a proposal)
@@ -324,3 +332,14 @@ jobs:
           node-version: "20"
       - name: Run ORCH-0776D gate
         run: node .github/scripts/strict-grep/orch-0776d-cancelled-at-schema.mjs
+
+  orch-0778-web-stripe-native-import-gate:
+    name: "ORCH-0778: Stripe native imports stay behind .native boundaries"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-0778 gate
+        run: node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs

--- a/Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md
+++ b/Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md
@@ -58,7 +58,7 @@ No Supabase migration, Edge Function deploy, provider mutation, EAS OTA, or nati
 
 ## Lock-In Status
 
-Implementation branch commit `14c3b59d` is close-ready. The main checkout currently contains unrelated dirty ORCH-0777/0779/product work, including files that overlap the ORCH-0781 implementation surface, so the final merge/remove step must wait until those unrelated changes are isolated or committed by their owners. Until then, `WORKTREE_REGISTRY.md` marks the worktree as `CLOSED PASS / branch push + merge/remove pending`.
+Implementation branch commit `14c3b59d` is close-ready, and close artifact commit `cc1dfabe` has been pushed to `origin/orch/0781-clean-tree-stripe-web-import-regression`. This branch push does not satisfy C-781-3 because the workflow's new `push` trigger intentionally targets only `[main, Seth]`; C-781-3 must be captured after merge/push to one of those branches. The main checkout currently contains unrelated dirty ORCH-0777/0779/product work, including files that overlap the ORCH-0781 implementation surface, so the final merge/remove step must wait until those unrelated changes are isolated or committed by their owners. Until then, `WORKTREE_REGISTRY.md` marks the worktree as `CLOSED PASS / branch pushed / merge-remove pending`.
 
 Recommended commit message for the close artifact sync:
 

--- a/Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md
+++ b/Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md
@@ -47,10 +47,14 @@ DIAG marker reap for `[ORCH-0781-DIAG]` across `mingla-business/src/`, `mingla-b
 
 Paste the URLs here when available:
 
-- C-781-1 PR/job run URL: _pending first push / PR_
-- C-781-3 push-run URL: _pending first push / merge_
+- C-781-1 PR: https://github.com/Mingla-LLC/mingla-main/pull/71 (`orch/0781-clean-tree-stripe-web-import-regression` → `Seth`)
+- C-781-1 PR run (against head `58ee4f39`): https://github.com/Mingla-LLC/mingla-main/actions/runs/25650581900 (workflow: `Strict Grep Gates (Mingla Business)`, event: `pull_request`)
+- C-781-1 job (target evidence): https://github.com/Mingla-LLC/mingla-main/actions/runs/25650581900/job/75287924718 — `ORCH-0778: Stripe native imports stay behind .native boundaries` — **success**
+  - Sibling ORCH-0776D job present and passing in same run: https://github.com/Mingla-LLC/mingla-main/actions/runs/25650581900/job/75287924716 (confirms ORCH-0781 added the ORCH-0778 job without replacing ORCH-0776D)
+  - Overall run `conclusion = failure` is driven by 4 pre-existing Seth gate failures unrelated to ORCH-0781: I-PROPOSED-A (job `75287924637`), I-PROPOSED-R (`75287924659`), I-PROPOSED-K (`75287924700`), I-PROPOSED-N (`75287924727`). These four were already red on Seth before ORCH-0781 branched and are out of scope for this dispatch.
+- C-781-3 push-run URL: _pending merge to `Seth` or `main` once unrelated dirty ORCH-0777 / ORCH-0779 / product work is isolated_
 
-These are not close blockers because QA proved the gate logic and workflow structure locally; they are external Actions receipt capture.
+These are not close blockers because QA proved the gate logic and workflow structure locally; they are external Actions receipt capture. C-781-1 is now captured; C-781-3 will be captured automatically by the `[main, Seth]` push trigger after the merge step that the dirty-tree hard guard currently blocks.
 
 ## Deploy Notes
 

--- a/Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md
+++ b/Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md
@@ -1,0 +1,72 @@
+# CLOSE NOTE ORCH-0781 — Clean-tree Stripe Web Import Gate Regression
+
+Date: 2026-05-11
+Close owner: Codex `orchestrator-mingla`
+Verdict: CLOSED PASS / Grade A
+Worktree: `.worktrees/orch-0781-clean-tree-stripe-web-import-regression/`
+Branch / implementation HEAD: `orch/0781-clean-tree-stripe-web-import-regression` @ `14c3b59d`
+
+## Plain-English Outcome
+
+ORCH-0781 re-armed the guard that protects Mingla Business Web from accidentally bundling native-only Stripe React Native code. The original ORCH-0778 boundary was correct, but commit `ca69de38` disarmed its enforcement by removing the npm script and CI job while also reintroducing generic Stripe React Native imports; `b7431fe1` restored only product code. ORCH-0781 closes the enforcement gap: the gate now fails if product imports regress, if `test:orch-0778` disappears, if the CI job disappears, or if the direct-push trigger for `[main, Seth]` disappears.
+
+## Evidence Chain
+
+- Investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Orchestrator investigation review: `Mingla_Artifacts/reports/REVIEW_INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Spec: `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Implementation: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- QA PASS: `Mingla_Artifacts/reports/QA_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Implementation commit: `14c3b59d ORCH-0781: re-arm Stripe web import gate (npm + CI + push + self-validate)`
+
+## What Changed
+
+- Restored `mingla-business` npm script `test:orch-0778`.
+- Restored strict-grep workflow job `orch-0778-web-stripe-native-import-gate` as a sibling job, without replacing ORCH-0776D.
+- Added `push` coverage for `[main, Seth]` to `.github/workflows/strict-grep-mingla-business.yml`.
+- Promoted `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` into a self-validating guard for npm wiring, CI job wiring, and push-trigger wiring.
+- Left product code, Supabase, EAS, providers, mobile, admin, new workflow files, and unrelated strict-grep gates untouched.
+
+## Verification
+
+QA independently re-ran T-781-1 through T-781-11. The historical replay against `ca69de38` failed with import-scan plus npm/CI/push wiring bullets; the replay against `b7431fe1` failed with exactly the three wiring bullets and no import-scan bullets. Final scope hard guards were clean: no product-code diff, no Supabase/EAS/provider/admin/mobile diff, no tracker/decision/invariant edits during implementation, no new workflow file, and no D-0781-2 implementation.
+
+DIAG marker reap for `[ORCH-0781-DIAG]` across `mingla-business/src/`, `mingla-business/app/`, `app-mobile/src/`, `supabase/functions/`, and `mingla-admin/src/` returned zero matches.
+
+## Artifact Sync
+
+- `DECISION_LOG.md` appends a follow-up under DEC-137 without rewriting the original decision.
+- `INVARIANT_REGISTRY.md` refreshes only the `Codified:` line for `I-PROPOSED-AE`.
+- `WORLD_MAP.md`, `MASTER_BUG_LIST.md`, `COVERAGE_MAP.md`, `PRODUCT_SNAPSHOT.md`, `PRIORITY_BOARD.md`, `AGENT_HANDOFFS.md`, `OPEN_INVESTIGATIONS.md`, `ROOT_CAUSE_REGISTER.md`, and `WORKTREE_REGISTRY.md` record ORCH-0781 as closed/pass or lock-in pending.
+- D-0781-2 is registered as a separate OPEN investigation row for ORCH-0776A / ORCH-0777 strict-grep CI-orphan audit.
+
+## Residual Evidence To Paste After First Push / Merge
+
+- C-781-1: GitHub Actions PR run URL showing job `ORCH-0778: Stripe native imports stay behind .native boundaries` present and passing.
+- C-781-3: GitHub Actions push-trigger run URL for `main` or `Seth`.
+
+Paste the URLs here when available:
+
+- C-781-1 PR/job run URL: _pending first push / PR_
+- C-781-3 push-run URL: _pending first push / merge_
+
+These are not close blockers because QA proved the gate logic and workflow structure locally; they are external Actions receipt capture.
+
+## Deploy Notes
+
+No Supabase migration, Edge Function deploy, provider mutation, EAS OTA, or native build belongs to ORCH-0781. This is a repo-tooling guard repair only.
+
+## Lock-In Status
+
+Implementation branch commit `14c3b59d` is close-ready. The main checkout currently contains unrelated dirty ORCH-0777/0779/product work, including files that overlap the ORCH-0781 implementation surface, so the final merge/remove step must wait until those unrelated changes are isolated or committed by their owners. Until then, `WORKTREE_REGISTRY.md` marks the worktree as `CLOSED PASS / branch push + merge/remove pending`.
+
+Recommended commit message for the close artifact sync:
+
+```text
+Close ORCH-0781: re-arm Stripe web import guard
+
+- Closes ORCH-0781 with QA PASS (0 P0/P1/P2/P3, 2 P4 notes)
+- Appends DEC-137 follow-up and refreshes I-PROPOSED-AE codified line
+- Registers D-0781-2 as separate strict-grep CI-orphan audit follow-up
+- Notes no Supabase, EAS, provider, or product-code deploy impact
+```

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
@@ -1,0 +1,293 @@
+# IMPLEMENTATION ORCH-0781 — Clean-tree Stripe Web Import Gate Regression
+
+Status: implemented and verified
+Date: 2026-05-11
+Working tree: `.worktrees/orch-0781-clean-tree-stripe-web-import-regression/`
+Branch: `orch/0781-clean-tree-stripe-web-import-regression`
+Spec: `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+
+## Summary
+
+ORCH-0781 re-arms the ORCH-0778 Stripe web import guard after `ca69de38` removed its npm/CI wiring and `b7431fe1` restored only product code. The implementation restores `npm run test:orch-0778`, appends the ORCH-0778 strict-grep job as a sibling of ORCH-0776D, adds push-trigger coverage for `[main, Seth]`, and promotes the existing gate script into a self-validating guard that fails if its own npm/CI/push wiring is removed again.
+
+No product code was edited. No Supabase, EAS, provider, or deploy steps were run.
+
+## Scope Compliance
+
+| Requirement | Result | Evidence |
+|---|---:|---|
+| Change only `mingla-business/package.json`, `.github/workflows/strict-grep-mingla-business.yml`, `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs`, plus this report | PASS | `git diff --stat` shows only those three implementation files before report creation; this report is the fourth scoped file. |
+| Do not edit `_layout.tsx`, `payment.tsx`, or `src/payments/*` | PASS | `git diff -- 'mingla-business/app/_layout.tsx' 'mingla-business/app/checkout/[eventId]/payment.tsx' 'mingla-business/src/payments/StripeNativeProvider.native.tsx' 'mingla-business/src/payments/stripePaymentSheet.native.ts'` returned no diff, exit 0. |
+| Keep D-0781-2 out of implementation | PASS | No ORCH-0776A or ORCH-0777 CI jobs were added; D-0781-2 remains a CLOSE-time registration only. |
+| Do not edit DEC-137, I-PROPOSED-AE, or global trackers | PASS | No global tracker or decision/invariant files were edited in this worktree implementation. |
+| No new workflow file or dependency | PASS | Existing `.github/workflows/strict-grep-mingla-business.yml` was updated in place; no dependency files changed. |
+
+Note: the worktree already contained an untracked scoped spec artifact, `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`, before implementation. It is an input artifact and is intentionally not included in the implementation commit per the dispatch's commit-scope rule.
+
+## Files Changed
+
+| File | Old behavior | New behavior |
+|---|---|---|
+| `mingla-business/package.json` | `test:orch-0778` was missing; the documented local gate command failed as an npm missing script. | Adds `"test:orch-0778": "node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs"` immediately after `test:orch-0777`. |
+| `.github/workflows/strict-grep-mingla-business.yml` | Workflow triggered only on `pull_request`; ORCH-0778 registry comment and job were absent; ORCH-0776D was the final job. | Adds `push:` trigger for `[main, Seth]` with the same path filters, appends the ORCH-0778 registry comment after ORCH-0776D, and appends `orch-0778-web-stripe-native-import-gate` as a sibling job after ORCH-0776D. |
+| `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` | Scanned imports only; succeeded even if npm and CI wiring were missing. | Still scans imports and now also validates npm script, CI job header, and push trigger. All failures are collected into one exit code. |
+
+## Self-Validation Design
+
+The script now performs four checks in one run:
+
+1. Import-scan check across `mingla-business/app` and `mingla-business/src`, allowing only the two approved `.native` Stripe boundary files.
+2. Npm wiring check via `JSON.parse` of `mingla-business/package.json`.
+3. CI job wiring check via a line-anchored regex for `  orch-0778-web-stripe-native-import-gate:`.
+4. Push-trigger wiring check by locating the workflow `on:` block and validating a `push:` child block with both `main` and `Seth`, accepting inline or YAML-list branches.
+
+The success line remains exactly:
+
+```text
+ORCH-0778 web Stripe native import gate passed.
+```
+
+Failure output now begins exactly:
+
+```text
+ORCH-0778 web Stripe native import gate failed.
+```
+
+Then each bullet includes the failing path and layer: import-scan, npm wiring, CI wiring, or push wiring.
+
+## Verification Receipts
+
+### T-781-1
+
+Command: `node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 0
+
+```text
+ORCH-0778 web Stripe native import gate passed.
+
+EXIT:0
+```
+
+Result: PASS.
+
+### T-781-2
+
+Command: `npm run test:orch-0778; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression/mingla-business`
+Exit code: 0
+
+```text
+> mingla-business@1.0.0 test:orch-0778
+> node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+
+ORCH-0778 web Stripe native import gate passed.
+
+EXIT:0
+```
+
+Result: PASS.
+
+### T-781-3
+
+Command: `grep -nE '^\s*"test:orch-0778":' mingla-business/package.json; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 0
+
+```text
+33:    "test:orch-0778": "node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs"
+
+EXIT:0
+```
+
+Result: PASS — exactly one match.
+
+### T-781-4
+
+Command: `grep -nE '^\s{2}orch-0778-web-stripe-native-import-gate:\s*$' .github/workflows/strict-grep-mingla-business.yml; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 0
+
+```text
+336:  orch-0778-web-stripe-native-import-gate:
+
+EXIT:0
+```
+
+Result: PASS — exactly one match.
+
+### T-781-5
+
+Command: `grep -nE '^\s{2}push:\s*$' .github/workflows/strict-grep-mingla-business.yml; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 0
+
+```text
+11:  push:
+
+EXIT:0
+```
+
+Result: PASS.
+
+### T-781-6
+
+Command: temporarily inserted `import "@stripe/stripe-react-native";` in `mingla-business/app/_layout.tsx`, then ran `node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 1
+
+```text
+ORCH-0778 web Stripe native import gate failed.
+- mingla-business/app/_layout.tsx import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries
+
+EXIT:1
+```
+
+Result: PASS. Temporary import was removed immediately after the receipt.
+
+### T-781-7
+
+Command: temporarily removed `scripts["test:orch-0778"]` from `mingla-business/package.json`, then ran `node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 1
+
+```text
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)
+
+EXIT:1
+```
+
+Result: PASS. Temporary package edit was restored immediately after the receipt.
+
+### T-781-8
+
+Command: temporarily removed `orch-0778-web-stripe-native-import-gate:` from `.github/workflows/strict-grep-mingla-business.yml`, then ran `node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 1
+
+```text
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)
+
+EXIT:1
+```
+
+Result: PASS. Temporary workflow edit was restored immediately after the receipt.
+
+### T-781-9
+
+Command: temporarily removed the workflow `push:` block, then ran `node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression`
+Exit code: 1
+
+```text
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)
+
+EXIT:1
+```
+
+Result: PASS. Temporary workflow edit was restored immediately after the receipt.
+
+### T-781-10
+
+Command: `git checkout ca69de38 && cp /Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression/.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs && node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/tmp/orch-0781-ca69de38`
+Exit code: 1
+
+```text
+HEAD is now at ca69de38 Clean tree
+ORCH-0778 web Stripe native import gate failed.
+- mingla-business/app/_layout.tsx import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries
+- mingla-business/app/checkout/[eventId]/payment.tsx import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries
+- ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)
+
+EXIT:1
+```
+
+Result: PASS — the SPEC-implemented script fails on `ca69de38` with import-scan plus all three wiring failures.
+
+### T-781-11
+
+Command: `git checkout b7431fe1 && cp /Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression/.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs && node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs; printf '\nEXIT:%s\n' $?`
+Cwd: `/tmp/orch-0781-b7431fe1`
+Exit code: 1
+
+```text
+HEAD is now at b7431fe1 Restore ORCH-0778 Stripe web import gating
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)
+
+EXIT:1
+```
+
+Result: PASS — exactly three wiring bullets and no import-scan bullets.
+
+## Additional Verification
+
+### Forbidden Product Diff Check
+
+Command:
+
+```bash
+git diff -- 'mingla-business/app/_layout.tsx' 'mingla-business/app/checkout/[eventId]/payment.tsx' 'mingla-business/src/payments/StripeNativeProvider.native.tsx' 'mingla-business/src/payments/stripePaymentSheet.native.ts'; printf '\nEXIT:%s\n' $?
+```
+
+Exit code: 0.
+
+```text
+
+EXIT:0
+```
+
+### `git diff --check`
+
+Command: `git diff --check; printf '\nEXIT:%s\n' $?`
+Exit code: 0.
+
+```text
+
+EXIT:0
+```
+
+### `git status --short --branch`
+
+Pre-report status:
+
+```text
+## orch/0781-clean-tree-stripe-web-import-regression
+ M .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+ M .github/workflows/strict-grep-mingla-business.yml
+ M mingla-business/package.json
+?? Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+```
+
+Final status after report creation:
+
+```text
+## orch/0781-clean-tree-stripe-web-import-regression
+ M .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+ M .github/workflows/strict-grep-mingla-business.yml
+ M mingla-business/package.json
+?? Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+?? Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+```
+
+## Discoveries
+
+- The ORCH-0781 investigation and review reports were present in the main checkout but not copied into this worktree. They were read from `/Users/sethogieva/Desktop/mingla-main/Mingla_Artifacts/reports/` as source evidence and were not copied or committed, preserving implementation scope.
+- The worktree contains untracked input spec artifact `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`; this implementation commit intentionally excludes it per the dispatch's commit-scope instruction.
+
+## Remaining Risks
+
+- GitHub Actions push-trigger evidence cannot be captured locally. Tester/close should confirm the workflow appears on PR/push after branch publication or merge per SPEC §11.
+- D-0781-2 remains open by design: ORCH-0776A and ORCH-0777 strict-grep CI orphan audit is not implemented here and must be registered by orchestrator at CLOSE.
+
+## Routing
+
+Route to Claude `mingla-forensics` TEST mode (or Claude `mingla-tester` if the operator intentionally uses the legacy mirror) for independent verification against this spec and report. After TEST PASS, route to Codex `orchestrator-mingla` for CLOSE. CLOSE owns DEC-137 follow-up, I-PROPOSED-AE codified-date refresh, worktree registry close, and D-0781-2 OPEN_INVESTIGATIONS registration.

--- a/Mingla_Artifacts/reports/QA_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
@@ -1,0 +1,254 @@
+# QA ORCH-0781 — Clean-tree Stripe Web Import Gate Regression
+
+Tester: Claude `mingla-tester` (canonical TEST owner per 2026-05-10 reversal of META-ORCH-0755 / DEC-133)
+Date: 2026-05-11
+Working tree: `.worktrees/orch-0781-clean-tree-stripe-web-import-regression/`
+Branch / HEAD: `orch/0781-clean-tree-stripe-web-import-regression` @ `14c3b59d`
+Inputs verified against:
+- SPEC: `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Implementation report: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md` (read from main checkout)
+- Orchestrator review: `Mingla_Artifacts/reports/REVIEW_INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md` (read from main checkout)
+
+---
+
+## Verdict
+
+**PASS.**
+
+All eleven T-781 receipts independently re-run on the worktree match the implementor's report, and every SPEC scope hard guard is honoured. The ORCH-0778 web Stripe import gate is re-armed across all three layers (npm script, CI job, push trigger) and the gate script now self-validates its own wiring so the next `Clean tree`-class sweep that disarms any layer fails the gate from a single invocation.
+
+## Severity Counts
+
+| Severity | Count |
+|---|---|
+| P0 — CRITICAL | 0 |
+| P1 — HIGH | 0 |
+| P2 — MEDIUM | 0 |
+| P3 — LOW | 0 |
+| P4 — NOTE | 2 |
+
+## Scope of Verification (T-781 only)
+
+Per dispatch hard guards, this QA validates only the ORCH-0778 npm + CI + push + self-validation repair. NOT verified (out of scope by design):
+
+- D-0781-2 / ORCH-0776A / ORCH-0777 strict-grep CI-orphan audit.
+- Any product-code path (`_layout.tsx`, `payment.tsx`, `src/payments/*`). Verified only that diff is empty.
+- DEC-137 / I-PROPOSED-AE retroactive edits (deferred to orchestrator CLOSE per SPEC §12).
+- Supabase migrations, edge functions, EAS builds, provider configuration.
+- New workflow files (forbidden; the strict-grep workflow registry pattern requires one yml — verified not added).
+- META-ORCH process changes (CLOSE-checklist amendments).
+
+## File-Level Compliance Audit (SPEC §6)
+
+| # | File | SPEC contract | Observed at `14c3b59d` | Result |
+|---|---|---|---|---|
+| 1 | `mingla-business/package.json` | Add `test:orch-0778` as the new last entry of the `scripts` object, immediately after `test:orch-0777`. No reordering of any other script. Trailing comma added to `test:orch-0777` line. | `git diff HEAD~1 HEAD -- mingla-business/package.json` shows exactly that 2-line change (trailing comma + new line at line 33). All other scripts unchanged at their prior indices (verified by reading the file). | PASS |
+| 2 | `.github/workflows/strict-grep-mingla-business.yml` | (a) Add `push:` sub-block to `on:` mirroring `pull_request:` paths for `[main, Seth]`. (b) Append ORCH-0778 registry comment line immediately after ORCH-0776D. (c) Append `orch-0778-web-stripe-native-import-gate:` job after `orch-0776d-cancelled-at-schema:` without renaming or reordering existing jobs. | `git diff HEAD~1 HEAD` shows (a) push block at workflow lines 11–17 with identical paths to pull_request, (b) ORCH-0778 comment at line 49 immediately after ORCH-0776D comment at line 48, (c) ORCH-0778 job at workflow line 336 immediately after ORCH-0776D job ending at line 334. ORCH-0776D job preserved. All 24 prior jobs at unchanged positions relative to their neighbours (verified via `grep -nE '^\s{2}[a-zA-Z0-9-]+:\s*$'`). | PASS |
+| 3 | `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` | Existing import-scan unchanged; three new wiring self-checks (npm script presence with correct path, CI job header line-anchored regex, push trigger with both `main` and `Seth`). All four checks contribute to one exit code. Pure Node `fs` + `path` + regex. No YAML parser dep. `process.cwd().endsWith("mingla-business")` heuristic preserved. Success message preserved exactly. Failure header preserved exactly. | Diff adds `checkNpmWiring`, `checkWorkflowWiring`, `getTopLevelBlock`, `getIndentedChildBlock`, `branchBlockHas` helpers and invokes them after the walk. Failure header changed from the old long sentence to the SPEC-required `ORCH-0778 web Stripe native import gate failed.` exactly. Success line `ORCH-0778 web Stripe native import gate passed.` preserved. All four failure messages start with the SPEC-required prefixes (verified against T-781-6 / T-781-7 / T-781-8 / T-781-9 receipts below). Import-scan pattern strengthened to also catch the bare-string side-effect form (`import "@stripe/stripe-react-native"`), which is a strict superset of the SPEC §9.1.1 pattern. | PASS |
+| 4 | `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md` | New implementor report following standard template (Summary / Files Changed / Verification receipts / Discoveries / Confidence). | Present; 293 lines; all eleven T-781 receipts with exit codes and stdout/stderr; Forbidden Product Diff Check + `git diff --check` + pre/post `git status` evidence. | PASS |
+
+`git show --stat 14c3b59d` confirms exactly four files in the commit (the three implementation files plus the report), with `293 insertions` for the new report file and `135 insertions / 11 deletions` across the other three. No fifth file leaked into the commit. The untracked SPEC artifact (`Mingla_Artifacts/specs/SPEC_ORCH-0781_*.md`) is correctly excluded from the commit per dispatch §14 / §6.
+
+## Scope Hard-Guard Compliance Audit
+
+| Guard | Verification command | Result |
+|---|---|---|
+| No product-code change in `_layout.tsx` / `payment.tsx` / `src/payments/*` | `git diff HEAD~1 HEAD -- 'mingla-business/app/_layout.tsx' 'mingla-business/app/checkout/[eventId]/payment.tsx' 'mingla-business/src/payments/StripeNativeProvider.native.tsx' 'mingla-business/src/payments/StripeNativeProvider.web.tsx' 'mingla-business/src/payments/stripePaymentSheet.native.ts' 'mingla-business/src/payments/stripePaymentSheet.web.ts'` | Empty diff. PASS |
+| No Supabase / EAS / provider / mobile / admin changes | `git diff HEAD~1 HEAD -- supabase/ mingla-business/eas.json mingla-business/app.json app-mobile/ mingla-admin/` | Empty diff. PASS |
+| No tracker / decision / invariant / close-note edits | `git diff HEAD~1 HEAD -- Mingla_Artifacts/DECISION_LOG.md Mingla_Artifacts/INVARIANT_REGISTRY.md Mingla_Artifacts/WORLD_MAP.md Mingla_Artifacts/MASTER_BUG_LIST.md Mingla_Artifacts/PRIORITY_BOARD.md Mingla_Artifacts/OPEN_INVESTIGATIONS.md Mingla_Artifacts/AGENT_HANDOFFS.md Mingla_Artifacts/WORKTREE_REGISTRY.md Mingla_Artifacts/ROOT_CAUSE_REGISTER.md Mingla_Artifacts/COVERAGE_MAP.md Mingla_Artifacts/PRODUCT_SNAPSHOT.md` | Empty diff. PASS |
+| No new workflow file | `git diff --name-only --diff-filter=A HEAD~1 HEAD -- .github/workflows/` returns nothing. The existing `strict-grep-mingla-business.yml` was edited in place. | PASS |
+| No other strict-grep gate script edited | `git diff --name-only HEAD~1 HEAD -- .github/scripts/strict-grep/` returns only `orch-0778-web-stripe-native-import-gate.mjs` | PASS |
+| ORCH-0776D job preserved alongside ORCH-0778 (registry pattern: never replace existing jobs) | `grep -nE 'orch-0776d-cancelled-at-schema' .github/workflows/strict-grep-mingla-business.yml` shows the registry comment at line 48 and the job header at line 325 — unchanged. | PASS |
+| D-0781-2 (ORCH-0776A / 0777 CI orphans) NOT implemented in this commit | `grep -nE 'orch-0776a-video-upload-progress-honesty\|orch-0777-ticket-checkout-production' .github/workflows/strict-grep-mingla-business.yml` returns no matches. Correctly deferred. | PASS |
+
+## Independent Verification Receipts (T-781 matrix)
+
+All commands run from `/Users/sethogieva/Desktop/mingla-main/.worktrees/orch-0781-clean-tree-stripe-web-import-regression/` unless noted.
+
+### T-781-1 — gate at HEAD, repo-root invocation
+
+```
+$ node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+ORCH-0778 web Stripe native import gate passed.
+EXIT:0
+```
+
+Result: PASS. Matches SPEC §10 expectation (exit 0 after this SPEC).
+
+### T-781-2 — npm-script invocation
+
+```
+$ (cd mingla-business && npm run test:orch-0778)
+> mingla-business@1.0.0 test:orch-0778
+> node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+ORCH-0778 web Stripe native import gate passed.
+EXIT:0
+```
+
+Result: PASS. Cwd heuristic (`process.cwd().endsWith("mingla-business")`) resolves `root` to repo root correctly.
+
+### T-781-3 — package.json line presence
+
+```
+$ grep -nE '^\s*"test:orch-0778":' mingla-business/package.json
+33:    "test:orch-0778": "node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs"
+EXIT:0
+```
+
+Result: PASS. Exactly one match at the new last-entry position of the `scripts` object.
+
+### T-781-4 — CI job header presence
+
+```
+$ grep -nE '^\s{2}orch-0778-web-stripe-native-import-gate:\s*$' .github/workflows/strict-grep-mingla-business.yml
+336:  orch-0778-web-stripe-native-import-gate:
+EXIT:0
+```
+
+Result: PASS. Exactly one match at the line-anchored two-space indent the script's wiring check regex requires.
+
+### T-781-5 — workflow push trigger header presence
+
+```
+$ grep -nE '^\s{2}push:\s*$' .github/workflows/strict-grep-mingla-business.yml
+11:  push:
+EXIT:0
+```
+
+Result: PASS. Sub-block found inside the `on:` block.
+
+### T-781-6 — synthetic regression A (Stripe RN import in `_layout.tsx`)
+
+Procedure: prepended `import "@stripe/stripe-react-native";` to `mingla-business/app/_layout.tsx` (held in a tempfile), ran the gate, restored the file from backup, and verified `diff -q` returned clean.
+
+```
+ORCH-0778 web Stripe native import gate failed.
+- mingla-business/app/_layout.tsx import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries
+EXIT:1
+```
+
+Result: PASS. Import-scan check fires, failure bullet names the exact path and layer as SPEC §9.2 requires.
+
+Additional sanity run with the `import { StripeProvider } from "@stripe/stripe-react-native"` form (the original `ca69de38` regression shape) was also rejected with the same bullet — confirms the new pattern catches both the bare-string side-effect form and the named-import form.
+
+### T-781-7 — synthetic regression B (remove `test:orch-0778` from `package.json`)
+
+Procedure: parsed `package.json`, deleted `scripts["test:orch-0778"]`, wrote back, ran the gate, restored from backup.
+
+```
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)
+EXIT:1
+```
+
+Result: PASS. Bullet begins with the exact SPEC §9.1.2 prefix `ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"]` and identifies the npm wiring layer.
+
+### T-781-8 — synthetic regression C (remove `orch-0778-web-stripe-native-import-gate` job from yml)
+
+Procedure: located the job header line in the workflow yml, truncated from there to end of file, ran the gate, restored.
+
+```
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)
+EXIT:1
+```
+
+Result: PASS. Bullet begins with the exact SPEC §9.1.3 prefix.
+
+### T-781-9 — synthetic regression D (remove `push:` sub-block from `on:` block)
+
+Procedure: located the `^\s{2}push:` line in the workflow yml, removed it and its 4-space-indented children, ran the gate, restored. Pre-check `grep` confirmed no `push:` header remained before the gate ran.
+
+```
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)
+EXIT:1
+```
+
+Result: PASS. Bullet begins with the exact SPEC §9.1.4 prefix.
+
+### T-781-10 — historical replay against `ca69de38`
+
+Procedure: `git clone -q /Users/sethogieva/Desktop/mingla-main /tmp/qa0781_ca69de38 && cd /tmp/qa0781_ca69de38 && git checkout -q ca69de38 && cp <new-script-from-worktree> .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs && node ...`
+
+```
+ORCH-0778 web Stripe native import gate failed.
+- mingla-business/app/_layout.tsx import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries
+- mingla-business/app/checkout/[eventId]/payment.tsx import-scan: @stripe/stripe-react-native must stay behind approved .native payment boundaries
+- ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)
+EXIT:1
+```
+
+Result: PASS. Five failure bullets covering all four layers (import-scan × 2 + npm wiring + CI wiring + push wiring). Matches SPEC §10 T-781-10 ("at least four failure bullets covering import-scan + all three wiring checks"). Confirms the gate would have caught both root-cause classes (F-0781-R1/R2 product + F-0781-R3/R4 wiring) had any caller invoked it at the time of `ca69de38`. Clone directory cleaned up after capture.
+
+### T-781-11 — historical replay against `b7431fe1`
+
+Procedure: same as T-781-10 with `b7431fe1`.
+
+```
+ORCH-0778 web Stripe native import gate failed.
+- ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"] or expected gate script path (npm wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate (CI wiring)
+- ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth] (push wiring)
+EXIT:1
+```
+
+Result: PASS. Exactly three wiring bullets and zero import-scan bullets — matches SPEC §10 T-781-11 literally. Confirms `b7431fe1` partial-restore: product code repaired, wiring still disarmed (which is exactly the state ORCH-0781 was scoped to repair).
+
+## Platform Parity Matrix (per dispatch §"Mandatory platform parity")
+
+This dispatch is a **repo-tooling change only** — npm script + GitHub Actions workflow + Node.js gate script. No application code paths are modified. Platform-parity coverage is recorded as N/A with reasoning, not silently skipped.
+
+| Platform | Coverage | Reasoning |
+|---|---|---|
+| iOS Simulator | N/A | No `mingla-business` iOS bundle code was modified by `14c3b59d`. Product Stripe boundary files (`StripeNativeProvider.native.tsx`, `stripePaymentSheet.native.ts`) are unchanged. Diff of those files: empty (verified). Running the iOS bundle would exercise only pre-existing code unchanged from `b7431fe1`. |
+| Android Emulator | N/A | Same reasoning as iOS. No `mingla-business` Android bundle code modified. The native Stripe boundary remains intact and unchanged. |
+| Web (mingla-business) | N/A (covered indirectly) | No `mingla-business` web bundle code modified. The boundary the gate protects (zero `@stripe/stripe-react-native` imports outside the two `.native` boundary files in `mingla-business/{app,src}`) is verified intact by T-781-1. Running `npx expo export --platform web` would only re-verify the same invariant the gate already verifies statically. |
+| CI runner (`ubuntu-latest`) | COVERED | The gate script itself is the "platform" for this dispatch. Verified by T-781-1 (repo-root invocation, mirrors the workflow step) and T-781-2 (npm invocation from `mingla-business/`). Both exit 0. The workflow yml step will run the identical command on `ubuntu-latest`. |
+
+## CI / GitHub-Actions Verification (SPEC §11)
+
+| ID | Check | Status | Note |
+|---|---|---|---|
+| C-781-1 | GitHub Actions PR run shows `ORCH-0778: Stripe native imports stay behind .native boundaries` job present and passing | UNVERIFIED — branch not yet pushed | Cannot be captured locally; must be observed once orchestrator pushes / opens PR. Not blocking for PASS. |
+| C-781-2 | All existing strict-grep jobs continue to appear and pass | LIKELY-OK by structural diff | The workflow diff added only a `push:` sub-block, a registry comment line, and a new job block; no existing job was modified. Final verification at first CI run. |
+| C-781-3 | Push event to `main` or `Seth` triggers a workflow run | UNVERIFIED — branch not yet pushed | Same as C-781-1. |
+| C-781-4 | Scratch push of synthetic regression A fails the ORCH-0778 job red | OPTIONAL per SPEC; not run | Synthetic-regression coverage already exhaustively proven locally by T-781-6 / T-781-7 / T-781-8 / T-781-9 / T-781-10. Skipping C-781-4 does not introduce risk. |
+
+C-781-1 and C-781-3 are residual unverified items. Recommendation: orchestrator captures both at first push/PR after CLOSE and pastes the run URLs into the CLOSE note. Tester PASS is NOT blocked on this — the gate logic is independently proven correct and the workflow yml structure matches SPEC §7 verbatim.
+
+## Notes (P4)
+
+### P4-1 — Import pattern strengthened beyond SPEC §9.1.1
+
+The implementor's `stripeReactNativeImportPattern` adds a fourth alternative for the bare-string side-effect form `import "@stripe/stripe-react-native"` on top of the three SPEC-required forms (named-from import, dynamic `import(...)`, `require(...)`). This is a strict superset of the SPEC and improves robustness against an obscure regression class that would have otherwise slipped past the gate. Worth replicating in sibling gates (e.g., the ORCH-0768 / ORCH-0769 / ORCH-0777 import-scan style scripts) if any of them only check `from … "..."`.
+
+### P4-2 — Push-trigger `on:` block reads cleanly under YAML rules
+
+The new `push:` block at lines 11–17 mirrors the `pull_request:` block at lines 4–10 with identical `paths:` filters. This is the smallest possible bypass-closure for the `ca69de38`-class direct-push regression — the workflow's effective surface area on push is exactly equal to its effective surface area on pull-request, no more, no less. Branch-protection tightening (require-checks-to-pass on push) is correctly deferred to a separate META-ORCH per SPEC §11.
+
+## Final Sanity Check
+
+```
+$ git status --short --branch
+## orch/0781-clean-tree-stripe-web-import-regression
+?? Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+```
+
+After this QA report is created, the only added untracked artifact at the worktree is the SPEC (correctly excluded from the implementor commit per dispatch) and this QA report. No accidental writes to product code or trackers.
+
+## Routing
+
+PASS → Codex `orchestrator-mingla` for CLOSE.
+
+Orchestrator CLOSE responsibilities per SPEC §12.2 (recap):
+1. Append the DEC-137 follow-up line specified by SPEC §12.2.1.
+2. Refresh the `Codified:` line on `I-PROPOSED-AE STRIPE_REACT_NATIVE_NATIVE_BOUNDARY_ONLY` per SPEC §12.2.2.
+3. Update `WORLD_MAP.md` strict-grep row with the now-present ORCH-0778 job and push-trigger note.
+4. Mark `orch-0781-clean-tree-stripe-web-import-regression` CLOSED in `WORKTREE_REGISTRY.md`.
+5. Standard CLOSE-protocol updates to `PRIORITY_BOARD.md`, `MASTER_BUG_LIST.md`, `OPEN_INVESTIGATIONS.md`.
+6. Register D-0781-2 (ORCH-0776A / 0777 CI orphans audit) as a fresh row in `OPEN_INVESTIGATIONS.md`.
+7. Optional: capture C-781-1 and C-781-3 Actions URLs from the first push / PR after CLOSE.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
@@ -1,0 +1,370 @@
+# SPEC ORCH-0781 — Clean-tree Stripe Web Import Gate Regression
+
+Author: Claude `mingla-forensics` (SPEC mode)
+Date: 2026-05-11
+Worktree: `.worktrees/orch-0781-clean-tree-stripe-web-import-regression/`
+Branch: `orch/0781-clean-tree-stripe-web-import-regression` (based off `Seth` @ `b7431fe1`)
+Investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+Orchestrator review: `Mingla_Artifacts/reports/REVIEW_INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+Invariant under repair: `I-PROPOSED-AE STRIPE_REACT_NATIVE_NATIVE_BOUNDARY_ONLY`
+Source decision: DEC-137 (do not rewrite; append-only follow-up at CLOSE).
+
+---
+
+## 1. Summary
+
+Commit `ca69de38` ("Clean tree") simultaneously reverted the two Stripe-boundary product files and disarmed the ORCH-0778 enforcement layer in the same commit (npm script removed, CI job slot overwritten). Commit `b7431fe1` restored the product files only. At HEAD the gate script still exists and still detects the regression class correctly, but it is orphaned: no `npm run test:orch-0778`, no CI job, and the strict-grep workflow itself only triggers on pull-requests so direct pushes to `Seth` bypass every gate.
+
+This SPEC re-arms the ORCH-0778 enforcement layer across npm + CI as a sibling job (not a replacement of ORCH-0776D), adds a `push` trigger to the strict-grep workflow for `main` and `Seth`, and makes the existing ORCH-0778 gate script self-validate its own wiring so that any future wholesale-sweep that removes the npm script or the CI job will fail the gate from a single invocation. No product code changes. No documentation rewrites — DEC-137 / I-PROPOSED-AE reconciliation is deferred to CLOSE.
+
+## 2. User / Launch Impact
+
+**End-user (buyer / brand) impact:** none directly. Mingla Business Web is already buildable at HEAD; production Vercel deploy `dpl_CPQgBkaXa5nTvVNsCgeAe1UVQ6M5` is READY against `business.usemingla.com`. The B2 Connect, B3 Checkout, B4 Scanner launch gates remain on their own schedules and are unchanged by this SPEC.
+
+**Internal / engineering impact:** restores the alarm system that catches direct `@stripe/stripe-react-native` imports into web-reachable files before they reach Metro/Vercel. Catches the next `ca69de38`-style wholesale sweep at push time, not at the next Vercel deploy attempt 2+ hours later. Closes the documented contradiction between `INVARIANT_REGISTRY.md` (which still names a CI job and an npm script that do not exist at HEAD) and the actual repo state.
+
+**Launch-readiness contribution:** this SPEC is a residual-guard repair; it does not unblock any launch gate. It prevents a regression in a guard that protects a launch gate (web export) so that future drift cannot silently re-introduce the bug ORCH-0778 closed.
+
+## 3. Proven Current State (at HEAD `b7431fe1`)
+
+| Layer | State | Evidence |
+|---|---|---|
+| `mingla-business/app/_layout.tsx` | ✅ Imports only `StripeNativeProvider` from local `../src/payments/StripeNativeProvider`. No direct `@stripe/stripe-react-native` import. | File read at HEAD lines 19–34. |
+| `mingla-business/app/checkout/[eventId]/payment.tsx` | ✅ Imports only `useStripePaymentSheet` from `../../../src/payments/stripePaymentSheet`. No direct `@stripe/stripe-react-native` import. | File read at HEAD lines 14–48. |
+| `mingla-business/src/payments/StripeNativeProvider.{native.tsx,web.tsx}` and `stripePaymentSheet.{native.ts,web.ts}` | ✅ Platform-resolved boundary files exist as established by ORCH-0778. | Unchanged since `76d2c26e`. |
+| `mingla-business/package.json` `scripts.test:orch-0778` | ❌ Missing. Last present at `76d2c26e`; removed by `ca69de38`; not restored by `b7431fe1`. | `grep -n "test:orch-0778" mingla-business/package.json` returns no match. |
+| `.github/workflows/strict-grep-mingla-business.yml` job `orch-0778-web-stripe-native-import-gate` | ❌ Missing. The yml slot is held by `orch-0776d-cancelled-at-schema` (lines 317–326). | File read at HEAD; only job is `orch-0776d-cancelled-at-schema`. |
+| Registry comment line for ORCH-0778 in the yml header | ❌ Missing. Replaced in place by ORCH-0776D comment at line 41. | File read at HEAD; ORCH-0778 comment line absent. |
+| `.github/workflows/strict-grep-mingla-business.yml` `on:` block | ❌ Triggers only on `pull_request`. Direct pushes to `Seth` and `main` bypass every job. | File read at HEAD lines 3–10. |
+| `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` | ✅ Present, functionally correct, but invocation surface is fully orphaned. Manual `node …mjs` run at HEAD prints `ORCH-0778 web Stripe native import gate passed.` and exits 0 — proves detection logic is healthy. | Run at HEAD inside this worktree, exit code 0. |
+| `Mingla_Artifacts/INVARIANT_REGISTRY.md` I-PROPOSED-AE | ⚠ Over-claims current enforcement. Names the `npm run test:orch-0778` command and the CI job that do not exist at HEAD. | F-0781-H1 in investigation. |
+
+## 4. Target State (after this SPEC's implementation)
+
+| Layer | Required state |
+|---|---|
+| Product code (`_layout.tsx`, `payment.tsx`, `src/payments/*.{native,web}.*`) | UNCHANGED. Implementor must NOT edit these files. |
+| `mingla-business/package.json` | Contains `"test:orch-0778": "node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs"` as a sibling of `test:orch-0777`. No other entries reordered or removed. |
+| `.github/workflows/strict-grep-mingla-business.yml` jobs | Contains `orch-0778-web-stripe-native-import-gate:` job appended after `orch-0776d-cancelled-at-schema:`. `orch-0776d-cancelled-at-schema:` MUST remain. Every existing job MUST remain at the same position relative to its current neighbours. |
+| `.github/workflows/strict-grep-mingla-business.yml` registry comment header | Contains the ORCH-0778 comment line appended immediately after the ORCH-0776D comment line. |
+| `.github/workflows/strict-grep-mingla-business.yml` `on:` block | Contains both a `pull_request:` trigger (existing, unchanged) AND a sibling `push:` trigger with the same `branches: [main, Seth]` and the same four `paths:` filters. |
+| `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` | Performs the existing import-scan AND three new wiring self-checks (npm script present, CI job present, push trigger present). All four checks contribute to a single exit code. |
+| `Mingla_Artifacts/INVARIANT_REGISTRY.md` and `Mingla_Artifacts/DECISION_LOG.md` | UNCHANGED during implementation. Reconciled at CLOSE only — append-only follow-up notes, no retroactive edits to DEC-137 text. |
+
+After implementation: a single command `cd mingla-business && npm run test:orch-0778` must exit 0 on the clean repo and must exit 1 on any tree that (a) introduces a non-`.native` Stripe RN import in `mingla-business/{app,src}`, OR (b) removes the npm script, OR (c) removes/renames the CI job, OR (d) removes the workflow `push:` trigger for `main`+`Seth`. The CI job runs the same script on every push and pull-request to `main` or `Seth`.
+
+## 5. Scope And Non-Goals
+
+### In scope (this SPEC only)
+
+- Restore the `test:orch-0778` npm script in `mingla-business/package.json`.
+- Append the `orch-0778-web-stripe-native-import-gate` CI job to the strict-grep workflow as a sibling job after `orch-0776d-cancelled-at-schema`. Append the matching registry comment line.
+- Add a `push:` trigger to the strict-grep workflow `on:` block for branches `main` and `Seth`, mirroring the existing `pull_request:` path filters.
+- Extend the ORCH-0778 `.mjs` gate script to self-validate the three wiring layers above (npm script, CI job header, push trigger).
+- Implementor verification with the three regression-test commands defined in §10.
+- Implementation report at the canonical path defined in §15.
+
+### Non-goals (explicitly out of scope)
+
+- Any product-code change in `mingla-business/`. Investigation §5 / §10 confirmed product code at HEAD already matches the ORCH-0778 boundary.
+- Any change to `mingla-business/src/payments/StripeNativeProvider.{native,web}.tsx` or `mingla-business/src/payments/stripePaymentSheet.{native,web}.ts`.
+- Any change to other strict-grep gate scripts (I-37/38/39, I-PROPOSED-*, ORCH-0768/0769/0770/0771/0774a/0776a/0776d/0777, ORCH-0754/0756/0758/0759/0763).
+- ORCH-0776A and ORCH-0777 CI-orphan audit (registered as D-0781-2 follow-up; see §13).
+- ORCH-0777 ticket-checkout backend, B2 Stripe Connect, B4 scanner, Resend/Twilio dispatch, QR pepper, Stripe restricted keys, native PaymentSheet live-fire.
+- DEC-137 retroactive text edits. I-PROPOSED-AE rewording to match the disarmed state.
+- Any new workflow file. The strict-grep workflow registry pattern requires one yml; do not create `strict-grep-mingla-business-push.yml` or similar.
+- META-ORCH process changes (e.g., CLOSE-checklist amendments for D-0778-QA-2; that is a separate orchestrator concern).
+- Native (iOS/Android) Stripe live-fire. The ORCH-0778 boundary protects the web export; native paths are functionally identical and already covered by Metro `.native` resolution.
+
+## 6. File-Level Change Contract
+
+Exactly four files change:
+
+| # | File | Change kind | Lines touched (approx) |
+|---|---|---|---|
+| 1 | `mingla-business/package.json` | Add one script entry, add one trailing-comma | 2 |
+| 2 | `.github/workflows/strict-grep-mingla-business.yml` | Add `push:` trigger sub-block in `on:`; add one registry-comment line; append one job block | ~25 |
+| 3 | `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` | Add three wiring self-checks + revised error reporting | ~60 |
+| 4 | (implementor report only) `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md` | New | n/a |
+
+No other file (product, test, doc, migration, infra) is permitted to change in the implementation commit. The implementor's `git status` immediately before commit must contain exactly the three modified files above plus the one new implementation report (and any agent artifact appends if the implementor's protocol requires them — those go in a separate commit, not this one).
+
+## 7. Strict-Grep Workflow Contract
+
+### 7.1 Registry comment line (top of yml, around current line 41)
+
+Append the following line **immediately after** the existing ORCH-0776D registry comment line. Do not reorder any prior comment line. Preserve trailing two-space indent identical to surrounding lines.
+
+```
+#   - ORCH-0778 (orch-0778-web-stripe-native-import-gate.mjs) — Stripe React Native imports stay behind .native payment boundaries (re-armed by ORCH-0781)
+```
+
+### 7.2 `on:` block — add `push:` trigger
+
+Replace the existing `on:` block (currently lines 3–10) with the following block. The `pull_request:` sub-block is identical to today; the `push:` sub-block is new and mirrors `pull_request:` exactly.
+
+```yaml
+on:
+  pull_request:
+    branches: [main, Seth]
+    paths:
+      - "mingla-business/**"
+      - "supabase/migrations/**"
+      - ".github/scripts/strict-grep/**"
+      - ".github/workflows/strict-grep-mingla-business.yml"
+  push:
+    branches: [main, Seth]
+    paths:
+      - "mingla-business/**"
+      - "supabase/migrations/**"
+      - ".github/scripts/strict-grep/**"
+      - ".github/workflows/strict-grep-mingla-business.yml"
+```
+
+Rationale: `ca69de38` was a direct push to `Seth` with no PR. Adding `push:` for `main` and `Seth` closes the bypass without expanding the workflow's effective surface — the path filters are identical, so the workflow still ignores commits that touch only non-strict-grep paths.
+
+### 7.3 ORCH-0778 job block — append after `orch-0776d-cancelled-at-schema:`
+
+Append the following block at the END of the `jobs:` section, immediately after the `orch-0776d-cancelled-at-schema:` block. Indent identically to the existing job blocks (two spaces under `jobs:`). Do not remove, rename, or reorder any existing job.
+
+```yaml
+  orch-0778-web-stripe-native-import-gate:
+    name: "ORCH-0778: Stripe native imports stay behind .native boundaries"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-0778 gate
+        run: node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+```
+
+The job name string MUST be the exact name above so the I-PROPOSED-AE registry text "CI job `orch-0778-web-stripe-native-import-gate`" remains true once CLOSE refreshes the codified date.
+
+## 8. Npm Script Contract
+
+### 8.1 Position
+
+Insert the new script entry in `mingla-business/package.json` immediately after the existing `test:orch-0777` entry. The current `test:orch-0777` is the last entry in the `scripts` object; therefore the implementor must (a) add a trailing comma to the `test:orch-0777` line and (b) add the new `test:orch-0778` line as the new last entry without a trailing comma.
+
+### 8.2 Exact line content
+
+```
+    "test:orch-0778": "node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs"
+```
+
+Use four leading spaces (matching surrounding indentation). Use the exact path `../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` — the `../` is required because the npm script runs with cwd `mingla-business/` while the script lives at repo root.
+
+### 8.3 No reordering
+
+Every other script in the `scripts` object MUST remain at the same index it occupies today. The implementor MUST NOT alphabetize, group, or re-emit the file with a different formatter. Use a targeted edit, not a full-file rewrite.
+
+## 9. Optional Self-Validation Contract (REQUIRED)
+
+This SPEC promotes the "optional" self-validation referenced in the dispatch to a hard requirement. Reason: a single self-validating script makes the next wholesale sweep fail from one invocation regardless of which layer is touched, which is the smallest structural defense against the F-0781-R3 / F-0781-R4 class.
+
+### 9.1 Behavior contract
+
+`.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` must perform four independent checks. ALL failures across all four are collected into a single failures array; the process exits 1 if ANY failure is present, 0 only if all four are clean.
+
+1. **Import-scan check (existing behavior, unchanged).** Walk `mingla-business/app` and `mingla-business/src`; flag any `.ts/.tsx/.js/.jsx` file (other than `mingla-business/src/payments/StripeNativeProvider.native.tsx` and `mingla-business/src/payments/stripePaymentSheet.native.ts`) that statically `import … from "@stripe/stripe-react-native"`, dynamic `import("@stripe/stripe-react-native")`, or `require("@stripe/stripe-react-native")`.
+2. **Npm-script wiring check (NEW).** Read `mingla-business/package.json`; fail if `scripts["test:orch-0778"]` is missing or is not a string containing the substring `orch-0778-web-stripe-native-import-gate.mjs`. Error message must begin with `ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"]`.
+3. **CI-job wiring check (NEW).** Read `.github/workflows/strict-grep-mingla-business.yml`; fail if it does not contain a line matching the regex `^\s{2}orch-0778-web-stripe-native-import-gate:\s*$` (two-space indent, exact job header). Error message must begin with `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate`.
+4. **Push-trigger wiring check (NEW).** Read the same workflow yml; locate the `on:` block; verify a `push:` sub-block exists AND its `branches:` list contains both `main` and `Seth`. The regex tolerance MUST allow `[main, Seth]`, `[Seth, main]`, or YAML-list form (`- main` / `- Seth`). Error message must begin with `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth]`.
+
+### 9.2 Output contract
+
+- On success (all four checks pass): print exactly `ORCH-0778 web Stripe native import gate passed.` (one line) and exit 0. The existing single-line success message is preserved unchanged so existing CI log scrapers continue to match.
+- On failure: print exactly one header line `ORCH-0778 web Stripe native import gate failed.`, then one bullet per failure, then exit 1. Each bullet begins with `- ` and contains the file path AND the wiring layer (import-scan / npm wiring / CI wiring / push wiring) so the reader can identify which check fired without reading the script.
+
+### 9.3 Implementation constraints
+
+- Pure Node `fs` + `path` + regex. Do NOT add a YAML parser dependency, do NOT add an `npm install` step to the CI job, do NOT introduce `js-yaml`.
+- Read `mingla-business/package.json` via `JSON.parse(fs.readFileSync(...))`. Tolerate `JSON.parse` throwing by emitting a single failure entry that names the parse error.
+- Read the workflow yml via `fs.readFileSync(...)`; pattern-match against substrings. Be explicit about line-anchored regex (`^…$` with `m` flag) for the job header so a comment containing the same string does not satisfy the check.
+- All paths resolved relative to `repoRoot` computed by the existing `process.cwd().endsWith("mingla-business")` heuristic at the top of the file. Do NOT change that heuristic.
+- Wiring checks MUST run regardless of whether the import-scan check finds any failure (collect all failures, exit once).
+
+### 9.4 Backwards-compatible invocation
+
+Any of the following must continue to work and produce the same exit code:
+
+```bash
+# Invocation A — operator runs from repo root
+node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+
+# Invocation B — operator runs through npm (post-implementation)
+cd mingla-business && npm run test:orch-0778
+
+# Invocation C — CI runs it from repo root (job step)
+node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
+```
+
+## 10. Regression Test Matrix
+
+The implementor MUST run these checks and paste exit-code receipts into the implementation report.
+
+| ID | Command (run from repo root unless noted) | Expected before this SPEC | Expected after this SPEC |
+|---|---|---|---|
+| T-781-1 | `node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` | exit 0 (script intact, product code clean, but ALL wiring missing — script does not yet self-validate) | exit 0 (all four checks pass) |
+| T-781-2 | `cd mingla-business && npm run test:orch-0778` | exit 1, `npm ERR! missing script: test:orch-0778` | exit 0, success line printed |
+| T-781-3 | `grep -nE '^\s*"test:orch-0778":' mingla-business/package.json` | no match | exactly one match |
+| T-781-4 | `grep -nE '^\s{2}orch-0778-web-stripe-native-import-gate:\s*$' .github/workflows/strict-grep-mingla-business.yml` | no match | exactly one match |
+| T-781-5 | `grep -nE '^\s{2}push:\s*$' .github/workflows/strict-grep-mingla-business.yml` | no match | at least one match (inside `on:` block) |
+| T-781-6 | Synthetic regression A: introduce `import "@stripe/stripe-react-native"` at top of `mingla-business/app/_layout.tsx` (commit locally to a scratch ref), then run T-781-1 | n/a | exit 1, failure bullet names `mingla-business/app/_layout.tsx` |
+| T-781-7 | Synthetic regression B: remove the `test:orch-0778` line from `mingla-business/package.json` (commit locally to a scratch ref), then run T-781-1 | n/a | exit 1, failure bullet begins with `ORCH-0781 wiring: mingla-business/package.json missing scripts["test:orch-0778"]` |
+| T-781-8 | Synthetic regression C: remove the `orch-0778-web-stripe-native-import-gate:` job from the workflow yml (commit locally to a scratch ref), then run T-781-1 | n/a | exit 1, failure bullet begins with `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml missing job orch-0778-web-stripe-native-import-gate` |
+| T-781-9 | Synthetic regression D: remove the `push:` sub-block from the workflow `on:` block (commit locally to a scratch ref), then run T-781-1 | n/a | exit 1, failure bullet begins with `ORCH-0781 wiring: .github/workflows/strict-grep-mingla-business.yml on: block missing push trigger for [main, Seth]` |
+| T-781-10 | At `ca69de38` (clone repo to `/tmp/orch-0781-ca69de38/`, `git checkout ca69de38`, copy the new SPEC-implemented `.mjs` over the old one), then run T-781-1 | n/a | exit 1 with at least four failure bullets covering import-scan + all three wiring checks |
+| T-781-11 | At `b7431fe1` (clone repo to `/tmp/orch-0781-b7431fe1/`, `git checkout b7431fe1`, copy the new SPEC-implemented `.mjs` over the old one), then run T-781-1 | n/a | exit 1 with exactly three failure bullets covering all three wiring checks (no import-scan bullets) |
+
+All synthetic-regression checks (T-781-6..T-781-9) MUST be run on a throwaway branch (`scratch/orch-0781-test-<id>`) and reverted before commit. Implementor MUST NOT push these synthetic regressions.
+
+T-781-10 and T-781-11 are the canonical correctness proofs that this SPEC achieves what the investigation prescribed: the gate now fails at the exact two commits the investigation pinned, and would have caught the regression if any caller had invoked it.
+
+## 11. CI / GitHub Verification Matrix
+
+After implementation lands on the worktree branch `orch/0781-clean-tree-stripe-web-import-regression`, the operator opens a PR into `Seth` (or merges directly via the orchestrator's standard merge flow). The following GitHub Actions evidence MUST be captured before tester PASS:
+
+| ID | Check | Expected |
+|---|---|---|
+| C-781-1 | GitHub Actions run on the PR shows a job named `ORCH-0778: Stripe native imports stay behind .native boundaries` | PRESENT and PASSING |
+| C-781-2 | All other strict-grep jobs that ran prior to this SPEC continue to appear and pass | UNCHANGED count and outcome |
+| C-781-3 | When the SPEC branch is merged (push event to `main` or `Seth`), the GitHub Actions UI shows a push-triggered run of the workflow | PRESENT |
+| C-781-4 | A scratch push of synthetic regression A (Stripe RN import in `_layout.tsx`) to a scratch branch under `Seth` namespace triggers the workflow AND the ORCH-0778 job fails red | OPTIONAL but recommended — if skipped, document why in QA report |
+
+If the operator's branch-protection rules do not yet require the workflow on push to `Seth`, that is acceptable. This SPEC does not require new branch-protection rules; it only requires that the workflow fires on push. Branch-protection tightening (require-checks-to-pass) is a separate META-ORCH and not in scope.
+
+## 12. Documentation And Artifact Reconciliation
+
+### 12.1 During implementation — NO doc edits
+
+The implementor MUST NOT edit:
+
+- `Mingla_Artifacts/DECISION_LOG.md` (DEC-137 text stays exactly as written by ORCH-0778).
+- `Mingla_Artifacts/INVARIANT_REGISTRY.md` (I-PROPOSED-AE text stays exactly as written).
+- `Mingla_Artifacts/WORLD_MAP.md`, `Mingla_Artifacts/MASTER_BUG_LIST.md`, `Mingla_Artifacts/PRIORITY_BOARD.md`, `Mingla_Artifacts/OPEN_INVESTIGATIONS.md`, `Mingla_Artifacts/AGENT_HANDOFFS.md`, `Mingla_Artifacts/WORKTREE_REGISTRY.md`, `Mingla_Artifacts/ROOT_CAUSE_REGISTER.md`.
+- Any `CLOSE_NOTE_ORCH-*.md` file.
+
+Those updates are the orchestrator's responsibility at the standard CLOSE step, after tester PASS.
+
+### 12.2 At CLOSE — append-only follow-up notes
+
+The orchestrator (Codex `orchestrator-mingla`) MUST at CLOSE:
+
+1. Append a one-line follow-up under DEC-137 in `Mingla_Artifacts/DECISION_LOG.md` of the form:
+   ```
+   - Follow-up (ORCH-0781, 2026-05-11+): Enforcement layer (npm script `test:orch-0778`, CI job `orch-0778-web-stripe-native-import-gate`, workflow `push` trigger for [main, Seth], and gate-script self-validation of its own wiring) was disarmed by commit `ca69de38` and re-armed by ORCH-0781. DEC-137's original decision text remains unchanged.
+   ```
+2. Refresh the `Codified:` line of `I-PROPOSED-AE STRIPE_REACT_NATIVE_NATIVE_BOUNDARY_ONLY` in `Mingla_Artifacts/INVARIANT_REGISTRY.md` to read:
+   ```
+   Codified: 2026-05-10 (DEC-137, ORCH-0778); re-armed 2026-05-11+ (ORCH-0781)
+   ```
+   No other invariant text is changed. Do NOT add new sub-bullets, do NOT rewrite the "Enforcement mechanism" or "Test that catches regression" lines — those become true again as soon as implementation lands.
+3. Update `Mingla_Artifacts/WORLD_MAP.md` strict-grep section to reflect the now-present ORCH-0778 job, and add a "push-trigger present for main + Seth" note alongside the strict-grep workflow row.
+4. Update `Mingla_Artifacts/WORKTREE_REGISTRY.md` to mark `orch-0781-clean-tree-stripe-web-import-regression` as CLOSED.
+5. Update `Mingla_Artifacts/PRIORITY_BOARD.md`, `Mingla_Artifacts/MASTER_BUG_LIST.md`, and `Mingla_Artifacts/OPEN_INVESTIGATIONS.md` per standard CLOSE protocol.
+6. Register D-0781-2 (see §13) as a fresh entry in `Mingla_Artifacts/OPEN_INVESTIGATIONS.md` so it is not lost.
+
+The implementor's deliverable does NOT include any of these doc edits. If the implementor edits them, the tester MUST flag this as a scope-violation and request rework before PASS.
+
+## 13. Deferred Follow-Ups
+
+### 13.1 D-0781-2 — ORCH-0776A / ORCH-0777 strict-grep scripts appear npm-wired but not CI-wired
+
+**Status:** OUT OF SCOPE for ORCH-0781. Register-only.
+
+`ca69de38` added `.github/scripts/strict-grep/orch-0776a-video-upload-progress-honesty.mjs` and `.github/scripts/strict-grep/orch-0777-ticket-checkout-production.mjs`, plus matching `test:orch-0776a` / `test:orch-0777` npm scripts in `mingla-business/package.json`. Neither script has a corresponding CI job in `.github/workflows/strict-grep-mingla-business.yml`. This is the same registry-pattern violation as F-0781-R3 (`new gate must add one script + one job, never replace existing jobs`).
+
+**Why deferred:** scoping ORCH-0781 to the ORCH-0778 re-arm + push-trigger keeps this SPEC small, fast, and auditable. ORCH-0776A and ORCH-0777 are separate ORCHs with their own invariants, owners, and close-state. A wholesale "audit every orphan strict-grep script" pass risks broadening this SPEC into a meta-cleanup that delays the immediate Stripe-boundary repair.
+
+**Registration target:** the orchestrator MUST at CLOSE add a row to `Mingla_Artifacts/OPEN_INVESTIGATIONS.md` of the form:
+
+```
+| OPEN-INV-XXX | strict-grep CI orphans (ORCH-0776A + ORCH-0777) — npm scripts present in mingla-business/package.json, no matching CI job in strict-grep-mingla-business.yml; same registry-pattern violation class as F-0781-R3. Audit-only follow-up; do NOT close-rearm in ORCH-0781. | P2 | open | spawned 2026-05-11 by ORCH-0781 |
+```
+
+The exact `OPEN-INV-XXX` ID is the orchestrator's choice. The follow-up itself runs as its own META-ORCH at the operator's discretion.
+
+### 13.2 D-0781-1 — strict-grep workflow push-trigger scope
+
+**Status:** PARTIALLY IN SCOPE for ORCH-0781. The push trigger is added in §7.2 for the `mingla-business` strict-grep workflow only.
+
+If other strict-grep workflows exist for `app-mobile` or `mingla-admin` (this SPEC does not audit that), those workflows MAY have the same PR-only trigger gap. Auditing and patching them is OUT OF SCOPE.
+
+**Registration target:** the orchestrator MAY add an OPEN-INV row at CLOSE if the operator wants a sweep of all strict-grep workflows for push-trigger coverage. This is operator-discretion, not an ORCH-0781 hard requirement.
+
+### 13.3 D-0781-3 / D-0781-4 — process drift discoveries
+
+The investigation's D-0781-3 (CLOSE-checklist amendment to act on D-0778-QA-2-style reconciliation discoveries) and D-0781-4 (split future "Clean tree"-style sweeps per-ORCH) are META-ORCH process concerns owned by Codex `orchestrator-mingla`. NOT part of this SPEC's implementation. Mentioned here only so they are not lost.
+
+## 14. Implementation Order
+
+The implementor MUST follow this order. All four steps land in a SINGLE commit on `orch/0781-clean-tree-stripe-web-import-regression`. No intermediate commits; no rebases.
+
+1. **Edit `mingla-business/package.json`:** add trailing comma to `test:orch-0777` line; insert `test:orch-0778` line per §8.
+2. **Edit `.github/workflows/strict-grep-mingla-business.yml`:**
+   - Add the `push:` sub-block to the `on:` block per §7.2.
+   - Add the ORCH-0778 registry comment line per §7.1.
+   - Append the `orch-0778-web-stripe-native-import-gate:` job block at the end of `jobs:` per §7.3.
+3. **Edit `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs`:** add the three wiring self-checks per §9. Preserve the existing import-scan behavior unchanged. Preserve the existing success message exactly.
+4. **Verify locally:** run T-781-1 through T-781-9 from §10. Re-clone `ca69de38` and `b7431fe1` to scratch dirs and run T-781-10 / T-781-11. Capture exit codes and the literal stdout/stderr of each run.
+5. **Write the implementation report** at `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md` using the standard implementor template (Summary / Old→New per file / Verification receipts / Discoveries / Confidence).
+6. **Commit on `orch/0781-clean-tree-stripe-web-import-regression`** with message exactly:
+   ```
+   ORCH-0781: re-arm Stripe web import gate (npm + CI + push + self-validate)
+   ```
+   No multi-line body, no Co-Authored-By line (per user preference).
+7. **Hand back to operator.** The operator routes to Claude `mingla-tester` for TEST mode (canonical per 2026-05-10 reversal).
+
+## 15. Handoff To Implementor
+
+**Target skill:** Codex `implementor-mingla` (Codex side, not Claude).
+
+**Working tree:** `.worktrees/orch-0781-clean-tree-stripe-web-import-regression/`. Open the implementor at that path; do NOT operate from `Users/sethogieva/Desktop/mingla-main/` (main checkout).
+
+**Required reads before any edit:**
+
+- This SPEC: `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- Orchestrator review: `Mingla_Artifacts/reports/REVIEW_INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
+- ORCH-0778 implementation report: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0778_ORCH0777_WEB_EXPORT_STRIPE_NATIVE_IMPORT_GATE.md`
+- DEC-137 in `Mingla_Artifacts/DECISION_LOG.md`
+- I-PROPOSED-AE in `Mingla_Artifacts/INVARIANT_REGISTRY.md`
+
+**Hard guards (REPEAT FROM §5):**
+
+- Touch only the three files listed in §6 (plus the new implementation report).
+- Do NOT edit `_layout.tsx`, `payment.tsx`, or any `src/payments/*` file.
+- Do NOT edit any other `.github/scripts/strict-grep/*.mjs` script.
+- Do NOT add a new workflow file.
+- Do NOT edit DEC-137, I-PROPOSED-AE, or any tracker document — those are CLOSE-only edits owned by the orchestrator.
+- Do NOT run `supabase db push`, `supabase functions deploy`, `eas update`, or `eas build`. This SPEC has no DB, no edge function, no mobile bundle component.
+- Do NOT alphabetize or reorder `package.json` scripts.
+- Do NOT reorder existing strict-grep workflow jobs or registry-comment lines.
+- Do NOT introduce a YAML parser dependency in the gate script.
+
+**Deliverable:**
+
+- Modified files per §6 / §7 / §8 / §9.
+- New file: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md` with all eleven test receipts (T-781-1 through T-781-11) and explicit exit codes.
+- Single commit per §14 step 6.
+
+**Routing after implementor returns:** route back to operator; operator dispatches Claude `mingla-tester` for TEST mode against this SPEC. After TEST PASS, operator dispatches Codex `orchestrator-mingla` for CLOSE.
+
+---
+
+## Spec Verdict
+
+**Spec Verdict: READY FOR IMPLEMENTATION**
+
+Implementor prompt title to write next (orchestrator action):
+
+```
+Mingla_Artifacts/prompts/IMPLEMENT_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md
+```
+
+**Operator action required before implementation:**
+
+None blocking. The worktree `.worktrees/orch-0781-clean-tree-stripe-web-import-regression/` is created and on branch `orch/0781-clean-tree-stripe-web-import-regression` at HEAD `b7431fe1`. The strict-grep workflow has a `push:` trigger only after implementation lands, so the first time the workflow fires on push for `Seth` will be when this branch (or a downstream merge) is pushed. That is expected and acceptable.

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -29,7 +29,8 @@
     "test:orch-0774a": "npx jest authReadiness.test brandListState.test eventCoverVideoProcessingService.test serverDraftLifecycleGuards.test eventCoverMedia.test",
     "test:orch-0776a": "node ../.github/scripts/strict-grep/orch-0776a-video-upload-progress-honesty.mjs && npx jest eventCoverVideoProcessingService.test",
     "test:orch-0776d": "node ../.github/scripts/strict-grep/orch-0776d-cancelled-at-schema.mjs && jest --runInBand src/services/__tests__/eventCoverVideoProcessingService.test.ts",
-    "test:orch-0777": "node ../.github/scripts/strict-grep/orch-0777-ticket-checkout-production.mjs && npx jest phone.test eventOrdersService.test ticketCheckoutService.test ticketCheckoutMigrationGuards.test && npx tsc --noEmit"
+    "test:orch-0777": "node ../.github/scripts/strict-grep/orch-0777-ticket-checkout-production.mjs && npx jest phone.test eventOrdersService.test ticketCheckoutService.test ticketCheckoutMigrationGuards.test && npx tsc --noEmit",
+    "test:orch-0778": "node ../.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary

Closes ORCH-0781 (CLOSED PASS / Grade A in Codex orchestrator-mingla). Re-arms the Stripe-web-import gate that `ca69de38` disarmed:

- Restored `mingla-business` npm script `test:orch-0778`
- Restored strict-grep workflow job `orch-0778-web-stripe-native-import-gate` (sibling to ORCH-0776D / ORCH-0777)
- Added `push` coverage for `[main, Seth]` to `.github/workflows/strict-grep-mingla-business.yml`
- Promoted `.github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs` to self-validate npm wiring, CI job wiring, and push-trigger wiring

## Evidence

- Investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
- Spec: `Mingla_Artifacts/specs/SPEC_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
- Implementation: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
- QA PASS: `Mingla_Artifacts/reports/QA_ORCH-0781_CLEAN_TREE_STRIPE_WEB_IMPORT_GATE_REGRESSION.md`
- Close note: `Mingla_Artifacts/CLOSE_NOTE_ORCH-0781.md`

Implementation HEAD: `14c3b59d` — close-artifact HEAD: `58ee4f39`.

## Test plan

- [x] Local QA T-781-1 through T-781-11 PASS (see QA report)
- [x] Historical replay vs `ca69de38` fails with import-scan + npm/CI/push wiring bullets
- [x] Historical replay vs `b7431fe1` fails with exactly the three wiring bullets, no import-scan bullets
- [x] DIAG marker reap for `[ORCH-0781-DIAG]` returned zero matches
- [ ] C-781-1: PR strict-grep job passes (captured by this PR)
- [ ] C-781-3: push-run on Seth/main after merge (captured post-merge)

Hard guard: merge waits until unrelated dirty ORCH-0777/0779/product work on `main`/`Seth` is isolated by its owners.