### PR TITLE
ORCH-0977 marketing: make support chip modal [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0977_MARKETING_SUPPORT_PAGE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0977_MARKETING_SUPPORT_PAGE.md
@@ -158,5 +158,12 @@ ORCH-0977 marketing: add support page [deploy]
 ## Ready-To-Test Checklist
 
 1. Open `/support` and confirm the page shows `How can we help?`, `support@usemingla.com`, and the quick links.
-2. Open `/` at mobile width and confirm the footer chip order is About, Support, Privacy, Terms.
+2. Open `/` at mobile width and confirm the footer chip order is About, Support, Privacy, Terms, then tap Support and confirm it opens a modal.
 3. Confirm the browser title for `/support` renders `Support — Mingla`.
+
+## Follow-Up Addendum: Support Chip Modal
+
+> Date: 2026-05-28
+> Status: implemented and verified
+
+After PR #226 merged, Seth clarified that the homepage Support chip should open a pop-up modal like the existing Privacy and Terms chips. The standalone `/support` route remains live for App Store Connect and Google Play, while `mingla-marketing/components/sections/explorer-home/hero.tsx` now renders the Support chip as a modal button with the same dialog, escape-key, backdrop-click, scroll-lock, animation, and close-button pattern as Privacy and Terms. `mingla-marketing/scripts/verify-support-page.mjs` now checks the modal wiring as part of the regression contract.

--- a/mingla-marketing/components/sections/explorer-home/hero.tsx
+++ b/mingla-marketing/components/sections/explorer-home/hero.tsx
@@ -412,8 +412,138 @@ function PrivacyModal({ open, onClose }: TermsModalProps) {
   )
 }
 
+function SupportModal({ open, onClose }: TermsModalProps) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [open])
+
+  return (
+    <AnimatePresence>
+      {open ? (
+        <motion.div
+          key="support-backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.22 }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="support-modal-title"
+          onClick={onClose}
+          className="fixed inset-0 z-[120] flex items-center justify-center bg-black/90 px-4 py-5 backdrop-blur-xl sm:px-6"
+        >
+          <motion.div
+            key="support-panel"
+            initial={{ opacity: 0, scale: 0.96, y: 16 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.98, y: 10 }}
+            transition={{ type: 'spring', stiffness: 240, damping: 28 }}
+            onClick={(event) => event.stopPropagation()}
+            className="relative flex max-h-[min(760px,calc(100svh-2.5rem))] w-full max-w-3xl flex-col overflow-hidden rounded-[28px] border border-white/14 bg-[#0d0d10] shadow-[0_40px_120px_rgba(0,0,0,0.72),inset_0_1px_0_rgba(255,255,255,0.08)]"
+          >
+            <div className="sticky top-0 z-10 border-b border-white/10 bg-[#0d0d10]/98 px-5 py-5 backdrop-blur-2xl sm:px-7">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-warm">
+                Support
+              </p>
+              <h2
+                id="support-modal-title"
+                className="mt-2 font-display text-3xl leading-none text-text-primary sm:text-5xl"
+              >
+                How can we help?
+              </h2>
+              <button
+                type="button"
+                autoFocus
+                onClick={onClose}
+                aria-label="Close support"
+                className="absolute right-4 top-4 grid size-10 place-items-center rounded-full border border-white/12 bg-white/10 text-text-primary transition-all duration-200 hover:bg-white/16 focus-ring"
+              >
+                <X className="size-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            <div className="overflow-y-auto px-5 py-6 text-left sm:px-7 sm:py-7">
+              <div className="space-y-6 text-sm leading-7 text-white/72 sm:text-base">
+                <p>
+                  The Mingla team reads every support message and aims to
+                  respond within 1–2 business days.
+                </p>
+
+                <div className="rounded-3xl border border-warm/25 bg-warm/10 p-5 text-white/82 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]">
+                  <p className="font-semibold text-white">
+                    For help with your account, app access, or a problem you
+                    spotted, email:
+                  </p>
+                  <a
+                    href="mailto:support@usemingla.com"
+                    className="mt-3 inline-flex min-h-10 items-center rounded-full border border-white/14 bg-white/10 px-4 text-sm font-semibold text-warm transition hover:bg-white/16 focus-ring"
+                  >
+                    support@usemingla.com
+                  </a>
+                </div>
+
+                <section className="space-y-3">
+                  <h3 className="font-display text-xl leading-tight text-white/95 sm:text-2xl">
+                    Quick links
+                  </h3>
+                  <ul className="space-y-2 pl-5">
+                    <li className="list-disc marker:text-warm/80">
+                      <Link
+                        href="/privacy-policy"
+                        className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                      >
+                        Privacy Policy
+                      </Link>
+                    </li>
+                    <li className="list-disc marker:text-warm/80">
+                      <Link
+                        href="/terms-of-service"
+                        className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                      >
+                        Terms of Service
+                      </Link>
+                    </li>
+                    <li className="list-disc marker:text-warm/80">
+                      <Link
+                        href="/delete-account"
+                        className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                      >
+                        Delete your account
+                      </Link>
+                    </li>
+                  </ul>
+                </section>
+
+                <p>
+                  Account deletion is also available in the app from Settings →
+                  Delete Account.
+                </p>
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  )
+}
+
 export function ExplorerHero() {
   const reduced = useMinglaReducedMotion()
+  const [supportOpen, setSupportOpen] = useState(false)
   const [termsOpen, setTermsOpen] = useState(false)
   const [privacyOpen, setPrivacyOpen] = useState(false)
 
@@ -529,6 +659,19 @@ export function ExplorerHero() {
             )
           }
 
+          if (chip.href === '/support') {
+            return (
+              <button
+                key={chip.href}
+                type="button"
+                onClick={() => setSupportOpen(true)}
+                className={chipClassName}
+              >
+                {chip.label}
+              </button>
+            )
+          }
+
           return chip.href === '/terms' ? (
             <button
               key={chip.href}
@@ -546,6 +689,7 @@ export function ExplorerHero() {
         })}
       </motion.nav>
       </div>
