### PR TITLE
ORCH-0964: mingla-business web reliability overhaul (blank/reload/mobile-crash + CI gate)

### DIFF
--- a/.github/workflows/web-build-check.yml
+++ b/.github/workflows/web-build-check.yml
@@ -1,0 +1,34 @@
+name: Web Build Check
+
+# ORCH-0964: catch web-build breaks BEFORE merge.
+#
+# mingla-business web is built on Vercel via `expo export -p web`, but that
+# build was NOT a blocking PR check — so a parallel ORCH (#237) merged a
+# duplicate `EventCoverMedia` import (broke the build) and a duplicate export
+# (runtime white-screen), each green in isolation but broken once merged to
+# main. The build then failed silently and froze production on a stale bundle.
+#
+# This job runs the real web export on the PR MERGE result (GitHub Actions
+# pull_request checks out PR+base merged), so duplicate imports/exports,
+# syntax errors, and merge-combination breaks fail the check instead of
+# silently breaking main. Mark it a REQUIRED status check in branch protection.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  mingla-business-web-build:
+    name: "mingla-business: web build (expo export)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        working-directory: mingla-business
+        run: npm install
+      - name: Build web bundle (fails on duplicate import/export + syntax errors)
+        working-directory: mingla-business
+        run: npx expo export -p web --output-dir /tmp/web-build-check

--- a/mingla-business/app/_layout.tsx
+++ b/mingla-business/app/_layout.tsx
@@ -20,6 +20,10 @@
 // arms the LogBox filter before route-level checkout screens can pull
 // @stripe/stripe-react-native. See src/diagnostics/silenceStripeForwardRef.ts
 // for full rationale.
+// ORCH-0964: chunk-load resilience — auto-reload once on a failed JS-chunk
+// fetch (the "needs multiple reloads to load" symptom). Loop-guarded. Web-only
+// side effect; must arm before any route chunk can fail. See the module header.
+import "../src/diagnostics/chunkReloadGuard";
 import "../src/diagnostics/silenceStripeForwardRef";
 import React, { useEffect, useRef, useState } from "react";
 import {
@@ -256,17 +260,35 @@ export default function RootLayout(): React.ReactElement {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            {/* ORCH-0892-A: KeyboardRoot wraps the app shell and stays OUTSIDE
-                RootLayoutInner's ErrorBoundary. Stripe's native provider is
-                intentionally route-scoped to checkout payment screens so Home
-                startup does not initialize the payment SDK. */}
-            <KeyboardRoot>
-              <RootLayoutInner />
-            </KeyboardRoot>
-          </AuthProvider>
-        </QueryClientProvider>
+        {/* ORCH-0964: top-level ErrorBoundary ABOVE the provider tree. A throw
+            in QueryClientProvider / AuthProvider / KeyboardRoot init previously
+            escaped RootLayoutInner's (inner) boundary and blanked the whole app
+            white. This outer boundary catches it and shows the recoverable
+            fallback. Kept inside Gesture/SafeArea so the fallback has its
+            required context. */}
+        <ErrorBoundary
+          onError={(error, info) => {
+            if (sentryDsn) {
+              Sentry.captureException(error, {
+                contexts: {
+                  react: { componentStack: info.componentStack ?? "" },
+                },
+              });
+            }
+          }}
+        >
+          <QueryClientProvider client={queryClient}>
+            <AuthProvider>
+              {/* ORCH-0892-A: KeyboardRoot wraps the app shell and stays OUTSIDE
+                  RootLayoutInner's ErrorBoundary. Stripe's native provider is
+                  intentionally route-scoped to checkout payment screens so Home
+                  startup does not initialize the payment SDK. */}
+              <KeyboardRoot>
+                <RootLayoutInner />
+              </KeyboardRoot>
+            </AuthProvider>
+          </QueryClientProvider>
+        </ErrorBoundary>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/mingla-business/src/config/queryClient.ts
+++ b/mingla-business/src/config/queryClient.ts
@@ -31,7 +31,12 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: FIVE_MINUTES_MS,
-      retry: 1,
+      // ORCH-0964: bumped 1 -> 2 with capped exponential backoff. A single
+      // transient failure on the brand/identity fetch left surfaces errored
+      // (empty state behind a lifted splash = "didn't fully load"); the extra
+      // retry lets flaky-network loads recover on their own.
+      retry: 2,
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 4000),
       refetchOnWindowFocus: false,
       refetchOnReconnect: true,
     },

