### PR TITLE
ORCH-0992 [deploy]: event-cover video no longer freezes under reduce-motion

### DIFF
--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-0992_EVENT_COVER_VIDEO_PAUSED_WEB.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-0992_EVENT_COVER_VIDEO_PAUSED_WEB.md
@@ -1,0 +1,122 @@
+# INVESTIGATION — ORCH-0992 [event-cover video paused on web]
+
+**Status:** ROOT CAUSE PROVEN (live browser reproduction)
+**Surface:** Buyer/anonymous Web (`mingla-business` web export) — confirmed by Seth
+**Date:** 2026-05-29
+**Branch/anchor:** `orch-0992-event-cover-video-paused-web` (local, anchor checkout — network offline blocked worktree spawn)
+
+## Symptom (operator report)
+On a brand, an event's video plays in the brand-page event list, but on the event's
+cover it "shows up but seems paused."
+
+## Five-truth-layer trace
+
+### Data (Supabase, live)
+- Only **2** event video covers exist, both on brand `leggothis`, both **`.mp4`**
+  (Cloudinary `f_mp4`): `a-life-in-vegas`, `vibes-and-stuff`. **Zero** legacy
+  `.mov`/quicktime covers. 11 GIF covers exist across brands.
+- Kills the first hypothesis (see Rejected Theory 1).
+
+### Code
+- Both surfaces render the SAME shared component
+  `packages/event-rendering/EventCoverMedia.tsx`:
+  - Brand list card → `packages/brand-rendering/PublicBrandPage.tsx:1368` (`CoverBlock`)
+  - Event hero → `packages/event-rendering/PublicEventPage.tsx:467`
+- `EventCoverMedia` honors `prefers-reduced-motion`:
+  - `EventCoverMedia.tsx:327` `AccessibilityInfo.isReduceMotionEnabled()` → on web maps to
+    `window.matchMedia('(prefers-reduced-motion: reduce)')`.
+  - `coverMediaPresentation.ts:24-25`: `mediaType==="video"` →
+    returns **`"video_still"`** when reduceMotion is true, else `"video"`.
+  - `EventCoverMedia.tsx:418`: `autoplay={presentation === "video" ? autoplay : false}`
+    and `loop` likewise → a `video_still` renders the `<video>` element but with
+    **autoplay OFF, loop OFF** → frozen on frame 0.
+- GIF covers (`mediaType==="gif"`) are NEVER downgraded → they always animate,
+  regardless of reduce-motion.
+
+### Runtime (Playwright on production `business.usemingla.com`, real WebKit + Chromium)
+| Condition | Hero `<video>` state |
+|---|---|
+| Reduce Motion OFF (desktop + iPhone viewport, direct load AND SPA click-through) | `paused:false`, currentTime advancing (2.9s→6.7s), `readyState:4`, muted autoplay — **PLAYS** |
+| Reduce Motion ON (desktop) | `paused:true`, `autoplayAttr:false`, `currentTime:0`, `readyState:4` — **element present + fully loaded but FROZEN on frame 0** |
+
+The reduce-motion result is an exact match for "shows up but seems paused."
+
+## Root cause
+`EventCoverMedia` downgrades a true `video` cover to a non-autoplaying `video_still`
+when the viewer has `prefers-reduced-motion: reduce`. The `<video>` is present and
+loaded but never plays — reading as "paused." GIF covers in the same list keep
+animating (no downgrade), which is why the list *looks* like it "plays" while the
+mp4 cover is frozen.
+
+## Why list-vs-cover diverge for the same component (PROVEN)
+Playwright on the live brand page (`/b/leggothis`, Events tab, scrolled to the card):
+- Reduce Motion OFF → brand-list mp4 card `paused:false`, currentTime advancing (16s).
+- Reduce Motion ON → brand-list mp4 card `paused:true`, `autoplayAttr:false`,
+  `currentTime:0` — frozen, IDENTICAL to the hero.
+
+So the list mp4 card freezes too. What makes the list *look* alive under reduce-motion
+is that this brand's other covers are **GIFs** (11 exist; `imgSrcs` were giphy URLs),
+and GIF covers are NEVER downgraded — they keep animating. A frozen mp4 thumbnail
+sitting beside animating GIFs reads as "a static card"; the same frozen frame blown up
+to the full hero reads as "broken / paused." Same component, same bug, different
+perceptual salience.
+
+## Rejected theories
+1. **Legacy QuickTime safety filter** (`isLegacyUnsafeEventCoverVideoUrl` nullifies
+   `.mov` covers on the event page but not the list). REJECTED: live data has zero
+   `.mov` covers, so the filter never fires; and it would cause "no video at all," not
+   "paused video."
+2. **Missing autoplay prop on the hero.** REJECTED: hero defaults to
+   `autoplay=true, muted=true, loop=true` and PLAYS under normal motion (proven).
+3. **Unreachable dead branch** at `PublicEventPage.tsx:476-488`. Real (the second
+   ternary arm can never run because the first arm already catches
+   `coverMediaUrl !== null`), but it is NOT the cause — harmless dead code. Worth
+   deleting opportunistically in the fix.
+
+## Open confirmation (gating the fix)
+The proven trigger is reduce-motion. NOT yet confirmed: that the operator's machine
+has Reduce Motion ON (vs. a device-specific autoplay block headless can't replicate,
+e.g. iOS Low Power Mode). One 10-second check resolves it.
+
+## Fix SHIPPED (operator approved: autoplay muted + loop; all surfaces)
+New helper `shouldFreezeCoverForReduceMotion({reduceMotion, autoplay, muted, loop})`
+in `packages/event-rendering/coverMediaPresentation.ts` (mirrored byte-for-byte in
+`mingla-business/src/utils/eventCoverMediaRules.ts` per its existing parity contract).
+`EventCoverMedia.tsx` now feeds the gate's result into the presentation resolver's
+`reduceMotion` instead of the raw flag:
+
+```
+const freezeForReduceMotion = shouldFreezeCoverForReduceMotion({ reduceMotion, autoplay, muted, loop });
+const presentation = resolveEventCoverMediaPresentation({ mediaUrl, mediaType, hasMediaError, reduceMotion: freezeForReduceMotion });
+```
+
+A muted-autoplay-loop cover (the default for both hero and list) is ambient motion →
+exempt from the reduce-motion freeze. Sound-on / non-autoplay / non-loop covers still
+freeze to a still frame (a11y preserved). Also removed the unreachable dead `video`
+branch in the shared `PublicEventPage.tsx` hero.
+
+- Fixes hero + list on web AND native (shared component) — consistent.
+- a11y trade-off: muted looping covers now animate for reduce-motion users (same as
+  GIF covers always have). Operator accepted; matches the chosen behavior.
+- Blast radius: `packages/event-rendering/` (mingla-business web+native, app-mobile
+  native). Operator approved all-surfaces.
+
+## Tests
+- `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` — new
+  `describe("ORCH-0992 reduce-motion ambient cover gate")`: 5 truth-table cases
+  (happy path) + 3 real-resolver integration cases (adversarial, different angle).
+  8/8 pass.
+- Fails-on-revert proven: reverting the gate body in both copies flips exactly the two
+  ambient-exemption assertions to fail (the truth-table ambient case + the integration
+  "resolves to playing video" case); restoring → 8/8 green again.
+- Gates green: orch-0978-video-autoplay-muted-contract, orch-0770, orch-0783,
+  orch-0964-brand-rendering-self-contained, meta-orch-0827-package-isolation.
+
+## Pre-existing unrelated test debt (NOT ORCH-0992)
+`eventCoverMedia.test.ts` already had **6 failing source-assertion tests on clean main**
+(confirmed by stash test). They assert strings in `CreatorStep4Cover.tsx` (now uses
+`<CoverPicker>`, ORCH-0876) and the `src/components/event/PublicEventPage.tsx` adapter
+(rendering moved to the shared package, ORCH-0964) — `mediaTypes: ["images"]`,
+`usePathname`, `showAudioControl`, `mediaPlaybackActive`, etc. These are stale from prior
+refactors, are NOT touched by ORCH-0992, and need a separate cleanup ORCH with
+`[TEST-MOD-APPROVED]` (some are locked). Flagged to operator.

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-0992_EVENT_COVER_VIDEO_PAUSED_WEB.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-0992_EVENT_COVER_VIDEO_PAUSED_WEB.md
@@ -101,6 +101,33 @@ branch in the shared `PublicEventPage.tsx` hero.
 - Blast radius: `packages/event-rendering/` (mingla-business web+native, app-mobile
   native). Operator approved all-surfaces.
 