+      <SupportModal open={supportOpen} onClose={() => setSupportOpen(false)} />
       <TermsModal open={termsOpen} onClose={() => setTermsOpen(false)} />
       <PrivacyModal open={privacyOpen} onClose={() => setPrivacyOpen(false)} />
     </section>

--- a/mingla-marketing/scripts/verify-support-page.mjs
+++ b/mingla-marketing/scripts/verify-support-page.mjs
@@ -18,6 +18,14 @@ const requiredSupportSnippets = [
   'Delete Account',
 ]
 
+const requiredHeroSnippets = [
+  'function SupportModal',
+  'aria-labelledby="support-modal-title"',
+  'const [supportOpen, setSupportOpen] = useState(false)',
+  "onClick={() => setSupportOpen(true)}",
+  '<SupportModal open={supportOpen} onClose={() => setSupportOpen(false)} />',
+]
+
 for (const snippet of requiredSupportSnippets) {
   if (!supportPage.includes(snippet)) {
     throw new Error(`Support page missing expected snippet: ${snippet}`)
@@ -38,6 +46,12 @@ if (aboutIndex === -1 || supportIndex === -1 || privacyIndex === -1) {
 
 if (!(aboutIndex < supportIndex && supportIndex < privacyIndex)) {
   throw new Error('Support chip must appear between About and Privacy')
+}
+
+for (const snippet of requiredHeroSnippets) {
+  if (!hero.includes(snippet)) {
+    throw new Error(`Hero missing expected support modal snippet: ${snippet}`)
+  }
 }
 
 console.log('Support page regression checks passed')


### PR DESCRIPTION
## Summary
- make the homepage Support chip open a modal like Privacy and Terms
- keep `/support` as the standalone public Support URL for app store requirements
- extend the support regression check to cover modal wiring
- add a follow-up addendum to `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0977_MARKETING_SUPPORT_PAGE.md`

## Verification
- `cd mingla-marketing && node scripts/verify-support-page.mjs`
- `cd mingla-marketing && npm run build`

## Notes
- no changes to Privacy/Terms modal content modules
- commit includes `[deploy]` so Vercel should not skip the build
