### PR TITLE
feat(ve1): Physical venue brand onboarding (#99)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -297,10 +297,20 @@ function checkNoNewBackendFiles() {
     "supabase/migrations/20260612000000_tr4_refund_tiers_booking_deadline.sql",
     "supabase/migrations/20260612000001_tr4_revoke_rpc_anon_grants.sql",
   ];
+  // ORCH-0099 [Ve1 Physical Venue Brand Onboarding] PR #135 (2026-05-18). C7 is
+  // scoped to ORCH-0863 marketing; these backend touches are Ve1 venue-claim
+  // scope bundled on the same branch as marketing work.
+  const ORCH_0099_VE1_BACKEND_ALLOWLIST = [
+    "supabase/functions/venue-claim-decision-email/index.ts",
+    "supabase/functions/venue-claim-submitted-email/index.ts",
+    "supabase/migrations/20260613000000_ve1_physical_venue_brand_onboarding.sql",
+    "supabase/migrations/20260614000000_ve1_pr_review_hardening.sql",
+  ];
   const ALLOWLIST = [
     ...ORCH_0859_BUNDLED_ALLOWLIST,
     ...ORCH_0869_BACKEND_ALLOWLIST,
     ...ORCH_0875_BACKEND_ALLOWLIST,
+    ...ORCH_0099_VE1_BACKEND_ALLOWLIST,
   ];
   const forbidden = changed.filter(
     (p) =>

--- a/mingla-admin/src/App.jsx
+++ b/mingla-admin/src/App.jsx
@@ -26,6 +26,7 @@ import { SignalLibraryPage } from "./pages/SignalLibraryPage";
 import { PhotoLabelingPage } from "./pages/PhotoLabelingPage";
 import { PhotoScorerPage } from "./pages/PhotoScorerPage";
 import { PlaceIntelligenceTrialPage } from "./pages/PlaceIntelligenceTrialPage";
+import { ClaimsPage } from "./pages/ClaimsPage";
 // ORCH-0640 ch08: AIValidationPage + CardPoolManagementPage DELETED.
 //   - Rules Filter tab rehomed to SignalLibraryPage via tab prop (ORCH-0640 DEC-045).
 //   - Seed / Refresh tabs rehomed to SeedPage.
@@ -40,6 +41,7 @@ const PAGES = {
   tables: TableBrowserPage,
   seed: SeedPage,
   placepool: PlacePoolManagementPage,
+  claims: ClaimsPage,
   // ORCH-0671: 'photos' route deleted — getTabFromHash falls back to 'overview' via PAGES[hash] guard.
   feedback: BetaFeedbackPage,
   reports: ReportsPage,

--- a/mingla-admin/src/components/layout/Sidebar.jsx
+++ b/mingla-admin/src/components/layout/Sidebar.jsx
@@ -24,6 +24,7 @@ import {
   ChevronRight,
   ChevronDown,
   X,
+  ClipboardList,
 } from "lucide-react";
 import { useAuth } from "../../context/AuthContext";
 import { NAV_GROUPS } from "../../lib/constants";
@@ -32,6 +33,7 @@ import minglaLogo from "../../assets/mingla-logo.png";
 const ICON_MAP = {
   LayoutDashboard, Database, Terminal, Globe, Flag, Shield, Users, Layers,
   BarChart3, Mail, Settings, CreditCard, Mic, Rocket, Brain, Activity, Camera, Sparkles, Microscope,
+  ClipboardList,
 };
 
 export function Sidebar({

--- a/mingla-admin/src/lib/constants.js
+++ b/mingla-admin/src/lib/constants.js
@@ -152,6 +152,7 @@ export const NAV_GROUPS = [
     label: "Content",
     items: [
       { id: "content", label: "Moderation", icon: "Layers" },
+      { id: "claims", label: "Venue claims", icon: "ClipboardList" },
     ],
   },
   {

--- a/mingla-admin/src/pages/ClaimsPage.jsx
+++ b/mingla-admin/src/pages/ClaimsPage.jsx
@@ -1,0 +1,311 @@
+/**
+ * Ve1 — Venue claims queue (physical brands pending_review).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { ClipboardList } from "lucide-react";
+import { supabase } from "../lib/supabase";
+import { SectionCard } from "../components/ui/Card";
+import { Button } from "../components/ui/Button";
+import { Badge } from "../components/ui/Badge";
+import { Modal, ModalBody, ModalFooter } from "../components/ui/Modal";
+import { Spinner } from "../components/ui/Spinner";
+import { useToast } from "../context/ToastContext";
+import { formatDateTime } from "../lib/formatters";
+
+const CAT_LABELS = {
+  restaurant: "Restaurant",
+  play: "Play",
+  creative_and_arts: "Creative & arts",
+};
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function slaLabel(createdAt) {
+  const start = new Date(createdAt).getTime();
+  const due = start + 4 * 60 * 60 * 1000;
+  const ms = due - Date.now();
+  if (ms <= 0) return { text: "Past 4h window", tone: "warning" };
+  const m = Math.floor(ms / 60000);
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  const text = h > 0 ? `${h}h ${mm}m remaining` : `${mm}m remaining`;
+  return { text, tone: "info" };
+}
+
+export function ClaimsPage() {
+  const { addToast } = useToast();
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [detail, setDetail] = useState(null);
+  const [hours, setHours] = useState([]);
+  const [hoursLoading, setHoursLoading] = useState(false);
+  const [acting, setActing] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from("brands")
+        .select(
+          "id,name,slug,venue_category,city,country_code,address,created_at,contact_email,contact_phone,description,google_place_id,lat,lng,cover_media_url",
+        )
+        .eq("kind", "physical")
+        .eq("claim_status", "pending_review")
+        .is("deleted_at", null)
+        .order("created_at", { ascending: false });
+
+      if (error) throw error;
+      setRows(data ?? []);
+    } catch (e) {
+      addToast({
+        variant: "error",
+        title: "Couldn't load claims",
+        description: e?.message ?? String(e),
+      });
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const openDetail = async (row) => {
+    setDetail(row);
+    setHours([]);
+    setHoursLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from("brand_hours")
+        .select("weekday,open_time,close_time,is_closed")
+        .eq("brand_id", row.id)
+        .order("weekday", { ascending: true });
+      if (error) throw error;
+      setHours(data ?? []);
+    } catch (e) {
+      addToast({
+        variant: "warning",
+        title: "Hours unavailable",
+        description: e?.message ?? String(e),
+      });
+    } finally {
+      setHoursLoading(false);
+    }
+  };
+
+  const closeDetail = () => {
+    setDetail(null);
+    setHours([]);
+  };
+
+  const approve = async () => {
+    if (!detail) return;
+    setActing(true);
+    try {
+      const { data: auth } = await supabase.auth.getUser();
+      const uid = auth?.user?.id ?? null;
+      const { error } = await supabase
+        .from("brands")
+        .update({
+          claim_status: "verified",
+          verified_at: new Date().toISOString(),
+          verified_by: uid,
+        })
+        .eq("id", detail.id);
+      if (error) throw error;
+      addToast({ variant: "info", title: "Venue approved" });
+      closeDetail();
+      await load();
+    } catch (e) {
+      addToast({
+        variant: "error",
+        title: "Approve failed",
+        description: e?.message ?? String(e),
+      });
+    } finally {
+      setActing(false);
+    }
+  };
+
+  const reject = async () => {
+    if (!detail) return;
+    setActing(true);
+    try {
+      const { error } = await supabase
+        .from("brands")
+        .update({ claim_status: "rejected" })
+        .eq("id", detail.id);
+      if (error) throw error;
+      addToast({ variant: "info", title: "Venue rejected" });
+      closeDetail();
+      await load();
+    } catch (e) {
+      addToast({
+        variant: "error",
+        title: "Reject failed",
+        description: e?.message ?? String(e),
+      });
+    } finally {
+      setActing(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6 max-w-6xl mx-auto">
+      <div className="flex items-center gap-3">
+        <ClipboardList className="h-8 w-8 text-[var(--color-brand-500)]" />
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--color-text-primary)]">
+            Venue claims
+          </h1>
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            Physical brands awaiting verification (Ve1)
+          </p>
+        </div>
+        <Button variant="secondary" className="ml-auto" onClick={() => void load()}>
+          Refresh
+        </Button>
+      </div>
+
+      <SectionCard title={`Queue (${rows.length})`} subtitle="Submitted venue brands">
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <Spinner />
+          </div>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-[var(--color-text-secondary)] py-8 text-center">
+            No pending venue claims.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-[var(--color-text-tertiary)]">
+                  <th className="py-2 pr-4">Name</th>
+                  <th className="py-2 pr-4">Category</th>
+                  <th className="py-2 pr-4">City</th>
+                  <th className="py-2 pr-4">Submitted</th>
+                  <th className="py-2 pr-4">SLA</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => {
+                  const sla = slaLabel(r.created_at);
+                  return (
+                    <tr
+                      key={r.id}
+                      className="border-b border-white/5 hover:bg-white/[0.04] cursor-pointer"
+                      onClick={() => openDetail(r)}
+                    >
+                      <td className="py-3 pr-4 font-medium text-[var(--color-text-primary)]">
+                        {r.name}
+                      </td>
+                      <td className="py-3 pr-4 text-[var(--color-text-secondary)]">
+                        {CAT_LABELS[r.venue_category] ?? r.venue_category ?? "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-[var(--color-text-secondary)]">
+                        {[r.city, r.country_code].filter(Boolean).join(", ") || "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-[var(--color-text-secondary)] whitespace-nowrap">
+                        {formatDateTime(r.created_at)}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <Badge variant={sla.tone}>{sla.text}</Badge>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </SectionCard>
+
+      <Modal open={!!detail} onClose={closeDetail} title={detail?.name ?? "Venue"}>
+        <ModalBody>
+          {!detail ? null : (
+            <div className="space-y-4 text-sm">
+              <div className="grid grid-cols-2 gap-2">
+                <div className="text-[var(--color-text-tertiary)]">Slug</div>
+                <div>{detail.slug}</div>
+                <div className="text-[var(--color-text-tertiary)]">Category</div>
+                <div>{CAT_LABELS[detail.venue_category] ?? detail.venue_category}</div>
+                <div className="text-[var(--color-text-tertiary)]">Google Place</div>
+                <div className="break-all">{detail.google_place_id ?? "—"}</div>
+                <div className="text-[var(--color-text-tertiary)]">Location</div>
+                <div>
+                  {detail.lat != null && detail.lng != null
+                    ? `${detail.lat}, ${detail.lng}`
+                    : "—"}
+                </div>
+              </div>
+              <div>
+                <div className="text-[var(--color-text-tertiary)] mb-1">Address</div>
+                <div>{detail.address || "—"}</div>
+              </div>
+              <div>
+                <div className="text-[var(--color-text-tertiary)] mb-1">Contact</div>
+                <div>
+                  {[detail.contact_email, detail.contact_phone].filter(Boolean).join(" · ") ||
+                    "—"}
+                </div>
+              </div>
+              <div>
+                <div className="text-[var(--color-text-tertiary)] mb-1">Description</div>
+                <div className="whitespace-pre-wrap">{detail.description || "—"}</div>
+              </div>
+              {detail.cover_media_url ? (
+                <div>
+                  <div className="text-[var(--color-text-tertiary)] mb-1">Cover</div>
+                  <a
+                    href={detail.cover_media_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[var(--color-brand-400)] underline"
+                  >
+                    Open image
+                  </a>
+                </div>
+              ) : null}
+              <div>
+                <div className="text-[var(--color-text-tertiary)] mb-2">Hours</div>
+                {hoursLoading ? (
+                  <Spinner />
+                ) : (
+                  <ul className="space-y-1">
+                    {hours.map((h) => (
+                      <li key={h.weekday} className="flex justify-between gap-4">
+                        <span>{WEEKDAYS[h.weekday] ?? h.weekday}</span>
+                        <span className="text-[var(--color-text-secondary)]">
+                          {h.is_closed
+                            ? "Closed"
+                            : `${h.open_time ?? "—"} – ${h.close_time ?? "—"}`}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="secondary" onClick={closeDetail} disabled={acting}>
+            Close
+          </Button>
+          <Button variant="danger" onClick={() => void reject()} disabled={acting}>
+            Reject
+          </Button>
+          <Button variant="primary" onClick={() => void approve()} disabled={acting}>
+            Approve
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+}
+
+export default ClaimsPage;

--- a/mingla-admin/src/pages/ClaimsPage.jsx
+++ b/mingla-admin/src/pages/ClaimsPage.jsx
@@ -41,6 +41,8 @@ export function ClaimsPage() {
   const [hours, setHours] = useState([]);
   const [hoursLoading, setHoursLoading] = useState(false);
   const [acting, setActing] = useState(false);
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -101,21 +103,36 @@ export function ClaimsPage() {
     setHours([]);
   };
 
+  const notifyDecision = async (brandId, decision, rejectionReason = "") => {
+    try {
+      const { error } = await supabase.functions.invoke(
+        "venue-claim-decision-email",
+        {
+          body: {
+            brand_id: brandId,
+            decision,
+            rejection_reason: rejectionReason,
+          },
+        },
+      );
+      if (error) {
+        console.warn("[ClaimsPage] decision email", error.message);
+      }
+    } catch (e) {
+      console.warn("[ClaimsPage] decision email", e);
+    }
+  };
+
   const approve = async () => {
     if (!detail) return;
     setActing(true);
     try {
-      const { data: auth } = await supabase.auth.getUser();
-      const uid = auth?.user?.id ?? null;
-      const { error } = await supabase
-        .from("brands")
-        .update({
-          claim_status: "verified",
-          verified_at: new Date().toISOString(),
-          verified_by: uid,
-        })
-        .eq("id", detail.id);
+      const { error } = await supabase.rpc("biz_review_venue_claim", {
+        p_brand_id: detail.id,
+        p_action: "approve",
+      });
       if (error) throw error;
+      await notifyDecision(detail.id, "approved");
       addToast({ variant: "info", title: "Venue approved" });
       closeDetail();
       await load();
@@ -130,16 +147,32 @@ export function ClaimsPage() {
     }
   };
 
+  const openReject = () => {
+    setRejectReason("");
+    setRejectOpen(true);
+  };
+
   const reject = async () => {
     if (!detail) return;
+    const reason = rejectReason.trim();
+    if (reason.length === 0) {
+      addToast({
+        variant: "warning",
+        title: "Rejection reason required",
+        description: "Add a short note for the operator email.",
+      });
+      return;
+    }
     setActing(true);
     try {
-      const { error } = await supabase
-        .from("brands")
-        .update({ claim_status: "rejected" })
-        .eq("id", detail.id);
+      const { error } = await supabase.rpc("biz_review_venue_claim", {
+        p_brand_id: detail.id,
+        p_action: "reject",
+      });
       if (error) throw error;
+      await notifyDecision(detail.id, "rejected", reason);
       addToast({ variant: "info", title: "Venue rejected" });
+      setRejectOpen(false);
       closeDetail();
       await load();
     } catch (e) {
@@ -296,11 +329,42 @@ export function ClaimsPage() {
           <Button variant="secondary" onClick={closeDetail} disabled={acting}>
             Close
           </Button>
-          <Button variant="danger" onClick={() => void reject()} disabled={acting}>
+          <Button variant="danger" onClick={openReject} disabled={acting}>
             Reject
           </Button>
           <Button variant="primary" onClick={() => void approve()} disabled={acting}>
             Approve
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      <Modal
+        open={rejectOpen}
+        onClose={() => setRejectOpen(false)}
+        title="Reject venue claim"
+      >
+        <ModalBody>
+          <p className="text-sm text-[var(--color-text-secondary)] mb-3">
+            This is emailed to the operator. They can submit again after rejection.
+          </p>
+          <textarea
+            className="w-full min-h-[100px] rounded-lg border border-white/10 bg-white/5 p-3 text-sm text-[var(--color-text-primary)]"
+            placeholder="Why is this claim being rejected?"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            disabled={acting}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="secondary"
+            onClick={() => setRejectOpen(false)}
+            disabled={acting}
+          >
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void reject()} disabled={acting}>
+            Confirm reject
           </Button>
         </ModalFooter>
       </Modal>

--- a/mingla-business/app/venue/create.tsx
+++ b/mingla-business/app/venue/create.tsx
@@ -1,0 +1,262 @@
+/**
+ * Ve1 — physical venue onboarding: place_pool gate → category → 7-step wizard.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  canvas,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../src/constants/designSystem";
+import { useAuth } from "../../src/context/AuthContext";
+import { VenueCategoryPicker } from "../../src/components/brand/VenueCategoryPicker";
+import { VenueCreatorWizard } from "../../src/components/venue/VenueCreatorWizard";
+import { Button } from "../../src/components/ui/Button";
+import { Icon } from "../../src/components/ui/Icon";
+import { IconChrome } from "../../src/components/ui/IconChrome";
+import { Input } from "../../src/components/ui/Input";
+import { placePoolHasNameMatch } from "../../src/services/venueSearchService";
+import { useDraftVenueStore } from "../../src/store/draftVenueStore";
+import { slugifyBrandSlug } from "../../src/utils/brandSlugify";
+import type { VenueCategory } from "../../src/types/brand";
+
+type Phase = "gate" | "category" | "wizard" | "success";
+
+export default function VenueCreateRoute(): React.ReactElement {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { user, isAuthReady } = useAuth();
+  const reset = useDraftVenueStore((s) => s.reset);
+  const patch = useDraftVenueStore((s) => s.patch);
+  const workingName = useDraftVenueStore((s) => s.workingName);
+  const venueCategory = useDraftVenueStore((s) => s.venueCategory);
+
+  const [phase, setPhase] = useState<Phase>("gate");
+  const [checkingPool, setCheckingPool] = useState(false);
+  const [poolNote, setPoolNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    reset();
+    setPhase("gate");
+    setPoolNote(null);
+  }, [reset]);
+
+  useEffect(() => {
+    if (!isAuthReady) return;
+    if (user === null) {
+      router.replace("/(tabs)/home" as never);
+    }
+  }, [isAuthReady, router, user]);
+
+  const handleClose = useCallback((): void => {
+    router.back();
+  }, [router]);
+
+  const handleGateContinue = useCallback(async (): Promise<void> => {
+    const n = workingName.trim();
+    if (n.length < 2) {
+      setPoolNote("Enter at least 2 characters.");
+      return;
+    }
+    setPoolNote(null);
+    setCheckingPool(true);
+    try {
+      const hit = await placePoolHasNameMatch(n);
+      if (hit) {
+        setPoolNote(
+          "This name matches a place already in our directory. Venue matching isn’t available yet — try another name or create an event brand instead.",
+        );
+        return;
+      }
+      patch({
+        displayName: n,
+        slug: slugifyBrandSlug(n),
+      });
+      setPhase("category");
+    } catch {
+      setPoolNote("Could not verify the name. Check your connection and try again.");
+    } finally {
+      setCheckingPool(false);
+    }
+  }, [patch, workingName]);
+
+  const handleCategoryContinue = useCallback((): void => {
+    if (venueCategory === null) return;
+    setPhase("wizard");
+  }, [venueCategory]);
+
+  if (!isAuthReady || user === null) {
+    return <View style={[styles.root, { paddingTop: insets.top }]} />;
+  }
+
+  if (phase === "wizard") {
+    return (
+      <VenueCreatorWizard
+        onClose={handleClose}
+        onDone={() => setPhase("success")}
+      />
+    );
+  }
+
+  if (phase === "success") {
+    return (
+      <View style={[styles.root, { paddingTop: insets.top, paddingHorizontal: spacing.lg }]}>
+        <View style={styles.successInner}>
+          <Text style={styles.successTitle}>Thanks — you’re in the queue</Text>
+          <Text style={styles.successBody}>
+            Pending review. We usually approve venues within 4 business hours.
+          </Text>
+          <Button
+            label="Done"
+            variant="primary"
+            size="lg"
+            onPress={() => router.replace("/(tabs)/home" as never)}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.root, { paddingTop: insets.top }]}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={styles.chrome}>
+        <IconChrome
+          icon="chevL"
+          accessibilityLabel="Back"
+          onPress={handleClose}
+        />
+        <Text style={styles.chromeTitle}>Add a venue</Text>
+        <View style={{ width: 36 }} />
+      </View>
+
+      {phase === "gate" ? (
+        <View style={styles.section}>
+          <Text style={styles.h1}>What’s your venue called?</Text>
+          <Text style={styles.sub}>
+            We’ll check our directory so we don’t duplicate listings.
+          </Text>
+          <Input
+            variant="text"
+            value={workingName}
+            onChangeText={(t) => patch({ workingName: t })}
+            placeholder="Venue name"
+            accessibilityLabel="Venue working name"
+          />
+          {poolNote !== null ? <Text style={styles.warn}>{poolNote}</Text> : null}
+          <Button
+            label={checkingPool ? "Checking…" : "Continue"}
+            variant="primary"
+            size="lg"
+            loading={checkingPool}
+            disabled={checkingPool}
+            onPress={() => void handleGateContinue()}
+          />
+        </View>
+      ) : (
+        <View style={styles.section}>
+          <Pressable
+            onPress={() => setPhase("gate")}
+            style={styles.backRow}
+            accessibilityRole="button"
+            accessibilityLabel="Back to venue name"
+          >
+            <Icon name="chevL" size={18} color={textTokens.tertiary} />
+            <Text style={styles.backText}>Back</Text>
+          </Pressable>
+          <Text style={styles.h1}>What kind of place is it?</Text>
+          <VenueCategoryPicker
+            value={venueCategory}
+            onChange={(v: VenueCategory) => patch({ venueCategory: v })}
+            testID="venue-category-picker"
+          />
+          <Button
+            label="Continue"
+            variant="primary"
+            size="lg"
+            disabled={venueCategory === null}
+            onPress={handleCategoryContinue}
+          />
+        </View>
+      )}
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: canvas.discover,
+  },
+  chrome: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  chromeTitle: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  section: {
+    flex: 1,
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  h1: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  sub: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  warn: {
+    fontSize: typography.caption.fontSize,
+    color: "#F59E0B",
+  },
+  backRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  backText: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  successInner: {
+    flex: 1,
+    justifyContent: "center",
+    gap: spacing.lg,
+    paddingBottom: spacing.xl,
+  },
+  successTitle: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  successBody: {
+    fontSize: typography.body.fontSize,
+    color: textTokens.secondary,
+    lineHeight: 22,
+  },
+});

--- a/mingla-business/app/venue/create.tsx
+++ b/mingla-business/app/venue/create.tsx
@@ -46,6 +46,7 @@ export default function VenueCreateRoute(): React.ReactElement {
   const [phase, setPhase] = useState<Phase>("gate");
   const [checkingPool, setCheckingPool] = useState(false);
   const [poolNote, setPoolNote] = useState<string | null>(null);
+  const [coverWarning, setCoverWarning] = useState<string | null>(null);
 
   useEffect(() => {
     reset();
@@ -105,7 +106,10 @@ export default function VenueCreateRoute(): React.ReactElement {
     return (
       <VenueCreatorWizard
         onClose={handleClose}
-        onDone={() => setPhase("success")}
+        onDone={(warning) => {
+          setCoverWarning(warning ?? null);
+          setPhase("success");
+        }}
       />
     );
   }
@@ -118,6 +122,9 @@ export default function VenueCreateRoute(): React.ReactElement {
           <Text style={styles.successBody}>
             Pending review. We usually approve venues within 4 business hours.
           </Text>
+          {coverWarning !== null ? (
+            <Text style={styles.successWarning}>{coverWarning}</Text>
+          ) : null}
           <Button
             label="Done"
             variant="primary"
@@ -258,5 +265,11 @@ const styles = StyleSheet.create({
     fontSize: typography.body.fontSize,
     color: textTokens.secondary,
     lineHeight: 22,
+  },
+  successWarning: {
+    fontSize: typography.body.fontSize,
+    color: textTokens.secondary,
+    lineHeight: 22,
+    marginTop: spacing.sm,
   },
 });

--- a/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
+++ b/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
@@ -28,6 +28,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useRouter } from "expo-router";
 import {
   accent,
   glass,
@@ -50,6 +51,7 @@ import { Input } from "../ui/Input";
 import { TopSheet } from "../ui/TopSheet";
 import { PersonaPickerCards, type PersonaDef } from "./PersonaPickerCards";
 import { TripBrandWizard } from "./TripBrandWizard";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
 
 export interface BrandSwitcherSheetProps {
   visible: boolean;
@@ -92,6 +94,8 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
   const { user } = useAuth();
   const createBrandMutation = useCreateBrand();
   const updateCreatorAccountMutation = useUpdateCreatorAccount();
+  const resetVenueDraft = useDraftVenueStore((s) => s.reset);
+  const router = useRouter();
 
   const initialMode: Mode = brandList.isTrueEmpty ? "persona" : "switch";
   const [mode, setMode] = useState<Mode>(initialMode);
@@ -198,19 +202,18 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
     setSubmitting(false);
   };
 
-  // ORCH-0855 (Tr1) — persona configuration. PersonaDef.id union locked
-  // per I-PROPOSED-TR1-PERSONA-INTERFACE (DRAFT → ACTIVE on CLOSE).
-  // "place" card disabled until Ve1 ships; "event" preserves today's flow
-  // verbatim via "popup-create" mode; "trip" opens TripBrandWizard.
+  // Ve1 — "A place" opens full-screen venue onboarding (place_pool gate + wizard).
   const personas: PersonaDef[] = [
     {
       id: "place",
       title: "A place",
       description: "I run a venue (restaurant, bar, gallery, studio)",
       icon: "location",
-      disabled: true,
+      disabled: false,
       onSelect: () => {
-        // Ve1 will wire this to open the venue claim flow.
+        resetVenueDraft();
+        onClose();
+        router.push("/venue/create" as never);
       },
       testID: "persona-place",
     },

--- a/mingla-business/src/components/brand/PersonaForkSheet.tsx
+++ b/mingla-business/src/components/brand/PersonaForkSheet.tsx
@@ -1,0 +1,21 @@
+/**
+ * Ve1 — persona fork reuses the same card primitive as BrandSwitcherSheet.
+ */
+
+import React from "react";
+
+import {
+  PersonaPickerCards,
+  type PersonaDef,
+  type PersonaPickerCardsProps,
+} from "./PersonaPickerCards";
+
+export type { PersonaDef };
+
+export type PersonaForkSheetProps = PersonaPickerCardsProps;
+
+export const PersonaForkSheet: React.FC<PersonaForkSheetProps> = (props) => (
+  <PersonaPickerCards {...props} />
+);
+
+export default PersonaForkSheet;

--- a/mingla-business/src/components/brand/VenueCategoryPicker.tsx
+++ b/mingla-business/src/components/brand/VenueCategoryPicker.tsx
@@ -1,0 +1,102 @@
+/**
+ * Ve1 — category pills (Restaurant / Play / Creative and arts).
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { VenueCategory } from "../../types/brand";
+import { GlassCard } from "../ui/GlassCard";
+
+const OPTIONS: {
+  id: VenueCategory;
+  label: string;
+  description: string;
+}[] = [
+  { id: "restaurant", label: "Restaurant", description: "Food & drink venues" },
+  { id: "play", label: "Play", description: "Activities & family fun" },
+  {
+    id: "creative_and_arts",
+    label: "Creative & arts",
+    description: "Studios, galleries, performance",
+  },
+];
+
+export interface VenueCategoryPickerProps {
+  value: VenueCategory | null;
+  onChange: (next: VenueCategory) => void;
+  testID?: string;
+}
+
+export const VenueCategoryPicker: React.FC<VenueCategoryPickerProps> = ({
+  value,
+  onChange,
+  testID,
+}) => {
+  return (
+    <View style={styles.host} testID={testID}>
+      {OPTIONS.map((opt) => {
+        const selected = value === opt.id;
+        return (
+          <Pressable
+            key={opt.id}
+            onPress={() => onChange(opt.id)}
+            accessibilityRole="button"
+            accessibilityLabel={`${opt.label}. ${opt.description}`}
+            accessibilityState={{ selected }}
+            style={({ pressed }) => [
+              styles.cardOuter,
+              pressed && styles.pressed,
+            ]}
+          >
+            <GlassCard
+              variant={selected ? "elevated" : "base"}
+              padding={spacing.md}
+            >
+              <Text style={[styles.title, selected && styles.titleOn]}>
+                {opt.label}
+              </Text>
+              <Text style={styles.desc}>{opt.description}</Text>
+            </GlassCard>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  cardOuter: {
+    borderRadius: radiusTokens.lg,
+  },
+  pressed: {
+    opacity: 0.88,
+  },
+  title: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "600",
+    color: textTokens.primary,
+  },
+  titleOn: {
+    color: accent.warm,
+  },
+  desc: {
+    marginTop: 4,
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight,
+    color: textTokens.secondary,
+  },
+});
+
+export default VenueCategoryPicker;

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
@@ -61,8 +61,7 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
     expect(tripBlockMatch![1]).toBe("compass");
   });
 
-  // SC-04 locked pre-Ve1; skipped after Ve1 enabled the place card (see Ve1 tests below).
-  test.skip("'A place' persona is disabled (Ve1 hasn't shipped — SC-04)", () => {
+  test("'A place' persona is disabled (Ve1 hasn't shipped — SC-04)", () => {
     const placeBlockMatch = sheetSource.match(
       /id: "place"[\s\S]*?disabled: (true|false)/,
     );
@@ -101,23 +100,5 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
   test("TripBrandWizard and PersonaPickerCards are imported", () => {
     expect(sheetSource).toMatch(/import.*PersonaPickerCards.*PersonaDef/);
     expect(sheetSource).toMatch(/import.*TripBrandWizard/);
-  });
-
-  // Ve1 (ORCH-0099): place persona enabled — additive contract; SC-04 above is historical.
-  test("Ve1 — 'A place' persona enabled and routes to /venue/create", () => {
-    const placeBlockMatch = sheetSource.match(
-      /id: "place"[\s\S]*?disabled: (true|false)/,
-    );
-    expect(placeBlockMatch).not.toBeNull();
-    expect(placeBlockMatch![1]).toBe("false");
-    expect(sheetSource).toMatch(
-      /id: "place"[\s\S]*?router\.push\("\/venue\/create"/,
-    );
-  });
-
-  test("Ve1 — imports expo-router useRouter for venue onboarding", () => {
-    expect(sheetSource).toMatch(
-      /import\s*\{[^}]*useRouter[^}]*\}\s*from\s*["']expo-router["']/,
-    );
   });
 });

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
@@ -61,7 +61,8 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
     expect(tripBlockMatch![1]).toBe("compass");
   });
 
-  test("'A place' persona is disabled (Ve1 hasn't shipped — SC-04)", () => {
+  // ORCH-0099 (Ve1): superseded by BrandSwitcherSheet.personaFork.ve1.test.ts.
+  test.skip("'A place' persona is disabled (Ve1 hasn't shipped — SC-04)", () => {
     const placeBlockMatch = sheetSource.match(
       /id: "place"[\s\S]*?disabled: (true|false)/,
     );

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
@@ -61,12 +61,10 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
     expect(tripBlockMatch![1]).toBe("compass");
   });
 
-  test("'A place' persona is disabled (Ve1 hasn't shipped — SC-04)", () => {
-    const placeBlockMatch = sheetSource.match(
-      /id: "place"[\s\S]*?disabled: (true|false)/,
+  test("'A place' routes to /venue/create (Ve1)", () => {
+    expect(sheetSource).toMatch(
+      /id: "place"[\s\S]*?router\.push\("\/venue\/create"/,
     );
-    expect(placeBlockMatch).not.toBeNull();
-    expect(placeBlockMatch![1]).toBe("true");
   });
 
   test("'A trip' onSelect routes to mode='trip-create'", () => {
@@ -97,8 +95,7 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
     expect(sheetSource).not.toMatch(/kind: "trip_planner"/);
   });
 
-  test("TripBrandWizard and PersonaPickerCards are imported", () => {
-    expect(sheetSource).toMatch(/import.*PersonaPickerCards.*PersonaDef/);
-    expect(sheetSource).toMatch(/import.*TripBrandWizard/);
+  test("imports expo-router useRouter for Ve1 venue flow", () => {
+    expect(sheetSource).toMatch(/import\s*\{[^}]*useRouter[^}]*\}\s*from\s*["']expo-router["']/);
   });
 });

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.test.ts
@@ -61,10 +61,13 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
     expect(tripBlockMatch![1]).toBe("compass");
   });
 
-  test("'A place' routes to /venue/create (Ve1)", () => {
-    expect(sheetSource).toMatch(
-      /id: "place"[\s\S]*?router\.push\("\/venue\/create"/,
+  // SC-04 locked pre-Ve1; skipped after Ve1 enabled the place card (see Ve1 tests below).
+  test.skip("'A place' persona is disabled (Ve1 hasn't shipped — SC-04)", () => {
+    const placeBlockMatch = sheetSource.match(
+      /id: "place"[\s\S]*?disabled: (true|false)/,
     );
+    expect(placeBlockMatch).not.toBeNull();
+    expect(placeBlockMatch![1]).toBe("true");
   });
 
   test("'A trip' onSelect routes to mode='trip-create'", () => {
@@ -95,7 +98,26 @@ describe("ORCH-0855 — BrandSwitcherSheet persona-fork structural contract", ()
     expect(sheetSource).not.toMatch(/kind: "trip_planner"/);
   });
 
-  test("imports expo-router useRouter for Ve1 venue flow", () => {
-    expect(sheetSource).toMatch(/import\s*\{[^}]*useRouter[^}]*\}\s*from\s*["']expo-router["']/);
+  test("TripBrandWizard and PersonaPickerCards are imported", () => {
+    expect(sheetSource).toMatch(/import.*PersonaPickerCards.*PersonaDef/);
+    expect(sheetSource).toMatch(/import.*TripBrandWizard/);
+  });
+
+  // Ve1 (ORCH-0099): place persona enabled — additive contract; SC-04 above is historical.
+  test("Ve1 — 'A place' persona enabled and routes to /venue/create", () => {
+    const placeBlockMatch = sheetSource.match(
+      /id: "place"[\s\S]*?disabled: (true|false)/,
+    );
+    expect(placeBlockMatch).not.toBeNull();
+    expect(placeBlockMatch![1]).toBe("false");
+    expect(sheetSource).toMatch(
+      /id: "place"[\s\S]*?router\.push\("\/venue\/create"/,
+    );
+  });
+
+  test("Ve1 — imports expo-router useRouter for venue onboarding", () => {
+    expect(sheetSource).toMatch(
+      /import\s*\{[^}]*useRouter[^}]*\}\s*from\s*["']expo-router["']/,
+    );
   });
 });

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve1.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve1.test.ts
@@ -1,0 +1,34 @@
+/**
+ * ORCH-0099 [Ve1 Physical Venue Brand Onboarding] — place persona enabled.
+ *
+ * Additive contract alongside ORCH-0855 personaFork.test.ts (SC-04 skipped there
+ * with [TEST-MOD-APPROVED ORCH-0099] once Ve1 ships).
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const sheetSource = readFileSync(
+  join(__dirname, "..", "BrandSwitcherSheet.tsx"),
+  "utf-8",
+);
+
+describe("ORCH-0099 — BrandSwitcherSheet place persona (Ve1)", () => {
+  test("'A place' persona enabled and routes to /venue/create", () => {
+    const placeBlockMatch = sheetSource.match(
+      /id: "place"[\s\S]*?disabled: (true|false)/,
+    );
+    expect(placeBlockMatch).not.toBeNull();
+    expect(placeBlockMatch![1]).toBe("false");
+    expect(sheetSource).toMatch(
+      /id: "place"[\s\S]*?router\.push\("\/venue\/create"/,
+    );
+  });
+
+  test("imports expo-router useRouter for venue onboarding", () => {
+    expect(sheetSource).toMatch(
+      /import\s*\{[^}]*useRouter[^}]*\}\s*from\s*["']expo-router["']/,
+    );
+  });
+});

--- a/mingla-business/src/components/ui/GooglePlacesAutocomplete.tsx
+++ b/mingla-business/src/components/ui/GooglePlacesAutocomplete.tsx
@@ -1,0 +1,11 @@
+/**
+ * Ve1 — Google Places field; server key stays in `places-autocomplete` edge function.
+ */
+
+export {
+  AddressAutocompleteInput as GooglePlacesAutocomplete,
+} from "../event/AddressAutocompleteInput";
+export type {
+  PlaceAutocompleteSuggestion,
+  PlaceDetails,
+} from "../../services/googlePlacesService";

--- a/mingla-business/src/components/venue/VenueCreatorWizard.tsx
+++ b/mingla-business/src/components/venue/VenueCreatorWizard.tsx
@@ -52,7 +52,8 @@ const STEPPER_STEPS: StepperStep[] = [
 ];
 
 export interface VenueCreatorWizardProps {
-  onDone: () => void;
+  /** Optional warning when venue was created but cover upload failed. */
+  onDone: (coverWarning?: string | null) => void;
   onClose: () => void;
 }
 
@@ -141,24 +142,30 @@ export const VenueCreatorWizard: React.FC<VenueCreatorWizardProps> = ({
         hours: st.hours,
       });
 
+      let coverWarning: string | null = null;
       const firstUri = st.photoUris[0];
       if (firstUri !== undefined) {
-        const up = await uploadBrandCover(
-          brand.id,
-          { uri: firstUri },
-          {},
-        );
-        await updateBrandMutation.mutateAsync({
-          brandId: brand.id,
-          accountId: user.id,
-          existingDescription: existingDesc,
-          patch: {
-            coverMediaUrl: up.publicUrl,
-            coverMediaType: up.mediaType === "gif" ? "gif" : "image",
-          },
-        });
+        try {
+          const up = await uploadBrandCover(
+            brand.id,
+            { uri: firstUri },
+            {},
+          );
+          await updateBrandMutation.mutateAsync({
+            brandId: brand.id,
+            accountId: user.id,
+            existingDescription: existingDesc,
+            patch: {
+              coverMediaUrl: up.publicUrl,
+              coverMediaType: up.mediaType === "gif" ? "gif" : "image",
+            },
+          });
+        } catch {
+          coverWarning =
+            "Your venue was submitted, but we couldn't save the cover photo. You can add one after approval.";
+        }
       }
-      onDone();
+      onDone(coverWarning);
     } catch (e) {
       if (e instanceof SlugCollisionError) {
         setSlugCollision(

--- a/mingla-business/src/components/venue/VenueCreatorWizard.tsx
+++ b/mingla-business/src/components/venue/VenueCreatorWizard.tsx
@@ -1,0 +1,313 @@
+/**
+ * Ve1 — 7-step venue onboarding wizard (after category selection).
+ */
+
+import React, { useCallback, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  canvas,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useAuth } from "../../context/AuthContext";
+import {
+  useCreateVenueBrand,
+  useUpdateBrand,
+  SlugCollisionError,
+} from "../../hooks/useBrands";
+import { joinBrandDescription } from "../../services/brandMapping";
+import { uploadBrandCover } from "../../services/brandCoverService";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { venueStepError } from "./venueWizardValidation";
+import { Button } from "../ui/Button";
+import { IconChrome } from "../ui/IconChrome";
+import { Stepper, type StepperStep } from "../ui/Stepper";
+import { VenueStep1Address } from "./VenueStep1Address";
+import { VenueStep2NameSlug } from "./VenueStep2NameSlug";
+import { VenueStep3Photos } from "./VenueStep3Photos";
+import { VenueStep4Hours } from "./VenueStep4Hours";
+import { VenueStep5Contact } from "./VenueStep5Contact";
+import { VenueStep6Description } from "./VenueStep6Description";
+import { VenueStep7Review } from "./VenueStep7Review";
+
+const TOTAL = 7;
+const STEPPER_STEPS: StepperStep[] = [
+  { id: "s0", label: "Address" },
+  { id: "s1", label: "Name" },
+  { id: "s2", label: "Photos" },
+  { id: "s3", label: "Hours" },
+  { id: "s4", label: "Contact" },
+  { id: "s5", label: "Story" },
+  { id: "s6", label: "Review" },
+];
+
+export interface VenueCreatorWizardProps {
+  onDone: () => void;
+  onClose: () => void;
+}
+
+export const VenueCreatorWizard: React.FC<VenueCreatorWizardProps> = ({
+  onDone,
+  onClose,
+}) => {
+  const insets = useSafeAreaInsets();
+  const { user } = useAuth();
+  const createVenue = useCreateVenueBrand();
+  const updateBrandMutation = useUpdateBrand();
+
+  const [step, setStep] = useState(0);
+  const [showErr, setShowErr] = useState(false);
+  const [slugCollision, setSlugCollision] = useState<string | null>(null);
+  const [submitErr, setSubmitErr] = useState<string | null>(null);
+
+  const draft = useDraftVenueStore();
+
+  const goNext = useCallback((): void => {
+    const e = venueStepError(step, draft);
+    if (e !== null) {
+      setShowErr(true);
+      return;
+    }
+    setShowErr(false);
+    setSlugCollision(null);
+    setStep((s) => Math.min(TOTAL - 1, s + 1));
+  }, [draft, step]);
+
+  const goBack = useCallback((): void => {
+    setShowErr(false);
+    setSlugCollision(null);
+    setStep((s) => Math.max(0, s - 1));
+  }, []);
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    if (user?.id === undefined) return;
+    setSubmitErr(null);
+    const st = useDraftVenueStore.getState();
+    const last = venueStepError(TOTAL - 1, st);
+    if (last !== null) {
+      setShowErr(true);
+      return;
+    }
+    if (
+      st.googlePlaceId === null ||
+      st.lat === null ||
+      st.lng === null ||
+      st.venueCategory === null
+    ) {
+      setSubmitErr("Some required fields are missing. Go back and check.");
+      return;
+    }
+    try {
+      for (let i = 0; i < TOTAL - 1; i++) {
+        const e = venueStepError(i, st);
+        if (e !== null) {
+          setSubmitErr(e);
+          setStep(i);
+          setShowErr(true);
+          return;
+        }
+      }
+      setShowErr(false);
+      const existingDesc = joinBrandDescription(st.tagline, st.description);
+      const brand = await createVenue.mutateAsync({
+        accountId: user.id,
+        name: st.displayName.trim(),
+        slug: st.slug.trim(),
+        tagline: st.tagline.trim() || undefined,
+        bio: st.description.trim(),
+        googlePlaceId: st.googlePlaceId,
+        lat: st.lat,
+        lng: st.lng,
+        city: st.city,
+        countryCode: st.countryCode,
+        address: st.formattedAddress.trim(),
+        venueCategory: st.venueCategory,
+        contact: {
+          email: st.contactEmail.trim() || undefined,
+          phone: st.contactPhone.trim() || undefined,
+        },
+        coverMediaUrl: null,
+        coverMediaType: null,
+        hours: st.hours,
+      });
+
+      const firstUri = st.photoUris[0];
+      if (firstUri !== undefined) {
+        const up = await uploadBrandCover(
+          brand.id,
+          { uri: firstUri },
+          {},
+        );
+        await updateBrandMutation.mutateAsync({
+          brandId: brand.id,
+          accountId: user.id,
+          existingDescription: existingDesc,
+          patch: {
+            coverMediaUrl: up.publicUrl,
+            coverMediaType: up.mediaType === "gif" ? "gif" : "image",
+          },
+        });
+      }
+      onDone();
+    } catch (e) {
+      if (e instanceof SlugCollisionError) {
+        setSlugCollision(
+          "This URL slug is taken. Go back to Name and adjust it.",
+        );
+        setStep(1);
+        return;
+      }
+      if (e instanceof Error && e.message.includes("Google location")) {
+        setSubmitErr(e.message);
+        return;
+      }
+      setSubmitErr(
+        e instanceof Error ? e.message : "Could not submit. Try again.",
+      );
+    }
+  }, [createVenue, onDone, updateBrandMutation, user?.id]);
+
+  const body = ((): React.ReactElement => {
+    switch (step) {
+      case 0:
+        return <VenueStep1Address showErrors={showErr} />;
+      case 1:
+        return (
+          <VenueStep2NameSlug
+            showErrors={showErr}
+            slugError={slugCollision}
+          />
+        );
+      case 2:
+        return <VenueStep3Photos showErrors={showErr} />;
+      case 3:
+        return <VenueStep4Hours showErrors={showErr} />;
+      case 4:
+        return <VenueStep5Contact showErrors={showErr} />;
+      case 5:
+        return <VenueStep6Description showErrors={showErr} />;
+      case 6:
+        return (
+          <VenueStep7Review
+            submitting={createVenue.isPending}
+            submitError={submitErr}
+            onSubmit={() => void handleSubmit()}
+          />
+        );
+      default:
+        return <View />;
+    }
+  })();
+
+  return (
+    <KeyboardAvoidingView
+      style={[styles.root, { paddingTop: insets.top }]}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={styles.chrome}>
+        <IconChrome
+          icon="x"
+          accessibilityLabel="Close venue setup"
+          onPress={onClose}
+        />
+        <View style={styles.chromeMid}>
+          <Text style={styles.chromeTitle}>List your venue</Text>
+          <Text style={styles.chromeSub}>
+            Step {step + 1} of {TOTAL}
+          </Text>
+        </View>
+        <View style={{ width: 36 }} />
+      </View>
+
+      <Stepper steps={STEPPER_STEPS} currentIndex={step} />
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={{
+          paddingBottom: insets.bottom + spacing.xl,
+        }}
+        keyboardShouldPersistTaps="handled"
+      >
+        {body}
+      </ScrollView>
+
+      {step < TOTAL - 1 ? (
+        <View
+          style={[
+            styles.dock,
+            { paddingBottom: insets.bottom + spacing.md },
+          ]}
+        >
+          <View style={styles.dockRow}>
+            {step > 0 ? (
+              <Button
+                label="Back"
+                variant="ghost"
+                size="lg"
+                onPress={goBack}
+              />
+            ) : (
+              <View style={{ width: 88 }} />
+            )}
+            <Button label="Continue" variant="primary" size="lg" onPress={goNext} />
+          </View>
+        </View>
+      ) : null}
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: canvas.discover,
+  },
+  chrome: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  chromeMid: {
+    flex: 1,
+    alignItems: "center",
+  },
+  chromeTitle: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  chromeSub: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+    marginTop: 2,
+  },
+  scroll: {
+    flex: 1,
+  },
+  dock: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(255,255,255,0.12)",
+  },
+  dockRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.md,
+  },
+});
+
+export default VenueCreatorWizard;

--- a/mingla-business/src/components/venue/VenueStep1Address.tsx
+++ b/mingla-business/src/components/venue/VenueStep1Address.tsx
@@ -1,0 +1,89 @@
+/**
+ * Ve1 wizard — Step 1: Address (Google Places proxy).
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { parseGooglePlaceResult } from "../../utils/parseGooglePlaceResult";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { AddressAutocompleteInput } from "../event/AddressAutocompleteInput";
+import type { PlaceDetails } from "../../services/googlePlacesService";
+
+export interface VenueStep1AddressProps {
+  showErrors: boolean;
+}
+
+export const VenueStep1Address: React.FC<VenueStep1AddressProps> = ({
+  showErrors,
+}) => {
+  const formattedAddress = useDraftVenueStore((s) => s.formattedAddress);
+  const googlePlaceId = useDraftVenueStore((s) => s.googlePlaceId);
+  const patch = useDraftVenueStore((s) => s.patch);
+
+  const error =
+    showErrors &&
+    (googlePlaceId === null || googlePlaceId.trim() === "")
+      ? "Pick your venue address from the suggestions."
+      : undefined;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Where is your venue?</Text>
+      <Text style={styles.helper}>
+        Start typing — choose a result so we can verify the location.
+      </Text>
+      <AddressAutocompleteInput
+        value={formattedAddress}
+        onChangeText={(t) => patch({ formattedAddress: t })}
+        onPick={(details: PlaceDetails): void => {
+          const p = parseGooglePlaceResult(details);
+          patch({
+            formattedAddress: p.formattedAddress,
+            googlePlaceId: p.googlePlaceId,
+            lat: p.lat,
+            lng: p.lng,
+            city: p.city,
+            countryCode: p.countryCode,
+          });
+        }}
+        onClear={(): void => {
+          patch({
+            formattedAddress: "",
+            googlePlaceId: null,
+            lat: null,
+            lng: null,
+            city: null,
+            countryCode: null,
+          });
+        }}
+        error={error}
+        placeholder="Search address"
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  helper: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+    marginBottom: spacing.xs,
+  },
+});
+
+export default VenueStep1Address;

--- a/mingla-business/src/components/venue/VenueStep2NameSlug.tsx
+++ b/mingla-business/src/components/venue/VenueStep2NameSlug.tsx
@@ -1,0 +1,90 @@
+/**
+ * Ve1 wizard — Step 2: Display name + slug.
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { Input } from "../ui/Input";
+import { slugifyBrandSlug } from "../../utils/brandSlugify";
+
+export interface VenueStep2NameSlugProps {
+  showErrors: boolean;
+  slugError: string | null;
+}
+
+export const VenueStep2NameSlug: React.FC<VenueStep2NameSlugProps> = ({
+  showErrors,
+  slugError,
+}) => {
+  const displayName = useDraftVenueStore((s) => s.displayName);
+  const slug = useDraftVenueStore((s) => s.slug);
+  const patch = useDraftVenueStore((s) => s.patch);
+
+  const nameErr =
+    showErrors && displayName.trim().length === 0
+      ? "Venue name is required."
+      : undefined;
+  const slugFieldErr =
+    slugError ??
+    (showErrors && slug.trim().length === 0 ? "Slug is required." : undefined);
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Venue name & web address</Text>
+      <Text style={styles.helper}>
+        Your public page will use the slug in the URL.
+      </Text>
+      <Input
+        variant="text"
+        value={displayName}
+        onChangeText={(t) => {
+          patch({ displayName: t });
+        }}
+        placeholder="Venue name"
+        accessibilityLabel="Venue display name"
+      />
+      {nameErr !== undefined ? (
+        <Text style={styles.err}>{nameErr}</Text>
+      ) : null}
+      <Input
+        variant="text"
+        value={slug}
+        onChangeText={(t) => patch({ slug: slugifyBrandSlug(t) })}
+        placeholder="your-venue-slug"
+        accessibilityLabel="Venue URL slug"
+      />
+      {slugFieldErr !== undefined ? (
+        <Text style={styles.err}>{slugFieldErr}</Text>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  helper: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  err: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
+  },
+});
+
+export default VenueStep2NameSlug;

--- a/mingla-business/src/components/venue/VenueStep3Photos.tsx
+++ b/mingla-business/src/components/venue/VenueStep3Photos.tsx
@@ -1,0 +1,147 @@
+/**
+ * Ve1 wizard — Step 3: Photos (local URIs; first image becomes cover after create).
+ */
+
+import React, { useCallback, useState } from "react";
+import {
+  Image,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import * as ImagePicker from "expo-image-picker";
+
+import {
+  accent,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { Button } from "../ui/Button";
+import { Icon } from "../ui/Icon";
+
+export interface VenueStep3PhotosProps {
+  showErrors: boolean;
+}
+
+export const VenueStep3Photos: React.FC<VenueStep3PhotosProps> = ({
+  showErrors,
+}) => {
+  const photoUris = useDraftVenueStore((s) => s.photoUris);
+  const patch = useDraftVenueStore((s) => s.patch);
+  const [busy, setBusy] = useState(false);
+
+  const pickPhotos = useCallback(async (): Promise<void> => {
+    if (busy) return;
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) return;
+    setBusy(true);
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        allowsMultipleSelection: Platform.OS !== "web",
+        selectionLimit: 8,
+        quality: 0.9,
+      });
+      if (result.canceled || result.assets.length === 0) return;
+      const next = result.assets.map((a) => a.uri);
+      patch({ photoUris: [...photoUris, ...next] });
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, photoUris, patch]);
+
+  const err =
+    showErrors && photoUris.length < 1
+      ? "Add at least one photo."
+      : undefined;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Photos</Text>
+      <Text style={styles.helper}>
+        Add at least one image. The first photo becomes your profile cover.
+      </Text>
+      <Button
+        label={busy ? "Opening…" : "Add photos"}
+        onPress={() => void pickPhotos()}
+        variant="secondary"
+        size="md"
+        leadingIcon="upload"
+        disabled={busy}
+      />
+      {err !== undefined ? <Text style={styles.err}>{err}</Text> : null}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={styles.row}>
+          {photoUris.map((uri) => (
+            <View key={uri} style={styles.thumbWrap}>
+              <Image source={{ uri }} style={styles.thumb} />
+              <Pressable
+                style={styles.remove}
+                onPress={() =>
+                  patch({ photoUris: photoUris.filter((u) => u !== uri) })
+                }
+                accessibilityLabel="Remove photo"
+                hitSlop={8}
+              >
+                <Icon name="x" size={16} color="#FFF" />
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  helper: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  err: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
+  },
+  row: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    paddingVertical: spacing.sm,
+  },
+  thumbWrap: {
+    position: "relative",
+  },
+  thumb: {
+    width: 96,
+    height: 96,
+    borderRadius: radiusTokens.md,
+    backgroundColor: accent.tint,
+  },
+  remove: {
+    position: "absolute",
+    top: 4,
+    right: 4,
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: "rgba(0,0,0,0.55)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+
+export default VenueStep3Photos;

--- a/mingla-business/src/components/venue/VenueStep4Hours.tsx
+++ b/mingla-business/src/components/venue/VenueStep4Hours.tsx
@@ -155,6 +155,8 @@ export const VenueStep4Hours: React.FC<VenueStep4HoursProps> = ({
               <Pressable
                 style={styles.timeBtn}
                 onPress={() => openPicker(row.weekday, "open", row)}
+                accessibilityRole="button"
+                accessibilityLabel={`Pick ${DAY_NAMES[row.weekday]} opening time`}
               >
                 <Text style={styles.timeLbl}>Opens</Text>
                 <Text style={styles.timeVal}>{row.openTime ?? "—"}</Text>
@@ -162,6 +164,8 @@ export const VenueStep4Hours: React.FC<VenueStep4HoursProps> = ({
               <Pressable
                 style={styles.timeBtn}
                 onPress={() => openPicker(row.weekday, "close", row)}
+                accessibilityRole="button"
+                accessibilityLabel={`Pick ${DAY_NAMES[row.weekday]} closing time`}
               >
                 <Text style={styles.timeLbl}>Closes</Text>
                 <Text style={styles.timeVal}>{row.closeTime ?? "—"}</Text>

--- a/mingla-business/src/components/venue/VenueStep4Hours.tsx
+++ b/mingla-business/src/components/venue/VenueStep4Hours.tsx
@@ -1,0 +1,285 @@
+/**
+ * Ve1 wizard — Step 4: Weekly hours (Mon–Sun).
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
+import DateTimePicker, {
+  type DateTimePickerEvent,
+} from "@react-native-community/datetimepicker";
+
+import {
+  accent,
+  glass,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { BrandHourEntry } from "../../types/brand";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { Button } from "../ui/Button";
+
+const DAY_NAMES = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+function hmToDate(hm: string | null, fallbackHour: number): Date {
+  const d = new Date(2020, 0, 1);
+  if (hm === null || hm.length < 4) {
+    d.setHours(fallbackHour, 0, 0, 0);
+    return d;
+  }
+  const parts = hm.split(":");
+  const h = Number(parts[0]);
+  const m = Number(parts[1]);
+  if (!Number.isFinite(h) || !Number.isFinite(m)) {
+    d.setHours(fallbackHour, 0, 0, 0);
+    return d;
+  }
+  d.setHours(h, m, 0, 0);
+  return d;
+}
+
+function dateToHm(d: Date): string {
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+export interface VenueStep4HoursProps {
+  showErrors: boolean;
+}
+
+export const VenueStep4Hours: React.FC<VenueStep4HoursProps> = ({
+  showErrors,
+}) => {
+  const hours = useDraftVenueStore((s) => s.hours);
+  const setHoursRow = useDraftVenueStore((s) => s.setHoursRow);
+  const [picker, setPicker] = useState<{
+    weekday: number;
+    field: "open" | "close";
+    temp: Date;
+  } | null>(null);
+
+  const stepErr = useMemo((): string | null => {
+    if (!showErrors) return null;
+    for (const h of hours) {
+      if (h.isClosed) continue;
+      const o = h.openTime ?? "";
+      const c = h.closeTime ?? "";
+      if (o.length === 0 || c.length === 0) {
+        return "Open and close times are required for open days.";
+      }
+      if (o >= c) return "Close time must be after open time.";
+    }
+    return null;
+  }, [hours, showErrors]);
+
+  const openPicker = useCallback(
+    (weekday: number, field: "open" | "close", row: BrandHourEntry): void => {
+      const hm = field === "open" ? row.openTime : row.closeTime;
+      const fb = field === "open" ? 9 : 17;
+      setPicker({
+        weekday,
+        field,
+        temp: hmToDate(hm, fb),
+      });
+    },
+    [],
+  );
+
+  const onPickerChange = useCallback(
+    (_e: DateTimePickerEvent, selected?: Date): void => {
+      if (Platform.OS === "android") {
+        if (selected === undefined) {
+          setPicker(null);
+          return;
+        }
+        if (picker !== null) {
+          const key = picker.field === "open" ? "openTime" : "closeTime";
+          setHoursRow(picker.weekday, { [key]: dateToHm(selected) });
+        }
+        setPicker(null);
+        return;
+      }
+      if (selected !== undefined && picker !== null) {
+        setPicker({ ...picker, temp: selected });
+      }
+    },
+    [picker, setHoursRow],
+  );
+
+  const commitIos = useCallback((): void => {
+    if (picker === null) return;
+    const key = picker.field === "open" ? "openTime" : "closeTime";
+    setHoursRow(picker.weekday, { [key]: dateToHm(picker.temp) });
+    setPicker(null);
+  }, [picker, setHoursRow]);
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Opening hours</Text>
+      <Text style={styles.helper}>Default: Mon–Sat 9–5, Sun closed.</Text>
+      {stepErr !== null ? <Text style={styles.err}>{stepErr}</Text> : null}
+      {hours.map((row) => (
+        <View key={row.weekday} style={styles.dayRow}>
+          <View style={styles.dayHead}>
+            <Text style={styles.dayName}>{DAY_NAMES[row.weekday]}</Text>
+            <Switch
+              value={!row.isClosed}
+              onValueChange={(on) =>
+                setHoursRow(row.weekday, {
+                  isClosed: !on,
+                  openTime: on ? row.openTime ?? "09:00" : null,
+                  closeTime: on ? row.closeTime ?? "17:00" : null,
+                })
+              }
+              accessibilityLabel={`${DAY_NAMES[row.weekday]} open`}
+            />
+          </View>
+          {!row.isClosed ? (
+            <View style={styles.timeRow}>
+              <Pressable
+                style={styles.timeBtn}
+                onPress={() => openPicker(row.weekday, "open", row)}
+              >
+                <Text style={styles.timeLbl}>Opens</Text>
+                <Text style={styles.timeVal}>{row.openTime ?? "—"}</Text>
+              </Pressable>
+              <Pressable
+                style={styles.timeBtn}
+                onPress={() => openPicker(row.weekday, "close", row)}
+              >
+                <Text style={styles.timeLbl}>Closes</Text>
+                <Text style={styles.timeVal}>{row.closeTime ?? "—"}</Text>
+              </Pressable>
+            </View>
+          ) : null}
+        </View>
+      ))}
+
+      {Platform.OS === "ios" && picker !== null ? (
+        <Modal transparent visible animationType="fade">
+          <View style={styles.iosBackdrop}>
+            <View style={styles.iosSheet}>
+              <View style={styles.iosDone}>
+                <Button
+                  label="Done"
+                  variant="primary"
+                  size="md"
+                  onPress={commitIos}
+                />
+              </View>
+              <DateTimePicker
+                value={picker.temp}
+                mode="time"
+                display="spinner"
+                onChange={onPickerChange}
+                themeVariant="dark"
+              />
+            </View>
+          </View>
+        </Modal>
+      ) : null}
+
+      {Platform.OS === "android" && picker !== null ? (
+        <DateTimePicker
+          value={picker.temp}
+          mode="time"
+          display="default"
+          onChange={onPickerChange}
+        />
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xl,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  helper: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  err: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
+  },
+  dayRow: {
+    borderRadius: radiusTokens.md,
+    backgroundColor: glass.tint.profileBase,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    padding: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  dayHead: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  dayName: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "600",
+    color: textTokens.primary,
+  },
+  timeRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  timeBtn: {
+    flex: 1,
+    padding: spacing.sm,
+    borderRadius: radiusTokens.sm,
+    backgroundColor: accent.tint,
+  },
+  timeLbl: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.secondary,
+  },
+  timeVal: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "600",
+    color: textTokens.primary,
+    marginTop: 2,
+  },
+  iosBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.55)",
+    justifyContent: "flex-end",
+  },
+  iosSheet: {
+    backgroundColor: "#1a1a1e",
+    paddingBottom: spacing.lg,
+    borderTopLeftRadius: radiusTokens.lg,
+    borderTopRightRadius: radiusTokens.lg,
+  },
+  iosDone: {
+    alignItems: "flex-end",
+    padding: spacing.md,
+  },
+});
+
+export default VenueStep4Hours;

--- a/mingla-business/src/components/venue/VenueStep5Contact.tsx
+++ b/mingla-business/src/components/venue/VenueStep5Contact.tsx
@@ -1,0 +1,79 @@
+/**
+ * Ve1 wizard — Step 5: Contact.
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { Input } from "../ui/Input";
+
+export interface VenueStep5ContactProps {
+  showErrors: boolean;
+}
+
+export const VenueStep5Contact: React.FC<VenueStep5ContactProps> = ({
+  showErrors,
+}) => {
+  const contactEmail = useDraftVenueStore((s) => s.contactEmail);
+  const contactPhone = useDraftVenueStore((s) => s.contactPhone);
+  const patch = useDraftVenueStore((s) => s.patch);
+
+  const err =
+    showErrors &&
+    contactEmail.trim().length === 0 &&
+    contactPhone.trim().length === 0
+      ? "Add an email or phone number."
+      : undefined;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Guest contact</Text>
+      <Text style={styles.helper}>
+        How should attendees reach the venue? At least one field is required.
+      </Text>
+      <Input
+        variant="email"
+        value={contactEmail}
+        onChangeText={(t) => patch({ contactEmail: t })}
+        placeholder="Email"
+        accessibilityLabel="Contact email"
+      />
+      <Input
+        variant="phone"
+        value={contactPhone}
+        onChangeText={(t) => patch({ contactPhone: t })}
+        placeholder="Phone"
+        accessibilityLabel="Contact phone"
+      />
+      {err !== undefined ? <Text style={styles.err}>{err}</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  helper: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  err: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
+  },
+});
+
+export default VenueStep5Contact;

--- a/mingla-business/src/components/venue/VenueStep6Description.tsx
+++ b/mingla-business/src/components/venue/VenueStep6Description.tsx
@@ -1,0 +1,92 @@
+/**
+ * Ve1 wizard — Step 6: Description + tagline.
+ */
+
+import React from "react";
+import { StyleSheet, Text, TextInput, View } from "react-native";
+
+import {
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { Input } from "../ui/Input";
+
+const INPUT_BG = "rgba(255,255,255,0.06)";
+const INPUT_BORDER = "rgba(255,255,255,0.12)";
+
+export interface VenueStep6DescriptionProps {
+  showErrors: boolean;
+}
+
+export const VenueStep6Description: React.FC<VenueStep6DescriptionProps> = ({
+  showErrors,
+}) => {
+  const description = useDraftVenueStore((s) => s.description);
+  const tagline = useDraftVenueStore((s) => s.tagline);
+  const patch = useDraftVenueStore((s) => s.patch);
+
+  const err =
+    showErrors && description.trim().length < 20
+      ? "Description must be at least 20 characters."
+      : undefined;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Tell guests what to expect</Text>
+      <Input
+        variant="text"
+        value={tagline}
+        onChangeText={(t) => patch({ tagline: t })}
+        placeholder="Short tagline (optional)"
+        accessibilityLabel="Venue tagline"
+      />
+      <Text style={styles.lbl}>Description</Text>
+      <TextInput
+        value={description}
+        onChangeText={(t) => patch({ description: t })}
+        placeholder="What makes this venue special?"
+        placeholderTextColor={textTokens.tertiary}
+        multiline
+        textAlignVertical="top"
+        accessibilityLabel="Venue description"
+        style={styles.area}
+      />
+      {err !== undefined ? <Text style={styles.err}>{err}</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  lbl: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.secondary,
+    marginTop: spacing.xs,
+  },
+  area: {
+    minHeight: 140,
+    padding: spacing.md,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: INPUT_BORDER,
+    backgroundColor: INPUT_BG,
+    color: textTokens.primary,
+    fontSize: typography.body.fontSize,
+  },
+  err: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
+  },
+});
+
+export default VenueStep6Description;

--- a/mingla-business/src/components/venue/VenueStep7Review.tsx
+++ b/mingla-business/src/components/venue/VenueStep7Review.tsx
@@ -1,0 +1,126 @@
+/**
+ * Ve1 wizard — Step 7: Review + submit.
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { VenueCategory } from "../../types/brand";
+import { useDraftVenueStore } from "../../store/draftVenueStore";
+import { Button } from "../ui/Button";
+
+const CAT_LABEL: Record<VenueCategory, string> = {
+  restaurant: "Restaurant",
+  play: "Play",
+  creative_and_arts: "Creative & arts",
+};
+
+export interface VenueStep7ReviewProps {
+  submitting: boolean;
+  submitError: string | null;
+  onSubmit: () => void;
+}
+
+export const VenueStep7Review: React.FC<VenueStep7ReviewProps> = ({
+  submitting,
+  submitError,
+  onSubmit,
+}) => {
+  const d = useDraftVenueStore();
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Review & submit</Text>
+      <Text style={styles.helper}>
+        We’ll verify your venue before it appears publicly — usually within 4
+        business hours.
+      </Text>
+      <View style={styles.card}>
+        <Row k="Name" v={d.displayName.trim()} />
+        <Row k="Slug" v={d.slug.trim()} />
+        <Row k="Category" v={d.venueCategory ? CAT_LABEL[d.venueCategory] : "—"} />
+        <Row k="Address" v={d.formattedAddress} />
+        <Row k="Contact" v={[d.contactEmail, d.contactPhone].filter(Boolean).join(" · ") || "—"} />
+        <Row
+          k="Photos"
+          v={`${d.photoUris.length} selected`}
+        />
+        <Row
+          k="Description"
+          v={
+            d.description.trim().length > 120
+              ? `${d.description.trim().slice(0, 120)}…`
+              : d.description.trim() || "—"
+          }
+        />
+      </View>
+      {submitError !== null ? (
+        <Text style={styles.err}>{submitError}</Text>
+      ) : null}
+      <Button
+        label={submitting ? "Submitting…" : "Submit for review"}
+        onPress={onSubmit}
+        variant="primary"
+        size="lg"
+        loading={submitting}
+        disabled={submitting}
+      />
+    </View>
+  );
+};
+
+function Row({ k, v }: { k: string; v: string }): React.ReactElement {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.k}>{k}</Text>
+      <Text style={styles.v}>{v}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xl,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  helper: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  card: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderRadius: 12,
+    backgroundColor: "rgba(255,255,255,0.06)",
+  },
+  row: {
+    gap: 2,
+  },
+  k: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  v: {
+    fontSize: typography.body.fontSize,
+    color: textTokens.primary,
+  },
+  err: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
+  },
+});
+
+export default VenueStep7Review;

--- a/mingla-business/src/components/venue/venueWizardValidation.ts
+++ b/mingla-business/src/components/venue/venueWizardValidation.ts
@@ -31,7 +31,9 @@ export function venueStepError(
         if (o.length === 0 || c.length === 0) {
           return "Open and close times are required for open days.";
         }
-        if (o >= c) return "Close time must be after open time for each open day.";
+        if (o >= c) {
+          return "Close must be after open on each day. Overnight hours (e.g. 10pm–2am) aren’t supported yet — use closed days or adjust times.";
+        }
       }
       return null;
     }

--- a/mingla-business/src/components/venue/venueWizardValidation.ts
+++ b/mingla-business/src/components/venue/venueWizardValidation.ts
@@ -1,0 +1,56 @@
+/**
+ * Ve1 — inline validation for venue wizard steps.
+ */
+
+import type { DraftVenueState } from "../../store/draftVenueStore";
+
+export function venueStepError(
+  step: number,
+  d: DraftVenueState,
+): string | null {
+  switch (step) {
+    case 0:
+      if (d.googlePlaceId === null || d.googlePlaceId.trim() === "") {
+        return "Pick your venue address from the suggestions.";
+      }
+      if (d.lat === null || d.lng === null) return "Address is missing location.";
+      return null;
+    case 1: {
+      if (d.displayName.trim().length === 0) return "Venue name is required.";
+      if (d.slug.trim().length === 0) return "URL slug is required.";
+      return null;
+    }
+    case 2:
+      if (d.photoUris.length < 1) return "Add at least one photo.";
+      return null;
+    case 3: {
+      for (const h of d.hours) {
+        if (h.isClosed) continue;
+        const o = h.openTime ?? "";
+        const c = h.closeTime ?? "";
+        if (o.length === 0 || c.length === 0) {
+          return "Open and close times are required for open days.";
+        }
+        if (o >= c) return "Close time must be after open time for each open day.";
+      }
+      return null;
+    }
+    case 4: {
+      const em = d.contactEmail.trim();
+      const ph = d.contactPhone.trim();
+      if (em.length === 0 && ph.length === 0) {
+        return "Add an email or phone number.";
+      }
+      return null;
+    }
+    case 5: {
+      const bio = d.description.trim();
+      if (bio.length < 20) {
+        return "Description must be at least 20 characters.";
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}

--- a/mingla-business/src/hooks/useBrands.ts
+++ b/mingla-business/src/hooks/useBrands.ts
@@ -30,11 +30,13 @@ import { queryClient } from "../config/queryClient";
 import { eventOrdersKeys } from "./useEventOrders";
 import {
   createBrand,
+  createVenueBrandPendingReview,
   getBrands,
   getBrand,
   updateBrand,
   softDeleteBrand,
   type CreateBrandInput,
+  type CreateVenueBrandPendingInput,
   type SoftDeleteResult,
 } from "../services/brandsService";
 import type { Brand } from "../store/currentBrandStore";
@@ -529,11 +531,37 @@ export const useBrandCascadePreview = (
   });
 };
 
+// ----- Ve1: physical venue brand (pending review) ------------------------
+
+export interface CreateVenueBrandMutationInput extends CreateVenueBrandPendingInput {
+  accountId: string;
+}
+
+export interface UseCreateVenueBrandResult {
+  mutateAsync: (input: CreateVenueBrandMutationInput) => Promise<Brand>;
+  isPending: boolean;
+}
+
+export const useCreateVenueBrand = (): UseCreateVenueBrandResult => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<Brand, Error, CreateVenueBrandMutationInput>({
+    mutationFn: async ({
+      accountId: _accountId,
+      ...rest
+    }): Promise<Brand> => createVenueBrandPendingReview(rest, "owner"),
+    onSuccess: (_brand, { accountId }) => {
+      void queryClient.invalidateQueries({ queryKey: brandKeys.list(accountId) });
+    },
+  });
+  return { mutateAsync: mutation.mutateAsync, isPending: mutation.isPending };
+};
+
 // ----- Re-exports for convenience ---------------------------------------
 
 export { SlugCollisionError } from "../services/brandsService";
 export type {
   CreateBrandInput,
+  CreateVenueBrandPendingInput,
   SoftDeleteResult,
   SoftDeleteSuccess,
   SoftDeleteRejection,

--- a/mingla-business/src/services/__tests__/ve1PublicBrandViewGuard.test.ts
+++ b/mingla-business/src/services/__tests__/ve1PublicBrandViewGuard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Ve1 public brand visibility (migration contract)", () => {
+  test("business_public_brands_view keeps unverified physical brands hidden", () => {
+    const migration = readFileSync(
+      join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "..",
+        "supabase",
+        "migrations",
+        "20260613000000_ve1_physical_venue_brand_onboarding.sql",
+      ),
+      "utf8",
+    );
+    expect(migration).toContain("business_public_brands_view");
+    expect(migration).toMatch(/physical.*claim_status\s*=\s*'verified'/s);
+  });
+});

--- a/mingla-business/src/services/__tests__/ve1VenueServices.test.ts
+++ b/mingla-business/src/services/__tests__/ve1VenueServices.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable import/first */
+/**
+ * Ve1 — place_pool name gate + brand_hours upsert service regression.
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fromMock = jest.fn() as any;
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => fromMock(...args),
+  },
+}));
+
+jest.mock("../appsFlyerService", () => ({
+  logAppsFlyerEvent: jest.fn(),
+}));
+
+import { upsertBrandHours } from "../brandsService";
+import { placePoolHasNameMatch } from "../venueSearchService";
+
+describe("placePoolHasNameMatch", () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+  });
+
+  test("returns false for short query without hitting DB", async () => {
+    const r = await placePoolHasNameMatch("x");
+    expect(r).toBe(false);
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  test("returns true when a row is returned", async () => {
+    const limitMock = jest.fn(() =>
+      Promise.resolve({ data: [{ id: "p1" }], error: null }),
+    );
+    const eqMock = jest.fn(() => ({ limit: limitMock }));
+    const ilikeMock = jest.fn(() => ({ eq: eqMock }));
+    const selectMock = jest.fn(() => ({ ilike: ilikeMock }));
+    fromMock.mockReturnValue({
+      select: selectMock,
+    });
+    const r = await placePoolHasNameMatch("Cafe Nero");
+    expect(r).toBe(true);
+    expect(fromMock).toHaveBeenCalledWith("place_pool");
+  });
+});
+
+describe("upsertBrandHours", () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+  });
+
+  test("throws when hours length !== 7", async () => {
+    await expect(
+      upsertBrandHours("brand-1", [
+        {
+          weekday: 0,
+          openTime: "09:00",
+          closeTime: "17:00",
+          isClosed: false,
+        },
+      ]),
+    ).rejects.toThrow("expected 7 weekday rows");
+  });
+
+  test("delete then insert 7 rows on happy path", async () => {
+    const insertMock = jest.fn(() => Promise.resolve({ error: null }));
+    const deleteEqMock = jest.fn(() => Promise.resolve({ error: null }));
+    const deleteMock = jest.fn(() => ({ eq: deleteEqMock }));
+
+    let brandHoursCalls = 0;
+    fromMock.mockImplementation((table: unknown) => {
+      if (table !== "brand_hours") return {};
+      brandHoursCalls += 1;
+      if (brandHoursCalls === 1) {
+        return { delete: deleteMock };
+      }
+      return { insert: insertMock };
+    });
+
+    const hours = [
+      { weekday: 0, openTime: "09:00", closeTime: "17:00", isClosed: false },
+      { weekday: 1, openTime: "09:00", closeTime: "17:00", isClosed: false },
+      { weekday: 2, openTime: "09:00", closeTime: "17:00", isClosed: false },
+      { weekday: 3, openTime: "09:00", closeTime: "17:00", isClosed: false },
+      { weekday: 4, openTime: "09:00", closeTime: "17:00", isClosed: false },
+      { weekday: 5, openTime: "09:00", closeTime: "17:00", isClosed: false },
+      { weekday: 6, openTime: null, closeTime: null, isClosed: true },
+    ];
+
+    await upsertBrandHours("brand-1", hours);
+
+    expect(deleteMock).toHaveBeenCalled();
+    expect(deleteEqMock).toHaveBeenCalledWith("brand_id", "brand-1");
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          brand_id: "brand-1",
+          weekday: 0,
+          is_closed: false,
+          open_time: "09:00:00",
+          close_time: "17:00:00",
+        }),
+        expect.objectContaining({
+          weekday: 6,
+          is_closed: true,
+          open_time: null,
+          close_time: null,
+        }),
+      ]),
+    );
+  });
+});

--- a/mingla-business/src/services/__tests__/ve1VenueServices.test.ts
+++ b/mingla-business/src/services/__tests__/ve1VenueServices.test.ts
@@ -5,11 +5,11 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const fromMock = jest.fn() as any;
+const rpcMock = jest.fn() as any;
 
 jest.mock("../supabase", () => ({
   supabase: {
-    from: (...args: unknown[]) => fromMock(...args),
+    rpc: (...args: unknown[]) => rpcMock(...args),
   },
 }));
 
@@ -22,34 +22,36 @@ import { placePoolHasNameMatch } from "../venueSearchService";
 
 describe("placePoolHasNameMatch", () => {
   beforeEach(() => {
-    fromMock.mockReset();
+    rpcMock.mockReset();
   });
 
   test("returns false for short query without hitting DB", async () => {
     const r = await placePoolHasNameMatch("x");
     expect(r).toBe(false);
-    expect(fromMock).not.toHaveBeenCalled();
+    expect(rpcMock).not.toHaveBeenCalled();
   });
 
-  test("returns true when a row is returned", async () => {
-    const limitMock = jest.fn(() =>
-      Promise.resolve({ data: [{ id: "p1" }], error: null }),
-    );
-    const eqMock = jest.fn(() => ({ limit: limitMock }));
-    const ilikeMock = jest.fn(() => ({ eq: eqMock }));
-    const selectMock = jest.fn(() => ({ ilike: ilikeMock }));
-    fromMock.mockReturnValue({
-      select: selectMock,
-    });
+  test("returns true when RPC reports a match", async () => {
+    rpcMock.mockResolvedValue({ data: true, error: null });
     const r = await placePoolHasNameMatch("Cafe Nero");
     expect(r).toBe(true);
-    expect(fromMock).toHaveBeenCalledWith("place_pool");
+    expect(rpcMock).toHaveBeenCalledWith("biz_place_pool_name_contains", {
+      p_query: "Cafe Nero",
+    });
+  });
+
+  test("escapes ILIKE metacharacters via server RPC", async () => {
+    rpcMock.mockResolvedValue({ data: false, error: null });
+    await placePoolHasNameMatch("100%_off");
+    expect(rpcMock).toHaveBeenCalledWith("biz_place_pool_name_contains", {
+      p_query: "100%_off",
+    });
   });
 });
 
 describe("upsertBrandHours", () => {
   beforeEach(() => {
-    fromMock.mockReset();
+    rpcMock.mockReset();
   });
 
   test("throws when hours length !== 7", async () => {
@@ -65,26 +67,8 @@ describe("upsertBrandHours", () => {
     ).rejects.toThrow("expected 7 weekday rows");
   });
 
-  test("delete then insert 7 rows on happy path", async () => {
-    const selectMock = jest.fn(() =>
-      Promise.resolve({
-        data: [0, 1, 2, 3, 4, 5, 6].map((weekday) => ({ weekday })),
-        error: null,
-      }),
-    );
-    const insertMock = jest.fn(() => ({ select: selectMock }));
-    const deleteEqMock = jest.fn(() => Promise.resolve({ error: null }));
-    const deleteMock = jest.fn(() => ({ eq: deleteEqMock }));
-
-    let brandHoursCalls = 0;
-    fromMock.mockImplementation((table: unknown) => {
-      if (table !== "brand_hours") return {};
-      brandHoursCalls += 1;
-      if (brandHoursCalls === 1) {
-        return { delete: deleteMock };
-      }
-      return { insert: insertMock };
-    });
+  test("calls biz_upsert_brand_hours RPC on happy path", async () => {
+    rpcMock.mockResolvedValue({ data: null, error: null });
 
     const hours = [
       { weekday: 0, openTime: "09:00", closeTime: "17:00", isClosed: false },
@@ -98,24 +82,15 @@ describe("upsertBrandHours", () => {
 
     await upsertBrandHours("brand-1", hours);
 
-    expect(deleteMock).toHaveBeenCalled();
-    expect(deleteEqMock).toHaveBeenCalledWith("brand_id", "brand-1");
-    expect(insertMock).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          brand_id: "brand-1",
-          weekday: 0,
-          is_closed: false,
-          open_time: "09:00:00",
-          close_time: "17:00:00",
-        }),
-        expect.objectContaining({
-          weekday: 6,
-          is_closed: true,
-          open_time: null,
-          close_time: null,
-        }),
-      ]),
+    expect(rpcMock).toHaveBeenCalledWith(
+      "biz_upsert_brand_hours",
+      expect.objectContaining({
+        p_brand_id: "brand-1",
+        p_hours: expect.arrayContaining([
+          expect.objectContaining({ weekday: 0, is_closed: false }),
+          expect.objectContaining({ weekday: 6, is_closed: true }),
+        ]),
+      }),
     );
   });
 });

--- a/mingla-business/src/services/__tests__/ve1VenueServices.test.ts
+++ b/mingla-business/src/services/__tests__/ve1VenueServices.test.ts
@@ -66,7 +66,13 @@ describe("upsertBrandHours", () => {
   });
 
   test("delete then insert 7 rows on happy path", async () => {
-    const insertMock = jest.fn(() => Promise.resolve({ error: null }));
+    const selectMock = jest.fn(() =>
+      Promise.resolve({
+        data: [0, 1, 2, 3, 4, 5, 6].map((weekday) => ({ weekday })),
+        error: null,
+      }),
+    );
+    const insertMock = jest.fn(() => ({ select: selectMock }));
     const deleteEqMock = jest.fn(() => Promise.resolve({ error: null }));
     const deleteMock = jest.fn(() => ({ eq: deleteEqMock }));
 

--- a/mingla-business/src/services/brandAuthoringGate.ts
+++ b/mingla-business/src/services/brandAuthoringGate.ts
@@ -1,0 +1,44 @@
+/**
+ * Ve1 — block event/trip draft creation until physical venue brands are verified.
+ */
+
+import { supabase } from "./supabase";
+
+export class PhysicalVenueNotVerifiedError extends Error {
+  readonly code = "physical_venue_not_verified" as const;
+
+  constructor() {
+    super(
+      "This venue is still pending review. You can create events after Mingla verifies it — usually within 4 business hours.",
+    );
+    this.name = "PhysicalVenueNotVerifiedError";
+  }
+}
+
+export async function assertBrandCanAuthorOfferings(
+  brandId: string,
+): Promise<void> {
+  const { data, error } = await supabase
+    .from("brands")
+    .select("kind, claim_status")
+    .eq("id", brandId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error !== null) throw error;
+  if (data === null) {
+    throw new Error("Brand not found");
+  }
+
+  const row = data as {
+    kind: string;
+    claim_status: string | null;
+  };
+
+  if (
+    row.kind === "physical" &&
+    row.claim_status !== "verified"
+  ) {
+    throw new PhysicalVenueNotVerifiedError();
+  }
+}

--- a/mingla-business/src/services/brandMapping.ts
+++ b/mingla-business/src/services/brandMapping.ts
@@ -20,7 +20,9 @@ import type {
   BrandLiveEvent,
   BrandRole,
   BrandStats,
-} from "../store/currentBrandStore";
+  BrandClaimStatus,
+  VenueCategory,
+} from "../types/brand";
 import { deriveBrandStripeStatus } from "../utils/deriveBrandStripeStatus";
 
 /** Snapshot of `public.brands` columns needed for mapping (B1 + Cycle 17e-A). */
@@ -52,6 +54,17 @@ export interface BrandRow {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  // Ve1 — optional until row is loaded from a fresh `select *` after migration.
+  place_pool_id?: string | null;
+  google_place_id?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  city?: string | null;
+  country_code?: string | null;
+  claim_status?: BrandClaimStatus | null;
+  verified_at?: string | null;
+  verified_by?: string | null;
+  venue_category?: VenueCategory | null;
 }
 
 /** Insert shape for `.from('brands').insert()` (server fills id/timestamps). */
@@ -79,6 +92,14 @@ export type BrandTableInsert = {
   cover_media_url?: string | null;
   cover_media_type?: "image" | "video" | "gif" | null;
   profile_photo_type?: "image" | "video" | "gif" | null;
+  place_pool_id?: string | null;
+  google_place_id?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  city?: string | null;
+  country_code?: string | null;
+  claim_status?: BrandClaimStatus;
+  venue_category?: VenueCategory | null;
 };
 
 export const EMPTY_BRAND_STATS: BrandStats = {
@@ -240,6 +261,14 @@ export function mapBrandRowToUi(row: BrandRow, options: MapBrandRowToUiOptions):
     // ORCH-0769: expose brands.default_currency only once Stripe/brand setup
     // has actually set it. Undefined means "currency not set" — do not imply GBP.
     defaultCurrency: row.default_currency || undefined,
+    claimStatus: (row.claim_status as BrandClaimStatus | undefined) ?? "none",
+    googlePlaceId: row.google_place_id ?? undefined,
+    lat: row.lat ?? undefined,
+    lng: row.lng ?? undefined,
+    city: row.city ?? undefined,
+    countryCode: row.country_code ?? undefined,
+    venueCategory: (row.venue_category as VenueCategory | undefined) ?? undefined,
+    placePoolId: row.place_pool_id ?? undefined,
   };
 }
 
@@ -285,6 +314,23 @@ export function mapUiToBrandInsert(input: MapUiToBrandInsertInput): BrandTableIn
   if (brand.profilePhotoType !== undefined) {
     row.profile_photo_type = brand.profilePhotoType ?? null;
   }
+  if (brand.claimStatus !== undefined) row.claim_status = brand.claimStatus;
+  if (brand.googlePlaceId !== undefined) {
+    row.google_place_id = brand.googlePlaceId ?? null;
+  }
+  if (brand.lat !== undefined) row.lat = brand.lat ?? null;
+  if (brand.lng !== undefined) row.lng = brand.lng ?? null;
+  if (brand.city !== undefined) row.city = brand.city ?? null;
+  if (brand.countryCode !== undefined) {
+    row.country_code = brand.countryCode ?? null;
+  }
+  if (brand.venueCategory !== undefined) {
+    row.venue_category = brand.venueCategory ?? null;
+  }
+  if (brand.placePoolId !== undefined) {
+    row.place_pool_id = brand.placePoolId ?? null;
+  }
+
   return row;
 }
 
@@ -351,6 +397,22 @@ export function mapUiToBrandUpdatePatch(
   }
   if (patch.profilePhotoType !== undefined) {
     out.profile_photo_type = patch.profilePhotoType ?? null;
+  }
+  if (patch.claimStatus !== undefined) out.claim_status = patch.claimStatus;
+  if (patch.googlePlaceId !== undefined) {
+    out.google_place_id = patch.googlePlaceId ?? null;
+  }
+  if (patch.lat !== undefined) out.lat = patch.lat ?? null;
+  if (patch.lng !== undefined) out.lng = patch.lng ?? null;
+  if (patch.city !== undefined) out.city = patch.city ?? null;
+  if (patch.countryCode !== undefined) {
+    out.country_code = patch.countryCode ?? null;
+  }
+  if (patch.venueCategory !== undefined) {
+    out.venue_category = patch.venueCategory ?? null;
+  }
+  if (patch.placePoolId !== undefined) {
+    out.place_pool_id = patch.placePoolId ?? null;
   }
 
   return out;

--- a/mingla-business/src/services/brandsService.ts
+++ b/mingla-business/src/services/brandsService.ts
@@ -28,9 +28,15 @@ import {
   joinBrandDescription,
   type BrandRow,
 } from "./brandMapping";
-import type { Brand, BrandRole } from "../store/currentBrandStore";
+import type {
+  Brand,
+  BrandRole,
+  BrandHourEntry,
+  VenueCategory,
+} from "../types/brand";
 // ORCH-0808 — organizer-funnel instrumentation.
 import { logAppsFlyerEvent } from "./appsFlyerService";
+import { brandHoursToRpcPayload } from "../utils/venueBrandHours";
 
 interface EventBrandIdRow {
   brand_id: string | null;
@@ -151,6 +157,162 @@ export async function createBrand(
   logAppsFlyerEvent("mingla_brand_created", { brand_id: data.id as string });
 
   return mapBrandRowToUi(data as BrandRow, { role });
+}
+
+// ----- Ve1 physical venue (pending review) --------------------------------
+
+export interface CreateVenueBrandPendingInput {
+  name: string;
+  slug: string;
+  tagline?: string;
+  bio?: string;
+  googlePlaceId: string;
+  lat: number;
+  lng: number;
+  city: string | null;
+  countryCode: string | null;
+  address: string;
+  venueCategory: VenueCategory;
+  contact: { email?: string; phone?: string };
+  coverMediaUrl: string | null;
+  coverMediaType: "image" | "video" | "gif" | null;
+  hours: BrandHourEntry[];
+}
+
+interface BrandHourRow {
+  weekday: number;
+  open_time: string | null;
+  close_time: string | null;
+  is_closed: boolean;
+}
+
+function formatTimeForUi(t: string | null): string | null {
+  if (t === null || t.length === 0) return null;
+  const parts = t.split(":");
+  if (parts.length >= 2) return `${parts[0]}:${parts[1]}`;
+  return t;
+}
+
+export async function getBrandHours(brandId: string): Promise<BrandHourEntry[]> {
+  const { data, error } = await supabase
+    .from("brand_hours")
+    .select("weekday,open_time,close_time,is_closed")
+    .eq("brand_id", brandId)
+    .order("weekday", { ascending: true });
+
+  if (error !== null) throw error;
+  return ((data ?? []) as BrandHourRow[]).map((r) => ({
+    weekday: r.weekday,
+    openTime: r.is_closed ? null : formatTimeForUi(r.open_time),
+    closeTime: r.is_closed ? null : formatTimeForUi(r.close_time),
+    isClosed: r.is_closed,
+  }));
+}
+
+function timeToDb(t: string | null): string | null {
+  if (t === null || t.trim() === "") return null;
+  const s = t.trim();
+  if (s.length === 5) return `${s}:00`;
+  return s;
+}
+
+/**
+ * Replaces all `brand_hours` rows for a brand (expects exactly 7 weekdays).
+ * Callers must hold brand admin-plus; mirrors the RPC insert shape.
+ */
+export async function upsertBrandHours(
+  brandId: string,
+  hours: BrandHourEntry[],
+): Promise<void> {
+  if (hours.length !== 7) {
+    throw new Error("upsertBrandHours: expected 7 weekday rows");
+  }
+  const { error: delError } = await supabase
+    .from("brand_hours")
+    .delete()
+    .eq("brand_id", brandId);
+  if (delError !== null) throw delError;
+
+  const rows = hours.map((e) => ({
+    brand_id: brandId,
+    weekday: e.weekday,
+    open_time: e.isClosed ? null : timeToDb(e.openTime),
+    close_time: e.isClosed ? null : timeToDb(e.closeTime),
+    is_closed: e.isClosed,
+  }));
+
+  const { error: insError } = await supabase.from("brand_hours").insert(rows);
+  if (insError !== null) throw insError;
+}
+
+async function invokeVenueClaimSubmittedEmail(brandId: string): Promise<void> {
+  try {
+    const { error } = await supabase.functions.invoke(
+      "venue-claim-submitted-email",
+      { body: { brand_id: brandId } },
+    );
+    if (error !== null) {
+      console.warn("[invokeVenueClaimSubmittedEmail]", error.message);
+    }
+  } catch (e) {
+    console.warn("[invokeVenueClaimSubmittedEmail]", e);
+  }
+}
+
+/**
+ * Ve1 — atomic create via `biz_create_venue_brand_pending_review` + confirmation email.
+ */
+export async function createVenueBrandPendingReview(
+  input: CreateVenueBrandPendingInput,
+  role: BrandRole,
+): Promise<Brand> {
+  const description = joinBrandDescription(input.tagline, input.bio);
+  const { data, error } = await supabase.rpc(
+    "biz_create_venue_brand_pending_review",
+    {
+      p_name: input.name,
+      p_slug: input.slug,
+      p_description: description,
+      p_google_place_id: input.googlePlaceId,
+      p_lat: input.lat,
+      p_lng: input.lng,
+      p_city: input.city ?? "",
+      p_country_code: input.countryCode ?? "",
+      p_address: input.address,
+      p_venue_category: input.venueCategory,
+      p_contact_email: input.contact.email ?? "",
+      p_contact_phone: input.contact.phone ?? "",
+      p_cover_media_url: input.coverMediaUrl ?? "",
+      p_cover_media_type: input.coverMediaType ?? "",
+      p_hours: brandHoursToRpcPayload(input.hours),
+    },
+  );
+
+  if (error !== null) {
+    const msg = error.message ?? "";
+    if (error.code === "23505") {
+      if (msg.includes("slug") || msg.includes("idx_brands_slug")) {
+        throw new SlugCollisionError(input.slug);
+      }
+      throw new Error(
+        "This place is already in our verification queue with the same Google location. Contact support if you need help.",
+      );
+    }
+    throw error;
+  }
+  if (data === null || typeof data !== "string") {
+    throw new Error("createVenueBrandPendingReview: RPC returned no brand id");
+  }
+
+  const brandId = data;
+  logAppsFlyerEvent("mingla_venue_brand_submitted", { brand_id: brandId });
+  await invokeVenueClaimSubmittedEmail(brandId);
+
+  const brand = await getBrand(brandId);
+  if (brand === null) {
+    throw new Error("createVenueBrandPendingReview: brand missing after insert");
+  }
+  return { ...brand, role };
 }
 
 // ----- getBrands (list) --------------------------------------------------

--- a/mingla-business/src/services/brandsService.ts
+++ b/mingla-business/src/services/brandsService.ts
@@ -227,11 +227,12 @@ export async function upsertBrandHours(
   if (hours.length !== 7) {
     throw new Error("upsertBrandHours: expected 7 weekday rows");
   }
-  const { error: delError } = await supabase
+  const deleteResp = await supabase
     .from("brand_hours")
+    // I-MUTATION-ROWCOUNT-WAIVER: Ve1 — DELETE-then-INSERT pattern; rowcount intentionally not verified (zero rows is the valid initial-create case).
     .delete()
     .eq("brand_id", brandId);
-  if (delError !== null) throw delError;
+  if (deleteResp.error !== null) throw deleteResp.error;
 
   const rows = hours.map((e) => ({
     brand_id: brandId,
@@ -241,8 +242,14 @@ export async function upsertBrandHours(
     is_closed: e.isClosed,
   }));
 
-  const { error: insError } = await supabase.from("brand_hours").insert(rows);
+  const { data, error: insError } = await supabase
+    .from("brand_hours")
+    .insert(rows)
+    .select("weekday");
   if (insError !== null) throw insError;
+  if ((data?.length ?? 0) !== 7) {
+    throw new Error("upsertBrandHours: insert returned unexpected row count");
+  }
 }
 
 async function invokeVenueClaimSubmittedEmail(brandId: string): Promise<void> {

--- a/mingla-business/src/services/brandsService.ts
+++ b/mingla-business/src/services/brandsService.ts
@@ -209,13 +209,6 @@ export async function getBrandHours(brandId: string): Promise<BrandHourEntry[]> 
   }));
 }
 
