### PR TITLE
[deploy] Close ORCH-0897-A [Group Chat polish] + ORCH-0896 [Stripe forwardRef] — operator-authorized bundle (replaces PR #163)

### DIFF
--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -1,24 +1,19 @@
 import '../src/i18n'  // Must be first — initializes i18next before any component renders
+// ORCH-0896 [Stripe forwardRef RedBox under React 19.1]: this side-effect file
+// MUST import BEFORE @mingla/payments-native (and any other module that pulls
+// @stripe/stripe-react-native). ES module imports hoist — the previous
+// `LogBox.ignoreLogs([...])` at this file's top level (post-imports) fired
+// AFTER the Stripe module had already emitted its forwardRef error, so the
+// dev-menu Console Error overlay still surfaced on every launch. Moving the
+// filter into a side-effect file imported at the FIRST import position arms
+// the filter before the Stripe import evaluates.
+// Originally tracked as DISC-QA-0892-A-RETEST-2-2 from ORCH-0892-A close.
+// See app-mobile/src/diagnostics/silenceStripeForwardRef.ts for full rationale.
+import '../src/diagnostics/silenceStripeForwardRef'
 import { Stack } from "expo-router";
 import * as Sentry from '@sentry/react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { LogBox } from "react-native";
 import { StripeNativeProvider } from "@mingla/payments-native";
-
-// ORCH-0836: silence the Stripe RN 0.65.1 forwardRef warning emitted at module
-// load by PaymentMethodMessagingElement.js — that file uses
-// `forwardRef(function(_ref){...})` (one parameter) which React 19.1.0's
-// stricter dev-mode arity check rejects. The component is NEVER rendered in
-// Mingla code (verified by grep across packages/, app-mobile/src/,
-// app-mobile/app/). The warning is informational noise that crowds out real
-// diagnostic logs during development. This filter is third-party-warning
-// specific and does NOT mask Mingla-side errors (the regex is anchored to
-// the exact Stripe message). Remove once Stripe ships 0.66+ with the
-// malformed forwardRef call fixed.
-// See INVESTIGATION_ORCH-0836_STRIPE_FORWARDREF_REACT19_INCOMPAT.md.
-LogBox.ignoreLogs([
-  /forwardRef render functions accept exactly two parameters/,
-]);
 
 // ORCH-0679 Wave 2B-2: SINGLE source of truth for Sentry init.
 // I-SENTRY-SINGLE-INIT — duplicate Sentry.init in app/index.tsx was deleted as

--- a/app-mobile/scripts/ci/orch-0836-regression-check.mjs
+++ b/app-mobile/scripts/ci/orch-0836-regression-check.mjs
@@ -36,28 +36,49 @@ const check = (name, pass, detail) => {
   checks.push({ name, pass, detail });
 };
 
-// ─── T-B0: LogBox import present in app/_layout.tsx ──────────────────────
+// ─── T-B0: LogBox import present in the side-effect module ──────────────
+//
+// ORCH-0896 [Stripe forwardRef RedBox under React 19.1] superseded the
+// original ORCH-0835 [bundled Discover/LogBox/Stripe card-only fix] location:
+// LogBox.ignoreLogs moved from app/_layout.tsx (which fired AFTER the Stripe
+// import due to ES module hoisting) to a side-effect module at
+// src/diagnostics/silenceStripeForwardRef.ts whose top-level statement runs
+// at the importing file's import position — armed BEFORE the Stripe import.
+// See: app-mobile/scripts/ci/orch-0896-regression-check.mjs for the
+// dedicated import-order check (T-S02).
 
 const layout = readMaybe(path.join(root, "app/_layout.tsx"));
+const sideEffect = readMaybe(
+  path.join(root, "src/diagnostics/silenceStripeForwardRef.ts"),
+);
 
 check(
-  "T-B0 app/_layout.tsx imports LogBox from react-native",
-  layout !== null &&
+  "T-B0 silenceStripeForwardRef.ts imports LogBox from react-native (post-ORCH-0896 location)",
+  sideEffect !== null &&
     /import\s+\{[^}]*\bLogBox\b[^}]*\}\s+from\s+["']react-native["']/.test(
-      layout,
+      sideEffect,
     ),
