### PR TITLE
feat(ve2): Pool match comparison flow (#100)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -306,6 +306,17 @@ function checkNoNewBackendFiles() {
     "supabase/migrations/20260613000000_ve1_physical_venue_brand_onboarding.sql",
     "supabase/migrations/20260614000000_ve1_pr_review_hardening.sql",
   ];
+  // ORCH-0100 [Ve2 Pool Match Comparison Flow] PR #142 (2026-05-19). C7 is
+  // scoped to ORCH-0863 marketing; these backend touches are Ve2 pool-match
+  // claim-search scope on the venue-claim track.
+  const ORCH_0100_VE2_BACKEND_ALLOWLIST = [
+    "supabase/functions/_shared/mapMinglaSlugToVenueCategory.ts",
+    "supabase/functions/_shared/poolMatchResponse.ts",
+    "supabase/functions/claim-search-pool/index.test.ts",
+    "supabase/functions/claim-search-pool/index.ts",
+    "supabase/migrations/20260618000000_ve2_pool_match_claim.sql",
+    "supabase/migrations/20260618000001_ve2_claim_search_rpc.sql",
+  ];
   // ORCH-0877 [Event end-time display + midnight-crossing single-day authoring]
   // PR #136 (2026-05-19). C7 is scoped to ORCH-0863 marketing; these backend
   // touches are end-time + cross-midnight + ICS Constitution #9 fix scope.
@@ -348,6 +359,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_0869_BACKEND_ALLOWLIST,
     ...ORCH_0875_BACKEND_ALLOWLIST,
     ...ORCH_0099_VE1_BACKEND_ALLOWLIST,
+    ...ORCH_0100_VE2_BACKEND_ALLOWLIST,
     ...ORCH_0877_BACKEND_ALLOWLIST,
     ...ORCH_0876_BACKEND_ALLOWLIST,
     ...ORCH_0879_BACKEND_ALLOWLIST,

--- a/mingla-business/app/venue/__tests__/create.ve2.test.ts
+++ b/mingla-business/app/venue/__tests__/create.ve2.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const ROUTE = join(__dirname, "..", "create.tsx");
+
+describe("venue/create Ve2 routing", () => {
+  test("skips reset when pool match param or placePoolId present", () => {
+    const src = readFileSync(ROUTE, "utf8");
+    expect(src).toContain('params.pool === "1"');
+    expect(src).toContain("placePoolId");
+    expect(src).toContain("PoolMatchCard");
+    expect(src).not.toContain("isn't available yet");
+  });
+});

--- a/mingla-business/app/venue/create.tsx
+++ b/mingla-business/app/venue/create.tsx
@@ -1,5 +1,5 @@
 /**
- * Ve1 — physical venue onboarding: place_pool gate → category → 7-step wizard.
+ * Ve1+Ve2 — physical venue onboarding: pool match → category (optional) → wizard.
  */
 
 import React, { useCallback, useEffect, useState } from "react";
