### PR TITLE
Close ORCH-0994: Discover grid renders video/gif covers via shared EventCoverMedia

### DIFF
--- a/app-mobile/src/components/discover/BusinessEventCard.tsx
+++ b/app-mobile/src/components/discover/BusinessEventCard.tsx
@@ -29,8 +29,13 @@ import {
   Text,
   View,
 } from "react-native";
-import { Image as ExpoImage } from "expo-image";
 import * as Haptics from "expo-haptics";
+// ORCH-0994 — shared cover renderer (image + GIF + video). Replaces the
+// image-only ExpoImage path so video covers PLAY in the Discover grid instead
+// of falling through to the solid hue band. Same component the event hero uses;
+// muted/looping ambient autoplay, reduce-motion aware, and renders its own
+// hue-band fallback (EventCover) when there is no media or media fails to load.
+import { EventCoverMedia } from "@mingla/event-rendering";
 
 import type { BusinessEventCard as BusinessEventCardData } from "../../types/mergedDiscover";
 // ORCH-0877 — centralized consumer-side date formatter.
@@ -43,16 +48,19 @@ interface BusinessEventCardProps {
   onPress: (data: BusinessEventCardData) => void;
 }
 
+// ORCH-0994 — single source for the card corner radius, shared by the card
+// container clip and the EventCoverMedia radius so the cover (and its fallback
+// band) corners align with the card.
+const CARD_RADIUS = 18;
+
 // ORCH-0877 — formatDateChip replaced by centralized
 // `formatEventDateChip` from app-mobile/src/utils/eventDateDisplay.ts.
 // I-14 single-source; cross-midnight aware via the shared helper.
