### PR TITLE
Close ORCH-0951 v2 [TEST-MOD-APPROVED ORCH-0951] [deploy]: revert v3 typeof-window initializer — fix React #418 multi-ticket hydration mismatch

### DIFF
--- a/mingla-business/app/checkout-trip/[tripEventId]/confirm.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/confirm.tsx
@@ -102,19 +102,30 @@ export default function CheckoutTripConfirmScreen(): React.ReactElement {
     buyerStatusToken: string;
   } | null>(null);
   const exitingViaCtaRef = useRef<boolean>(false);
-  // ORCH-0930 v3 (2026-05-23) — parent-level hydration gate via
-  // useState initializer. v2 used `useState(false) + useEffect(setTrue, [])`
-  // but Playwright forensic confirmed the carousel STILL never mounts on
-  // production after v2 deploy. Hypothesis: React's #418 hydration error
-  // recovery cycle resets the useEffect schedule before the effect
-  // fires, so `hydrated` stays false forever. v3 uses a useState
-  // initializer that resolves at render time — `typeof window !==
-  // "undefined"` is true on every client render (initial + re-render)
-  // and false at static-export build time. The carousel mount gate
-  // (`isClient && totalTickets > 0`) thus renders nothing during
-  // static-export pre-render (matches empty skeleton) AND renders the
-  // carousel on every client render (no effect dependency).
-  const [isClient] = useState<boolean>(() => typeof window !== "undefined");
+  // ORCH-0951 v2 (2026-05-24) — REVERTS ORCH-0930 v3 back to useState(false)
+  // + useEffect setIsClient(true). v3's typeof-window initializer was the
+  // REAL root cause of the React #418 hydration mismatch that broke the
+  // multi-ticket carousel render on production: the initializer returns
+  // `false` during SSR (static export, no window) but `true` on client
+  // first render (window exists). React's hydration pass sees `null` on
+  // SSR HTML vs `<TicketQrCarousel>` on client → mismatch → React aborts
+  // the carousel subtree → multi-ticket users see only the bare
+  // minHeight=320 strip (single-ticket "worked" because the simple
+  // <Image> subtree is hydration-recoverable; multi-ticket with
+  // onLayout-driven re-renders is not). Forensic confirmation:
+  // /tmp/orch-0928-forensic/probe-orch-0951-v2.js shows the bare host
+  // exists with width=0px, pageerror=React #418, and the full carousel
+  // subtree never mounts. v2 pattern (this fix) makes SSR + client first
+  // render BOTH produce `null` — no hydration mismatch — then the
+  // useEffect fires post-hydration and the carousel mounts cleanly via a
+  // regular re-render (no hydration check). The earlier belief that "v2
+  // failed because React #418 recovery prevented the effect from firing"
+  // was incorrect — v2 was masked by the unrelated SVG-generation bug
+  // that ORCH-0932 later fixed.
+  const [isClient, setIsClient] = useState<boolean>(false);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   // ----- Native back guard -----
   useEffect(() => {

--- a/mingla-business/app/checkout/[eventId]/confirm.tsx
+++ b/mingla-business/app/checkout/[eventId]/confirm.tsx
@@ -90,11 +90,18 @@ export default function CheckoutConfirmScreen(): React.ReactElement {
     checkoutSessionId: string;
     buyerStatusToken: string;
   } | null>(null);
-  // ORCH-0930 v3 (2026-05-23) — useState initializer pattern. See
-  // parallel patch in checkout-trip/[tripEventId]/confirm.tsx for the
-  // full rationale (v2 useEffect was insufficient; React #418 recovery
-  // cycle prevented the effect from firing).
-  const [isClient] = useState<boolean>(() => typeof window !== "undefined");
+  // ORCH-0951 v2 (2026-05-24) — REVERTS ORCH-0930 v3 back to
+  // useState(false) + useEffect setIsClient(true). See parallel patch in
+  // checkout-trip/[tripEventId]/confirm.tsx for the full rationale
+  // (v3's typeof-window initializer was the real root cause of the
+  // React #418 hydration mismatch that broke the multi-ticket carousel
+  // render on production; v2 makes SSR + client first render BOTH
+  // produce `null` → no mismatch → useEffect fires post-hydration → no
+  // React #418 → carousel mounts cleanly).
+  const [isClient, setIsClient] = useState<boolean>(false);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
   // Ref flag — flipped to true when buyer taps "Back to event." The
   // beforeRemove listener checks this and lets the navigation through
   // when set, so the explicit CTA exit isn't blocked by the same guard

--- a/mingla-business/src/components/checkout/__tests__/orch_0930_qr_carousel_mounted_guard.test.tsx
+++ b/mingla-business/src/components/checkout/__tests__/orch_0930_qr_carousel_mounted_guard.test.tsx
@@ -124,21 +124,37 @@ describe("ORCH-0932 — parent-level threading of qrImageDataUrl through confirm
     );
   });
 