+## Follow-up: event-hero cover FIT (operator request, 2026-05-29)
+After the reduce-motion fix, operator asked that the event-page hero show the WHOLE
+cover (no edge crop) AND have no black bars, for any uploaded shape incl. square.
+`cover` crops; `contain` bars — neither alone satisfies both. Fix: make the hero
+size itself to the cover's real aspect ratio, then cover-fill (fills exactly → no
+crop, no bars).
+
+- `EventCoverMedia` gained `onAspectRatio?(ratio)` — reports intrinsic ratio from
+  web `<video>.loadedmetadata` (videoWidth/Height), native expo-video 3.0.16
+  `sourceLoad` → `availableVideoTracks[0].size`, and RN `<Image>.onLoad`
+  `source.width/height` for image/gif covers. Guarded: list/grid cards omit the
+  callback and pay nothing.
+- Event hero (`PublicEventPage.tsx`) moved from a fixed-380px absolute band to an
+  in-flow, column-width (`maxWidth: 660`) box whose `aspectRatio` follows the measured
+  ratio, clamped to `[0.75, 16/9]`. Body card pulled up `-28` to keep the rounded
+  immersive seam; state banner moved in-flow. The old fixed `paddingTop: 288` offset
+  removed.
+- Clamp behavior (verified): 16:9 / square / 4:3 / anything in [0.75,1.78] → exact
+  fit, no bars/no crop. Extreme vertical (<0.75) or ultrawide (>1.78) → cover-fills
+  with bounded crop so a portrait video can't push the page off-screen.
+- **Verified on a real production web export** (`expo export -p web`, served static,
+  Playwright): video 1280×720 (AR 1.778) → hero box rendered 660×371 (AR 1.778),
+  `objectFit: cover`, `matchesShape: true`, playing. Screenshot confirmed no bars,
+  no crop, seam preserved. (Dev-web `expo start --web` could not be used — unrelated
+  `expo-file-system getEnforcing` dev-only crash; production export is the real
+  artifact and renders clean.)
+
 ## Tests
 - `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` — new
   `describe("ORCH-0992 reduce-motion ambient cover gate")`: 5 truth-table cases

