### PR TITLE
ORCH-0985: fix curated stop Replace (search-around-stop, single-source slugs, vibe ranking)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -891,7 +891,20 @@ function checkNoNewBackendFiles() {
     "supabase/migrations/20260725000000_orch_0950_trip_capacity_single_source.sql",
     "supabase/migrations/20260725000002_orch_0950_expanded_scope_dashboard_coherence.sql",
   ];
+  // ORCH-0985 [Curated stop "Replace" fix]. C7 is scoped to ORCH-0863 marketing;
+  // these backend touches are the Replace-stop fix: single-source slug validation
+  // (kills the stale VALID_CATEGORIES whitelist), center-search-on-the-replaced-
+  // stop, decoupled search radius, vibe rank-signal pass-through, best-score
+  // ordering, + the slug/rank-signal parity regression test. No marketing scope.
+  const ORCH_0985_BACKEND_ALLOWLIST = [
+    "supabase/functions/replace-curated-stop/index.ts",
+    "supabase/functions/_shared/stopAlternatives.ts",
+    "supabase/functions/_shared/signalRankFetch.ts",
+    "supabase/functions/generate-curated-experiences/index.ts",
+    "supabase/functions/_shared/replaceCuratedStopSlugParity.test.ts",
+  ];
   const ALLOWLIST = [
+    ...ORCH_0985_BACKEND_ALLOWLIST,
     ...META_ORCH_0952_BACKEND_ALLOWLIST,
     ...ORCH_0972_BACKEND_ALLOWLIST,
     ...ORCH_0954_BACKEND_ALLOWLIST,

--- a/app-mobile/src/components/ExpandedCardModal.tsx
+++ b/app-mobile/src/components/ExpandedCardModal.tsx
@@ -812,12 +812,14 @@ function MultiStopPlanView({
     const stop = stops[stopIndex];
     // comboCategory is the Mingla slug from the combo that originally selected this stop.
     // Set by the generator (buildCardStop). Falls back to placeType for older cards.
-    const categoryId = stop.comboCategory || stop.placeType || 'casual_eats';
-    const siblingStops = stops
-      .filter((_, i) => i !== stopIndex)
-      .map(s => ({ lat: s.lat, lng: s.lng }));
+    // ORCH-0985: terminal fallback is 'casual_food' — a real slug the backend
+    // accepts. The prior 'casual_eats' existed in neither the generator's slug
+    // universe nor COMBO_SLUG_TO_FILTER_SIGNAL, so it always 400-rejected.
+    const categoryId = stop.comboCategory || stop.placeType || 'casual_food';
+    // ORCH-0985: exclude EVERY stop already in the plan — including the one being
+    // replaced — so you never see the current stop (or a sibling) offered as an
+    // alternative to itself.
     const excludePlaceIds = stops
-      .filter((_, i) => i !== stopIndex)
       .map(s => s.placeId)
       .filter(Boolean);
 
@@ -825,10 +827,15 @@ function MultiStopPlanView({
     clearAlternatives();
     fetchAlternatives({
       categoryId,
-      location: { lat: userPreferences?.location?.lat ?? stops[0]?.lat ?? 0, lng: userPreferences?.location?.lng ?? stops[0]?.lng ?? 0 },
+      // ORCH-0985: search around the STOP BEING REPLACED, not the user's location
+      // or the midpoint of the other stops. This is what makes Replace return
+      // "the deck for this stop" — alternatives near where the stop actually is.
+      location: { lat: stop.lat, lng: stop.lng },
       travelMode: userPreferences?.travel_mode || 'walking',
       excludePlaceIds,
-      siblingStops,
+      // ORCH-0985: order alternatives by the same vibe signal this stop was
+      // ranked by (undefined for older cards → backend uses the category signal).
+      rankSignal: stop.rankSignal,
       limit: 10,
     });
   };

--- a/app-mobile/src/hooks/useReplaceStop.ts
+++ b/app-mobile/src/hooks/useReplaceStop.ts
@@ -7,7 +7,7 @@ interface GetAlternativesParams {
   location: { lat: number; lng: number };
   travelMode: string;
   excludePlaceIds: string[];
-  siblingStops: Array<{ lat: number; lng: number }>;
+  rankSignal?: string;
   limit?: number;
 }
 

--- a/app-mobile/src/services/stopReplacementService.ts
+++ b/app-mobile/src/services/stopReplacementService.ts
@@ -7,7 +7,7 @@ interface GetAlternativesParams {
   location: { lat: number; lng: number };
   travelMode: string;
   excludePlaceIds: string[];
-  siblingStops: Array<{ lat: number; lng: number }>;
+  rankSignal?: string;
   limit?: number;
 }
 
@@ -69,7 +69,7 @@ class StopReplacementService {
         location: params.location,
         travelMode: params.travelMode,
         excludePlaceIds: params.excludePlaceIds,
-        siblingStops: params.siblingStops,
+        rankSignal: params.rankSignal,
         limit: params.limit ?? 10,
       },
     });

--- a/app-mobile/src/types/curatedExperience.ts
+++ b/app-mobile/src/types/curatedExperience.ts
@@ -32,6 +32,7 @@ export interface CuratedStop {
   dismissible?: boolean;
   role?: string;
   comboCategory?: string;  // Mingla category slug from the combo that selected this stop (e.g., 'fine_dining')
+  rankSignal?: string;     // ORCH-0985: vibe signal this stop was ranked by (e.g. 'romantic'); used by Replace to order alternatives
 }
 
 // ORCH-0677 RC-2: surfaced by `generate-curated-experiences` when the response

--- a/app-mobile/src/utils/mutateCuratedCard.ts
+++ b/app-mobile/src/utils/mutateCuratedCard.ts
@@ -98,6 +98,7 @@ export function buildReplacementStop(
     optional: original.optional,
     dismissible: original.dismissible,
     comboCategory: original.comboCategory,
+    rankSignal: original.rankSignal, // ORCH-0985: slot vibe is preserved across replacement
     // Place data from alternative
     placeId: alternative.placeId,
     placeName: alternative.placeName,

--- a/supabase/functions/_shared/replaceCuratedStopSlugParity.test.ts
+++ b/supabase/functions/_shared/replaceCuratedStopSlugParity.test.ts
@@ -1,0 +1,165 @@
+// ORCH-0985 — regression guard for the curated-stop "Replace" slug-parity bug.
+//
+// The bug: replace-curated-stop/index.ts kept its own hardcoded VALID_CATEGORIES
+// whitelist (last touched ORCH-0434). The curated generator's slug universe later
+// changed (ORCH-0599.4/0601: brunch_lunch_casual→brunch+casual_food,
+// movies_theatre→movies+theatre, +hiking/+museum) but the whitelist did not, so
+// tapping Replace on those stops 400-rejected ("Couldn't load alternatives").
+//
+// The invariant this test enforces:
+//   (1) Every combo slug the generator can emit is accepted by the SINGLE slug
+//       authority isValidComboSlug (COMBO_SLUG_TO_FILTER_SIGNAL). If someone adds
+//       a new combo slug to the generator without registering it, this fails.
+//   (2) The replace edge function validates THROUGH that authority and no longer
+//       carries a private VALID_CATEGORIES whitelist. This fails on revert.
+
+import { assert, assertEquals } from 'https://deno.land/std@0.168.0/testing/asserts.ts';
+import {
+  isValidComboSlug,
+  COMBO_SLUG_TO_FILTER_SIGNAL,
+  isKnownRankSignal,
+  EXPERIENCE_VIBE_RANK_SIGNALS,
+} from './signalRankFetch.ts';
+
+const GENERATOR_SRC_URL = new URL(
+  '../generate-curated-experiences/index.ts',
+  import.meta.url,
+);
+const REPLACE_FN_SRC_URL = new URL(
+  '../replace-curated-stop/index.ts',
+  import.meta.url,
+);
+
+// Extract every combo slug from the generator's `combos: [ ... ]` blocks.
+// Line-scoped so taglines / role objects / unrelated arrays are never captured.
+async function extractGeneratorComboSlugs(): Promise<string[]> {
+  const src = await Deno.readTextFile(GENERATOR_SRC_URL);
+  const slugs = new Set<string>();
+  let inCombos = false;
+  for (const line of src.split('\n')) {
+    if (/^\s*combos:\s*\[/.test(line)) { inCombos = true; continue; }
+    if (inCombos && /^\s*\],\s*$/.test(line)) { inCombos = false; continue; }
+    if (inCombos) {
+      for (const m of line.matchAll(/'([a-z_]+)'/g)) slugs.add(m[1]);
+    }
+  }
+  return [...slugs];
+}
+
+Deno.test('every generator combo slug is accepted by the replace slug authority', async () => {
+  const slugs = await extractGeneratorComboSlugs();
+  assert(slugs.length > 0, 'failed to extract any combo slugs from the generator');
+  const rejected = slugs.filter((s) => !isValidComboSlug(s));
+  assertEquals(
+    rejected,
+    [],
+    `generator emits slugs the replace path rejects: ${rejected.join(', ')}. ` +
+      `Register them in COMBO_SLUG_TO_FILTER_SIGNAL (with verified place_scores).`,
+  );
+});
+
+Deno.test('the 6 slugs the stale whitelist broke now resolve', () => {
+  // brunch_lunch_casual→brunch+casual_food, movies_theatre→movies+theatre, +hiking/+museum
+  for (const slug of ['casual_food', 'brunch', 'movies', 'theatre', 'hiking', 'museum']) {
+    assert(isValidComboSlug(slug), `expected '${slug}' to be a valid combo slug`);
+    assert(
+      Object.prototype.hasOwnProperty.call(COMBO_SLUG_TO_FILTER_SIGNAL, slug),
+      `'${slug}' missing from COMBO_SLUG_TO_FILTER_SIGNAL`,
+    );
+  }
+});
+
+Deno.test('replace-curated-stop validates via the single authority, not a private whitelist', async () => {
+  const src = await Deno.readTextFile(REPLACE_FN_SRC_URL);
+  // Fails on revert: the stale whitelist must not come back.
+  assert(
+    !/VALID_CATEGORIES\s*=\s*new\s+Set/.test(src),
+    'replace-curated-stop reintroduced a private VALID_CATEGORIES whitelist — ' +
+      'validate via isValidComboSlug (COMBO_SLUG_TO_FILTER_SIGNAL) instead.',
+  );
+  assert(
+    src.includes('isValidComboSlug(categoryId)'),
+    'replace-curated-stop must gate categoryId through isValidComboSlug',
+  );
+});
+
+Deno.test('unknown slugs are still rejected (Constitution #3: no silent fallback)', () => {
+  assertEquals(isValidComboSlug('casual_eats'), false); // the old bad client fallback
+  assertEquals(isValidComboSlug('not_a_real_slug'), false);
+  assertEquals(isValidComboSlug(''), false);
+});
+
+// ── ORCH-0985: vibe rank-signal pass-through ─────────────────────────────────
+
+// Extract the RHS values of EXPERIENCE_RANK_SIGNAL_OVERRIDE from the generator.
+async function extractGeneratorVibeSignals(): Promise<string[]> {
+  const src = await Deno.readTextFile(GENERATOR_SRC_URL);
+  const vibes = new Set<string>();
+  let inBlock = false;
+  for (const line of src.split('\n')) {
+    if (/EXPERIENCE_RANK_SIGNAL_OVERRIDE\s*:/.test(line)) { inBlock = true; continue; }
+    if (inBlock && /^\};/.test(line)) { inBlock = false; continue; }
+    if (inBlock) {
+      const m = line.match(/'[a-z_]+'\s*:\s*'([a-z_]+)'/); // 'slug': 'vibe'
+      if (m) vibes.add(m[1]);
+    }
+  }
+  return [...vibes];
+}
+
+Deno.test('every vibe signal the generator ranks by is a known rank signal', async () => {
+  const vibes = await extractGeneratorVibeSignals();
+  assert(vibes.length > 0, 'failed to extract any vibe signals from the generator');
+  const unknown = vibes.filter((v) => !isKnownRankSignal(v));
+  assertEquals(
+    unknown,
+    [],
+    `generator ranks by signals the replace path rejects: ${unknown.join(', ')}. ` +
+      `Add them to EXPERIENCE_VIBE_RANK_SIGNALS in signalRankFetch.ts.`,
+  );
+  // And the curated vibe set must be fully covered (sync guard, both directions
+  // for the non-filter vibes).
+  for (const vibe of EXPERIENCE_VIBE_RANK_SIGNALS) {
+    assert(isKnownRankSignal(vibe), `vibe '${vibe}' should be a known rank signal`);
+  }
+});
+
+Deno.test('isKnownRankSignal accepts vibes + filter signals, rejects bogus', () => {
+  assert(isKnownRankSignal('romantic'));
+  assert(isKnownRankSignal('icebreakers'));
+  assert(isKnownRankSignal('lively'));
+  assert(isKnownRankSignal('scenic'));
+  assert(isKnownRankSignal('picnic_friendly'));
+  assert(isKnownRankSignal('fine_dining')); // a filter signal value
+  assertEquals(isKnownRankSignal('not_a_signal'), false);
+  assertEquals(isKnownRankSignal(''), false);
+});
+
+Deno.test('replace-curated-stop validates + forwards the vibe rankSignal', async () => {
+  const src = await Deno.readTextFile(REPLACE_FN_SRC_URL);
+  assert(src.includes('isKnownRankSignal'), 'edge fn must validate rankSignal via isKnownRankSignal');
+  assert(/rankSignal,?\s*$/m.test(src) || src.includes('rankSignal,'),
+    'edge fn must forward rankSignal to fetchStopAlternatives');
+});
+
+// ── ORCH-0985: Replace mechanics (center-on-stop, decoupled radius, ordering) ──
+
+Deno.test('replace-curated-stop centers on the stop being replaced, not a sibling centroid', async () => {
+  const src = await Deno.readTextFile(REPLACE_FN_SRC_URL);
+  assert(src.includes('const refLat = location.lat'), 'must center refLat on location (the replaced stop)');
+  assert(src.includes('const refLng = location.lng'), 'must center refLng on location (the replaced stop)');
+  // Fails on revert: the centroid-of-siblings logic was the Burning Coal root cause.
+  assert(!src.includes('validSiblings'),
+    'centroid-of-siblingStops logic must not return — it searched the wrong area');
+});
+
+Deno.test('stopAlternatives decouples search radius from travel mode and orders best-score-then-distance', async () => {
+  const src = await Deno.readTextFile(new URL('./stopAlternatives.ts', import.meta.url));
+  assert(src.includes('REPLACE_SEARCH_RADIUS_METERS'),
+    'replace must use a fixed search radius, not a travel-mode-derived one');
+  // Fails on revert: the walking 2.25km radius starved the result.
+  assert(!/TRAVEL_SPEEDS_KMH\[travelMode\]/.test(src),
+    'replace radius must not be derived from travelMode speed');
+  assert(src.includes('SCORE_BAND') && src.includes('band(b._rankScore') ,
+    'must order by score band first, distance tiebreaker');
+});

--- a/supabase/functions/_shared/signalRankFetch.ts
+++ b/supabase/functions/_shared/signalRankFetch.ts
@@ -119,6 +119,30 @@ export const COMBO_SLUG_FILTER_MIN: Record<string, number> = {
 // ── Resolvers ────────────────────────────────────────────────────────────────
 
 /**
+ * ORCH-0985: single source of truth for "is this a slug the curated pipeline
+ * can serve?". Replaces the stale `VALID_CATEGORIES` whitelist that lived in
+ * replace-curated-stop/index.ts and drifted out of sync with the slug split
+ * (ORCH-0599.4/0601: brunch_lunch_casual→brunch+casual_food,
+ * movies_theatre→movies+theatre, +hiking/+museum). Validity = "has an entry in
+ * COMBO_SLUG_TO_FILTER_SIGNAL", the same authority the generator resolves
+ * against, so the two can never disagree again (Constitution #6).
+ */
+export function isValidComboSlug(comboSlug: string): boolean {
+  return Object.prototype.hasOwnProperty.call(COMBO_SLUG_TO_FILTER_SIGNAL, comboSlug);
+}
+
+/**
+ * ORCH-0601/0985: resolve the required-types sub-filter for slugs that narrow a
+ * shared signal to specific Google Places types (hiking→nature-subset,
+ * museum→creative_arts-subset). Returns undefined for slugs with no narrowing.
+ * The replace flow MUST pass this through so swapping a "hiking" stop returns
+ * hiking trails, not a generic city park (matches the curated generator).
+ */
+export function resolveTypeFilter(comboSlug: string): string[] | undefined {
+  return COMBO_SLUG_TYPE_FILTER[comboSlug];
+}
+
+/**
  * Resolve a combo slug to its underlying signal_id. Throws on unknown slug
  * (Constitution #3: never silently fall back). Used by stopAlternatives.
  */
@@ -138,6 +162,33 @@ export function resolveFilterSignal(comboSlug: string): string {
  */
 export function resolveFilterMin(comboSlug: string): number {
   return COMBO_SLUG_FILTER_MIN[comboSlug] ?? 120;
+}
+
+// ORCH-0985: "vibe" rank signals the curated generator ranks stops by INSTEAD of
+// the slot's own filter signal (EXPERIENCE_RANK_SIGNAL_OVERRIDE in
+// generate-curated-experiences/index.ts — e.g. Romantic dinner ranks by
+// `romantic`, First-Date by `icebreakers`, Group-Fun by `lively`, Take-a-Stroll
+// nature by `scenic`, Picnic spot by `picnic_friendly`). The replace flow accepts
+// a stamped rankSignal from the client so swapped-in places are ordered by the
+// SAME vibe the plan was built with. This list MUST stay in sync with the values
+// of EXPERIENCE_RANK_SIGNAL_OVERRIDE — the slug-parity test enforces that.
+export const EXPERIENCE_VIBE_RANK_SIGNALS: ReadonlySet<string> = new Set([
+  'romantic', 'icebreakers', 'lively', 'scenic', 'picnic_friendly',
+]);
+
+/**
+ * ORCH-0985: a string is a valid rank signal if it is either a category filter
+ * signal (a value in COMBO_SLUG_TO_FILTER_SIGNAL) or one of the vibe signals
+ * above. Used by replace-curated-stop to reject bogus rankSignal inputs instead
+ * of silently ranking by a non-existent signal (Constitution #3).
+ */
+export function isKnownRankSignal(signal: string): boolean {
+  if (!signal) return false;
+  if (EXPERIENCE_VIBE_RANK_SIGNALS.has(signal)) return true;
+  for (const sig of Object.values(COMBO_SLUG_TO_FILTER_SIGNAL)) {
+    if (sig === signal) return true;
+  }
+  return false;
 }
 
 // ── fetchSinglesForSignalRank ────────────────────────────────────────────────

--- a/supabase/functions/_shared/stopAlternatives.ts
+++ b/supabase/functions/_shared/stopAlternatives.ts
@@ -12,6 +12,7 @@ import {
   fetchSinglesForSignalRank,
   resolveFilterSignal,
   resolveFilterMin,
+  resolveTypeFilter,
 } from './signalRankFetch.ts';
 import {
   CATEGORY_DURATION_MINUTES,
@@ -25,9 +26,15 @@ import {
 import { haversineKm, estimateTravelMinutes } from './distanceMath.ts';
 export { haversineKm, estimateTravelMinutes };
 
-const TRAVEL_SPEEDS_KMH: Record<string, number> = {
-  walking: 4.5, biking: 14, transit: 20, driving: 35,
-};
+// ORCH-0985: fixed metro-scale search radius for stop replacement (decoupled
+// from travel mode — see fetchStopAlternatives for why). 25km comfortably covers
+// a metropolitan area around the stop being replaced.
+const REPLACE_SEARCH_RADIUS_METERS = 25000;
+
+// ORCH-0985: score-band size for ordering. Alternatives are ordered best-score-
+// first; places whose rank-signal scores fall in the same band are treated as
+// comparable and ordered by distance (closest first). 5 points ≈ "comparable".
+const SCORE_BAND = 5;
 
 // ── Fetch Alternatives ─────────────────────────────────────────────────────
 
@@ -82,14 +89,18 @@ export async function fetchStopAlternatives(
     budgetMax: number;
     excludePlaceIds: string[];
     limit: number;
+    rankSignal?: string; // ORCH-0985: vibe rank signal stamped on the stop by the generator
   },
 ): Promise<{ alternatives: StopAlternativeResult[]; totalAvailable: number }> {
-  const { categoryId, refLat, refLng, travelMode, budgetMax, excludePlaceIds, limit } = params;
+  const { categoryId, refLat, refLng, budgetMax, excludePlaceIds, limit, rankSignal } = params;
 
-  // Compute search radius (same formula as curated generator)
-  const speedKmh = TRAVEL_SPEEDS_KMH[travelMode] ?? 4.5;
-  const radiusMeters = Math.round((speedKmh * 1000 / 60) * 30); // 30min constraint
-  const clampedRadius = Math.min(Math.max(radiusMeters, 500), 50000);
+  // ORCH-0985: replace uses a fixed, generous search radius around the stop being
+  // replaced — NOT a travel-mode-derived one. The travel-mode radius exists to
+  // chain stops within ~30 min when BUILDING a route; for swapping a single stop
+  // it just starves the result (a walking 2.25km radius hid every downtown
+  // theatre in the Burning Coal case). A metro-scale radius returns the same
+  // candidate set the deck would for this stop, ranked best-first below.
+  const clampedRadius = REPLACE_SEARCH_RADIUS_METERS;
 
   // ORCH-0707: Resolve combo slug → filter signal. Throws on unknown slug
   // (Constitution #3: never silently fall back). Same map the curated pipeline
@@ -98,19 +109,28 @@ export async function fetchStopAlternatives(
   const filterSignal = resolveFilterSignal(categoryId);
   const filterMin = resolveFilterMin(categoryId);
 
-  // Use the same RPC the curated pipeline uses for selection. rankSignal =
-  // filterSignal preserves the legacy "rating-then-distance" approximation
-  // (no vibe override for replace flow — user is replacing within a slot,
-  // not picking a new vibe).
+  // ORCH-0985: pass the slug's required-types narrowing through (hiking→trails,
+  // museum→museums) so replace matches the curated generator instead of
+  // returning a generic park / art class for those slots.
+  const requiredTypes = resolveTypeFilter(categoryId);
+
+  // ORCH-0985: rank by the vibe signal the generator stamped on the stop
+  // (romantic/icebreakers/lively/scenic/picnic_friendly) so alternatives are
+  // ordered by the SAME vibe the plan was built with. Filtering is always by the
+  // category filter signal — only the ORDER changes. Older cards without a
+  // stamped rankSignal fall back to the filter signal (documented compatibility
+  // path, validated upstream in the edge function — Constitution #3).
+  const effectiveRankSignal = rankSignal || filterSignal;
+
   const candidates = await fetchSinglesForSignalRank(supabaseAdmin, {
     filterSignal,
     filterMin,
-    rankSignal: filterSignal,
+    rankSignal: effectiveRankSignal,
     centerLat: refLat,
     centerLng: refLng,
     radiusMeters: clampedRadius,
     limit: 100,
-    requiredTypes: undefined,
+    requiredTypes,
   });
 
   // Filter: not in exclude list, within budget, fine-dining tier floor.
@@ -132,12 +152,21 @@ export async function fetchStopAlternatives(
 
   const totalAvailable = filtered.length;
 
-  // Sort by distance from reference point (closest first) — same UX contract
-  // as the prior implementation.
+  // ORCH-0985: order best-score-first, distance as the tiebreaker among
+  // comparable places. `_rankScore` is the slot's rank-signal score (the vibe
+  // signal for curated cards). Places whose scores fall in the same SCORE_BAND
+  // are treated as comparable and ordered closest-first. This is deterministic
+  // and predictable — the best venues always lead — unlike the prior normalized
+  // blend. (Bucketing keeps the comparator transitive.)
+  const distByPlace = new Map<string, number>();
+  for (const c of filtered) {
+    distByPlace.set(c.id, haversineKm(refLat, refLng, c.lat ?? 0, c.lng ?? 0));
+  }
+  const band = (score: number): number => Math.floor((score ?? 0) / SCORE_BAND);
   filtered.sort((a, b) => {
-    const distA = haversineKm(refLat, refLng, a.lat ?? 0, a.lng ?? 0);
-    const distB = haversineKm(refLat, refLng, b.lat ?? 0, b.lng ?? 0);
-    return distA - distB;
+    const bandDiff = band(b._rankScore ?? 0) - band(a._rankScore ?? 0); // higher score band first
+    if (bandDiff !== 0) return bandDiff;
+    return (distByPlace.get(a.id) ?? 0) - (distByPlace.get(b.id) ?? 0);  // then closest first
   });
 
   const selected = filtered.slice(0, limit);

--- a/supabase/functions/generate-curated-experiences/index.ts
+++ b/supabase/functions/generate-curated-experiences/index.ts
@@ -459,6 +459,14 @@ const EXPERIENCE_RANK_SIGNAL_OVERRIDE: Record<string, Record<string, string>> = 
   },
 };
 
+// ORCH-0985: resolve the vibe rank signal a stop is selected/ranked by — the
+// type's EXPERIENCE_RANK_SIGNAL_OVERRIDE entry if present, else the slug's own
+// filter signal. Mirrors the rankSignal computed in fetchForCombo so the value
+// stamped on the stop equals the value the stop was actually ranked by.
+function resolveStopRankSignal(typeId: string, catId: string): string | undefined {
+  return EXPERIENCE_RANK_SIGNAL_OVERRIDE[typeId]?.[catId] ?? COMBO_SLUG_TO_FILTER_SIGNAL[catId];
+}
+
 // Per-slug stop role label for dynamic role assignment (ORCH-0628). When a typeDef's
 // stop roles are generic placeholders and combos mix orderings (Activity-first vs
 // Food-first), the display label should reflect the actual slug. Falls back to
@@ -509,7 +517,10 @@ function buildCardStop(
   travelMode: string,
   // ORCH-0707: comboCategory is REQUIRED. TypeScript fails compilation at any
   // call site that omits it — structural safeguard for I-CURATED-LABEL-SOURCE.
-  opts: { optional?: boolean; dismissible?: boolean; comboCategory: string },
+  // ORCH-0985: rankSignal is the vibe signal this stop was selected/ranked by
+  // (e.g. 'romantic' for a Romantic dinner). Stamped onto the stop so the
+  // Replace flow can order alternatives by the same vibe the plan was built with.
+  opts: { optional?: boolean; dismissible?: boolean; comboCategory: string; rankSignal?: string },
 ): any {
   const lat = card.lat ?? 0;
   const lng = card.lng ?? 0;
@@ -580,6 +591,8 @@ function buildCardStop(
     // type doesn't declare it; silently dropped today). per OQ-2.
     // ORCH-0707: comboCategory always emitted (no longer conditional spread).
     comboCategory: opts.comboCategory,
+    // ORCH-0985: vibe rank signal (for Replace ordering); omitted when absent.
+    ...(opts.rankSignal ? { rankSignal: opts.rankSignal } : {}),
   };
 }
 
@@ -796,7 +809,7 @@ async function generateCardsForType(
             const stop = buildCardStop(
               anchor, stops.length + 1, typeDef.stops.length, resolveStopRole(catId, stopDef),
               lat, lng, stops.length > 0 ? prevLat : null, stops.length > 0 ? prevLng : null,
-              travelMode, { optional: stopDef.optional, dismissible: stopDef.dismissible, comboCategory: catId },
+              travelMode, { optional: stopDef.optional, dismissible: stopDef.dismissible, comboCategory: catId, rankSignal: resolveStopRankSignal(typeDef.id, catId) },
             );
             stops.push(stop);
             prevLat = anchor.lat;
@@ -828,7 +841,7 @@ async function generateCardsForType(
             const stop = buildCardStop(
               place, stops.length + 1, typeDef.stops.length, resolveStopRole(catId, stopDef),
               lat, lng, stops.length > 0 ? prevLat : null, stops.length > 0 ? prevLng : null,
-              travelMode, { optional: stopDef.optional, dismissible: stopDef.dismissible, comboCategory: catId },
+              travelMode, { optional: stopDef.optional, dismissible: stopDef.dismissible, comboCategory: catId, rankSignal: resolveStopRankSignal(typeDef.id, catId) },
             );
             stops.push(stop);
             prevLat = place.lat;
@@ -878,7 +891,7 @@ async function generateCardsForType(
         const stop = buildCardStop(
           place, stops.length + 1, typeDef.stops.length, resolveStopRole(catId, stopDef),
           lat, lng, stops.length > 0 ? prevLat : null, stops.length > 0 ? prevLng : null,
-          travelMode, { optional: stopDef.optional, dismissible: stopDef.dismissible, comboCategory: catId },
+          travelMode, { optional: stopDef.optional, dismissible: stopDef.dismissible, comboCategory: catId, rankSignal: resolveStopRankSignal(typeDef.id, catId) },
         );
         stops.push(stop);
         prevLat = place.lat;

--- a/supabase/functions/replace-curated-stop/index.ts
+++ b/supabase/functions/replace-curated-stop/index.ts
@@ -1,18 +1,20 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { fetchStopAlternatives, haversineKm } from '../_shared/stopAlternatives.ts';
+import { isValidComboSlug, isKnownRankSignal } from '../_shared/signalRankFetch.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-// ORCH-0434: Updated to new canonical slugs.
-const VALID_CATEGORIES = new Set([
-  'nature', 'icebreakers', 'drinks_and_music', 'brunch_lunch_casual',
-  'upscale_fine_dining', 'movies_theatre', 'creative_arts', 'play',
-  'flowers', 'groceries',
-]);
+// ORCH-0985: the stale local VALID_CATEGORIES whitelist (last touched ORCH-0434)
+// is gone. Slug validity is resolved against the SINGLE authority —
+// COMBO_SLUG_TO_FILTER_SIGNAL via isValidComboSlug — the same map the curated
+// generator uses. This is what fixes "Replace does nothing": the old whitelist
+// never learned about the brunch_lunch_casual→brunch+casual_food /
+// movies_theatre→movies+theatre split or the hiking/museum slots, so it
+// 400-rejected those stops. See I-CURATED-LABEL-SOURCE + Constitution #6.
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -48,12 +50,20 @@ serve(async (req) => {
       travelMode = 'walking',
       budgetMax = 1000,
       excludePlaceIds = [],
-      siblingStops = [],
+      rankSignal: rawRankSignal,
       limit: rawLimit = 10,
     } = body;
 
-    // Validate inputs
-    if (!categoryId || !VALID_CATEGORIES.has(categoryId)) {
+    // ORCH-0985: accept the vibe rank signal stamped on the stop. Ignore unknown
+    // values (Constitution #3 — never rank by a non-existent signal); fetchStop-
+    // Alternatives then falls back to the category filter signal.
+    const rankSignal =
+      typeof rawRankSignal === 'string' && isKnownRankSignal(rawRankSignal)
+        ? rawRankSignal
+        : undefined;
+
+    // Validate inputs against the single slug authority (ORCH-0985).
+    if (!categoryId || !isValidComboSlug(categoryId)) {
       return new Response(
         JSON.stringify({ error: `Invalid categoryId: ${categoryId}`, alternatives: [] }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
@@ -69,19 +79,14 @@ serve(async (req) => {
 
     const limit = Math.min(Math.max(rawLimit, 1), 20);
 
-    // Compute reference point: centroid of sibling stops if provided, else user location
-    let refLat = location.lat;
-    let refLng = location.lng;
-
-    if (Array.isArray(siblingStops) && siblingStops.length > 0) {
-      const validSiblings = siblingStops.filter(
-        (s: any) => typeof s.lat === 'number' && typeof s.lng === 'number',
-      );
-      if (validSiblings.length > 0) {
-        refLat = validSiblings.reduce((sum: number, s: any) => sum + s.lat, 0) / validSiblings.length;
-        refLng = validSiblings.reduce((sum: number, s: any) => sum + s.lng, 0) / validSiblings.length;
-      }
-    }
+    // ORCH-0985: search around the STOP BEING REPLACED. The client sends that
+    // stop's own coordinates as `location`. The previous "centroid of sibling
+    // stops" logic was the root cause of the Burning Coal bug: with one stop
+    // downtown and one stop 7km away, the midpoint landed in a theatre-desert,
+    // so the real downtown theatres were out of range and only mis-scored junk
+    // qualified. `siblingStops` is intentionally no longer used for centering.
+    const refLat = location.lat;
+    const refLng = location.lng;
 
     const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
@@ -93,6 +98,7 @@ serve(async (req) => {
       budgetMax,
       excludePlaceIds: Array.isArray(excludePlaceIds) ? excludePlaceIds : [],
       limit,
+      rankSignal,
     });
 
     console.log(`[replace-curated-stop] ${categoryId}: ${alternatives.length}/${totalAvailable} alternatives for user ${user.id}`);


### PR DESCRIPTION
## Summary
Fixes the curated-card stop **Replace** feature, which returned wrong/missing options (e.g. a balloon shop + a park instead of real theatres). Root causes, all fixed:

- **Wrong search center** — Replace searched the *midpoint of the other stops*, not the stop being replaced. A plan with one downtown stop + one stop 7km away searched a venue-desert, hiding every real downtown theatre. Now centers on the replaced stop's own location.
- **Travel-mode-choked radius** — radius was derived from travel mode (walking → 2.25km), starving results. Now a fixed metro-scale radius (25km), decoupled from travel mode.
- **Stale slug whitelist** — `replace-curated-stop` kept a private `VALID_CATEGORIES` list (last touched ORCH-0434) that 400-rejected `casual_food`/`brunch`/`movies`/`theatre`/`hiking`/`museum`. Now validates via the single `COMBO_SLUG_TO_FILTER_SIGNAL` authority.
- **Ordering + correctness** — alternatives ranked **best-score-first** (by the stop's vibe signal), distance as tiebreaker; current + sibling stops excluded from results; `hiking`/`museum` required-types passed through; client fallback `casual_eats`→`casual_food`.

Verified live on device (Burning Coal Theatre card): Replace now returns Meymandi Concert Hall, A.J. Fletcher Opera, Kennedy Theatre, etc., best-first.

Known follow-up: **ORCH-0986** — signal-scoring calibration (theatre + flowers admit mis-tagged non-venues at the eligibility gate; separate, data-driven effort).

## Test plan
- [x] 9 backend regression tests pass (slug parity, rank-signal validation, center-on-stop, decoupled radius, best-score ordering) — fail-on-revert guards included
- [x] Backend (`deno check`) + mobile (`tsc`) typecheck clean for touched files
- [x] `replace-curated-stop` + `generate-curated-experiences` deployed and reachable
- [x] Live device test on the Burning Coal card — confirmed real theatres returned, best-first