### PR TITLE
Ve3 (#101): Admin venue claims queue and verification workflow

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -317,6 +317,17 @@ function checkNoNewBackendFiles() {
     "supabase/migrations/20260618000000_ve2_pool_match_claim.sql",
     "supabase/migrations/20260618000001_ve2_claim_search_rpc.sql",
   ];
+  // ORCH-0101 [Ve3 Admin Queue + Verification Workflow] PR #143 (2026-05-19).
+  // C7 is scoped to ORCH-0863 marketing; these backend touches are Ve3
+  // venue-claim admin review scope (claim orchestrator + migration).
+  const ORCH_0101_VE3_BACKEND_ALLOWLIST = [
+    "supabase/functions/_shared/email/claimApprovedEmail.ts",
+    "supabase/functions/_shared/email/claimRejectedEmail.ts",
+    "supabase/functions/admin-review-venue-claim/index.test.ts",
+    "supabase/functions/admin-review-venue-claim/index.ts",
+    "supabase/functions/admin-review-venue-claim/reviewLogic.ts",
+    "supabase/migrations/20260619000000_ve3_admin_claim_review.sql",
+  ];
   // ORCH-0877 [Event end-time display + midnight-crossing single-day authoring]
   // PR #136 (2026-05-19). C7 is scoped to ORCH-0863 marketing; these backend
   // touches are end-time + cross-midnight + ICS Constitution #9 fix scope.
@@ -360,6 +371,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_0875_BACKEND_ALLOWLIST,
     ...ORCH_0099_VE1_BACKEND_ALLOWLIST,
     ...ORCH_0100_VE2_BACKEND_ALLOWLIST,
+    ...ORCH_0101_VE3_BACKEND_ALLOWLIST,
     ...ORCH_0877_BACKEND_ALLOWLIST,
     ...ORCH_0876_BACKEND_ALLOWLIST,
     ...ORCH_0879_BACKEND_ALLOWLIST,

--- a/Mingla_Artifacts/dev/VE3_SMOKE_FIXTURES.md
+++ b/Mingla_Artifacts/dev/VE3_SMOKE_FIXTURES.md
@@ -1,0 +1,28 @@
+# Ve3 — Staging smoke fixtures
+
+Use after Ve1+Ve2 onboarding paths are available. Ve3 queue is `#/claims` in mingla-admin.
+
+## Required scenarios
+
+| # | Scenario | How to create |
+|---|----------|----------------|
+| 1 | Pool-match pending claim | Submit via business app with pool match card → `place_pool_id` set |
+| 2 | Off-pool pending claim | Submit without pool match → operator `contact_phone` only |
+| 3 | Duplicate pair | Two accounts, same `google_place_id`, both `pending_review` |
+
+## DB probes
+
+```sql
+SELECT id, name, claim_status, place_pool_id, google_place_id,
+       marked_called_at, duplicate_of_brand_id, claim_follow_up_at
+FROM brands
+WHERE kind = 'physical' AND claim_status = 'pending_review' AND deleted_at IS NULL
+ORDER BY created_at ASC;
+```
+
+## Post-approve
+
+```sql
+SELECT claim_status, verified_at, verified_by, rejection_reason
+FROM brands WHERE id = '<brand-id>';
+```

--- a/Mingla_Artifacts/milestones/Ve3_ADMIN_QUEUE_AND_VERIFICATION.md
+++ b/Mingla_Artifacts/milestones/Ve3_ADMIN_QUEUE_AND_VERIFICATION.md
@@ -3,7 +3,7 @@
 > **Track:** Track 2 — Physical venues
 > **Duration:** 1 week
 > **Depends on:** Ve1, Ve2 (in TestFlight)
-> **Status:** locked, not started
+> **Status:** implemented on branch `feat/ve3-admin-claims` (queue at `#/claims`)
 
 ---
 
@@ -63,17 +63,18 @@ The phone-callback validation is the identity proof for physical venues (in cont
 ## 4. Files Touched
 
 **New:**
-- `mingla-admin/src/pages/AdminClaimsQueue.jsx`
-- `mingla-admin/src/components/ClaimRow.jsx`
-- `mingla-admin/src/components/ClaimDetailPanel.jsx`
+- `mingla-admin/src/pages/ClaimsPage.jsx` (extended; route `#/claims`)
+- `mingla-admin/src/components/claims/ClaimRow.jsx`
 - `mingla-admin/src/services/adminClaimsService.js`
-- `supabase/functions/admin-approve-claim/index.ts`
-- `supabase/functions/admin-reject-claim/index.ts`
+- `mingla-admin/src/lib/claimsPhone.js`
+- `supabase/functions/admin-review-venue-claim/index.ts`
 - `supabase/functions/_shared/email/claimApprovedEmail.ts`
 - `supabase/functions/_shared/email/claimRejectedEmail.ts`
 
 **Modified:**
-- `mingla-business/src/services/venueClaimService.ts` (handle the status change pull on the operator side)
+- `mingla-business/src/services/venueClaimService.ts` + `venueClaimBannerLogic.ts`
+- `mingla-business/app/(tabs)/hub/_layout.tsx` (claim status banner)
+- `supabase/migrations/20260619000000_ve3_admin_claim_review.sql`
 
 ---
 

--- a/mingla-admin/package.json
+++ b/mingla-admin/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test src/lib/__tests__/claimsPhone.test.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.98.0",

--- a/mingla-admin/src/components/claims/ClaimRow.jsx
+++ b/mingla-admin/src/components/claims/ClaimRow.jsx
@@ -1,0 +1,111 @@
+import { Badge } from "../ui/Badge";
+import { formatDateTime } from "../../lib/formatters";
+import { formatPhoneHref, resolveClaimDisplayPhone } from "../../lib/claimsPhone";
+
+const CAT_LABELS = {
+  restaurant: "Restaurant",
+  play: "Play",
+  creative_and_arts: "Creative & arts",
+};
+
+export function slaLabel(createdAt) {
+  const start = new Date(createdAt).getTime();
+  const due = start + 4 * 60 * 60 * 1000;
+  const ms = due - Date.now();
+  if (ms <= 0) return { text: "Past 4h window", tone: "warning" };
+  const m = Math.floor(ms / 60000);
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  const text = h > 0 ? `${h}h ${mm}m remaining` : `${mm}m remaining`;
+  return { text, tone: "info" };
+}
+
+/**
+ * @param {object} props
+ * @param {object} props.row
+ * @param {boolean} [props.hasDuplicateSiblings]
+ * @param {boolean} [props.isDuplicateOfApproved]
+ * @param {() => void} props.onSelect
+ */
+export function ClaimRow({
+  row,
+  hasDuplicateSiblings,
+  isDuplicateOfApproved,
+  onSelect,
+}) {
+  const sla = slaLabel(row.created_at);
+  const phoneInfo = resolveClaimDisplayPhone(row);
+  const tel = formatPhoneHref(phoneInfo.phone);
+  const addressLine = [row.address, row.city, row.country_code]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <tr
+      className="border-b border-white/5 hover:bg-white/[0.04] cursor-pointer"
+      onClick={onSelect}
+    >
+      <td className="py-3 pr-4 font-medium text-[var(--color-text-primary)]">
+        <NameCell row={row} />
+      </td>
+      <td className="py-3 pr-4 text-[var(--color-text-secondary)] max-w-[200px]">
+        <span className="line-clamp-2">{addressLine || "—"}</span>
+      </td>
+      <td className="py-3 pr-4 text-[var(--color-text-secondary)] whitespace-nowrap">
+        {phoneInfo.phone ? (
+          tel ? (
+            <a
+              href={tel}
+              className="text-[var(--color-brand-400)] underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {phoneInfo.phone}
+            </a>
+          ) : (
+            phoneInfo.phone
+          )
+        ) : (
+          "—"
+        )}
+      </td>
+      <td className="py-3 pr-4">
+        <div className="flex flex-wrap gap-1">
+          {row.place_pool_id ? (
+            <Badge variant="brand">Pool match</Badge>
+          ) : null}
+          {row.marked_called_at ? (
+            <Badge variant="success">Called</Badge>
+          ) : null}
+          {row.claim_follow_up_at ? (
+            <Badge variant="warning">Follow-up</Badge>
+          ) : null}
+          {hasDuplicateSiblings ? (
+            <Badge variant="warning">Duplicate queue</Badge>
+          ) : null}
+          {isDuplicateOfApproved ? (
+            <Badge variant="error">Dup. of approved</Badge>
+          ) : null}
+        </div>
+      </td>
+      <td className="py-3 pr-4 text-[var(--color-text-secondary)] whitespace-nowrap">
+        {formatDateTime(row.created_at)}
+      </td>
+      <td className="py-3 pr-4">
+        <Badge variant={sla.tone}>{sla.text}</Badge>
+      </td>
+    </tr>
+  );
+}
+
+function NameCell({ row }) {
+  return (
+    <>
+      {row.name}
+      <div className="text-xs font-normal text-[var(--color-text-tertiary)] mt-0.5">
+        {CAT_LABELS[row.venue_category] ?? row.venue_category ?? "—"}
+      </div>
+    </>
+  );
+}
+
+export default ClaimRow;

--- a/mingla-admin/src/lib/__tests__/claimsPhone.test.js
+++ b/mingla-admin/src/lib/__tests__/claimsPhone.test.js
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatPhoneHref, resolveClaimDisplayPhone } from "../claimsPhone.js";
+
+describe("resolveClaimDisplayPhone", () => {
+  it("uses pool national_phone_number when place_pool_id set", () => {
+    const r = resolveClaimDisplayPhone({
+      place_pool_id: "p1",
+      contact_phone: "+1 555 0000",
+      place_pool: { national_phone_number: "+1 212 555 0100" },
+    });
+    assert.equal(r.phone, "+1 212 555 0100");
+    assert.equal(r.source, "pool");
+    assert.equal(r.note, null);
+  });
+
+  it("off-pool uses operator phone with Maps note", () => {
+    const r = resolveClaimDisplayPhone({
+      place_pool_id: null,
+      contact_phone: "+1 555 9999",
+      place_pool: null,
+    });
+    assert.equal(r.phone, "+1 555 9999");
+    assert.equal(r.source, "operator");
+    assert.equal(r.note, "Verify via Google Maps lookup");
+  });
+
+  it("formatPhoneHref strips formatting", () => {
+    assert.equal(formatPhoneHref("+1 (212) 555-0100"), "tel:+12125550100");
+  });
+});

