### PR TITLE
ORCH-0977 marketing-cards: [deploy] AASA + assetlinks for Universal Links / App Links

### DIFF
--- a/mingla-marketing/public/.well-known/apple-app-site-association
+++ b/mingla-marketing/public/.well-known/apple-app-site-association
@@ -1,0 +1,16 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "782KVMY869.com.mingla.app.v2",
+        "paths": [
+          "/invite/*",
+          "/board/*",
+          "/orders/*",
+          "/chat/*"
+        ]
+      }
+    ]
+  }
+}

--- a/mingla-marketing/public/.well-known/assetlinks.json
+++ b/mingla-marketing/public/.well-known/assetlinks.json
@@ -1,0 +1,13 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.mingla.app.v2",
+      "sha256_cert_fingerprints": [
+        "06:4E:20:DE:0E:A7:4E:AC:72:9D:D7:68:66:5E:B2:70:56:3E:5B:9C:65:C9:12:B5:AC:E5:D6:A0:84:47:7A:BC",
+        "90:28:F8:B1:A5:80:79:26:73:AE:DF:DE:00:C3:3D:C1:BC:0A:2A:C6:A3:B2:C0:5B:56:6F:97:67:53:48:0E:02"
+      ]
+    }
+  }
+]

--- a/mingla-marketing/vercel.json
+++ b/mingla-marketing/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" }
+      ]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds the two well-known files iOS Universal Links + Android App Links require, plus a Vercel headers config so they're served as \`application/json\` (CI invariant requirement).

## Files
- \`mingla-marketing/public/.well-known/apple-app-site-association\` — appID \`782KVMY869.com.mingla.app.v2\`, paths \`/invite/*\`, \`/board/*\`, \`/orders/*\`, \`/chat/*\` (matches \`app-mobile/app.json\` intentFilters exactly).
- \`mingla-marketing/public/.well-known/assetlinks.json\` — package \`com.mingla.app.v2\` with both production SHA-256 fingerprints (Play Console: app signing key + upload key).
- \`mingla-marketing/vercel.json\` — \`Content-Type: application/json\` headers for both .well-known paths.

## Why this matters
Without these, the consumer app can't register Universal Links / App Links with Apple + Google. Tapping a \`https://usemingla.com/invite/...\` link would open the browser instead of the app. This was launch checklist item #21 for ORCH-0977.

## Verification
- [x] \`npm run build\` (mingla-marketing) — clean, 6 static pages, no regressions
- [x] \`.github/scripts/strict-grep/orch-0964-well-known-json-content-type.mjs\` — passes locally
- [ ] Post-merge: curl both URLs from usemingla.com, confirm 200 + \`Content-Type: application/json\`
- [ ] Post-merge: Apple's CDN validator + Google's Digital Asset Links validator

## Cutover context
The marketing site itself (#221) went live on usemingla.com earlier today. This PR completes ORCH-0977 marketing-cards by adding the deep-link metadata. Consumer app submission to App Store + Play Store with working deep links becomes possible after this lands.