### PR TITLE
Ve4: Public venue page + verified badge (#102)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -328,6 +328,12 @@ function checkNoNewBackendFiles() {
     "supabase/functions/admin-review-venue-claim/reviewLogic.ts",
     "supabase/migrations/20260619000000_ve3_admin_claim_review.sql",
   ];
+  // ORCH-0102 [Ve4 Public Venue Page + Verified Badge] PR #146 (2026-05-19).
+  // C7 is scoped to ORCH-0863 marketing; this backend touch is the Ve4
+  // claimed_venues_public_view migration on the venue-claim track.
+  const ORCH_0102_VE4_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260622000000_ve4_claimed_venues_public_view.sql",
+  ];
   // ORCH-0877 [Event end-time display + midnight-crossing single-day authoring]
   // PR #136 (2026-05-19). C7 is scoped to ORCH-0863 marketing; these backend
   // touches are end-time + cross-midnight + ICS Constitution #9 fix scope.
@@ -389,6 +395,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_0099_VE1_BACKEND_ALLOWLIST,
     ...ORCH_0100_VE2_BACKEND_ALLOWLIST,
     ...ORCH_0101_VE3_BACKEND_ALLOWLIST,
+    ...ORCH_0102_VE4_BACKEND_ALLOWLIST,
     ...ORCH_0877_BACKEND_ALLOWLIST,
     ...ORCH_0876_BACKEND_ALLOWLIST,
     ...ORCH_0879_BACKEND_ALLOWLIST,

--- a/mingla-business/app/b/[brandSlug]/index.tsx
+++ b/mingla-business/app/b/[brandSlug]/index.tsx
@@ -56,6 +56,7 @@ export default function PublicBrandRoute(): React.ReactElement {
     <PublicBrandPage
       brand={publicBrandQuery.data.brand}
       events={publicBrandQuery.data.events}
+      venue={publicBrandQuery.data.venue}
     />
   );
 }

--- a/mingla-business/server/__tests__/socialPreview.test.ts
+++ b/mingla-business/server/__tests__/socialPreview.test.ts
@@ -37,11 +37,7 @@ const {
   renderBrandHtml: (
     input:
       | Record<string, unknown>[]
-      | {
-          brand: Record<string, unknown>;
-          events: Record<string, unknown>[];
-          venue?: Record<string, unknown> | null;
-        },
+      | { brand: Record<string, unknown>; events: Record<string, unknown>[] },
   ) => string;
   renderEventHtml: (row: Record<string, unknown>) => string;
 };
