### PR TITLE
Close ORCH-0946 [deploy]: buyer-web sold-out gate — remaining bookable

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -631,6 +631,14 @@ function checkNoNewBackendFiles() {
   const ORCH_0931_BACKEND_ALLOWLIST = [
     "supabase/migrations/20260724000001_orch_0931_realtime_broadcast_session_updated.sql",
   ];
+  // ORCH-0946 [Buyer-web sold-out gate] — anon-callable RPC for
+  // remaining-bookable per ticket_type so the buyer-checkout sold-out
+  // banner + QuantityRow "+" cap reflect what's actually bookable
+  // instead of total tier capacity. C7 is scoped to ORCH-0863 marketing;
+  // this is an unrelated buyer-web checkout fix.
+  const ORCH_0946_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260724000006_orch_0946_public_ticket_types_remaining.sql",
+  ];
   const ALLOWLIST = [
     ...ORCH_0933_BACKEND_ALLOWLIST,
     ...ORCH_0940_BACKEND_ALLOWLIST,
@@ -662,6 +670,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_0914_BACKEND_ALLOWLIST,
     ...ORCH_0921_BACKEND_ALLOWLIST,
     ...ORCH_0925_BACKEND_ALLOWLIST,
+    ...ORCH_0946_BACKEND_ALLOWLIST,
   ];
   const forbidden = changed.filter(
     (p) =>

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -67,7 +67,12 @@ const tierToTicketStub = (tier: TripPricingTier): TicketStub => ({
   name: tier.tierName,
   priceGbp: tier.priceCents > 0 ? tier.priceCents / 100 : null,
   currency: tier.currency,
-  capacity: tier.quantityTotal,
+  // ORCH-0946 — buyer-checkout sold-out gate + QuantityRow "+" cap need
+  // remaining bookable seats, not total tier capacity. `quantityTotal`
+  // never decreases as tickets sell, so before this fix the buyer could
+  // tap "+" all the way to the payment screen on a sold-out trip and only
+  // failed at the final 409 `ticket_capacity_exceeded`.
+  capacity: tier.ticketsRemaining ?? tier.quantityTotal,
   isFree: tier.priceCents === 0,
   isUnlimited: tier.isUnlimited,
   visibility: "public" as TicketVisibility,

--- a/mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts
+++ b/mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts
@@ -119,6 +119,7 @@ const trip = (patch: Partial<Trip> = {}): Trip => ({
       priceCents: 150000,
       currency: "USD",
       quantityTotal: 12,
+      ticketsRemaining: null,
       isUnlimited: false,
       installmentSchedule: null,
     },

--- a/mingla-business/src/hooks/usePublicTripBySlug.ts
+++ b/mingla-business/src/hooks/usePublicTripBySlug.ts
@@ -186,6 +186,11 @@ export const usePublicTripBySlug = (
               priceCents: tt?.price_cents ?? 0,
               currency: tt?.currency ?? "",
               quantityTotal: tt?.quantity_total ?? null,
+              // ORCH-0946 — trip preview page (this hook) does not gate
+              // sold-out; the buyer-checkout page (`usePublicTripById`)
+              // does. Set null here; if the preview later adds a sold-out
+              // badge, wire `pg_public_ticket_types_remaining` here too.
+              ticketsRemaining: null,
               isUnlimited: tt?.is_unlimited ?? false,
               installmentSchedule,
             };

--- a/mingla-business/src/services/__tests__/orch_0946_sold_out_gate.test.ts
+++ b/mingla-business/src/services/__tests__/orch_0946_sold_out_gate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * ORCH-0946 — buyer-web sold-out gate regression tests.
+ *
+ * Bug: `tierToTicketStub` and `ticketRowToTicketStub` previously set
+ * `capacity` to total tier capacity (`quantityTotal` / `quantity_total`)
+ * which never decreases. The sold-out gate at
+ * `mingla-business/app/checkout-trip/[tripEventId]/index.tsx:237-239` and
+ * the event-side mirror at `app/checkout/[eventId]/index.tsx:173-176` then
+ * never triggered, so the buyer could tap "+" all the way to the payment
+ * screen on a sold-out tier and only failed at the final 409
+ * `ticket_capacity_exceeded`.
+ *
+ * Fix: anon-callable `pg_public_ticket_types_remaining(event_id)` RPC
+ * threads remaining-bookable-count through to the mappers, which now
+ * prefer remaining over total when sold-out gating.
+ *
+ * Two regression tests covering ORCH-0840 Step 0.5 gate (a) happy-path +
+ * (b) adversarial. fails-on-revert verified manually by reverting
+ * `tier.ticketsRemaining ?? tier.quantityTotal` back to `tier.quantityTotal`
+ * in `app/checkout-trip/[tripEventId]/index.tsx` and re-running this file.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import type { TripPricingTier } from "../tripsService";
+
+// Re-derive the trip-side mapper here (same logic as
+// `app/checkout-trip/[tripEventId]/index.tsx:65`) so the test is fully
+// hermetic and doesn't depend on RN module resolution.
+const tierToCapacityForGate = (tier: TripPricingTier): number | null =>
+  tier.isUnlimited ? null : (tier.ticketsRemaining ?? tier.quantityTotal);
+
+const tier = (patch: Partial<TripPricingTier> = {}): TripPricingTier => ({
+  id: "tier-1",
+  eventId: "event-1",
+  ticketTypeId: "tt-1",
+  tierName: "Standard",
+  tierMetadata: {},
+  priceCents: 5000,
+  currency: "USD",
+  quantityTotal: 55,
+  ticketsRemaining: null,
+  isUnlimited: false,
+  installmentSchedule: null,
+  ...patch,
+});
+
+// =====================================================================
+// (a) HAPPY-PATH REGRESSION — sold-out tier surfaces capacity=0 to the
+// gate at index.tsx:237-239 (which then renders the "Sold out" EmptyState).
+// =====================================================================
+describe("ORCH-0946 sold-out gate (happy path)", () => {
+  test("sold-out tier (remaining=0, total=55) maps to capacity=0", () => {
+    const t = tier({ quantityTotal: 55, ticketsRemaining: 0 });
+    expect(tierToCapacityForGate(t)).toBe(0);
+  });
+
+  test("aggregate sold-out detection fires when every non-unlimited tier has remaining=0", () => {
+    const tiers = [
+      tier({ id: "a", quantityTotal: 55, ticketsRemaining: 0 }),
+      tier({ id: "b", quantityTotal: 20, ticketsRemaining: 0 }),
+    ];
+    const allSoldOut = tiers.every(
+      (x) => !x.isUnlimited && (tierToCapacityForGate(x) ?? 0) <= 0,
+    );
+    expect(allSoldOut).toBe(true);
+  });
+
+  test("the trip-side mapper uses ticketsRemaining (not quantityTotal) for capacity", () => {
+    const file = readFileSync(
+      path.resolve(
+        __dirname,
+        "../../../app/checkout-trip/[tripEventId]/index.tsx",
+      ),
+      "utf-8",
+    );
+    expect(file).toMatch(
+      /capacity:\s*tier\.ticketsRemaining\s*\?\?\s*tier\.quantityTotal/,
+    );
+    expect(file).not.toMatch(/capacity:\s*tier\.quantityTotal,/);
+  });
+});
+
+// =====================================================================
+// (b) ADVERSARIAL REGRESSION — different angles than (a):
+//   - unlimited tier never reports sold-out even when remaining=0 leaks
+//   - partial-sold tier caps gate at remaining, not at total
+//   - ticketsRemaining=null (RPC degraded) falls back to quantityTotal
+//     so a partial-sold trip still bookable, never a false sold-out
+//   - server-side RPC SQL invariants hold (status filter + GREATEST guard)
+// =====================================================================
+describe("ORCH-0946 sold-out gate (adversarial)", () => {
+  test("unlimited tier stays unbounded (capacity=null) even with stale remaining=0", () => {
+    const t = tier({
+      isUnlimited: true,
+      quantityTotal: null,
+      ticketsRemaining: 0,
+    });
+    expect(tierToCapacityForGate(t)).toBeNull();
+    const isSoldOut = !t.isUnlimited && (tierToCapacityForGate(t) ?? 0) <= 0;
+    expect(isSoldOut).toBe(false);
+  });
+
+  test("partial-sold tier caps QuantityRow + at remaining, not at total", () => {
+    const t = tier({ quantityTotal: 55, ticketsRemaining: 3 });
+    expect(tierToCapacityForGate(t)).toBe(3);
+    expect(tierToCapacityForGate(t)).not.toBe(55);
+  });
+
+  test("RPC-degraded tier (ticketsRemaining=null) falls back to quantityTotal — no false sold-out, no crash", () => {
+    const t = tier({ quantityTotal: 55, ticketsRemaining: null });
+    expect(tierToCapacityForGate(t)).toBe(55);
+    const isSoldOut = !t.isUnlimited && (tierToCapacityForGate(t) ?? 0) <= 0;
+    expect(isSoldOut).toBe(false);
+  });
+
+  test("migration RPC counts only status IN (valid, used, transferred) and clamps remaining >= 0", () => {
+    const file = readFileSync(
+      path.resolve(
+        __dirname,
+        "../../../../supabase/migrations/20260724000006_orch_0946_public_ticket_types_remaining.sql",
+      ),
+      "utf-8",
+    );
+    expect(file).toMatch(/status\s+IN\s*\(\s*'valid',\s*'used',\s*'transferred'\s*\)/);
+    expect(file).toMatch(/GREATEST\(\s*tt\.quantity_total\s*-\s*COALESCE\(s\.sold,\s*0\),\s*0\s*\)/);
+    expect(file).toMatch(/GRANT EXECUTE ON FUNCTION public\.pg_public_ticket_types_remaining\(uuid\) TO anon, authenticated/);
+  });
+
+  test("event-side public read overwrites capacity with remaining for non-unlimited tickets", () => {
+    const file = readFileSync(
+      path.resolve(__dirname, "../publicEventsService.ts"),
+      "utf-8",
+    );
+    expect(file).toMatch(/fetchTicketTypesRemaining/);
+    expect(file).toMatch(/return \{ \.\.\.s, capacity: remaining \}/);
+    expect(file).toMatch(/if \(s\.isUnlimited\) return s/);
+  });
+});

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -544,6 +544,36 @@ export const publicEventViewRowToEvent = (
   };
 };
 
+/**
+ * ORCH-0946 — anon-callable RPC returning sold + remaining per ticket_type
+ * for one event. Used by both `fetchTickets` (event side) and
+ * `getPublicTripById` (trip side) to thread `remaining` through to the
+ * buyer-checkout sold-out gate. Falls back to an empty map on RPC error
+ * (sold-out gate is then a no-op, matching pre-ORCH-0946 behaviour — the
+ * checkout RPC still rejects oversold attempts as the last line of defence).
+ */
+const fetchTicketTypesRemaining = async (
+  eventId: string,
+): Promise<Map<string, number | null>> => {
+  const { data, error } = await supabase.rpc(
+    "pg_public_ticket_types_remaining",
+    { p_event_id: eventId },
+  );
+  if (error !== null) {
+    console.warn(
+      "[ORCH-0946] pg_public_ticket_types_remaining failed; sold-out gate degrades to checkout-RPC catch",
+      error,
+    );
+    return new Map();
+  }
+  const rows = (data ?? []) as Array<{
+    ticket_type_id: string;
+    sold: number;
+    remaining: number | null;
+  }>;
+  return new Map(rows.map((r) => [r.ticket_type_id, r.remaining]));
+};
+
 const fetchTickets = async (
   eventId: string,
 ): Promise<PublicTicketTypeRecord[]> => {
@@ -558,7 +588,17 @@ const fetchTickets = async (
     .order("display_order", { ascending: true });
 
   if (error !== null) throw error;
-  return ((data ?? []) as TicketTypeRow[]).map(ticketRowToTicketStub);
+  const stubs = ((data ?? []) as TicketTypeRow[]).map(ticketRowToTicketStub);
+  // ORCH-0946 — overwrite capacity with remaining so the buyer-checkout
+  // sold-out gate + QuantityRow "+" cap reflect what's actually bookable
+  // (not total tier capacity). Unlimited tiers keep capacity=null untouched.
+  const remainingById = await fetchTicketTypesRemaining(eventId);
+  return stubs.map((s) => {
+    if (s.isUnlimited) return s;
+    const remaining = remainingById.get(s.id);
+    if (remaining === undefined) return s;
+    return { ...s, capacity: remaining };
+  });
 };
 
 const detailFromRow = async (
@@ -817,6 +857,9 @@ export const getPublicTripById = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const tickets = (ticketsResp.data ?? []) as any[];
 
+  // ORCH-0946 — remaining-capacity per ticket_type for the sold-out gate.
+  const remainingById = await fetchTicketTypesRemaining(tripEventId);
+
   const ticketsById = new Map(tickets.map((tt) => [tt.id, tt]));
   const bt =
     (event.theme?.business_trip as Record<string, unknown> | undefined) ?? {};
@@ -868,6 +911,11 @@ export const getPublicTripById = async (
         (t.tier_metadata?.installments as
           | TripPricingTier["installmentSchedule"]
           | undefined) ?? null;
+      const isUnlimited = tt?.is_unlimited ?? false;
+      // ORCH-0946 — null when unlimited or unknown; otherwise GREATEST(total - sold, 0).
+      const ticketsRemaining = isUnlimited
+        ? null
+        : (remainingById.get(t.ticket_type_id) ?? null);
       return {
         id: t.id,
         eventId: t.event_id,
@@ -877,7 +925,8 @@ export const getPublicTripById = async (
         priceCents: tt?.price_cents ?? 0,
         currency: tt?.currency ?? "",
         quantityTotal: tt?.quantity_total ?? null,
-        isUnlimited: tt?.is_unlimited ?? false,
+        ticketsRemaining,
+        isUnlimited,
         installmentSchedule,
       };
     }),

--- a/mingla-business/src/services/tripsService.ts
+++ b/mingla-business/src/services/tripsService.ts
@@ -40,6 +40,14 @@ export interface TripPricingTier {
   priceCents: number;
   currency: string;
   quantityTotal: number | null;
+  /**
+   * ORCH-0946 — remaining bookable seats from `pg_public_ticket_types_remaining`.
+   * Null when `isUnlimited` is true OR when this tier was mapped outside the
+   * public-read path (e.g., admin draft loads via `mapTripPricingTier`).
+   * Buyer-checkout sold-out gate + QuantityRow "+" cap consume this;
+   * `quantityTotal` retains its prior meaning (total tier capacity).
+   */
+  ticketsRemaining: number | null;
   isUnlimited: boolean;
   /**
    * ORCH-0873 [Tr3 Stage 2 UI] — extracted from
@@ -277,6 +285,9 @@ function mapTripPricingTier(
     priceCents: ticketType?.price_cents ?? 0,
     currency: ticketType?.currency ?? "",
     quantityTotal: ticketType?.quantity_total ?? null,
+    // ORCH-0946 — admin/draft loads don't have a remaining-count source;
+    // public-read paths overwrite this via `getPublicTripById`.
+    ticketsRemaining: null,
     isUnlimited: ticketType?.is_unlimited ?? false,
     installmentSchedule: extractInstallmentSchedule(metadata),
   };

--- a/mingla-business/src/utils/__tests__/publishedTripEditGuards.test.ts
+++ b/mingla-business/src/utils/__tests__/publishedTripEditGuards.test.ts
@@ -54,6 +54,7 @@ const trip = (patch: Partial<Trip> = {}): Trip => ({
       priceCents: 150000,
       currency: "USD",
       quantityTotal: 12,
+      ticketsRemaining: null,
       isUnlimited: false,
       installmentSchedule: null,
     },

--- a/supabase/migrations/20260724000006_orch_0946_public_ticket_types_remaining.sql
+++ b/supabase/migrations/20260724000006_orch_0946_public_ticket_types_remaining.sql
@@ -1,0 +1,57 @@
+-- ORCH-0946 [Buyer-web sold-out gate]
+--
+-- Problem: buyer-web checkout pages (trip + event) gate the "Sold out" banner
+-- and QuantityRow "+" cap on `ticket_types.quantity_total` (total capacity),
+-- not on remaining capacity. The total never decreases, so the banner never
+-- shows and the buyer only fails at the final "Pay" tap with a 409
+-- `ticket_capacity_exceeded` from `biz_ticket_checkout_create_session`.
+--
+-- Fix: expose remaining-capacity per ticket_type as an anon-callable
+-- SECURITY DEFINER RPC. Returns only derived counts — no buyer/order data
+-- leaks. Sold-count matches the formula already used inside the checkout
+-- RPC (status IN ('valid','used','transferred')) so the two stay consistent.
+--
+-- Used by `getPublicTripById` and `getPublicEventById` to thread a
+-- `ticketsRemaining` field through to the buyer-checkout mappers.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.pg_public_ticket_types_remaining(
+  p_event_id uuid
+)
+RETURNS TABLE (
+  ticket_type_id uuid,
+  sold           integer,
+  remaining      integer
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    tt.id AS ticket_type_id,
+    COALESCE(s.sold, 0)::int AS sold,
+    CASE
+      WHEN tt.is_unlimited THEN NULL
+      WHEN tt.quantity_total IS NULL THEN NULL
+      ELSE GREATEST(tt.quantity_total - COALESCE(s.sold, 0), 0)::int
+    END AS remaining
+  FROM public.ticket_types tt
+  LEFT JOIN (
+    SELECT t.ticket_type_id, COUNT(*)::int AS sold
+    FROM public.tickets t
+    WHERE t.status IN ('valid', 'used', 'transferred')
+    GROUP BY t.ticket_type_id
+  ) s ON s.ticket_type_id = tt.id
+  WHERE tt.event_id = p_event_id
+    AND tt.deleted_at IS NULL;
+$$;
+
+REVOKE ALL ON FUNCTION public.pg_public_ticket_types_remaining(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.pg_public_ticket_types_remaining(uuid) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.pg_public_ticket_types_remaining(uuid) IS
+  'ORCH-0946: anon-callable per-event ticket_type remaining counts for the buyer-web sold-out gate. Sold formula matches biz_ticket_checkout_create_session: tickets.status IN (valid, used, transferred).';
+
+COMMIT;


### PR DESCRIPTION
## Summary

When a trip (or event) sells out, the buyer-web "Sold out" banner never appears. Both checkout-page sold-out gates compare **total tier capacity** (never decreases) to zero, so the gate is permanently false. Buyer taps "+" through ticket selection, fills the buyer step, picks a payment plan, then only fails at the final "Pay" tap with a confusing 409 `ticket_capacity_exceeded`.

Fix: anon-callable `pg_public_ticket_types_remaining(event_id)` RPC threads remaining-bookable count through to both buyer-checkout mappers (trip side + event side). The existing sold-out gates and `QuantityRow` "+" caps then work correctly without changing call-site logic.

- New migration: `20260724000006_orch_0946_public_ticket_types_remaining.sql` — `SECURITY DEFINER`, sold formula matches `biz_ticket_checkout_create_session` (`status IN ('valid','used','transferred')`), `remaining = GREATEST(quantity_total - sold, 0)`, granted to `anon, authenticated`. No buyer data leaked.
- `TripPricingTier` gains `ticketsRemaining: number | null`. `getPublicTripById` populates it. `usePublicTripBySlug` defaults to `null` (preview doesn't gate; future polish).
- `publicEventsService.fetchTickets` overwrites `TicketStub.capacity` with remaining for non-unlimited tickets (unlimited untouched).
- `app/checkout-trip/[tripEventId]/index.tsx:65` mapper uses `tier.ticketsRemaining ?? tier.quantityTotal`.
- RPC failure degrades to original capacity (pre-fix behaviour); checkout RPC remains the last line of defence.

8 regression tests at `mingla-business/src/services/__tests__/orch_0946_sold_out_gate.test.ts` — 3 happy-path + 5 adversarial covering distinct angles: unlimited stays unbounded with stale remaining=0, partial-sold caps at remaining, RPC-degraded falls back without false sold-out, migration SQL invariants (status filter + GREATEST clamp + anon grant), event-side path overwrites capacity. **Fails-on-revert verified locally** at commit `e8892fec` (anchor HEAD) by sed-reverting the trip mapper — happy-path test #3 fails as expected, restored, all 8 pass.

Pre-existing `publishedTripEditGuards.test.ts` + `ORCH-0876.adversarial.test.ts` updated for the new required `ticketsRemaining` field (36 tests still pass).

Strict-grep allowlist extended with `ORCH_0946_BACKEND_ALLOWLIST` so the marketing C7 no-backend-files guard (ORCH-0863 scope) doesn't fire on the one migration.

**Affected Surfaces:** mingla-business buyer-anonymous web (trip + event checkout). **NOT IN SCOPE:** consumer iOS/Android (no buyer-web), business iOS/Android/web-preview (separate flow), admin-web.

Sits inside META-ORCH-0953 batch INTAKE alongside ORCH-0947/0948/0949; does not collide with META-ORCH-0952 (carousel render on confirm page — different file).

## Test plan

- [ ] **Operator:** `supabase db push --linked` to apply `20260724000006_orch_0946_public_ticket_types_remaining.sql` **before** merging this PR (Vercel buyer-web bundle reads the new RPC).
- [ ] Smoke-test on `mingla-business` Vercel preview / production:
  - [ ] Visit `/checkout-trip/<DC-Adventure-event-id>` (currently 55/55 sold). Expect the full-page "Sold out" EmptyState instead of QuantityRow + "+" button. Tapping "Back to trip" returns.
  - [ ] On a partially-sold trip, confirm "+" stops at `remaining` (not at `quantity_total`).
  - [ ] On an unlimited tier, confirm "+" stays unbounded.
  - [ ] Repeat on the event side at `/checkout/<event-id>` for a sold-out non-trip event.
- [ ] Watch Vercel build (commit message contains `[deploy]`) — `state=BUILDING` on all 3 projects.
- [ ] CI: all required checks green; strict-grep C7 passes (ORCH-0946 allowlist).