### PR TITLE
ORCH-0977 marketing-cards: [deploy] fix duplicate title on /privacy-policy

### DIFF
--- a/mingla-marketing/app/privacy-policy/page.tsx
+++ b/mingla-marketing/app/privacy-policy/page.tsx
@@ -4,7 +4,7 @@ import { PRIVACY_SECTIONS, PRIVACY_EFFECTIVE_DATE } from '@/lib/privacyContent'
 import { cn } from '@/lib/cn'
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy — Mingla',
+  title: 'Privacy Policy',
   description:
     'How Mingla collects, uses, discloses, and safeguards your information when you use our app and website.',
 }


### PR DESCRIPTION
One-line metadata fix — root layout already appends "— Mingla" via title.template, so the page's own title shouldn't include it. Eliminates "Privacy Policy — Mingla — Mingla" in browser tabs and SERP.