### PR TITLE
ORCH-0964: fix mobile-web renderer crash on public brand/event pages

### DIFF
--- a/packages/brand-rendering/PublicBrandPage.tsx
+++ b/packages/brand-rendering/PublicBrandPage.tsx
@@ -8,7 +8,6 @@ import {
   Text,
   View,
 } from "react-native";
-import { BlurView } from "expo-blur";
 import type { LucideIcon } from "lucide-react-native";
 import {
   AtSign,
@@ -22,6 +21,7 @@ import {
 } from "lucide-react-native";
 import {
   EventCoverMedia,
+  GlassBlur,
   MINGLA_DEFAULT_THEME,
   ThemeEntranceAnimation,
   resolveTheme,
@@ -546,7 +546,7 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
             },
           ]}
         >
-          <BlurView
+          <GlassBlur
             tint={palette.glassTint}
             intensity={34}
             style={styles.glassLayer}
@@ -626,7 +626,7 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
             { backgroundColor: palette.accent, borderColor: palette.accent },
           ]}
         >
-          <BlurView
+          <GlassBlur
             tint={palette.glassTint}
             intensity={18}
             style={styles.glassLayer}
@@ -898,7 +898,7 @@ const EventMiniCard: React.FC<{
         pressed && styles.cardPressed,
       ]}
     >
-      <BlurView
+      <GlassBlur
         tint={palette.glassTint}
         intensity={24}
         style={styles.glassLayer}
@@ -977,7 +977,7 @@ const NextOfferingTeaser: React.FC<{
         pressed && styles.cardPressed,
       ]}
     >
-      <BlurView
+      <GlassBlur
         tint={palette.glassTint}
         intensity={14}
         style={styles.glassLayer}
@@ -1075,7 +1075,7 @@ const TripMiniCard: React.FC<{
         pressed && styles.cardPressed,
       ]}
     >
-      <BlurView
+      <GlassBlur
         tint={palette.glassTint}
         intensity={24}
         style={styles.glassLayer}
@@ -1232,7 +1232,7 @@ const OfferingMiniCard: React.FC<{
         pressed && styles.cardPressed,
       ]}
     >
-      <BlurView
+      <GlassBlur
         tint={palette.glassTint}
         intensity={24}
         style={styles.glassLayer}
@@ -1317,7 +1317,7 @@ const ExperienceMiniCard: React.FC<{
         pressed && styles.cardPressed,
       ]}
     >
-      <BlurView
+      <GlassBlur
         tint={palette.glassTint}
         intensity={24}
         style={styles.glassLayer}
@@ -1389,7 +1389,7 @@ const AboutTab: React.FC<{
           { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
         ]}
       >
-        <BlurView
+        <GlassBlur
           tint={palette.glassTint}
           intensity={22}
           style={styles.glassLayer}
@@ -1415,7 +1415,7 @@ const AboutTab: React.FC<{
           { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
         ]}
       >
-        <BlurView
+        <GlassBlur
           tint={palette.glassTint}
           intensity={22}
           style={styles.glassLayer}

--- a/packages/event-rendering/GlassBlur.tsx
+++ b/packages/event-rendering/GlassBlur.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Platform, View, useWindowDimensions } from "react-native";
+import { BlurView } from "expo-blur";
+
+const MOBILE_WEB_MAX_WIDTH = 768;
+
+// GlassBlur — drop-in BlurView that skips the blur layer on MOBILE WEB only.
+//
+// Stacked `backdrop-filter: blur()` (what expo-blur's BlurView renders on web)
+// hard-crashes the mobile browser renderer: a public page with several glass
+// panels (e.g. PublicBrandPage's 9) reliably kills the WebContent/GPU process
+// on iOS Safari + Chrome within ~1s, even on a near-empty heap (confirmed:
+// neutralizing backdrop-filter flips the page from crash to alive). The panels
+// already carry a translucent background color, so dropping the blur layer
+// leaves a clean solid-translucent glass on mobile web. Desktop web (>= 768)
+// and native apps (cheap native blur, no crash) keep the real blur.
+export const GlassBlur: React.FC<React.ComponentProps<typeof BlurView>> = (
+  props,
+) => {
+  const { width } = useWindowDimensions();
+  if (Platform.OS === "web" && width < MOBILE_WEB_MAX_WIDTH) {
+    return props.children !== undefined ? (
+      <View style={props.style}>{props.children}</View>
+    ) : null;
+  }
+  return <BlurView {...props} />;
+};
+
+export default GlassBlur;

--- a/packages/event-rendering/PublicEventPage.tsx
+++ b/packages/event-rendering/PublicEventPage.tsx
@@ -33,7 +33,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { BlurView } from "expo-blur";
+import { GlassBlur } from "./GlassBlur";
 
 import {
   accent,
@@ -529,7 +529,7 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
             isPast && styles.bodyContentMuted,
           ]}
         >
-          <BlurView
+          <GlassBlur
             tint={palette.glassTint}
             intensity={28}
             pointerEvents="none"

--- a/packages/event-rendering/index.ts
+++ b/packages/event-rendering/index.ts
@@ -40,6 +40,9 @@ export type {
   EventCoverMediaErrorEvent,
 } from "./EventCoverMedia";
 export { resolveEventCoverMediaPresentation } from "./coverMediaPresentation";
+// ORCH-0964 — BlurView wrapper that skips backdrop-filter on mobile web (where
+// stacked blur hard-crashes the renderer). Used by public brand + event pages.
+export { GlassBlur } from "./GlassBlur";
 export type {
   PublicEventProps,
   PublicBrandProps,


### PR DESCRIPTION
## Problem (buyer-facing)
Public brand (`/b/{slug}`) and event (`/e/{brand}/{event}`) pages **crash the mobile browser renderer** ("A problem repeatedly occurred" / "Can't open this page") within ~1s of load — on iOS Safari + Chrome. Desktop is fine.

## Root cause (confirmed)
Stacked `BlurView` (which renders `backdrop-filter: blur()` on web) overwhelms the mobile compositor. Evidence: heap flat at 10MB / 34 DOM nodes at crash (not OOM); crashes even a minimal image-only brand; survives with a desktop viewport; and **injecting `backdrop-filter: none` flips the page from `crashed=true` to `alive=true`** in headless.

## Fix
New shared `GlassBlur` wrapper (`packages/event-rendering/GlassBlur.tsx`) renders `BlurView` normally on desktop web (≥768px) and native apps, but skips the blur layer on mobile web (<768px) — where panels keep their translucent background color (clean solid glass, no crash). Replaces 9 `BlurView`s in `PublicBrandPage` + 1 in `PublicEventPage`. Desktop-web glass contracts + native blur unchanged.

## Verify
Post-deploy: `/b/agloat` on a mobile viewport loads instead of crashing (headless + real iPhone).

🤖 ORCH-0964 mobile blur crash