--- a/mingla-business/src/diagnostics/chunkReloadGuard.ts
+++ b/mingla-business/src/diagnostics/chunkReloadGuard.ts
@@ -1,0 +1,57 @@
+// ORCH-0964: web-only chunk-load resilience.
+//
+// mingla-business web is a single-output Expo Router SPA with code-split JS
+// chunks. A transient failed chunk fetch — CDN hiccup, flaky network, or a
+// stale index.html (served from cache after a deploy) pointing at hashed chunk
+// files that have since been evicted — throws ChunkLoadError / "Failed to fetch
+// dynamically imported module" and blanks the route until the user manually
+// reloads. That is the "needs reloading multiple times to load" symptom.
+//
+// This guard does ONE automatic reload when a chunk error is detected, which
+// re-fetches index.html + the current chunk hashes and almost always recovers.
+// It is time-guarded via sessionStorage so it can NEVER loop: if a chunk error
+// recurs within 10s of an auto-reload, we stop reloading and let the error
+// surface to the app's ErrorBoundary instead.
+//
+// Side-effect module: imported for its registration only (see app/_layout.tsx).
+
+const RELOAD_TS_KEY = "mingla:last-chunk-reload";
+const RELOAD_COOLDOWN_MS = 10_000;
+
+const CHUNK_ERROR_RE =
+  /ChunkLoadError|Loading chunk \d+ failed|Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i;
+
+function isChunkError(message: unknown): boolean {
+  return typeof message === "string" && CHUNK_ERROR_RE.test(message);
+}
+
+function reloadOnce(): void {
+  try {
+    const last = Number(window.sessionStorage.getItem(RELOAD_TS_KEY) ?? 0);
+    if (Number.isFinite(last) && Date.now() - last < RELOAD_COOLDOWN_MS) {
+      // Already auto-reloaded very recently — do not loop; let the
+      // ErrorBoundary show its recoverable fallback instead.
+      return;
+    }
+    window.sessionStorage.setItem(RELOAD_TS_KEY, String(Date.now()));
+    window.location.reload();
+  } catch {
+    // sessionStorage blocked (private mode) — skip the guard rather than risk a loop.
+  }
+}
+
+if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+  window.addEventListener("error", (event: ErrorEvent) => {
+    if (isChunkError(event?.message) || isChunkError((event?.error as Error | undefined)?.message)) {
+      reloadOnce();
+    }
+  });
+  window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason = event?.reason as unknown;
+    const message =
+      reason instanceof Error ? reason.message : typeof reason === "string" ? reason : undefined;
+    if (isChunkError(message)) reloadOnce();
+  });
+}
+
+export {};

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -255,6 +255,44 @@ const EventCoverVideo: React.FC<{
     <EventCoverNativeVideo {...props} />
   );
 
+// ORCH-0964: on WEB, only mount the heavy cover media (video / animated image)
+// once the card is at/near the viewport. A brand page renders many cards; if
+// all their covers (e.g. 12 animated GIFs + a video) decode at once, the mobile
+// renderer balloons past ~1GB and the WebContent process crashes ("Can't open
+// this page"). Lazy-mounting bounds concurrent decodes to what's visible.
+// One-way (load when first visible, then keep) to avoid scroll flicker. Native
+// is unaffected (always true) — no IntersectionObserver, native handles memory.
+function useInViewport(ref: React.RefObject<unknown>): boolean {
+  const [inView, setInView] = useState<boolean>(Platform.OS !== "web");
+  useEffect(() => {
+    if (Platform.OS !== "web") return;
+    if (typeof IntersectionObserver === "undefined") {
+      setInView(true);
+      return;
+    }
+    const node = ref.current as unknown as Element | null;
+    if (node === null) {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.disconnect();
+            return;
+          }
+        }
+      },
+      { rootMargin: "400px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [ref]);
+  return inView;
+}
+
 export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
   hue = 25,
   mediaUrl = null,
@@ -281,6 +319,8 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
   const [reduceMotion, setReduceMotion] = useState(false);
   const initialMuted = Platform.OS === "web" && autoplay ? true : muted;
   const [isMuted, setIsMuted] = useState(initialMuted);
+  const containerRef = useRef<View | null>(null);
+  const inView = useInViewport(containerRef);
 
   useEffect(() => {
     let mounted = true;
@@ -335,24 +375,40 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
     setHasMediaError(true);
   };
 
-  if (presentation === "fallback" || mediaUrl === null) {
+  // Render heavy media only when there IS media AND (native OR the card is at/
+  // near the viewport on web). Off-screen web cards show the lightweight
+  // EventCover placeholder until scrolled into view — bounding concurrent
+  // decodes so a media-dense brand page can't OOM the mobile renderer.
+  const renderMedia =
+    presentation !== "fallback" &&
+    mediaUrl !== null &&
+    (Platform.OS !== "web" || inView);
+
+  if (!renderMedia) {
     return (
-      <EventCover
-        hue={hue}
-        radius={radius}
-        label={label}
-        height={height}
-        width={width}
-        testID={testID}
-        style={style}
+      <View
+        ref={containerRef}
+        collapsable={false}
+        style={[{ height, width }, style]}
       >
-        {children}
-      </EventCover>
+        <EventCover
+          hue={hue}
+          radius={radius}
+          label={label}
+          height="100%"
+          width="100%"
+          testID={testID}
+        >
+          {children}
+        </EventCover>
+      </View>
     );
   }
 
   return (
     <View
+      ref={containerRef}
+      collapsable={false}
       testID={testID}
       style={[styles.container, { height, width, borderRadius: radius }, style]}
     >


### PR DESCRIPTION
Brutal root-cause pass on recurring mingla-business web failures. Four bundled fixes + a regression gate:

1. **Chunk-load resilience (P0)** — `chunkReloadGuard` one-shot loop-guarded reload on ChunkLoadError/failed dynamic import (fixes 'reload multiple times to load' / blank routes).
2. **ErrorBoundary hoisted above providers** — a provider/init throw no longer blanks the app white; shows recoverable fallback.
3. **Query retry 1→2 + backoff** — flaky brand/identity fetch self-recovers (fixes partial loads / empty surfaces behind lifted splash).
4. **Viewport-gated lazy cover media** — EventCoverMedia mounts heavy media only near-viewport on web; fixes the device-confirmed mobile renderer OOM crash (~1.26GB RSS, CrRendererMain fatal signal, respawn loop). Native unaffected.

**+ web-build-check CI workflow**: runs `expo export -p web` on the PR merge so the duplicate-import/export collision class (#237, which silently froze prod) fails the check pre-merge. Mark it required in branch protection.

Verification: jest net-neutral (12/19 identical to current-main baseline); no new tsc logic errors; ORCH-0805/0783/0964 gates pass. Will verify post-deploy: headless desktop renders + real Android device no longer crashes /b/leggothis.

🤖 ORCH-0964 web reliability