### PR TITLE
[deploy] Hotfix: vercel.json SPA-fallback for web.output:single (P0 production routing dead)

### DIFF
--- a/mingla-business/vercel.json
+++ b/mingla-business/vercel.json
@@ -44,13 +44,7 @@
       "destination": "/api/public-brand?brandSlug=:brandSlug"
     },
     { "source": "/stripe-onboarding-return", "destination": "/stripe-onboarding-return.html" },
-    { "source": "/e/:brandSlug/:eventSlug", "destination": "/e/[brandSlug]/[eventSlug]" },
-    { "source": "/t/:brandSlug/:tripSlug", "destination": "/t/[brandSlug]/[tripSlug]" },
-    { "source": "/b/:brandSlug", "destination": "/b/[brandSlug]" },
-    { "source": "/checkout/:eventId", "destination": "/checkout/[eventId]" },
-    { "source": "/checkout/:eventId/:step", "destination": "/checkout/[eventId]/:step" },
-    { "source": "/checkout-trip/:tripEventId", "destination": "/checkout-trip/[tripEventId]" },
-    { "source": "/checkout-trip/:tripEventId/:step", "destination": "/checkout-trip/[tripEventId]/:step" }
+    { "source": "/(.*)", "destination": "/" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary

P0 production hotfix. PR #205 (META-ORCH-0952 close) flipped \`mingla-business/app.json\` \`web.output: static → single\` to fix the React #418 hydration error firing across every dynamic route. Single-mode emits one \`dist/index.html\` instead of per-route bracket-notation HTML files. The seven \`vercel.json\` rewrites that pointed at \`/e/[brandSlug]/...\`, \`/checkout/[eventId]/...\`, etc. now target non-existent files → every non-root URL on \`business.usemingla.com\` returns Vercel NOT_FOUND. Every shared link in the wild is broken right now. Discovered by Seth via curl: \`/\` returns 200 (stale cache), \`/auth/sign-in\`, \`/checkout/*\`, \`/e/*/*\`, \`/b/*\`, \`/t/*/*\` all NOT_FOUND.

Fix: remove the seven broken bracket-target rewrites, add standard SPA catch-all \`{ "source": "/(.*)", "destination": "/" }\` at the end so the SPA shell hydrates for any path and React Router resolves the route client-side. OG rewrites + bot user-agent gated SSR rewrites preserved before the catch-all so social previews still work.

## Test plan

- [x] JSON validated locally (\`python3 -m json.tool\`)
- [ ] Post-merge: \`curl -I https://business.usemingla.com/auth/sign-in\` returns 200 (not NOT_FOUND)
- [ ] Post-merge: \`curl -I https://business.usemingla.com/checkout/test-id\` returns 200
- [ ] Post-merge: Seth fresh paid 3-ticket Apple Pay purchase on physical iPhone Safari — confirms BC-11 carousel + restored SPA routing both work

## Scope

Single file: \`mingla-business/vercel.json\`. No app code, no tests, no migrations, no edge fns, no Stripe, no DB.