### PR TITLE
ORCH-0977 marketing-cards: [deploy] /privacy-policy standalone page (#30)

### DIFF
--- a/mingla-marketing/app/privacy-policy/page.tsx
+++ b/mingla-marketing/app/privacy-policy/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { PRIVACY_SECTIONS, PRIVACY_EFFECTIVE_DATE } from '@/lib/privacyContent'
+import { cn } from '@/lib/cn'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Mingla',
+  description:
+    'How Mingla collects, uses, discloses, and safeguards your information when you use our app and website.',
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main
+      id="main"
+      className="relative min-h-screen overflow-hidden bg-[#08090b] px-5 py-8 text-text-primary sm:px-8 sm:py-10"
+    >
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_18%_12%,rgba(235,120,37,0.18),transparent_32%),radial-gradient(ellipse_at_84%_18%,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#08090b_0%,#0d0d10_58%,#07080a_100%)]" />
+        <div className="absolute inset-0 opacity-[0.09] [background-image:linear-gradient(rgba(235,120,37,0.22)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.14)_1px,transparent_1px)] [background-size:72px_72px]" />
+        <div className="absolute left-[-18%] top-[12%] h-[34rem] w-[70%] rotate-[-14deg] rounded-[50%] border border-dashed border-warm/20" />
+        <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-black to-transparent" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-3xl">
+        <Link
+          href="/"
+          className="mb-8 inline-flex w-fit min-h-10 items-center rounded-full border border-white/12 bg-white/8 px-4 text-sm font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+        >
+          Back to Mingla
+        </Link>
+
+        <article className="rounded-[28px] border border-white/12 bg-[#0d0d10]/94 p-6 shadow-[0_40px_120px_rgba(0,0,0,0.52),inset_0_1px_0_rgba(255,255,255,0.08)] sm:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-warm">
+            Effective Date: {PRIVACY_EFFECTIVE_DATE}
+          </p>
+          <h1 className="mt-3 font-display text-4xl leading-tight text-white sm:text-6xl">
+            Privacy Policy
+          </h1>
+
+          <div className="mt-8 space-y-6">
+            {PRIVACY_SECTIONS.map((section) => {
+              const hasContact = 'contact' in section
+
+              return (
+                <section
+                  key={section.title}
+                  className={cn(
+                    'space-y-3',
+                    hasContact &&
+                      'rounded-3xl border border-warm/25 bg-warm/10 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+                  )}
+                >
+                  <h2 className="font-display text-xl leading-tight text-white/95 sm:text-2xl">
+                    {section.title}
+                  </h2>
+                  <div className="space-y-3 text-sm leading-7 text-white/72 sm:text-base">
+                    {section.paragraphs.map((paragraph) => (
+                      <p key={paragraph}>{paragraph}</p>
+                    ))}
+                    {'bullets' in section ? (
+                      <ul className="space-y-2 pl-5">
+                        {section.bullets.map((bullet) => (
+                          <li key={bullet} className="list-disc marker:text-warm/80">
+                            {bullet}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                    {'footer' in section ? <p>{section.footer}</p> : null}
+                    {hasContact ? (
+                      <div className="space-y-3 rounded-2xl border border-white/12 bg-black/20 p-4 text-white/82">
+                        <p className="font-semibold text-white">
+                          {section.contact.name}
+                        </p>
+                        <p>
+                          Email:{' '}
+                          <a
+                            href={`mailto:${section.contact.email}`}
+                            className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                          >
+                            {section.contact.email}
+                          </a>
+                        </p>
+                        <p>
+                          Website:{' '}
+                          <a
+                            href={section.contact.website}
+                            className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                          >
+                            {section.contact.website}
+                          </a>
+                        </p>
+                      </div>
+                    ) : null}
+                  </div>
+                </section>
+              )
+            })}
+          </div>
+        </article>
+      </div>
+    </main>
+  )
+}

--- a/mingla-marketing/components/sections/explorer-home/hero.tsx
+++ b/mingla-marketing/components/sections/explorer-home/hero.tsx
@@ -23,6 +23,7 @@ import type { LucideIcon } from 'lucide-react'
 import { useMinglaReducedMotion } from '@/lib/reduced-motion'
 import { HeroVibeDeck } from '@/components/sections/explorer-home/hero-vibe-deck'
 import { cn } from '@/lib/cn'
+import { PRIVACY_SECTIONS, PRIVACY_EFFECTIVE_DATE } from '@/lib/privacyContent'
 
 // ---------------------------------------------------------------
 // Mingla Explorer Hero
@@ -199,162 +200,6 @@ const TERMS_SECTIONS = [
   },
 ] as const
 
-const PRIVACY_SECTIONS = [
-  {
-    title: '1. Introduction',
-    paragraphs: [
-      'Welcome to Mingla ("we," "our," or "us"). Mingla is a date and hangout planning app operated by usemingla.com. We are committed to protecting your personal information and your right to privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our mobile application and website (collectively, the "Service").',
-      'Please read this policy carefully. If you disagree with its terms, please discontinue use of our Service.',
-    ],
-  },
-  {
-    title: '2. Information We Collect',
-    paragraphs: [],
-  },
-  {
-    title: '2.1 Information You Provide',
-    paragraphs: [],
-    bullets: [
-      'Full name and display name',
-      'Email address',
-      'Phone number (used for SMS verification and invite features)',
-      'Profile information such as preferences, location, and interests',
-      'Content you submit, including date plans, reviews, and messages',
-    ],
-  },
-  {
-    title: '2.2 Information Collected Automatically',
-    paragraphs: [],
-    bullets: [
-      'Device information (device type, operating system, unique device identifiers)',
-      'Usage data (features used, pages visited, time spent in-app)',
-      'Location data (with your permission, to suggest local experiences)',
-      'Log data (IP address, browser type, referring URLs)',
-    ],
-  },
-  {
-    title: '2.3 Information from Third Parties',
-    paragraphs: [],
-    bullets: [
-      'Google Sign-In: name, email address, and profile picture from your Google account',
-      'Apple Sign-In: name and email address from your Apple ID',
-    ],
-  },
-  {
-    title: '3. How We Use Your Information',
-    paragraphs: ['We use the information we collect to:'],
-    bullets: [
-      'Create and manage your Mingla account',
-      'Verify your phone number via one-time SMS passcodes (OTP)',
-      'Send invite SMS messages on your behalf when you invite friends to join Mingla',
-      'Generate personalized date and hangout plans based on your preferences',
-      'Suggest local experiences, venues, and activities near you',
-      'Improve and develop our Service',
-      'Communicate with you about updates, features, and support',
-      'Detect and prevent fraud, abuse, and security incidents',
-      'Comply with legal obligations',
-    ],
-  },
-  {
-    title: '4. SMS Messaging',
-    paragraphs: ['Mingla uses SMS messaging for two purposes:'],
-  },
-  {
-    title: '4.1 Phone Number Verification (OTP)',
-    paragraphs: [
-      'When you sign up or add a phone number, we send a one-time passcode (OTP) to verify that the number belongs to you. This is a single transactional message and does not constitute marketing.',
-    ],
-  },
-  {
-    title: '4.2 Invite Messages',
-    paragraphs: [
-      'When you choose to invite a friend to Mingla, you may enter their phone number and we will send them a single SMS invite on your behalf. By submitting a contact’s phone number, you confirm that you have their permission to send them this message. The invited person will receive one SMS only and will not be contacted again unless they sign up and opt in to further communications.',
-      'To opt out of receiving SMS messages from Mingla, reply STOP to any message. For help, reply HELP.',
-    ],
-  },
-  {
-    title: '5. How We Share Your Information',
-    paragraphs: ['We do not sell your personal information. We may share your information with:'],
-  },
-  {
-    title: '5.1 Service Providers',
-    paragraphs: [],
-    bullets: [
-      'Supabase – database and authentication infrastructure',
-      'Twilio – SMS delivery for OTP verification and invite messages',
-      'Vonage – SMS delivery services',
-      'Google – authentication services (Google Sign-In)',
-      'Apple – authentication services (Apple Sign-In)',
-    ],
-  },
-  {
-    title: '5.2 Legal Requirements',
-    paragraphs: [
-      'We may disclose your information if required by law, court order, or governmental authority, or to protect the rights, property, or safety of Mingla, our users, or the public.',
-    ],
-  },
-  {
-    title: '5.3 Business Transfers',
-    paragraphs: [
-      'In the event of a merger, acquisition, or sale of assets, your information may be transferred as part of that transaction. We will notify you before your information is transferred and becomes subject to a different privacy policy.',
-    ],
-  },
-  {
-    title: '6. Data Retention',
-    paragraphs: [
-      'We retain your personal information for as long as your account is active or as needed to provide you with our Service. If you delete your account, we will delete or anonymize your personal data within 30 days, unless we are required to retain it for legal or regulatory reasons.',
-    ],
-  },
-  {
-    title: '7. Your Rights and Choices',
-    paragraphs: [
-      'Depending on your location, you may have the following rights:',
-    ],
-    bullets: [
-      'Access: Request a copy of the personal data we hold about you',
-      'Correction: Request that we correct inaccurate or incomplete data',
-      'Deletion: Request that we delete your personal data',
-      'Portability: Request a copy of your data in a machine-readable format',
-      'Opt-out: Opt out of SMS messages by replying STOP',
-    ],
-    footer: 'To exercise any of these rights, contact us at privacy@usemingla.com.',
-  },
-  {
-    title: '8. Children’s Privacy',
-    paragraphs: [
-      'Mingla is not intended for use by individuals under the age of 13. We do not knowingly collect personal information from children under 13. If we become aware that we have collected data from a child under 13, we will take steps to delete it promptly.',
-    ],
-  },
-  {
-    title: '9. Security',
-    paragraphs: [
-      'We implement industry-standard security measures to protect your information, including encryption in transit and at rest, secure authentication via Supabase, and access controls. However, no method of electronic storage or transmission is 100% secure, and we cannot guarantee absolute security.',
-    ],
-  },
-  {
-    title: '10. Third-Party Links',
-    paragraphs: [
-      'Our Service may contain links to third-party websites or services. We are not responsible for the privacy practices of those third parties and encourage you to review their privacy policies.',
-    ],
-  },
-  {
-    title: '11. Changes to This Policy',
-    paragraphs: [
-      'We may update this Privacy Policy from time to time. We will notify you of material changes by posting the new policy on our website and updating the effective date. Your continued use of the Service after changes are posted constitutes your acceptance of the updated policy.',
-    ],
-  },
-  {
-    title: '12. Contact Us',
-    paragraphs: [
-      'If you have any questions about this Privacy Policy, please contact us at:',
-    ],
-    contact: {
-      name: 'Mingla / usemingla.com',
-      email: 'developer@usemingla.com',
-      website: 'https://www.usemingla.com',
-    },
-  },
-] as const
 
 interface PreferenceChipCycleProps {
   chips: readonly PreferenceChip[]
@@ -602,7 +447,7 @@ function PrivacyModal({ open, onClose }: TermsModalProps) {
           >
             <div className="sticky top-0 z-10 border-b border-white/10 bg-[#0d0d10]/98 px-5 py-5 backdrop-blur-2xl sm:px-7">
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-warm">
-                Effective Date: February 16, 2026
+                Effective Date: {PRIVACY_EFFECTIVE_DATE}
               </p>
               <h2
                 id="privacy-modal-title"

--- a/mingla-marketing/lib/privacyContent.ts
+++ b/mingla-marketing/lib/privacyContent.ts
@@ -1,0 +1,158 @@
+export const PRIVACY_EFFECTIVE_DATE = 'February 16, 2026'
+
+export const PRIVACY_SECTIONS = [
+  {
+    title: '1. Introduction',
+    paragraphs: [
+      'Welcome to Mingla ("we," "our," or "us"). Mingla is a date and hangout planning app operated by usemingla.com. We are committed to protecting your personal information and your right to privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our mobile application and website (collectively, the "Service").',
+      'Please read this policy carefully. If you disagree with its terms, please discontinue use of our Service.',
+    ],
+  },
+  {
+    title: '2. Information We Collect',
+    paragraphs: [],
+  },
+  {
+    title: '2.1 Information You Provide',
+    paragraphs: [],
+    bullets: [
+      'Full name and display name',
+      'Email address',
+      'Phone number (used for SMS verification and invite features)',
+      'Profile information such as preferences, location, and interests',
+      'Content you submit, including date plans, reviews, and messages',
+    ],
+  },
+  {
+    title: '2.2 Information Collected Automatically',
+    paragraphs: [],
+    bullets: [
+      'Device information (device type, operating system, unique device identifiers)',
+      'Usage data (features used, pages visited, time spent in-app)',
+      'Location data (with your permission, to suggest local experiences)',
+      'Log data (IP address, browser type, referring URLs)',
+    ],
+  },
+  {
+    title: '2.3 Information from Third Parties',
+    paragraphs: [],
+    bullets: [
+      'Google Sign-In: name, email address, and profile picture from your Google account',
+      'Apple Sign-In: name and email address from your Apple ID',
+    ],
+  },
+  {
+    title: '3. How We Use Your Information',
+    paragraphs: ['We use the information we collect to:'],
+    bullets: [
+      'Create and manage your Mingla account',
+      'Verify your phone number via one-time SMS passcodes (OTP)',
+      'Send invite SMS messages on your behalf when you invite friends to join Mingla',
+      'Generate personalized date and hangout plans based on your preferences',
+      'Suggest local experiences, venues, and activities near you',
+      'Improve and develop our Service',
+      'Communicate with you about updates, features, and support',
+      'Detect and prevent fraud, abuse, and security incidents',
+      'Comply with legal obligations',
+    ],
+  },
+  {
+    title: '4. SMS Messaging',
+    paragraphs: ['Mingla uses SMS messaging for two purposes:'],
+  },
+  {
+    title: '4.1 Phone Number Verification (OTP)',
+    paragraphs: [
+      'When you sign up or add a phone number, we send a one-time passcode (OTP) to verify that the number belongs to you. This is a single transactional message and does not constitute marketing.',
+    ],
+  },
+  {
+    title: '4.2 Invite Messages',
+    paragraphs: [
+      'When you choose to invite a friend to Mingla, you may enter their phone number and we will send them a single SMS invite on your behalf. By submitting a contact’s phone number, you confirm that you have their permission to send them this message. The invited person will receive one SMS only and will not be contacted again unless they sign up and opt in to further communications.',
+      'To opt out of receiving SMS messages from Mingla, reply STOP to any message. For help, reply HELP.',
+    ],
+  },
+  {
+    title: '5. How We Share Your Information',
+    paragraphs: ['We do not sell your personal information. We may share your information with:'],
+  },
+  {
+    title: '5.1 Service Providers',
+    paragraphs: [],
+    bullets: [
+      'Supabase – database and authentication infrastructure',
+      'Twilio – SMS delivery for OTP verification and invite messages',
+      'Vonage – SMS delivery services',
+      'Google – authentication services (Google Sign-In)',
+      'Apple – authentication services (Apple Sign-In)',
+    ],
+  },
+  {
+    title: '5.2 Legal Requirements',
+    paragraphs: [
+      'We may disclose your information if required by law, court order, or governmental authority, or to protect the rights, property, or safety of Mingla, our users, or the public.',
+    ],
+  },
+  {
+    title: '5.3 Business Transfers',
+    paragraphs: [
+      'In the event of a merger, acquisition, or sale of assets, your information may be transferred as part of that transaction. We will notify you before your information is transferred and becomes subject to a different privacy policy.',
+    ],
+  },
+  {
+    title: '6. Data Retention',
+    paragraphs: [
+      'We retain your personal information for as long as your account is active or as needed to provide you with our Service. If you delete your account, we will delete or anonymize your personal data within 30 days, unless we are required to retain it for legal or regulatory reasons.',
+    ],
+  },
+  {
+    title: '7. Your Rights and Choices',
+    paragraphs: [
+      'Depending on your location, you may have the following rights:',
+    ],
+    bullets: [
+      'Access: Request a copy of the personal data we hold about you',
+      'Correction: Request that we correct inaccurate or incomplete data',
+      'Deletion: Request that we delete your personal data',
+      'Portability: Request a copy of your data in a machine-readable format',
+      'Opt-out: Opt out of SMS messages by replying STOP',
+    ],
+    footer: 'To exercise any of these rights, contact us at privacy@usemingla.com.',
+  },
+  {
+    title: '8. Children’s Privacy',
+    paragraphs: [
+      'Mingla is not intended for use by individuals under the age of 13. We do not knowingly collect personal information from children under 13. If we become aware that we have collected data from a child under 13, we will take steps to delete it promptly.',
+    ],
+  },
+  {
+    title: '9. Security',
+    paragraphs: [
+      'We implement industry-standard security measures to protect your information, including encryption in transit and at rest, secure authentication via Supabase, and access controls. However, no method of electronic storage or transmission is 100% secure, and we cannot guarantee absolute security.',
+    ],
+  },
+  {
+    title: '10. Third-Party Links',
+    paragraphs: [
+      'Our Service may contain links to third-party websites or services. We are not responsible for the privacy practices of those third parties and encourage you to review their privacy policies.',
+    ],
+  },
+  {
+    title: '11. Changes to This Policy',
+    paragraphs: [
+      'We may update this Privacy Policy from time to time. We will notify you of material changes by posting the new policy on our website and updating the effective date. Your continued use of the Service after changes are posted constitutes your acceptance of the updated policy.',
+    ],
+  },
+  {
+    title: '12. Contact Us',
+    paragraphs: [
+      'If you have any questions about this Privacy Policy, please contact us at:',
+    ],
+    contact: {
+      name: 'Mingla / usemingla.com',
+      email: 'developer@usemingla.com',
+      website: 'https://www.usemingla.com',
+    },
+  },
+] as const


### PR DESCRIPTION
## Summary
Closes ORCH-0977 launch checklist item #30. Consumer app references `https://www.usemingla.com/privacy-policy/` from 3 surfaces (ProfilePage, CustomPaywallScreen, OnboardingFlow) but that URL has been 404ing since the WordPress cutover.

## Files
- `mingla-marketing/lib/privacyContent.ts` (NEW, +156) — extracted `PRIVACY_SECTIONS` + `PRIVACY_EFFECTIVE_DATE` from hero.tsx so the existing modal and the new page share one source of truth.
- `mingla-marketing/app/privacy-policy/page.tsx` (NEW, +101) — standalone dark-theme page mirroring `/delete-account` pattern.
- `mingla-marketing/components/sections/explorer-home/hero.tsx` (\-156 / +2) — replaces inline const with import; replaces hardcoded effective date string with import. No visual change to home page.

## Verification
- [x] `npm run build` clean (5 static pages — adds /privacy-policy, no regressions)
- [ ] Post-merge: curl https://www.usemingla.com/privacy-policy/ → 200; visual eyeball
- [ ] Post-merge: tap Privacy from app's ProfilePage on a sim/device → loads standalone page (currently shows in-app modal which is fine; LEGAL_URLS link goes to browser which is what changes)

## Out of scope for #30
- Terms standalone page (will be its own item; TERMS_SECTIONS still inlined in hero.tsx)
- Removing the home page Privacy modal (intentional design — quick-glance for marketing visitors)