### PR TITLE
ORCH-0964: fix iOS Safari muted-autoplay for cover video

### DIFF
--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -120,12 +120,22 @@ const EventCoverWebVideo: React.FC<{
   useEffect(() => {
     const video = videoRef.current;
     if (video === null) return;
+    // iOS Safari only treats a video as eligible for inline muted autoplay when
+    // the `muted` + `playsinline` ATTRIBUTES are present at the element level.
+    // React 19 sets `muted` as a DOM property only (no attribute), so iOS refuses
+    // to autoplay and shows its native play button. Set the attributes + property
+    // imperatively, then play(). (Desktop works on the property alone.)
+    video.muted = muted;
+    if (muted) video.setAttribute("muted", "");
+    else video.removeAttribute("muted");
+    video.setAttribute("playsinline", "");
+    video.setAttribute("webkit-playsinline", "");
     if (shouldPlay) {
       void video.play().catch(() => undefined);
       return;
     }
     video.pause();
-  }, [shouldPlay, uri]);
+  }, [shouldPlay, uri, muted]);
 
   return React.createElement("video", {
     ref: videoRef,


### PR DESCRIPTION
## Problem
On iOS Safari, brand/event cover videos showed a play button and did not autoplay (confirmed live: `paused=true, muted=true, autoplay=true, controls=false, readyState=4`). Desktop autoplayed fine.

## Root cause
iOS Safari requires the `muted` + `playsinline` **attributes** present for inline muted-autoplay eligibility. React 19 sets `muted` as a DOM **property** only (no attribute), so iOS deemed the video ineligible and fell back to its native play button.

## Fix
In the shared `EventCoverWebVideo`, imperatively set the `muted`/`playsinline`/`webkit-playsinline` attributes + the muted property on the ref, then `play()`. Desktop unaffected. Video remains muted-by-default with the existing tap-to-unmute control (`showAudioControl`).

## Verification
- ORCH-0783 + ORCH-0805 gates pass; no new type-logic errors.
- Render proof on iPhone Safari to be eyeballed on the deployed preview.
- Note: iOS Low Power Mode disables all autoplay regardless — not a code issue.

🤖 ORCH-0964 iOS muted-autoplay