-  it("HP-9 (trip — preserved from ORCH-0930 v3): isClient parent gate remains as defense in depth for ORCH-0928 recovery race", () => {
+  it("HP-9 (trip — ORCH-0951 v2): isClient uses useState(false) + useEffect setIsClient(true) pattern (NOT v3's typeof-window initializer which caused React #418 hydration mismatch)", () => {
     expect(tripActive).toMatch(
-      /const\s+\[\s*isClient\s*\]\s*=\s*useState<boolean>\(\s*\(\)\s*=>\s*typeof\s+window\s*!==\s*["']undefined["']\s*\)/,
+      /const\s+\[\s*isClient\s*,\s*setIsClient\s*\]\s*=\s*useState<boolean>\(\s*false\s*\)/,
+    );
+    expect(tripActive).toMatch(
+      /useEffect\(\s*\(\)\s*=>\s*\{\s*setIsClient\(true\);?\s*\}\s*,\s*\[\s*\]\s*\)/,
     );
     expect(tripActive).toMatch(
       /\{\s*isClient\s*&&\s*totalTickets\s*>\s*0\s*\?\s*\(?\s*<TicketQrCarousel/,
+    );
+    // Anti-regression: must NOT re-introduce v3's typeof-window initializer
+    // (the root cause of the React #418 hydration mismatch — SSR=false,
+    // client first render=true → mismatch → React aborts the carousel subtree
+    // → multi-ticket users see only the bare minHeight=320 strip).
+    expect(tripActive).not.toMatch(
+      /useState<boolean>\(\s*\(\)\s*=>\s*typeof\s+window/,
     );
   });
 
-  it("HP-10 (event — preserved from ORCH-0930 v3): isClient parent gate remains as defense in depth", () => {
+  it("HP-10 (event — ORCH-0951 v2): mirrors the trip-side v2 pattern", () => {
     expect(eventActive).toMatch(
-      /const\s+\[\s*isClient\s*\]\s*=\s*useState<boolean>\(\s*\(\)\s*=>\s*typeof\s+window\s*!==\s*["']undefined["']\s*\)/,
+      /const\s+\[\s*isClient\s*,\s*setIsClient\s*\]\s*=\s*useState<boolean>\(\s*false\s*\)/,
+    );
+    expect(eventActive).toMatch(
+      /useEffect\(\s*\(\)\s*=>\s*\{\s*setIsClient\(true\);?\s*\}\s*,\s*\[\s*\]\s*\)/,
     );
     expect(eventActive).toMatch(
       /\{\s*isClient\s*&&\s*totalTickets\s*>\s*0\s*\?\s*\(?\s*<TicketQrCarousel/,
+    );
+    expect(eventActive).not.toMatch(
+      /useState<boolean>\(\s*\(\)\s*=>\s*typeof\s+window/,
     );
   });
 });


### PR DESCRIPTION
## Summary

**ORCH-0951 v1 [carousel host width] didn't fix the bug.** The strip pattern is still there on production after v1 deploy. Playwright forensic at `/tmp/orch-0928-forensic/probe-orch-0951-v2.js` (network-mocked confirm response with 3 fake-paid tickets bypassing buyer_status_token auth) proved the real cause:

```
pageerror: "Minified React error #418" (hydration mismatch)
bare-host element exists in DOM with width=0px (despite width:"100%" in CSS)
no carousel content past the bare host (subtree aborted)
parent chain depths 1-3 all width=32px (shrink-to-fit of empty children)
```

## Root cause

**ORCH-0930 v3's parent-level gate** `useState(() => typeof window !== "undefined")` IS the bug:

- SSR (static-export, no `window`): `false` → renders `null`
- Client first render (window exists): `true` → renders `<TicketQrCarousel>`

React's hydration sees `null` on SSR HTML vs `<TicketQrCarousel>` on client → mismatch → React aborts the carousel subtree → multi-ticket users see only the bare `minHeight: 320` strip.

Single-ticket "worked" because the simple `<Image>` subtree is hydration-recoverable; multi-ticket carousel with `onLayout`-driven re-renders is not.

## Fix (v2)

Revert to **ORCH-0930 v2 pattern**:

```tsx
// BEFORE (v3 — causes hydration mismatch)
const [isClient] = useState<boolean>(() => typeof window !== "undefined");

// AFTER (v2 — SSR=false, client first render=false, useEffect flips to true post-hydration)
const [isClient, setIsClient] = useState<boolean>(false);
useEffect(() => { setIsClient(true); }, []);
```

SSR and client first render BOTH produce `null` → no mismatch → no React #418 → useEffect fires post-hydration → re-render mounts carousel cleanly via regular render path. Earlier session belief that "v2 failed because React #418 recovery prevented effect from firing" was incorrect — v2 was actually masked by the unrelated `react-native-qrcode-svg` bug that ORCH-0932 server-side QR PNG later fixed.

ORCH-0951 v1's `width: "100%"` stays — harmless on web and defense-in-depth.

## Files

- `mingla-business/app/checkout-trip/[tripEventId]/confirm.tsx` — v3 → v2 pattern
- `mingla-business/app/checkout/[eventId]/confirm.tsx` — v3 → v2 pattern (mirror)
- `mingla-business/src/components/checkout/__tests__/orch_0930_qr_carousel_mounted_guard.test.tsx` — HP-9 + HP-10 updated to assert v2 pattern + explicitly reject v3's typeof-window initializer ([TEST-MOD-APPROVED ORCH-0951])

## Test plan

- [x] Jest: 11/11 pass on fixed code
- [x] Fails-on-revert verified at base commit `7095a2d2` (HP-9 + HP-10 fail when reverted)
- [x] TS check clean
- [x] Playwright forensic proved the actual bug (React #418, not layout)
- [ ] Operator: multi-ticket purchase on `business.usemingla.com` after merge, verify QR carousel renders (3 QRs + dots + swipe hint)

## Deploy notes

- `[deploy]` tag triggers Vercel rebuild
- No edge function changes
- No DB migration
- This is **the last-ever PR on Seth branch** per the worktree-per-ORCH cutover plan (now unblocked since ORCH-0945 closed). Next ORCH onwards will use dedicated worktrees.

Refs: ORCH-0951 v2 [React #418 hydration mismatch hotfix]