-
-const heroColorFromHue = (hue: number): string => {
-  // Hue-driven band; matches the EventCover.tsx pattern from mingla-business.
-  // hsl() format is RN-safe (oklch is not — see feedback_rn_color_formats.md).
-  const h = Number.isFinite(hue) ? Math.max(0, Math.min(360, hue)) : 25;
-  return `hsl(${h}, 60%, 45%)`;
-};
+//
+// ORCH-0994 — the local `heroColorFromHue` hue-band helper was removed: the
+// no-media / video-fallback band is now rendered by EventCoverMedia's built-in
+// EventCover (hsl(hue, 60%, 45%) base — identical to the prior local band),
+// keeping a single owner for cover rendering across hero + grid.
 
 const BusinessEventCardImpl: React.FC<BusinessEventCardProps> = ({
   data,
@@ -80,22 +88,20 @@ const BusinessEventCardImpl: React.FC<BusinessEventCardProps> = ({
         { width, height },
       ]}
     >
-      {/* Hero — image or hue band */}
-      {data.coverMediaUrl !== null && data.coverMediaType !== "video" ? (
-        <ExpoImage
-          source={{ uri: data.coverMediaUrl }}
-          style={styles.heroImage}
-          contentFit="cover"
-          transition={150}
-        />
-      ) : (
-        <View
-          style={[
-            styles.heroBand,
-            { backgroundColor: heroColorFromHue(data.coverHue) },
-          ]}
-        />
-      )}
+      {/* Hero — image / GIF / video, with built-in hue-band fallback.
+          ORCH-0994: routes through the shared EventCoverMedia so a video
+          cover plays (muted, looping) instead of dropping to a solid band.
+          videoContentFit="cover" fills the fixed grid cell (crop) — the
+          "contain" letterbox treatment is for the full-bleed event hero only. */}
+      <EventCoverMedia
+        hue={data.coverHue}
+        mediaUrl={data.coverMediaUrl}
+        mediaType={data.coverMediaType}
+        radius={CARD_RADIUS}
+        videoContentFit="cover"
+        label={data.title}
+        style={StyleSheet.absoluteFill}
+      />
 
       {/* Subtle "On Mingla" pill (top-right) */}
       <View style={styles.minglaPill}>
@@ -133,18 +139,10 @@ export const BusinessEventCard = React.memo(BusinessEventCardImpl);
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 18,
+    borderRadius: CARD_RADIUS,
     overflow: "hidden",
     backgroundColor: "rgba(255,255,255,0.04)",
     position: "relative",
-  },
-  heroImage: {
-    width: "100%",
-    height: "100%",
-  },
-  heroBand: {
-    width: "100%",
-    height: "100%",
   },
   minglaPill: {
     position: "absolute",

--- a/app-mobile/src/components/discover/__tests__/orch-0994-business-event-card-video-cover.test.tsx
+++ b/app-mobile/src/components/discover/__tests__/orch-0994-business-event-card-video-cover.test.tsx
@@ -1,0 +1,85 @@
+// @ts-nocheck
+/**
+ * ORCH-0994 [Discover grid video covers render as solid color] — implementor
+ * happy-path regression test.
+ *
+ * Bug: the Discover business-event card rendered covers through an image-only
+ * ExpoImage and explicitly EXCLUDED video (`data.coverMediaType !== "video"`),
+ * so any video cover fell through to the solid hue band ("solid color" report).
+ *
+ * Fix: route the cover through the shared `@mingla/event-rendering`
+ * `EventCoverMedia`, which plays video (muted/looping), animates GIFs, shows
+ * images, and renders its own hue-band fallback when there is no media.
+ *
+ * This is a source-assertion test (the established app-mobile regression
+ * pattern — see orch-0945-dead-end-render.test.tsx). It asserts the rendering
+ * contract at the source level so it runs without RN render / expo-video infra.
+ */
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function resolveRepoFile(relPath) {
+  const direct = path.resolve(process.cwd(), relPath);
+  if (fs.existsSync(direct)) return direct;
+  return path.resolve(process.cwd(), "app-mobile", relPath);
+}
+
+function readSource(relPath) {
+  return fs.readFileSync(resolveRepoFile(relPath), "utf8");
+}
+
+function runOrch0994VideoCoverHappyPath() {
+  const src = readSource("src/components/discover/BusinessEventCard.tsx");
+
+  // T-01: the shared video-capable renderer is imported from the shared package.
+  assert.match(
+    src,
+    /import\s*\{\s*EventCoverMedia\s*\}\s*from\s*["']@mingla\/event-rendering["']/,
+    "BusinessEventCard must import EventCoverMedia from @mingla/event-rendering",
+  );
+
+  // T-02: the cover is rendered through EventCoverMedia.
+  assert.ok(
+    src.includes("<EventCoverMedia"),
+    "BusinessEventCard must render <EventCoverMedia for the cover",
+  );
+
+  // T-03: the media URL + type are forwarded so EventCoverMedia can decide
+  // image/gif/video presentation (the type is what unlocks video playback).
+  assert.ok(
+    src.includes("mediaUrl={data.coverMediaUrl}"),
+    "EventCoverMedia must receive mediaUrl={data.coverMediaUrl}",
+  );
+  assert.ok(
+    src.includes("mediaType={data.coverMediaType}"),
+    "EventCoverMedia must receive mediaType={data.coverMediaType}",
+  );
+
+  // [FAILS-ON-REVERT KEY] T-04: the pre-fix code excluded video with the guard
+  // `data.coverMediaType !== "video"`, dropping video covers to the hue band.
+  // Reverting the fix re-introduces this guard → this assertion fails.
+  assert.ok(
+    !src.includes('coverMediaType !== "video"'),
+    "BusinessEventCard must NOT exclude video covers via `coverMediaType !== \"video\"`",
+  );
+
+  // [FAILS-ON-REVERT KEY] T-05: the pre-fix code rendered covers via the
+  // image-only ExpoImage. Reverting re-adds the expo-image import → fails.
+  assert.ok(
+    !/from\s*["']expo-image["']/.test(src),
+    "BusinessEventCard must NOT import the image-only expo-image for covers",
+  );
+}
+
+runOrch0994VideoCoverHappyPath();
+
+// Jest-visible wrapper (also runs as a plain node script).
+if (typeof describe === "function") {
+  describe("ORCH-0994: Discover business-event card renders video covers", () => {
+    it("routes covers through EventCoverMedia and no longer excludes video", () => {
+      runOrch0994VideoCoverHappyPath();
+    });
+  });
+}

--- a/app-mobile/src/components/discover/__tests__/orch-0994-business-event-card-video-cover.tester-adversarial.test.tsx
+++ b/app-mobile/src/components/discover/__tests__/orch-0994-business-event-card-video-cover.tester-adversarial.test.tsx
@@ -1,0 +1,86 @@
+// @ts-nocheck
+/**
+ * ORCH-0994 [Discover grid video covers render as solid color] — tester
+ * adversarial regression test.
+ *
+ * DIFFERENT ANGLE from the implementor happy-path test (which proves video now
+ * renders): this attacks the refactor's blast radius — that swapping the
+ * image-only branch for EventCoverMedia did NOT (a) break the genuine no-media
+ * hue-band fallback, or (b) leave orphaned dead code (the old hue helper,
+ * the heroImage/heroBand styles) that would mislead future readers, or (c)
+ * leave a second, competing cover-render path.
+ *
+ * Source-assertion test (matches the app-mobile regression pattern).
+ */
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function resolveRepoFile(relPath) {
+  const direct = path.resolve(process.cwd(), relPath);
+  if (fs.existsSync(direct)) return direct;
+  return path.resolve(process.cwd(), "app-mobile", relPath);
+}
+
+function readSource(relPath) {
+  return fs.readFileSync(resolveRepoFile(relPath), "utf8");
+}
+
+function runOrch0994VideoCoverAdversarial() {
+  const src = readSource("src/components/discover/BusinessEventCard.tsx");
+
+  // A-01: FALLBACK PRESERVED — the hue is forwarded so an event with no cover
+  // (coverMediaUrl null) still gets EventCoverMedia's built-in colored band.
+  // If `hue` were dropped, no-media events would render the package default
+  // hue (25) instead of the event's own coverHue — a silent visual regression.
+  assert.ok(
+    src.includes("hue={data.coverHue}"),
+    "EventCoverMedia must receive hue={data.coverHue} so the no-media fallback keeps the event's own band colour",
+  );
+
+  // A-02: NO ORPHANED DEAD CODE — the local hue-band helper was removed (its
+  // job moved into EventCoverMedia's EventCover fallback). A lingering
+  // `heroColorFromHue(` call site would mean a dead second band path survived.
+  assert.ok(
+    !src.includes("heroColorFromHue("),
+    "the local heroColorFromHue helper/call must be fully removed (EventCoverMedia owns the fallback band)",
+  );
+
+  // A-03: NO ORPHANED STYLES — the old hero image/band style keys were removed.
+  assert.ok(
+    !/heroImage\s*:/.test(src) && !/heroBand\s*:/.test(src),
+    "dead heroImage/heroBand style keys must be removed after the EventCoverMedia swap",
+  );
+
+  // A-04: SINGLE COVER PATH — exactly one cover renderer (EventCoverMedia), no
+  // competing <Image>/<ExpoImage> cover element left behind.
+  const eventCoverMediaCount = (src.match(/<EventCoverMedia/g) || []).length;
+  assert.equal(
+    eventCoverMediaCount,
+    1,
+    "there must be exactly one <EventCoverMedia cover renderer",
+  );
+  assert.ok(
+    !src.includes("<ExpoImage") && !src.includes("<Image "),
+    "no leftover <ExpoImage>/<Image> cover element may remain",
+  );
+
+  // A-05: grid cells use crop fill (videoContentFit="cover"); the "contain"
+  // letterbox treatment is reserved for the full-bleed event hero, not the
+  // fixed-size grid cell.
+  assert.ok(
+    src.includes('videoContentFit="cover"'),
+    "grid cover must use videoContentFit=\"cover\" (crop-fill the fixed cell)",
+  );
+}
+
+runOrch0994VideoCoverAdversarial();
+
+if (typeof describe === "function") {
+  describe("ORCH-0994 adversarial: cover refactor preserves fallback + leaves no dead code", () => {
+    it("forwards hue, removes dead helper/styles, keeps a single crop-fill cover path", () => {
+      runOrch0994VideoCoverAdversarial();
+    });
+  });
+}


### PR DESCRIPTION
## ORCH-0994 — Discover grid video covers render as solid color

**Root cause:** `app-mobile/src/components/discover/BusinessEventCard.tsx` rendered covers through an image-only `ExpoImage` and explicitly excluded video (`data.coverMediaType !== "video"`), so any video cover dropped to the solid hue band.

**Fix:** Route the cover through the shared `@mingla/event-rendering` `EventCoverMedia` (image + GIF + muted/looping video, reduce-motion aware, built-in hue-band fallback). Removed the now-dead local `heroColorFromHue` helper + heroImage/heroBand styles + expo-image import. Single-file change; no backend/data change (`cover_media_type`/`cover_media_url` already arrive correctly).

**Scope:** Consumer iOS + Android (Discover screen). Ticketmaster cards unaffected (always stills). Note: muted/looping autoplay with no per-card scroll-viewport gating — business-event cards (the only video-capable ones) are few and top-of-grid; viewport gating is a clean fast-follow if volume grows.

## Verification
- **Dev build (physical iPhone, tunnel):** Seth confirmed PASS — "Vibes and Stuff" / "A life in vegas" (Raleigh) play video in the Discover grid.
- **TypeScript:** clean (no errors in changed file).
- **Regression gate (Step 0.5):**
  - Happy-path `orch-0994-business-event-card-video-cover.test.tsx` — PASS on fix, **fails-on-revert VERIFIED**.
  - Adversarial `orch-0994-business-event-card-video-cover.tester-adversarial.test.tsx` — PASS, different angle (fallback preserved + dead-code removed + single crop-fill path).

app-mobile-only → no `[deploy]` tag (OTA, not web). OTA published after merge.