--- a/mingla-admin/src/lib/auditLog.js
+++ b/mingla-admin/src/lib/auditLog.js
@@ -60,4 +60,8 @@ export const ACTION_LABELS = {
   "place.stale_bulk_deactivate": "Bulk deactivated stale places",
   "place.batch_refresh": "Batch refreshed stale places",
   "place.refresh_single": "Refreshed single place",
+  "claim.mark_called": "Marked venue claim as called",
+  "claim.approve": "Approved venue claim",
+  "claim.reject": "Rejected venue claim",
+  "claim.need_more_info": "Requested more info on venue claim",
 };

--- a/mingla-admin/src/lib/claimsPhone.js
+++ b/mingla-admin/src/lib/claimsPhone.js
@@ -1,0 +1,37 @@
+/**
+ * Ve3 — resolve dial-ready phone for venue claim queue rows.
+ */
+
+/**
+ * @param {object} row
+ * @param {string | null | undefined} row.contact_phone
+ * @param {string | null | undefined} row.place_pool_id
+ * @param {{ national_phone_number?: string | null } | null | undefined} row.place_pool
+ */
+export function resolveClaimDisplayPhone(row) {
+  const poolPhone =
+    row?.place_pool?.national_phone_number?.trim?.() ?? "";
+  if (row?.place_pool_id && poolPhone.length > 0) {
+    return {
+      phone: poolPhone,
+      source: "pool",
+      note: null,
+    };
+  }
+
+  const operatorPhone = row?.contact_phone?.trim?.() ?? "";
+  return {
+    phone: operatorPhone.length > 0 ? operatorPhone : null,
+    source: "operator",
+    note:
+      row?.place_pool_id == null
+        ? "Verify via Google Maps lookup"
+        : "Pool match — no Google phone on file; use operator number or Maps",
+  };
+}
+
+export function formatPhoneHref(phone) {
+  if (!phone) return null;
+  const digits = phone.replace(/[^\d+]/g, "");
+  return digits.length > 0 ? `tel:${digits}` : null;
+}