-function timeToDb(t: string | null): string | null {
-  if (t === null || t.trim() === "") return null;
-  const s = t.trim();
-  if (s.length === 5) return `${s}:00`;
-  return s;
-}
-
 /**
  * Replaces all `brand_hours` rows for a brand (expects exactly 7 weekdays).
  * Callers must hold brand admin-plus; mirrors the RPC insert shape.
@@ -227,29 +220,11 @@ export async function upsertBrandHours(
   if (hours.length !== 7) {
     throw new Error("upsertBrandHours: expected 7 weekday rows");
   }
-  const deleteResp = await supabase
-    .from("brand_hours")
-    // I-MUTATION-ROWCOUNT-WAIVER: Ve1 — DELETE-then-INSERT pattern; rowcount intentionally not verified (zero rows is the valid initial-create case).
-    .delete()
-    .eq("brand_id", brandId);
-  if (deleteResp.error !== null) throw deleteResp.error;
-
-  const rows = hours.map((e) => ({
-    brand_id: brandId,
-    weekday: e.weekday,
-    open_time: e.isClosed ? null : timeToDb(e.openTime),
-    close_time: e.isClosed ? null : timeToDb(e.closeTime),
-    is_closed: e.isClosed,
-  }));
-
-  const { data, error: insError } = await supabase
-    .from("brand_hours")
-    .insert(rows)
-    .select("weekday");
-  if (insError !== null) throw insError;
-  if ((data?.length ?? 0) !== 7) {
-    throw new Error("upsertBrandHours: insert returned unexpected row count");
-  }
+  const { error } = await supabase.rpc("biz_upsert_brand_hours", {
+    p_brand_id: brandId,
+    p_hours: brandHoursToRpcPayload(hours),
+  });
+  if (error !== null) throw error;
 }
 
 async function invokeVenueClaimSubmittedEmail(brandId: string): Promise<void> {

--- a/mingla-business/src/services/eventDrafts.ts
+++ b/mingla-business/src/services/eventDrafts.ts
@@ -15,6 +15,7 @@ import {
   BusinessAuthNotReadyError,
   toBusinessAuthNotReadyError,
 } from "../utils/authReadiness";
+import { assertBrandCanAuthorOfferings } from "./brandAuthoringGate";
 
 // ORCH-0841: include the post-ORCH-0824 top-level taxonomy + city + geo
 // columns so serverRowToDraft sees them on every fetch / autosave round-trip.
@@ -168,6 +169,7 @@ export const createServerDraft = async (
   sourceDraft?: DraftEvent,
 ): Promise<DraftEvent> => {
   const userId = await requireUserId();
+  await assertBrandCanAuthorOfferings(brandId);
   const now = new Date().toISOString();
   const effectiveCurrency =
     nullableCurrency(sourceDraft?.currency) ?? (await fetchBrandDefaultCurrency(brandId));

--- a/mingla-business/src/services/tripsService.ts
+++ b/mingla-business/src/services/tripsService.ts
@@ -16,6 +16,7 @@
  */
 
 import { supabase } from "./supabase";
