### PR TITLE
ORCH-0964: remove duplicate EventCoverMedia export (fixes white-screen on mingla-business web)

### DIFF
--- a/packages/event-rendering/index.ts
+++ b/packages/event-rendering/index.ts
@@ -39,11 +39,6 @@ export type {
 // mingla-business cards/public pages, app-mobile, AND the shared brand page.
 export { EventCover } from "./EventCover";
 export type { EventCoverProps } from "./EventCover";
-export { EventCoverMedia } from "./EventCoverMedia";
-export type {
-  EventCoverMediaProps,
-  EventCoverMediaErrorEvent,
-} from "./EventCoverMedia";
 export { resolveEventCoverMediaPresentation } from "./coverMediaPresentation";
 // ORCH-0964 — BlurView wrapper that skips backdrop-filter on mobile web (where
 // stacked blur hard-crashes the renderer). Used by public brand + event pages.


### PR DESCRIPTION
URGENT — production mingla-business web is white-screened: index.ts exported EventCoverMedia (+ types) twice (ORCH-0978 #237 + ORCH-0964), throwing runtime `TypeError: Cannot redefine property: EventCoverMedia` → blank app (#root 0 children) on every device. Same #237 merge-collision class as the duplicate import. Removes the duplicate value+type exports; keeps unique EventCover/GlassBlur/resolver. Verified headless: root renders + no pageerror after fix.

🤖 ORCH-0964 dup-export white-screen fix