--- a/mingla-admin/src/pages/ClaimsPage.jsx
+++ b/mingla-admin/src/pages/ClaimsPage.jsx
@@ -1,8 +1,8 @@
 /**
- * Ve1 — Venue claims queue (physical brands pending_review).
+ * Ve3 — Venue claims queue (physical brands pending_review).
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ClipboardList } from "lucide-react";
 import { supabase } from "../lib/supabase";
 import { SectionCard } from "../components/ui/Card";
@@ -11,7 +11,14 @@ import { Badge } from "../components/ui/Badge";
 import { Modal, ModalBody, ModalFooter } from "../components/ui/Modal";
 import { Spinner } from "../components/ui/Spinner";
 import { useToast } from "../context/ToastContext";
-import { formatDateTime } from "../lib/formatters";
+import { logAdminAction } from "../lib/auditLog";
+import { resolveClaimDisplayPhone, formatPhoneHref } from "../lib/claimsPhone";
+import { ClaimRow } from "../components/claims/ClaimRow";
+import {
+  groupClaimsByGooglePlaceId,
+  listPendingClaims,
+  reviewClaim,
+} from "../services/adminClaimsService";
 
 const CAT_LABELS = {
   restaurant: "Restaurant",
@@ -20,18 +27,6 @@ const CAT_LABELS = {
 };
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-
-function slaLabel(createdAt) {
-  const start = new Date(createdAt).getTime();
-  const due = start + 4 * 60 * 60 * 1000;
-  const ms = due - Date.now();
-  if (ms <= 0) return { text: "Past 4h window", tone: "warning" };
-  const m = Math.floor(ms / 60000);
-  const h = Math.floor(m / 60);
-  const mm = m % 60;
-  const text = h > 0 ? `${h}h ${mm}m remaining` : `${mm}m remaining`;
-  return { text, tone: "info" };
-}
 
 export function ClaimsPage() {
   const { addToast } = useToast();
@@ -44,21 +39,16 @@ export function ClaimsPage() {
   const [rejectOpen, setRejectOpen] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
 
+  const duplicateGroups = useMemo(
+    () => groupClaimsByGooglePlaceId(rows),
+    [rows],
+  );
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const { data, error } = await supabase
-        .from("brands")
-        .select(
-          "id,name,slug,venue_category,city,country_code,address,created_at,contact_email,contact_phone,description,google_place_id,lat,lng,cover_media_url",
-        )
-        .eq("kind", "physical")
-        .eq("claim_status", "pending_review")
-        .is("deleted_at", null)
-        .order("created_at", { ascending: false });
-
-      if (error) throw error;
-      setRows(data ?? []);
+      const data = await listPendingClaims();
+      setRows(data);
     } catch (e) {
       addToast({
         variant: "error",
@@ -103,43 +93,45 @@ export function ClaimsPage() {
     setHours([]);
   };
 
-  const notifyDecision = async (brandId, decision, rejectionReason = "") => {
-    try {
-      const { error } = await supabase.functions.invoke(
-        "venue-claim-decision-email",
-        {
-          body: {
-            brand_id: brandId,
-            decision,
-            rejection_reason: rejectionReason,
-          },
-        },
-      );
-      if (error) {
-        console.warn("[ClaimsPage] decision email", error.message);
-      }
-    } catch (e) {
-      console.warn("[ClaimsPage] decision email", e);
-    }
-  };
-
-  const approve = async () => {
+  const runReview = async (action, opts = {}) => {
     if (!detail) return;
     setActing(true);
     try {
-      const { error } = await supabase.rpc("biz_review_venue_claim", {
-        p_brand_id: detail.id,
-        p_action: "approve",
+      const data = await reviewClaim(detail.id, action, opts);
+      await logAdminAction(`claim.${action}`, "venue_claim", detail.id, {
+        result: data?.result ?? null,
       });
-      if (error) throw error;
-      await notifyDecision(detail.id, "approved");
-      addToast({ variant: "info", title: "Venue approved" });
-      closeDetail();
-      await load();
+      if (action === "mark_called") {
+        addToast({ variant: "info", title: "Marked as called" });
+        setDetail((d) =>
+          d ? { ...d, marked_called_at: new Date().toISOString() } : d,
+        );
+      } else if (action === "need_more_info") {
+        addToast({ variant: "info", title: "Follow-up flagged" });
+        closeDetail();
+        await load();
+      } else if (action === "approve") {
+        const dup = data?.result?.duplicate_flagged_count ?? 0;
+        addToast({
+          variant: "info",
+          title: "Venue approved",
+          description:
+            dup > 0
+              ? `${dup} duplicate claim(s) flagged for review`
+              : undefined,
+        });
+        closeDetail();
+        await load();
+      } else if (action === "reject") {
+        addToast({ variant: "info", title: "Venue rejected" });
+        setRejectOpen(false);
+        closeDetail();
+        await load();
+      }
     } catch (e) {
       addToast({
         variant: "error",
-        title: "Approve failed",
+        title: "Action failed",
         description: e?.message ?? String(e),
       });
     } finally {
@@ -152,8 +144,7 @@ export function ClaimsPage() {
     setRejectOpen(true);
   };
 
-  const reject = async () => {
-    if (!detail) return;
+  const confirmReject = async () => {
     const reason = rejectReason.trim();
     if (reason.length === 0) {
       addToast({
@@ -163,28 +154,20 @@ export function ClaimsPage() {
       });
       return;
     }
-    setActing(true);
-    try {
-      const { error } = await supabase.rpc("biz_review_venue_claim", {
-        p_brand_id: detail.id,
-        p_action: "reject",
-      });
-      if (error) throw error;
-      await notifyDecision(detail.id, "rejected", reason);
-      addToast({ variant: "info", title: "Venue rejected" });
-      setRejectOpen(false);
-      closeDetail();
-      await load();
-    } catch (e) {
-      addToast({
-        variant: "error",
-        title: "Reject failed",
-        description: e?.message ?? String(e),
-      });
-    } finally {
-      setActing(false);
-    }
+    await runReview("reject", { rejectionReason: reason });
   };
+
+  const phoneInfo = detail ? resolveClaimDisplayPhone(detail) : null;
+  const tel = phoneInfo ? formatPhoneHref(phoneInfo.phone) : null;
+  const mapsUri = detail
+    ? (detail.place_pool?.google_maps_uri ??
+      (detail.google_place_id
+        ? `https://www.google.com/maps/search/?api=1&query_place_id=${encodeURIComponent(detail.google_place_id)}`
+        : null))
+    : null;
+  const isDuplicateOfApproved = Boolean(detail?.duplicate_of_brand_id);
+  const canApprove =
+    Boolean(detail?.marked_called_at) && !isDuplicateOfApproved;
 
   return (
     <div className="p-6 space-y-6 max-w-6xl mx-auto">
@@ -195,7 +178,7 @@ export function ClaimsPage() {
             Venue claims
           </h1>
           <p className="text-sm text-[var(--color-text-secondary)]">
-            Physical brands awaiting verification (Ve1)
+            Physical brands awaiting phone verification (Ve3)
           </p>
         </div>
         <Button variant="secondary" className="ml-auto" onClick={() => void load()}>
@@ -203,7 +186,10 @@ export function ClaimsPage() {
         </Button>
       </div>
 
-      <SectionCard title={`Queue (${rows.length})`} subtitle="Submitted venue brands">
+      <SectionCard
+        title={`Queue (${rows.length})`}
+        subtitle="Oldest first · call venue then approve"
+      >
         {loading ? (
           <div className="flex justify-center py-12">
             <Spinner />
@@ -218,37 +204,25 @@ export function ClaimsPage() {
               <thead>
                 <tr className="border-b border-white/10 text-left text-[var(--color-text-tertiary)]">
                   <th className="py-2 pr-4">Name</th>
-                  <th className="py-2 pr-4">Category</th>
-                  <th className="py-2 pr-4">City</th>
+                  <th className="py-2 pr-4">Address</th>
+                  <th className="py-2 pr-4">Phone</th>
+                  <th className="py-2 pr-4">Flags</th>
                   <th className="py-2 pr-4">Submitted</th>
                   <th className="py-2 pr-4">SLA</th>
                 </tr>
               </thead>
               <tbody>
                 {rows.map((r) => {
-                  const sla = slaLabel(r.created_at);
+                  const gid = r.google_place_id?.trim?.();
+                  const siblings = gid ? duplicateGroups.get(gid) ?? [] : [];
                   return (
-                    <tr
+                    <ClaimRow
                       key={r.id}
-                      className="border-b border-white/5 hover:bg-white/[0.04] cursor-pointer"
-                      onClick={() => openDetail(r)}
-                    >
-                      <td className="py-3 pr-4 font-medium text-[var(--color-text-primary)]">
-                        {r.name}
-                      </td>
-                      <td className="py-3 pr-4 text-[var(--color-text-secondary)]">
-                        {CAT_LABELS[r.venue_category] ?? r.venue_category ?? "—"}
-                      </td>
-                      <td className="py-3 pr-4 text-[var(--color-text-secondary)]">
-                        {[r.city, r.country_code].filter(Boolean).join(", ") || "—"}
-                      </td>
-                      <td className="py-3 pr-4 text-[var(--color-text-secondary)] whitespace-nowrap">
-                        {formatDateTime(r.created_at)}
-                      </td>
-                      <td className="py-3 pr-4">
-                        <Badge variant={sla.tone}>{sla.text}</Badge>
-                      </td>
-                    </tr>
+                      row={r}
+                      hasDuplicateSiblings={siblings.length > 1}
+                      isDuplicateOfApproved={Boolean(r.duplicate_of_brand_id)}
+                      onSelect={() => openDetail(r)}
+                    />
                   );
                 })}
               </tbody>
@@ -261,6 +235,23 @@ export function ClaimsPage() {
         <ModalBody>
           {!detail ? null : (
             <div className="space-y-4 text-sm">
+              {isDuplicateOfApproved ? (
+                <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-amber-100">
+                  Duplicate of an approved claim for this Google place. Reject unless
+                  the venue confirms this signup is theirs.
+                </div>
+              ) : null}
+              <div className="flex flex-wrap gap-2">
+                {detail.place_pool_id ? (
+                  <Badge variant="brand">Pool match</Badge>
+                ) : null}
+                {detail.marked_called_at ? (
+                  <Badge variant="success">Called</Badge>
+                ) : null}
+                {detail.claim_follow_up_at ? (
+                  <Badge variant="warning">Follow-up requested</Badge>
+                ) : null}
+              </div>
               <div className="grid grid-cols-2 gap-2">
                 <div className="text-[var(--color-text-tertiary)]">Slug</div>
                 <div>{detail.slug}</div>
@@ -280,12 +271,45 @@ export function ClaimsPage() {
                 <div>{detail.address || "—"}</div>
               </div>
               <div>
-                <div className="text-[var(--color-text-tertiary)] mb-1">Contact</div>
+                <div className="text-[var(--color-text-tertiary)] mb-1">Phone to dial</div>
                 <div>
-                  {[detail.contact_email, detail.contact_phone].filter(Boolean).join(" · ") ||
-                    "—"}
+                  {phoneInfo?.phone ? (
+                    tel ? (
+                      <a href={tel} className="text-[var(--color-brand-400)] underline">
+                        {phoneInfo.phone}
+                      </a>
+                    ) : (
+                      phoneInfo.phone
+                    )
+                  ) : (
+                    "—"
+                  )}
+                  {phoneInfo?.source === "pool" ? (
+                    <span className="ml-2 text-xs text-[var(--color-text-tertiary)]">
+                      (Google-listed)
+                    </span>
+                  ) : null}
                 </div>
+                {phoneInfo?.note ? (
+                  <p className="text-xs text-amber-200/90 mt-1">{phoneInfo.note}</p>
+                ) : null}
               </div>
+              <div>
+                <div className="text-[var(--color-text-tertiary)] mb-1">Contact email</div>
+                <div>{detail.contact_email || "—"}</div>
+              </div>
+              {mapsUri ? (
+                <div>
+                  <a
+                    href={mapsUri}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-[var(--color-brand-400)] underline"
+                  >
+                    Open in Google Maps
+                  </a>
+                </div>
+              ) : null}
               <div>
                 <div className="text-[var(--color-text-tertiary)] mb-1">Description</div>
                 <div className="whitespace-pre-wrap">{detail.description || "—"}</div>
@@ -329,12 +353,38 @@ export function ClaimsPage() {
           <Button variant="secondary" onClick={closeDetail} disabled={acting}>
             Close
           </Button>
+          <Button
+            variant="secondary"
+            onClick={() => void runReview("need_more_info")}
+            disabled={acting}
+          >
+            Need more info
+          </Button>
           <Button variant="danger" onClick={openReject} disabled={acting}>
             Reject
           </Button>
-          <Button variant="primary" onClick={() => void approve()} disabled={acting}>
-            Approve
-          </Button>
+          {!detail?.marked_called_at ? (
+            <Button
+              variant="secondary"
+              onClick={() => void runReview("mark_called")}
+              disabled={acting}
+            >
+              Mark as called
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              onClick={() => void runReview("approve")}
+              disabled={acting || !canApprove}
+              title={
+                isDuplicateOfApproved
+                  ? "Resolve duplicate — reject this claim first"
+                  : undefined
+              }
+            >
+              Approve
+            </Button>
+          )}
         </ModalFooter>
       </Modal>
 
@@ -363,7 +413,7 @@ export function ClaimsPage() {
           >
             Cancel
           </Button>
-          <Button variant="danger" onClick={() => void reject()} disabled={acting}>
+          <Button variant="danger" onClick={() => void confirmReject()} disabled={acting}>
             Confirm reject
           </Button>
         </ModalFooter>

--- a/mingla-admin/src/services/adminClaimsService.js
+++ b/mingla-admin/src/services/adminClaimsService.js
@@ -1,0 +1,82 @@
+/**
+ * Ve3 — venue claims queue data + review actions.
+ */
+
+import { supabase } from "../lib/supabase";
+
+const CLAIM_SELECT = `
+  id,
+  name,
+  slug,
+  venue_category,
+  city,
+  country_code,
+  address,
+  created_at,
+  contact_email,
+  contact_phone,
+  description,
+  google_place_id,
+  lat,
+  lng,
+  cover_media_url,
+  place_pool_id,
+  marked_called_at,
+  claim_follow_up_at,
+  duplicate_of_brand_id,
+  place_pool:place_pool_id (
+    national_phone_number,
+    google_maps_uri
+  )
+`;
+
+export async function listPendingClaims() {
+  const { data, error } = await supabase
+    .from("brands")
+    .select(CLAIM_SELECT)
+    .eq("kind", "physical")
+    .eq("claim_status", "pending_review")
+    .is("deleted_at", null)
+    .order("created_at", { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+/**
+ * @param {string} brandId
+ * @param {"mark_called"|"approve"|"reject"|"need_more_info"} action
+ * @param {{ rejectionReason?: string }} [opts]
+ */
+export async function reviewClaim(brandId, action, opts = {}) {
+  const body = { brand_id: brandId, action };
+  if (action === "reject") {
+    body.rejection_reason = opts.rejectionReason ?? "";
+  }
+
+  const { data, error } = await supabase.functions.invoke(
+    "admin-review-venue-claim",
+    { body },
+  );
+
+  if (error) throw error;
+  if (data?.error) throw new Error(data.error);
+  return data;
+}
+
+/**
+ * Group pending claims by google_place_id for duplicate warnings.
+ * @param {Array<{ id: string, google_place_id?: string | null }>} rows
+ */
+export function groupClaimsByGooglePlaceId(rows) {
+  /** @type {Map<string, string[]>} */
+  const map = new Map();
+  for (const row of rows) {
+    const gid = row.google_place_id?.trim?.();
+    if (!gid) continue;
+    const list = map.get(gid) ?? [];
+    list.push(row.id);
+    map.set(gid, list);
+  }
+  return map;
+}

--- a/mingla-business/app/(tabs)/hub/_layout.tsx
+++ b/mingla-business/app/(tabs)/hub/_layout.tsx
@@ -25,6 +25,9 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BrandDeleteSheet } from "../../../src/components/brand/BrandDeleteSheet";
 import { BrandSwitcherSheet } from "../../../src/components/brand/BrandSwitcherSheet";
 import { HubSubNav } from "../../../src/components/hub/HubSubNav";
+import { VenueClaimStatusBanner } from "../../../src/components/brand/VenueClaimStatusBanner";
+import { useCurrentBrand } from "../../../src/hooks/useCurrentBrand";
+import { useVenueClaimRefresh } from "../../../src/hooks/useVenueClaimRefresh";
 import { IconChrome } from "../../../src/components/ui/IconChrome";
 import { TopBar } from "../../../src/components/ui/TopBar";
 import { UniversalCreatorSheet } from "../../../src/components/ui/UniversalCreatorSheet";
@@ -39,6 +42,8 @@ export default function HubTabLayout(): React.ReactElement {
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
   const setCurrentBrand = useCurrentBrandStore((s) => s.setCurrentBrand);
+  const currentBrand = useCurrentBrand();
+  useVenueClaimRefresh();
 
   const [brandSheetVisible, setBrandSheetVisible] = useState<boolean>(false);
   const [isUniversalCreatorOpen, setIsUniversalCreatorOpen] = useState<boolean>(false);
@@ -96,6 +101,7 @@ export default function HubTabLayout(): React.ReactElement {
         />
       </View>
       <HubSubNav />
+      <VenueClaimStatusBanner brand={currentBrand} />
       <Slot />
       <BrandSwitcherSheet
         visible={brandSheetVisible}

--- a/mingla-business/src/components/brand/VenueClaimStatusBanner.tsx
+++ b/mingla-business/src/components/brand/VenueClaimStatusBanner.tsx
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   title: {
-    ...typography.subhead,
+    ...typography.bodySm,
     fontWeight: "600",
     marginBottom: spacing.xs,
     color: textTokens.primary,

--- a/mingla-business/src/components/brand/VenueClaimStatusBanner.tsx
+++ b/mingla-business/src/components/brand/VenueClaimStatusBanner.tsx
@@ -1,0 +1,92 @@
+/**
+ * Ve3 — surfaces physical-venue claim_status on Hub screens.
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  radius,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { Brand } from "../../store/currentBrandStore";
+import {
+  venueClaimBannerCopy,
+  venueClaimBannerVariant,
+} from "../../services/venueClaimService";
+
+interface VenueClaimStatusBannerProps {
+  brand: Brand | null | undefined;
+}
+
+export function VenueClaimStatusBanner({
+  brand,
+}: VenueClaimStatusBannerProps): React.ReactElement | null {
+  if (brand === null || brand === undefined || brand.kind !== "physical") {
+    return null;
+  }
+
+  const variant = venueClaimBannerVariant({
+    kind: "physical",
+    claim_status: brand.claimStatus ?? "none",
+    rejection_reason: brand.rejectionReason ?? null,
+    claim_follow_up_at: brand.claimFollowUpAt ?? null,
+  });
+
+  if (variant === null || variant === "verified") {
+    return null;
+  }
+
+  const copy = venueClaimBannerCopy(variant, brand.rejectionReason);
+  if (copy === null) return null;
+
+  const toneStyle =
+    variant === "rejected"
+      ? styles.toneError
+      : variant === "follow_up"
+        ? styles.toneWarning
+        : styles.toneInfo;
+
+  return (
+    <View style={[styles.wrap, toneStyle]} accessibilityRole="summary">
+      <Text style={styles.title}>{copy.title}</Text>
+      <Text style={styles.body}>{copy.body}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+    padding: spacing.md,
+    borderRadius: radius.md,
+    borderWidth: 1,
+  },
+  title: {
+    ...typography.subhead,
+    fontWeight: "600",
+    marginBottom: spacing.xs,
+    color: textTokens.primary,
+  },
+  body: {
+    ...typography.caption,
+    lineHeight: 18,
+    color: textTokens.secondary,
+  },
+  toneError: {
+    backgroundColor: semantic.errorTint,
+    borderColor: semantic.error,
+  },
+  toneWarning: {
+    backgroundColor: semantic.warningTint,
+    borderColor: semantic.warning,
+  },
+  toneInfo: {
+    backgroundColor: semantic.infoTint,
+    borderColor: semantic.info,
+  },
+});

--- a/mingla-business/src/hooks/useVenueClaimRefresh.ts
+++ b/mingla-business/src/hooks/useVenueClaimRefresh.ts
@@ -1,0 +1,37 @@
+/**
+ * Ve3 — refresh brand claim_status when app returns to foreground.
+ */
+
+import { useEffect } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useAuth } from "../context/AuthContext";
+import { brandKeys } from "./useBrands";
+import { useCurrentBrandStore } from "../store/currentBrandStore";
+
+export function useVenueClaimRefresh(): void {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const currentBrandId = useCurrentBrandStore((s) => s.currentBrandId);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener(
+      "change",
+      (next: AppStateStatus) => {
+        if (next !== "active") return;
+        if (user?.id) {
+          void queryClient.invalidateQueries({
+            queryKey: brandKeys.list(user.id),
+          });
+        }
+        if (currentBrandId) {
+          void queryClient.invalidateQueries({
+            queryKey: brandKeys.detail(currentBrandId),
+          });
+        }
+      },
+    );
+    return () => sub.remove();
+  }, [queryClient, user?.id, currentBrandId]);
+}

--- a/mingla-business/src/services/__tests__/ve3MigrationContract.test.ts
+++ b/mingla-business/src/services/__tests__/ve3MigrationContract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MIGRATION = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "supabase",
+  "migrations",
+  "20260619000000_ve3_admin_claim_review.sql",
+);
+
+describe("Ve3 migration contract", () => {
+  const sql = () => readFileSync(MIGRATION, "utf8");
+
+  test("adds admin review columns on brands", () => {
+    const s = sql();
+    expect(s).toContain("rejection_reason");
+    expect(s).toContain("claim_follow_up_at");
+    expect(s).toContain("duplicate_of_brand_id");
+    expect(s).toContain("marked_called_at");
+    expect(s).toContain("marked_called_by");
+    expect(s).toContain("claim_decision_emailed_at");
+  });
+
+  test("biz_review_venue_claim supports Ve3 actions", () => {
+    const s = sql();
+    expect(s).toMatch(
+      /mark_called.*approve.*reject.*need_more_info/s,
+    );
+    expect(s).toContain("must_mark_called_first");
+    expect(s).toContain("rejection_reason_required");
+    expect(s).toContain("duplicate_of_brand_id = p_brand_id");
+    expect(s).toMatch(/RETURNS jsonb/);
+  });
+
+  test("approve flags sibling pending claims on same google_place_id", () => {
+    const s = sql();
+    expect(s).toMatch(/claim_status = 'pending_review'/);
+    expect(s).toContain("google_place_id = v_brand.google_place_id");
+    expect(s).toContain("duplicate_flagged_count");
+  });
+
+  test("rejects approve when another verified brand owns google_place_id", () => {
+    expect(sql()).toContain("google_place_already_verified");
+  });
+});

--- a/mingla-business/src/services/__tests__/venueClaimService.test.ts
+++ b/mingla-business/src/services/__tests__/venueClaimService.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  venueClaimBannerCopy,
+  venueClaimBannerVariant,
+} from "../venueClaimBannerLogic";
+
+describe("venueClaimService", () => {
+  test("venueClaimBannerVariant for physical pending_review", () => {
+    expect(
+      venueClaimBannerVariant({
+        kind: "physical",
+        claim_status: "pending_review",
+        rejection_reason: null,
+        claim_follow_up_at: null,
+      }),
+    ).toBe("pending_review");
+  });
+
+  test("venueClaimBannerVariant for follow_up", () => {
+    expect(
+      venueClaimBannerVariant({
+        kind: "physical",
+        claim_status: "pending_review",
+        rejection_reason: null,
+        claim_follow_up_at: "2026-05-19T12:00:00Z",
+      }),
+    ).toBe("follow_up");
+  });
+
+  test("popup brands hide banner", () => {
+    expect(
+      venueClaimBannerVariant({
+        kind: "popup",
+        claim_status: "pending_review",
+        rejection_reason: null,
+        claim_follow_up_at: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("venueClaimBannerCopy includes rejection reason", () => {
+    const copy = venueClaimBannerCopy("rejected", "Could not verify by phone");
+    expect(copy?.body).toBe("Could not verify by phone");
+  });
+});

--- a/mingla-business/src/services/brandMapping.ts
+++ b/mingla-business/src/services/brandMapping.ts
@@ -62,6 +62,9 @@ export interface BrandRow {
   city?: string | null;
   country_code?: string | null;
   claim_status?: BrandClaimStatus | null;
+  rejection_reason?: string | null;
+  claim_follow_up_at?: string | null;
+  duplicate_of_brand_id?: string | null;
   verified_at?: string | null;
   verified_by?: string | null;
   venue_category?: VenueCategory | null;
@@ -262,6 +265,9 @@ export function mapBrandRowToUi(row: BrandRow, options: MapBrandRowToUiOptions):
     // has actually set it. Undefined means "currency not set" — do not imply GBP.
     defaultCurrency: row.default_currency || undefined,
     claimStatus: (row.claim_status as BrandClaimStatus | undefined) ?? "none",
+    rejectionReason: row.rejection_reason?.trim() || undefined,
+    claimFollowUpAt: row.claim_follow_up_at ?? undefined,
+    duplicateOfBrandId: row.duplicate_of_brand_id ?? undefined,
     googlePlaceId: row.google_place_id ?? undefined,
     lat: row.lat ?? undefined,
     lng: row.lng ?? undefined,

--- a/mingla-business/src/services/venueClaimBannerLogic.ts
+++ b/mingla-business/src/services/venueClaimBannerLogic.ts
@@ -1,0 +1,68 @@
+/**
+ * Ve3 — pure venue claim banner helpers (jest-testable without supabase).
+ */
+
+import type { BrandClaimStatus } from "../types/brand";
+
+export interface VenueClaimStatusRow {
+  kind: string;
+  claim_status: BrandClaimStatus | null;
+  rejection_reason: string | null;
+  claim_follow_up_at: string | null;
+}
+
+export type VenueClaimBannerVariant =
+  | "pending_review"
+  | "follow_up"
+  | "rejected"
+  | "verified"
+  | null;
+
+export function venueClaimBannerVariant(
+  row: VenueClaimStatusRow | null | undefined,
+): VenueClaimBannerVariant {
+  if (row === null || row === undefined) return null;
+  if (row.kind !== "physical") return null;
+  if (row.claim_status === "verified") return "verified";
+  if (row.claim_status === "rejected") return "rejected";
+  if (row.claim_status === "pending_review") {
+    if (row.claim_follow_up_at) return "follow_up";
+    return "pending_review";
+  }
+  return null;
+}
+
+export function venueClaimBannerCopy(
+  variant: VenueClaimBannerVariant,
+  rejectionReason?: string,
+): { title: string; body: string } | null {
+  switch (variant) {
+    case "pending_review":
+      return {
+        title: "Venue under review",
+        body:
+          "We are verifying your venue by phone — usually within 4 business hours.",
+      };
+    case "follow_up":
+      return {
+        title: "More information needed",
+        body:
+          "Our team needs more details about your venue claim. Watch for an email or in-app update.",
+      };
+    case "rejected":
+      return {
+        title: "Venue claim not approved",
+        body:
+          rejectionReason?.trim().length
+            ? rejectionReason.trim()
+            : "Contact support if you believe this was a mistake. You can submit a new claim with updated details.",
+      };
+    case "verified":
+      return {
+        title: "Venue verified",
+        body: "Your venue is live. You can publish events and experiences.",
+      };
+    default:
+      return null;
+  }
+}

--- a/mingla-business/src/services/venueClaimService.ts
+++ b/mingla-business/src/services/venueClaimService.ts
@@ -1,0 +1,30 @@
+/**
+ * Ve3 — fetch venue claim status for mingla-business operators.
+ */
+
+import { supabase } from "./supabase";
+import type { VenueClaimStatusRow } from "./venueClaimBannerLogic";
+
+export type {
+  VenueClaimBannerVariant,
+  VenueClaimStatusRow,
+} from "./venueClaimBannerLogic";
+export {
+  venueClaimBannerCopy,
+  venueClaimBannerVariant,
+} from "./venueClaimBannerLogic";
+
+export async function fetchVenueClaimStatus(
+  brandId: string,
+): Promise<VenueClaimStatusRow | null> {
+  const { data, error } = await supabase
+    .from("brands")
+    .select("kind, claim_status, rejection_reason, claim_follow_up_at")
+    .eq("id", brandId)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error !== null) throw error;
+  if (data === null) return null;
+  return data as VenueClaimStatusRow;
+}

--- a/mingla-business/src/types/brand.ts
+++ b/mingla-business/src/types/brand.ts
@@ -304,6 +304,12 @@ export type Brand = {
    * or create events/trips until verified.
    */
   claimStatus?: BrandClaimStatus;
+  /** Ve3 — admin rejection note when claim_status is rejected. */
+  rejectionReason?: string;
+  /** Ve3 — admin requested more info; claim stays pending_review. */
+  claimFollowUpAt?: string;
+  /** Ve3 — set when another claim for same google_place_id was approved. */
+  duplicateOfBrandId?: string;
   /** Ve1 — Google Place ID when captured during venue onboarding. */
   googlePlaceId?: string;
   lat?: number;

--- a/supabase/functions/_shared/email/claimApprovedEmail.ts
+++ b/supabase/functions/_shared/email/claimApprovedEmail.ts
@@ -1,0 +1,28 @@
+// Ve3 — venue claim approved operator email body.
+
+import type { GenericBodyInput } from "./types.ts";
+
+export function buildClaimApprovedEmail(input: {
+  brandName: string;
+  publicVenueUrl: string;
+}): GenericBodyInput {
+  return {
+    variant: "generic_notification",
+    title: "Your venue is live on Mingla",
+    paragraphs: [
+      `Good news — ${input.brandName} has been approved.`,
+      "Your venue profile is now visible to guests. Sign in to Mingla Business to manage events and your profile.",
+    ],
+    cta: {
+      label: "View your venue page",
+      url: input.publicVenueUrl,
+    },
+  };
+}
+
+export function defaultVenuePublicUrl(slug: string): string {
+  const base = (Deno.env.get("MINGLA_BUSINESS_WEB_URL") ??
+    "https://business.usemingla.com").replace(/\/+$/, "");
+  const safeSlug = encodeURIComponent(slug.trim());
+  return `${base}/b/${safeSlug}`;
+}

--- a/supabase/functions/_shared/email/claimRejectedEmail.ts
+++ b/supabase/functions/_shared/email/claimRejectedEmail.ts
@@ -1,0 +1,22 @@
+// Ve3 — venue claim rejected operator email body.
+
+import type { GenericBodyInput } from "./types.ts";
+
+export function buildClaimRejectedEmail(input: {
+  brandName: string;
+  rejectionReason: string;
+}): GenericBodyInput {
+  const reason = input.rejectionReason.trim();
+  return {
+    variant: "generic_notification",
+    title: "Update on your venue submission",
+    paragraphs: [
+      `We couldn't approve ${input.brandName} at this time.`,
+      reason.length > 0
+        ? `Reason: ${reason}`
+        : "Our team will follow up if we need more information.",
+      "You can submit a new claim with updated details when you're ready.",
+    ],
+    cta: null,
+  };
+}

--- a/supabase/functions/admin-review-venue-claim/index.test.ts
+++ b/supabase/functions/admin-review-venue-claim/index.test.ts
@@ -1,0 +1,83 @@
+// Ve3 — admin-review-venue-claim unit tests
+// Run: deno test supabase/functions/admin-review-venue-claim/index.test.ts
+
+import {
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  auditActionForReview,
+  normalizeReviewBody,
+  pushCopyForReview,
+} from "./reviewLogic.ts";
+import { buildClaimApprovedEmail } from "../_shared/email/claimApprovedEmail.ts";
+import { buildClaimRejectedEmail } from "../_shared/email/claimRejectedEmail.ts";
+
+Deno.test("normalizeReviewBody rejects missing brand_id", () => {
+  const r = normalizeReviewBody({ action: "approve" });
+  assertEquals(r.ok, false);
+  if (!r.ok) assertEquals(r.error, "brand_id_required");
+});
+
+Deno.test("normalizeReviewBody rejects invalid action", () => {
+  const r = normalizeReviewBody({
+    brand_id: "11111111-1111-1111-1111-111111111111",
+    action: "auto_approve",
+  });
+  assertEquals(r.ok, false);
+  if (!r.ok) assertEquals(r.error, "invalid_action");
+});
+
+Deno.test("normalizeReviewBody requires rejection_reason on reject", () => {
+  const r = normalizeReviewBody({
+    brand_id: "11111111-1111-1111-1111-111111111111",
+    action: "reject",
+  });
+  assertEquals(r.ok, false);
+  if (!r.ok) assertEquals(r.error, "rejection_reason_required");
+});
+
+Deno.test("normalizeReviewBody accepts mark_called", () => {
+  const r = normalizeReviewBody({
+    brand_id: "11111111-1111-1111-1111-111111111111",
+    action: "mark_called",
+  });
+  assertEquals(r.ok, true);
+  if (r.ok) {
+    assertEquals(r.action, "mark_called");
+    assertEquals(r.rejectionReason, "");
+  }
+});
+
+Deno.test("auditActionForReview maps claim actions", () => {
+  assertEquals(auditActionForReview("mark_called"), "claim.mark_called");
+  assertEquals(auditActionForReview("approve"), "claim.approve");
+  assertEquals(auditActionForReview("reject"), "claim.reject");
+  assertEquals(auditActionForReview("need_more_info"), "claim.need_more_info");
+});
+
+Deno.test("pushCopyForReview only for notify actions", () => {
+  assertStrictEquals(pushCopyForReview("mark_called", "Joe's"), null);
+  assertEquals(pushCopyForReview("approve", "Joe's")?.title, "Venue verified");
+  assertEquals(
+    pushCopyForReview("need_more_info", "Joe's")?.title,
+    "More info needed",
+  );
+});
+
+Deno.test("buildClaimApprovedEmail includes public CTA", () => {
+  const body = buildClaimApprovedEmail({
+    brandName: "Joe's Pizza",
+    publicVenueUrl: "https://business.usemingla.com/b/joes-pizza",
+  });
+  assertEquals(body.title, "Your venue is live on Mingla");
+  assertEquals(body.cta?.url, "https://business.usemingla.com/b/joes-pizza");
+});
+
+Deno.test("buildClaimRejectedEmail includes rejection reason", () => {
+  const body = buildClaimRejectedEmail({
+    brandName: "Joe's Pizza",
+    rejectionReason: "Could not verify by phone",
+  });
+  assertEquals(body.paragraphs[1], "Reason: Could not verify by phone");
+});

--- a/supabase/functions/admin-review-venue-claim/index.ts
+++ b/supabase/functions/admin-review-venue-claim/index.ts
@@ -156,6 +156,7 @@ serve(async (req) => {
           body: bodyInput,
         });
 
+        // no-attachment: Ve3 approve/reject operator notice has no PDF or file payload.
         const res = await fetch("https://api.resend.com/emails", {
           method: "POST",
           headers: {

--- a/supabase/functions/admin-review-venue-claim/index.ts
+++ b/supabase/functions/admin-review-venue-claim/index.ts
@@ -1,0 +1,215 @@
+/**
+ * Ve3 — orchestrate admin venue claim review (RPC + email + push + audit).
+ */
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  buildClaimApprovedEmail,
+  defaultVenuePublicUrl,
+} from "../_shared/email/claimApprovedEmail.ts";
+import { buildClaimRejectedEmail } from "../_shared/email/claimRejectedEmail.ts";
+import {
+  assertNotResendSandbox,
+  EMAIL_SENDERS,
+  formatSenderHeader,
+  renderTransactionalEmail,
+} from "../_shared/email/index.ts";
+import { sendPush } from "../_shared/push-utils.ts";
+import {
+  auditActionForReview,
+  normalizeReviewBody,
+  pushCopyForReview,
+} from "./reviewLogic.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? "";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader) return json({ error: "No authorization header" }, 401);
+
+    const parsed = normalizeReviewBody(await req.json().catch(() => null));
+    if (!parsed.ok) return json({ error: parsed.error }, 400);
+
+    const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const { data: { user }, error: userErr } = await userClient.auth.getUser();
+    if (userErr || !user) return json({ error: "Unauthorized" }, 401);
+
+    const { data: isAdmin, error: adminErr } = await userClient.rpc(
+      "is_admin_user",
+    );
+    if (adminErr) return json({ error: adminErr.message }, 500);
+    if (isAdmin !== true) return json({ error: "Forbidden" }, 403);
+
+    const { data: rpcResult, error: rpcErr } = await userClient.rpc(
+      "biz_review_venue_claim",
+      {
+        p_brand_id: parsed.brandId,
+        p_action: parsed.action,
+        p_rejection_reason: parsed.action === "reject"
+          ? parsed.rejectionReason
+          : null,
+      },
+    );
+    if (rpcErr) return json({ error: rpcErr.message }, 400);
+
+    const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const { data: brandRow, error: brandErr } = await admin
+      .from("brands")
+      .select(
+        "id, name, slug, account_id, claim_status, contact_email, rejection_reason, claim_decision_emailed_at",
+      )
+      .eq("id", parsed.brandId)
+      .maybeSingle();
+
+    if (brandErr) return json({ error: brandErr.message }, 500);
+    if (!brandRow) return json({ error: "Brand not found" }, 404);
+
+    const noop = rpcResult?.noop === true;
+    const brandName = brandRow.name as string;
+
+    await admin.from("admin_audit_log").insert({
+      admin_email: user.email ?? "unknown",
+      action: auditActionForReview(parsed.action),
+      target_type: "venue_claim",
+      target_id: parsed.brandId,
+      metadata: {
+        noop,
+        rpc_result: rpcResult ?? null,
+      },
+    });
+
+    let emailSent = false;
+    let pushSent = false;
+
+    const shouldNotify = (parsed.action === "approve" ||
+      parsed.action === "reject") &&
+      !noop &&
+      brandRow.claim_decision_emailed_at == null;
+
+    if (shouldNotify) {
+      const { data: ownerAuth, error: ownerErr } = await admin.auth.admin
+        .getUserById(brandRow.account_id as string);
+      if (ownerErr) {
+        console.warn("[admin-review-venue-claim] owner lookup", ownerErr.message);
+      }
+
+      const to =
+        (typeof ownerAuth?.user?.email === "string" &&
+            ownerAuth.user.email.length > 0
+          ? ownerAuth.user.email
+          : null) ??
+        (typeof brandRow.contact_email === "string" &&
+            brandRow.contact_email.length > 0
+          ? brandRow.contact_email
+          : null);
+
+      if (to && RESEND_API_KEY) {
+        const slug = typeof brandRow.slug === "string" ? brandRow.slug : "";
+        const bodyInput = parsed.action === "approve"
+          ? buildClaimApprovedEmail({
+            brandName,
+            publicVenueUrl: defaultVenuePublicUrl(slug),
+          })
+          : buildClaimRejectedEmail({
+            brandName,
+            rejectionReason: (brandRow.rejection_reason as string) ??
+              parsed.rejectionReason,
+          });
+
+        const sender = EMAIL_SENDERS.system;
+        try {
+          assertNotResendSandbox(sender);
+        } catch (e) {
+          return json(
+            { error: e instanceof Error ? e.message : String(e) },
+            500,
+          );
+        }
+
+        const rendered = renderTransactionalEmail({
+          variant: "generic_notification",
+          recipient: { name: null, email: to },
+          body: bodyInput,
+        });
+
+        const res = await fetch("https://api.resend.com/emails", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${RESEND_API_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            from: formatSenderHeader(rendered.from),
+            to: [to],
+            subject: rendered.subject,
+            html: rendered.html,
+            text: rendered.text,
+          }),
+        });
+
+        if (!res.ok) {
+          const t = await res.text();
+          return json({ error: `Resend ${res.status}: ${t}` }, 502);
+        }
+
+        emailSent = true;
+        await admin
+          .from("brands")
+          .update({ claim_decision_emailed_at: new Date().toISOString() })
+          .eq("id", parsed.brandId);
+      }
+    }
+
+    const pushCopy = pushCopyForReview(parsed.action, brandName);
+    if (pushCopy && !noop && typeof brandRow.account_id === "string") {
+      pushSent = await sendPush({
+        targetUserId: brandRow.account_id,
+        title: pushCopy.title,
+        body: pushCopy.body,
+        data: {
+          type: "venue_claim_review",
+          brand_id: parsed.brandId,
+          action: parsed.action,
+        },
+        androidChannelId: "system",
+      });
+    }
+
+    return json({
+      ok: true,
+      result: rpcResult,
+      email_sent: emailSent,
+      push_sent: pushSent,
+    });
+  } catch (e) {
+    console.error("[admin-review-venue-claim]", e);
+    return json(
+      { error: e instanceof Error ? e.message : String(e) },
+      500,
+    );
+  }
+});

--- a/supabase/functions/admin-review-venue-claim/reviewLogic.ts
+++ b/supabase/functions/admin-review-venue-claim/reviewLogic.ts
@@ -1,0 +1,83 @@
+/**
+ * Ve3 — pure helpers for admin-review-venue-claim (unit-testable without Deno env).
+ */
+
+export type ReviewAction =
+  | "mark_called"
+  | "approve"
+  | "reject"
+  | "need_more_info";
+
+export function normalizeReviewBody(
+  body: unknown,
+):
+  | { ok: true; brandId: string; action: ReviewAction; rejectionReason: string }
+  | { ok: false; error: string } {
+  if (body === null || typeof body !== "object") {
+    return { ok: false, error: "invalid_body" };
+  }
+  const b = body as Record<string, unknown>;
+  const brandId = typeof b.brand_id === "string" ? b.brand_id.trim() : "";
+  const action = typeof b.action === "string" ? b.action.trim() : "";
+  const rejectionReason = typeof b.rejection_reason === "string"
+    ? b.rejection_reason.trim()
+    : "";
+
+  if (brandId.length === 0) return { ok: false, error: "brand_id_required" };
+  if (
+    action !== "mark_called" &&
+    action !== "approve" &&
+    action !== "reject" &&
+    action !== "need_more_info"
+  ) {
+    return { ok: false, error: "invalid_action" };
+  }
+  if (action === "reject" && rejectionReason.length === 0) {
+    return { ok: false, error: "rejection_reason_required" };
+  }
+
+  return {
+    ok: true,
+    brandId,
+    action: action as ReviewAction,
+    rejectionReason,
+  };
+}
+
+export function auditActionForReview(action: ReviewAction): string {
+  switch (action) {
+    case "mark_called":
+      return "claim.mark_called";
+    case "approve":
+      return "claim.approve";
+    case "reject":
+      return "claim.reject";
+    case "need_more_info":
+      return "claim.need_more_info";
+  }
+}
+
+export function pushCopyForReview(
+  action: ReviewAction,
+  brandName: string,
+): { title: string; body: string } | null {
+  switch (action) {
+    case "approve":
+      return {
+        title: "Venue verified",
+        body: `${brandName} is now live on Mingla.`,
+      };
+    case "reject":
+      return {
+        title: "Venue submission update",
+        body: `We couldn't approve ${brandName} at this time.`,
+      };
+    case "need_more_info":
+      return {
+        title: "More info needed",
+        body: `We need more information about ${brandName}.`,
+      };
+    default:
+      return null;
+  }
+}

--- a/supabase/functions/venue-claim-decision-email/index.ts
+++ b/supabase/functions/venue-claim-decision-email/index.ts
@@ -7,12 +7,15 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { buildClaimApprovedEmail } from "../_shared/email/claimApprovedEmail.ts";
+import { buildClaimRejectedEmail } from "../_shared/email/claimRejectedEmail.ts";
 import {
   assertNotResendSandbox,
   EMAIL_SENDERS,
   formatSenderHeader,
   renderTransactionalEmail,
 } from "../_shared/email/index.ts";
+import { defaultVenuePublicUrl } from "../_shared/email/claimApprovedEmail.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -78,7 +81,9 @@ serve(async (req) => {
     const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
     const { data: brandRow, error: brandErr } = await admin
       .from("brands")
-      .select("id, name, account_id, claim_status, contact_email")
+      .select(
+        "id, name, slug, account_id, claim_status, contact_email, rejection_reason",
+      )
       .eq("id", brandId)
       .maybeSingle();
 
@@ -136,31 +141,27 @@ serve(async (req) => {
 
     const brandName = brandRow.name as string;
     const approved = decision === "approved";
-    const title = approved
-      ? "Your venue is live on Mingla"
-      : "Update on your venue submission";
-    const paragraphs = approved
-      ? [
-        `Good news — ${brandName} has been approved.`,
-        "Your venue profile is now visible to guests. Sign in to Mingla Business to manage events and your profile.",
-      ]
-      : [
-        `We couldn't approve ${brandName} at this time.`,
-        rejectionReason.length > 0
-          ? `Reason: ${rejectionReason}`
-          : "Our team will follow up if we need more information.",
-        "You can submit a new claim with updated details when you're ready.",
-      ];
+    const slug = typeof brandRow.slug === "string" ? brandRow.slug : "";
+    const persistedReason =
+      (typeof brandRow.rejection_reason === "string" &&
+          brandRow.rejection_reason.length > 0
+        ? brandRow.rejection_reason
+        : rejectionReason);
+
+    const bodyInput = approved
+      ? buildClaimApprovedEmail({
+        brandName,
+        publicVenueUrl: defaultVenuePublicUrl(slug),
+      })
+      : buildClaimRejectedEmail({
+        brandName,
+        rejectionReason: persistedReason,
+      });
 
     const rendered = renderTransactionalEmail({
       variant: "generic_notification",
       recipient: { name: null, email: to },
-      body: {
-        variant: "generic_notification",
-        title,
-        paragraphs,
-        cta: null,
-      },
+      body: bodyInput,
     });
 
     // no-attachment: Ve1 approve/reject operator notice has no PDF or file payload.

--- a/supabase/migrations/20260619000000_ve3_admin_claim_review.sql
+++ b/supabase/migrations/20260619000000_ve3_admin_claim_review.sql
@@ -1,0 +1,224 @@
+-- Ve3 (#101) — Admin claim review: call-then-approve, need-more-info, duplicate flags, persisted rejection.
+
+BEGIN;
+
+ALTER TABLE public.brands
+  ADD COLUMN IF NOT EXISTS rejection_reason text,
+  ADD COLUMN IF NOT EXISTS claim_follow_up_at timestamptz,
+  ADD COLUMN IF NOT EXISTS duplicate_of_brand_id uuid REFERENCES public.brands (id),
+  ADD COLUMN IF NOT EXISTS marked_called_at timestamptz,
+  ADD COLUMN IF NOT EXISTS marked_called_by uuid,
+  ADD COLUMN IF NOT EXISTS claim_decision_emailed_at timestamptz;
+
+COMMENT ON COLUMN public.brands.rejection_reason IS
+  'Ve3 — admin rejection note emailed to venue operator.';
+COMMENT ON COLUMN public.brands.claim_follow_up_at IS
+  'Ve3 — set when admin requests more info; claim_status stays pending_review.';
+COMMENT ON COLUMN public.brands.duplicate_of_brand_id IS
+  'Ve3 — sibling pending claim flagged after another brand with same google_place_id was approved.';
+COMMENT ON COLUMN public.brands.marked_called_at IS
+  'Ve3 — admin marked venue as called before approve.';
+COMMENT ON COLUMN public.brands.claim_decision_emailed_at IS
+  'Ve3 — last approve/reject decision email sent at.';
+
+CREATE INDEX IF NOT EXISTS idx_brands_duplicate_of_brand_id
+  ON public.brands (duplicate_of_brand_id)
+  WHERE duplicate_of_brand_id IS NOT NULL;
+
+DROP FUNCTION IF EXISTS public.biz_review_venue_claim (uuid, text);
+
+CREATE OR REPLACE FUNCTION public.biz_review_venue_claim (
+  p_brand_id uuid,
+  p_action text,
+  p_rejection_reason text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_brand public.brands%ROWTYPE;
+  v_dup_count integer := 0;
+  v_reason text;
+BEGIN
+  IF auth.uid () IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  IF NOT public.is_admin_user () THEN
+    RAISE EXCEPTION 'forbidden';
+  END IF;
+
+  IF p_action NOT IN ('mark_called', 'approve', 'reject', 'need_more_info') THEN
+    RAISE EXCEPTION 'invalid_action';
+  END IF;
+
+  SELECT *
+  INTO v_brand
+  FROM public.brands b
+  WHERE b.id = p_brand_id
+    AND b.deleted_at IS NULL
+    AND b.kind = 'physical';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found';
+  END IF;
+
+  IF p_action = 'mark_called' THEN
+    IF v_brand.claim_status <> 'pending_review' THEN
+      IF v_brand.marked_called_at IS NOT NULL THEN
+        RETURN jsonb_build_object('ok', true, 'noop', true);
+      END IF;
+      RAISE EXCEPTION 'brand_not_pending_review';
+    END IF;
+
+    IF v_brand.marked_called_at IS NOT NULL THEN
+      RETURN jsonb_build_object('ok', true, 'noop', true);
+    END IF;
+
+    UPDATE public.brands
+    SET
+      marked_called_at = now(),
+      marked_called_by = auth.uid()
+    WHERE id = p_brand_id;
+
+    RETURN jsonb_build_object('ok', true, 'action', 'mark_called');
+  END IF;
+
+  IF p_action = 'need_more_info' THEN
+    IF v_brand.claim_status <> 'pending_review' THEN
+      RAISE EXCEPTION 'brand_not_pending_review';
+    END IF;
+
+    UPDATE public.brands
+    SET claim_follow_up_at = now()
+    WHERE id = p_brand_id;
+
+    RETURN jsonb_build_object('ok', true, 'action', 'need_more_info');
+  END IF;
+
+  IF p_action = 'approve' THEN
+    IF v_brand.claim_status = 'verified' THEN
+      RETURN jsonb_build_object('ok', true, 'noop', true, 'claim_status', 'verified');
+    END IF;
+
+    IF v_brand.claim_status <> 'pending_review' THEN
+      RAISE EXCEPTION 'brand_not_pending_review';
+    END IF;
+
+    IF v_brand.marked_called_at IS NULL THEN
+      RAISE EXCEPTION 'must_mark_called_first';
+    END IF;
+
+    IF v_brand.google_place_id IS NOT NULL AND EXISTS (
+      SELECT 1
+      FROM public.brands b2
+      WHERE b2.deleted_at IS NULL
+        AND b2.id <> p_brand_id
+        AND b2.google_place_id = v_brand.google_place_id
+        AND b2.claim_status = 'verified'
+    ) THEN
+      RAISE EXCEPTION 'google_place_already_verified';
+    END IF;
+
+    UPDATE public.brands
+    SET
+      claim_status = 'verified',
+      verified_at = now(),
+      verified_by = auth.uid(),
+      rejection_reason = NULL,
+      claim_follow_up_at = NULL,
+      duplicate_of_brand_id = NULL
+    WHERE id = p_brand_id;
+
+    IF v_brand.google_place_id IS NOT NULL THEN
+      UPDATE public.brands
+      SET duplicate_of_brand_id = p_brand_id
+      WHERE deleted_at IS NULL
+        AND id <> p_brand_id
+        AND google_place_id = v_brand.google_place_id
+        AND claim_status = 'pending_review'
+        AND duplicate_of_brand_id IS DISTINCT FROM p_brand_id;
+
+      GET DIAGNOSTICS v_dup_count = ROW_COUNT;
+    END IF;
+
+    RETURN jsonb_build_object(
+      'ok',
+      true,
+      'action',
+      'approve',
+      'claim_status',
+      'verified',
+      'duplicate_flagged_count',
+      v_dup_count
+    );
+  END IF;
+
+  -- reject
+  IF v_brand.claim_status = 'rejected' THEN
+    RETURN jsonb_build_object('ok', true, 'noop', true, 'claim_status', 'rejected');
+  END IF;
+
+  IF v_brand.claim_status <> 'pending_review' THEN
+    RAISE EXCEPTION 'brand_not_pending_review';
+  END IF;
+
+  v_reason := nullif(trim(coalesce(p_rejection_reason, '')), '');
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'rejection_reason_required';
+  END IF;
+
+  UPDATE public.brands
+  SET
+    claim_status = 'rejected',
+    rejection_reason = v_reason,
+    verified_at = NULL,
+    verified_by = NULL,
+    claim_follow_up_at = NULL,
+    duplicate_of_brand_id = NULL
+  WHERE id = p_brand_id;
+
+  RETURN jsonb_build_object(
+    'ok',
+    true,
+    'action',
+    'reject',
+    'claim_status',
+    'rejected'
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_review_venue_claim (uuid, text, text) TO authenticated;
+
+COMMENT ON FUNCTION public.biz_review_venue_claim IS
+  'Ve3 — admin venue claim actions: mark_called, approve (requires call), reject, need_more_info.';
+
+-- Structural verify
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'brands'
+      AND column_name = 'rejection_reason'
+  ) THEN
+    RAISE EXCEPTION 'Ve3 verify FAIL: brands.rejection_reason missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'biz_review_venue_claim'
+      AND pg_get_function_result(p.oid) = 'jsonb'
+  ) THEN
+    RAISE EXCEPTION 'Ve3 verify FAIL: biz_review_venue_claim must return jsonb';
+  END IF;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes the Ve3 admin verification loop for physical venue claims ([#101](https://github.com/Mingla-LLC/mingla-main/issues/101)). Seth can review pending claims at `#/claims`, call the venue, then mark called → approve, reject (with persisted reason), or request more info. Operators receive branded email + OneSignal push on decision; duplicate pending claims for the same Google place are flagged when one is approved.

## Changes

- **Database:** `20260619000000_ve3_admin_claim_review.sql` — `rejection_reason`, `claim_follow_up_at`, `duplicate_of_brand_id`, `marked_called_at/by`, extended `biz_review_venue_claim` (`mark_called`, `approve`, `reject`, `need_more_info`)
- **Edge:** `admin-review-venue-claim` orchestrates RPC + Resend email + OneSignal push + `admin_audit_log`
- **Admin UI:** Rebuilt `ClaimsPage` with pool-match phone, oldest-first queue, SLA, duplicate badges, call-then-approve gating
- **Business app:** Hub claim-status banner + foreground brand refresh

## Test plan

- [x] `mingla-admin`: `npm run test` (claimsPhone resolver)
- [x] `mingla-business`: Jest `ve3MigrationContract` + `venueClaimService` (8 tests)
- [x] Deno: `admin-review-venue-claim/index.test.ts` (8 tests)
- [ ] Apply migration: `supabase db push`
- [ ] Deploy edge function: `admin-review-venue-claim`
- [ ] Staging smoke per `Mingla_Artifacts/dev/VE3_SMOKE_FIXTURES.md`
  - [ ] Pool-match claim shows Google-listed phone
  - [ ] Off-pool claim shows operator phone + Maps note
  - [ ] Mark called → Approve sets `claim_status=verified`
  - [ ] Reject persists reason + emails operator
  - [ ] Approve one of two duplicate `google_place_id` claims flags the other
  - [ ] `admin_audit_log` rows for each action
