### PR TITLE
ORCH-0991: home deck — 'Swipe History' pill + curated stop-number fix + image-count removal

### DIFF
--- a/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
+++ b/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, Image, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTranslation } from 'react-i18next';
 import { TrackedTouchableOpacity } from './TrackedTouchableOpacity';
@@ -42,6 +43,12 @@ interface Props {
 
 export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measurementSystem, currencyCode }: Props) {
   const { t } = useTranslation(['common']);
+  const insets = useSafeAreaInsets();
+  // ORCH-0991: deck is full-bleed under the floating glass top bar (HomePage safeArea has
+  // no top inset). Push the per-stop number badges below the chrome so they aren't clipped
+  // behind the status bar / Dynamic Island / preferences button. +62 matches the codebase's
+  // established "just below the glass top bar" offset.
+  const stopBadgeTop = insets.top + 62;
 
   // Compact card shows only main (non-optional) stops
   const mainStops = card.stops.filter(s => !s.optional);
@@ -101,7 +108,7 @@ export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measur
                 <View style={[styles.stopImage, styles.imagePlaceholder]} />
               )}
               {!isSingleStop && (
-                <View style={styles.stopBadgeWrapper}>
+                <View style={[styles.stopBadgeWrapper, { top: stopBadgeTop }]}>
                   <GlassBadge variant="circular" accessibilityLabel={`Stop ${idx + 1}`}>
                     {idx + 1}
                   </GlassBadge>
@@ -196,9 +203,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#2C2C2E',
   },
   // ORCH-0566: position-only wrapper — GlassBadge (variant=circular) provides its own skin.
+  // ORCH-0991: `top` is set at runtime (safe-area inset + 62) so the badge clears the
+  // floating glass top bar; `left` is static.
   stopBadgeWrapper: {
     position: 'absolute',
-    top: 8,
     left: 8,
   },
   // Hero fade — matches SwipeableCards.tsx heroGradient

--- a/app-mobile/src/components/SwipeableCards.tsx
+++ b/app-mobile/src/components/SwipeableCards.tsx
@@ -2323,22 +2323,30 @@ export default function SwipeableCards({
             </View>
           )}
 
-          {/* View Previous overlay — appears after first swipe.
-              ORCH-0589 v4 (V4): repositioned below the floating top-bar chrome so it
-              doesn't collide with the Notifications bell. top = safeArea.top + ~62
-              (row height 52 + topInset 2 + 8 breathing). Right-aligned position preserved. */}
+          {/* Swipe History overlay — appears after first swipe.
+              ORCH-0991: renamed from the "{count} viewed" pill to a static "Swipe History"
+              label, centered horizontally and sat in the empty center slot of the glass
+              top bar (just below the status bar). top = safeArea.top + 10 aligns the chip
+              vertically against the preferences/notifications buttons (button band
+              safeArea.top+2 → +46, center +24). The center slot is empty here
+              (sessionSwitcher={null} in HomePage), so it clears both buttons. */}
           {sessionSwipedCards.length > 0 && (
-            <TouchableOpacity
-              style={[styles.batchChip, { top: safeAreaInsets.top + 62 }]}
-              onPress={() => setDismissedSheetVisible(true)}
-              activeOpacity={0.7}
-              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            <View
+              style={[styles.batchChipWrap, { top: safeAreaInsets.top + 10 }]}
+              pointerEvents="box-none"
             >
-              <Icon name="time-outline" size={14} color="#6b7280" />
-              <Text style={styles.batchChipText}>
-                {t('cards:swipeable.viewed', { count: sessionSwipedCards.length })}
-              </Text>
-            </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.batchChip}
+                onPress={() => setDismissedSheetVisible(true)}
+                activeOpacity={0.7}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              >
+                <Icon name="time-outline" size={14} color="#6b7280" />
+                <Text style={styles.batchChipText}>
+                  {t('cards:swipeable.swipe_history')}
+                </Text>
+              </TouchableOpacity>
+            </View>
           )}
           {showNextBatchLoader && (
             <View style={styles.nextBatchOverlay} pointerEvents="none">
@@ -2376,12 +2384,7 @@ export default function SwipeableCards({
                       style={styles.heroGradient}
                     />
 
-                    {/* Gallery Indicator if multiple images (ORCH-0566: glass) */}
-                    {nextCard.images && nextCard.images.length > 1 && (
-                      <View style={styles.galleryIndicatorWrapper}>
-                        <GlassBadge iconName="images">{nextCard.images.length}</GlassBadge>
-                      </View>
-                    )}
+                    {/* ORCH-0991: image-count badge removed from cards. */}
 
                     {/* Title and Details Overlay */}
                     <View style={styles.titleOverlay}>
@@ -2513,12 +2516,7 @@ export default function SwipeableCards({
                       style={styles.heroGradient}
                     />
 
-                    {/* Gallery Indicator if multiple images (ORCH-0566: glass) */}
-                    {currentRec.images && currentRec.images.length > 1 && (
-                      <View style={styles.galleryIndicatorWrapper}>
-                        <GlassBadge iconName="images">{currentRec.images.length}</GlassBadge>
-                      </View>
-                    )}
+                    {/* ORCH-0991: image-count badge removed from cards. */}
 
                     {/* Title and Details Overlay - Bottom Left of Image */}
                     <Animated.View style={[
@@ -2799,12 +2797,6 @@ const styles = StyleSheet.create({
     color: "#1f2937",
     fontSize: 13,
     fontWeight: "600",
-  },
-  // ORCH-0566: position-only wrapper — GlassBadge provides its own skin.
-  galleryIndicatorWrapper: {
-    position: "absolute",
-    top: 16,
-    right: 16,
   },
   // ORCH-0589 v2 (G4): more breathing room — premium rhythm.
   // paddingBottom 24 → 40, cardTitle marginBottom 12 → 16.
@@ -3291,12 +3283,17 @@ const styles = StyleSheet.create({
     color: "#ffffff",
     fontWeight: "600",
   },
-  batchChip: {
-    // ORCH-0589 v4 (V4): `top` set at runtime via inline style using safeAreaInsets.top + 62
-    // so the chip sits below the floating top-bar chrome. Right-alignment preserved.
+  batchChipWrap: {
+    // ORCH-0991: full-width positioned wrapper so the content-sized chip centers
+    // horizontally. `top` set at runtime via inline style using safeAreaInsets.top + 10
+    // so the chip sits in the empty center slot of the glass top bar.
     position: "absolute",
-    right: 16,
+    left: 0,
+    right: 0,
     zIndex: 20,
+    alignItems: "center",
+  },
+  batchChip: {
     flexDirection: "row",
     alignItems: "center",
     gap: 4,

--- a/app-mobile/src/i18n/locales/ar/cards.json
+++ b/app-mobile/src/i18n/locales/ar/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "غيّر التفضيلات",
   "swipeable.review_all_cards": "مراجعة كل البطاقات",
   "swipeable.viewed": "{{count}} مشاهدة",
+  "swipeable.swipe_history": "سجل التمرير",
   "swipeable.nearby": "قريب",
   "swipeable.free": "مجاني",
   "swipeable.experience": "تجربة",

--- a/app-mobile/src/i18n/locales/bin/cards.json
+++ b/app-mobile/src/i18n/locales/bin/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Rhan emwi ne u rhie",
   "swipeable.review_all_cards": "Ghee kaadi hia",
   "swipeable.viewed": "A ghee {{count}}",
+  "swipeable.swipe_history": "Okha Swipe",
   "swipeable.nearby": "Ọ Vbe Iyeke",
   "swipeable.free": "I Gha Kha",
   "swipeable.experience": "Emwi",

--- a/app-mobile/src/i18n/locales/bn/cards.json
+++ b/app-mobile/src/i18n/locales/bn/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "পছন্দ পরিবর্তন করুন",
   "swipeable.review_all_cards": "সব কার্ড রিভিউ করুন",
   "swipeable.viewed": "{{count}} দেখা হয়েছে",
+  "swipeable.swipe_history": "সোয়াইপ ইতিহাস",
   "swipeable.nearby": "কাছাকাছি",
   "swipeable.free": "বিনামূল্যে",
   "swipeable.experience": "অভিজ্ঞতা",

--- a/app-mobile/src/i18n/locales/de/cards.json
+++ b/app-mobile/src/i18n/locales/de/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Einstellungen ändern",
   "swipeable.review_all_cards": "Alle Karten ansehen",
   "swipeable.viewed": "{{count}} angesehen",
+  "swipeable.swipe_history": "Wischverlauf",
   "swipeable.nearby": "In der Nähe",
   "swipeable.free": "Kostenlos",
   "swipeable.experience": "Erlebnis",

--- a/app-mobile/src/i18n/locales/el/cards.json
+++ b/app-mobile/src/i18n/locales/el/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Άλλαξε προτιμήσεις",
   "swipeable.review_all_cards": "Δες όλες τις κάρτες",
   "swipeable.viewed": "{{count}} προβεβλημένα",
+  "swipeable.swipe_history": "Ιστορικό σάρωσης",
   "swipeable.nearby": "Κοντά",
   "swipeable.free": "Δωρεάν",
   "swipeable.experience": "Εμπειρία",

--- a/app-mobile/src/i18n/locales/en/cards.json
+++ b/app-mobile/src/i18n/locales/en/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "Swipe History",
   "swipeable.nearby": "Nearby",
   "swipeable.free": "Free",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/es/cards.json
+++ b/app-mobile/src/i18n/locales/es/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Cambiar preferencias",
   "swipeable.review_all_cards": "Revisar todas las tarjetas",
   "swipeable.viewed": "{{count}} vistas",
+  "swipeable.swipe_history": "Historial de deslizamientos",
   "swipeable.nearby": "Cerca",
   "swipeable.free": "Gratis",
   "swipeable.experience": "Experiencia",

--- a/app-mobile/src/i18n/locales/fr/cards.json
+++ b/app-mobile/src/i18n/locales/fr/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Modifier les préférences",
   "swipeable.review_all_cards": "Revoir toutes les cartes",
   "swipeable.viewed": "{{count}} vues",
+  "swipeable.swipe_history": "Historique des balayages",
   "swipeable.nearby": "À proximité",
   "swipeable.free": "Gratuit",
   "swipeable.experience": "Expérience",

--- a/app-mobile/src/i18n/locales/ha/cards.json
+++ b/app-mobile/src/i18n/locales/ha/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Canja zaɓinka",
   "swipeable.review_all_cards": "Duba duk katuna",
   "swipeable.viewed": "An duba {{count}}",
+  "swipeable.swipe_history": "Tarihin Swipe",
   "swipeable.nearby": "Kusa",
   "swipeable.free": "Kyauta",
   "swipeable.experience": "Gogewa",

--- a/app-mobile/src/i18n/locales/he/cards.json
+++ b/app-mobile/src/i18n/locales/he/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "שנה העדפות",
   "swipeable.review_all_cards": "צפה בכל הכרטיסים",
   "swipeable.viewed": "{{count}} נצפו",
+  "swipeable.swipe_history": "היסטוריית החלקה",
   "swipeable.nearby": "בקרבת מקום",
   "swipeable.free": "חינם",
   "swipeable.experience": "חוויה",

--- a/app-mobile/src/i18n/locales/hi/cards.json
+++ b/app-mobile/src/i18n/locales/hi/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "पसंद बदलें",
   "swipeable.review_all_cards": "सभी कार्ड देखें",
   "swipeable.viewed": "{{count}} देखे गए",
+  "swipeable.swipe_history": "स्वाइप इतिहास",
   "swipeable.nearby": "पास में",
   "swipeable.free": "मुफ्त",
   "swipeable.experience": "अनुभव",

--- a/app-mobile/src/i18n/locales/id/cards.json
+++ b/app-mobile/src/i18n/locales/id/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Ubah preferensi",
   "swipeable.review_all_cards": "Tinjau semua kartu",
   "swipeable.viewed": "{{count}} dilihat",
+  "swipeable.swipe_history": "Riwayat geser",
   "swipeable.nearby": "Dekat",
   "swipeable.free": "Gratis",
   "swipeable.experience": "Pengalaman",

--- a/app-mobile/src/i18n/locales/ig/cards.json
+++ b/app-mobile/src/i18n/locales/ig/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Gbanwee nhọrọ",
   "swipeable.review_all_cards": "Lelee kaadị niile",
   "swipeable.viewed": "Elere {{count}}",
+  "swipeable.swipe_history": "Akụkọ Swipe",
   "swipeable.nearby": "Nso",
   "swipeable.free": "N'efu",
   "swipeable.experience": "Ahụmịhe",

--- a/app-mobile/src/i18n/locales/it/cards.json
+++ b/app-mobile/src/i18n/locales/it/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Cambia preferenze",
   "swipeable.review_all_cards": "Rivedi tutte le carte",
   "swipeable.viewed": "{{count}} visti",
+  "swipeable.swipe_history": "Cronologia scorrimenti",
   "swipeable.nearby": "Nelle vicinanze",
   "swipeable.free": "Gratuito",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/ja/cards.json
+++ b/app-mobile/src/i18n/locales/ja/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "好みを変更",
   "swipeable.review_all_cards": "すべてのカードを確認",
   "swipeable.viewed": "{{count}}件閲覧",
+  "swipeable.swipe_history": "スワイプ履歴",
   "swipeable.nearby": "近く",
   "swipeable.free": "無料",
   "swipeable.experience": "体験",

--- a/app-mobile/src/i18n/locales/ko/cards.json
+++ b/app-mobile/src/i18n/locales/ko/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "취향 변경",
   "swipeable.review_all_cards": "모든 카드 보기",
   "swipeable.viewed": "{{count}}개 조회",
+  "swipeable.swipe_history": "스와이프 기록",
   "swipeable.nearby": "근처",
   "swipeable.free": "무료",
   "swipeable.experience": "체험",

--- a/app-mobile/src/i18n/locales/ms/cards.json
+++ b/app-mobile/src/i18n/locales/ms/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Ubah pilihan",
   "swipeable.review_all_cards": "Semak semua kad",
   "swipeable.viewed": "{{count}} dilihat",
+  "swipeable.swipe_history": "Sejarah leret",
   "swipeable.nearby": "Berdekatan",
   "swipeable.free": "Percuma",
   "swipeable.experience": "Pengalaman",

--- a/app-mobile/src/i18n/locales/nl/cards.json
+++ b/app-mobile/src/i18n/locales/nl/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Voorkeuren aanpassen",
   "swipeable.review_all_cards": "Alle kaarten bekijken",
   "swipeable.viewed": "{{count}} bekeken",
+  "swipeable.swipe_history": "Veeggeschiedenis",
   "swipeable.nearby": "In de buurt",
   "swipeable.free": "Gratis",
   "swipeable.experience": "Ervaring",

--- a/app-mobile/src/i18n/locales/pl/cards.json
+++ b/app-mobile/src/i18n/locales/pl/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "Historia przesunięć",
   "swipeable.nearby": "W pobliżu",
   "swipeable.free": "Bezpłatne",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/pt/cards.json
+++ b/app-mobile/src/i18n/locales/pt/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Alterar preferências",
   "swipeable.review_all_cards": "Rever todos os cards",
   "swipeable.viewed": "{{count}} vistos",
+  "swipeable.swipe_history": "Histórico de deslizamentos",
   "swipeable.nearby": "Próximo",
   "swipeable.free": "Grátis",
   "swipeable.experience": "Experiência",

--- a/app-mobile/src/i18n/locales/ro/cards.json
+++ b/app-mobile/src/i18n/locales/ro/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "Istoric glisări",
   "swipeable.nearby": "În apropiere",
   "swipeable.free": "Gratuit",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/ru/cards.json
+++ b/app-mobile/src/i18n/locales/ru/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "История свайпов",
   "swipeable.nearby": "Поблизости",
   "swipeable.free": "Бесплатно",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/sv/cards.json
+++ b/app-mobile/src/i18n/locales/sv/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "Svephistorik",
   "swipeable.nearby": "I närheten",
   "swipeable.free": "Gratis",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/th/cards.json
+++ b/app-mobile/src/i18n/locales/th/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "เปลี่ยนความชอบ",
   "swipeable.review_all_cards": "ดูการ์ดทั้งหมด",
   "swipeable.viewed": "ดูแล้ว {{count}}",
+  "swipeable.swipe_history": "ประวัติการปัด",
   "swipeable.nearby": "ใกล้เคียง",
   "swipeable.free": "ฟรี",
   "swipeable.experience": "ประสบการณ์",

--- a/app-mobile/src/i18n/locales/tr/cards.json
+++ b/app-mobile/src/i18n/locales/tr/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "Kaydırma geçmişi",
   "swipeable.nearby": "Yakında",
   "swipeable.free": "Ücretsiz",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/uk/cards.json
+++ b/app-mobile/src/i18n/locales/uk/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Shift preferences",
   "swipeable.review_all_cards": "Review all cards",
   "swipeable.viewed": "{{count}} viewed",
+  "swipeable.swipe_history": "Історія свайпів",
   "swipeable.nearby": "Поблизу",
   "swipeable.free": "Безкоштовно",
   "swipeable.experience": "Experience",

--- a/app-mobile/src/i18n/locales/vi/cards.json
+++ b/app-mobile/src/i18n/locales/vi/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Thay đổi sở thích",
   "swipeable.review_all_cards": "Xem lại tất cả thẻ",
   "swipeable.viewed": "Đã xem {{count}}",
+  "swipeable.swipe_history": "Lịch sử vuốt",
   "swipeable.nearby": "Gần đây",
   "swipeable.free": "Miễn phí",
   "swipeable.experience": "Trải nghiệm",

--- a/app-mobile/src/i18n/locales/yo/cards.json
+++ b/app-mobile/src/i18n/locales/yo/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "Yí àṣàyàn padà",
   "swipeable.review_all_cards": "Wo gbogbo káàdì",
   "swipeable.viewed": "{{count}} tí a wò",
+  "swipeable.swipe_history": "Ìtàn Swipe",
   "swipeable.nearby": "Nítòsí",
   "swipeable.free": "Ọ̀fẹ́",
   "swipeable.experience": "Ìrírí",

--- a/app-mobile/src/i18n/locales/zh/cards.json
+++ b/app-mobile/src/i18n/locales/zh/cards.json
@@ -9,6 +9,7 @@
   "swipeable.shift_preferences": "调整偏好",
   "swipeable.review_all_cards": "回顾所有卡片",
   "swipeable.viewed": "已浏览 {{count}}",
+  "swipeable.swipe_history": "滑动历史",
   "swipeable.nearby": "附近",
   "swipeable.free": "免费",
   "swipeable.experience": "体验",


### PR DESCRIPTION
## What changed (consumer app only — no web surface, no `[deploy]` needed)

Home swipe deck polish (ORCH-0991):

1. **"X viewed" → "Swipe History" pill** — the top-right viewed-count chip is now a static "Swipe History" label, centered horizontally just below the status bar (safe-area inset + 10, seated in the glass top bar's empty center slot). Clock icon and tap-to-open-history behavior kept; still only appears after the first swipe.
2. **Image-count badge removed** — the photo-count `GlassBadge` is gone from both the current and next-preview cards (plus its now-orphaned `galleryIndicatorWrapper` style).
3. **Curated stop numbers no longer clipped** — on curated experience cards, the per-stop "1"/"2"… badges now sit at safe-area inset + 62 so they clear the floating glass top bar instead of hiding behind the status bar / Dynamic Island. Uses `useSafeAreaInsets()` so it's correct on every device.
4. **i18n** — `cards:swipeable.swipe_history` added across all 28 locales. 24 are confident translations; **bin / ha / ig / yo (Bini, Hausa, Igbo, Yoruba) are BEST-EFFORT guesses pending native review** (native word for "history/account" + borrowed "Swipe" gesture term, since the literal candidates mean "erase").

## Verification
- Typecheck clean on touched files.
- Confirmed live on a physical iPhone (dev client): "Swipe History" pill centered below the status bar; no image-count badge; curated stop numbers fully visible.

## Surfaces
Consumer iOS + Android (`app-mobile/`). No web, backend, or migration changes.