-  "app/_layout.tsx MUST import LogBox from react-native to enable the warning filter for the Stripe RN forwardRef defect.",
+  "src/diagnostics/silenceStripeForwardRef.ts MUST import LogBox from react-native — the canonical post-ORCH-0896 location for the Stripe forwardRef filter.",
 );
 
 // ─── T-B1: LogBox.ignoreLogs called with forwardRef regex ────────────────
 
 check(
-  "T-B1 app/_layout.tsx calls LogBox.ignoreLogs with the forwardRef regex pattern",
-  layout !== null &&
+  "T-B1 silenceStripeForwardRef.ts calls LogBox.ignoreLogs with the forwardRef regex pattern",
+  sideEffect !== null &&
     /LogBox\.ignoreLogs\(\s*\[[\s\S]{0,200}?\/forwardRef render functions accept exactly two parameters\//.test(
-      layout,
+      sideEffect,
     ),
-  "app/_layout.tsx MUST register the regex `/forwardRef render functions accept exactly two parameters/` in LogBox.ignoreLogs so the Stripe RN 0.65.1 PaymentMethodMessagingElement warning stops cluttering Metro logs.",
+  "src/diagnostics/silenceStripeForwardRef.ts MUST register the regex `/forwardRef render functions accept exactly two parameters/` in LogBox.ignoreLogs so the Stripe RN 0.65.1 PaymentMethodMessagingElement warning stops cluttering Metro logs.",
+);
+
+// ─── T-B2 (ORCH-0896): _layout.tsx imports the side-effect module ────────
+
+check(
+  "T-B2 app/_layout.tsx imports the silenceStripeForwardRef side-effect module (ORCH-0896 wiring)",
+  layout !== null &&
+    /import\s+["']\.\.\/src\/diagnostics\/silenceStripeForwardRef["']/.test(layout),
+  "Without this import the side-effect module never evaluates and the filter never registers. Side-effect-only modules MUST be imported (no named imports needed).",
 );
 
 // ─── Report ────────────────────────────────────────────────────────────────

--- a/app-mobile/scripts/ci/orch-0896-regression-check.mjs
+++ b/app-mobile/scripts/ci/orch-0896-regression-check.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * ORCH-0896 [Stripe forwardRef RedBox under React 19.1 — side-effect hoist] check.
+ *
+ * The original ORCH-0836 fix put LogBox.ignoreLogs after the Stripe import in
+ * _layout.tsx. ES module hoisting evaluated the Stripe import first, the
+ * forwardRef warning fired, then the filter registered too late. Operator
+ * still saw the Console Error overlay on every launch.
+ *
+ * The fix: side-effect modules at app-mobile/src/diagnostics/silenceStripeForwardRef.ts
+ * and mingla-business/src/diagnostics/silenceStripeForwardRef.ts whose top-level
+ * statements call LogBox.ignoreLogs at the importing file's import position —
+ * so the filter arms BEFORE @mingla/payments-native evaluates.
+ *
+ *   T-S01 — app-mobile side-effect module exists with LogBox.ignoreLogs at top level
+ *   T-S02 — app-mobile _layout.tsx imports the side-effect module BEFORE @mingla/payments-native
+ *   T-S03 — mingla-business side-effect module exists with LogBox.ignoreLogs at top level
+ *   T-S04 — mingla-business _layout.tsx imports the side-effect module BEFORE StripeProviderWrapper
+ *   T-S05 — Both apps use the identical forwardRef regex (anti-drift)
+ *
+ * FAILS-ON-REVERT key: T-S02 and T-S04 — reverting either side-effect import to its
+ * post-Stripe-import position causes the side-effect file to evaluate too late
+ * (the Stripe warning has already fired by then). Static check verifies the
+ * import APPEARS before the Stripe-pulling import in source order.
+ *
+ * Status: structural-only check authored by orchestrator at CLOSE time as
+ * Step 0.5 deferred-tester replacement. Operator-accepted deferral cites
+ * follow-up ORCH-0896-TEST for proper Claude mingla-tester adversarial test
+ * (would need a sim-runtime check that the Console Error overlay does not
+ * surface — non-trivial; structural check is the practical ceiling here).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const read = (rel) => {
+  try {
+    return fs.readFileSync(path.join(repoRoot, rel), "utf8");
+  } catch {
+    return null;
+  }
+};
+
+const checks = [];
+const check = (name, pass, detail) => checks.push({ name, pass, detail });
+
+const consumerSideEffect = read("app-mobile/src/diagnostics/silenceStripeForwardRef.ts");
+const consumerLayout = read("app-mobile/app/_layout.tsx");
+const businessSideEffect = read("mingla-business/src/diagnostics/silenceStripeForwardRef.ts");
+const businessLayout = read("mingla-business/app/_layout.tsx");
+
+check(
+  "T-S01 app-mobile side-effect module exists with LogBox.ignoreLogs at top level",
+  consumerSideEffect !== null &&
+    /import\s*\{\s*LogBox\s*\}\s*from\s*["']react-native["']/.test(consumerSideEffect) &&
+    /LogBox\.ignoreLogs\(\[\s*\/forwardRef render functions accept exactly two parameters/.test(consumerSideEffect),
+  "Side-effect module must import LogBox and register the forwardRef pattern as a top-level statement.",
+);
+
+check(
+  "T-S02 [FAILS-ON-REVERT KEY] app-mobile/_layout.tsx imports side-effect BEFORE @mingla/payments-native",
+  consumerLayout !== null &&
+    (() => {
+      const sideEffectIdx = consumerLayout.indexOf("../src/diagnostics/silenceStripeForwardRef");
+      const stripeIdx = consumerLayout.indexOf('"@mingla/payments-native"');
+      return sideEffectIdx > 0 && stripeIdx > 0 && sideEffectIdx < stripeIdx;
+    })(),
+  "ES module imports hoist in source order. The side-effect import MUST appear before any module that pulls @stripe/stripe-react-native (via @mingla/payments-native) — otherwise the warning fires before the filter registers.",
+);
+
+check(
+  "T-S03 mingla-business side-effect module exists with LogBox.ignoreLogs at top level",
+  businessSideEffect !== null &&
+    /import\s*\{\s*LogBox\s*\}\s*from\s*["']react-native["']/.test(businessSideEffect) &&
+    /LogBox\.ignoreLogs\(\[\s*\/forwardRef render functions accept exactly two parameters/.test(businessSideEffect),
+  "Parity with consumer side — mingla-business has its own copy of the filter for the same root cause.",
+);
+
+check(
+  "T-S04 [FAILS-ON-REVERT KEY] mingla-business/_layout.tsx imports side-effect BEFORE StripeProviderWrapper",
+  businessLayout !== null &&
+    (() => {
+      const sideEffectIdx = businessLayout.indexOf("../src/diagnostics/silenceStripeForwardRef");
+      const stripeIdx = businessLayout.indexOf("../src/payments/StripeProviderWrapper");
+      return sideEffectIdx > 0 && stripeIdx > 0 && sideEffectIdx < stripeIdx;
+    })(),
+  "Same hoisting concern as T-S02 — side-effect import must precede the wrapper that pulls @stripe/stripe-react-native.",
+);
+
+check(
+  "T-S05 Both apps use the identical anchor regex (no anti-drift)",
+  consumerSideEffect !== null &&
+    businessSideEffect !== null &&
+    /forwardRef render functions accept exactly two parameters/.test(consumerSideEffect) &&
+    /forwardRef render functions accept exactly two parameters/.test(businessSideEffect),
+  "Both apps' filters anchor on the exact unique forwardRef-arity phrase so neither masks Mingla-side forwardRef issues. Diverging regexes risk false negatives.",
+);
+
+const failed = checks.filter((c) => !c.pass);
+for (const c of checks) {
+  console.log(`${c.pass ? "PASS" : "FAIL"} ${c.name}`);
+  if (!c.pass) console.log(`     ${c.detail}`);
+}
+console.log("");
+if (failed.length === 0) {
+  console.log(`ORCH-0896 regression check passed: ${checks.length}/${checks.length}`);
+  process.exit(0);
+} else {
+  console.log(`ORCH-0896 regression check FAILED: ${failed.length} failure(s) out of ${checks.length}`);
+  process.exit(1);
+}

--- a/app-mobile/scripts/ci/orch-0897-a-regression-check.mjs
+++ b/app-mobile/scripts/ci/orch-0897-a-regression-check.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * ORCH-0897-A [Group Chat follow-up polish] structural regression check.
+ *
+ * Asserts the 5 surgical fixes shipped in commits c6ca00bd → bc345463 stay
+ * structurally present:
+ *
+ *   T-A01 — events JOIN by title (not name) in getEventGroupChat — events.title
+ *           is the live column (events.name does not exist; verified against
+ *           supabase/migrations/20260505000000_baseline_squash_orch_0729.sql:7796)
+ *   T-A02 — EventGroupConversation type exposes event_name (live event title,
+ *           not stale conversation.name snapshot)
+ *   T-A03 — GroupChatPanel header reads event_name (not name) — auto-rename-safe
+ *   T-A04 — Composer wrapped in KeyboardAvoidingView from react-native-keyboard-controller
+ *           (library-recommended sticky-composer-above-keyboard pattern;
+ *           inline orch-strict-grep-allow orch-0892 comment documents intent)
+ *   T-A05 — Composer uses useSafeAreaInsets + insets.bottom + spacing.lg for
+ *           floating bottom padding; borderTopWidth + borderTopColor dropped
+ *           (kills the backdrop line per operator screenshot)
+ *   T-A06 — Image attachment send path: postPlannerMessage accepts optional
+ *           attachment, uploads to messages bucket at <conv_id>/<userId>_<ts>.<ext>,
+ *           inserts message row with message_type='image' + file_url + file_name + file_size
+ *   T-A07 — Image render branch: GroupChatPanel renders <Image> when
+ *           message.message_type === 'image' && file_url !== null
+ *   T-A08 — Caption-with-image: composer placeholder swaps to "Add a caption (optional)"
+ *           when attachment is set
+ *   T-A09 — EventGroupMessage type extended with message_type + file_url + file_name + file_size
+ *   T-A10 — listMessages SELECT includes the new media columns
+ *
+ * FAILS-ON-REVERT key: T-A03 (event_name in header) — reverting commit c6ca00bd
+ * flips header back to chat.conversation?.name (the stale snapshot) and this
+ * check fails.
+ *
+ * Status: structural-only check authored by orchestrator at CLOSE time as
+ * Step 0.5 deferred-tester replacement. Operator-accepted deferral cites
+ * follow-up ORCH-0897-A-TEST for proper Claude mingla-tester adversarial
+ * regression test. See CLOSE banner.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const read = (rel) => {
+  try {
+    return fs.readFileSync(path.join(repoRoot, rel), "utf8");
+  } catch {
+    return null;
+  }
+};
+
+const checks = [];
+const check = (name, pass, detail) => checks.push({ name, pass, detail });
+
+const groupChatService = read("mingla-business/src/services/groupChatService.ts");
+const groupChatPanel = read("mingla-business/src/components/groupChat/GroupChatPanel.tsx");
+const useEventGroupChat = read("mingla-business/src/hooks/useEventGroupChat.ts");
+
+check(
+  "T-A01 getEventGroupChat JOINs events!event_id(title) — not events.name (which doesn't exist)",
+  groupChatService !== null &&
+    /events!event_id\(title\)/.test(groupChatService) &&
+    !/events!event_id\(name\)/.test(groupChatService),
+  "Service must JOIN by title; events.name is invented and triggers SQLSTATE 42703 (verified against baseline migration:7796).",
+);
+
+check(
+  "T-A02 EventGroupConversation type exposes event_name field",
+  groupChatService !== null &&
+    /event_name:\s*string/.test(groupChatService) &&
+    /interface EventGroupConversation/.test(groupChatService),
+  "Type must surface event_name so the header can read live title without depending on the trigger-time conversation.name snapshot.",
+);
+
+check(
+  "T-A03 [FAILS-ON-REVERT KEY] GroupChatPanel header reads event_name (live), not name (stale)",
+  groupChatPanel !== null &&
+    /chat\.conversation\?\.event_name\s*\?\?\s*"Group chat"/.test(groupChatPanel),
+  "Header must use event_name — reverting to conversation.name shows the stale 'Untitled draft' snapshot per operator screenshot.",
+);
+
+check(
+  "T-A04 Composer wrapped in KeyboardAvoidingView from react-native-keyboard-controller",
+  groupChatPanel !== null &&
+    /import\s*\{\s*KeyboardAvoidingView\s*\}\s*from\s*["']react-native-keyboard-controller["']/.test(groupChatPanel) &&
+    /<KeyboardAvoidingView\s+behavior="padding"/.test(groupChatPanel) &&
+    /orch-strict-grep-allow orch-0892/.test(groupChatPanel),
+  "KAV from the canonical Mingla keyboard library lifts composer above keyboard; orch-strict-grep-allow comment documents the I-PROPOSED-KEYBOARD-LIBRARY-ONLY allowance.",
+);
+
+check(
+  "T-A05 Composer floats: uses insets.bottom + spacing.lg for paddingBottom; top border dropped",
+  groupChatPanel !== null &&
+    /useSafeAreaInsets/.test(groupChatPanel) &&
+    /Math\.max\(insets\.bottom,\s*0\)\s*\+\s*spacing\.lg/.test(groupChatPanel) &&
+    !/borderTopWidth:\s*1[\s\S]{0,200}borderTopColor:\s*glass\.border\.profileBase[\s\S]{0,400}composer:/.test(groupChatPanel),
+  "Composer must apply safe-area + breathing room and have NO top border (the 'backdrop' line per operator screenshot).",
+);
+
+check(
+  "T-A06 postPlannerMessage accepts optional attachment + uploads to messages bucket",
+  groupChatService !== null &&
+    /attachment\?:\s*PlannerImageAttachment\s*\|\s*null/.test(groupChatService) &&
+    /supabase\.storage\s*\n?\s*\.from\(["']messages["']\)\s*\n?\s*\.upload\(filePath,\s*formData/.test(groupChatService) &&
+    /\$\{conversationId\}\/\$\{userId\}_\$\{Date\.now\(\)\}/.test(groupChatService) &&
+    /message_type:\s*messageType/.test(groupChatService),
+  "Service must accept attachment + upload to messages bucket at <conv_id>/<userId>_<ts>.<ext> path (storage RLS path format).",
+);
+
+check(
+  "T-A07 GroupChatPanel renders <Image> when message_type === 'image' && file_url !== null",
+  groupChatPanel !== null &&
+    /message\.message_type === "image"/.test(groupChatPanel) &&
+    /<Image[\s\S]{0,200}source=\{\{\s*uri:\s*message\.file_url\s*\?\?\s*undefined\s*\}\}/.test(groupChatPanel),
+  "Image messages must render via React Native <Image> sourced from message.file_url.",
+);
+
+check(
+  "T-A08 Composer placeholder swaps to caption mode when attachment is set",
+  groupChatPanel !== null &&
+    /placeholder=\{attachment \? "Add a caption \(optional\)" : "Write a reply"\}/.test(groupChatPanel),
+  "Caption-with-image UX requires placeholder swap so the planner knows the field is optional.",
+);
+
+check(
+  "T-A09 EventGroupMessage type extended with media columns",
+  groupChatService !== null &&
+    /message_type:\s*string/.test(groupChatService) &&
+    /file_url:\s*string\s*\|\s*null/.test(groupChatService) &&
+    /file_name:\s*string\s*\|\s*null/.test(groupChatService) &&
+    /file_size:\s*number\s*\|\s*null/.test(groupChatService),
+  "Render path needs these 4 fields to discriminate text vs image and source the asset.",
+);
+
+check(
+  "T-A10 listMessages SELECT includes media columns",
+  groupChatService !== null &&
+    /\.select\([\s\S]{0,200}message_type[\s\S]{0,200}file_url[\s\S]{0,200}file_name[\s\S]{0,200}file_size/.test(groupChatService),
+  "Service SELECT must fetch the new columns or render falls back to text-only.",
+);
+
+check(
+  "T-A11 useEventGroupChat hook passes attachment through to postPlannerMessage",
+  useEventGroupChat !== null &&
+    /attachment\?:\s*PlannerImageAttachment\s*\|\s*null/.test(useEventGroupChat) &&
+    /postPlannerMessage\(conversation\.id,\s*content,\s*attachment\)/.test(useEventGroupChat),
+  "Hook must thread the attachment through to the service call.",
+);
+
+const failed = checks.filter((c) => !c.pass);
+for (const c of checks) {
+  console.log(`${c.pass ? "PASS" : "FAIL"} ${c.name}`);
+  if (!c.pass) console.log(`     ${c.detail}`);
+}
+console.log("");
+if (failed.length === 0) {
+  console.log(`ORCH-0897-A regression check passed: ${checks.length}/${checks.length}`);
+  process.exit(0);
+} else {
+  console.log(`ORCH-0897-A regression check FAILED: ${failed.length} failure(s) out of ${checks.length}`);
+  process.exit(1);
+}

--- a/app-mobile/src/diagnostics/silenceStripeForwardRef.ts
+++ b/app-mobile/src/diagnostics/silenceStripeForwardRef.ts
@@ -1,0 +1,52 @@
+/**
+ * ORCH-0896 [Stripe forwardRef RedBox under React 19.1] — side-effect module.
+ *
+ * Silences the React 19.1 console.error fired at module-load time by
+ * @stripe/stripe-react-native@^0.65.1's PaymentMethodMessagingElement.js,
+ * which uses `forwardRef(function(_ref){...})` (single-arg) instead of the
+ * React 19-required two-arg `forwardRef((props, ref) => ...)`. React 19's
+ * stricter dev-mode arity check escalates this into a Console Error overlay
+ * that crowds out real diagnostic logs and (per operator screenshot) shows
+ * up as a RedBox-style "Console Error / Log 1 of 1" on every launch.
+ *
+ * Why this file exists (not just LogBox.ignoreLogs at _layout.tsx top level):
+ *
+ * ES module imports are hoisted — the engine evaluates ALL `import` statements
+ * in source order BEFORE any top-level statement in the importing module
+ * runs. So when app-mobile/app/_layout.tsx had:
+ *
+ *     import { LogBox } from "react-native";
+ *     import { StripeNativeProvider } from "@mingla/payments-native";  // ← fires the warning
+ *     LogBox.ignoreLogs([/forwardRef.../]);                            // ← too late
+ *
+ * the Stripe import evaluated `@stripe/stripe-react-native` and emitted the
+ * console.error BEFORE LogBox.ignoreLogs ran. Filter registered, but only
+ * for FUTURE matching errors — the one already-emitted error reached the
+ * dev-menu overlay.
+ *
+ * The fix is to put LogBox.ignoreLogs in a side-effect file and import THAT
+ * file BEFORE @mingla/payments-native. Module evaluation order: imports
+ * evaluate in source order, and a side-effect file's top-level statements
+ * fire at its import position. So:
+ *
+ *     import "../src/diagnostics/silenceStripeForwardRef";              // ← filter now armed
+ *     import { StripeNativeProvider } from "@mingla/payments-native";   // ← warning silenced
+ *
+ * This file ships in both app-mobile and mingla-business — both apps use
+ * the same @mingla/payments-native package which transitively imports the
+ * problematic Stripe RN module.
+ *
+ * Remove this file (and the import in _layout.tsx) once @stripe/stripe-react-native
+ * ships 0.66+ with the malformed forwardRef call fixed. Tracked under
+ * ORCH-0896 [Stripe forwardRef RedBox] in WORLD_MAP carry-forward list
+ * (originally flagged DISC-QA-0892-A-RETEST-2-2 during ORCH-0892-A close).
+ */
+
+import { LogBox } from "react-native";
+
+// Match Stripe RN 0.65.1's exact message + the React 19.1 trailing question.
+// Anchored to the unique forwardRef-arity phrase so this filter does not
+// mask any Mingla-side forwardRef issues.
+LogBox.ignoreLogs([
+  /forwardRef render functions accept exactly two parameters/,
+]);

--- a/mingla-business/app/_layout.tsx
+++ b/mingla-business/app/_layout.tsx
@@ -16,6 +16,13 @@
  * Per Cycle 16a SPEC §3.1.1.
  */
 
+// ORCH-0896 [Stripe forwardRef RedBox under React 19.1]: side-effect import
+// MUST come BEFORE any module that pulls @stripe/stripe-react-native (via
+// StripeProviderWrapper below). ES module imports hoist — registering
+// LogBox.ignoreLogs after the Stripe import fires too late and the
+// dev-menu Console Error still surfaces on every launch. See
+// src/diagnostics/silenceStripeForwardRef.ts for full rationale.
+import "../src/diagnostics/silenceStripeForwardRef";
 import React, { useEffect, useRef, useState } from "react";
 import { AppState, type AppStateStatus } from "react-native";
 import { Stack } from "expo-router";

--- a/mingla-business/src/components/groupChat/GroupChatPanel.tsx
+++ b/mingla-business/src/components/groupChat/GroupChatPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  Image,
   Pressable,
   StyleSheet,
   Text,
@@ -14,6 +15,7 @@ import {
 // orch-strict-grep-allow orch-0892 — chat composer needs sticky-above-keyboard lift
 import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as ImagePicker from "expo-image-picker";
 import { ScrollView } from "../../wrappers/SmartScrollView";
 import { useRouter } from "expo-router";
 
@@ -21,6 +23,7 @@ import { accent, glass, radius, spacing, text as textTokens } from "../../consta
 import { supabase } from "../../services/supabase";
 import { useEventGroupChat } from "../../hooks/useEventGroupChat";
 import { useEventGroupChatModeration } from "../../hooks/useEventGroupChatModeration";
+import type { PlannerImageAttachment } from "../../services/groupChatService";
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { SafeScreen } from "../ui/SafeScreen";
@@ -36,6 +39,7 @@ export const GroupChatPanel: React.FC<GroupChatPanelProps> = ({ eventId }) => {
   const chat = useEventGroupChat(eventId);
   const moderation = useEventGroupChatModeration(chat.conversation?.id ?? null);
   const [composer, setComposer] = useState("");
+  const [attachment, setAttachment] = useState<PlannerImageAttachment | null>(null);
   const [sending, setSending] = useState(false);
   const [moderationOpen, setModerationOpen] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
@@ -53,17 +57,48 @@ export const GroupChatPanel: React.FC<GroupChatPanelProps> = ({ eventId }) => {
 
   const handleSend = async () => {
     const content = composer.trim();
-    if (content.length === 0) return;
+    if (content.length === 0 && attachment === null) return;
     setSending(true);
     try {
-      const result = await chat.postMessage(content);
+      const result = await chat.postMessage(content, attachment);
       if (result.error) throw new Error(result.error);
       setComposer("");
+      setAttachment(null);
     } catch (err) {
       Alert.alert("Message failed", err instanceof Error ? err.message : "Try again.");
     } finally {
       setSending(false);
     }
+  };
+
+  const handlePickImage = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(
+        "Photo access needed",
+        "Grant Mingla access to your photos in iOS Settings to attach an image.",
+      );
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: "images",
+      allowsEditing: false,
+      quality: 0.7,
+      allowsMultipleSelection: false,
+    });
+    if (result.canceled || result.assets.length === 0) return;
+    const asset = result.assets[0];
+    const ext = asset.uri.split(".").pop()?.toLowerCase() || "jpg";
+    setAttachment({
+      uri: asset.uri,
+      name: asset.fileName ?? `image_${Date.now()}.${ext}`,
+      type: asset.mimeType ?? `image/${ext === "jpg" ? "jpeg" : ext}`,
+      size: asset.fileSize ?? 0,
+    });
+  };
+
+  const handleClearAttachment = () => {
+    setAttachment(null);
   };
 
   const handleToggleBroadcast = async (value: boolean) => {
@@ -141,6 +176,8 @@ export const GroupChatPanel: React.FC<GroupChatPanelProps> = ({ eventId }) => {
             {sortedMessages.map((message) => {
               const mine = message.sender_id === currentUserId;
               const blast = message.marketing_campaign_id !== null;
+              const hasImage = message.message_type === "image" && message.file_url !== null;
+              const hasCaption = message.content.length > 0;
               return (
                 <View
                   key={message.id}
@@ -150,9 +187,25 @@ export const GroupChatPanel: React.FC<GroupChatPanelProps> = ({ eventId }) => {
                     blast && styles.messageRowBlast,
                   ]}
                 >
-                  <Text style={[styles.messageText, mine && styles.messageTextMine]}>
-                    {message.content}
-                  </Text>
+                  {hasImage ? (
+                    <Image
+                      source={{ uri: message.file_url ?? undefined }}
+                      style={styles.messageImage}
+                      resizeMode="cover"
+                      accessibilityLabel={message.file_name ?? "Attached image"}
+                    />
+                  ) : null}
+                  {hasCaption ? (
+                    <Text
+                      style={[
+                        styles.messageText,
+                        mine && styles.messageTextMine,
+                        hasImage && styles.messageTextWithImage,
+                      ]}
+                    >
+                      {message.content}
+                    </Text>
+                  ) : null}
                   <View style={styles.messageMetaRow}>
                     <Text style={styles.messageMeta}>
                       {new Date(message.created_at).toLocaleString()}
@@ -171,16 +224,43 @@ export const GroupChatPanel: React.FC<GroupChatPanelProps> = ({ eventId }) => {
           </ScrollView>
 
           <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={0}>
+            {attachment ? (
+              <View style={styles.attachmentPreview}>
+                <Image
+                  source={{ uri: attachment.uri }}
+                  style={styles.attachmentPreviewImage}
+                  resizeMode="cover"
+                  accessibilityLabel="Selected image preview"
+                />
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Remove attachment"
+                  onPress={handleClearAttachment}
+                  style={styles.attachmentRemove}
+                >
+                  <Icon name="close" size={14} color={textTokens.primary} />
+                </Pressable>
+              </View>
+            ) : null}
             <View
               style={[
                 styles.composer,
                 { paddingBottom: Math.max(insets.bottom, 0) + spacing.lg },
               ]}
             >
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Attach image"
+                onPress={handlePickImage}
+                style={styles.attachButton}
+                disabled={sending}
+              >
+                <Icon name="plus" size={20} color={textTokens.primary} />
+              </Pressable>
               <TextInput
                 value={composer}
                 onChangeText={setComposer}
-                placeholder="Write a reply"
+                placeholder={attachment ? "Add a caption (optional)" : "Write a reply"}
                 placeholderTextColor={textTokens.tertiary}
                 style={styles.input}
                 multiline
@@ -190,7 +270,7 @@ export const GroupChatPanel: React.FC<GroupChatPanelProps> = ({ eventId }) => {
                 leadingIcon="send"
                 onPress={handleSend}
                 loading={sending}
-                disabled={composer.trim().length === 0 || sending}
+                disabled={(composer.trim().length === 0 && attachment === null) || sending}
               />
             </View>
           </KeyboardAvoidingView>
@@ -293,6 +373,15 @@ const styles = StyleSheet.create({
   messageTextMine: {
     color: textTokens.inverse,
   },
+  messageTextWithImage: {
+    marginTop: spacing.sm,
+  },
+  messageImage: {
+    width: "100%",
+    aspectRatio: 4 / 3,
+    borderRadius: radius.sm,
+    backgroundColor: "rgba(0,0,0,0.2)",
+  },
   messageMetaRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -312,6 +401,43 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
     paddingHorizontal: spacing.md,
     paddingTop: spacing.md,
+  },
+  attachButton: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.md,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: glass.tint.profileBase,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+  },
+  attachmentPreview: {
+    marginHorizontal: spacing.md,
+    marginTop: spacing.sm,
+    width: 120,
+    height: 120,
+    borderRadius: radius.md,
+    overflow: "hidden",
+    position: "relative",
+    backgroundColor: glass.tint.profileBase,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+  },
+  attachmentPreviewImage: {
+    width: "100%",
+    height: "100%",
+  },
+  attachmentRemove: {
+    position: "absolute",
+    top: 6,
+    right: 6,
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    alignItems: "center",
+    justifyContent: "center",
   },
   input: {
     flex: 1,

--- a/mingla-business/src/diagnostics/silenceStripeForwardRef.ts
+++ b/mingla-business/src/diagnostics/silenceStripeForwardRef.ts
@@ -1,0 +1,32 @@
+/**
+ * ORCH-0896 [Stripe forwardRef RedBox under React 19.1] — side-effect module
+ * (mingla-business mirror of app-mobile/src/diagnostics/silenceStripeForwardRef.ts).
+ *
+ * Silences the React 19.1 console.error fired at module-load time by
+ * @stripe/stripe-react-native@^0.65.1's PaymentMethodMessagingElement.js,
+ * which uses single-arg `forwardRef(function(_ref){...})` instead of React
+ * 19's required two-arg form. React 19's stricter dev-mode arity check
+ * escalates the warning into a Console Error overlay that crowds out real
+ * diagnostic logs.
+ *
+ * Why this file exists (not just LogBox.ignoreLogs at _layout.tsx top level):
+ *
+ * ES module imports are hoisted — the engine evaluates ALL `import`
+ * statements in source order BEFORE any top-level statement runs. So calling
+ * LogBox.ignoreLogs AFTER the StripeProviderWrapper import is too late: the
+ * warning already fired during the Stripe RN module's load.
+ *
+ * Solution: this side-effect file's top-level LogBox.ignoreLogs call runs
+ * at its import position. Import this file FIRST (before
+ * src/payments/StripeProviderWrapper) and the filter is armed in time.
+ *
+ * Remove once @stripe/stripe-react-native ships 0.66+ with the malformed
+ * forwardRef call fixed. Tracked under ORCH-0896 [Stripe forwardRef RedBox]
+ * in WORLD_MAP carry-forward list.
+ */
+
+import { LogBox } from "react-native";
+
+LogBox.ignoreLogs([
+  /forwardRef render functions accept exactly two parameters/,
+]);

--- a/mingla-business/src/hooks/useEventGroupChat.ts
+++ b/mingla-business/src/hooks/useEventGroupChat.ts
@@ -7,6 +7,7 @@ import {
   postPlannerMessage,
   type EventGroupConversation,
   type EventGroupMessage,
+  type PlannerImageAttachment,
 } from "../services/groupChatService";
 
 export function useEventGroupChat(eventId: string): {
@@ -15,7 +16,10 @@ export function useEventGroupChat(eventId: string): {
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
-  postMessage: (content: string) => Promise<{ messageId: string | null; error: string | null }>;
+  postMessage: (
+    content: string,
+    attachment?: PlannerImageAttachment | null,
+  ) => Promise<{ messageId: string | null; error: string | null }>;
 } {
   const [conversation, setConversation] = useState<EventGroupConversation | null>(null);
   const [messages, setMessages] = useState<EventGroupMessage[]>([]);
@@ -72,9 +76,9 @@ export function useEventGroupChat(eventId: string): {
   }, [conversation?.id, refresh]);
 
   const postMessage = useCallback(
-    async (content: string) => {
+    async (content: string, attachment?: PlannerImageAttachment | null) => {
       if (conversation === null) return { messageId: null, error: "Conversation not loaded" };
-      const result = await postPlannerMessage(conversation.id, content);
+      const result = await postPlannerMessage(conversation.id, content, attachment);
       if (result.error === null) await refresh();
       return result;
     },

--- a/mingla-business/src/services/groupChatService.ts
+++ b/mingla-business/src/services/groupChatService.ts
@@ -19,6 +19,25 @@ export interface EventGroupMessage {
   content: string;
   created_at: string;
   marketing_campaign_id: string | null;
+  /** 'text' | 'image' | 'video' | 'file' | 'card' per messages.message_type CHECK constraint. */
+  message_type: string;
+  /** Public URL into the `messages` storage bucket for image/video/file attachments. NULL for plain text. */
+  file_url: string | null;
+  file_name: string | null;
+  file_size: number | null;
+}
+
+/**
+ * Local picked-asset shape for image uploads. Mirrors the consumer-side
+ * pattern at ConnectionsPage.tsx:2210-2259. `uri` is the local file path
+ * from expo-image-picker; `name` + `type` + `size` come from the picker
+ * result.
+ */
+export interface PlannerImageAttachment {
+  uri: string;
+  name: string;
+  type: string;
+  size: number;
 }
 
 export interface EventGroupParticipant {
@@ -63,18 +82,65 @@ export async function getEventGroupChat(eventId: string): Promise<{
 export async function postPlannerMessage(
   conversationId: string,
   content: string,
+  attachment?: PlannerImageAttachment | null,
 ): Promise<{ messageId: string | null; error: string | null }> {
   const { data: auth } = await supabase.auth.getUser();
   const userId = auth.user?.id ?? null;
   if (userId === null) return { messageId: null, error: "Not signed in" };
+
+  let fileUrl: string | null = null;
+  let fileName: string | null = null;
+  let fileSize: number | null = null;
+  let messageType: "text" | "image" = "text";
+
+  if (attachment) {
+    // Mirror consumer-side pattern at app-mobile/src/components/ConnectionsPage.tsx:2210-2259.
+    // Path format `<conversation_id>/<file>` is what the messages-bucket storage RLS
+    // expects — `is_message_conversation_participant((storage.foldername(name))[1], auth.uid())`.
+    const ext =
+      attachment.name.split(".").pop()?.toLowerCase() ||
+      (attachment.type.startsWith("image/") ? "jpg" : "bin");
+    const safeExt = ext.replace(/[^a-z0-9]/g, "") || "jpg";
+    const filePath = `${conversationId}/${userId}_${Date.now()}.${safeExt}`;
+    const contentType = attachment.type.startsWith("image/")
+      ? attachment.type
+      : "image/jpeg";
+
+    const formData = new FormData();
+    formData.append("file", {
+      uri: attachment.uri,
+      type: contentType,
+      name: attachment.name,
+    } as unknown as Blob);
+
+    const { error: uploadError } = await supabase.storage
+      .from("messages")
+      .upload(filePath, formData, { contentType, upsert: false });
+    if (uploadError) {
+      return { messageId: null, error: `Upload failed: ${uploadError.message}` };
+    }
+    const { data: urlData } = supabase.storage.from("messages").getPublicUrl(filePath);
+    fileUrl = urlData.publicUrl;
+    fileName = attachment.name;
+    fileSize = attachment.size || null;
+    messageType = "image";
+  }
+
+  const trimmed = content.trim();
+  if (messageType === "text" && trimmed.length === 0) {
+    return { messageId: null, error: "Message is empty." };
+  }
 
   const { data, error } = await supabase
     .from("messages")
     .insert({
       conversation_id: conversationId,
       sender_id: userId,
-      content,
-      message_type: "text",
+      content: trimmed,
+      message_type: messageType,
+      file_url: fileUrl,
+      file_name: fileName,
+      file_size: fileSize,
     })
     .select("id")
     .single();
@@ -88,7 +154,9 @@ export async function listMessages(
 ): Promise<{ messages: EventGroupMessage[]; error: string | null }> {
   const { data, error } = await supabase
     .from("messages")
-    .select("id, sender_id, content, created_at, marketing_campaign_id")
+    .select(
+      "id, sender_id, content, created_at, marketing_campaign_id, message_type, file_url, file_name, file_size",
+    )
     .eq("conversation_id", conversationId)
     .is("deleted_at", null)
     .order("created_at", { ascending: true })


### PR DESCRIPTION
## Summary

Replaces conflicted PR #163 (Seth-based, abandoned). Fresh branch off `origin/main` post-PR-#161/#162 merges.

Operator-authorized bundle per `feedback_one_pr_per_close.md` narrow exception:
- **ORCH-0897-A** image-attachment MVP (Option B chosen; voice/video deferred)
- **ORCH-0896** Stripe RN 0.65.1 forwardRef RedBox once-and-for-all fix

Net-new vs main only — title/KAV/event_name pieces of original ORCH-0897-A were absorbed by PR #162 (consumer chat polish) and are not re-applied here.

## ORCH-0897-A — Image-attachment MVP

Operator-verified working on simulator (2026-05-22).

- `PlannerImageAttachment` type + extended `postPlannerMessage` upload to `messages` storage bucket (path `<conversation_id>/<userId>_<ts>.<ext>` per RLS `is_message_conversation_participant`)
- Extended `EventGroupMessage` with `message_type`/`file_url`/`file_name`/`file_size`; `listMessages` SELECT updated
- `handlePickImage` + thumbnail preview + caption-aware composer placeholder in `GroupChatPanel.tsx`
- `<Image>` bubble render when `message_type === 'image'`
- `useEventGroupChat` threads attachment through `postMessage`

**Regression check (T-A01..T-A11):** 11/11 PASS at HEAD `83d6e643`. T-A03 is the FAILS-ON-REVERT KEY.

## ORCH-0896 — Stripe forwardRef hoist

**Root cause:** ES module imports hoist before top-level statements. ORCH-0836's LogBox filter placed in `app/_layout.tsx` AFTER the Stripe import armed AFTER `PaymentMethodMessagingElement.js` had already emitted its forwardRef warning during import evaluation under React 19.1.0's stricter arity check.

**Fix:** Dedicated side-effect module `silenceStripeForwardRef.ts` whose top-level `LogBox.ignoreLogs` runs at the importing file's import position. Imported FIRST in both `_layout.tsx` files — before `@mingla/payments-native` (app-mobile) and before `StripeProviderWrapper` (mingla-business) — so the filter is armed before any Stripe code evaluates.

- `app-mobile/src/diagnostics/silenceStripeForwardRef.ts` (NEW)
- `mingla-business/src/diagnostics/silenceStripeForwardRef.ts` (NEW)
- `app-mobile/app/_layout.tsx`: import side-effect FIRST; REMOVED prior post-Stripe `LogBox.ignoreLogs` block
- `mingla-business/app/_layout.tsx`: import side-effect before `StripeProviderWrapper`
- `app-mobile/scripts/ci/orch-0836-regression-check.mjs`: UPDATED with `[TEST-MOD-APPROVED ORCH-0896]` token; added T-B2
- `app-mobile/scripts/ci/orch-0896-regression-check.mjs` (NEW): 5 contracts T-S01..T-S05

**Regression check (T-S01..T-S05):** 5/5 PASS. T-S02 + T-S04 are FAILS-ON-REVERT KEY tests asserting import-order.

**ORCH-0836 gate (post-relocation):** 3/3 PASS.

## Vercel `[deploy]` tag

Tag present in commit subject — required because `mingla-business/src/` + `mingla-business/app/` touched (Vercel-built surface).

## Test plan

- [ ] CI green on all required checks
- [ ] Local: `node app-mobile/scripts/ci/orch-0897-a-regression-check.mjs` → 11/11 PASS
- [ ] Local: `node app-mobile/scripts/ci/orch-0896-regression-check.mjs` → 5/5 PASS
- [ ] Local: `node app-mobile/scripts/ci/orch-0836-regression-check.mjs` → 3/3 PASS
- [ ] After merge: EAS publish both apps; verify cold-launch of mingla-business iOS sim shows no "forwardRef render functions accept exactly two parameters" RedBox in Metro logs
- [ ] After merge: open Trips/Events Group Chat in mingla-business, tap attach, pick image, send — image bubble renders for sender + recipient

## Closes

- ORCH-0897-A [Group Chat polish — image-attachment MVP]
- ORCH-0896 [Stripe forwardRef RedBox under React 19.1]

Supersedes PR #163.