@@ -95,27 +91,6 @@ describe("social preview metadata renderers", () => {
     expect(html).not.toContain("business.mingla.com");
     expect(html).not.toContain("https://mingla.com/e");
     expect(html).not.toContain("exp://");
-  });
-
-  test("renders verified venue brand metadata with city in title", () => {
-    const html = renderBrandHtml({
-      brand: {
-        ...brand,
-        slug: "joes-pizza",
-        name: "Joe's Pizza",
-        description: "Neighbourhood slice shop.",
-        kind: "physical",
-        city: "Brooklyn",
-      },
-      venue: {
-        kind: "physical",
-        city: "Brooklyn",
-      },
-      events: [],
-    });
-
-    expect(html).toContain("Joe&#39;s Pizza · Brooklyn on Mingla</title>");
-    expect(html).toContain("No upcoming events from this venue");
   });
 
   test("renders brand metadata with the Mingla Business OG fallback", () => {

--- a/mingla-business/server/__tests__/socialPreview.test.ts
+++ b/mingla-business/server/__tests__/socialPreview.test.ts
@@ -37,7 +37,11 @@ const {
   renderBrandHtml: (
     input:
       | Record<string, unknown>[]
-      | { brand: Record<string, unknown>; events: Record<string, unknown>[] },
+      | {
+          brand: Record<string, unknown>;
+          events: Record<string, unknown>[];
+          venue?: Record<string, unknown> | null;
+        },
   ) => string;
   renderEventHtml: (row: Record<string, unknown>) => string;
 };
@@ -91,6 +95,27 @@ describe("social preview metadata renderers", () => {
     expect(html).not.toContain("business.mingla.com");
     expect(html).not.toContain("https://mingla.com/e");
     expect(html).not.toContain("exp://");
+  });
+
+  test("renders verified venue brand metadata with city in title", () => {
+    const html = renderBrandHtml({
+      brand: {
+        ...brand,
+        slug: "joes-pizza",
+        name: "Joe's Pizza",
+        description: "Neighbourhood slice shop.",
+        kind: "physical",
+        city: "Brooklyn",
+      },
+      venue: {
+        kind: "physical",
+        city: "Brooklyn",
+      },
+      events: [],
+    });
+
+    expect(html).toContain("Joe&#39;s Pizza · Brooklyn on Mingla</title>");
+    expect(html).toContain("No upcoming events from this venue");
   });
 
   test("renders brand metadata with the Mingla Business OG fallback", () => {

--- a/mingla-business/server/__tests__/socialPreview.ve4.test.ts
+++ b/mingla-business/server/__tests__/socialPreview.ve4.test.ts
@@ -2,6 +2,49 @@ import { describe, expect, test } from "@jest/globals";
 import { readFileSync } from "fs";
 import { join } from "path";
 
+declare const require: <T = unknown>(path: string) => T;
+
+const { renderBrandHtml } = require("../socialPreview") as {
+  renderBrandHtml: (input: {
+    brand: Record<string, unknown>;
+    events: Record<string, unknown>[];
+    venue?: Record<string, unknown> | null;
+  }) => string;
+};
+
+const brand = {
+  id: "brand-1",
+  slug: "brand-3",
+  name: "Brand 3",
+  description: "Small-room popups and careful hosting.",
+  profile_photo_url: null,
+  cover_media_url: null,
+  cover_media_type: null,
+};
+
+describe("Ve4 social preview render", () => {
+  test("renders verified venue brand metadata with city in title", () => {
+    const html = renderBrandHtml({
+      brand: {
+        ...brand,
+        slug: "joes-pizza",
+        name: "Joe's Pizza",
+        description: "Neighbourhood slice shop.",
+        kind: "physical",
+        city: "Brooklyn",
+      },
+      venue: {
+        kind: "physical",
+        city: "Brooklyn",
+      },
+      events: [],
+    });
+
+    expect(html).toContain("Joe&#39;s Pizza · Brooklyn on Mingla</title>");
+    expect(html).toContain("No upcoming events from this venue");
+  });
+});
+
 describe("Ve4 social preview fetch", () => {
   const src = readFileSync(
     join(__dirname, "..", "socialPreview.js"),

--- a/mingla-business/server/__tests__/socialPreview.ve4.test.ts
+++ b/mingla-business/server/__tests__/socialPreview.ve4.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Ve4 social preview fetch", () => {
+  const src = readFileSync(
+    join(__dirname, "..", "socialPreview.js"),
+    "utf8",
+  );
+
+  test("fetchPublicBrandBySlug prefers claimed_venues_public_view", () => {
+    expect(src).toContain("claimed_venues_public_view");
+    expect(src).toMatch(
+      /fetchPublicBrandBySlug[\s\S]*claimed_venues_public_view[\s\S]*business_public_brands_view/,
+    );
+  });
+});

--- a/mingla-business/server/socialPreview.js
+++ b/mingla-business/server/socialPreview.js
@@ -229,21 +229,40 @@ const fetchPublicEventById = async (eventId) => {
   return Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
 };
 
+const fetchPublicBrandEvents = async (brandSlug) => {
+  const eventRows = await requestJson("business_public_events_view", {
+    select: "*",
+    brand_slug: `eq.${brandSlug}`,
+    order: "published_at.desc.nullslast",
+  });
+  return Array.isArray(eventRows) ? eventRows : [];
+};
+
 const fetchPublicBrandBySlug = async (brandSlug) => {
+  const claimedRows = await requestJson("claimed_venues_public_view", {
+    select: "*",
+    slug: `eq.${brandSlug}`,
+    limit: "1",
+  });
+  const events = await fetchPublicBrandEvents(brandSlug);
+  if (Array.isArray(claimedRows) && claimedRows.length > 0) {
+    return {
+      brand: claimedRows[0],
+      venue: claimedRows[0],
+      events,
+    };
+  }
+
   const brandRows = await requestJson("business_public_brands_view", {
     select: "*",
     slug: `eq.${brandSlug}`,
     limit: "1",
   });
   if (!Array.isArray(brandRows) || brandRows.length === 0) return null;
-  const eventRows = await requestJson("business_public_events_view", {
-    select: "*",
-    brand_slug: `eq.${brandSlug}`,
-    order: "published_at.desc.nullslast",
-  });
   return {
     brand: brandRows[0],
-    events: Array.isArray(eventRows) ? eventRows : [],
+    venue: null,
+    events,
   };
 };
 
@@ -494,19 +513,35 @@ const chooseBrandFeatureEvent = (rows) => {
 
 const normalizeBrandPreviewInput = (input) => {
   if (Array.isArray(input)) {
-    return { brand: input[0] ?? null, events: input };
+    return { brand: input[0] ?? null, venue: null, events: input };
   }
   if (input !== null && typeof input === "object") {
     return {
       brand: input.brand ?? null,
+      venue: input.venue ?? null,
       events: Array.isArray(input.events) ? input.events : [],
     };
   }
-  return { brand: null, events: [] };
+  return { brand: null, venue: null, events: [] };
 };
 
+const brandListingTitle = (brandRow, venueRow) => {
+  const name = brandName(brandRow);
+  const city =
+    venueRow !== null &&
+    typeof venueRow === "object" &&
+    typeof venueRow.city === "string" &&
+    venueRow.city.trim().length > 0
+      ? venueRow.city.trim()
+      : null;
+  return city !== null ? `${name} · ${city}` : name;
+};
+
+const brandSeoTitle = (brandRow, venueRow) =>
+  `${brandListingTitle(brandRow, venueRow)} on Mingla`;
+
 const buildBrandOgCardProps = (input) => {
-  const { brand, events } = normalizeBrandPreviewInput(input);
+  const { brand, events, venue } = normalizeBrandPreviewInput(input);
   const featureEvent = chooseBrandFeatureEvent(events);
   const eventCount = events.length;
   const eventCountLabel = `${eventCount} event${eventCount === 1 ? "" : "s"}`;
@@ -527,7 +562,8 @@ const buildBrandOgCardProps = (input) => {
         ? eventCoverUrl(featureEvent)
         : null;
 
-  const title = brand !== null ? brandName(brand) : "Mingla Business";
+  const title =
+    brand !== null ? brandListingTitle(brand, venue) : "Mingla Business";
   const subtitle =
     (brand !== null ? brandDescriptionText(brand) : "") ||
     (brand
@@ -673,12 +709,16 @@ const renderTripHtml = (row) => {
 };
 
 const renderBrandHtml = (input) => {
-  const { brand, events } = normalizeBrandPreviewInput(input);
+  const { brand, events, venue } = normalizeBrandPreviewInput(input);
   const row = brand ?? events[0];
-  const title = `${brandName(row)} on Mingla`;
+  const title = brandSeoTitle(row, venue);
   const description = brandDescription(row, events.length);
   const canonicalUrl = brandPublicUrl(row);
   const imageUrl = brandImageUrl(row);
+  const isVerifiedVenue =
+    venue !== null &&
+    typeof venue === "object" &&
+    venue.kind === "physical";
   const cards = events
     .slice(0, 8)
     .map(
@@ -687,7 +727,10 @@ const renderBrandHtml = (input) => {
         <span>${escapeHtml(eventDescription(event))}</span>
       </a>`,
     )
-    .join("") || `<div class="card"><strong>No upcoming events yet</strong><span>Check back soon for new events from ${escapeHtml(brandName(row))}.</span></div>`;
+    .join("") ||
+    (isVerifiedVenue
+      ? `<div class="card"><strong>No upcoming events from this venue</strong><span>Check back soon for events from ${escapeHtml(brandName(row))}.</span></div>`
+      : `<div class="card"><strong>No upcoming events yet</strong><span>Check back soon for new events from ${escapeHtml(brandName(row))}.</span></div>`);
 
   return pageShell({
     title,

--- a/mingla-business/src/components/brand/PublicBrandPage.tsx
+++ b/mingla-business/src/components/brand/PublicBrandPage.tsx
@@ -67,9 +67,10 @@ import {
   brandPublicUrl,
   eventPublicPath,
 } from "../../constants/publicUrls";
-import { useAuth } from "../../context/AuthContext";
-import { useBrandList, type Brand } from "../../store/currentBrandStore";
+import type { PublicVenueDetail } from "../../services/publicEventsService";
+import type { Brand } from "../../store/currentBrandStore";
 import type { LiveEvent } from "../../store/liveEventStore";
+import type { VenueCategory } from "../../types/brand";
 import { formatCurrencyRound } from "../../utils/currency";
 import { formatDraftDateLine } from "../../utils/eventDateDisplay";
 
@@ -79,6 +80,10 @@ import { Icon, type IconName } from "../ui/Icon";
 import { IconChrome } from "../ui/IconChrome";
 import { EventCoverMedia } from "../ui/EventCoverMedia";
 import { ShareModal } from "../ui/ShareModal";
+import { VerifiedBadge } from "./VerifiedBadge";
+import { VenueHoursTable } from "./VenueHoursTable";
+import { VenueLocationPreview } from "./VenueLocationPreview";
+import { VenuePhotoGallery } from "./VenuePhotoGallery";
 // ORCH-0850 [End-not-start parity systemic]: route Upcoming / Past memo
 // predicates through the canonical helper. Pre-0850 memos used
 // `new Date(e.date).getTime()` with a `Date.now() - 24h` cutoff — the same
@@ -90,7 +95,15 @@ import { computeMasterEndAtUtc } from "../../utils/eventDateMath";
 interface PublicBrandPageProps {
   brand: Brand;
   events: LiveEvent[];
+  /** Ve4 — verified physical venue listing fields; null for popup/trip brands. */
+  venue?: PublicVenueDetail | null;
 }
+
+const VENUE_CATEGORY_LABELS: Record<VenueCategory, string> = {
+  restaurant: "Restaurant",
+  play: "Play",
+  creative_and_arts: "Creative & Arts",
+};
 
 type Tab = "upcoming" | "past" | "about";
 
@@ -104,11 +117,10 @@ const canonicalUrl = (brand: Brand): string =>
 export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
   brand,
   events,
+  venue = null,
 }) => {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { user } = useAuth();
-  const userBrands = useBrandList();
   const [activeTab, setActiveTab] = useState<Tab>("upcoming");
   const [shareModalVisible, setShareModalVisible] = useState<boolean>(false);
   // ORCH-0805 — track cover media load failure so the hero falls back to the
@@ -119,14 +131,17 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
     setCoverMediaFailed(false);
   }, [coverMediaUrl]);
 
-  // Founder-aware close chrome: shown only when the visitor owns this
-  // brand. Forward-compat — when B-cycle wires real auth + useBrandList
-  // filters to user-owned brands, this check becomes precise. Today,
-  // useBrandList returns all stub brands so it resolves to "isSignedIn".
-  const ownsThisBrand = useMemo<boolean>(() => {
-    if (user === null) return false;
-    return userBrands.some((b) => b.id === brand.id);
-  }, [user, userBrands, brand.id]);
+  const isVerifiedVenue = venue?.isVerifiedVenue === true;
+  const pageTitle =
+    isVerifiedVenue && venue.city !== null
+      ? `${brand.displayName} · ${venue.city} on Mingla`
+      : `${brand.displayName} on Mingla`;
+  const metaDescription =
+    brand.bio?.slice(0, 160) ??
+    brand.tagline ??
+    (isVerifiedVenue && venue.city !== null
+      ? `${brand.displayName} in ${venue.city}`
+      : brand.displayName);
 
   // ORCH-0850: upcoming = not past AND not cancelled.
   // The pre-0850 24h cutoff was a band-aid for the UTC-midnight bug class;
@@ -161,13 +176,6 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
   const verifiedHostSinceYear = useMemo<number | null>(() => null, []);
   const publicEventCount = events.length;
   const showStatsCard = publicEventCount > 0;
-
-  const handleClose = useCallback((): void => {
-    // Cycle 7 FX3: route to founder brand profile, NOT all the way to
-    // Account tab. Founder lands on /brand/{brand.id} where they can
-    // Edit, Team, Stripe, etc. From there native back returns to Account.
-    router.replace(`/brand/${brand.id}` as never);
-  }, [router, brand.id]);
 
   const handleEventCardPress = useCallback(
     (event: LiveEvent): void => {
@@ -221,18 +229,13 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
           a registered origin URL (DEC-071); rendering Head there throws. */}
       {Platform.OS === "web" ? (
         <Head>
-          <title>{brand.displayName} on Mingla</title>
-          <meta
-            name="description"
-            content={
-              brand.bio?.slice(0, 160) ?? brand.tagline ?? brand.displayName
-            }
-          />
-          <meta property="og:title" content={brand.displayName} />
+          <title>{pageTitle}</title>
+          <meta name="description" content={metaDescription} />
+          <meta property="og:title" content={pageTitle} />
           <meta
             property="og:description"
             content={
-              brand.bio?.slice(0, 200) ?? brand.tagline ?? brand.displayName
+              brand.bio?.slice(0, 200) ?? brand.tagline ?? metaDescription
             }
           />
           <meta property="og:url" content={canonicalUrl(brand)} />
@@ -315,16 +318,7 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
         style={[styles.floatingChrome, { top: insets.top + spacing.sm }]}
         pointerEvents="box-none"
       >
-        {ownsThisBrand ? (
-          <IconChrome
-            icon="close"
-            size={40}
-            onPress={handleClose}
-            accessibilityLabel="Close"
-          />
-        ) : (
-          <View />
-        )}
+        <View />
         <IconChrome
           icon="share"
           size={40}
@@ -352,6 +346,7 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
             style={styles.heroAvatarCentered}
           />
           <Text style={styles.brandNameCentered}>{brand.displayName}</Text>
+          {isVerifiedVenue ? <VerifiedBadge /> : null}
           {identitySubline !== null ? (
             <Text style={styles.handleLineCentered}>{identitySubline}</Text>
           ) : null}
@@ -372,6 +367,33 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
           onPress={handleSocialPress}
           compact
         />
+
+        {isVerifiedVenue && venue !== null ? (
+          <GlassCard
+            variant="elevated"
+            radius="lg"
+            padding={spacing.md}
+            style={styles.venueCard}
+          >
+            {venue.venueCategory !== null ? (
+              <View style={styles.categoryRow}>
+                <View style={styles.categoryChip}>
+                  <Text style={styles.categoryChipLabel}>
+                    {VENUE_CATEGORY_LABELS[venue.venueCategory]}
+                  </Text>
+                </View>
+              </View>
+            ) : null}
+            <VenueLocationPreview
+              address={brand.address ?? null}
+              city={venue.city}
+              lat={venue.lat}
+              lng={venue.lng}
+            />
+            <VenueHoursTable hours={venue.hours} />
+            <VenuePhotoGallery photoUrls={venue.galleryPhotoUrls} />
+          </GlassCard>
+        ) : null}
 
         {/* Stats card (only when ≥1 non-zero stat) */}
         {showStatsCard ? (
@@ -418,6 +440,7 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
           <UpcomingTab
             events={upcomingEvents}
             brand={brand}
+            isVerifiedVenue={isVerifiedVenue}
             onEventPress={handleEventCardPress}
             onSocialPress={handleSocialPress}
           />
@@ -485,22 +508,26 @@ const TabButton: React.FC<TabButtonProps> = ({
 interface UpcomingTabProps {
   events: LiveEvent[];
   brand: Brand;
+  isVerifiedVenue: boolean;
   onEventPress: (e: LiveEvent) => void;
   onSocialPress: (url: string) => void;
 }
 
 const UpcomingTab: React.FC<UpcomingTabProps> = ({
   events,
-  brand,
+  isVerifiedVenue,
   onEventPress,
-  onSocialPress,
 }) => {
   if (events.length === 0) {
     // Cycle 7 FX2: socials moved to permanent slot below bio (above tabs),
     // so the empty-tab copy doesn't need to repeat them here.
     return (
       <View style={styles.emptyTabWrap}>
-        <Text style={styles.emptyTabTitle}>No upcoming events yet</Text>
+        <Text style={styles.emptyTabTitle}>
+          {isVerifiedVenue
+            ? "No upcoming events from this venue"
+            : "No upcoming events yet"}
+        </Text>
       </View>
     );
   }
@@ -871,6 +898,29 @@ const styles = StyleSheet.create({
   },
   statsCard: {
     marginBottom: spacing.md,
+  },
+  venueCard: {
+    marginTop: spacing.md,
+    gap: spacing.md,
+    width: "100%",
+  },
+  categoryRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  categoryChip: {
+    paddingVertical: 4,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radiusTokens.full,
+    backgroundColor: accent.tint,
+    borderWidth: 1,
+    borderColor: accent.border,
+  },
+  categoryChipLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: accent.warm,
   },
   statsRow: {
     flexDirection: "row",

--- a/mingla-business/src/components/brand/VenueHoursTable.tsx
+++ b/mingla-business/src/components/brand/VenueHoursTable.tsx
@@ -1,0 +1,103 @@
+/**
+ * Ve4 — weekly hours table for verified public venue pages.
+ * Times are shown in venue-local wall-clock (stored on brand_hours rows).
+ */
+
+import React, { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { BrandHourEntry } from "../../types/brand";
+
+const WEEKDAY_LABELS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+const formatHourRange = (entry: BrandHourEntry): string => {
+  if (entry.isClosed) return "Closed";
+  if (
+    entry.openTime !== null &&
+    entry.openTime.length > 0 &&
+    entry.closeTime !== null &&
+    entry.closeTime.length > 0
+  ) {
+    return `${entry.openTime} – ${entry.closeTime}`;
+  }
+  return "Hours not listed";
+};
+
+export interface VenueHoursTableProps {
+  hours: BrandHourEntry[];
+}
+
+export const VenueHoursTable: React.FC<VenueHoursTableProps> = ({ hours }) => {
+  const rows = useMemo(() => {
+    const byWeekday = new Map(hours.map((h) => [h.weekday, h]));
+    return WEEKDAY_LABELS.map((label, weekday) => ({
+      label,
+      value: formatHourRange(
+        byWeekday.get(weekday) ?? {
+          weekday,
+          openTime: null,
+          closeTime: null,
+          isClosed: true,
+        },
+      ),
+    }));
+  }, [hours]);
+
+  if (hours.length === 0) return null;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Hours</Text>
+      {rows.map((row) => (
+        <View key={row.label} style={styles.row}>
+          <Text style={styles.day}>{row.label}</Text>
+          <Text style={styles.time}>{row.value}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.xs,
+    width: "100%",
+  },
+  title: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+    marginBottom: spacing.xs,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: spacing.md,
+    paddingVertical: 4,
+  },
+  day: {
+    flex: 1,
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  time: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.primary,
+    textAlign: "right",
+  },
+});
+
+export default VenueHoursTable;

--- a/mingla-business/src/components/brand/VenueLocationPreview.tsx
+++ b/mingla-business/src/components/brand/VenueLocationPreview.tsx
@@ -1,0 +1,116 @@
+/**
+ * Ve4 — structured address + OpenStreetMap link for public venue pages.
+ */
+
+import React, { useCallback } from "react";
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { Icon } from "../ui/Icon";
+
+export interface VenueLocationPreviewProps {
+  address: string | null;
+  city: string | null;
+  lat: number | null;
+  lng: number | null;
+}
+
+const buildOsmUrl = (lat: number, lng: number): string =>
+  `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lng}#map=16/${lat}/${lng}`;
+
+export const VenueLocationPreview: React.FC<VenueLocationPreviewProps> = ({
+  address,
+  city,
+  lat,
+  lng,
+}) => {
+  const lines = [address, city].filter(
+    (line): line is string => typeof line === "string" && line.trim().length > 0,
+  );
+  const hasCoords =
+    typeof lat === "number" &&
+    Number.isFinite(lat) &&
+    typeof lng === "number" &&
+    Number.isFinite(lng);
+
+  const handleMapPress = useCallback(async (): Promise<void> => {
+    if (!hasCoords) return;
+    const url = buildOsmUrl(lat, lng);
+    try {
+      if (Platform.OS === "web") {
+        const win = (
+          globalThis as unknown as {
+            window?: { open?: (u: string, t: string) => unknown };
+          }
+        ).window;
+        if (win?.open !== undefined) {
+          win.open(url, "_blank");
+          return;
+        }
+      }
+      await Linking.openURL(url);
+    } catch {
+      // user-cancelled
+    }
+  }, [hasCoords, lat, lng]);
+
+  if (lines.length === 0 && !hasCoords) return null;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Location</Text>
+      {lines.map((line) => (
+        <Text key={line} style={styles.address}>
+          {line}
+        </Text>
+      ))}
+      {hasCoords ? (
+        <Pressable
+          onPress={() => void handleMapPress()}
+          accessibilityRole="link"
+          accessibilityLabel="Open map in OpenStreetMap"
+          style={styles.mapLink}
+        >
+          <Icon name="location" size={16} color={accent.warm} />
+          <Text style={styles.mapLabel}>View on map</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.xs,
+    width: "100%",
+  },
+  title: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+    marginBottom: spacing.xs,
+  },
+  address: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+    lineHeight: 20,
+  },
+  mapLink: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginTop: spacing.xs,
+  },
+  mapLabel: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: accent.warm,
+  },
+});
+
+export default VenueLocationPreview;

--- a/mingla-business/src/components/brand/VenuePhotoGallery.tsx
+++ b/mingla-business/src/components/brand/VenuePhotoGallery.tsx
@@ -1,0 +1,74 @@
+/**
+ * Ve4 — horizontal photo gallery for verified public venue pages.
+ */
+
+import React from "react";
+import {
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import {
+  accent,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+
+export interface VenuePhotoGalleryProps {
+  photoUrls: string[];
+}
+
+export const VenuePhotoGallery: React.FC<VenuePhotoGalleryProps> = ({
+  photoUrls,
+}) => {
+  if (photoUrls.length === 0) return null;
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.title}>Photos</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.row}
+      >
+        {photoUrls.map((uri) => (
+          <Image
+            key={uri}
+            source={{ uri }}
+            style={styles.thumb}
+            accessibilityLabel="Venue photo"
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    gap: spacing.sm,
+    width: "100%",
+  },
+  title: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  row: {
+    gap: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  thumb: {
+    width: 120,
+    height: 120,
+    borderRadius: radiusTokens.md,
+    backgroundColor: accent.tint,
+  },
+});
+
+export default VenuePhotoGallery;

--- a/mingla-business/src/components/brand/VerifiedBadge.tsx
+++ b/mingla-business/src/components/brand/VerifiedBadge.tsx
@@ -1,0 +1,50 @@
+/**
+ * Ve4 — subtle verified-venue badge for public physical venue pages.
+ */
+
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { Icon } from "../ui/Icon";
+
+export const VerifiedBadge: React.FC = () => (
+  <View style={styles.host} accessibilityRole="text">
+    <Icon name="check" size={14} color={accent.warm} />
+    <Text style={styles.label}>Verified</Text>
+    <Text style={styles.sub}>Claimed by venue</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  host: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    alignSelf: "center",
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radiusTokens.full,
+    backgroundColor: "rgba(59, 130, 246, 0.12)",
+    borderWidth: 1,
+    borderColor: "rgba(59, 130, 246, 0.35)",
+    marginTop: spacing.xs,
+  },
+  label: {
+    fontSize: typography.caption.fontSize,
+    fontWeight: "700",
+    color: accent.warm,
+  },
+  sub: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.secondary,
+  },
+});
+
+export default VerifiedBadge;

--- a/mingla-business/src/components/brand/__tests__/PublicBrandPage.ve4.test.ts
+++ b/mingla-business/src/components/brand/__tests__/PublicBrandPage.ve4.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Ve4 PublicBrandPage anon tolerance", () => {
+  const pageSrc = readFileSync(
+    join(__dirname, "..", "PublicBrandPage.tsx"),
+    "utf8",
+  );
+  const routeSrc = readFileSync(
+    join(__dirname, "..", "..", "..", "..", "app", "b", "[brandSlug]", "index.tsx"),
+    "utf8",
+  );
+
+  test("PublicBrandPage does not call useAuth (buyer /b/ route)", () => {
+    expect(pageSrc).not.toMatch(/\buseAuth\b/);
+    expect(pageSrc).not.toContain("AuthContext");
+  });
+
+  test("route passes venue prop from public brand query", () => {
+    expect(routeSrc).toContain("venue={publicBrandQuery.data.venue}");
+  });
+
+  test("renders VerifiedBadge only via isVerifiedVenue branch", () => {
+    expect(pageSrc).toContain("isVerifiedVenue ? <VerifiedBadge />");
+    expect(pageSrc).toContain("VenueHoursTable");
+    expect(pageSrc).toContain("VenueLocationPreview");
+    expect(pageSrc).toContain("VenuePhotoGallery");
+  });
+});

--- a/mingla-business/src/services/__tests__/publicEventsService.test.ts
+++ b/mingla-business/src/services/__tests__/publicEventsService.test.ts
@@ -87,6 +87,9 @@ const row = (patch: Record<string, unknown> = {}): Record<string, unknown> => ({
   status: "scheduled",
   published_at: "2026-05-08T18:30:00.000Z",
   timezone: "Europe/London",
+  master_start_at: "2026-05-08T19:00:00.000Z",
+  master_end_at: "2026-05-08T21:30:00.000Z",
+  master_timezone: "Europe/Paris",
   created_at: "2026-05-08T18:00:00.000Z",
   updated_at: "2026-05-08T18:30:00.000Z",
   public_theme: {
@@ -135,6 +138,29 @@ const brandRow = (patch: Record<string, unknown> = {}): Record<string, unknown> 
   profile_photo_type: "image",
   created_at: "2026-05-08T18:00:00.000Z",
   updated_at: "2026-05-08T18:30:00.000Z",
+  ...patch,
+});
+
+const claimedVenueRow = (
+  patch: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  ...brandRow({ display_attendee_count: undefined }),
+  city: "London",
+  country_code: "GB",
+  lat: 51.5,
+  lng: -0.12,
+  venue_category: "restaurant",
+  place_pool_id: "pool-1",
+  google_place_id: "gp-1",
+  hours: [
+    {
+      weekday: 0,
+      open_time: "09:00",
+      close_time: "17:00",
+      is_closed: false,
+    },
+  ],
+  pool_photo_urls: ["https://pool.example.com/a.jpg"],
   ...patch,
 });
 
@@ -222,6 +248,9 @@ describe("public event view mapper", () => {
   test("keeps Date TBD when the saved public payload lacks a valid date", () => {
     const event = publicEventViewRowToEvent(
       row({
+        master_start_at: null,
+        master_end_at: null,
+        master_timezone: null,
         public_theme: {
           business_event: {
             whenMode: "single",
@@ -237,9 +266,9 @@ describe("public event view mapper", () => {
 });
 
 describe("public brand lookup", () => {
-  test("returns a real empty brand instead of null when no public event rows exist", async () => {
-    const brandQuery = queryBuilder("maybeSingle", {
-      data: brandRow(),
+  test("returns a verified physical venue with listing detail when no events exist", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: claimedVenueRow(),
       error: null,
     });
     const eventsQuery = queryBuilder("order", {
@@ -247,7 +276,7 @@ describe("public brand lookup", () => {
       error: null,
     });
     mockFrom.mockImplementation((table) => {
-      if (table === "business_public_brands_view") return brandQuery;
+      if (table === "claimed_venues_public_view") return claimedQuery;
       if (table === "business_public_events_view") return eventsQuery;
       throw new Error(`Unexpected table ${String(table)}`);
     });
@@ -267,42 +296,70 @@ describe("public brand lookup", () => {
       profilePhotoType: "image",
       photo: "https://cdn.example.com/brand.png",
       bio: "Tiny parties, big feelings.",
-      displayAttendeeCount: false,
+      claimStatus: "verified",
+      city: "London",
       stats: { events: 0, followers: 0, rev: 0, rev7d: 0, attendees: 0 },
     });
     expect(detail?.brand.links).toEqual({
       instagram: "@brand3",
       custom: [{ label: "Menu", url: "https://brand.example.com/menu" }],
     });
+    expect(detail?.venue).toMatchObject({
+      isVerifiedVenue: true,
+      city: "London",
+      venueCategory: "restaurant",
+      galleryPhotoUrls: [
+        "https://cdn.example.com/cover.gif",
+        "https://cdn.example.com/brand.png",
+      ],
+    });
     expect(detail?.events).toEqual([]);
-    expect(brandQuery.eq).toHaveBeenCalledWith("slug", "brand-3");
+    expect(claimedQuery.eq).toHaveBeenCalledWith("slug", "brand-3");
     expect(eventsQuery.eq).toHaveBeenCalledWith("brand_slug", "brand-3");
     expect(mockFrom).toHaveBeenCalledTimes(2);
   });
 
   test("returns null only when the brand profile row is missing", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: null,
+      error: null,
+    });
     const brandQuery = queryBuilder("maybeSingle", {
       data: null,
       error: null,
     });
     mockFrom.mockImplementation((table) => {
+      if (table === "claimed_venues_public_view") return claimedQuery;
       if (table === "business_public_brands_view") return brandQuery;
       throw new Error(`Unexpected table ${String(table)}`);
     });
 
     await expect(getPublicBrandBySlug("missing-brand")).resolves.toBeNull();
-    expect(mockFrom).toHaveBeenCalledTimes(1);
+    expect(mockFrom).toHaveBeenCalledTimes(2);
   });
 
   test("keeps populated brand events and ticket fetches public-event-backed", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: null,
+      error: null,
+    });
     const brandQuery = queryBuilder("maybeSingle", {
-      data: brandRow({ slug: "test-stripe", name: "Test Stripe" }),
+      data: brandRow({ slug: "test-stripe", name: "Test Stripe", kind: "popup" }),
       error: null,
     });
     const eventsQuery = queryBuilder("order", {
       data: [row()],
       error: null,
     });
+    const eventTypesQuery = {
+      select: jest.fn(() => eventTypesQuery),
+      in: jest.fn(() =>
+        Promise.resolve({
+          data: [{ id: "event-1", event_type: "event" }],
+          error: null,
+        }),
+      ),
+    };
     const ticketsQuery = queryBuilder("order", {
       data: [
         {
@@ -333,8 +390,10 @@ describe("public brand lookup", () => {
       error: null,
     });
     mockFrom.mockImplementation((table) => {
+      if (table === "claimed_venues_public_view") return claimedQuery;
       if (table === "business_public_brands_view") return brandQuery;
       if (table === "business_public_events_view") return eventsQuery;
+      if (table === "events") return eventTypesQuery;
       if (table === "ticket_types") return ticketsQuery;
       throw new Error(`Unexpected table ${String(table)}`);
     });
@@ -342,6 +401,7 @@ describe("public brand lookup", () => {
     const detail = await getPublicBrandBySlug("test-stripe");
 
     expect(detail?.brand.displayName).toBe("Test Stripe");
+    expect(detail?.venue).toBeNull();
     expect(detail?.brand.stats.events).toBe(1);
     expect(detail?.events).toHaveLength(1);
     expect(detail?.events[0]).toMatchObject({

--- a/mingla-business/src/services/__tests__/publicEventsService.test.ts
+++ b/mingla-business/src/services/__tests__/publicEventsService.test.ts
@@ -141,29 +141,6 @@ const brandRow = (patch: Record<string, unknown> = {}): Record<string, unknown> 
   ...patch,
 });
 
-const claimedVenueRow = (
-  patch: Record<string, unknown> = {},
-): Record<string, unknown> => ({
-  ...brandRow({ display_attendee_count: undefined }),
-  city: "London",
-  country_code: "GB",
-  lat: 51.5,
-  lng: -0.12,
-  venue_category: "restaurant",
-  place_pool_id: "pool-1",
-  google_place_id: "gp-1",
-  hours: [
-    {
-      weekday: 0,
-      open_time: "09:00",
-      close_time: "17:00",
-      is_closed: false,
-    },
-  ],
-  pool_photo_urls: ["https://pool.example.com/a.jpg"],
-  ...patch,
-});
-
 beforeEach(() => {
   mockFrom.mockReset();
 });
@@ -266,9 +243,13 @@ describe("public event view mapper", () => {
 });
 
 describe("public brand lookup", () => {
-  test("returns a verified physical venue with listing detail when no events exist", async () => {
+  test("returns a real empty brand instead of null when no public event rows exist", async () => {
     const claimedQuery = queryBuilder("maybeSingle", {
-      data: claimedVenueRow(),
+      data: null,
+      error: null,
+    });
+    const brandQuery = queryBuilder("maybeSingle", {
+      data: brandRow(),
       error: null,
     });
     const eventsQuery = queryBuilder("order", {
@@ -277,6 +258,7 @@ describe("public brand lookup", () => {
     });
     mockFrom.mockImplementation((table) => {
       if (table === "claimed_venues_public_view") return claimedQuery;
+      if (table === "business_public_brands_view") return brandQuery;
       if (table === "business_public_events_view") return eventsQuery;
       throw new Error(`Unexpected table ${String(table)}`);
     });
@@ -296,27 +278,17 @@ describe("public brand lookup", () => {
       profilePhotoType: "image",
       photo: "https://cdn.example.com/brand.png",
       bio: "Tiny parties, big feelings.",
-      claimStatus: "verified",
-      city: "London",
+      displayAttendeeCount: false,
       stats: { events: 0, followers: 0, rev: 0, rev7d: 0, attendees: 0 },
     });
     expect(detail?.brand.links).toEqual({
       instagram: "@brand3",
       custom: [{ label: "Menu", url: "https://brand.example.com/menu" }],
     });
-    expect(detail?.venue).toMatchObject({
-      isVerifiedVenue: true,
-      city: "London",
-      venueCategory: "restaurant",
-      galleryPhotoUrls: [
-        "https://cdn.example.com/cover.gif",
-        "https://cdn.example.com/brand.png",
-      ],
-    });
     expect(detail?.events).toEqual([]);
-    expect(claimedQuery.eq).toHaveBeenCalledWith("slug", "brand-3");
+    expect(brandQuery.eq).toHaveBeenCalledWith("slug", "brand-3");
     expect(eventsQuery.eq).toHaveBeenCalledWith("brand_slug", "brand-3");
-    expect(mockFrom).toHaveBeenCalledTimes(2);
+    expect(mockFrom).toHaveBeenCalledTimes(3);
   });
 
   test("returns null only when the brand profile row is missing", async () => {
@@ -344,7 +316,7 @@ describe("public brand lookup", () => {
       error: null,
     });
     const brandQuery = queryBuilder("maybeSingle", {
-      data: brandRow({ slug: "test-stripe", name: "Test Stripe", kind: "popup" }),
+      data: brandRow({ slug: "test-stripe", name: "Test Stripe" }),
       error: null,
     });
     const eventsQuery = queryBuilder("order", {
@@ -401,7 +373,6 @@ describe("public brand lookup", () => {
     const detail = await getPublicBrandBySlug("test-stripe");
 
     expect(detail?.brand.displayName).toBe("Test Stripe");
-    expect(detail?.venue).toBeNull();
     expect(detail?.brand.stats.events).toBe(1);
     expect(detail?.events).toHaveLength(1);
     expect(detail?.events[0]).toMatchObject({

--- a/mingla-business/src/services/__tests__/publicEventsService.ve4.test.ts
+++ b/mingla-business/src/services/__tests__/publicEventsService.ve4.test.ts
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const mockFrom = jest.fn();
+jest.mock("../supabase", () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+import { getPublicBrandBySlug } from "../publicEventsService";
+
+const queryBuilder = <T,>(
+  terminal: "maybeSingle" | "order",
+  result: { data: T; error: Error | null },
+) => {
+  const builder = {
+    select: jest.fn(() => builder),
+    eq: jest.fn(() => builder),
+    is: jest.fn(() => builder),
+    order: jest.fn(() =>
+      terminal === "order" ? Promise.resolve(result) : builder,
+    ),
+    maybeSingle: jest.fn(() =>
+      terminal === "maybeSingle" ? Promise.resolve(result) : builder,
+    ),
+  };
+  return builder;
+};
+
+const row = (patch: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: "event-1",
+  brand_id: "brand-1",
+  brand_slug: "test-stripe",
+  brand_name: "Test Stripe",
+  brand_description: null,
+  brand_profile_photo_url: null,
+  brand_display_attendee_count: true,
+  title: "Great Free Event",
+  description: "A real public event.",
+  slug: "great-free-event",
+  location_text: "Fallback venue",
+  online_url: null,
+  is_online: false,
+  is_recurring: false,
+  is_multi_date: false,
+  recurrence_rules: null,
+  cover_media_url: null,
+  cover_media_type: null,
+  cover_media_provider: null,
+  cover_media_source_url: null,
+  cover_media_credit: null,
+  cover_media_credit_url: null,
+  cover_media_alt: null,
+  visibility: "public",
+  show_on_discover: true,
+  status: "scheduled",
+  published_at: "2026-05-08T18:30:00.000Z",
+  timezone: "Europe/London",
+  master_start_at: "2026-05-08T19:00:00.000Z",
+  master_end_at: "2026-05-08T21:30:00.000Z",
+  master_timezone: "Europe/Paris",
+  created_at: "2026-05-08T18:00:00.000Z",
+  updated_at: "2026-05-08T18:30:00.000Z",
+  public_theme: {
+    business_event: {
+      whenMode: "single",
+      when: { date: "2026-05-08" },
+    },
+  },
+  ...patch,
+});
+
+const brandRow = (patch: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: "brand-1",
+  slug: "brand-3",
+  name: "Brand 3",
+  description: "Tiny parties, big feelings.",
+  profile_photo_url: "https://cdn.example.com/brand.png",
+  social_links: { instagram: "@brand3" },
+  custom_links: [{ label: "Menu", url: "https://brand.example.com/menu" }],
+  display_attendee_count: false,
+  kind: "physical",
+  address: "3 Brand Street",
+  cover_hue: 180,
+  cover_media_url: "https://cdn.example.com/cover.gif",
+  cover_media_type: "gif",
+  profile_photo_type: "image",
+  claim_status: "verified",
+  created_at: "2026-05-08T18:00:00.000Z",
+  updated_at: "2026-05-08T18:30:00.000Z",
+  ...patch,
+});
+
+const claimedVenueRow = (
+  patch: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  ...brandRow({ display_attendee_count: undefined }),
+  city: "London",
+  country_code: "GB",
+  lat: 51.5,
+  lng: -0.12,
+  venue_category: "restaurant",
+  place_pool_id: "pool-1",
+  google_place_id: "gp-1",
+  hours: [
+    {
+      weekday: 0,
+      open_time: "09:00",
+      close_time: "17:00",
+      is_closed: false,
+    },
+  ],
+  pool_photo_urls: ["https://pool.example.com/a.jpg"],
+  ...patch,
+});
+
+beforeEach(() => {
+  mockFrom.mockReset();
+});
+
+describe("Ve4 public brand lookup", () => {
+  test("returns a verified physical venue with listing detail when no events exist", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: claimedVenueRow(),
+      error: null,
+    });
+    const eventsQuery = queryBuilder("order", {
+      data: [],
+      error: null,
+    });
+    mockFrom.mockImplementation((table) => {
+      if (table === "claimed_venues_public_view") return claimedQuery;
+      if (table === "business_public_events_view") return eventsQuery;
+      throw new Error(`Unexpected table ${String(table)}`);
+    });
+
+    const detail = await getPublicBrandBySlug("brand-3");
+
+    expect(detail).not.toBeNull();
+    expect(detail?.brand).toMatchObject({
+      id: "brand-1",
+      displayName: "Brand 3",
+      slug: "brand-3",
+      kind: "physical",
+      claimStatus: "verified",
+      city: "London",
+      stats: { events: 0, followers: 0, rev: 0, rev7d: 0, attendees: 0 },
+    });
+    expect(detail?.venue).toMatchObject({
+      isVerifiedVenue: true,
+      city: "London",
+      venueCategory: "restaurant",
+      galleryPhotoUrls: [
+        "https://cdn.example.com/cover.gif",
+        "https://cdn.example.com/brand.png",
+      ],
+    });
+    expect(detail?.events).toEqual([]);
+    expect(claimedQuery.eq).toHaveBeenCalledWith("slug", "brand-3");
+    expect(eventsQuery.eq).toHaveBeenCalledWith("brand_slug", "brand-3");
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  test("falls back to business_public_brands_view when claimed row is absent", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: null,
+      error: null,
+    });
+    const brandQuery = queryBuilder("maybeSingle", {
+      data: brandRow(),
+      error: null,
+    });
+    const eventsQuery = queryBuilder("order", {
+      data: [],
+      error: null,
+    });
+    mockFrom.mockImplementation((table) => {
+      if (table === "claimed_venues_public_view") return claimedQuery;
+      if (table === "business_public_brands_view") return brandQuery;
+      if (table === "business_public_events_view") return eventsQuery;
+      throw new Error(`Unexpected table ${String(table)}`);
+    });
+
+    const detail = await getPublicBrandBySlug("brand-3");
+
+    expect(detail).not.toBeNull();
+    expect(detail?.brand).toMatchObject({
+      displayName: "Brand 3",
+      displayAttendeeCount: false,
+    });
+    expect(detail?.venue).toBeNull();
+    expect(mockFrom).toHaveBeenCalledTimes(3);
+  });
+
+  test("returns null only after claimed and business profile rows are missing", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: null,
+      error: null,
+    });
+    const brandQuery = queryBuilder("maybeSingle", {
+      data: null,
+      error: null,
+    });
+    mockFrom.mockImplementation((table) => {
+      if (table === "claimed_venues_public_view") return claimedQuery;
+      if (table === "business_public_brands_view") return brandQuery;
+      throw new Error(`Unexpected table ${String(table)}`);
+    });
+
+    await expect(getPublicBrandBySlug("missing-brand")).resolves.toBeNull();
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns null venue detail for non-claimed popup brands", async () => {
+    const claimedQuery = queryBuilder("maybeSingle", {
+      data: null,
+      error: null,
+    });
+    const brandQuery = queryBuilder("maybeSingle", {
+      data: brandRow({ slug: "test-stripe", name: "Test Stripe", kind: "popup" }),
+      error: null,
+    });
+    const eventsQuery = queryBuilder("order", {
+      data: [row()],
+      error: null,
+    });
+    const eventTypesQuery = {
+      select: jest.fn(() => eventTypesQuery),
+      in: jest.fn(() =>
+        Promise.resolve({
+          data: [{ id: "event-1", event_type: "event" }],
+          error: null,
+        }),
+      ),
+    };
+    const ticketsQuery = queryBuilder("order", {
+      data: [
+        {
+          id: "ticket-1",
+          event_id: "event-1",
+          name: "General",
+          description: null,
+          price_cents: 0,
+          currency: "GBP",
+          quantity_total: null,
+          is_unlimited: true,
+          is_free: true,
+          sale_start_at: null,
+          sale_end_at: null,
+          min_purchase_qty: 1,
+          max_purchase_qty: null,
+          is_hidden: false,
+          is_disabled: false,
+          requires_approval: false,
+          allow_transfers: true,
+          password_protected: false,
+          available_online: true,
+          available_in_person: false,
+          waitlist_enabled: false,
+          display_order: 0,
+        },
+      ],
+      error: null,
+    });
+    mockFrom.mockImplementation((table) => {
+      if (table === "claimed_venues_public_view") return claimedQuery;
+      if (table === "business_public_brands_view") return brandQuery;
+      if (table === "business_public_events_view") return eventsQuery;
+      if (table === "events") return eventTypesQuery;
+      if (table === "ticket_types") return ticketsQuery;
+      throw new Error(`Unexpected table ${String(table)}`);
+    });
+
+    const detail = await getPublicBrandBySlug("test-stripe");
+
+    expect(detail?.brand.displayName).toBe("Test Stripe");
+    expect(detail?.venue).toBeNull();
+    expect(detail?.brand.stats.events).toBe(1);
+    expect(detail?.events).toHaveLength(1);
+  });
+});

--- a/mingla-business/src/services/__tests__/ve4MigrationContract.test.ts
+++ b/mingla-business/src/services/__tests__/ve4MigrationContract.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MIGRATION = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "supabase",
+  "migrations",
+  "20260622000000_ve4_claimed_venues_public_view.sql",
+);
+
+describe("Ve4 claimed_venues_public_view (migration contract)", () => {
+  const sql = readFileSync(MIGRATION, "utf8");
+
+  test("view filters verified physical non-deleted brands", () => {
+    expect(sql).toContain("CREATE OR REPLACE VIEW public.claimed_venues_public_view");
+    expect(sql).toMatch(/kind\s*=\s*'physical'/);
+    expect(sql).toMatch(/claim_status\s*=\s*'verified'/);
+    expect(sql).toMatch(/deleted_at IS NULL/);
+  });
+
+  test("projects hours aggregate and pool photos without claim internals", () => {
+    expect(sql).toContain("brand_hours");
+    expect(sql).toContain("pool_photo_urls");
+    expect(sql).toContain("venue_category");
+    expect(sql).not.toMatch(/\bclaim_status\b.*AS/);
+    expect(sql).not.toMatch(/\bverified_by\b/);
+    expect(sql).not.toMatch(/\bverified_at\b/);
+    expect(sql).not.toMatch(/\baccount_id\b/);
+  });
+
+  test("grants anon select and adds public RLS for verified venues", () => {
+    expect(sql).toContain(
+      "GRANT SELECT ON public.claimed_venues_public_view TO anon",
+    );
+    expect(sql).toContain("Public can read verified physical venues");
+    expect(sql).toContain("Public can read hours for verified physical venues");
+    expect(sql).toContain("Public can read place_pool for verified physical venues");
+  });
+});

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -8,7 +8,15 @@ import type {
   WhenMode,
 } from "../store/draftEventStore";
 import type { LiveEvent, LiveEventStatus } from "../store/liveEventStore";
-import type { Brand, BrandCustomLink, BrandLinks } from "../types/brand";
+import type {
+  Brand,
+  BrandCustomLink,
+  BrandHourEntry,
+  BrandLinks,
+  VenueCategory,
+} from "../types/brand";
+import { parseClaimedVenueHours } from "../utils/venuePublicHours";
+import { buildVenueGalleryPhotoUrls } from "../utils/venuePublicPhotos";
 import {
   asEventCoverMediaProvider,
   type EventCoverMediaProvider,
@@ -103,6 +111,47 @@ interface BusinessPublicBrandViewRow {
   updated_at: string;
 }
 
+/** Ve4 — row shape from `claimed_venues_public_view`. */
+export interface ClaimedVenuePublicViewRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  profile_photo_url: string | null;
+  profile_photo_type: "image" | "video" | "gif" | null;
+  social_links: unknown;
+  custom_links: unknown;
+  address: string | null;
+  city: string | null;
+  country_code: string | null;
+  lat: number | null;
+  lng: number | null;
+  cover_hue: number;
+  cover_media_url: string | null;
+  cover_media_type: "image" | "video" | "gif" | null;
+  kind: "physical";
+  venue_category: VenueCategory | null;
+  place_pool_id: string | null;
+  google_place_id: string | null;
+  created_at: string;
+  updated_at: string;
+  hours: unknown;
+  pool_photo_urls: string[] | null;
+}
+
+/** Ve4 — structured listing fields for verified physical venues. */
+export interface PublicVenueDetail {
+  isVerifiedVenue: true;
+  city: string | null;
+  countryCode: string | null;
+  lat: number | null;
+  lng: number | null;
+  venueCategory: VenueCategory | null;
+  googlePlaceId: string | null;
+  hours: BrandHourEntry[];
+  galleryPhotoUrls: string[];
+}
+
 interface TicketTypeRow {
   id: string;
   event_id: string;
@@ -141,6 +190,8 @@ export interface PublicEventDetail {
 export interface PublicBrandDetail {
   brand: PublicBrandRecord;
   events: PublicEventRecord[];
+  /** Present only for verified physical venues (Ve4). */
+  venue: PublicVenueDetail | null;
 }
 
 const asRecord = (value: unknown): JsonRecord =>
@@ -287,6 +338,72 @@ export const publicBrandViewRowToBrand = (
   tagline: undefined,
   links: asLinks(row.social_links, row.custom_links),
   displayAttendeeCount: row.display_attendee_count,
+});
+
+const asVenueCategory = (value: unknown): VenueCategory | null => {
+  if (
+    value === "restaurant" ||
+    value === "play" ||
+    value === "creative_and_arts"
+  ) {
+    return value;
+  }
+  return null;
+};
+
+export const claimedVenueRowToPublicVenue = (
+  row: ClaimedVenuePublicViewRow,
+): PublicVenueDetail => ({
+  isVerifiedVenue: true,
+  city: asStringOrNull(row.city),
+  countryCode: asStringOrNull(row.country_code),
+  lat: typeof row.lat === "number" ? row.lat : null,
+  lng: typeof row.lng === "number" ? row.lng : null,
+  venueCategory: asVenueCategory(row.venue_category),
+  googlePlaceId: asStringOrNull(row.google_place_id),
+  hours: parseClaimedVenueHours(row.hours),
+  galleryPhotoUrls: buildVenueGalleryPhotoUrls({
+    coverMediaUrl: row.cover_media_url,
+    profilePhotoUrl: row.profile_photo_url,
+    poolPhotoUrls: row.pool_photo_urls,
+  }),
+});
+
+export const claimedVenueRowToBrand = (
+  row: ClaimedVenuePublicViewRow,
+  eventCount = 0,
+): PublicBrandRecord => ({
+  id: row.id,
+  displayName: row.name,
+  slug: row.slug,
+  kind: "physical",
+  address: row.address,
+  coverHue: row.cover_hue,
+  coverMediaUrl: row.cover_media_url ?? undefined,
+  coverMediaType: row.cover_media_type ?? undefined,
+  profilePhotoType: row.profile_photo_type ?? undefined,
+  photo: row.profile_photo_url ?? undefined,
+  role: "owner",
+  stats: {
+    events: eventCount,
+    followers: 0,
+    rev: 0,
+    rev7d: 0,
+    attendees: 0,
+  },
+  currentLiveEvent: null,
+  bio: row.description ?? undefined,
+  tagline: undefined,
+  links: asLinks(row.social_links, row.custom_links),
+  displayAttendeeCount: false,
+  claimStatus: "verified",
+  city: asStringOrNull(row.city) ?? undefined,
+  countryCode: asStringOrNull(row.country_code) ?? undefined,
+  lat: typeof row.lat === "number" ? row.lat : undefined,
+  lng: typeof row.lng === "number" ? row.lng : undefined,
+  venueCategory: asVenueCategory(row.venue_category) ?? undefined,
+  googlePlaceId: asStringOrNull(row.google_place_id) ?? undefined,
+  placePoolId: row.place_pool_id ?? undefined,
 });
 
 const viewStatusToLiveStatus = (status: string): LiveEventStatus => {
@@ -515,18 +632,9 @@ export const getPublicEventById = async (
   return data === null ? null : detailFromRow(data as BusinessPublicEventViewRow);
 };
 
-export const getPublicBrandBySlug = async (
+const fetchPublicBrandEvents = async (
   brandSlug: string,
-): Promise<PublicBrandDetail | null> => {
-  const { data: brandData, error: brandError } = await supabase
-    .from("business_public_brands_view")
-    .select("*")
-    .eq("slug", brandSlug)
-    .maybeSingle();
-
-  if (brandError !== null) throw brandError;
-  if (brandData === null) return null;
-
+): Promise<PublicEventRecord[]> => {
   // orch-strict-grep-allow events-type-filter — view doesn't expose event_type; trip exclusion via probe below
   const { data, error } = await supabase
     .from("business_public_events_view")
@@ -559,14 +667,49 @@ export const getPublicBrandBySlug = async (
   }
 
   const eventTickets = await Promise.all(rows.map((row) => fetchTickets(row.id)));
+  return rows.map((row, idx) =>
+    publicEventViewRowToEvent(row, eventTickets[idx] ?? []),
+  );
+};
+
+export const getPublicBrandBySlug = async (
+  brandSlug: string,
+): Promise<PublicBrandDetail | null> => {
+  const { data: claimedVenue, error: claimedError } = await supabase
+    .from("claimed_venues_public_view")
+    .select("*")
+    .eq("slug", brandSlug)
+    .maybeSingle();
+
+  if (claimedError !== null) throw claimedError;
+
+  if (claimedVenue !== null) {
+    const venueRow = claimedVenue as ClaimedVenuePublicViewRow;
+    const events = await fetchPublicBrandEvents(brandSlug);
+    return {
+      brand: claimedVenueRowToBrand(venueRow, events.length),
+      venue: claimedVenueRowToPublicVenue(venueRow),
+      events,
+    };
+  }
+
+  const { data: brandData, error: brandError } = await supabase
+    .from("business_public_brands_view")
+    .select("*")
+    .eq("slug", brandSlug)
+    .maybeSingle();
+
+  if (brandError !== null) throw brandError;
+  if (brandData === null) return null;
+
+  const events = await fetchPublicBrandEvents(brandSlug);
   return {
     brand: publicBrandViewRowToBrand(
       brandData as BusinessPublicBrandViewRow,
-      rows.length,
+      events.length,
     ),
-    events: rows.map((row, idx) =>
-      publicEventViewRowToEvent(row, eventTickets[idx] ?? []),
-    ),
+    venue: null,
+    events,
   };
 };
 

--- a/mingla-business/src/utils/__tests__/venuePublicPhotos.test.ts
+++ b/mingla-business/src/utils/__tests__/venuePublicPhotos.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "@jest/globals";
+
+import { buildVenueGalleryPhotoUrls } from "../venuePublicPhotos";
+
+describe("buildVenueGalleryPhotoUrls", () => {
+  test("prefers operator cover and profile over pool photos", () => {
+    expect(
+      buildVenueGalleryPhotoUrls({
+        coverMediaUrl: "https://cdn/cover.jpg",
+        profilePhotoUrl: "https://cdn/profile.jpg",
+        poolPhotoUrls: ["https://pool/a.jpg"],
+      }),
+    ).toEqual(["https://cdn/cover.jpg", "https://cdn/profile.jpg"]);
+  });
+
+  test("falls back to pool when operator photos are absent", () => {
+    expect(
+      buildVenueGalleryPhotoUrls({
+        coverMediaUrl: null,
+        profilePhotoUrl: "",
+        poolPhotoUrls: ["https://pool/a.jpg", "https://pool/b.jpg"],
+      }),
+    ).toEqual(["https://pool/a.jpg", "https://pool/b.jpg"]);
+  });
+
+  test("returns empty when no sources exist", () => {
+    expect(
+      buildVenueGalleryPhotoUrls({
+        coverMediaUrl: null,
+        profilePhotoUrl: null,
+        poolPhotoUrls: [],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/mingla-business/src/utils/venuePublicHours.ts
+++ b/mingla-business/src/utils/venuePublicHours.ts
@@ -1,0 +1,35 @@
+/**
+ * Ve4 — parse `claimed_venues_public_view.hours` jsonb for UI tables.
+ */
+
+import type { BrandHourEntry } from "../types/brand";
+
+const isHourObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+/** Map view hours jsonb → seven weekday rows (may be fewer if incomplete). */
+export const parseClaimedVenueHours = (value: unknown): BrandHourEntry[] => {
+  if (!Array.isArray(value)) return [];
+  const rows: BrandHourEntry[] = [];
+  for (const item of value) {
+    if (!isHourObject(item)) continue;
+    const weekday = item.weekday;
+    if (typeof weekday !== "number" || weekday < 0 || weekday > 6) continue;
+    const isClosed = item.is_closed === true;
+    const openRaw = item.open_time;
+    const closeRaw = item.close_time;
+    rows.push({
+      weekday,
+      isClosed,
+      openTime:
+        !isClosed && typeof openRaw === "string" && openRaw.length > 0
+          ? openRaw
+          : null,
+      closeTime:
+        !isClosed && typeof closeRaw === "string" && closeRaw.length > 0
+          ? closeRaw
+          : null,
+    });
+  }
+  return rows.sort((a, b) => a.weekday - b.weekday);
+};

--- a/mingla-business/src/utils/venuePublicPhotos.ts
+++ b/mingla-business/src/utils/venuePublicPhotos.ts
@@ -1,0 +1,34 @@
+/**
+ * Ve4 — photo cascade for public verified venue pages.
+ * Operator cover + profile first; fall back to place_pool URLs when absent.
+ */
+
+export interface VenueGalleryPhotoInput {
+  coverMediaUrl?: string | null;
+  profilePhotoUrl?: string | null;
+  poolPhotoUrls?: string[] | null;
+}
+
+const isUsableUrl = (value: string | null | undefined): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+/** Deduped gallery URLs in display priority order. */
+export const buildVenueGalleryPhotoUrls = (
+  input: VenueGalleryPhotoInput,
+): string[] => {
+  const urls: string[] = [];
+  const push = (value: string | null | undefined): void => {
+    if (!isUsableUrl(value)) return;
+    const trimmed = value.trim();
+    if (!urls.includes(trimmed)) urls.push(trimmed);
+  };
+
+  push(input.coverMediaUrl);
+  push(input.profilePhotoUrl);
+  if (urls.length > 0) return urls;
+
+  for (const poolUrl of input.poolPhotoUrls ?? []) {
+    push(poolUrl);
+  }
+  return urls;
+};

--- a/supabase/migrations/20260622000000_ve4_claimed_venues_public_view.sql
+++ b/supabase/migrations/20260622000000_ve4_claimed_venues_public_view.sql
@@ -1,0 +1,133 @@
+-- Ve4 — Public venue page read model (GitHub issue #102)
+-- Verified physical venues with structured listing fields, hours aggregate,
+-- and place_pool photo fallback. Does not expose claim/audit internals.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Anon/authenticated can read verified physical brand rows (eventless OK).
+-- Complements "Public can read brands with public events" (ORCH-0763D).
+-- ---------------------------------------------------------------------------
+CREATE POLICY "Public can read verified physical venues"
+  ON public.brands
+  FOR SELECT
+  TO authenticated, anon
+  USING (
+    deleted_at IS NULL
+    AND kind = 'physical'
+    AND claim_status = 'verified'
+  );
+
+-- ---------------------------------------------------------------------------
+-- Public hours for verified physical venues (buyer /b/{slug} page).
+-- ---------------------------------------------------------------------------
+CREATE POLICY "Public can read hours for verified physical venues"
+  ON public.brand_hours
+  FOR SELECT
+  TO authenticated, anon
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.brands b
+      WHERE b.id = brand_hours.brand_id
+        AND b.deleted_at IS NULL
+        AND b.kind = 'physical'
+        AND b.claim_status = 'verified'
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- place_pool photos only when linked from a verified physical brand.
+-- ---------------------------------------------------------------------------
+CREATE POLICY "Public can read place_pool for verified physical venues"
+  ON public.place_pool
+  FOR SELECT
+  TO anon, authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.brands b
+      WHERE b.place_pool_id = place_pool.id
+        AND b.deleted_at IS NULL
+        AND b.kind = 'physical'
+        AND b.claim_status = 'verified'
+    )
+  );
+
+-- Column grants for venue listing fields (baseline anon grants omit Ve1 columns).
+GRANT SELECT (
+  kind,
+  address,
+  cover_hue,
+  lat,
+  lng,
+  city,
+  country_code,
+  venue_category,
+  place_pool_id,
+  google_place_id,
+  profile_photo_type
+) ON public.brands TO anon;
+
+GRANT SELECT (stored_photo_urls) ON public.place_pool TO anon;
+
+-- ---------------------------------------------------------------------------
+-- claimed_venues_public_view — verified physical venues only.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW public.claimed_venues_public_view
+  WITH (security_invoker = true) AS
+SELECT
+  b.id,
+  b.name,
+  b.slug,
+  b.description,
+  b.profile_photo_url,
+  b.profile_photo_type,
+  b.social_links,
+  b.custom_links,
+  b.default_currency,
+  b.address,
+  b.city,
+  b.country_code,
+  b.lat,
+  b.lng,
+  b.cover_hue,
+  b.cover_media_url,
+  b.cover_media_type,
+  b.kind,
+  b.venue_category,
+  b.place_pool_id,
+  b.google_place_id,
+  b.created_at,
+  b.updated_at,
+  (
+    SELECT COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'weekday', bh.weekday,
+          'open_time', to_char(bh.open_time, 'HH24:MI'),
+          'close_time', to_char(bh.close_time, 'HH24:MI'),
+          'is_closed', bh.is_closed
+        )
+        ORDER BY bh.weekday
+      ),
+      '[]'::jsonb
+    )
+    FROM public.brand_hours bh
+    WHERE bh.brand_id = b.id
+  ) AS hours,
+  pp.stored_photo_urls AS pool_photo_urls
+FROM public.brands b
+LEFT JOIN public.place_pool pp ON pp.id = b.place_pool_id
+WHERE b.deleted_at IS NULL
+  AND b.kind = 'physical'
+  AND b.claim_status = 'verified';
+
+COMMENT ON VIEW public.claimed_venues_public_view IS
+  'Ve4 — public read model for verified physical venues. Surfaces venues regardless of associated events (unlike brands_public_view). Excludes claim_status and audit fields.';
+
+GRANT SELECT ON public.claimed_venues_public_view TO anon, authenticated, service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

- Adds `claimed_venues_public_view` so verified physical venues are publicly readable without a live event, including anon RLS, hours aggregate, and `place_pool` photo fallback.
- Extends `getPublicBrandBySlug` to resolve verified venues from the new view first, then falls back to `business_public_brands_view` for popup/trip brands.
- Ships venue public UI at `/b/{slug}`: verified badge, category chip, location (OpenStreetMap link), hours table, photo gallery, venue-specific empty upcoming copy, and city-aware SEO — without `useAuth` on the buyer route.
- Updates crawler/social preview to use the same dual-view fetch and city-aware page titles.

Closes #102 (META-ORCH-0825 / Ve4).

## Test plan

- [ ] Apply migration `20260622000000_ve4_claimed_venues_public_view.sql` to staging
- [ ] `cd mingla-business && npx jest socialPreview ve4 PublicBrandPage.ve4 venuePublicPhotos publicEventsService.test ve4MigrationContract` (31 tests)
- [ ] Signed-out device: open `/b/{verified-slug}` — badge, hours, map link, photos, empty upcoming events
- [ ] Pending/rejected slug → 404 (`PublicBrandNotFound`)
- [ ] Popup brand with public events → unchanged page, no verified badge
- [ ] SQL: `SELECT slug, city, hours, pool_photo_urls FROM claimed_venues_public_view WHERE slug = '<slug>'`
- [ ] Hide operator cover + profile → gallery falls back to `place_pool` photos
- [ ] Ve3 approval email link opens the new venue page