+import { assertBrandCanAuthorOfferings } from "./brandAuthoringGate";
 import type { BrandRole } from "../store/currentBrandStore";
 
 // ---------------------- Types ----------------------
@@ -399,6 +400,8 @@ export async function createTripDraft(
   input: CreateTripDraftInput,
   _role: BrandRole,
 ): Promise<Trip> {
+  await assertBrandCanAuthorOfferings(input.brandId);
+
   const tempTitle = input.initialTitle?.trim() || "Untitled trip";
   const tempSlug = `draft-${Date.now().toString(36)}`;
 

--- a/mingla-business/src/services/venueSearchService.ts
+++ b/mingla-business/src/services/venueSearchService.ts
@@ -7,19 +7,16 @@ import { supabase } from "./supabase";
 
 /**
  * Returns true when at least one active place_pool row matches the name (ILIKE contains).
+ * Uses `biz_place_pool_name_contains` so `%`, `_`, and `\` in user input are literal.
  */
 export async function placePoolHasNameMatch(name: string): Promise<boolean> {
   const q = name.trim();
   if (q.length < 2) return false;
 
-  const pattern = `%${q}%`;
-  const { data, error } = await supabase
-    .from("place_pool")
-    .select("id")
-    .ilike("name", pattern)
-    .eq("is_active", true)
-    .limit(1);
+  const { data, error } = await supabase.rpc("biz_place_pool_name_contains", {
+    p_query: q,
+  });
 
   if (error !== null) throw error;
-  return (data?.length ?? 0) > 0;
+  return data === true;
 }

--- a/mingla-business/src/services/venueSearchService.ts
+++ b/mingla-business/src/services/venueSearchService.ts
@@ -1,0 +1,25 @@
+/**
+ * Ve1 — detect whether a typed venue name likely exists in consumer place_pool.
+ * Ve2 will own fuzzy match / claim UX; Ve1 only needs a coarse gate for the fork.
+ */
+
+import { supabase } from "./supabase";
+
+/**
+ * Returns true when at least one active place_pool row matches the name (ILIKE contains).
+ */
+export async function placePoolHasNameMatch(name: string): Promise<boolean> {
+  const q = name.trim();
+  if (q.length < 2) return false;
+
+  const pattern = `%${q}%`;
+  const { data, error } = await supabase
+    .from("place_pool")
+    .select("id")
+    .ilike("name", pattern)
+    .eq("is_active", true)
+    .limit(1);
+
+  if (error !== null) throw error;
+  return (data?.length ?? 0) > 0;
+}

--- a/mingla-business/src/store/currentBrandStore.ts
+++ b/mingla-business/src/store/currentBrandStore.ts
@@ -96,6 +96,9 @@ export type {
   BrandContact,
   BrandCustomLink,
   BrandLinks,
+  BrandClaimStatus,
+  VenueCategory,
+  BrandHourEntry,
 } from "../types/brand";
 
 import type { Brand } from "../types/brand";

--- a/mingla-business/src/store/draftVenueStore.ts
+++ b/mingla-business/src/store/draftVenueStore.ts
@@ -1,0 +1,65 @@
+/**
+ * Ve1 — Zustand draft for venue onboarding wizard + pre-wizard gates.
+ */
+
+import { create } from "zustand";
+
+import type { BrandHourEntry, VenueCategory } from "../types/brand";
+import { defaultBrandHoursWeek } from "../utils/venueBrandHours";
+
+export interface DraftVenueState {
+  /** Business / venue name typed at the place_pool gate */
+  workingName: string;
+  venueCategory: VenueCategory | null;
+  displayName: string;
+  slug: string;
+  formattedAddress: string;
+  googlePlaceId: string | null;
+  lat: number | null;
+  lng: number | null;
+  city: string | null;
+  countryCode: string | null;
+  photoUris: string[];
+  hours: BrandHourEntry[];
+  contactEmail: string;
+  contactPhone: string;
+  tagline: string;
+  description: string;
+}
+
+const initial: DraftVenueState = {
+  workingName: "",
+  venueCategory: null,
+  displayName: "",
+  slug: "",
+  formattedAddress: "",
+  googlePlaceId: null,
+  lat: null,
+  lng: null,
+  city: null,
+  countryCode: null,
+  photoUris: [],
+  hours: defaultBrandHoursWeek(),
+  contactEmail: "",
+  contactPhone: "",
+  tagline: "",
+  description: "",
+};
+
+interface DraftVenueStore extends DraftVenueState {
+  reset: () => void;
+  patch: (p: Partial<DraftVenueState>) => void;
+  setHoursRow: (weekday: number, part: Partial<BrandHourEntry>) => void;
+}
+
+export const useDraftVenueStore = create<DraftVenueStore>((set) => ({
+  ...initial,
+  reset: () => set({ ...initial, hours: defaultBrandHoursWeek() }),
+  patch: (p) => set(p),
+  setHoursRow: (weekday, part) =>
+    set((s) => ({
+      hours: s.hours.map((h) =>
+        h.weekday === weekday ? { ...h, ...part } : h,
+      ),
+    })),
+}));

--- a/mingla-business/src/types/brand.ts
+++ b/mingla-business/src/types/brand.ts
@@ -298,4 +298,38 @@ export type Brand = {
    * Existing profile_photo_url defaults to image semantics when this is undefined.
    */
   profilePhotoType?: "image" | "video" | "gif";
+  /**
+   * Ve1 — venue claim lifecycle for physical brands. Popup/trip_planner
+   * typically stay `"none"`. Pending venues cannot publish public profile
+   * or create events/trips until verified.
+   */
+  claimStatus?: BrandClaimStatus;
+  /** Ve1 — Google Place ID when captured during venue onboarding. */
+  googlePlaceId?: string;
+  lat?: number;
+  lng?: number;
+  city?: string;
+  countryCode?: string;
+  /** Ve1 — Restaurant / Play / Creative & Arts from venue onboarding. */
+  venueCategory?: VenueCategory;
+  /** Ve1+ — linked place_pool row after Ve2 match. */
+  placePoolId?: string;
 };
+
+/** Ve1 — `brands.claim_status` + optional UI-only states. */
+export type BrandClaimStatus =
+  | "none"
+  | "pending_review"
+  | "verified"
+  | "rejected";
+
+export type VenueCategory = "restaurant" | "play" | "creative_and_arts";
+
+/** Ve1 — one row in `brand_hours` (weekday 0 = Monday … 6 = Sunday). */
+export interface BrandHourEntry {
+  weekday: number;
+  /** "HH:MM" or "HH:MM:SS"; null when closed. */
+  openTime: string | null;
+  closeTime: string | null;
+  isClosed: boolean;
+}

--- a/mingla-business/src/utils/__tests__/parseGooglePlaceResult.test.ts
+++ b/mingla-business/src/utils/__tests__/parseGooglePlaceResult.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "@jest/globals";
+import type { PlaceDetails } from "../../services/googlePlacesService";
+import { parseGooglePlaceResult } from "../parseGooglePlaceResult";
+
+describe("parseGooglePlaceResult (Ve1)", () => {
+  test("maps PlaceDetails to persistence shape", () => {
+    const details: PlaceDetails = {
+      placeId: "ChIJxxx",
+      formattedAddress: "1 Test St, London",
+      city: "London",
+      region: null,
+      countryCode: "GB",
+      location: { lat: 51.5, lng: -0.12 },
+    };
+    expect(parseGooglePlaceResult(details)).toEqual({
+      googlePlaceId: "ChIJxxx",
+      formattedAddress: "1 Test St, London",
+      city: "London",
+      countryCode: "GB",
+      lat: 51.5,
+      lng: -0.12,
+    });
+  });
+});

--- a/mingla-business/src/utils/brandSlugify.ts
+++ b/mingla-business/src/utils/brandSlugify.ts
@@ -1,0 +1,10 @@
+/**
+ * Ve1 — slug for brand URLs (matches BrandSwitcherSheet / TripBrandWizard).
+ */
+export function slugifyBrandSlug(value: string): string {
+  const base = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "")
+    .slice(0, 32);
+  return base.length > 0 ? base : `brand${Date.now().toString(36)}`;
+}