@@ -7,11 +7,12 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   View,
 } from "react-native";
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import {
@@ -21,38 +22,72 @@ import {
   typography,
 } from "../../src/constants/designSystem";
 import { useAuth } from "../../src/context/AuthContext";
+import { PoolMatchCard } from "../../src/components/brand/PoolMatchCard";
 import { VenueCategoryPicker } from "../../src/components/brand/VenueCategoryPicker";
 import { VenueCreatorWizard } from "../../src/components/venue/VenueCreatorWizard";
 import { Button } from "../../src/components/ui/Button";
 import { Icon } from "../../src/components/ui/Icon";
 import { IconChrome } from "../../src/components/ui/IconChrome";
 import { Input } from "../../src/components/ui/Input";
-import { placePoolHasNameMatch } from "../../src/services/venueSearchService";
+import { usePoolMatchSearch } from "../../src/hooks/usePoolMatchSearch";
 import { useDraftVenueStore } from "../../src/store/draftVenueStore";
+import { prefillDraftFromPoolMatch } from "../../src/utils/prefillDraftFromPoolMatch";
 import { slugifyBrandSlug } from "../../src/utils/brandSlugify";
 import type { VenueCategory } from "../../src/types/brand";
 
 type Phase = "gate" | "category" | "wizard" | "success";
 
+function resolveInitialPhase(
+  fromPoolParam: boolean,
+): Phase {
+  const st = useDraftVenueStore.getState();
+  if (fromPoolParam || st.placePoolId !== null) {
+    return "wizard";
+  }
+  if (st.workingName.trim().length >= 2 && st.venueCategory !== null) {
+    return "wizard";
+  }
+  if (st.workingName.trim().length >= 2) {
+    return "category";
+  }
+  return "gate";
+}
+
 export default function VenueCreateRoute(): React.ReactElement {
   const router = useRouter();
+  const params = useLocalSearchParams<{ pool?: string }>();
+  const fromPoolParam = params.pool === "1";
   const insets = useSafeAreaInsets();
   const { user, isAuthReady } = useAuth();
   const reset = useDraftVenueStore((s) => s.reset);
   const patch = useDraftVenueStore((s) => s.patch);
   const workingName = useDraftVenueStore((s) => s.workingName);
+  const placePoolId = useDraftVenueStore((s) => s.placePoolId);
   const venueCategory = useDraftVenueStore((s) => s.venueCategory);
 
-  const [phase, setPhase] = useState<Phase>("gate");
-  const [checkingPool, setCheckingPool] = useState(false);
+  const [phase, setPhase] = useState<Phase>(() =>
+    resolveInitialPhase(fromPoolParam),
+  );
   const [poolNote, setPoolNote] = useState<string | null>(null);
   const [coverWarning, setCoverWarning] = useState<string | null>(null);
 
+  const {
+    match: poolMatch,
+    loading: poolSearchLoading,
+    error: poolSearchError,
+  } = usePoolMatchSearch(phase === "gate" ? workingName : "");
+
   useEffect(() => {
+    if (fromPoolParam || useDraftVenueStore.getState().placePoolId !== null) {
+      return;
+    }
+    if (useDraftVenueStore.getState().workingName.trim().length > 0) {
+      return;
+    }
     reset();
     setPhase("gate");
     setPoolNote(null);
-  }, [reset]);
+  }, [fromPoolParam, reset]);
 
   useEffect(() => {
     if (!isAuthReady) return;
@@ -65,33 +100,37 @@ export default function VenueCreateRoute(): React.ReactElement {
     router.back();
   }, [router]);
 
-  const handleGateContinue = useCallback(async (): Promise<void> => {
+  const goToCategory = useCallback((): void => {
     const n = workingName.trim();
     if (n.length < 2) {
       setPoolNote("Enter at least 2 characters.");
       return;
     }
     setPoolNote(null);
-    setCheckingPool(true);
-    try {
-      const hit = await placePoolHasNameMatch(n);
-      if (hit) {
-        setPoolNote(
-          "This name matches a place already in our directory. Venue matching isn’t available yet — try another name or create an event brand instead.",
-        );
-        return;
-      }
-      patch({
-        displayName: n,
-        slug: slugifyBrandSlug(n),
-      });
-      setPhase("category");
-    } catch {
-      setPoolNote("Could not verify the name. Check your connection and try again.");
-    } finally {
-      setCheckingPool(false);
-    }
+    patch({
+      displayName: n,
+      slug: slugifyBrandSlug(n),
+      placePoolId: null,
+    });
+    setPhase("category");
   }, [patch, workingName]);
+
+  const goToWizardFromPool = useCallback(
+    (match: NonNullable<typeof poolMatch>): void => {
+      patch(prefillDraftFromPoolMatch(match));
+      setPoolNote(null);
+      setPhase("wizard");
+    },
+    [patch],
+  );
+
+  const handleGateContinue = useCallback((): void => {
+    if (poolMatch !== null) {
+      setPoolNote("Tap Yes on the match card, or No to enter details manually.");
+      return;
+    }
+    goToCategory();
+  }, [goToCategory, poolMatch]);
 
   const handleCategoryContinue = useCallback((): void => {
     if (venueCategory === null) return;
@@ -151,55 +190,73 @@ export default function VenueCreateRoute(): React.ReactElement {
         <View style={{ width: 36 }} />
       </View>
 
-      {phase === "gate" ? (
-        <View style={styles.section}>
-          <Text style={styles.h1}>What’s your venue called?</Text>
-          <Text style={styles.sub}>
-            We’ll check our directory so we don’t duplicate listings.
-          </Text>
-          <Input
-            variant="text"
-            value={workingName}
-            onChangeText={(t) => patch({ workingName: t })}
-            placeholder="Venue name"
-            accessibilityLabel="Venue working name"
-          />
-          {poolNote !== null ? <Text style={styles.warn}>{poolNote}</Text> : null}
-          <Button
-            label={checkingPool ? "Checking…" : "Continue"}
-            variant="primary"
-            size="lg"
-            loading={checkingPool}
-            disabled={checkingPool}
-            onPress={() => void handleGateContinue()}
-          />
-        </View>
-      ) : (
-        <View style={styles.section}>
-          <Pressable
-            onPress={() => setPhase("gate")}
-            style={styles.backRow}
-            accessibilityRole="button"
-            accessibilityLabel="Back to venue name"
-          >
-            <Icon name="chevL" size={18} color={textTokens.tertiary} />
-            <Text style={styles.backText}>Back</Text>
-          </Pressable>
-          <Text style={styles.h1}>What kind of place is it?</Text>
-          <VenueCategoryPicker
-            value={venueCategory}
-            onChange={(v: VenueCategory) => patch({ venueCategory: v })}
-            testID="venue-category-picker"
-          />
-          <Button
-            label="Continue"
-            variant="primary"
-            size="lg"
-            disabled={venueCategory === null}
-            onPress={handleCategoryContinue}
-          />
-        </View>
-      )}
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.section}
+        keyboardShouldPersistTaps="handled"
+      >
+        {phase === "gate" ? (
+          <>
+            <Text style={styles.h1}>What’s your venue called?</Text>
+            <Text style={styles.sub}>
+              We’ll check our directory so we can prefill your listing when we know you.
+            </Text>
+            <Input
+              variant="text"
+              value={workingName}
+              onChangeText={(t) => patch({ workingName: t, placePoolId: null })}
+              placeholder="Venue name"
+              accessibilityLabel="Venue working name"
+            />
+            {poolSearchLoading ? (
+              <Text style={styles.hint}>Searching our directory…</Text>
+            ) : null}
+            {poolSearchError !== null ? (
+              <Text style={styles.warn}>{poolSearchError}</Text>
+            ) : null}
+            {poolMatch !== null && placePoolId === null ? (
+              <PoolMatchCard
+                match={poolMatch}
+                onYes={() => goToWizardFromPool(poolMatch)}
+                onNo={goToCategory}
+                onSkip={goToCategory}
+              />
+            ) : null}
+            {poolNote !== null ? <Text style={styles.warn}>{poolNote}</Text> : null}
+            <Button
+              label="Continue without a match"
+              variant="primary"
+              size="lg"
+              onPress={handleGateContinue}
+            />
+          </>
+        ) : (
+          <>
+            <Pressable
+              onPress={() => setPhase("gate")}
+              style={styles.backRow}
+              accessibilityRole="button"
+              accessibilityLabel="Back to venue name"
+            >
+              <Icon name="chevL" size={18} color={textTokens.tertiary} />
+              <Text style={styles.backText}>Back</Text>
+            </Pressable>
+            <Text style={styles.h1}>What kind of place is it?</Text>
+            <VenueCategoryPicker
+              value={venueCategory}
+              onChange={(v: VenueCategory) => patch({ venueCategory: v })}
+              testID="venue-category-picker"
+            />
+            <Button
+              label="Continue"
+              variant="primary"
+              size="lg"
+              disabled={venueCategory === null}
+              onPress={handleCategoryContinue}
+            />
+          </>
+        )}
+      </ScrollView>
     </KeyboardAvoidingView>
   );
 }
@@ -221,11 +278,15 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     color: textTokens.primary,
   },
-  section: {
+  scroll: {
     flex: 1,
+  },
+  section: {
+    flexGrow: 1,
     gap: spacing.md,
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
   },
   h1: {
     fontSize: typography.h3.fontSize,
@@ -235,6 +296,10 @@ const styles = StyleSheet.create({
   sub: {
     fontSize: typography.bodySm.fontSize,
     color: textTokens.secondary,
+  },
+  hint: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
   },
   warn: {
     fontSize: typography.caption.fontSize,

--- a/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
+++ b/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
@@ -49,7 +49,10 @@ import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { Input } from "../ui/Input";
 import { TopSheet } from "../ui/TopSheet";
+import { usePoolMatchSearch } from "../../hooks/usePoolMatchSearch";
+import { prefillDraftFromPoolMatch } from "../../utils/prefillDraftFromPoolMatch";
 import { PersonaPickerCards, type PersonaDef } from "./PersonaPickerCards";
+import { PoolMatchCard } from "./PoolMatchCard";
 import { TripBrandWizard } from "./TripBrandWizard";
 import { useDraftVenueStore } from "../../store/draftVenueStore";
 
@@ -95,18 +98,28 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
   const createBrandMutation = useCreateBrand();
   const updateCreatorAccountMutation = useUpdateCreatorAccount();
   const resetVenueDraft = useDraftVenueStore((s) => s.reset);
+  const patchVenueDraft = useDraftVenueStore((s) => s.patch);
   const router = useRouter();
 
   const initialMode: Mode = brandList.isTrueEmpty ? "persona" : "switch";
   const [mode, setMode] = useState<Mode>(initialMode);
+  const [venueSearchName, setVenueSearchName] = useState("");
   const [displayName, setDisplayName] = useState<string>("Lonely Moth");
   const [submitting, setSubmitting] = useState<boolean>(false);
   // Cycle 17e-A: inline slug-collision error per Decision 11 hybrid UX
   const [slugError, setSlugError] = useState<string | null>(null);
 
+  const {
+    match: poolMatch,
+    loading: poolSearchLoading,
+    error: poolSearchError,
+    clearError: clearPoolSearchError,
+  } = usePoolMatchSearch(venueSearchName);
+
   useEffect(() => {
     if (visible) {
       setMode(brandList.isTrueEmpty ? "persona" : "switch");
+      setVenueSearchName("");
       setDisplayName("Lonely Moth");
       setSubmitting(false);
       setSlugError(null);
@@ -202,7 +215,36 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
     setSubmitting(false);
   };
 
-  // Ve1 — "A place" opens full-screen venue onboarding (place_pool gate + wizard).
+  const openVenueCreateFromPool = (): void => {
+    resetVenueDraft();
+    if (poolMatch !== null) {
+      patchVenueDraft(prefillDraftFromPoolMatch(poolMatch));
+    } else {
+      const n = venueSearchName.trim();
+      patchVenueDraft({ workingName: n, displayName: n });
+    }
+    onClose();
+    router.push(
+      (poolMatch !== null ? "/venue/create?pool=1" : "/venue/create") as never,
+    );
+  };
+
+  const handlePoolMatchYes = (): void => {
+    openVenueCreateFromPool();
+  };
+
+  const handlePoolMatchNo = (): void => {
+    const n = venueSearchName.trim();
+    resetVenueDraft();
+    patchVenueDraft({ workingName: n, displayName: n, placePoolId: null });
+    clearPoolSearchError();
+  };
+
+  const handlePoolMatchSkip = (): void => {
+    handlePoolMatchNo();
+  };
+
+  // Ve1+Ve2 — "A place" opens venue onboarding; pool match can skip ahead via card.
   const personas: PersonaDef[] = [
     {
       id: "place",
@@ -211,9 +253,7 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
       icon: "location",
       disabled: false,
       onSelect: () => {
-        resetVenueDraft();
-        onClose();
-        router.push("/venue/create" as never);
+        openVenueCreateFromPool();
       },
       testID: "persona-place",
     },
@@ -336,7 +376,41 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
                 {brands.length > 0 ? "Choose a brand type" : "What kind of brand?"}
               </Text>
             </View>
-            <PersonaPickerCards personas={personas} testID="persona-picker" />
+            <ScrollView
+              style={styles.personaScroll}
+              contentContainerStyle={styles.personaScrollContent}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.venueSearchBlock}>
+                <Text style={styles.venueSearchLabel}>
+                  Starting with a venue? Search our directory
+                </Text>
+                <Input
+                  variant="text"
+                  value={venueSearchName}
+                  onChangeText={setVenueSearchName}
+                  placeholder="Venue name"
+                  accessibilityLabel="Venue name search"
+                  testID="venue-name-search-input"
+                />
+                {poolSearchLoading ? (
+                  <Text style={styles.poolSearchHint}>Searching…</Text>
+                ) : null}
+                {poolSearchError !== null ? (
+                  <Text style={styles.poolSearchError}>{poolSearchError}</Text>
+                ) : null}
+                {poolMatch !== null ? (
+                  <PoolMatchCard
+                    match={poolMatch}
+                    onYes={handlePoolMatchYes}
+                    onNo={handlePoolMatchNo}
+                    onSkip={handlePoolMatchSkip}
+                  />
+                ) : null}
+              </View>
+              <PersonaPickerCards personas={personas} testID="persona-picker" />
+            </ScrollView>
           </>
         ) : mode === "trip-create" ? (
           // ORCH-0855 (Tr1) — trip-planner wizard. Mounted inside this TopSheet
@@ -465,6 +539,29 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.md,
     paddingBottom: spacing.md,
+  },
+  personaScroll: {
+    flex: 1,
+  },
+  personaScrollContent: {
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+  },
+  venueSearchBlock: {
+    gap: spacing.sm,
+  },
+  venueSearchLabel: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  poolSearchHint: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+  },
+  poolSearchError: {
+    fontSize: typography.caption.fontSize,
+    color: "#EF4444",
   },
   brandRowOuter: {
     flexDirection: "row",

--- a/mingla-business/src/components/brand/PoolMatchCard.tsx
+++ b/mingla-business/src/components/brand/PoolMatchCard.tsx
@@ -1,0 +1,133 @@
+/**
+ * Ve2 — inline pool match comparison card ("Is this you?").
+ */
+
+import React from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { PoolMatch } from "../../types/poolMatch";
+import { Button } from "../ui/Button";
+import { GlassCard } from "../ui/GlassCard";
+
+export interface PoolMatchCardProps {
+  match: PoolMatch;
+  onYes: () => void;
+  onNo: () => void;
+  onSkip: () => void;
+  testID?: string;
+}
+
+export const PoolMatchCard: React.FC<PoolMatchCardProps> = ({
+  match,
+  onYes,
+  onNo,
+  onSkip,
+  testID = "pool-match-card",
+}) => {
+  const addressLine = [match.address, match.city].filter(Boolean).join(", ");
+
+  return (
+    <GlassCard variant="elevated" padding={spacing.md} testID={testID}>
+      <Text style={styles.eyebrow}>We found a match in our directory</Text>
+      <View style={styles.row}>
+        {match.primaryPhotoUrl !== null ? (
+          <Image
+            source={{ uri: match.primaryPhotoUrl }}
+            style={styles.photo}
+            accessibilityLabel={`Photo of ${match.name}`}
+          />
+        ) : (
+          <View style={styles.photoPlaceholder} />
+        )}
+        <View style={styles.textCol}>
+          <Text style={styles.name} numberOfLines={2}>
+            {match.name}
+          </Text>
+          {addressLine.length > 0 ? (
+            <Text style={styles.address} numberOfLines={2}>
+              {addressLine}
+            </Text>
+          ) : null}
+          <Text style={styles.prompt}>Is this you?</Text>
+        </View>
+      </View>
+      <View style={styles.actions}>
+        <Button
+          label="Yes, this is me"
+          variant="primary"
+          size="md"
+          onPress={onYes}
+          testID="pool-match-yes"
+        />
+        <Button
+          label="No, different business"
+          variant="secondary"
+          size="md"
+          onPress={onNo}
+          testID="pool-match-no"
+        />
+        <Button
+          label="Skip — create from scratch"
+          variant="ghost"
+          size="sm"
+          onPress={onSkip}
+          testID="pool-match-skip"
+        />
+      </View>
+    </GlassCard>
+  );
+};
+
+const styles = StyleSheet.create({
+  eyebrow: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.secondary,
+    marginBottom: spacing.sm,
+  },
+  row: {
+    flexDirection: "row",
+    gap: spacing.md,
+    marginBottom: spacing.md,
+  },
+  photo: {
+    width: 72,
+    height: 72,
+    borderRadius: radiusTokens.md,
+    backgroundColor: "#E5E7EB",
+  },
+  photoPlaceholder: {
+    width: 72,
+    height: 72,
+    borderRadius: radiusTokens.md,
+    backgroundColor: "#E5E7EB",
+  },
+  textCol: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  name: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  address: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  prompt: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: accent.warm,
+    marginTop: spacing.xs,
+  },
+  actions: {
+    gap: spacing.sm,
+  },
+});

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve1.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve1.test.ts
@@ -1,7 +1,8 @@
 /**
- * ORCH-0099 [Ve1] + Ve2 pool match — place persona and venue create routing.
+ * ORCH-0099 [Ve1 Physical Venue Brand Onboarding] — place persona enabled.
  *
- * Additive contract alongside ORCH-0855 personaFork.test.ts.
+ * Additive contract alongside ORCH-0855 personaFork.test.ts (SC-04 skipped there
+ * with [TEST-MOD-APPROVED ORCH-0099] once Ve1 ships).
  */
 
 import { describe, expect, test } from "@jest/globals";
@@ -22,12 +23,6 @@ describe("ORCH-0099 — BrandSwitcherSheet place persona (Ve1)", () => {
     expect(placeBlockMatch![1]).toBe("false");
     expect(sheetSource).toMatch(/openVenueCreateFromPool/);
     expect(sheetSource).toMatch(/\/venue\/create/);
-  });
-
-  test("Ve2 pool match search in persona mode", () => {
-    expect(sheetSource).toContain("usePoolMatchSearch");
-    expect(sheetSource).toContain("PoolMatchCard");
-    expect(sheetSource).toContain("venue-name-search-input");
   });
 
   test("imports expo-router useRouter for venue onboarding", () => {

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve1.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve1.test.ts
@@ -1,8 +1,7 @@
 /**
- * ORCH-0099 [Ve1 Physical Venue Brand Onboarding] — place persona enabled.
+ * ORCH-0099 [Ve1] + Ve2 pool match — place persona and venue create routing.
  *
- * Additive contract alongside ORCH-0855 personaFork.test.ts (SC-04 skipped there
- * with [TEST-MOD-APPROVED ORCH-0099] once Ve1 ships).
+ * Additive contract alongside ORCH-0855 personaFork.test.ts.
  */
 
 import { describe, expect, test } from "@jest/globals";
@@ -21,9 +20,14 @@ describe("ORCH-0099 — BrandSwitcherSheet place persona (Ve1)", () => {
     );
     expect(placeBlockMatch).not.toBeNull();
     expect(placeBlockMatch![1]).toBe("false");
-    expect(sheetSource).toMatch(
-      /id: "place"[\s\S]*?router\.push\("\/venue\/create"/,
-    );
+    expect(sheetSource).toMatch(/openVenueCreateFromPool/);
+    expect(sheetSource).toMatch(/\/venue\/create/);
+  });
+
+  test("Ve2 pool match search in persona mode", () => {
+    expect(sheetSource).toContain("usePoolMatchSearch");
+    expect(sheetSource).toContain("PoolMatchCard");
+    expect(sheetSource).toContain("venue-name-search-input");
   });
 
   test("imports expo-router useRouter for venue onboarding", () => {

--- a/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve2.test.ts
+++ b/mingla-business/src/components/brand/__tests__/BrandSwitcherSheet.personaFork.ve2.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Ve2 (#100) — pool match search on brand sheet persona entry.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const sheetSource = readFileSync(
+  join(__dirname, "..", "BrandSwitcherSheet.tsx"),
+  "utf-8",
+);
+
+describe("BrandSwitcherSheet Ve2 pool match", () => {
+  test("persona mode includes debounced pool search UI", () => {
+    expect(sheetSource).toContain("usePoolMatchSearch");
+    expect(sheetSource).toContain("PoolMatchCard");
+    expect(sheetSource).toContain("venue-name-search-input");
+  });
+});

--- a/mingla-business/src/components/venue/VenueCreatorWizard.tsx
+++ b/mingla-business/src/components/venue/VenueCreatorWizard.tsx
@@ -72,6 +72,7 @@ export const VenueCreatorWizard: React.FC<VenueCreatorWizardProps> = ({
   const [submitErr, setSubmitErr] = useState<string | null>(null);
 
   const draft = useDraftVenueStore();
+  const poolLinked = draft.placePoolId !== null;
 
   const goNext = useCallback((): void => {
     const e = venueStepError(step, draft);
@@ -120,12 +121,16 @@ export const VenueCreatorWizard: React.FC<VenueCreatorWizardProps> = ({
       }
       setShowErr(false);
       const existingDesc = joinBrandDescription(st.tagline, st.description);
+      const firstUri = st.photoUris[0];
+      const remoteCover =
+        firstUri !== undefined && firstUri.startsWith("https://");
       const brand = await createVenue.mutateAsync({
         accountId: user.id,
         name: st.displayName.trim(),
         slug: st.slug.trim(),
         tagline: st.tagline.trim() || undefined,
         bio: st.description.trim(),
+        placePoolId: st.placePoolId,
         googlePlaceId: st.googlePlaceId,
         lat: st.lat,
         lng: st.lng,
@@ -137,14 +142,13 @@ export const VenueCreatorWizard: React.FC<VenueCreatorWizardProps> = ({
           email: st.contactEmail.trim() || undefined,
           phone: st.contactPhone.trim() || undefined,
         },
-        coverMediaUrl: null,
-        coverMediaType: null,
+        coverMediaUrl: remoteCover ? firstUri : null,
+        coverMediaType: remoteCover ? "image" : null,
         hours: st.hours,
       });
 
       let coverWarning: string | null = null;
-      const firstUri = st.photoUris[0];
-      if (firstUri !== undefined) {
+      if (firstUri !== undefined && !remoteCover) {
         try {
           const up = await uploadBrandCover(
             brand.id,
@@ -238,6 +242,12 @@ export const VenueCreatorWizard: React.FC<VenueCreatorWizardProps> = ({
 
       <Stepper steps={STEPPER_STEPS} currentIndex={step} />
 
+      {poolLinked ? (
+        <Text style={styles.poolBanner}>
+          Prefilled from our directory — review each step before you submit.
+        </Text>
+      ) : null}
+
       <ScrollView
         style={styles.scroll}
         contentContainerStyle={{
@@ -299,6 +309,13 @@ const styles = StyleSheet.create({
     fontSize: typography.caption.fontSize,
     color: textTokens.tertiary,
     marginTop: 2,
+  },
+  poolBanner: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.secondary,
+    textAlign: "center",
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.sm,
   },
   scroll: {
     flex: 1,

--- a/mingla-business/src/components/venue/__tests__/VenueCreatorWizard.ve2.test.ts
+++ b/mingla-business/src/components/venue/__tests__/VenueCreatorWizard.ve2.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const WIZARD = join(__dirname, "..", "VenueCreatorWizard.tsx");
+
+describe("VenueCreatorWizard Ve2 submit", () => {
+  test("passes place_pool_id and supports remote pool photo cover", () => {
+    const src = readFileSync(WIZARD, "utf8");
+    expect(src).toContain("placePoolId: st.placePoolId");
+    expect(src).toContain('firstUri.startsWith("https://")');
+    expect(src).toContain("remoteCover");
+  });
+});

--- a/mingla-business/src/hooks/usePoolMatchSearch.ts
+++ b/mingla-business/src/hooks/usePoolMatchSearch.ts
@@ -1,0 +1,84 @@
+/**
+ * Ve2 — debounced place_pool search for brand creation name field.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { searchPoolMatches } from "../services/poolSearchService";
+import type { PoolMatch } from "../types/poolMatch";
+import { POOL_SEARCH_DEBOUNCE_MS, POOL_SEARCH_MIN_QUERY_LENGTH } from "../types/poolMatch";
+
+export interface UsePoolMatchSearchResult {
+  match: PoolMatch | null;
+  loading: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+export function usePoolMatchSearch(query: string): UsePoolMatchSearchResult {
+  const [match, setMatch] = useState<PoolMatch | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const clearError = useCallback((): void => {
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    abortRef.current?.abort();
+    abortRef.current = null;
+
+    const q = query.trim();
+    if (q.length < POOL_SEARCH_MIN_QUERY_LENGTH) {
+      setMatch(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    debounceRef.current = setTimeout(() => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+      void (async (): Promise<void> => {
+        try {
+          const matches = await searchPoolMatches(q, {
+            signal: controller.signal,
+          });
+          if (controller.signal.aborted) return;
+          setMatch(matches[0] ?? null);
+        } catch (e) {
+          if (controller.signal.aborted) return;
+          const msg = e instanceof Error ? e.message : "search_failed";
+          if (msg === "rate_limited") {
+            setError("Too many searches — wait a moment and try again.");
+          } else {
+            setError("Could not search our directory. Check your connection.");
+          }
+          setMatch(null);
+        } finally {
+          if (!controller.signal.aborted) {
+            setLoading(false);
+          }
+        }
+      })();
+    }, POOL_SEARCH_DEBOUNCE_MS);
+
+    return (): void => {
+      if (debounceRef.current !== null) {
+        clearTimeout(debounceRef.current);
+      }
+      abortRef.current?.abort();
+    };
+  }, [query]);
+
+  return { match, loading, error, clearError };
+}

--- a/mingla-business/src/services/__tests__/poolSearchService.test.ts
+++ b/mingla-business/src/services/__tests__/poolSearchService.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable import/first */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const invokeMock = jest.fn() as any;
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    functions: {
+      invoke: (...args: unknown[]) => invokeMock(...args),
+    },
+  },
+}));
+
+import { searchPoolMatches } from "../poolSearchService";
+
+describe("searchPoolMatches", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  test("returns empty array without calling edge fn when query too short", async () => {
+    const r = await searchPoolMatches("ab");
+    expect(r).toEqual([]);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  test("maps edge function matches", async () => {
+    invokeMock.mockResolvedValue({
+      data: {
+        matches: [
+          {
+            id: "pid",
+            name: "Joe's Pizza",
+            address: "123 Main",
+            city: "NYC",
+            country: "US",
+            lat: 40.1,
+            lng: -73.9,
+            googlePlaceId: "gid",
+            primaryPhotoUrl: "https://x/a.jpg",
+            primaryType: "pizza_restaurant",
+            types: [],
+            venueCategory: "restaurant",
+            openingHours: null,
+            photoUrls: ["https://x/a.jpg"],
+          },
+        ],
+      },
+      error: null,
+    });
+
+    const r = await searchPoolMatches("joe");
+    expect(r).toHaveLength(1);
+    expect(r[0]?.googlePlaceId).toBe("gid");
+    expect(invokeMock).toHaveBeenCalledWith("claim-search-pool", {
+      body: { query: "joe", limit: 1 },
+    });
+  });
+});

--- a/mingla-business/src/services/__tests__/ve2MigrationContract.test.ts
+++ b/mingla-business/src/services/__tests__/ve2MigrationContract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MIGRATION = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "supabase",
+  "migrations",
+  "20260618000000_ve2_pool_match_claim.sql",
+);
+
+describe("Ve2 migration contract", () => {
+  test("allows duplicate pending_review per google_place_id", () => {
+    const sql = readFileSync(MIGRATION, "utf8");
+    expect(sql).toContain("idx_brands_google_place_id_verified_unique");
+    expect(sql).toMatch(/claim_status\s*=\s*'verified'/);
+    expect(sql).not.toMatch(
+      /claim_status IN \('pending_review', 'verified'\)/,
+    );
+  });
+
+  test("create RPC accepts place_pool_id", () => {
+    const sql = readFileSync(MIGRATION, "utf8");
+    expect(sql).toContain("p_place_pool_id uuid");
+    expect(sql).toContain("place_pool_google_place_id_mismatch");
+  });
+});

--- a/mingla-business/src/services/__tests__/ve2MigrationContract.test.ts
+++ b/mingla-business/src/services/__tests__/ve2MigrationContract.test.ts
@@ -28,4 +28,23 @@ describe("Ve2 migration contract", () => {
     expect(sql).toContain("p_place_pool_id uuid");
     expect(sql).toContain("place_pool_google_place_id_mismatch");
   });
+
+  test("claim search RPC is service_role only", () => {
+    const sql = readFileSync(
+      join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "..",
+        "supabase",
+        "migrations",
+        "20260618000001_ve2_claim_search_rpc.sql",
+      ),
+      "utf8",
+    );
+    expect(sql).toContain("biz_search_place_pool_for_claim");
+    expect(sql).toContain("GRANT EXECUTE");
+    expect(sql).toContain("service_role");
+  });
 });

--- a/mingla-business/src/services/__tests__/ve2PoolMatchFlow.test.ts
+++ b/mingla-business/src/services/__tests__/ve2PoolMatchFlow.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Ve2 pool match flow contracts", () => {
+  test("no-match path does not auto-claim (requires explicit Yes)", () => {
+    const card = readFileSync(
+      join(__dirname, "..", "..", "components", "brand", "PoolMatchCard.tsx"),
+      "utf8",
+    );
+    expect(card).toContain("Yes, this is me");
+    expect(card).not.toContain("auto");
+  });
+
+  test("declining match clears placePoolId on gate continue", () => {
+    const create = readFileSync(
+      join(__dirname, "..", "..", "..", "app", "venue", "create.tsx"),
+      "utf8",
+    );
+    expect(create).toContain("placePoolId: null");
+  });
+
+  test("venue create route uses claim-search flow not legacy boolean gate", () => {
+    const create = readFileSync(
+      join(__dirname, "..", "..", "..", "app", "venue", "create.tsx"),
+      "utf8",
+    );
+    expect(create).toContain("usePoolMatchSearch");
+    expect(create).not.toContain("placePoolHasNameMatch");
+  });
+});

--- a/mingla-business/src/services/brandsService.ts
+++ b/mingla-business/src/services/brandsService.ts
@@ -166,6 +166,7 @@ export interface CreateVenueBrandPendingInput {
   slug: string;
   tagline?: string;
   bio?: string;
+  placePoolId?: string | null;
   googlePlaceId: string;
   lat: number;
   lng: number;
@@ -267,6 +268,7 @@ export async function createVenueBrandPendingReview(
       p_cover_media_url: input.coverMediaUrl ?? "",
       p_cover_media_type: input.coverMediaType ?? "",
       p_hours: brandHoursToRpcPayload(input.hours),
+      p_place_pool_id: input.placePoolId ?? null,
     },
   );
 

--- a/mingla-business/src/services/poolSearchService.ts
+++ b/mingla-business/src/services/poolSearchService.ts
@@ -1,0 +1,75 @@
+/**
+ * Ve2 — debounced place_pool search via claim-search-pool edge function.
+ */
+
+import type { PoolMatch, PoolSearchResponse } from "../types/poolMatch";
+import { POOL_SEARCH_DEFAULT_LIMIT, POOL_SEARCH_MIN_QUERY_LENGTH } from "../types/poolMatch";
+import { supabase } from "./supabase";
+
+function mapMatchRow(raw: Record<string, unknown>): PoolMatch {
+  return {
+    id: String(raw.id),
+    name: String(raw.name),
+    address: raw.address === null || raw.address === undefined
+      ? null
+      : String(raw.address),
+    city: raw.city === null || raw.city === undefined ? null : String(raw.city),
+    country: raw.country === null || raw.country === undefined
+      ? null
+      : String(raw.country),
+    lat: Number(raw.lat),
+    lng: Number(raw.lng),
+    googlePlaceId: String(raw.googlePlaceId),
+    primaryPhotoUrl: raw.primaryPhotoUrl === null ||
+        raw.primaryPhotoUrl === undefined
+      ? null
+      : String(raw.primaryPhotoUrl),
+    primaryType: raw.primaryType === null || raw.primaryType === undefined
+      ? null
+      : String(raw.primaryType),
+    types: Array.isArray(raw.types) ? raw.types.map(String) : [],
+    venueCategory: raw.venueCategory as PoolMatch["venueCategory"],
+    openingHours: raw.openingHours ?? null,
+    photoUrls: Array.isArray(raw.photoUrls)
+      ? raw.photoUrls.map(String)
+      : [],
+  };
+}
+
+/**
+ * Search place_pool by name (authenticated). Returns [] when query too short.
+ */
+export async function searchPoolMatches(
+  query: string,
+  options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<PoolMatch[]> {
+  const q = query.trim();
+  if (q.length < POOL_SEARCH_MIN_QUERY_LENGTH) {
+    return [];
+  }
+
+  const { data, error } = await supabase.functions.invoke("claim-search-pool", {
+    body: {
+      query: q,
+      limit: options.limit ?? POOL_SEARCH_DEFAULT_LIMIT,
+    },
+  });
+
+  if (error !== null) {
+    throw error;
+  }
+
+  const body = data as PoolSearchResponse | { error?: string };
+  if (body !== null && typeof body === "object" && "error" in body) {
+    const code = String((body as { error: string }).error);
+    if (code === "rate_limited") {
+      throw new Error("rate_limited");
+    }
+    throw new Error(code);
+  }
+
+  const matches = (body as PoolSearchResponse)?.matches ?? [];
+  return matches.map((m) =>
+    mapMatchRow(m as unknown as Record<string, unknown>),
+  );
+}

--- a/mingla-business/src/services/venueSearchService.ts
+++ b/mingla-business/src/services/venueSearchService.ts
@@ -1,6 +1,6 @@
 /**
- * Ve1 — detect whether a typed venue name likely exists in consumer place_pool.
- * Ve2 will own fuzzy match / claim UX; Ve1 only needs a coarse gate for the fork.
+ * Ve1 legacy — boolean place_pool name probe (biz_place_pool_name_contains).
+ * Ve2 claim UX uses poolSearchService + claim-search-pool instead.
  */
 
 import { supabase } from "./supabase";

--- a/mingla-business/src/store/draftVenueStore.ts
+++ b/mingla-business/src/store/draftVenueStore.ts
@@ -8,6 +8,8 @@ import type { BrandHourEntry, VenueCategory } from "../types/brand";
 import { defaultBrandHoursWeek } from "../utils/venueBrandHours";
 
 export interface DraftVenueState {
+  /** Ve2 — set when operator accepts a pool match card */
+  placePoolId: string | null;
   /** Business / venue name typed at the place_pool gate */
   workingName: string;
   venueCategory: VenueCategory | null;
@@ -28,6 +30,7 @@ export interface DraftVenueState {
 }
 
 const initial: DraftVenueState = {
+  placePoolId: null,
   workingName: "",
   venueCategory: null,
   displayName: "",

--- a/mingla-business/src/types/poolMatch.ts
+++ b/mingla-business/src/types/poolMatch.ts
@@ -1,0 +1,38 @@
+/**
+ * Ve2 — public-safe pool match contract (claim-search-pool edge function).
+ */
+
+import type { VenueCategory } from "./brand";
+
+/** Single row returned by `claim-search-pool` (whitelist fields only). */
+export interface PoolMatch {
+  id: string;
+  name: string;
+  address: string | null;
+  city: string | null;
+  country: string | null;
+  lat: number;
+  lng: number;
+  googlePlaceId: string;
+  primaryPhotoUrl: string | null;
+  primaryType: string | null;
+  types: string[];
+  venueCategory: VenueCategory;
+  openingHours: unknown | null;
+  photoUrls: string[];
+}
+
+export interface PoolSearchResponse {
+  matches: PoolMatch[];
+}
+
+/** Edge function request body. */
+export interface PoolSearchRequest {
+  query: string;
+  limit?: number;
+}
+
+export const POOL_SEARCH_MIN_QUERY_LENGTH = 3;
+export const POOL_SEARCH_DEBOUNCE_MS = 300;
+export const POOL_SEARCH_DEFAULT_LIMIT = 1;
+export const POOL_SEARCH_MAX_LIMIT = 5;

--- a/mingla-business/src/utils/__tests__/claimSearchPoolLogic.test.ts
+++ b/mingla-business/src/utils/__tests__/claimSearchPoolLogic.test.ts
@@ -1,0 +1,28 @@
+import {
+  checkClaimSearchRateLimit,
+  normalizeClaimSearchBody,
+} from "../claimSearchPoolLogic";
+
+describe("claimSearchPoolLogic", () => {
+  test("normalizeClaimSearchBody rejects short query", () => {
+    expect(normalizeClaimSearchBody({ query: "ab" })).toEqual({
+      ok: false,
+      error: "query_too_short",
+    });
+  });
+
+  test("normalizeClaimSearchBody clamps limit", () => {
+    const r = normalizeClaimSearchBody({ query: "pizza", limit: 99 });
+    expect(r).toEqual({ ok: true, query: "pizza", limit: 5 });
+  });
+
+  test("checkClaimSearchRateLimit blocks after 10 per minute", () => {
+    const buckets = new Map<string, number[]>();
+    const uid = "u1";
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 10; i++) {
+      expect(checkClaimSearchRateLimit(uid, buckets, t0 + i)).toBe(true);
+    }
+    expect(checkClaimSearchRateLimit(uid, buckets, t0 + 10)).toBe(false);
+  });
+});

--- a/mingla-business/src/utils/__tests__/mapMinglaSlugToVenueCategory.test.ts
+++ b/mingla-business/src/utils/__tests__/mapMinglaSlugToVenueCategory.test.ts
@@ -1,0 +1,20 @@
+import { mapMinglaSlugToVenueCategory } from "../mapMinglaSlugToVenueCategory";
+
+describe("mapMinglaSlugToVenueCategory", () => {
+  test("play slug → play", () => {
+    expect(mapMinglaSlugToVenueCategory("play")).toBe("play");
+  });
+
+  test("creative_arts slug → creative_and_arts", () => {
+    expect(mapMinglaSlugToVenueCategory("creative_arts")).toBe(
+      "creative_and_arts",
+    );
+  });
+
+  test("dining slugs → restaurant", () => {
+    expect(mapMinglaSlugToVenueCategory("brunch_lunch_casual")).toBe(
+      "restaurant",
+    );
+    expect(mapMinglaSlugToVenueCategory(null)).toBe("restaurant");
+  });
+});

--- a/mingla-business/src/utils/__tests__/mapPoolOpeningHoursToBrandHours.test.ts
+++ b/mingla-business/src/utils/__tests__/mapPoolOpeningHoursToBrandHours.test.ts
@@ -1,0 +1,38 @@
+import { mapPoolOpeningHoursToBrandHours } from "../mapPoolOpeningHoursToBrandHours";
+
+describe("mapPoolOpeningHoursToBrandHours", () => {
+  test("returns default week when opening_hours is null", () => {
+    const rows = mapPoolOpeningHoursToBrandHours(null);
+    expect(rows).toHaveLength(7);
+    expect(rows[6]?.isClosed).toBe(true);
+  });
+
+  test("maps Google Sunday period to weekday 6", () => {
+    const rows = mapPoolOpeningHoursToBrandHours({
+      periods: [
+        {
+          open: { day: 0, hour: 11, minute: 0 },
+          close: { day: 0, hour: 22, minute: 0 },
+        },
+      ],
+    });
+    const sun = rows.find((r) => r.weekday === 6);
+    expect(sun?.isClosed).toBe(false);
+    expect(sun?.openTime).toBe("11:00");
+    expect(sun?.closeTime).toBe("22:00");
+  });
+
+  test("maps Google Monday period to weekday 0", () => {
+    const rows = mapPoolOpeningHoursToBrandHours({
+      periods: [
+        {
+          open: { day: 1, hour: 9, minute: 30 },
+          close: { day: 1, hour: 17, minute: 0 },
+        },
+      ],
+    });
+    const mon = rows.find((r) => r.weekday === 0);
+    expect(mon?.openTime).toBe("09:30");
+    expect(mon?.closeTime).toBe("17:00");
+  });
+});

--- a/mingla-business/src/utils/__tests__/prefillDraftFromPoolMatch.test.ts
+++ b/mingla-business/src/utils/__tests__/prefillDraftFromPoolMatch.test.ts
@@ -1,0 +1,31 @@
+import { prefillDraftFromPoolMatch } from "../prefillDraftFromPoolMatch";
+import type { PoolMatch } from "../../types/poolMatch";
+
+const sample: PoolMatch = {
+  id: "pool-1",
+  name: "Joe's Pizza",
+  address: "123 Main St",
+  city: "New York",
+  country: "US",
+  lat: 40.7,
+  lng: -74.0,
+  googlePlaceId: "ChIJx",
+  primaryPhotoUrl: "https://cdn/a.jpg",
+  primaryType: "pizza_restaurant",
+  types: [],
+  venueCategory: "restaurant",
+  openingHours: null,
+  photoUrls: ["https://cdn/a.jpg"],
+};
+
+describe("prefillDraftFromPoolMatch", () => {
+  test("sets placePoolId and location fields", () => {
+    const p = prefillDraftFromPoolMatch(sample);
+    expect(p.placePoolId).toBe("pool-1");
+    expect(p.googlePlaceId).toBe("ChIJx");
+    expect(p.displayName).toBe("Joe's Pizza");
+    expect(p.formattedAddress).toBe("123 Main St");
+    expect(p.photoUris).toEqual(["https://cdn/a.jpg"]);
+    expect(p.venueCategory).toBe("restaurant");
+  });
+});

--- a/mingla-business/src/utils/claimSearchPoolLogic.ts
+++ b/mingla-business/src/utils/claimSearchPoolLogic.ts
@@ -1,0 +1,48 @@
+/**
+ * Ve2 — pure helpers mirrored from claim-search-pool edge function (jest-testable).
+ */
+
+export const CLAIM_SEARCH_MIN_QUERY_LENGTH = 3;
+export const CLAIM_SEARCH_DEFAULT_LIMIT = 1;
+export const CLAIM_SEARCH_MAX_LIMIT = 5;
+export const CLAIM_SEARCH_RATE_LIMIT_WINDOW_MS = 60_000;
+export const CLAIM_SEARCH_RATE_LIMIT_MAX = 10;
+
+export function normalizeClaimSearchBody(
+  body: unknown,
+):
+  | { ok: true; query: string; limit: number }
+  | { ok: false; error: string } {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "invalid_json" };
+  }
+  const b = body as Record<string, unknown>;
+  const query = typeof b.query === "string" ? b.query.trim() : "";
+  if (query.length < CLAIM_SEARCH_MIN_QUERY_LENGTH) {
+    return { ok: false, error: "query_too_short" };
+  }
+  let limit = CLAIM_SEARCH_DEFAULT_LIMIT;
+  if (typeof b.limit === "number" && Number.isFinite(b.limit)) {
+    limit = Math.max(
+      1,
+      Math.min(Math.floor(b.limit), CLAIM_SEARCH_MAX_LIMIT),
+    );
+  }
+  return { ok: true, query, limit };
+}
+
+export function checkClaimSearchRateLimit(
+  userId: string,
+  buckets: Map<string, number[]>,
+  now = Date.now(),
+): boolean {
+  const windowStart = now - CLAIM_SEARCH_RATE_LIMIT_WINDOW_MS;
+  const hits = (buckets.get(userId) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= CLAIM_SEARCH_RATE_LIMIT_MAX) {
+    buckets.set(userId, hits);
+    return false;
+  }
+  hits.push(now);
+  buckets.set(userId, hits);
+  return true;
+}

--- a/mingla-business/src/utils/mapMinglaSlugToVenueCategory.ts
+++ b/mingla-business/src/utils/mapMinglaSlugToVenueCategory.ts
@@ -1,0 +1,19 @@
+/**
+ * Ve2 — client mirror of mapPoolTypesToVenueCategory (venue wizard pills).
+ */
+
+import type { VenueCategory } from "../types/brand";
+
+const PLAY_SLUG = "play";
+const CREATIVE_SLUG = "creative_arts";
+
+/**
+ * Maps Mingla canonical category slug (from edge fn) to venue_category.
+ */
+export function mapMinglaSlugToVenueCategory(
+  minglaSlug: string | null | undefined,
+): VenueCategory {
+  if (minglaSlug === PLAY_SLUG) return "play";
+  if (minglaSlug === CREATIVE_SLUG) return "creative_and_arts";
+  return "restaurant";
+}

--- a/mingla-business/src/utils/mapPoolOpeningHoursToBrandHours.ts
+++ b/mingla-business/src/utils/mapPoolOpeningHoursToBrandHours.ts
@@ -1,0 +1,86 @@
+/**
+ * Ve2 — map place_pool.opening_hours (Google jsonb) → brand_hours wizard rows.
+ */
+
+import type { BrandHourEntry } from "../types/brand";
+import { defaultBrandHoursWeek } from "./venueBrandHours";
+
+interface GoogleTimePoint {
+  day?: number;
+  hour?: number;
+  minute?: number;
+}
+
+interface GooglePeriod {
+  open?: GoogleTimePoint;
+  close?: GoogleTimePoint;
+}
+
+interface GoogleOpeningHours {
+  periods?: GooglePeriod[];
+}
+
+/** Google Places day 0=Sunday; brand_hours weekday 0=Monday. */
+function googleDayToWeekday(googleDay: number): number {
+  if (googleDay === 0) return 6;
+  return googleDay - 1;
+}
+
+function formatHm(hour: number, minute: number): string {
+  const h = String(hour).padStart(2, "0");
+  const m = String(minute).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function mapPoolOpeningHoursToBrandHours(
+  openingHours: unknown | null | undefined,
+): BrandHourEntry[] {
+  if (openingHours === null || openingHours === undefined) {
+    return defaultBrandHoursWeek();
+  }
+  if (typeof openingHours !== "object") {
+    return defaultBrandHoursWeek();
+  }
+
+  const raw = openingHours as GoogleOpeningHours;
+  const periods = raw.periods;
+  if (!Array.isArray(periods) || periods.length === 0) {
+    return defaultBrandHoursWeek();
+  }
+
+  const byWeekday = new Map<number, BrandHourEntry>();
+  for (let w = 0; w <= 6; w++) {
+    byWeekday.set(w, {
+      weekday: w,
+      openTime: null,
+      closeTime: null,
+      isClosed: true,
+    });
+  }
+
+  for (const period of periods) {
+    const open = period.open;
+    const close = period.close;
+    if (
+      open?.day === undefined ||
+      open.hour === undefined ||
+      open.minute === undefined ||
+      close?.hour === undefined ||
+      close.minute === undefined
+    ) {
+      continue;
+    }
+    const weekday = googleDayToWeekday(open.day);
+    if (byWeekday.get(weekday)?.isClosed === false) {
+      continue;
+    }
+    byWeekday.set(weekday, {
+      weekday,
+      openTime: formatHm(open.hour, open.minute),
+      closeTime: formatHm(close.hour, close.minute),
+      isClosed: false,
+    });
+  }
+
+  return Array.from(byWeekday.values()).sort((a, b) => a.weekday - b.weekday);
+}

--- a/mingla-business/src/utils/prefillDraftFromPoolMatch.ts
+++ b/mingla-business/src/utils/prefillDraftFromPoolMatch.ts
@@ -1,0 +1,29 @@
+/**
+ * Ve2 — apply pool match row to venue onboarding draft store fields.
+ */
+
+import type { PoolMatch } from "../types/poolMatch";
+import type { DraftVenueState } from "../store/draftVenueStore";
+import { slugifyBrandSlug } from "./brandSlugify";
+import { mapPoolOpeningHoursToBrandHours } from "./mapPoolOpeningHoursToBrandHours";
+
+export function prefillDraftFromPoolMatch(
+  match: PoolMatch,
+): Partial<DraftVenueState> {
+  const name = match.name.trim();
+  return {
+    placePoolId: match.id,
+    workingName: name,
+    displayName: name,
+    slug: slugifyBrandSlug(name),
+    formattedAddress: match.address?.trim() ?? "",
+    googlePlaceId: match.googlePlaceId,
+    lat: match.lat,
+    lng: match.lng,
+    city: match.city,
+    countryCode: match.country?.slice(0, 2) ?? null,
+    venueCategory: match.venueCategory,
+    hours: mapPoolOpeningHoursToBrandHours(match.openingHours),
+    photoUris: [...match.photoUrls],
+  };
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -31,6 +31,10 @@ verify_jwt = false
 [functions.places-autocomplete]
 verify_jwt = true
 
+# Ve2 — place_pool name search for venue claim comparison (public-safe fields).
+[functions.claim-search-pool]
+verify_jwt = true
+
 # Ve1 — venue operator confirmation after biz_create_venue_brand_pending_review.
 [functions.venue-claim-submitted-email]
 verify_jwt = true

--- a/supabase/functions/_shared/mapMinglaSlugToVenueCategory.ts
+++ b/supabase/functions/_shared/mapMinglaSlugToVenueCategory.ts
@@ -1,0 +1,18 @@
+/**
+ * Ve2 — map Mingla consumer category slug → business venue_category pill.
+ */
+
+import { derivePoolCategory } from "./derivePoolCategory.ts";
+
+export type VenueCategorySlug = "restaurant" | "play" | "creative_and_arts";
+
+/** Maps place_pool primary_type + types[] to Ve1 venue_category. */
+export function mapPoolTypesToVenueCategory(
+  primaryType: string | null | undefined,
+  types: string[] | null | undefined,
+): VenueCategorySlug {
+  const slug = derivePoolCategory(primaryType ?? null, types ?? null);
+  if (slug === "play") return "play";
+  if (slug === "creative_arts") return "creative_and_arts";
+  return "restaurant";
+}

--- a/supabase/functions/_shared/poolMatchResponse.ts
+++ b/supabase/functions/_shared/poolMatchResponse.ts
@@ -1,0 +1,89 @@
+/**
+ * Ve2 — map place_pool DB row → claim-search-pool response (whitelist only).
+ */
+
+import { mapPoolTypesToVenueCategory } from "./mapMinglaSlugToVenueCategory.ts";
+
+export type VenueCategorySlug = "restaurant" | "play" | "creative_and_arts";
+
+export interface PoolMatchRow {
+  id: string;
+  name: string;
+  address: string | null;
+  city: string | null;
+  country: string | null;
+  lat: number;
+  lng: number;
+  google_place_id: string;
+  primary_type: string | null;
+  types: string[] | null;
+  opening_hours: unknown | null;
+  stored_photo_urls: string[] | null;
+}
+
+export interface PoolMatchResult {
+  id: string;
+  name: string;
+  address: string | null;
+  city: string | null;
+  country: string | null;
+  lat: number;
+  lng: number;
+  googlePlaceId: string;
+  primaryPhotoUrl: string | null;
+  primaryType: string | null;
+  types: string[];
+  venueCategory: VenueCategorySlug;
+  openingHours: unknown | null;
+  photoUrls: string[];
+}
+
+const FORBIDDEN_RESPONSE_KEYS = new Set([
+  "bouncer_reason",
+  "is_servable",
+  "photo_aesthetic_data",
+  "raw_google_data",
+  "ai_categories",
+  "seeding_category",
+  "ai_reason",
+  "ai_primary_identity",
+  "ai_confidence",
+  "ai_web_evidence",
+  "rating",
+  "review_count",
+]);
+
+export function photoUrlsFromRow(row: PoolMatchRow, max = 6): string[] {
+  const stored = (row.stored_photo_urls ?? []).filter(
+    (u) => typeof u === "string" && u.length > 0,
+  );
+  return stored.slice(0, max);
+}
+
+export function rowToPoolMatch(row: PoolMatchRow): PoolMatchResult {
+  const photoUrls = photoUrlsFromRow(row);
+  return {
+    id: row.id,
+    name: row.name,
+    address: row.address,
+    city: row.city,
+    country: row.country,
+    lat: row.lat,
+    lng: row.lng,
+    googlePlaceId: row.google_place_id,
+    primaryPhotoUrl: photoUrls[0] ?? null,
+    primaryType: row.primary_type,
+    types: row.types ?? [],
+    venueCategory: mapPoolTypesToVenueCategory(row.primary_type, row.types),
+    openingHours: row.opening_hours,
+    photoUrls,
+  };
+}
+
+export function assertNoForbiddenKeys(obj: Record<string, unknown>): void {
+  for (const key of Object.keys(obj)) {
+    if (FORBIDDEN_RESPONSE_KEYS.has(key)) {
+      throw new Error(`forbidden_field_leaked:${key}`);
+    }
+  }
+}

--- a/supabase/functions/claim-search-pool/index.test.ts
+++ b/supabase/functions/claim-search-pool/index.test.ts
@@ -1,0 +1,78 @@
+// Ve2 — claim-search-pool unit tests
+// Run: deno test supabase/functions/claim-search-pool/index.test.ts
+
+import {
+  assertEquals,
+  assertFalse,
+  assertStrictEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { checkRateLimit, normalizeSearchBody } from "./index.ts";
+import {
+  assertNoForbiddenKeys,
+  rowToPoolMatch,
+  type PoolMatchRow,
+} from "../_shared/poolMatchResponse.ts";
+
+Deno.test("normalizeSearchBody rejects short query", () => {
+  const r = normalizeSearchBody({ query: "ab" });
+  assertEquals(r.ok, false);
+  if (!r.ok) assertEquals(r.error, "query_too_short");
+});
+
+Deno.test("normalizeSearchBody accepts valid query and clamps limit", () => {
+  const r = normalizeSearchBody({ query: "  pizza  ", limit: 99 });
+  assertEquals(r.ok, true);
+  if (r.ok) {
+    assertEquals(r.query, "pizza");
+    assertEquals(r.limit, 5);
+  }
+});
+
+Deno.test("checkRateLimit blocks after 10 requests per minute", () => {
+  const uid = "user-rate-test";
+  const t0 = 1_700_000_000_000;
+  for (let i = 0; i < 10; i++) {
+    assertStrictEquals(checkRateLimit(uid, t0 + i), true);
+  }
+  assertFalse(checkRateLimit(uid, t0 + 10));
+});
+
+Deno.test("rowToPoolMatch whitelists fields and maps venue category", () => {
+  const row: PoolMatchRow = {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "Joe's Pizza",
+    address: "123 Main St",
+    city: "New York",
+    country: "US",
+    lat: 40.7,
+    lng: -74.0,
+    google_place_id: "ChIJtest",
+    primary_type: "pizza_restaurant",
+    types: ["pizza_restaurant", "restaurant"],
+    opening_hours: { periods: [] },
+    stored_photo_urls: ["https://cdn.example.com/a.jpg"],
+  };
+  const match = rowToPoolMatch(row);
+  assertEquals(match.name, "Joe's Pizza");
+  assertEquals(match.venueCategory, "restaurant");
+  assertEquals(match.photoUrls.length, 1);
+  assertNoForbiddenKeys(match as unknown as Record<string, unknown>);
+});
+
+Deno.test("rowToPoolMatch maps bowling to play", () => {
+  const row: PoolMatchRow = {
+    id: "22222222-2222-2222-2222-222222222222",
+    name: "Strike Zone",
+    address: null,
+    city: null,
+    country: null,
+    lat: 0,
+    lng: 0,
+    google_place_id: "gid",
+    primary_type: "bowling_alley",
+    types: [],
+    opening_hours: null,
+    stored_photo_urls: [],
+  };
+  assertEquals(rowToPoolMatch(row).venueCategory, "play");
+});

--- a/supabase/functions/claim-search-pool/index.ts
+++ b/supabase/functions/claim-search-pool/index.ts
@@ -1,0 +1,142 @@
+/**
+ * Ve2 — authenticated place_pool name search for venue claim comparison.
+ * Returns public-safe fields only (no scoring / bouncer / AI columns).
+ */
+
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  assertNoForbiddenKeys,
+  rowToPoolMatch,
+  type PoolMatchRow,
+} from "../_shared/poolMatchResponse.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const MIN_QUERY_LENGTH = 3;
+const DEFAULT_LIMIT = 1;
+const MAX_LIMIT = 5;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+
+const rateBuckets = new Map<string, number[]>();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+export function normalizeSearchBody(
+  body: unknown,
+):
+  | { ok: true; query: string; limit: number }
+  | { ok: false; error: string } {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "invalid_json" };
+  }
+  const b = body as Record<string, unknown>;
+  const query = typeof b.query === "string" ? b.query.trim() : "";
+  if (query.length < MIN_QUERY_LENGTH) {
+    return { ok: false, error: "query_too_short" };
+  }
+  let limit = DEFAULT_LIMIT;
+  if (typeof b.limit === "number" && Number.isFinite(b.limit)) {
+    limit = Math.max(1, Math.min(Math.floor(b.limit), MAX_LIMIT));
+  }
+  return { ok: true, query, limit };
+}
+
+export function checkRateLimit(userId: string, now = Date.now()): boolean {
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const hits = (rateBuckets.get(userId) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= RATE_LIMIT_MAX) {
+    rateBuckets.set(userId, hits);
+    return false;
+  }
+  hits.push(now);
+  rateBuckets.set(userId, hits);
+  return true;
+}
+
+export async function requireUser(
+  req: Request,
+): Promise<{ userId: string } | Response> {
+  const authHeader = req.headers.get("authorization") ?? "";
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (!tokenMatch) return jsonResponse({ error: "auth_required" }, 401);
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  if (!supabaseUrl || !serviceRoleKey) {
+    return jsonResponse({ error: "server_misconfigured" }, 500);
+  }
+
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+  const { data, error } = await client.auth.getUser(tokenMatch[1]);
+  if (error !== null || data.user === null) {
+    return jsonResponse({ error: "auth_invalid" }, 401);
+  }
+  return { userId: data.user.id };
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method_not_allowed" }, 405);
+  }
+
+  const userResult = await requireUser(req);
+  if (userResult instanceof Response) return userResult;
+
+  if (!checkRateLimit(userResult.userId)) {
+    return jsonResponse({ error: "rate_limited" }, 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, 400);
+  }
+
+  const normalized = normalizeSearchBody(body);
+  if (!normalized.ok) {
+    return jsonResponse({ error: normalized.error }, 400);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const { data, error } = await client.rpc("biz_search_place_pool_for_claim", {
+    p_query: normalized.query,
+    p_limit: normalized.limit,
+  });
+
+  if (error !== null) {
+    console.error("[claim-search-pool]", error.message);
+    return jsonResponse({ error: "search_failed" }, 500);
+  }
+
+  const rows = (data ?? []) as PoolMatchRow[];
+  const matches = rows.map((row) => {
+    const match = rowToPoolMatch(row);
+    assertNoForbiddenKeys(match as unknown as Record<string, unknown>);
+    return match;
+  });
+
+  return jsonResponse({ matches });
+});

--- a/supabase/migrations/20260618000000_ve2_pool_match_claim.sql
+++ b/supabase/migrations/20260618000000_ve2_pool_match_claim.sql
@@ -1,0 +1,268 @@
+-- Ve2 Pool Match Comparison (GitHub issue #100)
+-- Allow duplicate pending_review claims per google_place_id; persist place_pool_id on create.
+
+BEGIN;
+
+-- Multiple pending_review claims for the same place queue for admin (Ve3 arbitrates).
+DROP INDEX IF EXISTS idx_brands_google_place_id_claim_active_unique;
+
+CREATE UNIQUE INDEX idx_brands_google_place_id_verified_unique
+  ON public.brands (google_place_id)
+  WHERE
+    deleted_at IS NULL
+    AND google_place_id IS NOT NULL
+    AND claim_status = 'verified';
+
+COMMENT ON INDEX idx_brands_google_place_id_verified_unique IS
+  'Ve2 — only one verified brand per Google place; duplicate pending_review claims allowed.';
+
+-- Extend venue create RPC with optional place_pool_id linkage.
+DROP FUNCTION IF EXISTS public.biz_create_venue_brand_pending_review (
+  text,
+  text,
+  text,
+  text,
+  double precision,
+  double precision,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb
+);
+
+CREATE OR REPLACE FUNCTION public.biz_create_venue_brand_pending_review (
+  p_name text,
+  p_slug text,
+  p_description text,
+  p_google_place_id text,
+  p_lat double precision,
+  p_lng double precision,
+  p_city text,
+  p_country_code text,
+  p_address text,
+  p_venue_category text,
+  p_contact_email text,
+  p_contact_phone text,
+  p_cover_media_url text,
+  p_cover_media_type text,
+  p_hours jsonb,
+  p_place_pool_id uuid DEFAULT NULL
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_uid uuid;
+  v_brand_id uuid;
+  v_idx int;
+  v_hour jsonb;
+  v_cover_url text;
+  v_cover_type text;
+  v_pool_google text;
+BEGIN
+  v_uid := auth.uid ();
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF length(trim(coalesce(p_name, ''))) = 0 THEN
+    RAISE EXCEPTION 'name_required';
+  END IF;
+
+  IF length(trim(coalesce(p_slug, ''))) = 0 THEN
+    RAISE EXCEPTION 'slug_required';
+  END IF;
+
+  IF trim(p_slug) !~ '^[a-z0-9]{1,32}$' THEN
+    RAISE EXCEPTION 'invalid_slug';
+  END IF;
+
+  IF p_google_place_id IS NULL OR length(trim(p_google_place_id)) = 0 THEN
+    RAISE EXCEPTION 'google_place_id_required';
+  END IF;
+
+  IF p_hours IS NULL OR jsonb_typeof(p_hours) != 'array' OR jsonb_array_length(p_hours) != 7 THEN
+    RAISE EXCEPTION 'hours_must_have_7_rows';
+  END IF;
+
+  IF p_venue_category IS NULL OR p_venue_category NOT IN ('restaurant', 'play', 'creative_and_arts') THEN
+    RAISE EXCEPTION 'invalid_venue_category';
+  END IF;
+
+  IF p_place_pool_id IS NOT NULL THEN
+    SELECT p.google_place_id
+    INTO v_pool_google
+    FROM public.place_pool p
+    WHERE p.id = p_place_pool_id
+      AND p.is_active = true;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'place_pool_not_found';
+    END IF;
+
+    IF trim(v_pool_google) IS DISTINCT FROM trim(p_google_place_id) THEN
+      RAISE EXCEPTION 'place_pool_google_place_id_mismatch';
+    END IF;
+  END IF;
+
+  v_cover_url := nullif(trim(coalesce(p_cover_media_url, '')), '');
+  v_cover_type := nullif(trim(coalesce(p_cover_media_type, '')), '');
+
+  IF v_cover_type IS NOT NULL AND v_cover_type NOT IN ('image', 'video', 'gif') THEN
+    RAISE EXCEPTION 'invalid_cover_media_type';
+  END IF;
+
+  IF v_cover_url IS NOT NULL AND v_cover_type IS NULL THEN
+    RAISE EXCEPTION 'cover_media_type_required';
+  END IF;
+
+  IF v_cover_url IS NULL THEN
+    v_cover_type := NULL;
+  END IF;
+
+  INSERT INTO public.brands (
+    account_id,
+    name,
+    slug,
+    description,
+    kind,
+    address,
+    google_place_id,
+    place_pool_id,
+    lat,
+    lng,
+    city,
+    country_code,
+    claim_status,
+    venue_category,
+    contact_email,
+    contact_phone,
+    cover_media_url,
+    cover_media_type,
+    cover_hue,
+    tax_settings,
+    social_links,
+    custom_links,
+    display_attendee_count,
+    stripe_connect_id,
+    stripe_payouts_enabled,
+    stripe_charges_enabled
+  )
+  VALUES (
+    v_uid,
+    trim(p_name),
+    trim(p_slug),
+    p_description,
+    'physical',
+    nullif(trim(p_address), ''),
+    trim(p_google_place_id),
+    p_place_pool_id,
+    p_lat,
+    p_lng,
+    nullif(trim(p_city), ''),
+    nullif(trim(p_country_code), ''),
+    'pending_review',
+    p_venue_category,
+    nullif(trim(p_contact_email), ''),
+    nullif(trim(p_contact_phone), ''),
+    v_cover_url,
+    v_cover_type,
+    25,
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '[]'::jsonb,
+    true,
+    NULL,
+    false,
+    false
+  )
+  RETURNING id INTO v_brand_id;
+
+  FOR v_idx IN 0 .. 6 LOOP
+    v_hour := p_hours -> v_idx;
+    IF v_hour IS NULL THEN
+      RAISE EXCEPTION 'missing_hour_index_%', v_idx;
+    END IF;
+
+    INSERT INTO public.brand_hours (
+      brand_id,
+      weekday,
+      open_time,
+      close_time,
+      is_closed
+    )
+    VALUES (
+      v_brand_id,
+      (v_hour ->> 'weekday')::smallint,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'open_time' IS NULL OR (v_hour ->> 'open_time') = '' THEN NULL
+        ELSE (v_hour ->> 'open_time')::time
+      END,
+      CASE
+        WHEN coalesce((v_hour ->> 'is_closed')::boolean, false) THEN NULL
+        WHEN v_hour ->> 'close_time' IS NULL OR (v_hour ->> 'close_time') = '' THEN NULL
+        ELSE (v_hour ->> 'close_time')::time
+      END,
+      coalesce((v_hour ->> 'is_closed')::boolean, false)
+    );
+  END LOOP;
+
+  RETURN v_brand_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_create_venue_brand_pending_review (
+  text,
+  text,
+  text,
+  text,
+  double precision,
+  double precision,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  jsonb,
+  uuid
+) TO authenticated;
+
+COMMENT ON FUNCTION public.biz_create_venue_brand_pending_review IS
+  'Ve1+Ve2 — physical brand pending_review + optional place_pool_id when pool match accepted.';
+
+-- Structural verify: verified-only uniqueness (pending_review duplicates allowed).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'idx_brands_google_place_id_verified_unique'
+  ) THEN
+    RAISE EXCEPTION 'Ve2 verify FAIL: idx_brands_google_place_id_verified_unique missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'biz_create_venue_brand_pending_review'
+      AND pg_get_function_identity_arguments(p.oid) NOT LIKE '%uuid%'
+  ) THEN
+    RAISE EXCEPTION 'Ve2 verify FAIL: create RPC missing p_place_pool_id uuid arg';
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260618000001_ve2_claim_search_rpc.sql
+++ b/supabase/migrations/20260618000001_ve2_claim_search_rpc.sql
@@ -1,0 +1,66 @@
+-- Ve2 — ILIKE-safe place_pool name search for claim-search-pool edge function.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.biz_search_place_pool_for_claim (
+  p_query text,
+  p_limit int DEFAULT 5
+) RETURNS TABLE (
+  id uuid,
+  name text,
+  address text,
+  city text,
+  country text,
+  lat double precision,
+  lng double precision,
+  google_place_id text,
+  primary_type text,
+  types text[],
+  opening_hours jsonb,
+  stored_photo_urls text[]
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    p.id,
+    p.name,
+    p.address,
+    p.city,
+    p.country,
+    p.lat,
+    p.lng,
+    p.google_place_id,
+    p.primary_type,
+    p.types,
+    p.opening_hours,
+    p.stored_photo_urls
+  FROM public.place_pool p
+  WHERE p.is_active = true
+    AND length(trim(coalesce(p_query, ''))) >= 3
+    AND p.name ILIKE (
+      '%' || public.escape_like_pattern(trim(p_query)) || '%'
+    ) ESCAPE '\'
+  ORDER BY
+    CASE
+      WHEN p.name ILIKE (
+        public.escape_like_pattern(trim(p_query)) || '%'
+      ) ESCAPE '\' THEN 0
+      ELSE 1
+    END,
+    coalesce(p.review_count, 0) DESC,
+    p.name ASC
+  LIMIT greatest(1, least(coalesce(p_limit, 5), 10));
+$$;
+
+REVOKE ALL ON FUNCTION public.biz_search_place_pool_for_claim (text, int)
+FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.biz_search_place_pool_for_claim (text, int)
+TO service_role;
+
+COMMENT ON FUNCTION public.biz_search_place_pool_for_claim IS
+  'Ve2 — public-safe place_pool rows for claim-search-pool (service_role only).';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Implements Ve2 pool match comparison for physical venue onboarding (GitHub #100): debounced directory search, inline match card, and prefilled wizard when the operator confirms a `place_pool` hit.
- Adds `claim-search-pool` edge function and `biz_search_place_pool_for_claim` RPC (public-safe fields only), extends `biz_create_venue_brand_pending_review` with optional `place_pool_id`, and allows multiple `pending_review` claims per `google_place_id` (verified-only uniqueness).
- Wires brand sheet persona entry, `/venue/create` gate, and submit path (`place_pool_id`, HTTPS pool photos as cover).

## Test plan

- [ ] Apply migrations on staging:
  - `20260618000000_ve2_pool_match_claim.sql`
  - `20260618000001_ve2_claim_search_rpc.sql`
- [ ] Deploy edge function: `supabase functions deploy claim-search-pool`
- [ ] Run regression tests:
  ```bash
  cd mingla-business && npx jest --config jest.config.cjs \
    --testPathPattern="ve2|poolSearch|poolMatch|claimSearch|mapPool|prefillDraft|create.ve2|VenueCreatorWizard.ve2|ve2Migration|ve1VenueServices|BrandSwitcherSheet.personaFork"
  ```
- [ ] New account → brand sheet → type known `place_pool` venue name → match card appears (~300ms debounce)
- [ ] Tap **Yes, this is me** → wizard prefilled, category step skipped
- [ ] Submit → verify DB: `place_pool_id` and `google_place_id` both populated
- [ ] Second account, same venue → second `pending_review` claim succeeds (no UI block)
- [ ] Tap **No** / **Skip** → Ve1 category + manual wizard path unchanged
- [ ] Popup / trip brand creation regression (persona fork unchanged for event/trip)