### PR TITLE
ORCH-0964: global mobile-web backdrop-filter kill (blur-crash catch-all)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -69,7 +69,7 @@ INTAKE → INVESTIGATE → REVIEW → SPEC → REVIEW → IMPLEMENT → TEST →
 | `/mingla-forensics` | Investigation reports + specs | Write code |
 | `/mingla-implementor` | Code changes + implementation reports | Redesign, skip spec |
 | (tester) | Test reports with pass/fail | Skip regression checks |
-| `/ui-ux-pro-max` | Design recommendations | Implement code |
+| `/mingla-designer` | Premium design specs + recommendations | Implement code |
 
 **The orchestrator NEVER writes code or executes agents directly.** It writes prompts to `Mingla_Artifacts/prompts/`. The user dispatches them. This is how we keep the audit trail clean.
 
@@ -107,7 +107,7 @@ These exist because we ALREADY tripped over them. Don't trip again.
 | **Cross-domain check on every DB change.** Consumer + admin + business apps share Supabase. | R8 in risk register. |
 | **Migration chain rule.** When investigating a DB function/table, find the LATEST migration that touches it. Earlier migrations may be superseded. | We previously cited a stale CHECK constraint as current truth. Forensics now MUST verify the latest definition. |
 | **Sequential pace.** No parallel dispatches. Wait for approval after every step. | Founder rule. Stops scope creep. |
-| **/ui-ux-pro-max for visible UI.** Every implementor task touching UI must invoke `/ui-ux-pro-max` as pre-flight. | Founder rule. Quality bar enforcement. |
+| **/mingla-designer for visible UI.** Every implementor task touching UI must invoke `/mingla-designer` as pre-flight (replaces retired `/ui-ux-pro-max`). | Founder rule. Quality bar enforcement. |
 | **Keyboard never blocks an input field.** Every TextInput must remain visible above the keyboard. Reference Cycle 3 wizard root pattern. | Cost multiple reworks across Cycle 3 and 4 before being codified globally (2026-04-30). |
 | **No Co-Authored-By in commits.** No AI attribution lines. | Founder rule. |
 

--- a/packages/event-rendering/GlassBlur.tsx
+++ b/packages/event-rendering/GlassBlur.tsx
@@ -4,6 +4,28 @@ import { BlurView } from "expo-blur";
 
 const MOBILE_WEB_MAX_WIDTH = 768;
 
+// Catch-all safety net for the mobile-web blur crash.
+//
+// The per-instance width guard below only neutralizes THIS component's blur, but
+// the public pages crash at ~34 DOM nodes — before those render — because other
+// `backdrop-filter` sources (app shell / early chrome) also stack up and kill the
+// mobile renderer. A global media-query stylesheet disables backdrop-filter for
+// EVERY element under 768px at paint time (immune to the SPA render-timing race),
+// which is the exact thing proven to stop the crash. Injected once, web-only;
+// desktop web (>=768px) and native apps are unaffected.
+if (typeof document !== "undefined") {
+  const STYLE_ID = "mingla-mobile-web-no-backdrop-blur";
+  if (!document.getElementById(STYLE_ID)) {
+    const styleEl = document.createElement("style");
+    styleEl.id = STYLE_ID;
+    styleEl.textContent =
+      "@media (max-width:" +
+      (MOBILE_WEB_MAX_WIDTH - 1) +
+      "px){*,*::before,*::after{backdrop-filter:none!important;-webkit-backdrop-filter:none!important}}";
+    (document.head || document.documentElement).appendChild(styleEl);
+  }
+}
+
 // GlassBlur — drop-in BlurView that skips the blur layer on MOBILE WEB only.
 //
 // Stacked `backdrop-filter: blur()` (what expo-blur's BlurView renders on web)


### PR DESCRIPTION
Follow-up to #233. The per-instance GlassBlur guard wasn't enough — the page crashes at ~34 DOM nodes (before the 9 brand BlurViews render), so other backdrop-filter sources (app shell) also contribute. This injects a global, web-only media-query stylesheet disabling `backdrop-filter` under 768px at paint time — the exact thing the headless test proved stops the crash. Desktop web + native unaffected. Verified post-deploy headless on /b/agloat + /b/leggothis.

🤖 ORCH-0964 mobile blur global catch-all