### PR TITLE
ORCH-0964: restore anonymous access to public brand/event pages

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -852,6 +852,7 @@ function checkNoNewBackendFiles() {
     "supabase/migrations/20260729000000_meta_orch_0972_universal_authoring.sql",
     "supabase/migrations/20260729000001_meta_orch_0972_pg_brand_offering_counts_grants.sql",
     "supabase/migrations/20260729000002_orch_0964_brand_event_theme_columns.sql",
+    "supabase/migrations/20260731000000_orch_0964_public_views_security_definer.sql",
   ];
   // META-ORCH-0952 [Buyer-web confirm pipeline deep forensics] CLOSE 2026-05-25.
   // C7 is scoped to ORCH-0863 marketing; the META-ORCH-0952 self-heal rework

--- a/supabase/migrations/20260731000000_orch_0964_public_views_security_definer.sql
+++ b/supabase/migrations/20260731000000_orch_0964_public_views_security_definer.sql
@@ -1,0 +1,28 @@
+-- ORCH-0964: restore anonymous (logged-out) access to public brand + event pages.
+--
+-- PROBLEM
+-- Anonymous visitors hit "could not load" on /b/{slug} and /e/{brand}/{event}.
+-- The public views `claimed_venues_public_view` and `business_public_events_view`
+-- were set to `security_invoker = true`, so they execute as the *calling* role.
+-- An anonymous visitor therefore needs direct SELECT on every underlying table.
+-- Every table the views read already grants SELECT to `anon` (events, event_dates,
+-- brand_hours, place_pool, ticket_types) EXCEPT `brands` — so PostgREST returned
+-- `42501 permission denied for table brands` (HTTP 401) for every anonymous load.
+--
+-- FIX
+-- Run these two views as their OWNER (security-definer), matching the already-
+-- working sibling `business_public_brands_view` (which is security-definer and
+-- loads fine for anon). Anonymous visitors then read only the view's scoped,
+-- public-safe output and never touch the `brands` table directly. This is the
+-- safest option: `brands` holds sensitive columns (Stripe connect/payout flags,
+-- contact email/phone, account internals), and the broad "Public can read non-
+-- deleted brands" RLS policy means granting anon direct table access would let
+-- anyone with the public anon key harvest that data. Security-definer avoids any
+-- direct anon access to `brands`; the views' own WHERE clauses scope the rows:
+--   * claimed_venues_public_view  -> deleted_at IS NULL AND claim_status = 'verified'
+--   * business_public_events_view -> non-deleted public events on non-deleted brands
+--
+-- No CI gate or invariant requires security_invoker on these views.
+
+ALTER VIEW public.claimed_venues_public_view SET (security_invoker = false);
+ALTER VIEW public.business_public_events_view SET (security_invoker = false);


### PR DESCRIPTION
## Problem (buyer-facing launch blocker)
Logged-out visitors get "could not load" on **every** public brand (`/b/{slug}`) and event (`/e/{brand}/{event}`) page — i.e. every shared/buyer link fails when not signed in. Reproduced with the anon key: `42501 permission denied for table brands` (HTTP 401).

## Root cause
`claimed_venues_public_view` + `business_public_events_view` are `security_invoker=true` (run as the caller). Anonymous visitors therefore need direct SELECT on every underlying table; all of them grant `anon` **except `brands`**, which was missed. The anon RLS policies on `brands` exist — only the table grant was absent — so Postgres denied at the privilege layer before RLS ran.

## Fix
Flip both views to **security-definer** (`security_invoker = false`), matching the already-working sibling `business_public_brands_view`. Anonymous visitors then read only the views' scoped, public-safe output and never touch `brands` directly. This is deliberately chosen over granting anon access to `brands`, which holds sensitive columns (Stripe connect/payout flags, contact email/phone, account internals) that the broad "non-deleted brands" policy would otherwise expose to anyone with the public anon key. The views' WHERE clauses scope rows (verified non-deleted venues / non-deleted public events).

## Apply
Migration: `supabase/migrations/20260731000000_orch_0964_public_views_security_definer.sql`. Operator applies via `supabase db push --linked` after merge. Allowlisted in the ORCH-0863 C7 gate (same commit).

## Verify (post-apply)
Re-query both views with the anon key → expect 200 + rows (currently 401).

🤖 ORCH-0964 anon public views