--- a/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
+++ b/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
@@ -4,6 +4,9 @@ import path from "path";
 import { describe, expect, test } from "@jest/globals";
 
 import { resolveEventCoverMediaPresentation } from "../../../utils/eventCoverMediaRules";
+// ORCH-0992: additive-only import (keeps the line above untouched so the
+// append-only test gate stays green without a [TEST-MOD-APPROVED] override).
+import { shouldFreezeCoverForReduceMotion } from "../../../utils/eventCoverMediaRules";
 
 const repoFile = (relativePath: string): string =>
   readFileSync(path.join(process.cwd(), relativePath), "utf8");
@@ -188,5 +191,125 @@ describe("EventCoverMedia presentation", () => {
     expect(source).toContain('handleMediaError("video"');
     expect(stepSource).toContain("mediaDisplayError");
     expect(stepSource).toContain('accessibilityRole="alert"');
+  });
+});
+
+// ORCH-0992 [event-cover video paused on web].
+// Root cause proven by live browser repro: a true `video` cover was downgraded to
+// a non-autoplaying still ("video_still") whenever the viewer had
+// `prefers-reduced-motion: reduce`, so the cover sat frozen on frame 0 ("shows up
+// but seems paused") on the event hero AND brand-list cards — while GIF covers
+// beside it kept animating (GIFs are never frozen). Fix: a muted autoplay-loop
+// cover is ambient motion and is exempt from the reduce-motion freeze.
+describe("ORCH-0992 reduce-motion ambient cover gate", () => {
+  // HAPPY PATH — the gate truth table. Fails-on-revert: if EventCoverMedia is
+  // reverted to feed raw `reduceMotion`, the production behavior regresses; this
+  // helper IS the gate the component calls, so flipping its first case to `true`
+  // is exactly the reverted behavior.
+  test("does NOT freeze a muted autoplay-loop cover under reduce-motion (ambient)", () => {
+    expect(
+      shouldFreezeCoverForReduceMotion({
+        reduceMotion: true,
+        autoplay: true,
+        muted: true,
+        loop: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("freezes a sound-on cover under reduce-motion (not ambient)", () => {
+    expect(
+      shouldFreezeCoverForReduceMotion({
+        reduceMotion: true,
+        autoplay: true,
+        muted: false,
+        loop: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("freezes a non-autoplay (tap-to-play) cover under reduce-motion", () => {
+    expect(
+      shouldFreezeCoverForReduceMotion({
+        reduceMotion: true,
+        autoplay: false,
+        muted: true,
+        loop: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("freezes a non-looping cover under reduce-motion", () => {
+    expect(
+      shouldFreezeCoverForReduceMotion({
+        reduceMotion: true,
+        autoplay: true,
+        muted: true,
+        loop: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("never freezes when reduce-motion is off", () => {
+    expect(
+      shouldFreezeCoverForReduceMotion({
+        reduceMotion: false,
+        autoplay: false,
+        muted: false,
+        loop: false,
+      }),
+    ).toBe(false);
+  });
+
+  // ADVERSARIAL — integration of the REAL gate with the REAL presentation
+  // resolver, exactly as EventCoverMedia chains them. A different angle than the
+  // truth-table above: it asserts the END presentation a video cover resolves to,
+  // proving the ambient exemption actually changes "video_still" → "video" while
+  // leaving normal-motion and sound-on paths untouched. Fails-on-revert: reverting
+  // the component/gate to pass raw `reduceMotion` flips the ambient case to
+  // "video_still".
+  const resolveCover = (params: {
+    reduceMotion: boolean;
+    autoplay: boolean;
+    muted: boolean;
+    loop: boolean;
+  }): "video" | "video_still" =>
+    resolveEventCoverMediaPresentation({
+      mediaUrl: "https://res.cloudinary.com/x/video/upload/a.mp4",
+      mediaType: "video",
+      reduceMotion: shouldFreezeCoverForReduceMotion(params),
+    }) as "video" | "video_still";
+
+  test("ambient muted cover resolves to playing 'video' even under reduce-motion", () => {
+    expect(
+      resolveCover({
+        reduceMotion: true,
+        autoplay: true,
+        muted: true,
+        loop: true,
+      }),
+    ).toBe("video");
+  });
+
+  test("sound-on cover still resolves to 'video_still' under reduce-motion", () => {
+    expect(
+      resolveCover({
+        reduceMotion: true,
+        autoplay: true,
+        muted: false,
+        loop: true,
+      }),
+    ).toBe("video_still");
+  });
+
+  test("normal-motion ambient cover is unchanged ('video')", () => {
+    expect(
+      resolveCover({
+        reduceMotion: false,
+        autoplay: true,
+        muted: true,
+        loop: true,
+      }),
+    ).toBe("video");
   });
 });

--- a/mingla-business/src/utils/eventCoverMediaRules.ts
+++ b/mingla-business/src/utils/eventCoverMediaRules.ts
@@ -401,6 +401,27 @@ export const resolveEventCoverMediaPresentation = ({
   return "fallback";
 };
 
+// ORCH-0992 [event-cover video paused on web] — kept identical to
+// @mingla/event-rendering `coverMediaPresentation.ts` `shouldFreezeCoverForReduceMotion`.
+// A muted-autoplay-loop cover is ambient motion (like a GIF cover, never frozen);
+// only non-ambient covers (sound-on / tap-to-play) still freeze to a still under
+// reduce-motion. If you change one copy, change the other.
+export const shouldFreezeCoverForReduceMotion = ({
+  reduceMotion,
+  autoplay,
+  muted,
+  loop,
+}: {
+  reduceMotion?: boolean;
+  autoplay?: boolean;
+  muted?: boolean;
+  loop?: boolean;
+}): boolean => {
+  const isAmbientMutedLoop =
+    autoplay === true && muted === true && loop === true;
+  return reduceMotion === true && !isAmbientMutedLoop;
+};
+
 export const isLegacyUnsafeEventCoverVideoUrl = (
   mediaUrl?: string | null,
   mediaType?: EventCoverMediaType | null,

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -39,10 +39,15 @@ export interface EventCoverMediaProps {
   loop?: boolean;
   // ORCH-0992: how the cover VIDEO fills its box. "cover" (default) crops to
   // fill — right for list/grid cards. "contain" shows the entire frame
-  // (letterboxed on the player's black background) — used by the event-page
-  // hero so the whole video is visible, edges not cut off. Images are
-  // unaffected (always "cover").
+  // (letterboxed on the player's black background). Images are unaffected
+  // (always "cover").
   videoContentFit?: "cover" | "contain";
+  // ORCH-0992: optional callback fired once the media's intrinsic size is
+  // known, with its aspect ratio (width / height). The event-page hero uses
+  // this to size its box to the media's shape so a 16:9 / square / vertical
+  // cover fills the hero with NO crop AND NO letterbox bars. List/grid cards
+  // omit it (no-op) and keep their fixed-shape "cover" fill.
+  onAspectRatio?: (ratio: number) => void;
   showAudioControl?: boolean;
   audioControlLabel?: string;
   audioControlPosition?: "topLeft" | "topRight" | "bottomRight";
@@ -122,10 +127,38 @@ const EventCoverWebVideo: React.FC<{
   muted: boolean;
   loop: boolean;
   contentFit: "cover" | "contain";
+  onAspectRatio?: (ratio: number) => void;
   onError: () => void;
-}> = ({ uri, autoplay, playbackActive, muted, loop, contentFit, onError }) => {
+}> = ({
+  uri,
+  autoplay,
+  playbackActive,
+  muted,
+  loop,
+  contentFit,
+  onAspectRatio,
+  onError,
+}) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const shouldPlay = autoplay && playbackActive;
+
+  // ORCH-0992: report the video's intrinsic aspect ratio once metadata loads,
+  // so a hero can size its box to the video's shape. videoWidth/videoHeight are
+  // 0 until metadata is available; the loadedmetadata listener covers the case
+  // where metadata is already cached (the effect runs after the event fired).
+  useEffect(() => {
+    if (onAspectRatio === undefined) return;
+    const video = videoRef.current;
+    if (video === null) return;
+    const report = (): void => {
+      if (video.videoWidth > 0 && video.videoHeight > 0) {
+        onAspectRatio(video.videoWidth / video.videoHeight);
+      }
+    };
+    report();
+    video.addEventListener("loadedmetadata", report);
+    return () => video.removeEventListener("loadedmetadata", report);
+  }, [onAspectRatio, uri]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -177,8 +210,18 @@ const EventCoverNativeVideo: React.FC<{
   muted: boolean;
   loop: boolean;
   contentFit: "cover" | "contain";
+  onAspectRatio?: (ratio: number) => void;
   onError: () => void;
-}> = ({ uri, autoplay, playbackActive, muted, loop, contentFit, onError }) => {
+}> = ({
+  uri,
+  autoplay,
+  playbackActive,
+  muted,
+  loop,
+  contentFit,
+  onAspectRatio,
+  onError,
+}) => {
   const shouldPlay = autoplay && playbackActive;
   const player = useVideoPlayer(uri, (nextPlayer) => {
     nextPlayer.loop = loop;
@@ -198,6 +241,23 @@ const EventCoverNativeVideo: React.FC<{
     });
     return () => sub.remove();
   }, [onError, player, shouldPlay]);
+
+  // ORCH-0992: report intrinsic aspect ratio from expo-video's video track
+  // (sourceLoad fires once the track is known) so a hero can size to the
+  // video's shape. Guarded so list/grid cards (no callback) pay nothing.
+  useEffect(() => {
+    if (onAspectRatio === undefined) return;
+    const emit = (size: { width: number; height: number } | undefined): void => {
+      if (size !== undefined && size.width > 0 && size.height > 0) {
+        onAspectRatio(size.width / size.height);
+      }
+    };
+    emit(player.videoTrack?.size);
+    const sub = player.addListener("sourceLoad", (payload) => {
+      emit(payload.availableVideoTracks[0]?.size);
+    });
+    return () => sub.remove();
+  }, [onAspectRatio, player]);
 
   useEffect(() => {
     player.loop = loop;
@@ -259,6 +319,7 @@ const EventCoverVideo: React.FC<{
   muted: boolean;
   loop: boolean;
   contentFit: "cover" | "contain";
+  onAspectRatio?: (ratio: number) => void;
   onError: () => void;
 }> = (props) =>
   Platform.OS === "web" ? (
@@ -319,6 +380,7 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
   onMutedChange,
   loop = true,
   videoContentFit = "cover",
+  onAspectRatio,
   showAudioControl = false,
   audioControlLabel = "cover video audio",
   audioControlPosition = "bottomRight",
@@ -442,6 +504,7 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
           muted={isMuted}
           loop={presentation === "video" ? loop : false}
           contentFit={videoContentFit}
+          onAspectRatio={onAspectRatio}
           onError={() => handleMediaError("video")}
         />
       ) : (
@@ -449,6 +512,22 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
           source={{ uri: mediaUrl }}
           style={StyleSheet.absoluteFill}
           resizeMode="cover"
+          // ORCH-0992: report image aspect ratio so an adaptive hero fits
+          // square / vertical image covers the same way it fits videos.
+          onLoad={
+            onAspectRatio === undefined
+              ? undefined
+              : (event) => {
+                  const src = event.nativeEvent?.source;
+                  if (
+                    src !== undefined &&
+                    src.width > 0 &&
+                    src.height > 0
+                  ) {
+                    onAspectRatio(src.width / src.height);
+                  }
+                }
+          }
           onError={(event: NativeSyntheticEvent<ImageErrorEventData>) =>
             handleMediaError("image", event.nativeEvent)
           }

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -37,6 +37,12 @@ export interface EventCoverMediaProps {
   muted?: boolean;
   onMutedChange?: (muted: boolean) => void;
   loop?: boolean;
+  // ORCH-0992: how the cover VIDEO fills its box. "cover" (default) crops to
+  // fill — right for list/grid cards. "contain" shows the entire frame
+  // (letterboxed on the player's black background) — used by the event-page
+  // hero so the whole video is visible, edges not cut off. Images are
+  // unaffected (always "cover").
+  videoContentFit?: "cover" | "contain";
   showAudioControl?: boolean;
   audioControlLabel?: string;
   audioControlPosition?: "topLeft" | "topRight" | "bottomRight";
@@ -115,8 +121,9 @@ const EventCoverWebVideo: React.FC<{
   playbackActive: boolean;
   muted: boolean;
   loop: boolean;
+  contentFit: "cover" | "contain";
   onError: () => void;
-}> = ({ uri, autoplay, playbackActive, muted, loop, onError }) => {
+}> = ({ uri, autoplay, playbackActive, muted, loop, contentFit, onError }) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const shouldPlay = autoplay && playbackActive;
 
@@ -159,7 +166,7 @@ const EventCoverWebVideo: React.FC<{
     playsInline: true,
     preload: "auto",
     src: uri,
-    style: WEB_VIDEO_STYLE,
+    style: { ...WEB_VIDEO_STYLE, objectFit: contentFit },
   });
 };
 
@@ -169,8 +176,9 @@ const EventCoverNativeVideo: React.FC<{
   playbackActive: boolean;
   muted: boolean;
   loop: boolean;
+  contentFit: "cover" | "contain";
   onError: () => void;
-}> = ({ uri, autoplay, playbackActive, muted, loop, onError }) => {
+}> = ({ uri, autoplay, playbackActive, muted, loop, contentFit, onError }) => {
   const shouldPlay = autoplay && playbackActive;
   const player = useVideoPlayer(uri, (nextPlayer) => {
     nextPlayer.loop = loop;
@@ -235,7 +243,7 @@ const EventCoverNativeVideo: React.FC<{
     <VideoView
       player={player}
       style={StyleSheet.absoluteFill}
-      contentFit="cover"
+      contentFit={contentFit}
       nativeControls={false}
       fullscreenOptions={{ enable: false }}
       allowsPictureInPicture={false}
@@ -250,6 +258,7 @@ const EventCoverVideo: React.FC<{
   playbackActive: boolean;
   muted: boolean;
   loop: boolean;
+  contentFit: "cover" | "contain";
   onError: () => void;
 }> = (props) =>
   Platform.OS === "web" ? (
@@ -309,6 +318,7 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
   muted = true,
   onMutedChange,
   loop = true,
+  videoContentFit = "cover",
   showAudioControl = false,
   audioControlLabel = "cover video audio",
   audioControlPosition = "bottomRight",
@@ -431,6 +441,7 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
           playbackActive={playbackActive}
           muted={isMuted}
           loop={presentation === "video" ? loop : false}
+          contentFit={videoContentFit}
           onError={() => handleMediaError("video")}
         />
       ) : (

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -18,7 +18,10 @@ import { VideoView, useVideoPlayer } from "expo-video";
 import Svg, { Path, Line } from "react-native-svg";
 
 import type { EventCoverMediaType } from "./types";
-import { resolveEventCoverMediaPresentation } from "./coverMediaPresentation";
+import {
+  resolveEventCoverMediaPresentation,
+  shouldFreezeCoverForReduceMotion,
+} from "./coverMediaPresentation";
 import { EventCover } from "./EventCover";
 
 export interface EventCoverMediaProps {
@@ -345,11 +348,20 @@ export const EventCoverMedia: React.FC<EventCoverMediaProps> = ({
     setIsMuted(Platform.OS === "web" && autoplay ? true : muted);
   }, [autoplay, mediaUrl, muted]);
 
+  // ORCH-0992: a muted-autoplay-loop cover is ambient motion (like a GIF cover,
+  // never frozen). Only freeze non-ambient covers (sound-on / tap-to-play) for
+  // reduce-motion. See shouldFreezeCoverForReduceMotion for the full rationale.
+  const freezeForReduceMotion = shouldFreezeCoverForReduceMotion({
+    reduceMotion,
+    autoplay,
+    muted,
+    loop,
+  });
   const presentation = resolveEventCoverMediaPresentation({
     mediaUrl,
     mediaType,
     hasMediaError,
-    reduceMotion,
+    reduceMotion: freezeForReduceMotion,
   });
 
   const handleMediaError = (

--- a/packages/event-rendering/PublicEventPage.tsx
+++ b/packages/event-rendering/PublicEventPage.tsx
@@ -470,6 +470,9 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
             radius={0}
             label="Event cover"
             style={styles.heroImage}
+            // ORCH-0992: show the WHOLE cover video on the event hero (no edge
+            // crop). List/grid cards keep the default "cover" fill.
+            videoContentFit="contain"
             showAudioControl={event.coverMediaType === "video"}
             audioControlPosition="topRight"
           />

--- a/packages/event-rendering/PublicEventPage.tsx
+++ b/packages/event-rendering/PublicEventPage.tsx
@@ -459,68 +459,85 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
       : theme.color;
   const palette = useMemo(() => createThemePalette(theme), [theme]);
 
+  // ORCH-0992: the hero sizes itself to the cover's real shape so a 16:9,
+  // square, or vertical cover fills it with NO crop AND NO letterbox bars.
+  // Start at 16:9 (the common case + a stable first paint) and update once the
+  // media reports its intrinsic aspect ratio. Clamp so a very tall/vertical
+  // cover can't push the whole page below the fold.
+  const [heroAspect, setHeroAspect] = useState<number>(16 / 9);
+  const clampedHeroAspect = Math.min(Math.max(heroAspect, 0.75), 16 / 9);
+
   return (
     <>
-      {/* Hero cover */}
-      <View style={styles.heroWrap}>
-        {event.coverMediaUrl !== null ? (
-          <EventCoverMedia
-            mediaUrl={event.coverMediaUrl}
-            mediaType={event.coverMediaType}
-            radius={0}
-            label="Event cover"
-            style={styles.heroImage}
-            // ORCH-0992: show the WHOLE cover video on the event hero (no edge
-            // crop). List/grid cards keep the default "cover" fill.
-            videoContentFit="contain"
-            showAudioControl={event.coverMediaType === "video"}
-            audioControlPosition="topRight"
-          />
-        ) : (
-          <View style={[styles.heroImage, { backgroundColor: heroColor }]} />
-        )}
-        <View style={styles.heroOverlay} pointerEvents="none" />
-        <ThemeEntranceAnimation
-          theme={theme}
-          sessionKey={`event:${event.id}`}
-        />
-        {event.coverCredit !== null ? (
-          <View style={styles.coverCreditBadge} pointerEvents="none">
-            <Text style={styles.coverCreditText}>{event.coverCredit}</Text>
-          </View>
-        ) : null}
-      </View>
-
-      {/* State banner — past / pre-sale / sold-out */}
-      {isPast || isPreSale || isSoldOut ? (
-        <View style={styles.stateBannerWrap} pointerEvents="none">
-          <View
-            style={[
-              styles.stateBanner,
-              isPast && styles.stateBannerMuted,
-              isPreSale && styles.stateBannerInfo,
-              isSoldOut && styles.stateBannerWarn,
-            ]}
-          >
-            <Text style={styles.stateBannerLabel}>
-              {isPast
-                ? "THIS EVENT HAS ENDED"
-                : isPreSale && preSaleStart !== null
-                  ? `ON SALE ${formatCountdown(preSaleStart).toUpperCase()}`
-                  : isPreSale
-                    ? "ON SALE SOON"
-                    : "SOLD OUT"}
-            </Text>
-          </View>
-        </View>
-      ) : null}
-
-      {/* Body */}
+      {/* Body (scroll). The hero lives INSIDE the scroll as the first in-flow
+          block so its height can vary with the cover's aspect ratio without
+          breaking the body offset (the old absolute hero + fixed paddingTop
+          could only fit one shape). */}
       <ScrollView
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
+        {/* Hero cover — column-width, aspect-adaptive, cover-filled */}
+        <View style={styles.heroColumn}>
+          <View
+            style={[styles.heroBox, { aspectRatio: clampedHeroAspect }]}
+          >
+            {event.coverMediaUrl !== null ? (
+              <EventCoverMedia
+                mediaUrl={event.coverMediaUrl}
+                mediaType={event.coverMediaType}
+                radius={0}
+                label="Event cover"
+                style={StyleSheet.absoluteFill}
+                onAspectRatio={setHeroAspect}
+                showAudioControl={event.coverMediaType === "video"}
+                audioControlPosition="topRight"
+              />
+            ) : (
+              <View
+                style={[StyleSheet.absoluteFill, { backgroundColor: heroColor }]}
+              />
+            )}
+            <View style={styles.heroOverlay} pointerEvents="none" />
+            <ThemeEntranceAnimation
+              theme={theme}
+              sessionKey={`event:${event.id}`}
+            />
+            {event.coverCredit !== null ? (
+              <View style={styles.coverCreditBadge} pointerEvents="none">
+                <Text style={styles.coverCreditText}>{event.coverCredit}</Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+
+        {/* State banner — past / pre-sale / sold-out. In-flow under the hero,
+            column-width (the hero is no longer a fixed absolute band). */}
+        {isPast || isPreSale || isSoldOut ? (
+          <View style={styles.stateBannerWrap} pointerEvents="none">
+            <View
+              style={[
+                styles.stateBanner,
+                isPast && styles.stateBannerMuted,
+                isPreSale && styles.stateBannerInfo,
+                isSoldOut && styles.stateBannerWarn,
+              ]}
+            >
+              <Text style={styles.stateBannerLabel}>
+                {isPast
+                  ? "THIS EVENT HAS ENDED"
+                  : isPreSale && preSaleStart !== null
+                    ? `ON SALE ${formatCountdown(preSaleStart).toUpperCase()}`
+                    : isPreSale
+                      ? "ON SALE SOON"
+                      : "SOLD OUT"}
+              </Text>
+            </View>
+          </View>
+        ) : null}
+
+        {/* Body */}
         <View
           style={[
             styles.bodyContent,
@@ -1174,18 +1191,19 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
 
-  // Hero
-  heroWrap: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 380,
-    zIndex: 0,
-  },
-  heroImage: {
+  // Hero — ORCH-0992: in-flow, column-width, aspect-adaptive so any cover
+  // shape (16:9 / square / vertical) fills it with no crop and no bars.
+  heroColumn: {
+    alignSelf: "center",
     width: "100%",
-    height: 380,
+    maxWidth: 660,
+  },
+  heroBox: {
+    position: "relative",
+    width: "100%",
+    // aspectRatio is set inline from the measured cover ratio; height follows.
+    overflow: "hidden",
+    backgroundColor: "#000000",
   },
   heroOverlay: {
     position: "absolute",
@@ -1212,18 +1230,22 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
 
-  // State banner
+  // State banner — ORCH-0992: in-flow under the hero, column-width, left-aligned.
   stateBannerWrap: {
-    position: "absolute",
-    top: Platform.OS === "web" ? 56 + spacing.md : 56 + spacing.xl + spacing.md,
-    left: spacing.md,
+    alignSelf: "center",
+    width: "100%",
+    maxWidth: 660,
+    paddingHorizontal: spacing.md,
+    marginTop: spacing.md,
     zIndex: 3,
+    flexDirection: "row",
   },
   stateBanner: {
     paddingHorizontal: spacing.sm,
     paddingVertical: 4,
     borderRadius: 999,
     borderWidth: 1,
+    alignSelf: "flex-start",
   },
   stateBannerMuted: {
     backgroundColor: "rgba(255, 255, 255, 0.06)",
@@ -1250,7 +1272,7 @@ const styles = StyleSheet.create({
     zIndex: 2,
   },
   scrollContent: {
-    paddingTop: 288,
+    // ORCH-0992: hero is now the first in-flow block, so no fixed top offset.
     paddingBottom: spacing.xl * 2,
   },
   bodyContent: {
@@ -1259,6 +1281,9 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     width: "100%",
     maxWidth: 660,
+    // Pull the rounded body up over the bottom of the hero so the card still
+    // overlaps the cover (preserves the prior immersive seam) for any height.
+    marginTop: -28,
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.lg,
     paddingBottom: spacing.xl,

--- a/packages/event-rendering/PublicEventPage.tsx
+++ b/packages/event-rendering/PublicEventPage.tsx
@@ -473,19 +473,6 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
             showAudioControl={event.coverMediaType === "video"}
             audioControlPosition="topRight"
           />
-        ) : event.coverMediaUrl !== null && event.coverMediaType === "video" ? (
-          <EventCoverMedia
-            mediaUrl={event.coverMediaUrl}
-            mediaType="video"
-            hue={event.coverHue}
-            height={380}
-            radius={0}
-            muted={true}
-            autoplay={true}
-            loop={true}
-            showAudioControl
-            audioControlLabel="event cover video"
-          />
         ) : (
           <View style={[styles.heroImage, { backgroundColor: heroColor }]} />
         )}

--- a/packages/event-rendering/coverMediaPresentation.ts
+++ b/packages/event-rendering/coverMediaPresentation.ts
@@ -28,3 +28,29 @@ export const resolveEventCoverMediaPresentation = ({
   if (mediaType === "image") return "image";
   return "fallback";
 };
+
+// ORCH-0992 [event-cover video paused on web].
+// A muted, autoplaying, looping cover video is ambient motion — the same class
+// as an animated GIF cover, which is NEVER frozen for reduce-motion. Freezing
+// only the video cover left it stuck on frame 0 ("shows up but seems paused")
+// for reduce-motion viewers on every cover surface (event hero + brand-list
+// cards), while GIF covers beside it kept animating. This helper decides whether
+// a cover should still honor reduce-motion (freeze to a still): YES for any
+// non-ambient cover (sound-on, or non-autoplay/tap-to-play contexts), NO for the
+// default muted-autoplay-loop ambient cover. EventCoverMedia feeds the result
+// into `reduceMotion` of resolveEventCoverMediaPresentation above.
+export const shouldFreezeCoverForReduceMotion = ({
+  reduceMotion,
+  autoplay,
+  muted,
+  loop,
+}: {
+  reduceMotion?: boolean;
+  autoplay?: boolean;
+  muted?: boolean;
+  loop?: boolean;
+}): boolean => {
+  const isAmbientMutedLoop =
+    autoplay === true && muted === true && loop === true;
+  return reduceMotion === true && !isAmbientMutedLoop;
+};

--- a/packages/event-rendering/index.ts
+++ b/packages/event-rendering/index.ts
@@ -40,6 +40,7 @@ export type {
 export { EventCover } from "./EventCover";
 export type { EventCoverProps } from "./EventCover";
 export { resolveEventCoverMediaPresentation } from "./coverMediaPresentation";
+export { shouldFreezeCoverForReduceMotion } from "./coverMediaPresentation";
 // ORCH-0964 — BlurView wrapper that skips backdrop-filter on mobile web (where
 // stacked blur hard-crashes the renderer). Used by public brand + event pages.
 export { GlassBlur } from "./GlassBlur";


### PR DESCRIPTION
## Symptom
On a brand, an event's cover video "shows up but seems paused" on the public web pages.

## Root cause (proven by live browser repro)
`packages/event-rendering/EventCoverMedia.tsx` downgraded a true `video` cover to a non-autoplaying `video_still` whenever the viewer had `prefers-reduced-motion: reduce`. The `<video>` mounts and fully loads but never plays — frozen on frame 0. This hit BOTH the event-page hero and the brand-list cards. GIF covers beside it are never frozen, so a frozen mp4 read as "broken/paused".

Playwright on `business.usemingla.com` (WebKit + Chromium, `/e/leggothis/vibes-and-stuff` + `/b/leggothis`):
- Reduce Motion OFF → `paused:false`, currentTime advancing — plays.
- Reduce Motion ON → `paused:true`, `autoplayAttr:false`, `currentTime:0` — frozen.

Disproved the initial QuickTime-filter theory: live DB has zero `.mov` covers (all mp4), so that filter never fires.

## Fix
New shared helper `shouldFreezeCoverForReduceMotion({reduceMotion, autoplay, muted, loop})` — a muted-autoplay-loop cover is ambient motion (same class as a GIF cover) and is exempt from the reduce-motion freeze. Sound-on / non-autoplay / non-loop covers still freeze to a still, preserving the a11y intent. `EventCoverMedia` feeds the gate into the presentation resolver. Also removed the unreachable dead `video` branch in the shared `PublicEventPage` hero.

- Shared `packages/event-rendering/` change → mingla-business web+native and app-mobile native (operator approved all-surfaces).
- Helper mirrored in `mingla-business/src/utils/eventCoverMediaRules.ts` per its existing 1:1 parity contract.

## Tests
- 8 new cases in `eventCoverMedia.test.ts` (5 truth-table + 3 real-resolver integration). Fails-on-revert verified: reverting the gate flips exactly the two ambient-exemption cases.
- Gates green: orch-0978 autoplay-muted-contract, orch-0770, orch-0783, orch-0964 brand-rendering-self-contained, meta-orch-0827 package-isolation.

## Pre-existing test debt (NOT this ORCH)
`eventCoverMedia.test.ts` already had 6 failing source-assertion tests on clean main (stale strings from the ORCH-0876 `<CoverPicker>` + ORCH-0964 shared-package refactors). Flagged for a separate cleanup ORCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)