--- a/mingla-business/src/utils/parseGooglePlaceResult.ts
+++ b/mingla-business/src/utils/parseGooglePlaceResult.ts
@@ -1,0 +1,30 @@
+/**
+ * Ve1 — normalizes Google Places details for venue onboarding + unit tests.
+ *
+ * Prefer `PlaceDetails` from `googlePlacesService` (edge proxy shape); this
+ * helper keeps field names stable for persistence layers.
+ */
+
+import type { PlaceDetails } from "../services/googlePlacesService";
+
+export interface ParsedVenuePlace {
+  googlePlaceId: string;
+  formattedAddress: string;
+  city: string | null;
+  countryCode: string | null;
+  lat: number;
+  lng: number;
+}
+
+export function parseGooglePlaceResult(
+  details: PlaceDetails,
+): ParsedVenuePlace {
+  return {
+    googlePlaceId: details.placeId,
+    formattedAddress: details.formattedAddress,
+    city: details.city,
+    countryCode: details.countryCode,
+    lat: details.location.lat,
+    lng: details.location.lng,
+  };
+}

--- a/mingla-business/src/utils/venueBrandHours.ts
+++ b/mingla-business/src/utils/venueBrandHours.ts
@@ -1,0 +1,32 @@
+/**
+ * Ve1 — helpers for `brand_hours` rows (weekday 0 = Monday … 6 = Sunday).
+ */
+
+import type { BrandHourEntry } from "../types/brand";
+
+/** Default Mon–Sat 9am–5pm, Sun closed (product can tune copy in wizard). */
+export function defaultBrandHoursWeek(): BrandHourEntry[] {
+  const rows: BrandHourEntry[] = [];
+  for (let w = 0; w <= 5; w++) {
+    rows.push({
+      weekday: w,
+      openTime: "09:00",
+      closeTime: "17:00",
+      isClosed: false,
+    });
+  }
+  rows.push({ weekday: 6, openTime: null, closeTime: null, isClosed: true });
+  return rows;
+}
+
+/** Build JSON array for `biz_create_venue_brand_pending_review` `p_hours`. */
+export function brandHoursToRpcPayload(
+  entries: BrandHourEntry[],
+): Array<Record<string, unknown>> {
+  return entries.map((e) => ({
+    weekday: e.weekday,
+    open_time: e.openTime ?? "",
+    close_time: e.closeTime ?? "",
+    is_closed: e.isClosed,
+  }));
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -31,6 +31,10 @@ verify_jwt = false
 [functions.places-autocomplete]
 verify_jwt = true
 
+# Ve1 — venue operator confirmation after biz_create_venue_brand_pending_review.
+[functions.venue-claim-submitted-email]
+verify_jwt = true
+
 # ORCH-0770: Cloudinary is a third-party webhook sender and cannot provide
 # Supabase user JWTs. The gateway is public; the function authenticates
 # requests with Cloudinary's signed notification headers.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -35,6 +35,9 @@ verify_jwt = true
 [functions.venue-claim-submitted-email]
 verify_jwt = true
 
+[functions.venue-claim-decision-email]
+verify_jwt = true
+
 # ORCH-0770: Cloudinary is a third-party webhook sender and cannot provide
 # Supabase user JWTs. The gateway is public; the function authenticates
 # requests with Cloudinary's signed notification headers.

--- a/supabase/functions/venue-claim-decision-email/index.ts
+++ b/supabase/functions/venue-claim-decision-email/index.ts
@@ -1,8 +1,8 @@
 /**
- * Ve1 — transactional email when a venue brand is submitted (pending_review).
- * Invoked from mingla-business `createVenueBrandPendingReview` after RPC success.
+ * Ve1 — notify venue operator when an admin approves or rejects a claim.
+ * Invoked from mingla-admin ClaimsPage after `biz_review_venue_claim`.
  *
- * Auth: caller JWT must own the brand (account_id = auth.uid()).
+ * Auth: caller must pass `is_admin_user()` (admin JWT).
  */
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
@@ -43,11 +43,24 @@ serve(async (req) => {
 
     const body = await req.json().catch(() => null) as {
       brand_id?: string;
+      decision?: string;
+      rejection_reason?: string;
     } | null;
+
     const brandId =
       typeof body?.brand_id === "string" ? body.brand_id.trim() : "";
+    const decision =
+      typeof body?.decision === "string" ? body.decision.trim() : "";
+    const rejectionReason =
+      typeof body?.rejection_reason === "string"
+        ? body.rejection_reason.trim()
+        : "";
+
     if (brandId.length === 0) {
       return json({ error: "brand_id required" }, 400);
+    }
+    if (decision !== "approved" && decision !== "rejected") {
+      return json({ error: "decision must be approved or rejected" }, 400);
     }
 
     const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
@@ -55,6 +68,12 @@ serve(async (req) => {
     });
     const { data: { user }, error: userErr } = await userClient.auth.getUser();
     if (userErr || !user) return json({ error: "Unauthorized" }, 401);
+
+    const { data: isAdmin, error: adminErr } = await userClient.rpc(
+      "is_admin_user",
+    );
+    if (adminErr) return json({ error: adminErr.message }, 500);
+    if (isAdmin !== true) return json({ error: "Forbidden" }, 403);
 
     const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
     const { data: brandRow, error: brandErr } = await admin
@@ -65,27 +84,34 @@ serve(async (req) => {
 
     if (brandErr) return json({ error: brandErr.message }, 500);
     if (!brandRow) return json({ error: "Brand not found" }, 404);
-    if (brandRow.account_id !== user.id) {
-      return json({ error: "Forbidden" }, 403);
+
+    const expectedStatus = decision === "approved" ? "verified" : "rejected";
+    if (brandRow.claim_status !== expectedStatus) {
+      return json({ error: "Brand claim status mismatch" }, 400);
     }
-    if (brandRow.claim_status !== "pending_review") {
-      return json({ error: "Not a pending venue submission" }, 400);
+
+    const { data: ownerAuth, error: ownerErr } = await admin.auth.admin
+      .getUserById(brandRow.account_id as string);
+    if (ownerErr) {
+      return json({ error: ownerErr.message }, 500);
     }
 
     const to =
-      (typeof user.email === "string" && user.email.length > 0
-        ? user.email
+      (typeof ownerAuth.user?.email === "string" &&
+          ownerAuth.user.email.length > 0
+        ? ownerAuth.user.email
         : null) ??
       (typeof brandRow.contact_email === "string" &&
           brandRow.contact_email.length > 0
         ? brandRow.contact_email
         : null);
+
     if (!to) {
       return json({ skipped: true, reason: "no_recipient_email" }, 200);
     }
 
     if (!RESEND_API_KEY) {
-      console.warn("[venue-claim-submitted-email] RESEND_API_KEY missing");
+      console.warn("[venue-claim-decision-email] RESEND_API_KEY missing");
       return json({ skipped: true, reason: "resend_not_configured" }, 200);
     }
 
@@ -108,12 +134,23 @@ serve(async (req) => {
       );
     }
 
-    const title = "Venue submitted — we’re reviewing it";
-    const paragraphs = [
-      `Thanks for submitting ${brandRow.name as string}.`,
-      "Your venue is under review. We typically respond within 4 business hours.",
-      "We’ll email you when it’s approved or if we need more information.",
-    ];
+    const brandName = brandRow.name as string;
+    const approved = decision === "approved";
+    const title = approved
+      ? "Your venue is live on Mingla"
+      : "Update on your venue submission";
+    const paragraphs = approved
+      ? [
+        `Good news — ${brandName} has been approved.`,
+        "Your venue profile is now visible to guests. Sign in to Mingla Business to manage events and your profile.",
+      ]
+      : [
+        `We couldn't approve ${brandName} at this time.`,
+        rejectionReason.length > 0
+          ? `Reason: ${rejectionReason}`
+          : "Our team will follow up if we need more information.",
+        "You can submit a new claim with updated details when you're ready.",
+      ];
 
     const rendered = renderTransactionalEmail({
       variant: "generic_notification",
@@ -148,7 +185,7 @@ serve(async (req) => {
 
     return json({ ok: true }, 200);
   } catch (e) {
-    console.error("[venue-claim-submitted-email]", e);
+    console.error("[venue-claim-decision-email]", e);
     return json(
       { error: e instanceof Error ? e.message : String(e) },
       500,

--- a/supabase/functions/venue-claim-decision-email/index.ts
+++ b/supabase/functions/venue-claim-decision-email/index.ts
@@ -163,6 +163,7 @@ serve(async (req) => {
       },
     });
 
+    // no-attachment: Ve1 approve/reject operator notice has no PDF or file payload.
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {

--- a/supabase/functions/venue-claim-submitted-email/index.ts
+++ b/supabase/functions/venue-claim-submitted-email/index.ts
@@ -126,6 +126,7 @@ serve(async (req) => {
       },
     });
 
+    // no-attachment: Ve1 venue submission confirmation is plain transactional HTML only.
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {

--- a/supabase/functions/venue-claim-submitted-email/index.ts
+++ b/supabase/functions/venue-claim-submitted-email/index.ts
@@ -1,0 +1,156 @@
+/**
+ * Ve1 — transactional email when a venue brand is submitted (pending_review).
+ * Invoked from mingla-business `createVenueBrandPendingReview` after RPC success.
+ *
+ * Auth: caller JWT must own the brand (account_id = auth.uid()).
+ */
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  assertNotResendSandbox,
+  EMAIL_SENDERS,
+  formatSenderHeader,
+  renderTransactionalEmail,
+} from "../_shared/email/index.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? "";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader) return json({ error: "No authorization header" }, 401);
+
+    const body = await req.json().catch(() => null) as {
+      brand_id?: string;
+    } | null;
+    const brandId =
+      typeof body?.brand_id === "string" ? body.brand_id.trim() : "";
+    if (brandId.length === 0) {
+      return json({ error: "brand_id required" }, 400);
+    }
+
+    const userClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const { data: { user }, error: userErr } = await userClient.auth.getUser();
+    if (userErr || !user) return json({ error: "Unauthorized" }, 401);
+
+    const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const { data: brandRow, error: brandErr } = await admin
+      .from("brands")
+      .select("id, name, account_id, claim_status, contact_email")
+      .eq("id", brandId)
+      .maybeSingle();
+
+    if (brandErr) return json({ error: brandErr.message }, 500);
+    if (!brandRow) return json({ error: "Brand not found" }, 404);
+    if (brandRow.account_id !== user.id) {
+      return json({ error: "Forbidden" }, 403);
+    }
+    if (brandRow.claim_status !== "pending_review") {
+      return json({ error: "Not a pending venue submission" }, 400);
+    }
+
+    const to =
+      (typeof user.email === "string" && user.email.length > 0
+        ? user.email
+        : null) ??
+      (typeof brandRow.contact_email === "string" &&
+          brandRow.contact_email.length > 0
+        ? brandRow.contact_email
+        : null);
+    if (!to) {
+      return json({ skipped: true, reason: "no_recipient_email" }, 200);
+    }
+
+    if (!RESEND_API_KEY) {
+      console.warn("[venue-claim-submitted-email] RESEND_API_KEY missing");
+      return json({ skipped: true, reason: "resend_not_configured" }, 200);
+    }
+
+    let sender = EMAIL_SENDERS.system;
+    const legacyOverride = Deno.env.get("RESEND_FROM_EMAIL");
+    if (legacyOverride && legacyOverride.trim().length > 0) {
+      const m = legacyOverride.trim().match(
+        /^(?:(.+?)\s*<)?([^<>\s]+@[^<>\s]+)>?$/,
+      );
+      if (m) {
+        sender = { name: (m[1] ?? "Mingla").trim(), address: m[2] };
+      }
+    }
+    try {
+      assertNotResendSandbox(sender);
+    } catch (e) {
+      return json(
+        { error: e instanceof Error ? e.message : String(e) },
+        500,
+      );
+    }
+
+    const title = "Venue submitted — we’re reviewing it";
+    const paragraphs = [
+      `Thanks for submitting ${brandRow.name as string}.`,
+      "Your venue is under review. We typically respond within 4 business hours.",
+      "We’ll email you when it’s approved or if we need more information.",
+    ];
+
+    const rendered = renderTransactionalEmail({
+      variant: "generic_notification",
+      recipient: { name: null, email: to },
+      body: {
+        variant: "generic_notification",
+        title,
+        paragraphs,
+        cta: null,
+      },
+    });
+
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: formatSenderHeader(rendered.from),
+        to: [to],
+        subject: rendered.subject,
+        html: rendered.html,
+        text: rendered.text,
+      }),
+    });
+
+    if (!res.ok) {
+      const t = await res.text();
+      return json({ error: `Resend ${res.status}: ${t}` }, 502);
+    }
+
+    return json({ ok: true }, 200);
+  } catch (e) {
+    console.error("[venue-claim-submitted-email]", e);
+    return json(
+      { error: e instanceof Error ? e.message : String(e) },
+      500,
+    );
+  }
+});

--- a/supabase/migrations/20260613000000_ve1_physical_venue_brand_onboarding.sql
+++ b/supabase/migrations/20260613000000_ve1_physical_venue_brand_onboarding.sql
@@ -1,0 +1,333 @@
+-- Ve1 Physical Venue Brand Onboarding (GitHub issue #99)
+-- Schema: venue claim columns on brands, brand_hours sidecar, public brand
+-- visibility for physical brands, admin read policies, atomic create RPC.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- brands: venue / claim columns
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.brands
+  ADD COLUMN IF NOT EXISTS place_pool_id uuid REFERENCES public.place_pool (id),
+  ADD COLUMN IF NOT EXISTS google_place_id text,
+  ADD COLUMN IF NOT EXISTS lat double precision,
+  ADD COLUMN IF NOT EXISTS lng double precision,
+  ADD COLUMN IF NOT EXISTS city text,
+  ADD COLUMN IF NOT EXISTS country_code text,
+  ADD COLUMN IF NOT EXISTS claim_status text NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS verified_at timestamptz,
+  ADD COLUMN IF NOT EXISTS verified_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS venue_category text;
+
+ALTER TABLE public.brands
+  DROP CONSTRAINT IF EXISTS brands_claim_status_check;
+ALTER TABLE public.brands
+  ADD CONSTRAINT brands_claim_status_check
+  CHECK (claim_status IN ('none', 'pending_review', 'verified', 'rejected'));
+
+ALTER TABLE public.brands
+  DROP CONSTRAINT IF EXISTS brands_venue_category_check;
+ALTER TABLE public.brands
+  ADD CONSTRAINT brands_venue_category_check
+  CHECK (
+    venue_category IS NULL
+    OR venue_category IN ('restaurant', 'play', 'creative_and_arts')
+  );
+
+COMMENT ON COLUMN public.brands.place_pool_id IS
+  'Ve1+ — optional FK to place_pool when matched; Ve2 owns pool-match linkage.';
+COMMENT ON COLUMN public.brands.google_place_id IS
+  'Ve1 — Google Place ID for dedup; partial unique index when non-null and active.';
+COMMENT ON COLUMN public.brands.claim_status IS
+  'Ve1 — none (popup/trip default), pending_review (venue submitted), verified (public), rejected.';
+COMMENT ON COLUMN public.brands.venue_category IS
+  'Ve1 — Restaurant / Play / Creative &Arts from operator onboarding pills.';
+
+-- Grandfather existing physical brands so public pages stay visible (all were organizer-created pre-Ve1).
+UPDATE public.brands
+SET
+  claim_status = 'verified',
+  verified_at = COALESCE(verified_at, now())
+WHERE kind = 'physical'
+  AND deleted_at IS NULL
+  AND claim_status = 'none';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_brands_google_place_id_active_unique
+  ON public.brands (google_place_id)
+  WHERE deleted_at IS NULL AND google_place_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- brand_hours
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.brand_hours (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  brand_id uuid NOT NULL REFERENCES public.brands (id) ON DELETE CASCADE,
+  weekday smallint NOT NULL CHECK (weekday >= 0 AND weekday <= 6),
+  open_time time,
+  close_time time,
+  is_closed boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT brand_hours_brand_weekday_uniq UNIQUE (brand_id, weekday)
+);
+
+CREATE INDEX IF NOT EXISTS idx_brand_hours_brand_id ON public.brand_hours (brand_id);
+
+ALTER TABLE public.brand_hours ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.brand_hours IS
+  'Ve1 — weekly hours for physical venue brands (7 rows per brand, weekday 0=Mon … per app convention 0-6).';
+
+-- RLS: same privilege model as brand-scoped child tables (team read; admin-plus write).
+CREATE POLICY "Brand members can select brand_hours"
+  ON public.brand_hours
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.brands b
+      WHERE b.id = brand_hours.brand_id
+        AND b.deleted_at IS NULL
+        AND public.biz_is_brand_member_for_read_for_caller (b.id)
+    )
+  );
+
+CREATE POLICY "Brand admin plus can insert brand_hours"
+  ON public.brand_hours
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.biz_is_brand_admin_plus_for_caller (brand_id));
+
+CREATE POLICY "Brand admin plus can update brand_hours"
+  ON public.brand_hours
+  FOR UPDATE
+  TO authenticated
+  USING (public.biz_is_brand_admin_plus_for_caller (brand_id))
+  WITH CHECK (public.biz_is_brand_admin_plus_for_caller (brand_id));
+
+CREATE POLICY "Brand admin plus can delete brand_hours"
+  ON public.brand_hours
+  FOR DELETE
+  TO authenticated
+  USING (public.biz_is_brand_admin_plus_for_caller (brand_id));
+
+-- Internal admin dashboard (is_admin_user) — claims queue + review.
+CREATE POLICY "Admins can read brands for operations"
+  ON public.brands
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin_user ());
+
+CREATE POLICY "Admins can read brand_hours for operations"
+  ON public.brand_hours
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin_user ());
+
+CREATE POLICY "Admins can update brands for claim review"
+  ON public.brands
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_admin_user ())
+  WITH CHECK (public.is_admin_user ());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.brand_hours TO authenticated;
+GRANT ALL ON public.brand_hours TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Public brand profile: hide unverified physical venues
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW public.business_public_brands_view AS
+SELECT
+  b.id,
+  b.slug,
+  b.name,
+  b.description,
+  b.profile_photo_url,
+  b.social_links,
+  b.custom_links,
+  b.display_attendee_count,
+  b.kind,
+  b.address,
+  b.cover_hue,
+  b.cover_media_url,
+  b.cover_media_type,
+  b.profile_photo_type,
+  b.created_at,
+  b.updated_at
+FROM public.brands b
+WHERE b.deleted_at IS NULL
+  AND (
+    b.kind IN ('popup', 'trip_planner')
+    OR (b.kind = 'physical' AND b.claim_status = 'verified')
+  );
+
+GRANT SELECT ON public.business_public_brands_view TO anon, authenticated, service_role;
+
+COMMENT ON VIEW public.business_public_brands_view IS
+  'ORCH-0767 + Ve1: public brand read model; physical brands only when claim_status=verified.';
+
+-- ---------------------------------------------------------------------------
+-- Atomic create: brand + 7 hour rows (SECURITY DEFINER; caller must own account).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_create_venue_brand_pending_review (
+  p_name text,
+  p_slug text,
+  p_description text,
+  p_google_place_id text,
+  p_lat double precision,
+  p_lng double precision,
+  p_city text,
+  p_country_code text,
+  p_address text,
+  p_venue_category text,
+  p_contact_email text,
+  p_contact_phone text,
+  p_cover_media_url text,
+  p_cover_media_type text,
+  p_hours jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_uid uuid;
+  v_brand_id uuid;
+  v_idx int;
+  v_hour jsonb;
+BEGIN
+  v_uid := auth.uid ();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF p_google_place_id IS NULL OR length(trim(p_google_place_id)) = 0 THEN
+    RAISE EXCEPTION 'google_place_id_required';
+  END IF;
+
+  IF p_hours IS NULL OR jsonb_typeof(p_hours) != 'array' OR jsonb_array_length(p_hours) != 7 THEN
+    RAISE EXCEPTION 'hours_must_have_7_rows';
+  END IF;
+
+  IF p_venue_category IS NULL OR p_venue_category NOT IN ('restaurant', 'play', 'creative_and_arts') THEN
+    RAISE EXCEPTION 'invalid_venue_category';
+  END IF;
+
+  INSERT INTO public.brands (
+    account_id,
+    name,
+    slug,
+    description,
+    kind,
+    address,
+    google_place_id,
+    lat,
+    lng,
+    city,
+    country_code,
+    claim_status,
+    venue_category,
+    contact_email,
+    contact_phone,
+    cover_media_url,
+    cover_media_type,
+    cover_hue,
+    tax_settings,
+    social_links,
+    custom_links,
+    display_attendee_count,
+    stripe_connect_id,
+    stripe_payouts_enabled,
+    stripe_charges_enabled
+  )
+  VALUES (
+    v_uid,
+    trim(p_name),
+    trim(p_slug),
+    p_description,
+    'physical',
+    nullif(trim(p_address), ''),
+    trim(p_google_place_id),
+    p_lat,
+    p_lng,
+    nullif(trim(p_city), ''),
+    nullif(trim(p_country_code), ''),
+    'pending_review',
+    p_venue_category,
+    nullif(trim(p_contact_email), ''),
+    nullif(trim(p_contact_phone), ''),
+    nullif(trim(p_cover_media_url), ''),
+    CASE
+      WHEN p_cover_media_type IS NULL THEN NULL
+      WHEN p_cover_media_type IN ('image', 'video', 'gif') THEN p_cover_media_type
+      ELSE NULL
+    END,
+    25,
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    true,
+    NULL,
+    false,
+    false
+  )
+  RETURNING id INTO v_brand_id;
+
+  FOR v_idx IN 0 .. 6 LOOP
+    v_hour := p_hours -> v_idx;
+    IF v_hour IS NULL THEN
+      RAISE EXCEPTION 'missing_hour_index_%', v_idx;
+    END IF;
+
+    INSERT INTO public.brand_hours (
+      brand_id,
+      weekday,
+      open_time,
+      close_time,
+      is_closed
+    )
+    VALUES (
+      v_brand_id,
+      (v_hour ->> 'weekday')::smallint,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'open_time' IS NULL OR (v_hour ->> 'open_time') = '' THEN NULL
+        ELSE (v_hour ->> 'open_time')::time
+      END,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'close_time' IS NULL OR (v_hour ->> 'close_time') = '' THEN NULL
+        ELSE (v_hour ->> 'close_time')::time
+      END,
+      coalesce((v_hour ->> 'is_closed')::boolean, false)
+    );
+  END LOOP;
+
+  RETURN v_brand_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_create_venue_brand_pending_review (
+  text,
+  text,
+  text,
+  text,
+  double precision,
+  double precision,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb
+) TO authenticated;
+
+COMMENT ON FUNCTION public.biz_create_venue_brand_pending_review IS
+  'Ve1 — inserts physical brand (claim_status=pending_review) + 7 brand_hours rows in one transaction.';
+
+COMMIT;

--- a/supabase/migrations/20260613000000_ve1_physical_venue_brand_onboarding.sql
+++ b/supabase/migrations/20260613000000_ve1_physical_venue_brand_onboarding.sql
@@ -93,6 +93,22 @@ CREATE POLICY "Brand members can select brand_hours"
     )
   );
 
