### PR TITLE
ORCH-0956 [TEST-MOD-APPROVED ORCH-0956]: Stripe ops alerts email

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -760,6 +760,17 @@ function checkNoNewBackendFiles() {
     "supabase/functions/brand-stripe-account-session/index.ts",
   ];
 
+  // ORCH-0956 [Stripe ops alerts → email]: swaps the OneSignal push-based
+  // dispute + webhook-signature-failure operator alerts shipped by ORCH-0953
+  // for Resend email sends. New shared helper + two adversarial test files.
+  // Modified files (stripeDisputeHandlers.ts, stripe-webhook/index.ts, and the
+  // ORCH-0953 dispute + signature-failure test files) are already covered by
+  // ORCH_0953_BACKEND_ALLOWLIST above; only the three NEW files are listed here.
+  const ORCH_0956_BACKEND_ALLOWLIST = [
+    "supabase/functions/_shared/stripeOpsAlertEmail.ts",
+    "supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts",
+    "supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts",
+  ];
   const ALLOWLIST = [
     ...ORCH_0954_BACKEND_ALLOWLIST,
     ...ORCH_0915_BACKEND_ALLOWLIST,
@@ -798,6 +809,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_0946_BACKEND_ALLOWLIST,
     ...ORCH_0947_BACKEND_ALLOWLIST,
     ...ORCH_0953_BACKEND_ALLOWLIST,
+    ...ORCH_0956_BACKEND_ALLOWLIST,
   ];
   const forbidden = changed.filter(
     (p) =>

--- a/Mingla_Artifacts/WORKTREE_REGISTRY.md
+++ b/Mingla_Artifacts/WORKTREE_REGISTRY.md
@@ -35,6 +35,7 @@ Reference: [WORKTREE_STRATEGY.md](WORKTREE_STRATEGY.md).
 
 | Worktree path | Branch | ORCH-ID | Reaped | Merged via PR |
 |---------------|--------|---------|--------|---------------|
+| `~/Desktop/mingla-orchs/ORCH-0956-[stripe-ops-alerts-email]/` | `ORCH-0956-stripe-ops-alerts-email` | ORCH-0956 | 2026-05-25 | PR #202 |
 | `~/Desktop/mingla-orchs/META-ORCH-0954-[cross-chat-comms-ledger-and-2-section-output]/` | `META-ORCH-0954-cross-chat-comms-ledger-and-2-section-output` | META-ORCH-0954 | 2026-05-24 | (pending PR merge) |
 | `~/Desktop/mingla-orchs/ORCH-0948-[waitlist-feature]/` | `ORCH-0948-waitlist-feature` | ORCH-0948 | 2026-05-24 | PR #200 (squash 8b7b06e4) |
 

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
@@ -95,7 +95,7 @@ Command:
 DENO_TESTING=1 SUPABASE_URL=https://example-test.supabase.co SUPABASE_SERVICE_ROLE_KEY=test-service-role-key-not-real STRIPE_WEBHOOK_SECRET=whsec_test STRIPE_WEBHOOK_SECRET_PLATFORM=whsec_test_platform STRIPE_WEBHOOK_SECRET_PREVIOUS= deno test --allow-env --allow-net --allow-read --no-check supabase/functions/_shared/__tests__/stripeIpAllowlist.test.ts supabase/functions/_shared/__tests__/stripeKycRemediation.test.ts supabase/functions/_shared/__tests__/stripeKycReminderSchedule.test.ts supabase/functions/_shared/__tests__/stripeWebhookRouter.test.ts supabase/functions/_shared/__tests__/stripeWebhookSignature.test.ts supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
 ```
 
-Result: **PASS** — `21 passed | 0 failed`.
+Result: **PASS** — `22 passed | 0 failed`.
 
 ### Deno check
 
@@ -126,7 +126,7 @@ Command:
 DENO_TESTING=1 deno test --allow-env --allow-net --allow-read --no-check supabase/functions/_shared/__tests__/ supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
 ```
 
-Result: **FAIL, unrelated existing tests** — `214 passed | 3 failed`.
+Result: **FAIL, unrelated existing tests** — `215 passed | 3 failed`.
 
 Failures were outside ORCH-0956 touched code:
 

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
@@ -1,0 +1,208 @@
+# IMPLEMENTATION — ORCH-0956 [Stripe ops alerts → email]
+
+**Status:** implemented and verified  
+**Date:** 2026-05-25  
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-0956-[stripe-ops-alerts-email]/`  
+**Branch:** `ORCH-0956-stripe-ops-alerts-email`  
+**Implementation commit:** `eedf32ea` (`Implement ORCH-0956 Stripe ops alert emails`)  
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md`
+
+## Summary
+
+ORCH-0956 replaces the two Stripe operator alert paths that previously used OneSignal push notifications with Resend email alerts:
+
+1. `charge.dispute.created` now emails `STRIPE_DISPUTE_ALERT_EMAILS` with amount, brand name, reason, evidence due timestamp, dispute ID, and a Stripe Dashboard CTA.
+2. `charge.dispute.closed` with `status: "lost"` now emails the same operator allowlist before preserving the existing `dispute_lost` AppsFlyer side-effect.
+3. `charge.dispute.updated` remains quiet.
+4. Stripe webhook signature failures now email `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` with signature prefix, timestamp, remediation guidance, and a Stripe webhooks dashboard CTA while preserving the invalid-signature HTTP 400 response.
+
+No migration, Supabase secret write, Stripe Dashboard mutation, Supabase deploy, or client-surface change was performed.
+
+## Diff Summary
+
+### Created
+
+- `supabase/functions/_shared/stripeOpsAlertEmail.ts`
+  - Adds `sendOpsAlertEmail(input)` using `renderTransactionalEmail({ variant: "generic_notification" })`, `EMAIL_SENDERS.system`, `formatSenderHeader`, and direct Resend POSTs to `https://api.resend.com/emails`.
+  - Normalizes recipients by trim + lowercase + dedupe + basic `@` filter.
+  - Returns `{ attempted, succeeded, failed }`.
+  - Missing `RESEND_API_KEY` warns and returns without throwing.
+  - `@resend.dev` sandbox sender rejection remains a hard invariant before POST.
+
+### Modified
+
+- `supabase/functions/_shared/stripeDisputeHandlers.ts`
+  - Replaced `dispatchNotification` DI with `sendOpsAlertEmail`.
+  - Replaced `STRIPE_DISPUTE_ALERT_USERS` with `STRIPE_DISPUTE_ALERT_EMAILS`.
+  - Added brand-name lookup from `brands.name`, with warning + `unknown brand` fallback.
+  - Added `formatCurrencyAmount`.
+  - Reworked `alertDisputeCreated`.
+  - Added `alertDisputeLost` and wired it into `charge.dispute.closed && status === "lost"` before the existing AppsFlyer event.
+  - Left `charge.dispute.updated` alert-free.
+
+- `supabase/functions/stripe-webhook/index.ts`
+  - Replaced `dispatchNotification` import with `sendOpsAlertEmail`.
+  - Replaced `STRIPE_WEBHOOK_FAILURE_ALERT_USERS` with `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS`.
+  - Reworked `notifyWebhookSignatureFailure` to send operator email alerts and return the succeeded count.
+  - Exported `stripeWebhookHandler` and guarded `serve(...)` behind `DENO_TESTING !== "1"` so the exported notification helper can be directly tested without starting a server. Runtime behavior is unchanged outside tests.
+
+- `supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts`
+  - Mechanical `[TEST-MOD-APPROVED ORCH-0956]` effects mock rename from `dispatchNotification` to `sendOpsAlertEmail`.
+  - Added T-01, T-02, and T-03.
+
+- `supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts`
+  - Reworked the ORCH-0953 source assertions into ORCH-0956 email assertions.
+  - Added direct mocked-send coverage for T-04 and retained a source-level assertion that the invalid-signature branch returns HTTP 400.
+
+## Spec Traceability
+
+| Spec item | Result |
+|---|---|
+| Phase 7 step 1 — create `_shared/stripeOpsAlertEmail.ts` | Implemented. |
+| Phase 7 step 2 — update `_shared/stripeDisputeHandlers.ts` | Implemented. |
+| Phase 7 step 3 — update `stripe-webhook/index.ts` | Implemented. |
+| Phase 7 step 4 — update dispute handler tests T-01/T-02/T-03 + effects mock rename | Implemented. |
+| Phase 7 step 5 — add webhook signature-failure happy-path T-04 | Implemented. |
+| Phase 7 step 6 — run Deno tests | Implemented; evidence below. |
+| Phase 7 step 7 — run format/lint/check gates | Implemented; evidence below. |
+| Phase 7 step 8 — T-05 through T-08 adversarial tests | Not implemented by design; reserved for tester. |
+| Phase 7 step 9 — commit/push/PR | Local implementation commit created at `eedf32ea`; report commit follows this file. Push/PR status is recorded in the final chat. |
+
+## Verification Evidence
+
+### Targeted happy-path test run
+
+Command:
+
+```bash
+DENO_TESTING=1 deno test --allow-env --allow-net --allow-read supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+```
+
+Result: **PASS** — `8 passed | 0 failed`.
+
+Covered:
+
+- T-01: `charge.dispute.created` sends operator email alert with rich subject/body/CTA and preserves `dispute_created` AppsFlyer event.
+- T-02: `charge.dispute.closed` + `status: "lost"` sends operator email alert and preserves `dispute_lost` AppsFlyer event.
+- T-03: `charge.dispute.updated` upserts without sending operator email alert.
+- T-04: signature failure routes operator email alert via mocked `sendOpsAlertEmail` and preserves invalid-signature 400 branch.
+
+### Stripe-scoped workflow gate plus ORCH-0956 tests
+
+Command:
+
+```bash
+DENO_TESTING=1 SUPABASE_URL=https://example-test.supabase.co SUPABASE_SERVICE_ROLE_KEY=test-service-role-key-not-real STRIPE_WEBHOOK_SECRET=whsec_test STRIPE_WEBHOOK_SECRET_PLATFORM=whsec_test_platform STRIPE_WEBHOOK_SECRET_PREVIOUS= deno test --allow-env --allow-net --allow-read --no-check supabase/functions/_shared/__tests__/stripeIpAllowlist.test.ts supabase/functions/_shared/__tests__/stripeKycRemediation.test.ts supabase/functions/_shared/__tests__/stripeKycReminderSchedule.test.ts supabase/functions/_shared/__tests__/stripeWebhookRouter.test.ts supabase/functions/_shared/__tests__/stripeWebhookSignature.test.ts supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+```
+
+Result: **PASS** — `21 passed | 0 failed`.
+
+### Deno check
+
+Command:
+
+```bash
+deno check supabase/functions/stripe-webhook/index.ts supabase/functions/_shared/stripeDisputeHandlers.ts supabase/functions/_shared/stripeOpsAlertEmail.ts
+```
+
+Result: **PASS**.
+
+### Format and lint
+
+Commands:
+
+```bash
+deno fmt --check supabase/functions/_shared/stripeOpsAlertEmail.ts supabase/functions/_shared/stripeDisputeHandlers.ts supabase/functions/stripe-webhook/index.ts supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+deno lint supabase/functions/_shared/stripeOpsAlertEmail.ts supabase/functions/_shared/stripeDisputeHandlers.ts supabase/functions/stripe-webhook/index.ts supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+```
+
+Result: **PASS** — `Checked 5 files` for each gate.
+
+### Broad `_shared` suite note
+
+Command:
+
+```bash
+DENO_TESTING=1 deno test --allow-env --allow-net --allow-read --no-check supabase/functions/_shared/__tests__/ supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+```
+
+Result: **FAIL, unrelated existing tests** — `214 passed | 3 failed`.
+
+Failures were outside ORCH-0956 touched code:
+
+- `supabase/functions/_shared/__tests__/bouncer.test.ts`
+  - `ORCH-0678 T-03a`
+  - `ORCH-0678 T-03b`
+- `supabase/functions/_shared/__tests__/scorer.test.ts`
+  - `T-31: ORCH-0597 — pre-OTA Brunch, Lunch & Casual alias still unions brunch + casual_food`
+
+The Stripe-scoped workflow gate plus ORCH-0956 tests passed, so these failures are recorded as pre-existing/unrelated and not modified in this ORCH.
+
+## ORCH-0840 Step 0.5 Fails-on-Revert Evidence
+
+Implementation commit tested: `eedf32ea`.
+
+Method: temporarily restored the two implementation source files to `eedf32ea^` while leaving the new ORCH-0956 tests in place, then ran the targeted test command. The branch was restored to `HEAD` immediately afterward and the targeted test command was rerun successfully.
+
+Command:
+
+```bash
+DENO_TESTING=1 deno test --allow-env --allow-net --allow-read supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+```
+
+Expected/observed on revert: **FAIL**.
+
+Failure evidence:
+
+- T-01 failed at type-check because `sendOpsAlertEmail` does not exist in the reverted `DisputeHandlerEffects`.
+- T-02 failed at type-check for the same missing `sendOpsAlertEmail` DI seam.
+- T-03 failed at type-check for the same missing `sendOpsAlertEmail` DI seam.
+- T-04 failed before runtime because the reverted signature-failure module lacks the new email helper/import shape and test seam.
+
+Required lines:
+
+- T-01 fails-on-revert verified at `eedf32ea`.
+- T-02 fails-on-revert verified at `eedf32ea`.
+- T-03 fails-on-revert verified at `eedf32ea`.
+- T-04 fails-on-revert verified at `eedf32ea`.
+
+Post-restore proof: targeted command rerun after restoring `HEAD` returned **PASS** — `8 passed | 0 failed`.
+
+## Guardrail Confirmation
+
+| Guard | Result |
+|---|---|
+| No migration writes | Confirmed; no files under `supabase/migrations/` changed. |
+| No `supabase db push` | Confirmed; not run. |
+| No edge-function deploy | Confirmed; not run. |
+| No Supabase secret writes | Confirmed; not run. |
+| No Stripe Dashboard mutation | Confirmed; not run. |
+| No client code touched | Confirmed; no `app-mobile/`, `mingla-business/`, or `mingla-admin/` source files changed. |
+| No out-of-scope `dispatchNotification` callers modified | Confirmed; only the two spec swap sites were changed. |
+| T-05 through T-08 adversarial tests not written by implementor | Confirmed; reserved for tester. |
+
+## Deviations
+
+None from the implementation scope.
+
+Verification note: `stripe-webhook/index.ts` now exposes `stripeWebhookHandler` behind a `DENO_TESTING` serve guard so the notification helper can be imported and mocked in T-04 without starting an edge-function server during tests. This is testability-only; production/runtime behavior remains `serve(stripeWebhookHandler)`.
+
+## Deployment / Operations Notes
+
+Orchestrator owns post-merge deploy:
+
+```bash
+supabase functions deploy stripe-webhook --project-ref gqnoajqerqhnvulmnyvv
+```
+
+Seth owns post-deploy secret updates:
+
+- Add `STRIPE_DISPUTE_ALERT_EMAILS=seth@usemingla.com` or comma-separated operator allowlist.
+- Add `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS=seth@usemingla.com` or comma-separated operator allowlist.
+- Remove legacy `STRIPE_DISPUTE_ALERT_USERS` and `STRIPE_WEBHOOK_FAILURE_ALERT_USERS` at his pace.
+
+No `[deploy]` tag is needed at CLOSE because this is backend-only.
+
+## Downstream Routing
+
+Next: orchestrator review, then Claude `mingla-tester` adversarial tests T-05 through T-08 plus independent verification, then orchestrator CLOSE with `[TEST-MOD-APPROVED ORCH-0956]` in the commit subject and no `[deploy]` tag. After close/merge, orchestrator deploys `stripe-webhook`; Seth sets the two email allowlist env vars.

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
@@ -1,0 +1,295 @@
+# INVESTIGATION — ORCH-0956 [Stripe ops alerts → email]
+
+**Mode:** INVESTIGATE-only (no fix proposed in this report; SPEC follows separately).
+**Date:** 2026-05-24
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-0956-[stripe-ops-alerts-email]/` on branch `ORCH-0956-stripe-ops-alerts-email`
+**Branched from:** `main` @ `c8ab3fcd` (latest main as of dispatch).
+**Confidence:** `proven` for everything below (read directly from canonical files; no runtime layer required — pure backend code audit, exempt per Prime Directive 7).
+
+---
+
+## Symptom summary
+
+ORCH-0953 [Stripe live cutover] shipped Stripe dispute and webhook-signature-failure alerts via OneSignal push (`dispatchNotification` from `_shared/stripeEdgeAuth.ts`). Seth flagged during ORCH-0953 Phase E that push routing is unreliable for ops alerts (device-registration drift across consumer/business apps, OneSignal may silently drop) and email is the right channel for operator alerts. ORCH-0956 swaps both alert hooks to Resend email, with a comma-separated email allowlist replacing the user-ID allowlist.
+
+Expected after swap: dispute + signature-failure events trigger a Resend POST to a known operator inbox (default `seth@usemingla.com`) with an actionable subject line and a body containing full triage context (brand, event, amount, dispute reason, evidence due date, dashboard link).
+
+Actual today (on ORCH-0953 branch, where the alert hooks live): both call sites push notifications via OneSignal — no email path exists, no Resend integration is referenced from the dispute or signature-failure paths.
+
+---
+
+## 🚨 Critical dependency blocker (must be resolved before SPEC dispatch)
+
+**Branch base mismatch.** The worktree is on a branch off `main`, but ORCH-0953's implementation (the code ORCH-0956 needs to modify) has NOT yet merged to `main`. ORCH-0953's work currently lives on branch `ORCH-0953-stripe-live-cutover` only.
+
+Evidence:
+
+| Check | Result |
+|---|---|
+| `git log --oneline -10` on this worktree | Top commit is `c8ab3fcd WORKTREE_REGISTRY: record ORCH-0948 reaped row` — no ORCH-0953 commits present. |
+| `ls supabase/functions/_shared/stripeDisputeHandlers.ts` (this worktree) | File does not exist. |
+| `grep -rn "STRIPE_DISPUTE_ALERT\|STRIPE_WEBHOOK_FAILURE\|dispatchNotification" supabase/functions/` (this worktree) | Zero hits for `STRIPE_DISPUTE_ALERT` or `STRIPE_WEBHOOK_FAILURE`. `dispatchNotification` exists in `_shared/stripeEdgeAuth.ts` line 93, but no dispute caller. |
+| `git ls-tree -r ORCH-0953-stripe-live-cutover --name-only \| grep dispute` | `supabase/functions/_shared/stripeDisputeHandlers.ts` + `supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts` + `supabase/migrations/20260726000000_orch_0953_create_stripe_disputes.sql` — present on ORCH-0953 branch only. |
+| `git branch --contains bc5935fc` (the ORCH-0953 implementation commit) | `ORCH-0953-stripe-live-cutover` only — not on `main` and not on `ORCH-0956-stripe-ops-alerts-email`. |
+
+**Implication:** A SPEC written against current branch state would describe a swap of code that doesn't exist in this branch. Implementation cannot apply cleanly without first integrating ORCH-0953's code. Three resolution options the orchestrator must pick from (this report does not recommend — that's the orchestrator's call):
+
+1. **Wait for ORCH-0953 to merge to `main`, then rebase ORCH-0956 onto the new `main`.** Cleanest. Sequence ORCH-0956 strictly after ORCH-0953 close. Risk: blocks ORCH-0956 on parallel work.
+2. **Rebase ORCH-0956 branch onto `ORCH-0953-stripe-live-cutover`.** Lets work proceed now, but ORCH-0956's PR target becomes coupled to ORCH-0953's PR — must merge in order.
+3. **Cherry-pick ORCH-0953's commits onto ORCH-0956 branch.** Tightest coupling — duplicate commits will need careful PR-time handling.
+
+All technical findings below describe the code as it exists on `ORCH-0953-stripe-live-cutover`, since that is the code ORCH-0956 will modify regardless of integration strategy.
+
+---
+
+## Phase 0 ingestion (completed)
+
+- Read `Mingla_Artifacts/prompts/INTAKE_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md` (in this worktree).
+- Read `COMMS_LEDGER.md` at `/Users/sethogieva/Desktop/mingla-main/COMMS_LEDGER.md` — Active table empty, no acks required.
+- Read the canonical Mingla email helper module surface: `supabase/functions/_shared/email/index.ts`, `senders.ts` (latest, in this worktree).
+- Read ORCH-0953-branch code via `git show ORCH-0953-stripe-live-cutover:<path>` for: `_shared/stripeDisputeHandlers.ts`, `stripe-webhook/index.ts`, surrounding `dispatchNotification` consumers.
+- Read reference Resend send patterns: `supabase/functions/venue-claim-submitted-email/index.ts`, `supabase/functions/admin-send-email/index.ts`, `supabase/functions/notify-dispatch/index.ts` (latest, in this worktree).
+- Migration chain rule: not applicable (no DB migration in ORCH-0956 scope per INTAKE).
+
+---
+
+## Investigation manifest
+
+| File | Layer | Why read |
+|---|---|---|
+| `supabase/functions/_shared/email/senders.ts` | Email infra | Sender identity registry + verified-domain confirmation. |
+| `supabase/functions/_shared/email/index.ts` | Email infra | Public surface of the brand shell renderer + how callers obtain `from`/`subject`/`html`/`text`. |
+| `supabase/functions/_shared/email/genericBody.ts` (referenced; not re-read) | Email infra | Confirms the `generic_notification` variant accepts `{ title, paragraphs, cta }`. |
+| `supabase/functions/venue-claim-submitted-email/index.ts` | Reference caller | Canonical "simple ops/internal email" send pattern — direct POST to Resend with rendered shell. |
+| `supabase/functions/admin-send-email/index.ts` | Reference caller | Alternate pattern with attachment + retry hooks; richer than needed for ops alerts. |
+| `supabase/functions/notify-dispatch/index.ts` | Reference caller | Cross-checks `RESEND_API_KEY` env name + Resend endpoint URL. |
+| `supabase/functions/_shared/stripeEdgeAuth.ts` lines 93–115 | Current `dispatchNotification` definition | Confirms it's the push-path helper (writes to `notifications` table + OneSignal). |
+| `git show ORCH-0953-stripe-live-cutover:supabase/functions/_shared/stripeDisputeHandlers.ts` | Swap site #1 | Exact `alertDisputeCreated` body + invocation path. |
+| `git show ORCH-0953-stripe-live-cutover:supabase/functions/stripe-webhook/index.ts` | Swap site #2 | Exact `notifyWebhookSignatureFailure` body + invocation path. |
+| `git show ORCH-0953-stripe-live-cutover:supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts` | Test fixtures | Confirms tests mock `dispatchNotification` via injected `effects` — the swap must update fixtures. |
+
+---
+
+## Findings
+
+### 🔴 Root finding 1 — Resend helper location + sender identity (PROVEN)
+
+- **Module:** `supabase/functions/_shared/email/` is the canonical email-render module. Public surface in `index.ts`. **There is no central Resend-send wrapper** — every caller does its own `fetch("https://api.resend.com/emails", …)` POST, using the rendered `{ from, subject, html, text }` payload from `renderTransactionalEmail()`.
+- **API key env var:** `RESEND_API_KEY`. Consistent across all 7 existing callers (`admin-send-email`, `notify-dispatch`, `marketing-send`, `venue-claim-submitted-email`, `ticket-confirmation-dispatch`, `venue-claim-decision-email`, `admin-review-venue-claim`).
+- **Verified sender domain:** `usemingla.com`. Three operator-defined identities in `EMAIL_SENDERS` (`supabase/functions/_shared/email/senders.ts` lines 24–28):
+
+| Key | Default name | Default address | Override env var |
+|---|---|---|---|
+| `tickets` | Mingla | `tickets@usemingla.com` | `RESEND_TICKET_FROM` |
+| `admin` | Mingla | `hello@usemingla.com` | `RESEND_ADMIN_FROM` |
+| `system` | Mingla | `notifications@usemingla.com` | `RESEND_SYSTEM_FROM` |
+
+- **Sandbox guard:** `assertNotResendSandbox(sender)` in `senders.ts:30` rejects any `*@resend.dev` address — enforces invariant I-PROPOSED-AE `RESEND_NO_SANDBOX_SENDER`. Any new Stripe-ops email MUST call this before POST (or call `renderTransactionalEmail`, which calls it internally at `index.ts:107`).
+- **Best-fit sender for Stripe ops alerts:** `EMAIL_SENDERS.system` → `notifications@usemingla.com`. Rationale: dispute and webhook-failure alerts are operator-facing system notifications, not ticket confirmations and not admin compose. Matches the existing usage in `venue-claim-submitted-email` for similar operator-facing system notifications.
+
+### 🔴 Root finding 2 — Swap site #1: dispute alert call site (PROVEN)
+
+- **File on ORCH-0953 branch:** `supabase/functions/_shared/stripeDisputeHandlers.ts`
+- **Affected function:** `alertDisputeCreated` (lines 111–141 in the ORCH-0953-branch file).
+- **Current code (verbatim, lines 122–141 on ORCH-0953 branch):**
+
+  ```ts
+  const userIds = alertUserIdsFromEnv();
+  if (userIds.length === 0) {
+    console.warn(
+      "[stripe-dispute] STRIPE_DISPUTE_ALERT_USERS missing; dispute persisted without operator notification",
+    );
+    return;
+  }
+  for (const userId of userIds) {
+    await input.effects.dispatchNotification({
+      userId,
+      brandId: input.brandId,
+      type: "stripe_dispute_created",
+      title: "Stripe dispute opened",
+      body: `A ${input.currency.toUpperCase()} ${input.amount} dispute needs review.`,
+      data: { stripe_dispute_id: input.disputeId, amount: input.amount, currency: input.currency },
+      relatedId: input.disputeId,
+      relatedType: "stripe_dispute",
+      idempotencyKey: `stripe_dispute_created:${input.disputeId}:${userId}`,
+    });
+  }
+  ```
+
+- **Env var helper to retire:** `alertUserIdsFromEnv()` (lines 64–68) reads `STRIPE_DISPUTE_ALERT_USERS`.
+- **Trigger surface:** `alertDisputeCreated` is invoked only on `event.type === "charge.dispute.created"` (line 232). **Important scope clarification needed at SPEC time:** the INTAKE asks for `charge.dispute.created` / `updated` / `closed` alerts, but the current code only fires on `created`. SPEC must explicitly decide whether to (a) extend alert fan-out to all three event types, or (b) keep alerts only on `created` and treat the INTAKE bullet as aspirational. The `closed`-with-`status: "lost"` branch already exists (line 247) but only triggers AppsFlyer reporting, no operator alert. Recommend SPEC explicitly addresses this. (See "Open questions for SPEC" below.)
+
+### 🔴 Root finding 3 — Swap site #2: signature-failure alert call site (PROVEN)
+
+- **File on ORCH-0953 branch:** `supabase/functions/stripe-webhook/index.ts`
+- **Affected function:** `notifyWebhookSignatureFailure` (function definition lines 33–58 in the ORCH-0953-branch file).
+- **Current code (verbatim, lines 35–57 on ORCH-0953 branch):**
+
+  ```ts
+  export async function notifyWebhookSignatureFailure(
+    signature: string | null,
+    effect: typeof dispatchNotification = dispatchNotification,
+  ): Promise<number> {
+    const raw = Deno.env.get("STRIPE_WEBHOOK_FAILURE_ALERT_USERS") ?? "";
+    const userIds = Array.from(
+      new Set(raw.split(",").map((s) => s.trim()).filter(Boolean)),
+    );
+    if (userIds.length === 0) return 0;
+    for (const userId of userIds) {
+      await effect({
+        userId,
+        type: "stripe_webhook_signature_failure",
+        title: "Stripe webhook signature failed",
+        body: "Stripe webhook signature verification failed. Check live webhook signing secrets.",
+        data: { event_id: signature?.slice(0, 20) ?? null },
+        relatedId: signature?.slice(0, 20) ?? null,
+        relatedType: "stripe_webhook_signature",
+        idempotencyKey: `stripe_webhook_signature_failure:${signature?.slice(0, 20) ?? "missing"}:${userId}`,
+      });
+    }
+    return userIds.length;
+  }
+  ```
+
+- **Env var to retire:** `STRIPE_WEBHOOK_FAILURE_ALERT_USERS`.
+- **Caller:** the `catch` block at lines 86–92 of `stripe-webhook/index.ts` on signature-verify failure — single invocation site. Resilient already (`try/catch` around `notifyWebhookSignatureFailure` so an alert failure does not break the webhook 400 response). Preserve that envelope in SPEC.
+- **Mild file overlap with ORCH-0955 [Native Stripe Tax].** The INTAKE warned about this. The signature-failure swap touches the same file but in a narrowly scoped function (`notifyWebhookSignatureFailure`) and its caller block. ORCH-0955 is unlikely to touch this exact area unless it expands tax-event signature handling. Rebase risk is low but real — whichever PR merges second will need a 5-line manual fixup of imports + the catch block.
+
+### 🔴 Root finding 4 — Canonical reference pattern for the swap (PROVEN)
+
+`venue-claim-submitted-email/index.ts` lines 87–149 is the cleanest reference for a simple ops-style Resend email:
+
+```ts
+if (!RESEND_API_KEY) {
+  console.warn("[venue-claim-submitted-email] RESEND_API_KEY missing");
+  return json({ skipped: true, reason: "resend_not_configured" }, 200);
+}
+// … resolve sender from EMAIL_SENDERS.system + optional legacy override …
+const rendered = renderTransactionalEmail({
+  variant: "generic_notification",
+  recipient: { name: null, email: to },
+  body: { variant: "generic_notification", title, paragraphs, cta: null },
+});
+const res = await fetch("https://api.resend.com/emails", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${RESEND_API_KEY}`, "Content-Type": "application/json" },
+  body: JSON.stringify({
+    from: formatSenderHeader(rendered.from),
+    to: [to],
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+  }),
+});
+if (!res.ok) { /* surface error, do not throw past the ops alert envelope */ }
+```
+
+For Stripe ops alerts, the `to` field becomes an array of recipients (one POST per recipient OR a single POST with `to: [list]` — Resend supports both; SPEC should pick one consistently). The "skipped" early-return on missing API key matches the INTAKE's adversarial test case ("missing env var → no email sent + no throw").
+
+### 🟠 Contributing factor 1 — `subject` line + body content not yet specified at evidence-grade detail
+
+INTAKE describes the desired subject as `🚨 [LIVE] New chargeback dispute — $XX on event Y, evidence due 7 days`, but the existing `alertDisputeCreated` doesn't have all of those fields in scope when it fires (specifically: event name, evidence due-date relative phrasing, brand name). The function has `brandId`, `disputeId`, `amount`, `currency`. To render the INTAKE's subject, SPEC must either:
+
+- (a) Pass additional fields into `alertDisputeCreated` (brand name from `brands.name`, event name from `orders.events.name`, evidence due-date timestamp from the dispute payload), OR
+- (b) Look them up inside the alert function from `supabase` + the dispute payload, OR
+- (c) Ship a less-rich subject for v1 (e.g., `🚨 [LIVE] New chargeback dispute — ${currency.toUpperCase()} ${amount}`) and defer brand/event enrichment to a follow-up ORCH.
+
+The dispute payload already includes `evidence_details.due_by` (the `evidenceDueBy()` helper at lines 54–62 extracts it). Brand name + event name require an additional DB read. SPEC decision required.
+
+### 🟠 Contributing factor 2 — Test fixtures use injected `effects` dependency-injection pattern
+
+`_shared/__tests__/stripeDisputeHandlers.test.ts` (on ORCH-0953 branch) mocks `dispatchNotification` via the `effects` parameter of `handleChargeDispute`. The implementor's regression tests must follow the same DI pattern — pass a fake email-sender (probably a `sendOpsAlertEmail` function) through `effects`, assert it was called with the expected subject/body. This is a structural constraint on the swap: keep the DI seam (don't refactor away to direct `fetch` calls) so tests can mock without spinning up Resend.
+
+### 🟡 Hidden flaw 1 — Per-recipient idempotency key may need new shape
+
+Current keys embed `userId` (`stripe_dispute_created:${disputeId}:${userId}`). After the swap, keys embed recipient email (`stripe_dispute_created:${disputeId}:${email}` or similar). If the swap reuses keys against the same `notifications` table (where `dispatchNotification` writes), old-key rows may be orphaned. **Resolution depends on whether the new email path still writes to `notifications`.** If email-only (no `notifications` row), the key shape doesn't matter for cross-channel dedupe. If both (email + record in `notifications` for audit), pick a key shape that's stable per `(disputeId, email)`. SPEC must pick.
+
+### 🔵 Observation 1 — OneSignal `dispatchNotification` remains in use for non-Stripe-ops callers
+
+`dispatchNotification` is still called from: `brand-stripe-detach`, `stripe-webhook-health-check`, `stripeWebhookRouter` (KYC + receivable settlement), `stripe-kyc-stall-reminder`. None of those are in scope for ORCH-0956 per INTAKE ("other notification types keep using OneSignal where appropriate"). Confirmed — no swap needed for those.
+
+### 🔵 Observation 2 — Dashboard link generation for the email body
+
+To meet the INTAKE's "direct link to Stripe Dashboard dispute page", the URL pattern is `https://dashboard.stripe.com/disputes/{disputeId}` for live mode (or `https://dashboard.stripe.com/test/disputes/{disputeId}` for test). The dispute payload's `livemode: boolean` field determines mode (Stripe canonical). SPEC should pick the URL shape and decide whether to include only the live-mode link or both.
+
+### 🔵 Observation 3 — Email body recipient handling
+
+`renderTransactionalEmail` requires `recipient: { name, email }`. For ops alerts to multiple addresses, options are:
+- Loop POSTs (one per recipient) — clean idempotency, easy to assert.
+- Single POST with `to: [list]` — fewer API calls, but all recipients see all others' addresses in the `to:` header.
+- Single POST with `to: ["seth@usemingla.com"]` + `bcc: [others]` — privacy if more than one operator.
+
+Loop POSTs is the safest default and matches the existing `alertDisputeCreated` loop structure. SPEC should explicitly pick.
+
+---
+
+## Five-Layer cross-check
+
+| Layer | Truth | Disagreement? |
+|---|---|---|
+| **Docs (INTAKE)** | "Swap dispatchNotification for Resend email to `STRIPE_DISPUTE_ALERT_EMAILS` + `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS`. Reuse existing Resend integration." | — |
+| **Schema** | No DB migration in scope. `stripe_disputes` table already created by ORCH-0953 migration `20260726000000_orch_0953_create_stripe_disputes.sql` (read on ORCH-0953 branch); no new columns needed for the swap. | None. |
+| **Code (ORCH-0953 branch)** | `alertDisputeCreated` (dispute handler) + `notifyWebhookSignatureFailure` (webhook router) both call `dispatchNotification` with `userId` allowlist from `STRIPE_DISPUTE_ALERT_USERS` / `STRIPE_WEBHOOK_FAILURE_ALERT_USERS`. | None — code matches INTAKE description. |
+| **Code (this worktree, branched from main)** | Neither function exists. | **YES** — branch base predates ORCH-0953. See Critical dependency blocker. |
+| **Runtime** | Not exercised — pure backend code audit, no sim repro per Prime Directive 7 exemption. | N/A. |
+| **Data** | Production `stripe_disputes` table is empty (no live disputes yet); `STRIPE_DISPUTE_ALERT_USERS` is not set in production env per ORCH-0953 Phase E memo. The swap is therefore non-disruptive: no in-flight alert delivery to break. | None. |
+
+---
+
+## Blast radius
+
+- **Files modified by SPEC (on whichever base ORCH-0953-integrated branch becomes ORCH-0956's working base):**
+  1. `supabase/functions/_shared/stripeDisputeHandlers.ts` — `alertDisputeCreated` body + `alertUserIdsFromEnv` helper.
+  2. `supabase/functions/stripe-webhook/index.ts` — `notifyWebhookSignatureFailure` body.
+  3. `supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts` — fixture updates (mock email-sender instead of `dispatchNotification`).
+  4. (Optional, recommended) New file `supabase/functions/_shared/stripeOpsAlertEmail.ts` to host the shared `sendOpsAlertEmail(input: { subject, paragraphs, recipients[] })` helper that both call sites can call. Keeps fan-out logic DRY.
+
+- **Files NOT modified:** all other `dispatchNotification` callers (4 of them, listed in Observation 1).
+
+- **Env vars touched (Supabase project secrets):**
+  - DEPRECATED: `STRIPE_DISPUTE_ALERT_USERS`, `STRIPE_WEBHOOK_FAILURE_ALERT_USERS`. Once code stops reading them, Seth removes from project secrets at his pace.
+  - NEW: `STRIPE_DISPUTE_ALERT_EMAILS`, `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS`. Comma-separated. Seth adds at IMPLEMENT time (per INTAKE hard guard, the orchestrator does not write Supabase secrets).
+  - Reused: `RESEND_API_KEY`, `RESEND_SYSTEM_FROM` (optional), `MINGLA_LOGO_URL`, `MINGLA_FOOTER_ADDRESS`, `SUPPORT_EMAIL` — already set in production for other Resend callers.
+
+- **Edge functions to redeploy after PR merge:** `stripe-webhook` (because `_shared/stripeDisputeHandlers.ts` is bundled into it). `stripeWebhookRouter` (also imports `dispatchNotification` but isn't touched — still must redeploy if any `_shared/` import graph changed). Orchestrator owns the deploys per `feedback_orchestrator_deploys_edge_functions.md`.
+
+- **Surfaces affected:** backend-only. No client surface. No `[deploy]` tag at CLOSE commit (Vercel is not involved).
+
+- **Invariants potentially touched:** I-PROPOSED-AE `RESEND_NO_SANDBOX_SENDER` — automatic compliance if the swap uses `EMAIL_SENDERS.system` and routes through `renderTransactionalEmail` (which calls `assertNotResendSandbox` internally at `_shared/email/index.ts:107`). SPEC should explicitly cite this invariant.
+
+---
+
+## Open questions for SPEC (must be answered before IMPLEMENT dispatch)
+
+1. **Event-type scope:** does `alertDisputeCreated` extend to fire on `charge.dispute.updated` and `charge.dispute.closed` (status: `lost` / `won`), or stay scoped to `created` only as today? INTAKE bullet 1 implies all three; current code does one.
+2. **Subject-line richness:** rich subject (brand name + event name + evidence due-date phrasing) or minimal subject (`${currency} ${amount}` only) for v1? Rich requires an additional DB lookup in the alert path.
+3. **Body content depth:** plain-paragraph body (matching `generic_notification` variant — INTAKE's "simple subject + body") or richer template? Recommend plain-paragraph for v1.
+4. **Recipient fan-out:** one POST per recipient, or one POST with `to: [list]`, or `to: [first] + bcc: [rest]`?
+5. **Idempotency surface:** does the new email path also write to the `notifications` table for audit, or is the email the sole record? If sole record, no idempotency-key concern; if dual-write, what key shape?
+6. **Branch-base integration strategy:** wait for ORCH-0953 merge, rebase onto ORCH-0953 branch, or cherry-pick? (See Critical dependency blocker.)
+
+---
+
+## Discoveries for Orchestrator
+
+1. **Dependency blocker is the headline.** SPEC cannot be authored against this worktree's current branch state. Orchestrator must pick the integration strategy (wait / rebase / cherry-pick) before dispatching SPEC.
+2. **Mild file overlap with ORCH-0955 on `stripe-webhook/index.ts` is confirmed but narrow.** Both touch the file; collision is in different functions/blocks. Whichever PR merges second has a ~5-line manual rebase. Worth a Section-A note in CLOSE banner.
+3. **No new COMMS-LEDGER entry written.** The dependency on ORCH-0953 is intra-pipeline-sequencing, not a cross-chat surprise that would affect ORCH-0954 or ORCH-0955. The orchestrator can route this in-chat. If the resolution becomes "wait for ORCH-0953 PR merge", and ORCH-0953 is owned by a different chat, a COMMS-LEDGER FYI may be warranted then.
+
+---
+
+## Fix strategy (direction only — not a spec)
+
+Direction: introduce a small shared helper `_shared/stripeOpsAlertEmail.ts` exposing `sendOpsAlertEmail({ subject, paragraphs, recipients, supabase? })` that wraps the canonical `renderTransactionalEmail` + Resend POST pattern (mirroring `venue-claim-submitted-email`). The two existing alert call sites (`alertDisputeCreated`, `notifyWebhookSignatureFailure`) become thin functions that compose the subject + paragraphs from event data and call `sendOpsAlertEmail`. Both replace their `STRIPE_*_ALERT_USERS` env-var reads with comma-separated `STRIPE_*_ALERT_EMAILS` reads, normalizing email addresses (trim + lowercase). The DI seam in `DisputeHandlerEffects` swaps `dispatchNotification: typeof dispatchNotification` for `sendOpsAlertEmail: typeof sendOpsAlertEmail` so tests continue mocking via injected effects. Webhook signature-failure path swaps the `effect` parameter shape similarly.
+
+Tests:
+- Implementor happy-path (in `stripeDisputeHandlers.test.ts`): inject a fake `sendOpsAlertEmail`, fire `charge.dispute.created`, assert one call with expected subject + paragraphs + recipient list. Add a parallel test for the signature-failure path. Both must `fails-on-revert verified` at the implementation commit hash.
+- Tester adversarial: missing env var (no `STRIPE_DISPUTE_ALERT_EMAILS` set) → no email sent + no throw. Malformed event payload (missing `dispute.amount`) → graceful fallback (still sends a basic alert with what's available; logs the missing field).
+
+---
+
+## Confidence + handoff direction
+
+**Confidence:** `proven` for all findings (read from canonical source files; no runtime layer required for backend code audit).
+
+**Next phase:** SPEC (Claude `mingla-forensics` SPEC mode), but **only after the orchestrator resolves the branch-base dependency blocker and answers the six open questions above**. Without those answers, a SPEC will either be wrong or be a SPEC for the implementor to make product decisions, which is not what SPEC is for.

--- a/Mingla_Artifacts/reports/QA_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
@@ -1,0 +1,204 @@
+# QA Report: Stripe ops alerts to email (ORCH-0956)
+
+> Date: 2026-05-25
+> Mode: TARGETED + SPEC-COMPLIANCE
+> Verdict: CONDITIONAL PASS
+> Findings: P0:0 P1:0 P2:2 P3:0 P4:2
+
+## 1. Layman Summary
+
+ORCH-0956 correctly moves the targeted Stripe operator alerts from push notifications to Resend email and the tester-owned adversarial tests T-05 through T-08 pass locally. I did not find a product-code blocker in the dispute, webhook-signature, or email helper paths. The release is conditional because PR #202 is currently blocked by two GitHub checks: the append-only test gate needs the requested `[TEST-MOD-APPROVED ORCH-0956]` token on the latest close commit, and the ORCH-0863 strict-grep gate is incorrectly blocking this backend ORCH for adding a `supabase/functions/` file.
+
+No migrations were applied, no edge functions were deployed, no Supabase secrets were written, and no Stripe Dashboard settings were changed.
+
+## 2. Inputs Reviewed
+
+- Spec: `Mingla_Artifacts/specs/SPEC_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md`
+- Investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md`
+- Implementation report: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md`
+- PR: #202, `ORCH-0956-stripe-ops-alerts-email` into `main`
+- Changed implementation files:
+  - `supabase/functions/_shared/stripeOpsAlertEmail.ts`
+  - `supabase/functions/_shared/stripeDisputeHandlers.ts`
+  - `supabase/functions/stripe-webhook/index.ts`
+- Changed / added tests:
+  - `supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts`
+  - `supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts`
+  - `supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts`
+  - `supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts`
+
+## 3. Test Manifest
+
+| Layer | Files / artifacts | What was checked |
+|---|---|---|
+| Database/RLS | `stripe_disputes` migration referenced by existing tests | No ORCH-0956 migration; dispute upsert behavior still covered by existing ORCH-0953 tests. |
+| Edge/RPC/Webhooks | `stripe-webhook/index.ts`, `stripeDisputeHandlers.ts` | Invalid signature still returns 400; dispute created/lost alerts are email-only; updated remains quiet. |
+| Services/helpers | `stripeOpsAlertEmail.ts`, shared email renderer | Resend POST fan-out, recipient normalization, missing API key handling, sandbox sender guard. |
+| Hooks/State/Cache | N/A | Backend-only ORCH. |
+| Components/Screens | N/A | Backend-only ORCH. |
+| Business/Admin/Public | N/A | No client/admin UI touched. |
+| Tests/Build | Deno fmt/check/lint/test | ORCH-0956 targeted tests and Stripe-scoped gate pass locally. |
+
+## 4. Claim Verification
+
+| Claim / criterion | Evidence checked | Status | Notes |
+|---|---|---|---|
+| `charge.dispute.created` sends operator email using `STRIPE_DISPUTE_ALERT_EMAILS`. | `stripeDisputeHandlers.ts:73-75`, `137-204`, `339-349`; T-01 passing. | Verified | Uses `sendOpsAlertEmail`; no legacy user-id env in this path. |
+| `charge.dispute.closed` with `status: "lost"` sends operator email and keeps AppsFlyer. | `stripeDisputeHandlers.ts:206-249`, `359-375`; T-02 passing. | Verified | Alert happens before existing `dispute_lost` AppsFlyer event. |
+| `charge.dispute.updated` sends no alert. | `stripeDisputeHandlers.ts:339-376`; T-03 passing. | Verified | No updated branch alert exists. |
+| Missing `STRIPE_DISPUTE_ALERT_EMAILS` does not block persistence or AppsFlyer. | T-05 at `stripeDisputeHandlers.test.ts:306`; local test pass. | Verified | Warns and returns before email call. |
+| Malformed amount degrades without throwing. | T-06 at `stripeDisputeHandlers.test.ts:351`; local test pass. | Verified | Current implementation degrades missing amount to `USD 0.00`. |
+| Recipient normalization trims, lowercases, dedupes, and drops malformed values. | `stripeOpsAlertEmail.ts:27-34`; T-07 at `stripeOpsAlertEmailRecipients.test.ts:3`; local test pass. | Verified | One POST attempted to `seth@usemingla.com`. |
+| Resend sandbox sender guard prevents send and does not break dispute upsert. | `stripeOpsAlertEmail.ts:57-68`; T-08 at `stripeOpsAlertEmailSandbox.test.ts:67`; local test pass. | Verified | Direct helper rejects; dispute alert envelope catches; no fetch call. |
+| Signature-failure alert emails `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` and preserves HTTP 400. | `stripe-webhook/index.ts:33-58`, `91-102`; T-04 passing. | Verified | Alert failure is caught and invalid-signature response still returns. |
+| Legacy `*_USERS` env vars removed from the two target paths. | `rg "STRIPE_DISPUTE_ALERT_USERS|STRIPE_WEBHOOK_FAILURE_ALERT_USERS" supabase/functions` | Verified | No legacy env hits remain. |
+| Out-of-scope `dispatchNotification` callers remain untouched. | `rg "dispatchNotification" supabase/functions` | Verified | Remaining callers are brand detach, webhook health, KYC/remediation/settlement, and KYC stall reminder paths. |
+
+## 5. Verification Performed
+
+| Check | Command / method | Result | Evidence |
+|---|---|---|---|
+| Tester-owned adversarial tests T-05 through T-08 | `DENO_TESTING=1 deno test --allow-env --allow-net --allow-read supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts` | PASS | `9 passed | 0 failed` |
+| ORCH-0956 targeted suite including T-01 through T-08 and webhook T-04 | `DENO_TESTING=1 deno test --allow-env --allow-net --allow-read supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts` | PASS | `12 passed | 0 failed` |
+| Stripe-scoped workflow gate with ORCH-0956 tests | `DENO_TESTING=1 SUPABASE_URL=https://example-test.supabase.co SUPABASE_SERVICE_ROLE_KEY=test-service-role-key-not-real STRIPE_WEBHOOK_SECRET=whsec_test STRIPE_WEBHOOK_SECRET_PLATFORM=whsec_test_platform STRIPE_WEBHOOK_SECRET_PREVIOUS= deno test --allow-env --allow-net --allow-read --no-check ...` | PASS | `26 passed | 0 failed` |
+| Deno check | `deno check supabase/functions/stripe-webhook/index.ts supabase/functions/_shared/stripeDisputeHandlers.ts supabase/functions/_shared/stripeOpsAlertEmail.ts supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts` | PASS | Typecheck completed. |
+| Deno format | `deno fmt --check ...` on touched ORCH-0956 files | PASS | `Checked 7 files` |
+| Deno lint | `deno lint ...` on touched ORCH-0956 files | PASS | `Checked 7 files` |
+| PR required checks | `gh pr view 202 --json ...` + failed run logs | CONDITIONAL | PR #202 is `OPEN`, `mergeStateStatus: BLOCKED`; see P2 findings. |
+
+## 6. Constitution Compliance
+
+| Rule | Verdict | Evidence |
+|---|---|---|
+| No dead taps | N/A | Backend-only. |
+| One owner per truth | PASS | Email allowlists are env-owned; no `notifications` dual-write added. |
+| No silent failures | PASS | Missing alert env/API key warn; Resend non-2xx and send exceptions log; webhook invalid-signature still returns 400. |
+| One key per entity | N/A | No app cache/query keys. |
+| Server state server-side | PASS | Stripe dispute persistence remains server-side in edge handler. |
+| Logout clears everything | N/A | No client state. |
+| Label temporary | N/A | No transitional labels added. |
+| Subtract before adding | PASS | Replaced the two push alert paths; did not add parallel notification rows. |
+| No fabricated data | PASS | Subjects/bodies derive from Stripe payload and brand lookup, with explicit `unknown brand` fallback. |
+| Currency-aware | PASS | `formatCurrencyAmount` handles zero-decimal currencies and default USD fallback. |
+| One auth instance | N/A | No auth client surface changed. |
+| Validate at right time | PASS | Webhook signature failure handling remains before routing/persistence. |
+| Exclusion consistency | PASS | `charge.dispute.updated` stays alert-free and covered by T-03. |
+| Persisted-state startup | N/A | No persisted client state. |
+
+## 7. Findings
+
+### P0 Critical
+
+None.
+
+### P1 High
+
+None.
+
+### P2 Medium
+
+**P2-001: PR #202 is blocked by append-only test gate until the latest close commit carries the approval token**
+- **Evidence:** GitHub Actions run `26381105638`, `Test files: append-only`; log reports deleted lines in `stripeDisputeHandlers.test.ts` and `signatureFailureAlert.test.ts` and says the latest commit body lacks `[TEST-MOD-APPROVED ORCH-NNNN]`.
+- **What is wrong:** The implementation intentionally modified existing tests per spec, but CI only accepts this when the latest commit body includes `[TEST-MOD-APPROVED ORCH-0956]`. Seth also requested that token in the close commit subject.
+- **Impact:** PR cannot merge until a new close/report commit carries the token.
+- **Required fix:** Orchestrator CLOSE commit should include `[TEST-MOD-APPROVED ORCH-0956]` in the subject and body so the CI parser and Seth's requested convention are both satisfied.
+- **Retest:** Re-run PR checks and confirm `Test files: append-only` passes.
+
+**P2-002: ORCH-0863 strict-grep gate is incorrectly blocking this backend ORCH**
+- **Evidence:** GitHub Actions run `26381105657`, job `ORCH-0863: Marketing Hub Phase B invariants`; failure `C7: no-new-backend-files` flags `supabase/functions/_shared/stripeOpsAlertEmail.ts`.
+- **What is wrong:** ORCH-0956 is a legitimate backend-only Stripe ORCH, but the marketing-hub gate is globally rejecting `supabase/functions/` changes in this PR.
+- **Impact:** PR #202 cannot merge even though the ORCH-0956 local Stripe tests pass. This may also block other backend Stripe/tax ORCHs.
+- **Required fix:** Orchestrator should either scope/allowlist the ORCH-0863 gate for non-marketing backend ORCHs or explicitly waive/reroute this CI failure before close.
+- **Retest:** Re-run PR checks and confirm `ORCH-0863: Marketing Hub Phase B invariants` passes or is no longer required for this backend PR.
+
+### P3 Low
+
+None.
+
+### P4 Notes
+
+- **P4-001:** Wrote COMMS-0002 to the comms ledger for the cross-ORCH CI-gate discovery; committed directly to anchor `main` as `63d33645`.
+- **P4-002:** Existing broad `_shared` suite failures from the implementation report (`bouncer.test.ts`, `scorer.test.ts`) were not re-investigated because the dispatch scoped tester-owned adversarial tests to T-05 through T-08 only.
+
+## 8. Spec Traceability
+
+| Criterion | Status | Evidence | Finding |
+|---|---|---|---|
+| SC-1 dispute.created email alert | Implemented | T-01 pass; code `stripeDisputeHandlers.ts:137-204`, `339-349` | None |
+| SC-2 dispute.closed lost email alert | Implemented | T-02 pass; code `stripeDisputeHandlers.ts:206-249`, `359-375` | None |
+| SC-3 dispute.updated no alert | Implemented | T-03 pass | None |
+| SC-4 missing dispute email env | Implemented | T-05 pass | None |
+| SC-5 signature failure email + 400 | Implemented | T-04 pass; `stripe-webhook/index.ts:91-102` | None |
+| SC-6 missing `RESEND_API_KEY` no throw | Implemented | `stripeOpsAlertEmail.ts:45-52`; implementation evidence accepted; not one of requested T-05..T-08 | None |
+| SC-7 legacy env names removed | Implemented | `rg` shows no `STRIPE_*_ALERT_USERS` hits | None |
+| SC-8 no `notifications` dual-write | Implemented | No `dispatchNotification` call in target paths; helper only posts to Resend | None |
+| SC-9 no deploy/migration/secret/Stripe mutation | Implemented | Command history and diff review | None |
+| SC-10 sandbox sender guard | Implemented | T-08 pass | None |
+
+## 9. Security
+
+| Finding/check | Severity | Evidence | Result |
+|---|---|---|---|
+| No secret logging | P4 | Helper logs subject/count/status/detail, not API key; webhook logs signature prefix only. | PASS |
+| Sandbox sender blocked | P4 | T-08; `assertNotResendSandbox` before POST. | PASS |
+| Alert failure cannot break webhook invalid-signature response | P4 | `stripe-webhook/index.ts:94-102`; T-04. | PASS |
+| Alert failure cannot break dispute upsert | P4 | `stripeDisputeHandlers.ts:184-203`, `230-249`; T-08. | PASS |
+
+## 10. UX / Accessibility
+
+Backend-only. No user-facing UI or accessibility surface changed.
+
+## 11. Parity
+
+| Surface/path | Tested? | Result | Notes |
+|---|---|---|---|
+| Mobile | N/A | N/A | Backend-only. |
+| Business | N/A | N/A | Backend-only. |
+| Admin | N/A | N/A | Existing admin disputes surface not touched. |
+| Public/web | N/A | N/A | Backend-only. |
+| Solo | N/A | N/A | Backend-only. |
+| Collab | N/A | N/A | Backend-only. |
+| iOS | N/A | N/A | Backend-only. |
+| Android | N/A | N/A | Backend-only. |
+
+## 12. Cross-Domain Impact
+
+| Change | Mobile | Business | Admin | Edge/RPC | RLS/Data | Notes |
+|---|---|---|---|---|---|---|
+| Replace Stripe ops push alerts with email | None | None | None | `stripe-webhook`, dispute handler shared module | Existing `stripe_disputes` upsert unchanged | Backend deploy required after merge. |
+| Add shared Resend helper | None | None | None | `_shared/stripeOpsAlertEmail.ts` | None | Uses existing email shell and Resend API key. |
+
+## 13. Production Verification
+
+| Check | Method | Result | Remaining manual test |
+|---|---|---|---|
+| Local edge-function behavior | Deno unit tests and static code review | PASS | None before merge. |
+| Production secret presence | Not mutated by tester | CONDITIONAL | Seth sets `STRIPE_DISPUTE_ALERT_EMAILS` and `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` after deploy. |
+| Edge deploy | Not performed by tester | CONDITIONAL | Orchestrator deploys `stripe-webhook` after close/merge. |
+| Real Resend delivery | Not performed to avoid live email mutation | CONDITIONAL | After deploy + env vars, trigger a safe Stripe test-mode webhook or monitor first live alert. |
+
+## 14. Required Actions
+
+1. **P2-001:** Orchestrator CLOSE commit must include `[TEST-MOD-APPROVED ORCH-0956]` in the subject and body, then push so the append-only CI gate can re-evaluate.
+2. **P2-002:** Orchestrator must resolve or waive the ORCH-0863 strict-grep backend-file blocker for PR #202 before merge.
+
+## 15. Conditional / Recommended Actions
+
+1. After merge, orchestrator deploys `stripe-webhook`; no `[deploy]` tag is needed in the close commit.
+2. Seth sets `STRIPE_DISPUTE_ALERT_EMAILS` and `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` in Supabase project secrets.
+3. Seth removes legacy `STRIPE_DISPUTE_ALERT_USERS` and `STRIPE_WEBHOOK_FAILURE_ALERT_USERS` at his pace after the new env vars are live.
+
+## 16. Discoveries For Orchestrator
+
+- COMMS-0002 recorded the ORCH-0863 gate issue because it can affect other backend ORCHs, including Stripe/tax work.
+
+## 17. Retest Notes
+
+| Previous finding | Fixed? | Evidence | Regression? |
+|---|---|---|---|
+| T-05 missing dispute alert env | Verified | Local Deno test pass | No regression found. |
+| T-06 malformed amount | Verified | Local Deno test pass | No regression found. |
+| T-07 recipient normalization | Verified | Local Deno test pass | No regression found. |
+| T-08 sandbox sender rejection | Verified | Local Deno test pass | No regression found. |
+
+Retest cycle: N/A

--- a/Mingla_Artifacts/specs/SPEC_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md
@@ -1,0 +1,509 @@
+# SPEC — ORCH-0956 [Stripe ops alerts → email]
+
+**Mode:** SPEC (binding contract for implementor + tester).
+**Date:** 2026-05-25
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-0956-[stripe-ops-alerts-email]/` on branch `ORCH-0956-stripe-ops-alerts-email` (rebased onto `main` containing merged ORCH-0953 [Stripe live-mode cutover] commit `44c643c0`).
+**Severity:** S2-medium (operator visibility improvement; not a launch blocker).
+**Classification:** missing-feature + quality-gap.
+
+---
+
+## Phase 1 — Ingest the investigation
+
+This SPEC is built on `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md`. All six open product questions from the investigation are now answered by Seth (operator-locked 2026-05-25):
+
+1. **Event-type scope:** `charge.dispute.created` + `charge.dispute.closed` with `status: "lost"`. NOT `charge.dispute.updated`.
+2. **Subject richness:** rich — brand name + amount + evidence-due-days (created) / amount + brand name (closed-lost). Costs one DB lookup of `brands.name`.
+3. **Body content depth:** `generic_notification` Resend variant with structured paragraphs + Stripe Dashboard link as CTA.
+4. **Recipient fan-out:** loop POSTs (one per recipient), trim + lowercase + dedupe via `new Set`.
+5. **Idempotency surface:** email-only. No `notifications` table dual-write. Idempotency key is a stable log-only identifier.
+6. **Branch strategy:** wait-for-merge + rebase (executed 2026-05-25).
+
+The investigation's "Fix strategy" direction (introduce `_shared/stripeOpsAlertEmail.ts`, keep DI seam) is adopted unchanged.
+
+---
+
+## Phase 2 — Scope and non-goals
+
+### Scope (in)
+
+1. **New shared helper** `supabase/functions/_shared/stripeOpsAlertEmail.ts` that exposes a single `sendOpsAlertEmail` function. It wraps the canonical `EMAIL_SENDERS.system` + `renderTransactionalEmail({ variant: "generic_notification" })` + direct `fetch("https://api.resend.com/emails", …)` POST pattern used by `venue-claim-submitted-email`. Loop POST per recipient. Returns a count of successful sends.
+2. **Swap site #1:** `supabase/functions/_shared/stripeDisputeHandlers.ts` — modify `alertDisputeCreated` (lines 111–141) to read `STRIPE_DISPUTE_ALERT_EMAILS` (replaces `STRIPE_DISPUTE_ALERT_USERS`) and call `sendOpsAlertEmail` with the rich subject + paragraphs. Add a NEW alert call for `charge.dispute.closed` with `status: "lost"` — wired from `handleChargeDispute` line 247-ish where the AppsFlyer `dispute_lost` event already fires.
+3. **Swap site #2:** `supabase/functions/stripe-webhook/index.ts` — modify `notifyWebhookSignatureFailure` (lines 33–58) to read `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` (replaces `STRIPE_WEBHOOK_FAILURE_ALERT_USERS`) and call `sendOpsAlertEmail` with a signature-failure subject + body.
+4. **Env-var rename:**
+   - `STRIPE_DISPUTE_ALERT_USERS` → `STRIPE_DISPUTE_ALERT_EMAILS` (comma-separated email allowlist)
+   - `STRIPE_WEBHOOK_FAILURE_ALERT_USERS` → `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` (comma-separated email allowlist)
+   - The legacy `*_USERS` names are removed from code in the same PR. Seth removes them from Supabase project secrets at his pace post-merge.
+5. **DI-seam update:** `DisputeHandlerEffects` interface gains `sendOpsAlertEmail: typeof sendOpsAlertEmail` and loses `dispatchNotification: typeof dispatchNotification`. The webhook signature-failure path adopts the analogous DI shape (the existing `effect` parameter becomes `sendOpsAlertEmail`).
+6. **Test fixtures:** `supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts` updated to mock `sendOpsAlertEmail` instead of `dispatchNotification`, assert subject + paragraphs + recipient count on `created`, assert ZERO calls on `updated`, assert exactly one call per recipient on `closed`-with-`status:"lost"`. New parallel test file for the webhook signature-failure happy path (new file or extend existing `stripe-webhook` tests — implementor picks).
+7. **Brand-name lookup:** when the dispute payload resolves a `brand_id`, fetch `brands.name` via `supabase.from("brands").select("name").eq("id", brandId).maybeSingle()` and use it in the subject. If `brand_id` is null OR the lookup returns null/error, fall back to the literal string `"unknown brand"` in the subject — log a warning, do not throw.
+8. **Stripe Dashboard URL:** for created/closed-lost alerts, generate `https://dashboard.stripe.com/disputes/{disputeId}` when the dispute payload's `livemode === true`, else `https://dashboard.stripe.com/test/disputes/{disputeId}`. Pass as `cta: { label: "Open in Stripe Dashboard", url }` to `renderGenericBody` (via `renderTransactionalEmail`).
+
+### Non-goals (out of scope)
+
+- `charge.dispute.updated` does NOT trigger an alert (noisy during evidence period — explicit operator decision).
+- No Slack alerts. No SMS alerts. No per-brand notification preferences (operator alerts only).
+- No new DB migration. No `stripe_disputes` schema changes. No new `notifications` table rows from these paths.
+- No changes to OneSignal `dispatchNotification` callers OUTSIDE these two swap sites: `brand-stripe-detach`, `stripe-webhook-health-check`, `stripeWebhookRouter` (KYC + settlement), and `stripe-kyc-stall-reminder` are untouched.
+- No new email template variant — re-use the existing `generic_notification`.
+- No HTML email branding work (logos, custom typography) — `renderShell` already wraps everything in the Mingla brand shell.
+- No tests for the rendered HTML output (the `generic_notification` shell renderer is already covered by ORCH-0785 tests).
+
+### Assumptions
+
+- The merged ORCH-0953 code in `supabase/functions/_shared/stripeDisputeHandlers.ts` and `supabase/functions/stripe-webhook/index.ts` is the authoritative pre-swap state. (Verified by `git log` post-rebase — `44c643c0` is the merge commit.)
+- `RESEND_API_KEY`, `MINGLA_LOGO_URL`, `MINGLA_FOOTER_ADDRESS`, `SUPPORT_EMAIL` are already configured in production Supabase project secrets (assumed from 7 existing Resend callers).
+- The `brands` table has a `name` column accessible to service-role queries (verified by existing `_shared/` consumers).
+- The `livemode` boolean on Stripe dispute payloads is canonically present (Stripe API contract).
+- No active live disputes exist at merge time (per ORCH-0953 Phase E memo), so the swap is non-disruptive — no in-flight alert delivery to break.
+
+---
+
+## Phase 2.5 — Cross-Surface Impact
+
+| Surface | In scope? | Behavior |
+|---|---|---|
+| Consumer iOS (`app-mobile/` iOS) | **NO** | Backend-only — no client code touched. No surface impact. |
+| Consumer Android (`app-mobile/` Android) | **NO** | Same as above. |
+| Buyer/anonymous Web (`mingla-business/` buyer routes) | **NO** | No buyer-facing path touched. Disputes are operator-internal. |
+| Business iOS (`mingla-business/` iOS) | **NO** | No business-app code touched. Business owners do not receive Stripe ops alerts (only Mingla operator does). |
+| Business Android (`mingla-business/` Android) | **NO** | Same as above. |
+| Admin Web (`mingla-admin/`) — adjacent | **NO** | No admin UI touched. Admin already has a Stripe Disputes view (via ORCH-0953); this ORCH does not modify it. |
+| Business Web preview (`mingla-business/` dev/web) | **NO** | Same as buyer/business surfaces. |
+
+**Declared scope:** backend-only — no client surface. **No `[deploy]` tag at CLOSE commit** (no Vercel build target). Parity-enforcement at TEST is N/A across all 7 surfaces — tester verifies via Deno unit tests + edge-function runtime probe only.
+
+---
+
+## Phase 3 — Layer specifications
+
+### Edge function layer
+
+#### New file: `supabase/functions/_shared/stripeOpsAlertEmail.ts`
+
+```ts
+// ORCH-0956 — Shared helper for Stripe operator alerts via Resend email.
+// Replaces the prior OneSignal push path for dispute + webhook-signature-failure
+// alerts. See SPEC_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md.
+
+import {
+  assertNotResendSandbox,
+  EMAIL_SENDERS,
+  formatSenderHeader,
+  renderTransactionalEmail,
+} from "./email/index.ts";
+
+export interface OpsAlertEmailInput {
+  subject: string;          // Becomes both the email subject and the body H1.
+  paragraphs: string[];     // One paragraph per array entry; rendered top-to-bottom.
+  recipients: string[];     // Raw env-var-derived list; this helper normalizes.
+  cta?: { label: string; url: string } | null; // Optional CTA button (e.g. Stripe Dashboard).
+}
+
+export interface OpsAlertEmailResult {
+  attempted: number;        // Recipient count after normalize + dedupe.
+  succeeded: number;        // Resend POSTs that returned 2xx.
+  failed: number;           // Resend POSTs that returned non-2xx or threw.
+}
+
+const RESEND_API_URL = "https://api.resend.com/emails";
+
+function normalizeRecipients(raw: string[]): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .map((s) => s.trim().toLowerCase())
+        .filter((s) => s.length > 0 && s.includes("@")),
+    ),
+  );
+}
+
+export async function sendOpsAlertEmail(
+  input: OpsAlertEmailInput,
+): Promise<OpsAlertEmailResult> {
+  const recipients = normalizeRecipients(input.recipients);
+  if (recipients.length === 0) {
+    return { attempted: 0, succeeded: 0, failed: 0 };
+  }
+  const apiKey = Deno.env.get("RESEND_API_KEY");
+  if (!apiKey) {
+    console.warn("[stripe-ops-alert] RESEND_API_KEY missing; alert not sent", {
+      subject: input.subject,
+      recipientCount: recipients.length,
+    });
+    return { attempted: recipients.length, succeeded: 0, failed: 0 };
+  }
+
+  let succeeded = 0;
+  let failed = 0;
+  for (const to of recipients) {
+    try {
+      const rendered = renderTransactionalEmail({
+        variant: "generic_notification",
+        recipient: { name: null, email: to },
+        body: {
+          variant: "generic_notification",
+          title: input.subject,
+          paragraphs: input.paragraphs,
+          cta: input.cta ?? null,
+        },
+      });
+      assertNotResendSandbox(rendered.from);
+      const res = await fetch(RESEND_API_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: formatSenderHeader(rendered.from),
+          to: [to],
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+        }),
+      });
+      if (res.ok) {
+        succeeded += 1;
+      } else {
+        const detail = await res.text();
+        console.error("[stripe-ops-alert] Resend non-2xx", {
+          to,
+          status: res.status,
+          detail,
+        });
+        failed += 1;
+      }
+    } catch (err) {
+      console.error("[stripe-ops-alert] send failed", {
+        to,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      failed += 1;
+    }
+  }
+  return { attempted: recipients.length, succeeded, failed };
+}
+```
+
+Notes for implementor:
+- `EMAIL_SENDERS.system` is selected implicitly via `variant: "generic_notification"` — `renderTransactionalEmail`'s switch in `_shared/email/index.ts:25-41` routes that variant to `EMAIL_SENDERS.system` (`notifications@usemingla.com`).
+- The function MUST NOT throw on partial failures — return `OpsAlertEmailResult` instead. Callers log the result; the dispute upsert and webhook 400 response must not be derailed by alert failures.
+
+#### Modified: `supabase/functions/_shared/stripeDisputeHandlers.ts`
+
+Concrete changes (line numbers reference the post-rebase file):
+
+1. **Line 3:** delete `import { dispatchNotification } from "./stripeEdgeAuth.ts";`. Add `import { sendOpsAlertEmail } from "./stripeOpsAlertEmail.ts";`.
+2. **Lines 16–25 (DisputeHandlerEffects + defaultEffects):**
+   - Replace `dispatchNotification: typeof dispatchNotification;` with `sendOpsAlertEmail: typeof sendOpsAlertEmail;`.
+   - Replace `dispatchNotification,` in `defaultEffects` with `sendOpsAlertEmail,`.
+3. **Lines 64–68 (`alertUserIdsFromEnv`):** rename to `alertEmailsFromEnv()`. Read `STRIPE_DISPUTE_ALERT_EMAILS` instead of `STRIPE_DISPUTE_ALERT_USERS`. Body becomes:
+   ```ts
+   function alertEmailsFromEnv(): string[] {
+     const raw = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS") ?? "";
+     return raw.split(",").map((s) => s.trim()).filter(Boolean);
+   }
+   ```
+   (Dedupe + lowercase happens inside `sendOpsAlertEmail`.)
+4. **Lines 111–141 (`alertDisputeCreated`):** rewrite to call `sendOpsAlertEmail`. Signature gains a `brandName: string | null` parameter (looked up by the caller — see #6 below). Body:
+   ```ts
+   async function alertDisputeCreated(
+     input: {
+       brandName: string | null;
+       disputeId: string;
+       amount: number;
+       currency: string;
+       reason: string;
+       evidenceDueBy: string | null;
+       livemode: boolean;
+       effects: DisputeHandlerEffects;
+     },
+   ): Promise<void> {
+     const emails = alertEmailsFromEnv();
+     if (emails.length === 0) {
+       console.warn(
+         "[stripe-dispute] STRIPE_DISPUTE_ALERT_EMAILS missing; dispute persisted without operator notification",
+       );
+       return;
+     }
+     const amountStr = formatCurrencyAmount(input.amount, input.currency);
+     const brand = input.brandName ?? "unknown brand";
+     const daysUntilDue = input.evidenceDueBy
+       ? Math.max(0, Math.ceil(
+           (new Date(input.evidenceDueBy).getTime() - Date.now()) / 86_400_000,
+         ))
+       : null;
+     const subject = daysUntilDue !== null
+       ? `🚨 [LIVE] Chargeback dispute — ${amountStr} on ${brand}, evidence due in ${daysUntilDue} day${daysUntilDue === 1 ? "" : "s"}`
+       : `🚨 [LIVE] Chargeback dispute — ${amountStr} on ${brand}`;
+     const paragraphs = [
+       `A new Stripe chargeback dispute requires your review.`,
+       `Amount: ${amountStr}`,
+       `Brand: ${brand}`,
+       `Reason: ${input.reason}`,
+       input.evidenceDueBy
+         ? `Evidence due: ${input.evidenceDueBy}`
+         : `Evidence due: (not provided)`,
+       `Dispute ID: ${input.disputeId}`,
+     ];
+     const dashboardBase = input.livemode
+       ? "https://dashboard.stripe.com/disputes"
+       : "https://dashboard.stripe.com/test/disputes";
+     await input.effects.sendOpsAlertEmail({
+       subject,
+       paragraphs,
+       recipients: emails,
+       cta: { label: "Open in Stripe Dashboard", url: `${dashboardBase}/${input.disputeId}` },
+     });
+   }
+   ```
+5. **New function `alertDisputeLost`** (analogous shape, called from `handleChargeDispute` when `event.type === "charge.dispute.closed" && status === "lost"`):
+   ```ts
+   async function alertDisputeLost(
+     input: {
+       brandName: string | null;
+       disputeId: string;
+       amount: number;
+       currency: string;
+       livemode: boolean;
+       effects: DisputeHandlerEffects;
+     },
+   ): Promise<void> {
+     const emails = alertEmailsFromEnv();
+     if (emails.length === 0) return; // Already warned at creation; stay quiet on close.
+     const amountStr = formatCurrencyAmount(input.amount, input.currency);
+     const brand = input.brandName ?? "unknown brand";
+     const subject = `❌ [LIVE] Chargeback LOST — ${amountStr} on ${brand}`;
+     const paragraphs = [
+       `A Stripe chargeback was closed with status "lost".`,
+       `Amount: ${amountStr}`,
+       `Brand: ${brand}`,
+       `Dispute ID: ${input.disputeId}`,
+     ];
+     const dashboardBase = input.livemode
+       ? "https://dashboard.stripe.com/disputes"
+       : "https://dashboard.stripe.com/test/disputes";
+     await input.effects.sendOpsAlertEmail({
+       subject,
+       paragraphs,
+       recipients: emails,
+       cta: { label: "Open in Stripe Dashboard", url: `${dashboardBase}/${input.disputeId}` },
+     });
+   }
+   ```
+6. **`handleChargeDispute` (lines 188-onwards):** add a brand-name lookup right after `brandId` is resolved:
+   ```ts
+   const brandName = brandId ? await brandNameForBrandId(supabase, brandId) : null;
+   ```
+   Helper:
+   ```ts
+   async function brandNameForBrandId(
+     supabase: SupabaseClient,
+     brandId: string,
+   ): Promise<string | null> {
+     const { data, error } = await supabase
+       .from("brands")
+       .select("name")
+       .eq("id", brandId)
+       .maybeSingle();
+     if (error) {
+       console.warn("[stripe-dispute] brand name lookup failed", { brandId, error: error.message });
+       return null;
+     }
+     return (data?.name as string | undefined) ?? null;
+   }
+   ```
+   Then:
+   - In the `event.type === "charge.dispute.created"` branch (line 232 area), call `alertDisputeCreated({ brandName, disputeId, amount, currency, reason, evidenceDueBy: evidenceDueBy(dispute), livemode: dispute.livemode === true, effects })` instead of the old form.
+   - In the `event.type === "charge.dispute.closed" && status === "lost"` branch (line 247 area), ADD a call to `alertDisputeLost({ brandName, disputeId, amount, currency, livemode: dispute.livemode === true, effects })` BEFORE the existing `postDisputeAppsFlyerEvent` call.
+   - **DO NOT** add any alert for `charge.dispute.updated`.
+7. **Add `formatCurrencyAmount` helper** at the top of the file (or import from an existing shared place if one exists — implementor's call):
+   ```ts
+   function formatCurrencyAmount(amount: number, currency: string): string {
+     // Stripe amounts are in the smallest unit. For most currencies that's cents (÷100).
+     // Zero-decimal currencies (JPY, KRW) divide by 1. Mingla operates USD primarily;
+     // a quick switch covers the bases without pulling in Intl.NumberFormat.
+     const zeroDecimal = new Set(["jpy", "krw", "vnd"]);
+     const lower = currency.toLowerCase();
+     const major = zeroDecimal.has(lower) ? amount : amount / 100;
+     return `${currency.toUpperCase()} ${major.toFixed(zeroDecimal.has(lower) ? 0 : 2)}`;
+   }
+   ```
+
+#### Modified: `supabase/functions/stripe-webhook/index.ts`
+
+1. **Line 20:** delete `import { dispatchNotification } from "../_shared/stripeEdgeAuth.ts";`. Add `import { sendOpsAlertEmail } from "../_shared/stripeOpsAlertEmail.ts";`.
+2. **Lines 33–58 (`notifyWebhookSignatureFailure`):** rewrite to:
+   ```ts
+   export async function notifyWebhookSignatureFailure(
+     signature: string | null,
+     send: typeof sendOpsAlertEmail = sendOpsAlertEmail,
+   ): Promise<number> {
+     const raw = Deno.env.get("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS") ?? "";
+     const emails = raw.split(",").map((s) => s.trim()).filter(Boolean);
+     if (emails.length === 0) return 0;
+     const sigPrefix = signature?.slice(0, 20) ?? "missing";
+     const subject = `⚠️ [LIVE] Stripe webhook signature failure detected`;
+     const paragraphs = [
+       `A Stripe webhook delivery failed signature verification.`,
+       `This typically means the live webhook signing secret is wrong, the request is being replayed, or a third party is probing the endpoint.`,
+       `Signature prefix: ${sigPrefix}`,
+       `Timestamp: ${new Date().toISOString()}`,
+       `Action: confirm STRIPE_WEBHOOK_SECRET_LIVE in Supabase secrets matches the active endpoint signing secret in Stripe Dashboard → Developers → Webhooks.`,
+     ];
+     const result = await send({
+       subject,
+       paragraphs,
+       recipients: emails,
+       cta: { label: "Open Stripe webhooks dashboard", url: "https://dashboard.stripe.com/webhooks" },
+     });
+     return result.succeeded;
+   }
+   ```
+3. **Caller at lines 86–92** is unchanged in shape (still wrapped in try/catch — failure of the alert MUST NOT alter the 400 response).
+
+### Service layer
+
+N/A — no service-layer (mobile / business / admin) code touched.
+
+### Hook + Component layer
+
+N/A — no client code.
+
+### Database layer
+
+N/A — no migration. The pre-existing `stripe_disputes` table (created by ORCH-0953 migration `20260726000000_orch_0953_create_stripe_disputes.sql`) is read-only from this ORCH's perspective. The optional `brand_name` lookup reads from the pre-existing `brands.name` column.
+
+### Realtime
+
+N/A.
+
+---
+
+## Phase 4 — Success criteria (numbered, observable, testable)
+
+- **SC-1** When `charge.dispute.created` fires on `stripe-webhook` and `STRIPE_DISPUTE_ALERT_EMAILS` contains one or more valid addresses, exactly one Resend POST is issued per address, the response subject begins with `🚨 [LIVE] Chargeback dispute — ${CURRENCY} ${amount}`, the body includes amount + brand name (or `"unknown brand"` if lookup fails) + reason + evidence-due timestamp + dispute ID, and a CTA button pointing to `https://dashboard.stripe.com/disputes/{disputeId}` (or `.../test/disputes/...` when `livemode === false`) renders.
+- **SC-2** When `charge.dispute.closed` fires with `status: "lost"` and `STRIPE_DISPUTE_ALERT_EMAILS` is populated, exactly one Resend POST is issued per address with subject `❌ [LIVE] Chargeback LOST — ${CURRENCY} ${amount} on ${brand}` and the analogous body + CTA.
+- **SC-3** When `charge.dispute.updated` fires, ZERO Resend POSTs are issued from the dispute path. (No alert for updates.)
+- **SC-4** When `STRIPE_DISPUTE_ALERT_EMAILS` is unset or empty, the dispute upsert still succeeds and the AppsFlyer dispute_created event still fires. A `console.warn` is emitted with message `[stripe-dispute] STRIPE_DISPUTE_ALERT_EMAILS missing; dispute persisted without operator notification`. No exception propagates.
+- **SC-5** When the Stripe-webhook signature verification fails and `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` is populated, exactly one Resend POST per address is issued with subject `⚠️ [LIVE] Stripe webhook signature failure detected`, body containing the signature prefix + timestamp + remediation guidance, and CTA to `https://dashboard.stripe.com/webhooks`. The webhook still returns HTTP 400 `{ "error": "invalid_signature", ... }` regardless of alert send outcome.
+- **SC-6** When `RESEND_API_KEY` is unset on the production project but the alert function is invoked, `sendOpsAlertEmail` returns `{ attempted: N, succeeded: 0, failed: 0 }`, emits `console.warn` with message `[stripe-ops-alert] RESEND_API_KEY missing; alert not sent`, and does NOT throw.
+- **SC-7** Recipient normalization: `"Seth@UseMingla.com, seth@usemingla.com, , bogus"` resolves to exactly one POST to `seth@usemingla.com`. Trailing whitespace, mixed case, empty entries, and entries without `@` are filtered.
+- **SC-8** Idempotency: replaying the same `charge.dispute.created` event twice triggers TWO sets of alert POSTs (the dispute upsert is idempotent per ORCH-0953; alert dedupe is NOT in scope for ORCH-0956 — Stripe's own webhook delivery dedupe is the upstream guarantee). This is an explicit non-goal documented here so the tester does not flag it as a defect.
+- **SC-9** Resend sender identity: `from` header equals `Mingla <notifications@usemingla.com>` (the `EMAIL_SENDERS.system` default) unless `RESEND_SYSTEM_FROM` is overridden in env.
+- **SC-10** Sandbox guard: invariant I-PROPOSED-AE `RESEND_NO_SANDBOX_SENDER` is enforced — if `RESEND_SYSTEM_FROM` is set to anything ending in `@resend.dev`, `sendOpsAlertEmail` throws `email_sender_resend_sandbox_forbidden` (propagated from `assertNotResendSandbox`) and the alert is not sent.
+
+---
+
+## Phase 5 — Invariants
+
+### Preserved (existing)
+
+| Invariant | How preserved | Verifier |
+|---|---|---|
+| **I-PROPOSED-AE RESEND_NO_SANDBOX_SENDER** | `sendOpsAlertEmail` calls `assertNotResendSandbox(rendered.from)` for every recipient before POST. | Test T-08 below + existing `senders.test.ts` coverage of the assertion. |
+| **I-EMAIL-BRAND-SHELL-SINGLETON** (ORCH-0785 I-PROPOSED-AD) | All ops alerts flow through `renderTransactionalEmail` → `renderShell`. No bespoke HTML body construction. | Code review + grep for `<html` outside `_shared/email/`. |
+| **ORCH-0953 dispute persistence invariant** | The `stripe_disputes` upsert path is untouched; only the post-upsert alert side-effect changes. | Existing ORCH-0953 idempotency test (`Deno.test "replaying the same dispute is idempotent"`) continues to pass — `assertEquals(supabase.disputes.size, 1)`. |
+| **Stripe webhook 400-on-invalid-signature contract** | `notifyWebhookSignatureFailure` is still wrapped in try/catch; its return value is unused; the 400 response shape is unchanged. | Test T-05 + existing stripe-webhook tests. |
+
+### New
+
+| Invariant | Description |
+|---|---|
+| **I-PROPOSED-STRIPE-OPS-ALERT-EMAIL-ONLY** | Stripe dispute (`created`, `closed-lost`) and webhook signature-failure alerts MUST route through `sendOpsAlertEmail` to the `STRIPE_*_EMAILS` env-var allowlist. The OneSignal `dispatchNotification` path is forbidden for these two trigger types. Other Stripe-touching notifications (KYC stall, brand detach, health check, settlement receivable) keep using `dispatchNotification` and are out of scope. |
+
+No CI strict-grep gate is required for the new invariant (the swap is small and locally enforced by the import structure). Codify in `INVARIANT_REGISTRY.md` at CLOSE per the orchestrator's CLOSE Step 5e (decommissioning extension) since OneSignal-push is being decommissioned for the Stripe ops alert family specifically.
+
+---
+
+## Phase 6 — Test cases
+
+All tests live under `supabase/functions/_shared/__tests__/`. The implementor-written happy-path tests go in `stripeDisputeHandlers.test.ts` (extending the existing file) and either a new `stripeWebhookSignatureFailure.test.ts` or `stripeOpsAlertEmail.test.ts`. Implementor picks the file structure but ALL of T-01 through T-08 must be present as `Deno.test(...)` cases.
+
+| Test | Scenario | Input | Expected | Layer | Owner |
+|------|----------|-------|----------|-------|-------|
+| **T-01 (happy)** | `charge.dispute.created` triggers email alerts | `STRIPE_DISPUTE_ALERT_EMAILS="ops@example.com,ops2@example.com"`, brand lookup returns `"Acme Co"`, dispute amount 5000 USD, livemode true, evidence_details.due_by = `now + 7 days` | Exactly two `sendOpsAlertEmail` calls, OR one call with `recipients: ["ops@example.com","ops2@example.com"]` (implementor's choice — see SC-1; the helper internally loops). Subject starts with `🚨 [LIVE] Chargeback dispute — USD 50.00 on Acme Co, evidence due in 7 days`. Body contains all required fields. CTA URL = `https://dashboard.stripe.com/disputes/dp_123`. | Effects DI + helper | Implementor |
+| **T-02 (happy)** | `charge.dispute.closed` with `status: "lost"` triggers email alert | Same env, dispute closed-lost | One `sendOpsAlertEmail` call with subject `❌ [LIVE] Chargeback LOST — USD 50.00 on Acme Co`. AppsFlyer `dispute_lost` event ALSO fires (unchanged from ORCH-0953). | Effects DI + helper | Implementor |
+| **T-03 (negative)** | `charge.dispute.updated` does NOT trigger alert | Same env, dispute updated event | ZERO `sendOpsAlertEmail` calls. The dispute upsert succeeds. | Effects DI | Implementor |
+| **T-04 (happy)** | Signature failure triggers webhook alert | `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS="ops@example.com"`, webhook receives malformed body | One `sendOpsAlertEmail` call with subject `⚠️ [LIVE] Stripe webhook signature failure detected`. Body contains signature prefix + remediation guidance. Webhook returns HTTP 400. | Webhook + helper | Implementor |
+| **T-05 (adversarial — env)** | Missing `STRIPE_DISPUTE_ALERT_EMAILS` | Env var unset, dispute.created fires | Dispute upsert succeeds. ZERO `sendOpsAlertEmail` calls. `console.warn` includes `STRIPE_DISPUTE_ALERT_EMAILS missing`. No exception. | Effects DI | Tester |
+| **T-06 (adversarial — payload)** | Malformed dispute payload missing `amount` | Dispute event with `amount: undefined`, env populated | `sendOpsAlertEmail` still called; subject + paragraphs use the literal string `USD NaN.00` or `USD 0.00` (implementor picks — both acceptable; the goal is graceful degradation, not crash). Test asserts NO throw. | Effects DI | Tester |
+| **T-07 (adversarial — recipients)** | Recipient normalization | `STRIPE_DISPUTE_ALERT_EMAILS="Seth@UseMingla.com, seth@usemingla.com, , bogus"` | `sendOpsAlertEmail` receives a 4-element raw array; after internal normalization, exactly ONE Resend POST is attempted to `seth@usemingla.com`. | Helper | Tester |
+| **T-08 (adversarial — sandbox)** | Resend sandbox sender rejection | `RESEND_SYSTEM_FROM="Test <noreply@resend.dev>"`, dispute fires | `sendOpsAlertEmail` throws `email_sender_resend_sandbox_forbidden` (propagated from `assertNotResendSandbox`). The outer `handleChargeDispute` catches via the existing effects pattern and the dispute upsert still completes. | Helper + invariant | Tester |
+
+**Regression-test gate compliance (ORCH-0840 Step 0.5):** the implementor's happy-path tests (T-01, T-02, T-03, T-04) must each include a `fails-on-revert verified at <commit hash>` line in the implementation report — revert the swap commit, confirm each test FAILS, restore the swap, confirm each test PASSES. The tester's adversarial tests (T-05 through T-08) cover env-var, payload, normalization, and invariant boundary conditions that the implementor's happy-paths do not. Each set MUST be in append-only mode (no modification of existing ORCH-0953 tests beyond the documented `dispatchNotification` → `sendOpsAlertEmail` rename in the effects-mock construction).
+
+**Note on test mutation of existing ORCH-0953 tests:** the implementor MUST modify the `effects` mock in lines 99–107 + 142–146 + 171–178 of `stripeDisputeHandlers.test.ts` to swap `dispatchNotification` for `sendOpsAlertEmail`. This is a NECESSARY rename, not a weakening of test semantics. The CLOSE commit body MUST include `[TEST-MOD-APPROVED ORCH-0956]` per the append-only CI gate.
+
+---
+
+## Phase 7 — Implementation order
+
+1. **Create `supabase/functions/_shared/stripeOpsAlertEmail.ts`** with the body spec'd in Phase 3.
+2. **Update `_shared/stripeDisputeHandlers.ts`:** swap imports, rename `alertUserIdsFromEnv` → `alertEmailsFromEnv` + change env-var name, rewrite `alertDisputeCreated` body, add `alertDisputeLost`, add `brandNameForBrandId` helper, add `formatCurrencyAmount` helper, wire `alertDisputeLost` into `handleChargeDispute` closed-lost branch, update `DisputeHandlerEffects` shape.
+3. **Update `stripe-webhook/index.ts`:** swap import, rewrite `notifyWebhookSignatureFailure` body + env-var name.
+4. **Update `_shared/__tests__/stripeDisputeHandlers.test.ts`:** rename effects-mock field on existing tests (the `[TEST-MOD-APPROVED ORCH-0956]` change), add T-01, T-02, T-03 as new `Deno.test(...)` cases.
+5. **Create new test file** (or extend existing) covering T-04 happy-path for the webhook signature-failure path. Implementor picks file location.
+6. **Run** `deno test supabase/functions/_shared/__tests__/` + the new webhook test file. All tests pass.
+7. **Run** `deno fmt --check` + `deno lint` (or whatever the repo's existing edge-function gate is — implementor checks `package.json` / `Makefile` / `.github/workflows/`).
+8. **Author tester-adversarial tests T-05 through T-08.** These are written BY THE TESTER after handoff — not by implementor. (Per ORCH-0840 Step 0.5 split: implementor writes happy-path; tester writes adversarial.)
+9. **Commit on branch `ORCH-0956-stripe-ops-alerts-email`**, push, open PR to `main`.
+10. **Orchestrator deploys edge function `stripe-webhook`** post-merge via `supabase functions deploy stripe-webhook --project-ref gqnoajqerqhnvulmnyvv` (the orchestrator owns this — see `feedback_orchestrator_deploys_edge_functions.md`).
+11. **Seth adds the two new env vars** at the production project after deploy: `STRIPE_DISPUTE_ALERT_EMAILS=seth@usemingla.com` (or comma-separated list), `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS=seth@usemingla.com`. The legacy `*_USERS` vars can be removed from Supabase secrets at the same pace.
+
+No database migration. No `supabase db push`. No `[deploy]` tag at CLOSE (backend-only — no Vercel surface).
+
+---
+
+## Phase 8 — Regression prevention
+
+| Bug class | Structural safeguard |
+|---|---|
+| Future maintainer accidentally re-routes Stripe ops alerts through OneSignal | Invariant **I-PROPOSED-STRIPE-OPS-ALERT-EMAIL-ONLY** in `INVARIANT_REGISTRY.md` (added at CLOSE). |
+| Future maintainer adds `charge.dispute.updated` alerts (noisy) | Test T-03 explicitly asserts ZERO alerts on `updated`; any future code change that violates this fails the test. |
+| Resend sandbox sender accidentally configured in production | `assertNotResendSandbox` already enforced in every Resend caller; test T-08 covers this specifically for the new helper. |
+| Recipient env-var contains uppercased/duplicate/malformed entries | Test T-07 covers normalization explicitly; the `normalizeRecipients` helper enforces the contract. |
+| Resend API key rotation causing silent alert drop | Test T-06-equivalent + the `console.warn` on missing key is grep-able in logs. (Not directly enforced by CI — out of scope.) |
+| Brand name lookup throws and breaks the dispute upsert | Lookup wrapped in maybeSingle + null fallback; T-01 covers the happy lookup path; T-02 covers the closed-lost path; an explicit P3 follow-up could add a test for `brandNameForBrandId` returning error.message — currently logged via `console.warn` and returns null. |
+| Future change accidentally drops the try/catch around `notifyWebhookSignatureFailure` and causes a webhook signature-failure to throw instead of returning 400 | T-04 plus existing stripe-webhook tests pin the 400-response contract. |
+
+---
+
+## Phase 9 — Deliverables summary
+
+**Files created:**
+- `supabase/functions/_shared/stripeOpsAlertEmail.ts` (new shared helper)
+
+**Files modified:**
+- `supabase/functions/_shared/stripeDisputeHandlers.ts` (effects DI + 2 alert call sites + brand-name lookup + currency formatter)
+- `supabase/functions/stripe-webhook/index.ts` (import swap + `notifyWebhookSignatureFailure` rewrite)
+- `supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts` (`[TEST-MOD-APPROVED ORCH-0956]` effects-field rename + 3 new happy-path tests)
+
+**Files possibly created (implementor's choice):**
+- `supabase/functions/_shared/__tests__/stripeOpsAlertEmail.test.ts` (T-04 + helper-level tests) OR added to existing webhook test file.
+
+**Files NOT modified:**
+- All other `dispatchNotification` callers (`brand-stripe-detach`, `stripe-webhook-health-check`, `_shared/stripeWebhookRouter.ts`, `stripe-kyc-stall-reminder`) — untouched.
+- Any client code, migrations, RLS, admin web, business web, mobile.
+
+**Env vars (Seth adds post-merge):**
+- `STRIPE_DISPUTE_ALERT_EMAILS` (comma-separated)
+- `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` (comma-separated)
+
+**Env vars (Seth removes post-merge, at his pace):**
+- `STRIPE_DISPUTE_ALERT_USERS`
+- `STRIPE_WEBHOOK_FAILURE_ALERT_USERS`
+
+**Edge functions to deploy post-merge (orchestrator-owned):**
+- `stripe-webhook` (bundles `_shared/stripeDisputeHandlers.ts` + the new `_shared/stripeOpsAlertEmail.ts`)
+
+**CLOSE tags required in commit subject:**
+- `[TEST-MOD-APPROVED ORCH-0956]` — because the implementor renames the effects-mock field in 3 existing ORCH-0953 tests (necessary mechanical rename, not a weakening).
+- NO `[deploy]` tag — backend-only, no Vercel surface.
+
+**Downstream routing:**
+- Implementor (Codex `implementor-mingla`) executes Phase 7 steps 1–7 + 9.
+- Tester (Claude `mingla-tester`) executes Phase 7 step 8 (T-05 through T-08) + independent verification.
+- Orchestrator executes Phase 7 step 10 (deploy) post-merge.
+- Seth executes Phase 7 step 11 (env var add/remove).

--- a/supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts
+++ b/supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts
@@ -12,7 +12,7 @@ class FakeQuery {
   private filters: Record<string, unknown> = {};
   private updatePayload: Record<string, unknown> | null = null;
 
-  select(): FakeQuery {
+  select(_columns?: string): FakeQuery {
     return this;
   }
   eq(column: string, value: unknown): FakeQuery {
@@ -27,20 +27,29 @@ class FakeQuery {
     this.updatePayload = payload;
     return this;
   }
-  async maybeSingle(): Promise<QueryResult> {
+  maybeSingle(): Promise<QueryResult> {
     if (this.table === "stripe_connect_accounts") {
-      return { data: { brand_id: this.db.brandId }, error: null };
+      return Promise.resolve({
+        data: { brand_id: this.db.brandId },
+        error: null,
+      });
     }
     if (this.table === "orders") {
       const byCharge = this.filters.stripe_charge_id === this.db.chargeId;
       const byPi =
         this.filters.stripe_payment_intent_id === this.db.paymentIntentId;
-      return {
+      return Promise.resolve({
         data: byCharge || byPi ? { id: this.db.orderId } : null,
         error: null,
-      };
+      });
     }
-    return { data: null, error: null };
+    if (this.table === "brands") {
+      return Promise.resolve({
+        data: { name: this.db.brandName },
+        error: null,
+      });
+    }
+    return Promise.resolve({ data: null, error: null });
   }
   then(resolve: (value: QueryResult) => void): Promise<void> {
     if (this.table === "stripe_disputes" && this.updatePayload) {
@@ -56,6 +65,7 @@ class FakeQuery {
 
 class FakeSupabase {
   brandId = "00000000-0000-4000-8000-000000000001";
+  brandName = "Acme Co";
   orderId = "00000000-0000-4000-8000-000000000002";
   chargeId = "ch_123";
   paymentIntentId = "pi_123";
@@ -66,7 +76,11 @@ class FakeSupabase {
   }
 }
 
-const event = (type: string, status = "needs_response") => ({
+const event = (
+  type: string,
+  status = "needs_response",
+  disputeOverrides: Record<string, unknown> = {},
+) => ({
   id: `evt_${type}`,
   type,
   account: "acct_connected",
@@ -81,37 +95,73 @@ const event = (type: string, status = "needs_response") => ({
       reason: "fraudulent",
       evidence_details: { due_by: 1_800_000_000 },
       is_charge_refundable: false,
+      livemode: true,
+      ...disputeOverrides,
     },
   },
 });
 
-Deno.test("ORCH-0953 §3.3 — dispute.created upserts one row and dispatches configured operator alerts", async () => {
-  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_USERS");
-  Deno.env.set("STRIPE_DISPUTE_ALERT_USERS", "user-a,user-b");
+Deno.test("ORCH-0956 T-01 — dispute.created upserts one row and sends configured operator email alerts", async () => {
+  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  Deno.env.set(
+    "STRIPE_DISPUTE_ALERT_EMAILS",
+    "ops@example.com,ops2@example.com",
+  );
   const supabase = new FakeSupabase();
-  const notifications: unknown[] = [];
+  const alerts: {
+    subject: string;
+    paragraphs: string[];
+    recipients: string[];
+    cta?: { label: string; url: string } | null;
+  }[] = [];
   const appsFlyerEvents: string[] = [];
+  const dueBy = Math.floor(Date.now() / 1000) + 7 * 86_400;
   try {
     await handleChargeDispute(
       supabase as never,
-      event("charge.dispute.created"),
+      event("charge.dispute.created", "needs_response", {
+        evidence_details: { due_by: dueBy },
+      }),
       {
-        dispatchNotification: (async (input: unknown) => {
-          notifications.push(input);
+        sendOpsAlertEmail: ((input: {
+          subject: string;
+          paragraphs: string[];
+          recipients: string[];
+          cta?: { label: string; url: string } | null;
+        }) => {
+          alerts.push(input);
+          return Promise.resolve({
+            attempted: input.recipients.length,
+            succeeded: input.recipients.length,
+            failed: 0,
+          });
         }) as never,
-        resolveBrandOwnerUserId: (async () => "owner-user") as never,
-        postAppsFlyerS2SEvent: (async (input: { eventName: string }) => {
+        resolveBrandOwnerUserId: (() => Promise.resolve("owner-user")) as never,
+        postAppsFlyerS2SEvent: ((input: { eventName: string }) => {
           appsFlyerEvents.push(input.eventName);
-          return true;
+          return Promise.resolve(true);
         }) as never,
       },
     );
     assertEquals(supabase.disputes.size, 1);
-    assertEquals(notifications.length, 2);
+    assertEquals(alerts.length, 1);
+    assertStringIncludes(
+      alerts[0].subject,
+      "🚨 [LIVE] Chargeback dispute — USD 50.00 on Acme Co, evidence due in 7 days",
+    );
+    assertEquals(alerts[0].recipients, ["ops@example.com", "ops2@example.com"]);
+    assertStringIncludes(alerts[0].paragraphs.join("\n"), "Amount: USD 50.00");
+    assertStringIncludes(alerts[0].paragraphs.join("\n"), "Brand: Acme Co");
+    assertStringIncludes(alerts[0].paragraphs.join("\n"), "Reason: fraudulent");
+    assertStringIncludes(alerts[0].paragraphs.join("\n"), "Dispute ID: dp_123");
+    assertEquals(alerts[0].cta, {
+      label: "Open in Stripe Dashboard",
+      url: "https://dashboard.stripe.com/disputes/dp_123",
+    });
     assertEquals(appsFlyerEvents, ["dispute_created"]);
   } finally {
-    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_USERS");
-    else Deno.env.set("STRIPE_DISPUTE_ALERT_USERS", prior);
+    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);
   }
 });
 
@@ -136,13 +186,18 @@ Deno.test("ORCH-0953 §3.3 — stripe_disputes migration declares schema, RLS, a
 });
 
 Deno.test("ORCH-0953 §3.3 — replaying the same dispute is idempotent", async () => {
-  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_USERS");
-  Deno.env.delete("STRIPE_DISPUTE_ALERT_USERS");
+  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
   const supabase = new FakeSupabase();
   const effects = {
-    dispatchNotification: (async () => {}) as never,
-    resolveBrandOwnerUserId: (async () => null) as never,
-    postAppsFlyerS2SEvent: (async () => true) as never,
+    sendOpsAlertEmail: (() =>
+      Promise.resolve({
+        attempted: 0,
+        succeeded: 0,
+        failed: 0,
+      })) as never,
+    resolveBrandOwnerUserId: (() => Promise.resolve(null)) as never,
+    postAppsFlyerS2SEvent: (() => Promise.resolve(true)) as never,
   };
   try {
     await handleChargeDispute(
@@ -157,25 +212,90 @@ Deno.test("ORCH-0953 §3.3 — replaying the same dispute is idempotent", async 
     );
     assertEquals(supabase.disputes.size, 1);
   } finally {
-    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_USERS");
-    else Deno.env.set("STRIPE_DISPUTE_ALERT_USERS", prior);
+    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);
   }
 });
 
-Deno.test("ORCH-0953 §3.3 — closed lost dispute posts dispute_lost AppsFlyer event", async () => {
+Deno.test("ORCH-0956 T-02 — closed lost dispute sends email alert and posts dispute_lost AppsFlyer event", async () => {
+  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", "ops@example.com");
   const supabase = new FakeSupabase();
+  const alerts: {
+    subject: string;
+    paragraphs: string[];
+    recipients: string[];
+    cta?: { label: string; url: string } | null;
+  }[] = [];
   const appsFlyerEvents: string[] = [];
-  await handleChargeDispute(
-    supabase as never,
-    event("charge.dispute.closed", "lost"),
-    {
-      dispatchNotification: (async () => {}) as never,
-      resolveBrandOwnerUserId: (async () => "owner-user") as never,
-      postAppsFlyerS2SEvent: (async (input: { eventName: string }) => {
-        appsFlyerEvents.push(input.eventName);
-        return true;
-      }) as never,
-    },
-  );
-  assertEquals(appsFlyerEvents, ["dispute_lost"]);
+  try {
+    await handleChargeDispute(
+      supabase as never,
+      event("charge.dispute.closed", "lost"),
+      {
+        sendOpsAlertEmail: ((input: {
+          subject: string;
+          paragraphs: string[];
+          recipients: string[];
+          cta?: { label: string; url: string } | null;
+        }) => {
+          alerts.push(input);
+          return Promise.resolve({
+            attempted: input.recipients.length,
+            succeeded: input.recipients.length,
+            failed: 0,
+          });
+        }) as never,
+        resolveBrandOwnerUserId: (() => Promise.resolve("owner-user")) as never,
+        postAppsFlyerS2SEvent: ((input: { eventName: string }) => {
+          appsFlyerEvents.push(input.eventName);
+          return Promise.resolve(true);
+        }) as never,
+      },
+    );
+    assertEquals(alerts.length, 1);
+    assertEquals(
+      alerts[0].subject,
+      "❌ [LIVE] Chargeback LOST — USD 50.00 on Acme Co",
+    );
+    assertEquals(alerts[0].recipients, ["ops@example.com"]);
+    assertStringIncludes(
+      alerts[0].paragraphs.join("\n"),
+      'A Stripe chargeback was closed with status "lost".',
+    );
+    assertEquals(alerts[0].cta, {
+      label: "Open in Stripe Dashboard",
+      url: "https://dashboard.stripe.com/disputes/dp_123",
+    });
+    assertEquals(appsFlyerEvents, ["dispute_lost"]);
+  } finally {
+    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);
+  }
+});
+
+Deno.test("ORCH-0956 T-03 — dispute.updated upserts without sending operator email alerts", async () => {
+  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", "ops@example.com");
+  const supabase = new FakeSupabase();
+  const alerts: unknown[] = [];
+  try {
+    await handleChargeDispute(
+      supabase as never,
+      event("charge.dispute.updated"),
+      {
+        sendOpsAlertEmail: ((input: unknown) => {
+          alerts.push(input);
+          return Promise.resolve({ attempted: 1, succeeded: 1, failed: 0 });
+        }) as never,
+        resolveBrandOwnerUserId: (() => Promise.resolve("owner-user")) as never,
+        postAppsFlyerS2SEvent: (() => Promise.resolve(true)) as never,
+      },
+    );
+    assertEquals(supabase.disputes.size, 1);
+    assertEquals(alerts.length, 0);
+  } finally {
+    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);
+  }
 });

--- a/supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts
+++ b/supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts
@@ -1,5 +1,8 @@
-import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
-import { assertStringIncludes } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
 import { handleChargeDispute } from "../stripeDisputeHandlers.ts";
 
 type QueryResult = { data?: unknown; error?: { message: string } | null };
@@ -294,6 +297,100 @@ Deno.test("ORCH-0956 T-03 — dispute.updated upserts without sending operator e
     );
     assertEquals(supabase.disputes.size, 1);
     assertEquals(alerts.length, 0);
+  } finally {
+    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);
+  }
+});
+
+Deno.test("ORCH-0956 T-05 — missing dispute email env does not block upsert or AppsFlyer", async () => {
+  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+  console.warn = ((message?: unknown) => {
+    warnings.push(String(message));
+  }) as typeof console.warn;
+  const supabase = new FakeSupabase();
+  const alerts: unknown[] = [];
+  const appsFlyerEvents: string[] = [];
+  try {
+    await handleChargeDispute(
+      supabase as never,
+      event("charge.dispute.created"),
+      {
+        sendOpsAlertEmail: ((input: unknown) => {
+          alerts.push(input);
+          return Promise.resolve({ attempted: 1, succeeded: 1, failed: 0 });
+        }) as never,
+        resolveBrandOwnerUserId: (() => Promise.resolve("owner-user")) as never,
+        postAppsFlyerS2SEvent: ((input: { eventName: string }) => {
+          appsFlyerEvents.push(input.eventName);
+          return Promise.resolve(true);
+        }) as never,
+      },
+    );
+    assertEquals(supabase.disputes.size, 1);
+    assertEquals(alerts.length, 0);
+    assertEquals(appsFlyerEvents, ["dispute_created"]);
+    assert(
+      warnings.some((warning) =>
+        warning.includes(
+          "STRIPE_DISPUTE_ALERT_EMAILS missing; dispute persisted without operator notification",
+        )
+      ),
+      "missing alert email env warning should be emitted",
+    );
+  } finally {
+    console.warn = originalWarn;
+    if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);
+  }
+});
+
+Deno.test("ORCH-0956 T-06 — missing dispute amount degrades without throwing", async () => {
+  const prior = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", "ops@example.com");
+  const supabase = new FakeSupabase();
+  const alerts: {
+    subject: string;
+    paragraphs: string[];
+    recipients: string[];
+  }[] = [];
+  try {
+    await handleChargeDispute(
+      supabase as never,
+      event("charge.dispute.created", "needs_response", { amount: undefined }),
+      {
+        sendOpsAlertEmail: ((input: {
+          subject: string;
+          paragraphs: string[];
+          recipients: string[];
+        }) => {
+          alerts.push(input);
+          return Promise.resolve({
+            attempted: input.recipients.length,
+            succeeded: input.recipients.length,
+            failed: 0,
+          });
+        }) as never,
+        resolveBrandOwnerUserId: (() => Promise.resolve("owner-user")) as never,
+        postAppsFlyerS2SEvent: (() => Promise.resolve(true)) as never,
+      },
+    );
+    assertEquals(supabase.disputes.size, 1);
+    assertEquals(alerts.length, 1);
+    assert(
+      alerts[0].subject.includes("USD 0.00") ||
+        alerts[0].subject.includes("USD NaN.00"),
+      "malformed amount should degrade to an explicit currency amount",
+    );
+    assert(
+      alerts[0].paragraphs.some((paragraph) =>
+        paragraph === "Amount: USD 0.00" || paragraph === "Amount: USD NaN.00"
+      ),
+      "body should include the degraded amount",
+    );
   } finally {
     if (prior === undefined) Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
     else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", prior);

--- a/supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts
+++ b/supabase/functions/_shared/__tests__/stripeOpsAlertEmailRecipients.test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+Deno.test("ORCH-0956 T-07 — ops alert email normalizes duplicate and malformed recipients", async () => {
+  const priorTesting = Deno.env.get("DENO_TESTING");
+  const priorApiKey = Deno.env.get("RESEND_API_KEY");
+  const priorSystemFrom = Deno.env.get("RESEND_SYSTEM_FROM");
+  const originalFetch = globalThis.fetch;
+  const posts: Record<string, unknown>[] = [];
+  Deno.env.set("DENO_TESTING", "1");
+  Deno.env.set("RESEND_API_KEY", "re_test_key");
+  Deno.env.delete("RESEND_SYSTEM_FROM");
+  globalThis.fetch = ((_url, init) => {
+    const body = (init as { body?: BodyInit | null } | undefined)?.body;
+    posts.push(JSON.parse(String(body)));
+    return Promise.resolve(new Response("{}", { status: 202 }));
+  }) as typeof fetch;
+  try {
+    const { sendOpsAlertEmail } = await import(
+      `../stripeOpsAlertEmail.ts?t07=${Date.now()}`
+    );
+    const result = await sendOpsAlertEmail({
+      subject: "Recipient normalization test",
+      paragraphs: ["Only one normalized recipient should receive this."],
+      recipients: ["Seth@UseMingla.com", " seth@usemingla.com", " ", "bogus"],
+      cta: null,
+    });
+    assertEquals(result, { attempted: 1, succeeded: 1, failed: 0 });
+    assertEquals(posts.length, 1);
+    assertEquals(posts[0].to, ["seth@usemingla.com"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (priorTesting === undefined) Deno.env.delete("DENO_TESTING");
+    else Deno.env.set("DENO_TESTING", priorTesting);
+    if (priorApiKey === undefined) Deno.env.delete("RESEND_API_KEY");
+    else Deno.env.set("RESEND_API_KEY", priorApiKey);
+    if (priorSystemFrom === undefined) Deno.env.delete("RESEND_SYSTEM_FROM");
+    else Deno.env.set("RESEND_SYSTEM_FROM", priorSystemFrom);
+  }
+});

--- a/supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts
+++ b/supabase/functions/_shared/__tests__/stripeOpsAlertEmailSandbox.test.ts
@@ -1,0 +1,150 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+type QueryResult = { data?: unknown; error?: { message: string } | null };
+
+class FakeQuery {
+  constructor(private table: string, private db: FakeSupabase) {}
+  private filters: Record<string, unknown> = {};
+  private payload: Record<string, unknown> | null = null;
+
+  select(): FakeQuery {
+    return this;
+  }
+  eq(column: string, value: unknown): FakeQuery {
+    this.filters[column] = value;
+    return this;
+  }
+  upsert(payload: Record<string, unknown>): FakeQuery {
+    this.payload = payload;
+    return this;
+  }
+  maybeSingle(): Promise<QueryResult> {
+    if (this.table === "stripe_connect_accounts") {
+      return Promise.resolve({
+        data: { brand_id: this.db.brandId },
+        error: null,
+      });
+    }
+    if (this.table === "brands") {
+      return Promise.resolve({ data: { name: "Acme Co" }, error: null });
+    }
+    if (this.table === "orders") {
+      const byCharge = this.filters.stripe_charge_id === "ch_123";
+      return Promise.resolve({
+        data: byCharge ? { id: this.db.orderId } : null,
+        error: null,
+      });
+    }
+    return Promise.resolve({ data: null, error: null });
+  }
+  then(resolve: (value: QueryResult) => void): Promise<void> {
+    if (this.table === "stripe_disputes" && this.payload) {
+      this.db.disputes.set(
+        String(this.payload.stripe_dispute_id),
+        this.payload,
+      );
+      resolve({ data: this.payload, error: null });
+      return Promise.resolve();
+    }
+    resolve({ data: null, error: null });
+    return Promise.resolve();
+  }
+}
+
+class FakeSupabase {
+  brandId = "00000000-0000-4000-8000-000000000001";
+  orderId = "00000000-0000-4000-8000-000000000002";
+  disputes = new Map<string, Record<string, unknown>>();
+  from(table: string): FakeQuery {
+    return new FakeQuery(table, this);
+  }
+}
+
+Deno.test("ORCH-0956 T-08 — sandbox sender rejection is caught by dispute alert envelope", async () => {
+  const priorTesting = Deno.env.get("DENO_TESTING");
+  const priorApiKey = Deno.env.get("RESEND_API_KEY");
+  const priorEmails = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS");
+  const priorSystemFrom = Deno.env.get("RESEND_SYSTEM_FROM");
+  const originalFetch = globalThis.fetch;
+  const originalError = console.error;
+  const errors: string[] = [];
+  let fetchCalls = 0;
+  Deno.env.set("DENO_TESTING", "1");
+  Deno.env.set("RESEND_API_KEY", "re_test_key");
+  Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", "ops@example.com");
+  Deno.env.set("RESEND_SYSTEM_FROM", "Test <noreply@resend.dev>");
+  globalThis.fetch = (() => {
+    fetchCalls += 1;
+    return Promise.resolve(new Response("{}", { status: 202 }));
+  }) as typeof fetch;
+  console.error = ((...args: unknown[]) => {
+    errors.push(args.map((arg) => JSON.stringify(arg)).join(" "));
+  }) as typeof console.error;
+  try {
+    const [{ sendOpsAlertEmail }, { handleChargeDispute }] = await Promise.all([
+      import(`../stripeOpsAlertEmail.ts?t08=${Date.now()}`),
+      import(`../stripeDisputeHandlers.ts?t08=${Date.now()}`),
+    ]);
+    await assertRejects(
+      () =>
+        sendOpsAlertEmail({
+          subject: "Sandbox sender test",
+          paragraphs: ["This should never send."],
+          recipients: ["ops@example.com"],
+          cta: null,
+        }),
+      Error,
+      "email_sender_resend_sandbox_forbidden",
+    );
+    const supabase = new FakeSupabase();
+    await handleChargeDispute(
+      supabase as never,
+      {
+        id: "evt_t08",
+        type: "charge.dispute.created",
+        account: "acct_connected",
+        data: {
+          object: {
+            id: "dp_t08",
+            charge: "ch_123",
+            payment_intent: "pi_123",
+            amount: 5000,
+            currency: "usd",
+            status: "needs_response",
+            reason: "fraudulent",
+            evidence_details: { due_by: 1_800_000_000 },
+            is_charge_refundable: false,
+            livemode: true,
+          },
+        },
+      },
+      {
+        sendOpsAlertEmail,
+        resolveBrandOwnerUserId: (() => Promise.resolve("owner-user")) as never,
+        postAppsFlyerS2SEvent: (() => Promise.resolve(true)) as never,
+      },
+    );
+    assertEquals(supabase.disputes.size, 1);
+    assertEquals(fetchCalls, 0);
+    assertStringIncludes(
+      errors.join("\n"),
+      "email_sender_resend_sandbox_forbidden",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalError;
+    if (priorTesting === undefined) Deno.env.delete("DENO_TESTING");
+    else Deno.env.set("DENO_TESTING", priorTesting);
+    if (priorApiKey === undefined) Deno.env.delete("RESEND_API_KEY");
+    else Deno.env.set("RESEND_API_KEY", priorApiKey);
+    if (priorEmails === undefined) {
+      Deno.env.delete("STRIPE_DISPUTE_ALERT_EMAILS");
+    } else Deno.env.set("STRIPE_DISPUTE_ALERT_EMAILS", priorEmails);
+    if (priorSystemFrom === undefined) Deno.env.delete("RESEND_SYSTEM_FROM");
+    else Deno.env.set("RESEND_SYSTEM_FROM", priorSystemFrom);
+  }
+});

--- a/supabase/functions/_shared/stripeDisputeHandlers.ts
+++ b/supabase/functions/_shared/stripeDisputeHandlers.ts
@@ -1,10 +1,10 @@
 // @ts-ignore — Deno ESM import
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { dispatchNotification } from "./stripeEdgeAuth.ts";
 import {
   postAppsFlyerS2SEvent,
   resolveBrandOwnerUserId,
 } from "./appsFlyerS2S.ts";
+import { sendOpsAlertEmail } from "./stripeOpsAlertEmail.ts";
 
 export interface StripeDisputeWebhookEvent {
   id: string;
@@ -14,16 +14,25 @@ export interface StripeDisputeWebhookEvent {
 }
 
 export interface DisputeHandlerEffects {
-  dispatchNotification: typeof dispatchNotification;
+  sendOpsAlertEmail: typeof sendOpsAlertEmail;
   postAppsFlyerS2SEvent: typeof postAppsFlyerS2SEvent;
   resolveBrandOwnerUserId: typeof resolveBrandOwnerUserId;
 }
 
 const defaultEffects: DisputeHandlerEffects = {
-  dispatchNotification,
+  sendOpsAlertEmail,
   postAppsFlyerS2SEvent,
   resolveBrandOwnerUserId,
 };
+
+function formatCurrencyAmount(amount: number, currency: string): string {
+  const zeroDecimal = new Set(["jpy", "krw", "vnd"]);
+  const lower = currency.toLowerCase();
+  const major = zeroDecimal.has(lower) ? amount : amount / 100;
+  return `${currency.toUpperCase()} ${
+    major.toFixed(zeroDecimal.has(lower) ? 0 : 2)
+  }`;
+}
 
 function stringValue(
   obj: Record<string, unknown>,
@@ -61,11 +70,9 @@ function evidenceDueBy(dispute: Record<string, unknown>): string | null {
   return dueBy === null ? null : new Date(dueBy * 1000).toISOString();
 }
 
-function alertUserIdsFromEnv(): string[] {
-  const raw = Deno.env.get("STRIPE_DISPUTE_ALERT_USERS") ?? "";
-  return Array.from(
-    new Set(raw.split(",").map((s) => s.trim()).filter(Boolean)),
-  );
+function alertEmailsFromEnv(): string[] {
+  const raw = Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS") ?? "";
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
 }
 
 async function brandIdForStripeAccount(
@@ -85,7 +92,7 @@ async function orderIdForDispute(
   supabase: SupabaseClient,
   input: { chargeId: string; paymentIntentId: string | null },
 ): Promise<string | null> {
-  let query = supabase
+  const query = supabase
     .from("orders")
     .select("id")
     .eq("stripe_charge_id", input.chargeId)
@@ -108,38 +115,136 @@ async function orderIdForDispute(
   return data?.id ?? null;
 }
 
+async function brandNameForBrandId(
+  supabase: SupabaseClient,
+  brandId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("brands")
+    .select("name")
+    .eq("id", brandId)
+    .maybeSingle();
+  if (error) {
+    console.warn("[stripe-dispute] brand name lookup failed", {
+      brandId,
+      error: error.message,
+    });
+    return null;
+  }
+  return (data?.name as string | undefined) ?? null;
+}
+
 async function alertDisputeCreated(
   input: {
-    brandId: string | null;
+    brandName: string | null;
     disputeId: string;
     amount: number;
     currency: string;
+    reason: string;
+    evidenceDueBy: string | null;
+    livemode: boolean;
     effects: DisputeHandlerEffects;
   },
 ): Promise<void> {
-  const userIds = alertUserIdsFromEnv();
-  if (userIds.length === 0) {
+  const emails = alertEmailsFromEnv();
+  if (emails.length === 0) {
     console.warn(
-      "[stripe-dispute] STRIPE_DISPUTE_ALERT_USERS missing; dispute persisted without operator notification",
+      "[stripe-dispute] STRIPE_DISPUTE_ALERT_EMAILS missing; dispute persisted without operator notification",
     );
     return;
   }
-  for (const userId of userIds) {
-    await input.effects.dispatchNotification({
-      userId,
-      brandId: input.brandId,
-      type: "stripe_dispute_created",
-      title: "Stripe dispute opened",
-      body:
-        `A ${input.currency.toUpperCase()} ${input.amount} dispute needs review.`,
-      data: {
-        stripe_dispute_id: input.disputeId,
-        amount: input.amount,
-        currency: input.currency,
+  const amountStr = formatCurrencyAmount(input.amount, input.currency);
+  const brand = input.brandName ?? "unknown brand";
+  const daysUntilDue = input.evidenceDueBy
+    ? Math.max(
+      0,
+      Math.ceil(
+        (new Date(input.evidenceDueBy).getTime() - Date.now()) / 86_400_000,
+      ),
+    )
+    : null;
+  const subject = daysUntilDue !== null
+    ? `🚨 [LIVE] Chargeback dispute — ${amountStr} on ${brand}, evidence due in ${daysUntilDue} day${
+      daysUntilDue === 1 ? "" : "s"
+    }`
+    : `🚨 [LIVE] Chargeback dispute — ${amountStr} on ${brand}`;
+  const paragraphs = [
+    "A new Stripe chargeback dispute requires your review.",
+    `Amount: ${amountStr}`,
+    `Brand: ${brand}`,
+    `Reason: ${input.reason}`,
+    input.evidenceDueBy
+      ? `Evidence due: ${input.evidenceDueBy}`
+      : "Evidence due: (not provided)",
+    `Dispute ID: ${input.disputeId}`,
+  ];
+  const dashboardBase = input.livemode
+    ? "https://dashboard.stripe.com/disputes"
+    : "https://dashboard.stripe.com/test/disputes";
+  try {
+    const result = await input.effects.sendOpsAlertEmail({
+      subject,
+      paragraphs,
+      recipients: emails,
+      cta: {
+        label: "Open in Stripe Dashboard",
+        url: `${dashboardBase}/${input.disputeId}`,
       },
-      relatedId: input.disputeId,
-      relatedType: "stripe_dispute",
-      idempotencyKey: `stripe_dispute_created:${input.disputeId}:${userId}`,
+    });
+    console.info("[stripe-dispute] dispute-created email alert result", {
+      disputeId: input.disputeId,
+      result,
+    });
+  } catch (err) {
+    console.error("[stripe-dispute] dispute-created email alert failed", {
+      disputeId: input.disputeId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function alertDisputeLost(
+  input: {
+    brandName: string | null;
+    disputeId: string;
+    amount: number;
+    currency: string;
+    livemode: boolean;
+    effects: DisputeHandlerEffects;
+  },
+): Promise<void> {
+  const emails = alertEmailsFromEnv();
+  if (emails.length === 0) return;
+  const amountStr = formatCurrencyAmount(input.amount, input.currency);
+  const brand = input.brandName ?? "unknown brand";
+  const subject = `❌ [LIVE] Chargeback LOST — ${amountStr} on ${brand}`;
+  const paragraphs = [
+    'A Stripe chargeback was closed with status "lost".',
+    `Amount: ${amountStr}`,
+    `Brand: ${brand}`,
+    `Dispute ID: ${input.disputeId}`,
+  ];
+  const dashboardBase = input.livemode
+    ? "https://dashboard.stripe.com/disputes"
+    : "https://dashboard.stripe.com/test/disputes";
+  try {
+    const result = await input.effects.sendOpsAlertEmail({
+      subject,
+      paragraphs,
+      recipients: emails,
+      cta: {
+        label: "Open in Stripe Dashboard",
+        url: `${dashboardBase}/${input.disputeId}`,
+      },
+    });
+    console.info("[stripe-dispute] dispute-lost email alert result", {
+      disputeId: input.disputeId,
+      result,
+    });
+  } catch (err) {
+    console.error("[stripe-dispute] dispute-lost email alert failed", {
+      disputeId: input.disputeId,
+      error: err instanceof Error ? err.message : String(err),
     });
   }
 }
@@ -200,6 +305,9 @@ export async function handleChargeDispute(
   const reason = stringValue(dispute, "reason") ?? "unknown";
   const isChargeRefundable = dispute.is_charge_refundable === true;
   const brandId = await brandIdForStripeAccount(supabase, stripeAccountId);
+  const brandName = brandId
+    ? await brandNameForBrandId(supabase, brandId)
+    : null;
   const orderId = await orderIdForDispute(supabase, {
     chargeId: stripeChargeId,
     paymentIntentId,
@@ -230,10 +338,13 @@ export async function handleChargeDispute(
 
   if (event.type === "charge.dispute.created") {
     await alertDisputeCreated({
-      brandId,
+      brandName,
       disputeId,
       amount,
       currency,
+      reason,
+      evidenceDueBy: evidenceDueBy(dispute),
+      livemode: dispute.livemode === true,
       effects,
     });
     await postDisputeAppsFlyerEvent(supabase, {
@@ -246,6 +357,14 @@ export async function handleChargeDispute(
     });
   }
   if (event.type === "charge.dispute.closed" && status === "lost") {
+    await alertDisputeLost({
+      brandName,
+      disputeId,
+      amount,
+      currency,
+      livemode: dispute.livemode === true,
+      effects,
+    });
     await postDisputeAppsFlyerEvent(supabase, {
       brandId,
       eventName: "dispute_lost",

--- a/supabase/functions/_shared/stripeOpsAlertEmail.ts
+++ b/supabase/functions/_shared/stripeOpsAlertEmail.ts
@@ -1,0 +1,105 @@
+// ORCH-0956 — Shared helper for Stripe operator alerts via Resend email.
+// Replaces the prior OneSignal push path for dispute + webhook-signature-failure
+// alerts. See SPEC_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md.
+
+import {
+  assertNotResendSandbox,
+  EMAIL_SENDERS,
+  formatSenderHeader,
+  renderTransactionalEmail,
+} from "./email/index.ts";
+
+export interface OpsAlertEmailInput {
+  subject: string;
+  paragraphs: string[];
+  recipients: string[];
+  cta?: { label: string; url: string } | null;
+}
+
+export interface OpsAlertEmailResult {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+}
+
+const RESEND_API_URL = "https://api.resend.com/emails";
+
+function normalizeRecipients(raw: string[]): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .map((s) => s.trim().toLowerCase())
+        .filter((s) => s.length > 0 && s.includes("@")),
+    ),
+  );
+}
+
+export async function sendOpsAlertEmail(
+  input: OpsAlertEmailInput,
+): Promise<OpsAlertEmailResult> {
+  const recipients = normalizeRecipients(input.recipients);
+  if (recipients.length === 0) {
+    return { attempted: 0, succeeded: 0, failed: 0 };
+  }
+
+  const apiKey = Deno.env.get("RESEND_API_KEY");
+  if (!apiKey) {
+    console.warn("[stripe-ops-alert] RESEND_API_KEY missing; alert not sent", {
+      subject: input.subject,
+      recipientCount: recipients.length,
+    });
+    return { attempted: recipients.length, succeeded: 0, failed: 0 };
+  }
+
+  let succeeded = 0;
+  let failed = 0;
+  for (const to of recipients) {
+    const rendered = renderTransactionalEmail({
+      variant: "generic_notification",
+      sender: EMAIL_SENDERS.system,
+      recipient: { name: null, email: to },
+      body: {
+        variant: "generic_notification",
+        title: input.subject,
+        paragraphs: input.paragraphs,
+        cta: input.cta ?? null,
+      },
+    });
+    assertNotResendSandbox(rendered.from);
+
+    try {
+      const res = await fetch(RESEND_API_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: formatSenderHeader(rendered.from),
+          to: [to],
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+        }),
+      });
+      if (res.ok) {
+        succeeded += 1;
+      } else {
+        const detail = await res.text();
+        console.error("[stripe-ops-alert] Resend non-2xx", {
+          to,
+          status: res.status,
+          detail,
+        });
+        failed += 1;
+      }
+    } catch (err) {
+      console.error("[stripe-ops-alert] send failed", {
+        to,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      failed += 1;
+    }
+  }
+  return { attempted: recipients.length, succeeded, failed };
+}

--- a/supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
+++ b/supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts
@@ -1,15 +1,81 @@
 import {
   assert,
+  assertEquals,
   assertStringIncludes,
 } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 
-Deno.test("ORCH-0953 §3.10 — stripe-webhook has signature-failure notification hook", async () => {
+Deno.test("ORCH-0956 T-04 — signature failure routes operator email alert", async () => {
+  const priorTesting = Deno.env.get("DENO_TESTING");
+  const priorEmails = Deno.env.get("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS");
+  Deno.env.set("DENO_TESTING", "1");
+  Deno.env.set("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS", "ops@example.com");
+  try {
+    const mod = await import(`../index.ts?orch0956=${Date.now()}`);
+    const alerts: {
+      subject: string;
+      paragraphs: string[];
+      recipients: string[];
+      cta?: { label: string; url: string } | null;
+    }[] = [];
+    const count = await mod.notifyWebhookSignatureFailure(
+      "t=12345,v1=abcdef0123456789abcdef",
+      ((input: {
+        subject: string;
+        paragraphs: string[];
+        recipients: string[];
+        cta?: { label: string; url: string } | null;
+      }) => {
+        alerts.push(input);
+        return Promise.resolve({ attempted: 1, succeeded: 1, failed: 0 });
+      }) as never,
+    );
+    assertEquals(count, 1);
+    assertEquals(alerts.length, 1);
+    assertEquals(
+      alerts[0].subject,
+      "⚠️ [LIVE] Stripe webhook signature failure detected",
+    );
+    assertEquals(alerts[0].recipients, ["ops@example.com"]);
+    assertStringIncludes(
+      alerts[0].paragraphs.join("\n"),
+      "Signature prefix: t=12345,v1=abcdef01",
+    );
+    assertStringIncludes(
+      alerts[0].paragraphs.join("\n"),
+      "STRIPE_WEBHOOK_SECRET_LIVE",
+    );
+    assertEquals(alerts[0].cta, {
+      label: "Open Stripe webhooks dashboard",
+      url: "https://dashboard.stripe.com/webhooks",
+    });
+  } finally {
+    if (priorTesting === undefined) Deno.env.delete("DENO_TESTING");
+    else Deno.env.set("DENO_TESTING", priorTesting);
+    if (priorEmails === undefined) {
+      Deno.env.delete("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS");
+    } else {
+      Deno.env.set("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS", priorEmails);
+    }
+  }
+});
+
+Deno.test("ORCH-0956 T-04 — invalid-signature branch preserves 400 response", async () => {
   const source = await Deno.readTextFile(
     new URL("../index.ts", import.meta.url),
   );
-  assertStringIncludes(source, "STRIPE_WEBHOOK_FAILURE_ALERT_USERS");
-  assertStringIncludes(source, "stripe_webhook_signature_failure");
+  assertStringIncludes(source, "STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS");
+  assertStringIncludes(
+    source,
+    "⚠️ [LIVE] Stripe webhook signature failure detected",
+  );
+  assertStringIncludes(source, "Signature prefix: ${sigPrefix}");
+  assertStringIncludes(source, "STRIPE_WEBHOOK_SECRET_LIVE");
+  assertStringIncludes(source, "https://dashboard.stripe.com/webhooks");
   assertStringIncludes(source, "notifyWebhookSignatureFailure(signature)");
+  assertStringIncludes(
+    source,
+    'return plainResponse({ error: "invalid_signature"',
+  );
   assert(
     source.indexOf("notifyWebhookSignatureFailure(signature)") >
       source.indexOf("signature verification failed"),
@@ -17,9 +83,9 @@ Deno.test("ORCH-0953 §3.10 — stripe-webhook has signature-failure notificatio
   );
 });
 
-Deno.test("ORCH-0953 §3.10 — missing alert env returns without throwing", async () => {
+Deno.test("ORCH-0956 §3.10 — missing signature-failure email env returns without throwing", async () => {
   const source = await Deno.readTextFile(
     new URL("../index.ts", import.meta.url),
   );
-  assertStringIncludes(source, "if (userIds.length === 0) return 0;");
+  assertStringIncludes(source, "if (emails.length === 0) return 0;");
 });

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -17,7 +17,7 @@ import {
   getStripeWebhookSecretsFromEnv,
   verifyStripeWebhookSignature,
 } from "../_shared/stripeWebhookSignature.ts";
-import { dispatchNotification } from "../_shared/stripeEdgeAuth.ts";
+import { sendOpsAlertEmail } from "../_shared/stripeOpsAlertEmail.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -32,31 +32,33 @@ function plainResponse(body: unknown, status = 200): Response {
 
 export async function notifyWebhookSignatureFailure(
   signature: string | null,
-  effect: typeof dispatchNotification = dispatchNotification,
+  send: typeof sendOpsAlertEmail = sendOpsAlertEmail,
 ): Promise<number> {
-  const raw = Deno.env.get("STRIPE_WEBHOOK_FAILURE_ALERT_USERS") ?? "";
-  const userIds = Array.from(
-    new Set(raw.split(",").map((s) => s.trim()).filter(Boolean)),
-  );
-  if (userIds.length === 0) return 0;
-  for (const userId of userIds) {
-    await effect({
-      userId,
-      type: "stripe_webhook_signature_failure",
-      title: "Stripe webhook signature failed",
-      body: "Stripe webhook signature verification failed. Check live webhook signing secrets.",
-      data: {
-        event_id: signature?.slice(0, 20) ?? null,
-      },
-      relatedId: signature?.slice(0, 20) ?? null,
-      relatedType: "stripe_webhook_signature",
-      idempotencyKey: `stripe_webhook_signature_failure:${signature?.slice(0, 20) ?? "missing"}:${userId}`,
-    });
-  }
-  return userIds.length;
+  const raw = Deno.env.get("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS") ?? "";
+  const emails = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  if (emails.length === 0) return 0;
+  const sigPrefix = signature?.slice(0, 20) ?? "missing";
+  const subject = "⚠️ [LIVE] Stripe webhook signature failure detected";
+  const paragraphs = [
+    "A Stripe webhook delivery failed signature verification.",
+    "This typically means the live webhook signing secret is wrong, the request is being replayed, or a third party is probing the endpoint.",
+    `Signature prefix: ${sigPrefix}`,
+    `Timestamp: ${new Date().toISOString()}`,
+    "Action: confirm STRIPE_WEBHOOK_SECRET_LIVE in Supabase secrets matches the active endpoint signing secret in Stripe Dashboard -> Developers -> Webhooks.",
+  ];
+  const result = await send({
+    subject,
+    paragraphs,
+    recipients: emails,
+    cta: {
+      label: "Open Stripe webhooks dashboard",
+      url: "https://dashboard.stripe.com/webhooks",
+    },
+  });
+  return result.succeeded;
 }
 
-serve(async (req) => {
+export async function stripeWebhookHandler(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return plainResponse({ error: "method_not_allowed" }, 405);
   }
@@ -80,14 +82,22 @@ serve(async (req) => {
   const stripe = stripeWebhook();
   let verified;
   try {
-    verified = await verifyStripeWebhookSignature(stripe, rawBody, signature, secrets);
+    verified = await verifyStripeWebhookSignature(
+      stripe,
+      rawBody,
+      signature,
+      secrets,
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[stripe-webhook] signature verification failed:", message);
     try {
       await notifyWebhookSignatureFailure(signature);
     } catch (notifyErr) {
-      console.error("[stripe-webhook] signature-failure alert failed:", notifyErr);
+      console.error(
+        "[stripe-webhook] signature-failure alert failed:",
+        notifyErr,
+      );
     }
     return plainResponse({ error: "invalid_signature", detail: message }, 400);
   }
@@ -98,10 +108,13 @@ serve(async (req) => {
   const ipAllowed = verifyStripeSourceIp(req);
   if (!ipAllowed) {
     const sourceIp = extractClientIp(req);
-    console.warn("[stripe-webhook] Stripe signature valid but source IP not allowlisted", {
-      sourceIp,
-      event_id: event.id,
-    });
+    console.warn(
+      "[stripe-webhook] Stripe signature valid but source IP not allowlisted",
+      {
+        sourceIp,
+        event_id: event.id,
+      },
+    );
     try {
       await writeAudit(supabase, {
         user_id: null,
@@ -134,14 +147,23 @@ serve(async (req) => {
     eventRowId = existingRow.id;
     priorRetryCount = Number(existingRow.retry_count ?? 0);
     if (existingRow.processed === true) {
-      return plainResponse({ status: "replayed_processed", event_id: event.id }, 200);
+      return plainResponse(
+        { status: "replayed_processed", event_id: event.id },
+        200,
+      );
     }
-    if (existingRow.retries_exhausted === true || priorRetryCount >= MAX_WEBHOOK_ATTEMPTS) {
+    if (
+      existingRow.retries_exhausted === true ||
+      priorRetryCount >= MAX_WEBHOOK_ATTEMPTS
+    ) {
       await supabase
         .from("payment_webhook_events")
         .update({ retries_exhausted: true })
         .eq("id", eventRowId);
-      return plainResponse({ status: "retries_exhausted", event_id: event.id }, 200);
+      return plainResponse(
+        { status: "retries_exhausted", event_id: event.id },
+        200,
+      );
     }
   } else {
     const { data: insertedRow, error: insertError } = await supabase
@@ -175,7 +197,8 @@ serve(async (req) => {
   }
 
   const nextRetryCount = priorRetryCount + 1;
-  const exhausted = processingError !== null && nextRetryCount >= MAX_WEBHOOK_ATTEMPTS;
+  const exhausted = processingError !== null &&
+    nextRetryCount >= MAX_WEBHOOK_ATTEMPTS;
   const updatePayload: Record<string, unknown> = {
     processed: processingError === null,
     processed_at: new Date().toISOString(),
@@ -188,7 +211,9 @@ serve(async (req) => {
     .from("payment_webhook_events")
     .update(updatePayload)
     .eq("id", eventRowId);
-  if (markError) console.error("[stripe-webhook] mark processed failed:", markError);
+  if (markError) {
+    console.error("[stripe-webhook] mark processed failed:", markError);
+  }
 
   return plainResponse({
     status: processingError === null ? "ok" : "processing_failed",
@@ -197,4 +222,8 @@ serve(async (req) => {
     signature_secret: verified.secretName,
     ip_allowed: ipAllowed,
   }, 200);
-});
+}
+
+if (Deno.env.get("DENO_TESTING") !== "1") {
+  serve(stripeWebhookHandler);
+}


### PR DESCRIPTION
## Summary
- Replaces Stripe dispute + signature-failure OneSignal operator alerts with Resend email alerts.
- Adds `_shared/stripeOpsAlertEmail.ts`, rich dispute created/lost subjects + CTA, and signature-failure email body + CTA.
- Adds implementor happy-path tests T-01 through T-04 and implementation report at `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0956_STRIPE_OPS_ALERTS_EMAIL.md`.

## Verification
- PASS: `DENO_TESTING=1 deno test --allow-env --allow-net --allow-read supabase/functions/_shared/__tests__/stripeDisputeHandlers.test.ts supabase/functions/stripe-webhook/__tests__/signatureFailureAlert.test.ts` (`8 passed`).
- PASS: Stripe-scoped workflow gate plus ORCH-0956 tests (`21 passed`).
- PASS: `deno check` on edited edge modules.
- PASS: `deno fmt --check` and `deno lint` on edited files/tests.
- FAIL noted in report: full `_shared` suite has unrelated existing bouncer/scorer failures outside ORCH-0956 touched code.

## Guards
No migrations, no Supabase secret writes, no Supabase deploy, no Stripe Dashboard mutations, no client surfaces, and no `[deploy]` tag. Tester owns T-05 through T-08 adversarial tests next.