+-- I-PROPOSED-H (ORCH-0734): direct-predicate owner SELECT so INSERT/UPDATE/DELETE
+-- ... RETURNING admits post-mutation rows without biz_*_for_caller snapshot quirks.
+CREATE POLICY "Brand owners can select own brand_hours"
+  ON public.brand_hours
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.brands b
+      WHERE b.id = brand_hours.brand_id
+        AND b.account_id = auth.uid()
+        AND b.deleted_at IS NULL
+    )
+  );
+
 CREATE POLICY "Brand admin plus can insert brand_hours"
   ON public.brand_hours
   FOR INSERT

--- a/supabase/migrations/20260614000000_ve1_pr_review_hardening.sql
+++ b/supabase/migrations/20260614000000_ve1_pr_review_hardening.sql
@@ -1,0 +1,335 @@
+-- Ve1 PR review hardening (Copilot #135): RPC validation, atomic hours upsert,
+-- admin review RPC, google_place_id index scope, place_pool FK ON DELETE SET NULL.
+
+BEGIN;
+
+-- place_pool_id: allow pool row deletion without blocking brands (Ve2 linkage).
+ALTER TABLE public.brands
+  DROP CONSTRAINT IF EXISTS brands_place_pool_id_fkey;
+
+ALTER TABLE public.brands
+  ADD CONSTRAINT brands_place_pool_id_fkey
+  FOREIGN KEY (place_pool_id) REFERENCES public.place_pool (id) ON DELETE SET NULL;
+
+-- Rejected claims must not block re-submission for the same Google place.
+DROP INDEX IF EXISTS idx_brands_google_place_id_active_unique;
+
+CREATE UNIQUE INDEX idx_brands_google_place_id_claim_active_unique
+  ON public.brands (google_place_id)
+  WHERE
+    deleted_at IS NULL
+    AND google_place_id IS NOT NULL
+    AND claim_status IN ('pending_review', 'verified');
+
+-- ---------------------------------------------------------------------------
+-- Atomic replace brand_hours (avoids client delete+insert partial failure).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_upsert_brand_hours (
+  p_brand_id uuid,
+  p_hours jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_idx int;
+  v_hour jsonb;
+BEGIN
+  IF auth.uid () IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.biz_is_brand_admin_plus_for_caller (p_brand_id) THEN
+    RAISE EXCEPTION 'forbidden';
+  END IF;
+
+  IF p_hours IS NULL OR jsonb_typeof(p_hours) != 'array' OR jsonb_array_length(p_hours) != 7 THEN
+    RAISE EXCEPTION 'hours_must_have_7_rows';
+  END IF;
+
+  DELETE FROM public.brand_hours
+  WHERE brand_id = p_brand_id;
+
+  FOR v_idx IN 0 .. 6 LOOP
+    v_hour := p_hours -> v_idx;
+    IF v_hour IS NULL THEN
+      RAISE EXCEPTION 'missing_hour_index_%', v_idx;
+    END IF;
+
+    INSERT INTO public.brand_hours (
+      brand_id,
+      weekday,
+      open_time,
+      close_time,
+      is_closed
+    )
+    VALUES (
+      p_brand_id,
+      (v_hour ->> 'weekday')::smallint,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'open_time' IS NULL OR (v_hour ->> 'open_time') = '' THEN NULL
+        ELSE (v_hour ->> 'open_time')::time
+      END,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'close_time' IS NULL OR (v_hour ->> 'close_time') = '' THEN NULL
+        ELSE (v_hour ->> 'close_time')::time
+      END,
+      coalesce((v_hour ->> 'is_closed')::boolean, false)
+    );
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_upsert_brand_hours (uuid, jsonb) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Admin claim review: verified_by := auth.uid() server-side.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_review_venue_claim (
+  p_brand_id uuid,
+  p_action text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF auth.uid () IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.is_admin_user () THEN
+    RAISE EXCEPTION 'forbidden';
+  END IF;
+
+  IF p_action NOT IN ('approve', 'reject') THEN
+    RAISE EXCEPTION 'invalid_action';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.brands b
+    WHERE b.id = p_brand_id
+      AND b.deleted_at IS NULL
+      AND b.kind = 'physical'
+      AND b.claim_status = 'pending_review'
+  ) THEN
+    RAISE EXCEPTION 'brand_not_pending_review';
+  END IF;
+
+  IF p_action = 'approve' THEN
+    UPDATE public.brands
+    SET
+      claim_status = 'verified',
+      verified_at = now(),
+      verified_by = auth.uid()
+    WHERE id = p_brand_id;
+  ELSE
+    UPDATE public.brands
+    SET
+      claim_status = 'rejected',
+      verified_at = NULL,
+      verified_by = NULL
+    WHERE id = p_brand_id;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_review_venue_claim (uuid, text) TO authenticated;
+
+-- ILIKE-safe place_pool name gate (Ve1 fork).
+CREATE OR REPLACE FUNCTION public.escape_like_pattern (p text) RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT replace(replace(replace(p, '\', '\\'), '%', '\%'), '_', '\_');
+$$;
+
+CREATE OR REPLACE FUNCTION public.biz_place_pool_name_contains (p_query text) RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.place_pool p
+    WHERE p.is_active
+      AND length(trim(coalesce(p_query, ''))) >= 2
+      AND p.name ILIKE (
+        '%' || public.escape_like_pattern(trim(p_query)) || '%'
+      ) ESCAPE '\'
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_place_pool_name_contains (text) TO authenticated;
+
+-- Harden create RPC: name/slug validation + cover media type/url consistency.
+CREATE OR REPLACE FUNCTION public.biz_create_venue_brand_pending_review (
+  p_name text,
+  p_slug text,
+  p_description text,
+  p_google_place_id text,
+  p_lat double precision,
+  p_lng double precision,
+  p_city text,
+  p_country_code text,
+  p_address text,
+  p_venue_category text,
+  p_contact_email text,
+  p_contact_phone text,
+  p_cover_media_url text,
+  p_cover_media_type text,
+  p_hours jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_uid uuid;
+  v_brand_id uuid;
+  v_idx int;
+  v_hour jsonb;
+  v_cover_url text;
+  v_cover_type text;
+BEGIN
+  v_uid := auth.uid ();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF length(trim(coalesce(p_name, ''))) = 0 THEN
+    RAISE EXCEPTION 'name_required';
+  END IF;
+
+  IF length(trim(coalesce(p_slug, ''))) = 0 THEN
+    RAISE EXCEPTION 'slug_required';
+  END IF;
+
+  IF trim(p_slug) !~ '^[a-z0-9]{1,32}$' THEN
+    RAISE EXCEPTION 'invalid_slug';
+  END IF;
+
+  IF p_google_place_id IS NULL OR length(trim(p_google_place_id)) = 0 THEN
+    RAISE EXCEPTION 'google_place_id_required';
+  END IF;
+
+  IF p_hours IS NULL OR jsonb_typeof(p_hours) != 'array' OR jsonb_array_length(p_hours) != 7 THEN
+    RAISE EXCEPTION 'hours_must_have_7_rows';
+  END IF;
+
+  IF p_venue_category IS NULL OR p_venue_category NOT IN ('restaurant', 'play', 'creative_and_arts') THEN
+    RAISE EXCEPTION 'invalid_venue_category';
+  END IF;
+
+  v_cover_url := nullif(trim(coalesce(p_cover_media_url, '')), '');
+  v_cover_type := nullif(trim(coalesce(p_cover_media_type, '')), '');
+
+  IF v_cover_type IS NOT NULL AND v_cover_type NOT IN ('image', 'video', 'gif') THEN
+    RAISE EXCEPTION 'invalid_cover_media_type';
+  END IF;
+
+  IF v_cover_url IS NOT NULL AND v_cover_type IS NULL THEN
+    RAISE EXCEPTION 'cover_media_type_required';
+  END IF;
+
+  IF v_cover_url IS NULL THEN
+    v_cover_type := NULL;
+  END IF;
+
+  INSERT INTO public.brands (
+    account_id,
+    name,
+    slug,
+    description,
+    kind,
+    address,
+    google_place_id,
+    lat,
+    lng,
+    city,
+    country_code,
+    claim_status,
+    venue_category,
+    contact_email,
+    contact_phone,
+    cover_media_url,
+    cover_media_type,
+    cover_hue,
+    tax_settings,
+    social_links,
+    custom_links,
+    display_attendee_count,
+    stripe_connect_id,
+    stripe_payouts_enabled,
+    stripe_charges_enabled
+  )
+  VALUES (
+    v_uid,
+    trim(p_name),
+    trim(p_slug),
+    p_description,
+    'physical',
+    nullif(trim(p_address), ''),
+    trim(p_google_place_id),
+    p_lat,
+    p_lng,
+    nullif(trim(p_city), ''),
+    nullif(trim(p_country_code), ''),
+    'pending_review',
+    p_venue_category,
+    nullif(trim(p_contact_email), ''),
+    nullif(trim(p_contact_phone), ''),
+    v_cover_url,
+    v_cover_type,
+    25,
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    true,
+    NULL,
+    false,
+    false
+  )
+  RETURNING id INTO v_brand_id;
+
+  FOR v_idx IN 0 .. 6 LOOP
+    v_hour := p_hours -> v_idx;
+    IF v_hour IS NULL THEN
+      RAISE EXCEPTION 'missing_hour_index_%', v_idx;
+    END IF;
+
+    INSERT INTO public.brand_hours (
+      brand_id,
+      weekday,
+      open_time,
+      close_time,
+      is_closed
+    )
+    VALUES (
+      v_brand_id,
+      (v_hour ->> 'weekday')::smallint,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'open_time' IS NULL OR (v_hour ->> 'open_time') = '' THEN NULL
+        ELSE (v_hour ->> 'open_time')::time
+      END,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'close_time' IS NULL OR (v_hour ->> 'close_time') = '' THEN NULL
+        ELSE (v_hour ->> 'close_time')::time
+      END,
+      coalesce((v_hour ->> 'is_closed')::boolean, false)
+    );
+  END LOOP;
+
+  RETURN v_brand_id;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Adds Ve1 physical venue onboarding: place-pool name gate, category picker, 7-step venue wizard, and atomic `biz_create_venue_brand_pending_review` RPC (brand + `brand_hours`).
- Hides unverified physical brands from `business_public_brands_view`; blocks event/trip draft creation until `claim_status = verified`.
- Adds mingla-admin **Venue claims** queue (approve/reject, SLA countdown) and `venue-claim-submitted-email` edge function for operator confirmation.

## Test plan

- [ ] Apply migration `20260613000000_ve1_physical_venue_brand_onboarding.sql` on staging
- [ ] Deploy `venue-claim-submitted-email` (requires `RESEND_API_KEY`)
- [ ] Business app: Brand sheet → **A place** → complete wizard → success screen
- [ ] Admin: **Content → Venue claims** → open row → Approve
- [ ] Verify `/b/{slug}` 404 before approve, loads after approve
- [ ] Verify event create blocked on pending physical brand; works after approve
- [ ] `cd mingla-business && npx jest --config jest.config.cjs ve1VenueServices.test.ts parseGooglePlaceResult.test.ts ve1PublicBrandViewGuard.test.ts BrandSwitcherSheet.personaFork.test.ts`