### PR TITLE
Close ORCH-0995: Android tab-nav fluidity — UI-thread spotlight + instant tap feedback

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md
@@ -127,3 +127,122 @@ Per contract, no blur/visual treatment was changed. The investigation's Root Cau
 
 - `TabConfig` type (GlassBottomNav.tsx line ~47) is defined but never used — pre-existing dead code, lint warning, NOT introduced by this ORCH. Left untouched (out of scope). Flag for a future cleanup sweep if desired.
 - Runtime perceptual smoothness is the one criterion that can't be machine-verified. A mid-tier physical device (SM-A725F) with the consumer dev client is attached and is the correct target for Seth's eyeball confirmation.
+
+---
+
+# IMPLEMENT-2 — instant tab-tap feedback (optimistic nav + deferred mount)
+
+- **Date:** 2026-05-29
+- **Builds on:** IMPLEMENT-1 spotlight UI-thread fix (`b91770195`) + hash-record commit (`22ad396ae`).
+- **Commit:** the single IMPLEMENT-2 commit on branch `ORCH-0995-android-nav-jank` whose parent is `22ad396ae` (the IMPLEMENT-1 hash-record commit). The exact hash is reported in the chat handoff and is the current branch HEAD; it is omitted here to avoid a self-referential amend loop (a report that records its own commit hash changes the hash on every edit).
+- **Status:** implemented and verified (automated tsc + lint + regression test with fails-on-revert) · runtime perceptual confirmation pending Seth on the attached mid-tier device.
+
+## Operator feedback that triggered this
+After IMPLEMENT-1 (spotlight off the JS thread), tab-switching was "much better but still a noticeable lag between tapping a tab and seeing the effect."
+
+## Proven root cause
+The bottom-nav highlight was **hostage to the destination screen's mount**. Flow before: tap → `GlassBottomNav` `onNavigate(key)` → parent `app/index.tsx` onNavigate (`closeProfileOverlays()` + `setCurrentPage(page)`) → `AppContent` re-renders → the `switch(currentPage)` IIFE **unmounts the old screen and mounts the new heavy screen SYNCHRONOUSLY on the JS thread** → only after that commit does `GlassBottomNav` receive the new `currentPage` prop and move the spotlight + active icon. So the tap feedback (highlight) was blocked behind the heavy mount. `currentPage`/`setCurrentPage` is plain React `useState` (`AppStateManager.tsx:124`), so React transitions apply to it.
+
+## The fix — two parts
+
+### PART A — `GlassBottomNav.tsx` optimistic selection (instant tap feedback, decoupled from mount)
+Added local optimistic state so the highlight responds on the tap frame regardless of when `currentPage` catches up:
+- `const [pendingPage, setPendingPage] = useState<BottomNavPage | null>(null);`
+- `const displayPage = pendingPage ?? currentPage;`
+- Reconcile: `useEffect(() => { setPendingPage(null); }, [currentPage]);` — clears the optimistic lead whenever the REAL `currentPage` commits (the tapped page OR a programmatic page via deep-link/notification). This guarantees the optimistic state can never desync from the source of truth.
+- The spotlight `useEffect` now looks up `tabLayoutsRef.current[displayPage]` and its dep array is `[displayPage, layoutTick, reduceMotion, spotlightX, spotlightWidth]`.
+- The `active` flag is now `key === displayPage`, which already feeds the icon color, the active/inactive label style, AND `accessibilityState.selected` (all three derive from `active`).
+- `reduceMotion` instant-set path and the `layoutTick` re-run are **unchanged** (still in the same effect; reduceMotion still instant-sets, layoutTick still in deps).
+
+**onPress — exact before/after:**
+
+Before:
+```tsx
+onPress={() => {
+  if (active) return;
+  if (Platform.OS === 'ios') {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+  }
+  onNavigate(key);
+}}
+```
+After:
+```tsx
+onPress={() => {
+  // Guard against re-tapping the already-selected tab (optimistic-aware).
+  if (key === displayPage) return;
+  if (Platform.OS === 'ios') {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+  }
+  // ORCH-0995 IMPLEMENT-2: set optimistic selection FIRST so the
+  // spotlight + active styling move on the tap frame, then trigger the
+  // (heavier) navigation. The reconcile effect clears pendingPage once
+  // currentPage catches up.
+  setPendingPage(key);
+  onNavigate(key);
+}}
+```
+The guard switched from the stale `active` closure to `key === displayPage` so an in-flight optimistic tap isn't re-fired. iOS haptic preserved in place.
+
+### PART B — `app/index.tsx` onNavigate: defer the heavy mount via `React.startTransition`
+`React` is already imported (`import React, { ... } from "react"`), React 19.1.0 — `startTransition` is a named React export and concurrent features are live (New Architecture/Fabric).
+
+Before:
+```tsx
+onNavigate={(page: BottomNavPage) => {
+  logger.action(`Tab pressed: ${page}`);
+  closeProfileOverlays();
+  setCurrentPage(page);
+}}
+```
+After:
+```tsx
+onNavigate={(page: BottomNavPage) => {
+  logger.action(`Tab pressed: ${page}`);
+  // closeProfileOverlays() stays URGENT (commits synchronously).
+  closeProfileOverlays();
+  // ORCH-0995 IMPLEMENT-2: de-prioritize the heavy screen mount so the
+  // urgent optimistic nav highlight + spotlight animation commit first.
+  React.startTransition(() => {
+    setCurrentPage(page);
+  });
+}}
+```
+`closeProfileOverlays()` stays outside the transition (urgent — overlay must be gone before the new screen paints). Only `setCurrentPage(page)` — which drives the `switch(currentPage)` IIFE mount — is deferred/interruptible. **No pending spinner** added; the optimistic nav state IS the feedback. The mount structure is untouched (still single active tab via the IIFE).
+
+## Optimistic-state mechanism (why it can't desync)
+`displayPage = pendingPage ?? currentPage` means the optimistic page only ever *leads* the real page. The `[currentPage]` reconcile effect fires on EVERY `currentPage` commit — whether from the tap's deferred `setCurrentPage`, OR from any programmatic caller (deep links / push notification at `app/index.tsx` lines ~455/469/764/1008+/2039, e.g. a notification that switches to `'connections'` with no tab tapped). In the no-tap case `pendingPage` is already `null`, so `displayPage === currentPage` and the highlight follows the programmatic nav immediately. In the tap case, once the deferred `setCurrentPage` commits, the effect clears `pendingPage` and `displayPage` falls back to the now-correct `currentPage`. If a programmatic nav lands on a DIFFERENT page than an in-flight optimistic tap, the reconcile still clears `pendingPage` and `displayPage` follows the authoritative `currentPage` — the highlight can never strand on a stale optimistic page.
+
+## Files changed (IMPLEMENT-2)
+| File | Lines | What |
+|---|---|---|
+| `app-mobile/src/components/GlassBottomNav.tsx` | +~24 / -3 | optimistic `pendingPage` + `displayPage`, reconcile effect, effect/active/onPress driven by `displayPage` |
+| `app-mobile/app/index.tsx` | +~12 / -1 | tab `onNavigate` wraps `setCurrentPage(page)` in `React.startTransition`; `closeProfileOverlays()` stays urgent |
+| `app-mobile/src/components/__tests__/orch-0995-impl2-optimistic-tab-feedback.test.tsx` | new | behavioral + source-wiring regression test |
+| `app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx` | T-07 updated | dep-array assertion repointed `currentPage` → `displayPage` (`[TEST-MOD-APPROVED ORCH-0995]`) |
+
+## Regression Test (IMPLEMENT-2)
+- **Path:** `app-mobile/src/components/__tests__/orch-0995-impl2-optimistic-tab-feedback.test.tsx`
+- **Run:** `cd app-mobile && node src/components/__tests__/orch-0995-impl2-optimistic-tab-feedback.test.tsx`
+- **Passing output:** `PASS T-08..T-18 ORCH-0995 IMPLEMENT-2 optimistic tab-tap feedback ...`
+- **Coverage:** T-08 press sets optimistic `displayPage` to the pressed key BEFORE `currentPage` changes; T-09 reconcile clears the optimistic state once `currentPage` commits to the tapped page; T-10 a programmatic `currentPage` change (deep-link/notification, no tap) is reflected by `displayPage`; T-11 an optimistic lead that diverges from a programmatic `currentPage` change is cleared (no desync); T-12 re-tapping the active tab is a no-op; T-13..T-18 static source-wiring keys binding the test to the real `GlassBottomNav.tsx` + `app/index.tsx` (these are the fails-on-revert keys).
+- **fails-on-revert verified at `22ad396aee5b4f2376d6e11e27dd8cee14e7a8f2`** (HEAD before IMPLEMENT-2): reverted both source files to HEAD (keeping the test), re-ran → **FAILED at T-13** (`T-13 GlassBottomNav must declare optimistic 'pendingPage' state`). Restored the fix → **PASSES** again. The IMPLEMENT-1 test also re-passes (T-07 now asserts the `displayPage` dep array).
+
+## Verification Matrix (IMPLEMENT-2)
+| Criterion | How verified | Result |
+|---|---|---|
+| Tapping a tab moves the highlight on the tap frame (optimistic `displayPage`) | onPress sets `setPendingPage(key)` before `onNavigate`; spotlight effect + active flag read `displayPage`; T-08 + T-16 + T-17 assert. | PASS |
+| Heavy screen mount no longer blocks the feedback | `setCurrentPage(page)` wrapped in `React.startTransition`; `closeProfileOverlays()` stays urgent; T-18 asserts. | PASS |
+| Only the active tab still mounts | `switch(currentPage)` IIFE untouched; `check-active-tab-only.sh` → `I-ONLY-ACTIVE-TAB-MOUNTED: PASS`. | PASS |
+| All programmatic nav paths still drive the highlight | `[currentPage]` reconcile effect clears `pendingPage` on every commit; T-10 + T-11 assert deep-link/notification semantics. | PASS |
+| reduceMotion + layoutTick preserved | reduceMotion instant-set branch and `layoutTick` in deps unchanged; IMPLEMENT-1 T-06/T-07 still pass. | PASS |
+| No new native dependency (OTA-safe) | `React.startTransition` is built into React 19.1.0; `pendingPage` is plain `useState`. Zero package.json change. | PASS |
+| tsc clean (touched files) | `npx tsc --noEmit` → 0 errors referencing `GlassBottomNav.tsx` / `app/index.tsx`; pre-existing unrelated errors only. | PASS |
+| lint clean (touched files) | `npx eslint app/index.tsx src/components/GlassBottomNav.tsx` → 0 errors; only pre-existing warnings (`TabConfig` unused; app/index unused-vars/exhaustive-deps), none on changed lines. | PASS |
+| Runtime perceptual confirmation | Perceptual — not machine-verifiable. Physical SM-A725F mid-tier attached for Seth's eyeball. | UNVERIFIED — needs Seth device eyeball |
+
+## Scope guards honored
+- Did NOT reintroduce `tabVisible`/`tabHidden` or the all-mounted pattern; CI gate passes.
+- `switch(currentPage)` IIFE mount structure untouched — only WHEN `setCurrentPage` commits changed.
+- Spotlight resting geometry pixel-identical (animates `left`+`width` via existing Reanimated shared values, no scaleX); reduceMotion + layoutTick preserved.
+- No new native dependency. Scope limited to `GlassBottomNav.tsx` + the onNavigate handler in `app/index.tsx` + tests. Did NOT touch DiscoverScreen / ORCH-0996.

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md
@@ -20,11 +20,9 @@ This is **OTA-deliverable**: `react-native-reanimated@4.1.5` + `react-native-wor
 
 | File | Commit | Lines |
 |---|---|---|
-| `app-mobile/src/components/GlassBottomNav.tsx` | `<see below>` | +34 / -33 |
-| `app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx` | `<see below>` | new file |
-| `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md` | `<see below>` | new file |
-
-Commit hash recorded in the chat summary / git log after commit.
+| `app-mobile/src/components/GlassBottomNav.tsx` | `b91770195` | +34 / -33 |
+| `app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx` | `b91770195` | new file |
+| `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md` | `b91770195` | new file |
 
 ---
 

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md
@@ -1,0 +1,131 @@
+# IMPLEMENTATION — ORCH-0995 [Android-wide UI jank + tab-navigation animation lag — iOS-fluidity parity]
+
+- **Date:** 2026-05-29
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-0995-[android-nav-jank]/` on branch `ORCH-0995-android-nav-jank` (from main `2a30c8edc`)
+- **Status:** implemented and verified (automated) · runtime perceptual smoothness pending Seth on a mid-tier device
+- **Investigation read:** `Mingla_Artifacts/reports/INVESTIGATION_ORCH-0995_AND_0996_APP_PERFORMANCE.md` (ORCH-0995 section, Root Cause A)
+- **Comms ledger:** read on entry; no OPEN entry targets ORCH-0995 / this skill. No new cross-ORCH discovery to write.
+
+---
+
+## Outcome
+
+The tab "spotlight" pill in the consumer-app bottom nav now animates **entirely on the UI thread** via `react-native-reanimated` shared values, instead of the old `Animated.spring(..., { useNativeDriver: false })` that ran every frame on the JS thread. On mid-tier Android the JS thread can't sustain 60fps during a tab switch while also rendering the incoming screen, so the old approach dropped frames → the lag Seth felt. The new approach removes the JS thread from the per-frame loop entirely. Resting geometry, the reduce-motion path, the first-mount layout-tick re-run, and the spring feel are all preserved pixel-for-pixel.
+
+This is **OTA-deliverable**: `react-native-reanimated@4.1.5` + `react-native-worklets@0.5.1` are already in the native binary (`package.json` line 137; `app-mobile/babel.config.js` has `react-native-worklets/plugin`), and the component is already used elsewhere (PopularityIndicators, Toast, ConfidenceScore, SwipeableMessage, DoubleTapHeart). **No new native dependency added.**
+
+---
+
+## Files changed
+
+| File | Commit | Lines |
+|---|---|---|
+| `app-mobile/src/components/GlassBottomNav.tsx` | `<see below>` | +34 / -33 |
+| `app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx` | `<see below>` | new file |
+| `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-0995_ANDROID_NAV_FLUIDITY.md` | `<see below>` | new file |
+
+Commit hash recorded in the chat summary / git log after commit.
+
+---
+
+## Old → New Receipt
+
+### `app-mobile/src/components/GlassBottomNav.tsx`
+
+**What it did before:**
+- Imported `Animated`, `Easing`, `useMemo`, `useWindowDimensions` from `react-native` (the last three were unused dead imports).
+- `spotlightX` / `spotlightWidth` were RN `Animated.Value`s (`useRef(new Animated.Value(0)).current`).
+- On tab switch the effect ran `Animated.parallel([Animated.spring(spotlightX,…), Animated.spring(spotlightWidth,…)])` with **`useNativeDriver: false`** on both. `left` and `width` are not native-drivable layout props, so every frame of the spring was computed in JavaScript and shipped over the bridge → JS-thread-bound layout animation → dropped frames on mid-tier Android.
+- The spotlight `<Animated.View>` consumed the values inline as `{ left: spotlightX, width: spotlightWidth }`.
+
+**What it does now:**
+- Imports `Animated, { useSharedValue, useAnimatedStyle, withSpring }` from `react-native-reanimated`. Removed the three unused `react-native` imports (`useMemo`, `Easing`, `useWindowDimensions`) — subtract-before-add.
+- `spotlightX` / `spotlightWidth` are Reanimated `useSharedValue(0)` (UI-thread state).
+- On tab switch the effect sets `spotlightX.value = withSpring(targetX, springConfig)` and `spotlightWidth.value = withSpring(targetWidth, springConfig)`. Reanimated drives `left` + `width` on the **UI thread** — it is NOT subject to the RN-Animated native-driver limitation for layout props, so the JS thread is out of the per-frame loop.
+- A `useAnimatedStyle(() => ({ left: spotlightX.value, width: spotlightWidth.value }))` worklet feeds the spotlight `<Animated.View style={[styles.spotlight, spotlightAnimatedStyle]}>`.
+- **reduceMotion branch preserved**: instant set (`spotlightX.value = targetX; spotlightWidth.value = targetWidth;`), no spring.
+- **layoutTick branch preserved**: identical dep array `[currentPage, layoutTick, reduceMotion, spotlightX, spotlightWidth]` so the effect re-runs when `onLayout` fires on first mount.
+- **Resting geometry pixel-identical**: `targetX = layout.x + c.nav.spotlightInset`, `targetWidth = layout.width - c.nav.spotlightInset * 2` — unchanged. Same `spotlightInset` (0), same `spotlightRadius` (32), same `styles.spotlight`. Animating true `left`/`width` (not `scaleX`) means **no corner-radius distortion** — preferred path per the contract.
+- **Spring feel preserved**: `withSpring` config maps the designSystem motion tokens 1:1 — `damping: c.motion.springDamping` (18), `stiffness: c.motion.springStiffness` (260), `mass: c.motion.springMass` (0.9). Reanimated's spring uses the same damping/stiffness/mass physical model as RN Animated's spring.
+
+**Why:** ORCH-0995 Root Cause A — JS-thread-driven layout animation on tab switch. Contract clause 1 (animate off the JS thread), clause 2 (pixel-identical resting geometry), clause 3 (preserve reduceMotion + layoutTick + spring feel), clause 4 (no new native dep, OTA-deliverable).
+
+**Lines changed:** ~34 changed / 33 removed.
+
+### `app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx` (new)
+
+Source-static-analysis regression test (the repo convention for component tests — mirrors `orch-0945-dead-end-render.test.tsx`: standalone `node:assert` script, `require.main === module` runner). Asserts:
+- **T-01 [fails-on-revert key]**: no `useNativeDriver: false` anywhere in the file.
+- **T-02 / T-02b**: no RN `Animated.spring(` / `Animated.parallel(` (the old JS-thread path).
+- **T-03**: imports from `react-native-reanimated` + uses `useSharedValue`, `useAnimatedStyle`, `withSpring`.
+- **T-04**: resting geometry math preserved — `targetX = layout.x + c.nav.spotlightInset`, `targetWidth = layout.width - c.nav.spotlightInset * 2`, and the animated style drives `left`/`width` (not scaleX).
+- **T-05**: spring feel — `withSpring` damping/stiffness/mass come from `c.motion.spring*`.
+- **T-06**: reduceMotion branch instant-sets the shared values and does NOT call `withSpring`.
+- **T-07**: effect dep array still includes `layoutTick`.
+
+---
+
+## Regression Test
+
+- **Path:** `app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx`
+- **Run command:** `cd app-mobile && node src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx`
+- **Passing-run output (on the fix):**
+  ```
+  PASS T-01..T-07 ORCH-0995 bottom-nav spotlight animates on UI thread with pixel-identical resting geometry + preserved reduceMotion/layoutTick paths
+  ```
+- **fails-on-revert verified at `2a30c8edcfa11607b5cbf6140b86b6bc36db5db0`** (HEAD before fix). Procedure: `git stash push -- app-mobile/src/components/GlassBottomNav.tsx` (restores the old JS-thread `useNativeDriver: false` code, keeps the test), re-ran the test → **FAILED at T-01** (`AssertionError: T-01 spotlight must NOT use any 'useNativeDriver: false' animation`). `git stash pop` restored the fix → test PASSES again. Proven the test exercises the actual bug, not a tautology.
+
+---
+
+## Verification Matrix
+
+| Clause | How verified | Result |
+|---|---|---|
+| 1. Spotlight animates off the JS thread | Converted to Reanimated shared values + `useAnimatedStyle` worklet; `react-native-worklets/plugin` confirmed in babel.config.js (transforms worklet to UI thread); full Android bundle export succeeded (worklet transform would fail the export otherwise). | PASS |
+| 2. Resting geometry pixel-identical | `targetX`/`targetWidth` math byte-unchanged; same `spotlightInset`/`spotlightRadius`/`styles.spotlight`; animates true `left`/`width` (no scaleX distortion). T-04 asserts. | PASS |
+| 3a. reduceMotion path preserved | Instant `.value` set, no spring. T-06 asserts. | PASS |
+| 3b. layoutTick first-mount re-run preserved | Dep array unchanged. T-07 asserts. | PASS |
+| 3c. Spring feel preserved | `withSpring` damping/stiffness/mass = designSystem tokens (18/260/0.9). T-05 asserts. | PASS |
+| 4. No new native dependency / OTA-deliverable | reanimated 4.1.5 + worklets 0.5.1 already resolved in node_modules + already in native binary + babel plugin present. Zero package.json change. | PASS |
+| tsc clean (touched file) | `npx tsc --noEmit` → exit 0, no GlassBottomNav / orch-0995 errors. | PASS |
+| lint clean (touched file) | `npx expo lint` → no NEW warnings/errors on GlassBottomNav.tsx. (`require()` warnings on the test file match the existing orch-0945 test convention; `TabConfig` unused warning is pre-existing in original, out of scope.) | PASS |
+| Bundle compiles through worklets transform | `npx expo export --platform android` → succeeded, 16.7 MB Hermes bundle, no errors. | PASS |
+| Runtime perceptual smoothness on mid-tier Android | NOT auto-verifiable (perceptual). A physical Samsung Galaxy A72 (SM-A725F, mid-tier) with `com.mingla.app.v2` dev client is attached — ideal for Seth to eyeball. | UNVERIFIED — needs Seth device eyeball |
+
+---
+
+## Cross-Surface Impact
+
+- **Consumer iOS** (affected, automatic parity): same `GlassBottomNav.tsx` code path; spotlight now Reanimated on iOS too. iOS was already smooth (fast JS thread); this keeps it smooth and removes bridge traffic. File: `app-mobile/src/components/GlassBottomNav.tsx`.
+- **Consumer Android** (affected, automatic parity): the primary win — UI-thread animation eliminates the felt tab-switch lag. Same file.
+- **Buyer/anon Web, Business iOS, Business Android, Admin Web, Business Web preview**: NOT affected — `GlassBottomNav` is consumer-app-only chrome; none of those surfaces render it.
+
+Parity is automatic (single shared component, no platform-forked code).
+
+---
+
+## Invariant / Constitutional Check
+
+- No invariant in `references/invariant-checklist.md` governs the bottom-nav animation mechanism. No DB / RLS / edge / query-key / Zustand boundary touched.
+- Constitution: state handling unchanged (no async states added); no silent failures introduced; StyleSheet-only styling preserved; copy untouched; accessibility (`accessibilityRole`/`accessibilityState`/labels) untouched. PASS / N/A across all 14.
+
+---
+
+## Parity / Cache / Regression Surface
+
+- **Parity (solo/collab):** N/A — bottom nav is global chrome, not deck-mode-specific.
+- **Cache:** no query keys touched.
+- **Regression surface (for tester):** (1) tab-switch spotlight lands at correct x/width on all 5 tabs; (2) first-mount spotlight positions correctly (layoutTick path) — no x:0/width:0 flash; (3) reduce-motion ON → spotlight jumps instantly, no animation; (4) spotlight corner radius not distorted mid-animation; (5) rapid tab tapping doesn't strand the spotlight.
+
+---
+
+## Secondary (blur) — report only, NO change made
+
+Per contract, no blur/visual treatment was changed. The investigation's Root Cause B (persistent Android `dimezisBlurView` surfaces) remains in place at `GlassBottomNav.tsx` L1 BlurView and elsewhere. No profiling was performed to attribute residual jank to blur after this fix (would require a native dev build + frame trace on a mid-tier device). If Seth still feels tab-switch jank after this ships, the next lever is the Android blur cost — but that is a product/visual decision and a separate ORCH, not changed here.
+
+---
+
+## Discoveries for Orchestrator
+
+- `TabConfig` type (GlassBottomNav.tsx line ~47) is defined but never used — pre-existing dead code, lint warning, NOT introduced by this ORCH. Left untouched (out of scope). Flag for a future cleanup sweep if desired.
+- Runtime perceptual smoothness is the one criterion that can't be machine-verified. A mid-tier physical device (SM-A725F) with the consumer dev client is attached and is the correct target for Seth's eyeball confirmation.

--- a/Mingla_Artifacts/reports/QA_ORCH-0995_NAV_FLUIDITY.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-0995_NAV_FLUIDITY.md
@@ -1,0 +1,120 @@
+# QA — ORCH-0995 [Android nav jank — UI-thread spotlight + instant tab-tap feedback]
+
+- **Date:** 2026-05-29
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-0995-[android-nav-jank]/` on branch `ORCH-0995-android-nav-jank`
+- **Branch HEAD at QA:** `77174c9f80f075580ede8d47c7c1c4b3ffc02d9e` (pre-adversarial-commit) → `2b33d0debffdf5df1523e714865d56c510ed14a5` (adversarial test committed)
+- **Commits under test:** `b91770195` (spotlight → Reanimated UI thread) · `77174c9f8` (optimistic tab feedback + startTransition deferred mount)
+- **Mode:** TARGETED
+- **Comms ledger:** read on entry; no OPEN entry targets ORCH-0995 / mingla-tester. No new cross-ORCH discovery.
+
+---
+
+## VERDICT: CONDITIONAL PASS
+
+- **P0:** 0 | **P1:** 0 | **P2:** 0 | **P3:** 1 (pre-existing, not introduced) | **P4:** 2
+- **Condition:** the one remaining unverified criterion is *perceptual* tab-switch smoothness on mid-tier Android — inherently a human-eyeball measurement (no automated test, Maestro flow, or even a frame trace short of a native profiler can assert "feels fluid"). The implementor's matrix flags this same single criterion UNVERIFIED. All FUNCTIONAL behavior (the desync risk surface) is machine-proven. Seth confirms perceptual fluidity on the attached SM-A725F to upgrade to full PASS.
+
+---
+
+## Why CONDITIONAL, not PASS
+
+The functional contract of this fix — an optimistic-selection state machine that must never desync the highlight from the source of truth — is **pure React state with zero native/async dependency**. It is therefore fully and deterministically machine-verifiable, and it is (see below). The fix's *purpose*, however, is perceptual 60fps smoothness during the tab-switch on a mid-tier Android device. That cannot be asserted by any test in this repo's toolchain; it needs Seth's eye on the physical SM-A725F (already attached: `adb devices` → `R58R54YV7JT`). Per `feedback_tester_3sims_plus_operator_physical.md`, the tester does not drive Seth's physical device — it hands off. The booted iOS sims (`17091E60…`, `F7ECAC25…`) are unassigned to this ORCH and no Metro is running; per `feedback_no_cross_session_test_interference.md` I did not commandeer them or start a global Metro. iOS was already smooth pre-fix, so an iOS functional tap-through would not exercise the Android jank anyway.
+
+---
+
+## Adversarial regression test (tester-authored)
+
+- **Path:** `app-mobile/src/components/__tests__/orch-0995-tester-optimistic-desync-adversarial.test.tsx`
+- **Committed:** `2b33d0debffdf5df1523e714865d56c510ed14a5` on `ORCH-0995-android-nav-jank`
+- **Run:** `cd app-mobile && node src/components/__tests__/orch-0995-tester-optimistic-desync-adversarial.test.tsx`
+- **Output (on the fix):**
+  ```
+  PASS ADV-1..ADV-3 + ADV-W1..ADV-W4 ORCH-0995 tester adversarial — optimistic-nav
+  desync edge cases (rapid multi-tap, programmatic-same-page reconcile, reduce-motion
+  geometry) hold against a faithful effect-timing model wired to the real component
+  ```
+
+### Different angle from the implementor's tests (NOT a rename)
+
+The implementor's `createNav` model commits exactly one press and **unconditionally** clears `pending` on every `commitCurrentPage` — it never models that the real reconcile `useEffect(..., [currentPage])` fires **only when `currentPage`'s value actually changes**. My model reproduces that React dependency-comparison semantics faithfully (`runReconcileIfCurrentPageChanged` tracks the previously-seen value), then attacks the gaps that the naive model hides:
+
+- **ADV-1 — rapid triple-tap (home→discover→connections→likes) before any commit.** Asserts `displayPage` tracks the LAST tap (`likes`), then attacks two reconcile orderings: (a) `currentPage` coalesces straight to `likes` → no strand; (b) `currentPage` lands on an INTERMEDIATE page (`connections`) first — the reconcile fires early and clears pending, and `displayPage` must hand authority back to the authoritative `currentPage` (`connections`) rather than stranding on the stale last-tap (`likes`), then follow the final commit. This is the exact desync the optimistic pattern risks under `startTransition` coalescing.
+- **ADV-2 — programmatic nav to the SAME page a stale lead points to.** Because the real reconcile is keyed on `currentPage`'s VALUE, a tap whose pending equals the eventual `currentPage` must still leave pending cleared; proven by showing a SUBSEQUENT programmatic nav to a different page still moves the highlight (i.e. pending didn't stick and deadlock the reconcile).
+- **ADV-3 — reduce-motion geometry.** While an optimistic lead is active, the instant-set spotlight geometry is computed from `displayPage`'s tab layout (the tapped tab), NOT `currentPage`'s — asserted against five tabs with distinct x/width so a wrong-tab landing is detectable, plus a negative assertion that it does NOT land on the old `currentPage` tab.
+- **ADV-W1..W4 — source-wiring guards** bind the faithful model to the real component (reconcile keyed on `[currentPage]`; geometry read from `tabLayoutsRef.current[displayPage]`; re-tap guard `key === displayPage`; `active = key === displayPage`). These are the fails-on-revert keys.
+
+### Fails-on-revert (proven)
+
+Reverted the optimistic logic in `GlassBottomNav.tsx` (reconcile dep `[currentPage]`→`[]`; `displayPage` lookup→`currentPage`; `active`→`currentPage`; re-tap guard→`currentPage`) at HEAD **`77174c9f80f075580ede8d47c7c1c4b3ffc02d9e`** → adversarial test **FAILED** at `ADV-W1` (`reconcile effect must be ... keyed ONLY on currentPage`), exit 1. Restored the fix → **PASS**, exit 0. The test exercises the actual fix, not a tautology.
+
+---
+
+## Existing happy-path tests (re-run, green)
+
+| Test | Result |
+|---|---|
+| `orch-0995-bottom-nav-spotlight-ui-thread.test.tsx` | `PASS T-01..T-07` exit 0 |
+| `orch-0995-impl2-optimistic-tab-feedback.test.tsx` | `PASS T-08..T-18` exit 0 |
+
+Implementor fails-on-revert hashes verified to be real commits: `22ad396aee5b4f2376d6e11e27dd8cee14e7a8f2`, `2a30c8edcfa11607b5cbf6140b86b6bc36db5db0` (`git cat-file -t` → `commit`).
+
+---
+
+## Independent code verification (read the source, not the report)
+
+| Claim | Verified | Evidence |
+|---|---|---|
+| No `useNativeDriver: false` on the spotlight | YES | `grep` over `GlassBottomNav.tsx` → 0 hits; spotlight now uses `useSharedValue`/`useAnimatedStyle`/`withSpring` (lines 30-34, 169-203). No `Animated.spring(`/`Animated.parallel(` (RN) remain. |
+| `displayPage` drives spotlight + active icon + label + a11y | YES | `displayPage = pendingPage ?? currentPage` (L96). Spotlight effect reads `tabLayoutsRef.current[displayPage]` (L175). `active = key === displayPage` (L242) feeds icon color (L274), label style (L287), and `accessibilityState={{ selected: active }}` (L268). |
+| Reconcile clears pending on every real commit | YES | `useEffect(() => { setPendingPage(null); }, [currentPage])` (L102-104). Fires on tapped OR programmatic `currentPage` change → cannot desync. |
+| onPress sets pending BEFORE onNavigate; re-tap is a no-op | YES | `if (key === displayPage) return;` then `setPendingPage(key); onNavigate(key);` (L249-259). Guard is optimistic-aware (uses `displayPage`, not stale `currentPage`). |
+| `startTransition` wraps `setCurrentPage`; `closeProfileOverlays()` stays urgent | YES | `app/index.tsx` L2488-2504: `closeProfileOverlays()` runs OUTSIDE; only `setCurrentPage(page)` is inside `React.startTransition(() => { ... })`. |
+| Only active tab mounts (CI gate) | YES | `bash scripts/ci/check-active-tab-only.sh` → `I-ONLY-ACTIVE-TAB-MOUNTED: PASS`, exit 0. No `tabVisible`/`tabHidden` reintroduced. |
+| reduceMotion instant-set + layoutTick re-run preserved | YES | reduceMotion branch instant-sets `.value` with no `withSpring` (L180-185); effect dep array `[displayPage, layoutTick, reduceMotion, spotlightX, spotlightWidth]` (L197) keeps `layoutTick`. |
+| Spring feel = designSystem tokens | YES | `withSpring` config = `c.motion.springDamping`(18)/`springStiffness`(260)/`springMass`(0.9) (L188-192), matching `designSystem.ts` L610-612. |
+| No new native dependency (OTA-safe) | YES | `react-native-reanimated@^4.1.5` + `react-native-worklets@0.5.1` already in `package.json` (L137/143); `react-native-worklets/plugin` in `babel.config.js` (L6); `React.startTransition`/`useState` are built-in. Zero package.json change. |
+
+---
+
+## tsc + lint (touched files)
+
+- **tsc:** `npx tsc --noEmit` → 0 errors referencing `orch-0995*`, `GlassBottomNav.tsx`, or `app/index.tsx` (grep of output empty). The adversarial test is `@ts-nocheck` per the repo's standalone-node-script test convention (same as both implementor tests).
+- **lint (adversarial test):** `npx eslint` → 0 errors, 3 `@typescript-eslint/no-require-imports` warnings — identical to the implementor's two test files and the orch-0945 convention (these are node:assert scripts, not RN modules), accepted.
+
+---
+
+## CI-gate result
+
+`app-mobile/scripts/ci/check-active-tab-only.sh` → **`I-ONLY-ACTIVE-TAB-MOUNTED: PASS`** (exit 0). The `startTransition` change did not regress the single-active-tab mount structure.
+
+---
+
+## Regression-test gate (ORCH-0840)
+
+1. Tester adversarial test committed at `2b33d0de…`, attacks a DIFFERENT angle (effect-timing-faithful desync edge cases) — **satisfied**.
+2. Implementor happy-path tests exist, run green, fails-on-revert verified by implementor at cited hashes `22ad396a…` / `2a30c8ed…` — **satisfied**.
+3. All three test files appear in `git diff main...HEAD --name-only` — **satisfied** (both implementor tests added in-branch; adversarial test committed this turn). Spotlight test was ADDED in this branch (absent on `main`), so the append-only gate requires no `[TEST-MOD-APPROVED]` tag.
+
+---
+
+## Constitution (relevant rules)
+
+- **R1 no dead taps:** PASS — every tab responds; optimistic highlight on the tap frame.
+- **R2 one owner per truth:** PASS — `currentPage` (parent) remains the single source; `pendingPage` is a transient optimistic *lead* that the `[currentPage]` reconcile always collapses back into the source. Cannot fork ownership.
+- **R3 no silent failures:** PASS — no new error paths; reduceMotion/a11y init unchanged.
+- R4-R14: N/A or unchanged (no DB/RLS/edge/query-key/currency/auth/persisted-state touched).
+
+---
+
+## Findings
+
+- **P3 (pre-existing, NOT introduced):** `TabConfig` type in `GlassBottomNav.tsx` (~L49) is declared but unused — lint warning predating this ORCH. Out of scope; flag for a cleanup sweep.
+- **P4:** Clean optimistic-state design — the `displayPage = pendingPage ?? currentPage` + `[currentPage]`-keyed reconcile is the correct, desync-proof shape; `closeProfileOverlays()` correctly kept urgent outside the transition.
+- **P4:** Resting geometry is animated via true `left`/`width` (not `scaleX`), avoiding corner-radius distortion mid-animation — the right call.
+
+---
+
+## Discoveries for orchestrator
+
+- The ONLY criterion that cannot be machine-verified is perceptual fps smoothness on mid-tier Android. The attached SM-A725F (`R58R54YV7JT`) with `com.mingla.app.v2` is the correct target for Seth's eyeball. This is the gating item for full PASS.
+- No cross-ORCH impact; `GlassBottomNav` is consumer-app-only chrome (not rendered on web/business/admin).

--- a/app-mobile/app/index.tsx
+++ b/app-mobile/app/index.tsx
@@ -2486,8 +2486,22 @@ function AppContent() {
                             currentPage={currentPage as BottomNavPage}
                             onNavigate={(page: BottomNavPage) => {
                               logger.action(`Tab pressed: ${page}`);
+                              // Closing profile overlays is URGENT — it must commit
+                              // synchronously so the overlay is gone before the new
+                              // screen paints.
                               closeProfileOverlays();
-                              setCurrentPage(page);
+                              // ORCH-0995 IMPLEMENT-2: de-prioritize the heavy screen
+                              // mount. The switch(currentPage) IIFE unmounts the old
+                              // screen and mounts the new (often heavy) one synchronously
+                              // when currentPage commits. Wrapping it in a transition lets
+                              // the urgent optimistic nav highlight (GlassBottomNav
+                              // pendingPage) + spotlight animation commit first; the mount
+                              // is interruptible and no longer blocks tap feedback. The
+                              // mount structure is unchanged — only WHEN setCurrentPage
+                              // commits is deferred.
+                              React.startTransition(() => {
+                                setCurrentPage(page);
+                              });
                             }}
                             labels={{
                               home: t('navigation:tabs.explore'),

--- a/app-mobile/src/components/GlassBottomNav.tsx
+++ b/app-mobile/src/components/GlassBottomNav.tsx
@@ -85,6 +85,24 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
   const [reduceTransparency, setReduceTransparency] = useState(false);
   const [reduceMotion, setReduceMotion] = useState(false);
 
+  // ORCH-0995 IMPLEMENT-2: optimistic tab selection.
+  // The destination screen mounts synchronously on the JS thread when the parent
+  // commits `setCurrentPage(page)` (app/index.tsx onNavigate). Because the nav only
+  // learns the new active tab AFTER that heavy mount commits, the spotlight + active
+  // icon used to wait for the mount → felt like a lag between tap and highlight.
+  // `pendingPage` lets the highlight respond on the tap frame, decoupled from the
+  // mount. `displayPage` is the single source the spotlight/active styling reads.
+  const [pendingPage, setPendingPage] = useState<BottomNavPage | null>(null);
+  const displayPage = pendingPage ?? currentPage;
+
+  // Reconcile: clear the optimistic lead whenever the REAL currentPage commits —
+  // whether that's the tab we tapped OR a programmatic page (deep link / push
+  // notification). This guarantees the optimistic state can never desync from the
+  // source of truth: once currentPage catches up, `displayPage` falls back to it.
+  useEffect(() => {
+    setPendingPage(null);
+  }, [currentPage]);
+
   useEffect(() => {
     let mounted = true;
     (async (): Promise<void> => {
@@ -152,7 +170,9 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
   const spotlightWidth = useSharedValue(0);
 
   useEffect(() => {
-    const layout = tabLayoutsRef.current[currentPage];
+    // ORCH-0995 IMPLEMENT-2: drive off `displayPage` (optimistic) so the spotlight
+    // animates to the tapped tab on the tap frame, before the currentPage prop commits.
+    const layout = tabLayoutsRef.current[displayPage];
     if (!layout) return;
     const targetX = layout.x + c.nav.spotlightInset;
     const targetWidth = layout.width - c.nav.spotlightInset * 2;
@@ -174,7 +194,7 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
     spotlightWidth.value = withSpring(targetWidth, springConfig);
     // R6 fix: layoutTick included so this effect re-runs when onLayout fires
     // for the active tab on first mount.
-  }, [currentPage, layoutTick, reduceMotion, spotlightX, spotlightWidth]);
+  }, [displayPage, layoutTick, reduceMotion, spotlightX, spotlightWidth]);
 
   // UI-thread animated style for the spotlight pill (left + width).
   const spotlightAnimatedStyle = useAnimatedStyle(() => ({
@@ -219,17 +239,23 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
       {/* Tabs */}
       <View style={styles.tabsRow}>
         {TAB_ORDER.map((key) => {
-          const active = key === currentPage;
+          const active = key === displayPage;
           const badge = badges?.[key] ?? 0;
           return (
             <Pressable
               key={key}
               ref={key === 'likes' ? (coachLikesRef as React.Ref<View>) : undefined}
               onPress={() => {
-                if (active) return;
+                // Guard against re-tapping the already-selected tab (optimistic-aware).
+                if (key === displayPage) return;
                 if (Platform.OS === 'ios') {
                   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
                 }
+                // ORCH-0995 IMPLEMENT-2: set optimistic selection FIRST so the
+                // spotlight + active styling move on the tap frame, then trigger the
+                // (heavier) navigation. The reconcile effect clears pendingPage once
+                // currentPage catches up.
+                setPendingPage(key);
                 onNavigate(key);
               }}
               onLayout={(e) => {

--- a/app-mobile/src/components/GlassBottomNav.tsx
+++ b/app-mobile/src/components/GlassBottomNav.tsx
@@ -18,7 +18,7 @@
  * Spec: SPEC_ORCH-0589_FLOATING_GLASS_HOME.md §5 Variant A
  * Tokens: designSystem.ts → glass.chrome.*
  */
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -26,10 +26,12 @@ import {
   StyleSheet,
   Platform,
   AccessibilityInfo,
-  Animated,
-  Easing,
-  useWindowDimensions,
 } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from 'react-native-reanimated';
 import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import { Icon, type IconName } from './ui/Icon';
@@ -139,9 +141,15 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
     setLayoutTick((v) => v + 1);
   };
 
-  // Spotlight animation: translateX + width interpolates to the active tab's position.
-  const spotlightX = useRef(new Animated.Value(0)).current;
-  const spotlightWidth = useRef(new Animated.Value(0)).current;
+  // ORCH-0995: Spotlight position (left) + width animate on the UI THREAD via
+  // react-native-reanimated shared values. The previous implementation animated `left`
+  // and `width` (non-native-drivable layout props) on the JS thread, forcing every frame
+  // through the bridge → dropped frames + tab-switch lag on mid-tier Android. Reanimated
+  // animates `left`/`width` on the UI thread (it is NOT subject to the RN-Animated
+  // native-driver limitation for layout props), keeping resting geometry pixel-identical
+  // (translateX-via-`left` + true `width`, no scaleX radius distortion).
+  const spotlightX = useSharedValue(0);
+  const spotlightWidth = useSharedValue(0);
 
   useEffect(() => {
     const layout = tabLayoutsRef.current[currentPage];
@@ -150,30 +158,29 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
     const targetWidth = layout.width - c.nav.spotlightInset * 2;
 
     if (reduceMotion) {
-      spotlightX.setValue(targetX);
-      spotlightWidth.setValue(targetWidth);
+      // Instant set, no animation (a11y reduce-motion path preserved).
+      spotlightX.value = targetX;
+      spotlightWidth.value = targetWidth;
       return;
     }
 
-    Animated.parallel([
-      Animated.spring(spotlightX, {
-        toValue: targetX,
-        damping: c.motion.springDamping,
-        stiffness: c.motion.springStiffness,
-        mass: c.motion.springMass,
-        useNativeDriver: false,
-      }),
-      Animated.spring(spotlightWidth, {
-        toValue: targetWidth,
-        damping: c.motion.springDamping,
-        stiffness: c.motion.springStiffness,
-        mass: c.motion.springMass,
-        useNativeDriver: false,
-      }),
-    ]).start();
+    // designSystem motion tokens map 1:1 onto Reanimated withSpring config.
+    const springConfig = {
+      damping: c.motion.springDamping,
+      stiffness: c.motion.springStiffness,
+      mass: c.motion.springMass,
+    };
+    spotlightX.value = withSpring(targetX, springConfig);
+    spotlightWidth.value = withSpring(targetWidth, springConfig);
     // R6 fix: layoutTick included so this effect re-runs when onLayout fires
     // for the active tab on first mount.
   }, [currentPage, layoutTick, reduceMotion, spotlightX, spotlightWidth]);
+
+  // UI-thread animated style for the spotlight pill (left + width).
+  const spotlightAnimatedStyle = useAnimatedStyle(() => ({
+    left: spotlightX.value,
+    width: spotlightWidth.value,
+  }));
 
   return (
     <View style={styles.container}>
@@ -203,16 +210,10 @@ export const GlassBottomNav: React.FC<GlassBottomNavProps> = ({
       ) : null}
       {/* ORCH-0589 v4 (V5): top-highlight line removed — see designSystem comment. */}
 
-      {/* Spotlight */}
+      {/* Spotlight — left + width animate on the UI thread (ORCH-0995). */}
       <Animated.View
         pointerEvents="none"
-        style={[
-          styles.spotlight,
-          {
-            left: spotlightX,
-            width: spotlightWidth,
-          },
-        ]}
+        style={[styles.spotlight, spotlightAnimatedStyle]}
       />
 
       {/* Tabs */}

--- a/app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx
+++ b/app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx
@@ -1,0 +1,157 @@
+// @ts-nocheck
+// ORCH-0995 [Android-wide UI jank + tab-navigation animation lag — iOS-fluidity parity]
+//
+// Regression test: the GlassBottomNav tab "spotlight" pill MUST animate entirely off the
+// JS thread (on the UI thread) so tab switching is buttery on mid-tier Android.
+//
+// Root cause being guarded against: the spotlight previously animated `left`/`width` with
+// RN `Animated.spring(..., { useNativeDriver: false })`, which runs every frame on the JS
+// thread → dropped frames + visible tab-switch lag on Android. The fix moves the spotlight
+// to react-native-reanimated shared values (UI thread), preserving pixel-identical resting
+// geometry, the reduceMotion instant-set branch, and the layoutTick re-run.
+//
+// This is a source-static-analysis test (the repo convention for component tests — see
+// orch-0945-dead-end-render.test.tsx). It reads GlassBottomNav.tsx as a string and asserts
+// the corrected animation mechanism + the preserved geometry math.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function resolveRepoFile(relPath) {
+  const direct = path.resolve(process.cwd(), relPath);
+  if (fs.existsSync(direct)) return direct;
+  return path.resolve(process.cwd(), 'app-mobile', relPath);
+}
+
+function readSource(relPath) {
+  return fs.readFileSync(resolveRepoFile(relPath), 'utf8');
+}
+
+function runOrch0995SpotlightUiThreadTest() {
+  const source = readSource('src/components/GlassBottomNav.tsx');
+
+  // ---- T-01 [FAILS-ON-REVERT KEY]: no JS-thread-driven layout spring on the spotlight ----
+  // The old code shipped `useNativeDriver: false` springs on `left`/`width`. That string
+  // existing anywhere in this file means the spotlight is (or could be) animated on the
+  // JS thread — forbidden by the ORCH-0995 contract.
+  assert.ok(
+    !/useNativeDriver:\s*false/.test(source),
+    'T-01 spotlight must NOT use any `useNativeDriver: false` animation (JS-thread layout animation forbidden)'
+  );
+
+  // ---- T-02 [FAILS-ON-REVERT KEY]: the old RN Animated.spring path is gone ----
+  assert.ok(
+    !/Animated\.spring\(/.test(source),
+    'T-02 spotlight must NOT use RN `Animated.spring(` (JS-thread spring). Use reanimated withSpring on the UI thread.'
+  );
+  assert.ok(
+    !/Animated\.parallel\(/.test(source),
+    'T-02b old RN `Animated.parallel(` orchestration of the JS-thread spring must be removed'
+  );
+
+  // ---- T-03: spotlight uses the reanimated UI-thread shared-value path ----
+  assert.match(
+    source,
+    /from ['"]react-native-reanimated['"]/,
+    'T-03 GlassBottomNav must import from react-native-reanimated (UI-thread animation engine)'
+  );
+  assert.match(
+    source,
+    /useSharedValue/,
+    'T-03 spotlight must use useSharedValue (UI-thread state)'
+  );
+  assert.match(
+    source,
+    /useAnimatedStyle/,
+    'T-03 spotlight must use useAnimatedStyle (UI-thread style worklet)'
+  );
+  assert.match(
+    source,
+    /withSpring\(/,
+    'T-03 spotlight must animate via reanimated withSpring (UI-thread spring)'
+  );
+
+  // ---- T-04: resting geometry math is pixel-identical to before ----
+  // targetX = layout.x + inset ; targetWidth = layout.width - inset*2
+  assert.match(
+    source,
+    /const\s+targetX\s*=\s*layout\.x\s*\+\s*c\.nav\.spotlightInset\s*;/,
+    'T-04 resting X landing must remain `layout.x + c.nav.spotlightInset`'
+  );
+  assert.match(
+    source,
+    /const\s+targetWidth\s*=\s*layout\.width\s*-\s*c\.nav\.spotlightInset\s*\*\s*2\s*;/,
+    'T-04 resting width must remain `layout.width - c.nav.spotlightInset * 2`'
+  );
+  // The animated style must drive `left` + `width` (true geometry, not scaleX which
+  // would distort the corner radius).
+  assert.match(
+    source,
+    /left:\s*spotlightX\.value/,
+    'T-04 animated style must set `left` from the shared value (translateX-equivalent, no radius distortion)'
+  );
+  assert.match(
+    source,
+    /width:\s*spotlightWidth\.value/,
+    'T-04 animated style must set `width` from the shared value (true width, no scaleX distortion)'
+  );
+
+  // ---- T-05: spring feel preserved — designSystem motion tokens drive withSpring ----
+  assert.match(
+    source,
+    /damping:\s*c\.motion\.springDamping/,
+    'T-05 withSpring damping must come from c.motion.springDamping'
+  );
+  assert.match(
+    source,
+    /stiffness:\s*c\.motion\.springStiffness/,
+    'T-05 withSpring stiffness must come from c.motion.springStiffness'
+  );
+  assert.match(
+    source,
+    /mass:\s*c\.motion\.springMass/,
+    'T-05 withSpring mass must come from c.motion.springMass'
+  );
+
+  // ---- T-06: reduceMotion instant-set branch preserved (no animation) ----
+  // In the reduceMotion branch the shared values must be set directly (not via withSpring).
+  const rmStart = source.indexOf('if (reduceMotion) {');
+  assert.notEqual(rmStart, -1, 'T-06 reduceMotion branch must still exist');
+  const rmEnd = source.indexOf('}', rmStart);
+  const rmBlock = source.slice(rmStart, rmEnd + 1);
+  assert.match(
+    rmBlock,
+    /spotlightX\.value\s*=\s*targetX\s*;/,
+    'T-06 reduceMotion must instant-set spotlightX (no spring)'
+  );
+  assert.match(
+    rmBlock,
+    /spotlightWidth\.value\s*=\s*targetWidth\s*;/,
+    'T-06 reduceMotion must instant-set spotlightWidth (no spring)'
+  );
+  assert.ok(
+    !/withSpring/.test(rmBlock),
+    'T-06 reduceMotion branch must NOT call withSpring (instant set only)'
+  );
+
+  // ---- T-07: layoutTick re-run preserved (first-mount positioning) ----
+  assert.match(
+    source,
+    /\}, \[currentPage, layoutTick, reduceMotion, spotlightX, spotlightWidth\]\);/,
+    'T-07 spotlight effect dep array must still include layoutTick (re-runs when onLayout fires on first mount)'
+  );
+}
+
+if (require.main === module) {
+  try {
+    runOrch0995SpotlightUiThreadTest();
+    console.log(
+      'PASS T-01..T-07 ORCH-0995 bottom-nav spotlight animates on UI thread with pixel-identical resting geometry + preserved reduceMotion/layoutTick paths'
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = { runOrch0995SpotlightUiThreadTest };

--- a/app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx
+++ b/app-mobile/src/components/__tests__/orch-0995-bottom-nav-spotlight-ui-thread.test.tsx
@@ -135,10 +135,13 @@ function runOrch0995SpotlightUiThreadTest() {
   );
 
   // ---- T-07: layoutTick re-run preserved (first-mount positioning) ----
+  // ORCH-0995 IMPLEMENT-2: the effect now keys off `displayPage` (optimistic) instead of
+  // `currentPage` so the spotlight moves on the tap frame; layoutTick still present so the
+  // effect re-runs when onLayout fires on first mount.
   assert.match(
     source,
-    /\}, \[currentPage, layoutTick, reduceMotion, spotlightX, spotlightWidth\]\);/,
-    'T-07 spotlight effect dep array must still include layoutTick (re-runs when onLayout fires on first mount)'
+    /\}, \[displayPage, layoutTick, reduceMotion, spotlightX, spotlightWidth\]\);/,
+    'T-07 spotlight effect dep array must include displayPage + layoutTick (re-runs when onLayout fires on first mount; optimistic-driven post IMPLEMENT-2)'
   );
 }
 

--- a/app-mobile/src/components/__tests__/orch-0995-impl2-optimistic-tab-feedback.test.tsx
+++ b/app-mobile/src/components/__tests__/orch-0995-impl2-optimistic-tab-feedback.test.tsx
@@ -1,0 +1,249 @@
+// @ts-nocheck
+// ORCH-0995 IMPLEMENT-2 [instant tab-tap feedback — optimistic nav selection + deferred mount]
+//
+// Follow-on to the ORCH-0995 spotlight UI-thread fix (commit b91770195). After that fix the
+// spotlight animated on the UI thread, but the highlight was still HOSTAGE to the destination
+// screen's mount: tap → onNavigate → parent setCurrentPage → AppContent re-renders, the
+// switch(currentPage) IIFE unmounts the old screen + mounts the new heavy screen SYNCHRONOUSLY
+// on the JS thread → only THEN does GlassBottomNav receive the new currentPage prop and move
+// the spotlight. So the tap feedback was blocked by the screen mount → "noticeable lag between
+// tapping a tab and seeing the effect."
+//
+// THE FIX (two parts):
+//   PART A — GlassBottomNav keeps a local optimistic `pendingPage`; `displayPage =
+//            pendingPage ?? currentPage` drives the spotlight effect + active icon + active
+//            label + accessibilityState.selected. onPress sets `setPendingPage(key)` BEFORE
+//            `onNavigate(key)`. A `useEffect(..., [currentPage])` clears pendingPage whenever
+//            the real currentPage commits (tapped page OR programmatic page) — guaranteeing
+//            the optimistic state can never desync from the source of truth.
+//   PART B — app/index.tsx onNavigate keeps closeProfileOverlays() URGENT and wraps
+//            setCurrentPage(page) in React.startTransition(...) so the urgent optimistic nav
+//            update + spotlight animation commit first and the heavy mount is de-prioritized.
+//
+// This file proves BOTH:
+//   1. The optimistic state-machine SEMANTICS (behavioral simulation that mirrors the exact
+//      code: press sets displayPage before currentPage changes; reconcile clears it; a
+//      programmatic currentPage change to a DIFFERENT page is reflected — no desync).
+//   2. The SOURCE actually wires it that way (static assertions that bind this test to the
+//      real GlassBottomNav.tsx + app/index.tsx → these are the FAILS-ON-REVERT keys).
+//
+// Convention: standalone node:assert script (the repo's component-test convention — there is
+// no jest/RTL in app-mobile). Mirrors orch-0995-bottom-nav-spotlight-ui-thread.test.tsx.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function resolveRepoFile(relPath) {
+  const direct = path.resolve(process.cwd(), relPath);
+  if (fs.existsSync(direct)) return direct;
+  return path.resolve(process.cwd(), 'app-mobile', relPath);
+}
+
+function readSource(relPath) {
+  return fs.readFileSync(resolveRepoFile(relPath), 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Behavioral model — a faithful, minimal re-implementation of the GlassBottomNav
+// optimistic state machine. It mirrors the EXACT semantics of the component:
+//   - displayPage = pendingPage ?? currentPage
+//   - press(key): if key === displayPage → no-op; else setPendingPage(key)
+//   - commitCurrentPage(page): set currentPage = page, then run the reconcile
+//     effect (setPendingPage(null)) because the [currentPage] dep changed.
+// This lets us assert the ordering guarantees the UI thread depends on, in pure JS.
+// ---------------------------------------------------------------------------
+function createNav(initialPage) {
+  let currentPage = initialPage;
+  let pendingPage = null;
+  return {
+    get displayPage() {
+      return pendingPage ?? currentPage;
+    },
+    get currentPage() {
+      return currentPage;
+    },
+    get pendingPage() {
+      return pendingPage;
+    },
+    // Mirrors the Pressable onPress optimistic-set.
+    press(key) {
+      if (key === (pendingPage ?? currentPage)) return; // guard: re-tap is a no-op
+      pendingPage = key; // setPendingPage(key) — instant, before onNavigate
+    },
+    // Mirrors the parent committing setCurrentPage(page) → currentPage prop change →
+    // the reconcile useEffect(() => setPendingPage(null), [currentPage]) firing.
+    commitCurrentPage(page) {
+      currentPage = page;
+      pendingPage = null; // reconcile effect clears the optimistic lead
+    },
+  };
+}
+
+function runOptimisticSemanticsTests() {
+  // ---- T-08: pressing an inactive tab sets optimistic displayPage IMMEDIATELY, ----
+  //            BEFORE the currentPage prop changes (the core of "instant feedback").
+  {
+    const nav = createNav('home');
+    nav.press('discover');
+    assert.equal(
+      nav.displayPage,
+      'discover',
+      'T-08 pressing an inactive tab must set displayPage to the pressed key on the tap frame'
+    );
+    assert.equal(
+      nav.currentPage,
+      'home',
+      'T-08 currentPage must NOT have changed yet (still the old page — mount is deferred)'
+    );
+    assert.equal(nav.pendingPage, 'discover', 'T-08 pendingPage holds the optimistic lead');
+  }
+
+  // ---- T-09: when currentPage later commits to the tapped page, the optimistic ----
+  //            state CLEARS (displayPage stays correct, no double-source). ----
+  {
+    const nav = createNav('home');
+    nav.press('discover'); // optimistic lead
+    nav.commitCurrentPage('discover'); // parent's deferred setCurrentPage finally commits
+    assert.equal(
+      nav.pendingPage,
+      null,
+      'T-09 reconcile effect must clear pendingPage once currentPage catches up'
+    );
+    assert.equal(
+      nav.displayPage,
+      'discover',
+      'T-09 displayPage must remain the tapped page after reconcile (now sourced from currentPage)'
+    );
+  }
+
+  // ---- T-10: a programmatic currentPage change to a DIFFERENT page (deep link / ----
+  //            push notification, NO tab tapped) is reflected by displayPage — no desync. ----
+  {
+    const nav = createNav('home');
+    // No press(). A notification routes the app to 'connections' directly.
+    nav.commitCurrentPage('connections');
+    assert.equal(
+      nav.pendingPage,
+      null,
+      'T-10 no optimistic lead when nothing was tapped'
+    );
+    assert.equal(
+      nav.displayPage,
+      'connections',
+      'T-10 programmatic nav must be reflected by displayPage (highlight follows deep-link/notification)'
+    );
+  }
+
+  // ---- T-11: optimistic lead can NEVER desync — if currentPage commits to a page ----
+  //            DIFFERENT from the optimistic one (e.g. a notification fires mid-tap), ----
+  //            the reconcile clears pending and displayPage follows the real source. ----
+  {
+    const nav = createNav('home');
+    nav.press('discover'); // user optimistically heading to discover
+    // ...but a push notification wins and routes to 'connections' instead.
+    nav.commitCurrentPage('connections');
+    assert.equal(nav.pendingPage, null, 'T-11 reconcile clears the stale optimistic lead');
+    assert.equal(
+      nav.displayPage,
+      'connections',
+      'T-11 displayPage must follow the authoritative currentPage, never strand on the stale optimistic page'
+    );
+  }
+
+  // ---- T-12: re-tapping the already-displayed tab is a no-op (no spurious pending). ----
+  {
+    const nav = createNav('home');
+    nav.press('home');
+    assert.equal(nav.pendingPage, null, 'T-12 re-tapping the active tab must not set pendingPage');
+    assert.equal(nav.displayPage, 'home', 'T-12 displayPage unchanged on re-tap');
+  }
+}
+
+function runSourceWiringTests() {
+  const nav = readSource('src/components/GlassBottomNav.tsx');
+  const idx = readSource('app/index.tsx');
+
+  // ===== FAILS-ON-REVERT KEYS (PART A — GlassBottomNav.tsx) =====
+
+  // ---- T-13 [FAILS-ON-REVERT]: optimistic pendingPage state exists ----
+  assert.match(
+    nav,
+    /const\s+\[pendingPage,\s*setPendingPage\]\s*=\s*useState<BottomNavPage\s*\|\s*null>\(null\)/,
+    'T-13 GlassBottomNav must declare optimistic `pendingPage` state (useState<BottomNavPage | null>(null))'
+  );
+
+  // ---- T-14 [FAILS-ON-REVERT]: displayPage = pendingPage ?? currentPage ----
+  assert.match(
+    nav,
+    /const\s+displayPage\s*=\s*pendingPage\s*\?\?\s*currentPage\s*;/,
+    'T-14 GlassBottomNav must derive `displayPage = pendingPage ?? currentPage`'
+  );
+
+  // ---- T-15 [FAILS-ON-REVERT]: reconcile effect clears pendingPage on currentPage change ----
+  assert.match(
+    nav,
+    /setPendingPage\(null\)\s*;[\s\S]*?\},\s*\[currentPage\]\)/,
+    'T-15 GlassBottomNav must clear pendingPage in a useEffect keyed on [currentPage] (reconcile / anti-desync)'
+  );
+
+  // ---- T-16 [FAILS-ON-REVERT]: onPress sets pending BEFORE onNavigate ----
+  const pendIdx = nav.indexOf('setPendingPage(key)');
+  const navIdx = nav.indexOf('onNavigate(key)');
+  assert.notEqual(pendIdx, -1, 'T-16 onPress must call setPendingPage(key)');
+  assert.notEqual(navIdx, -1, 'T-16 onPress must call onNavigate(key)');
+  assert.ok(
+    pendIdx < navIdx,
+    'T-16 setPendingPage(key) must run BEFORE onNavigate(key) so the highlight moves on the tap frame'
+  );
+
+  // ---- T-17 [FAILS-ON-REVERT]: spotlight + active styling are driven by displayPage ----
+  assert.match(
+    nav,
+    /const\s+layout\s*=\s*tabLayoutsRef\.current\[displayPage\]\s*;/,
+    'T-17 spotlight effect must look up layout via displayPage (optimistic), not currentPage'
+  );
+  assert.match(
+    nav,
+    /const\s+active\s*=\s*key\s*===\s*displayPage\s*;/,
+    'T-17 active flag (icon color + label style + accessibilityState.selected) must derive from displayPage'
+  );
+  // The old currentPage-driven wiring must be gone from the active flag + effect lookup.
+  assert.ok(
+    !/const\s+active\s*=\s*key\s*===\s*currentPage\s*;/.test(nav),
+    'T-17 the old `active = key === currentPage` must be replaced by displayPage'
+  );
+
+  // ===== FAILS-ON-REVERT KEYS (PART B — app/index.tsx) =====
+
+  // ---- T-18 [FAILS-ON-REVERT]: the tab onNavigate defers setCurrentPage via startTransition ----
+  // closeProfileOverlays() stays urgent (outside the transition); setCurrentPage(page) is wrapped.
+  assert.match(
+    idx,
+    /closeProfileOverlays\(\)\s*;[\s\S]*?React\.startTransition\(\s*\(\)\s*=>\s*\{[\s\S]*?setCurrentPage\(page\)\s*;[\s\S]*?\}\)/,
+    'T-18 onNavigate must keep closeProfileOverlays() urgent then wrap setCurrentPage(page) in React.startTransition (deferred mount)'
+  );
+  // The old un-deferred `closeProfileOverlays(); setCurrentPage(page);` bare pair must be gone.
+  assert.ok(
+    !/closeProfileOverlays\(\)\s*;\s*\n\s*setCurrentPage\(page\)\s*;/.test(idx),
+    'T-18 the old un-deferred setCurrentPage(page) immediately after closeProfileOverlays() must be wrapped in startTransition'
+  );
+}
+
+function runAll() {
+  runOptimisticSemanticsTests();
+  runSourceWiringTests();
+}
+
+if (require.main === module) {
+  try {
+    runAll();
+    console.log(
+      'PASS T-08..T-18 ORCH-0995 IMPLEMENT-2 optimistic tab-tap feedback (instant displayPage on press, reconcile clears on currentPage commit, programmatic nav reflected, no desync) + source wired for optimistic nav + startTransition-deferred mount'
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = { runOptimisticSemanticsTests, runSourceWiringTests, runAll, createNav };

--- a/app-mobile/src/components/__tests__/orch-0995-tester-optimistic-desync-adversarial.test.tsx
+++ b/app-mobile/src/components/__tests__/orch-0995-tester-optimistic-desync-adversarial.test.tsx
@@ -1,0 +1,261 @@
+// @ts-nocheck
+// ORCH-0995 [Android nav jank] — TESTER ADVERSARIAL regression test.
+//
+// Angle (DIFFERENT from the implementor's happy-path tests, which simulate exactly one
+// press → one commit and unconditionally clear pending on every commitCurrentPage):
+// this test models the optimistic state machine the way React ACTUALLY runs it, where the
+// reconcile `useEffect(() => setPendingPage(null), [currentPage])` fires ONLY when the
+// `currentPage` value genuinely CHANGES between renders — not on every render, and not on a
+// commit to the same value. It then attacks the desync edge cases that a naive model hides:
+//
+//   ADV-1  Rapid multi-tap (A→B→C) before ANY currentPage commit. displayPage must track the
+//          LAST pressed tab, and once currentPage finally catches up it must NEVER strand on a
+//          stale pending — including the realistic path where currentPage lands on an
+//          INTERMEDIATE page first (startTransition can coalesce/interleave commits), which
+//          fires the reconcile early and must hand authority back to currentPage.
+//
+//   ADV-2  Programmatic nav (notification) lands on the SAME page a stale optimistic lead
+//          points to. Because the real reconcile is keyed on the VALUE of currentPage, a tab
+//          tap whose pending happens to equal the eventual currentPage must still leave
+//          pending cleared so a later programmatic nav to a different page is not blocked by a
+//          stuck non-null pending. Proves the wiring can't deadlock the highlight.
+//
+//   ADV-3  reduceMotion geometry: while an optimistic lead is active, the instant-set spotlight
+//          geometry must be computed from displayPage's tab layout (the LAST tap), NOT
+//          currentPage's — otherwise the highlight jumps to the wrong tab under reduce-motion.
+//
+// These attack real BEHAVIOR (final highlight + geometry), not implementation trivia. The
+// model is held faithful to the source by binding source-wiring guards (ADV-W*) that assert
+// the component is actually wired the way the model assumes (reconcile keyed on [currentPage],
+// displayPage drives geometry + active). Those are the fails-on-revert keys.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function resolveRepoFile(relPath) {
+  const direct = path.resolve(process.cwd(), relPath);
+  if (fs.existsSync(direct)) return direct;
+  return path.resolve(process.cwd(), 'app-mobile', relPath);
+}
+function readSource(relPath) {
+  return fs.readFileSync(resolveRepoFile(relPath), 'utf8');
+}
+
+// designSystem tokens (mirrored from src/constants/designSystem.ts → glass.chrome.nav).
+const SPOTLIGHT_INSET = 0; // c.nav.spotlightInset
+
+// ---------------------------------------------------------------------------
+// FAITHFUL optimistic-nav model.
+//
+// Differences from the implementor's createNav (deliberately stricter):
+//   - The reconcile effect fires ONLY when currentPage's value CHANGES (mirrors React's
+//     [currentPage] dependency comparison). committing the SAME value does NOT re-run it.
+//   - `setCurrentPage` and the reconcile are separated so we can interleave rapid taps and
+//     out-of-order / coalesced commits the way startTransition can in production.
+//   - Geometry (spotlight target) is computed from displayPage against a tab-layout map, so we
+//     can assert the highlight lands on the right tab — not just that a string matches.
+// ---------------------------------------------------------------------------
+function createFaithfulNav(initialPage, tabLayouts) {
+  let currentPage = initialPage;
+  let prevCommittedCurrentPage = initialPage; // last value the reconcile effect "saw"
+  let pendingPage = null;
+
+  const displayPage = () => pendingPage ?? currentPage;
+
+  // Run the reconcile effect the way React would: only if [currentPage] changed since the
+  // last time the effect ran.
+  const runReconcileIfCurrentPageChanged = () => {
+    if (currentPage !== prevCommittedCurrentPage) {
+      pendingPage = null; // setPendingPage(null)
+      prevCommittedCurrentPage = currentPage;
+    }
+  };
+
+  return {
+    displayPage,
+    get currentPage() {
+      return currentPage;
+    },
+    get pendingPage() {
+      return pendingPage;
+    },
+    // onPress optimistic-set: re-tapping the displayed tab is a no-op.
+    press(key) {
+      if (key === displayPage()) return;
+      pendingPage = key;
+    },
+    // Parent commits setCurrentPage(page); React then re-renders and (if currentPage changed)
+    // runs the reconcile effect.
+    commitCurrentPage(page) {
+      currentPage = page;
+      runReconcileIfCurrentPageChanged();
+    },
+    // Spotlight target geometry for the CURRENT displayPage (UI-thread effect reads displayPage).
+    spotlightTarget() {
+      const layout = tabLayouts[displayPage()];
+      if (!layout) return null;
+      return {
+        x: layout.x + SPOTLIGHT_INSET,
+        width: layout.width - SPOTLIGHT_INSET * 2,
+      };
+    },
+  };
+}
+
+// Five real tabs with distinct geometry so a wrong-tab landing is detectable.
+const LAYOUTS = {
+  home: { x: 0, width: 60 },
+  discover: { x: 60, width: 60 },
+  connections: { x: 120, width: 70 },
+  likes: { x: 190, width: 60 },
+  profile: { x: 250, width: 60 },
+};
+
+function runBehavioralAdversarial() {
+  // ===== ADV-1: rapid triple-tap before any commit, then out-of-order/coalesced commit =====
+  {
+    const nav = createFaithfulNav('home', LAYOUTS);
+    // User stabs three tabs fast before the deferred mount commits anything.
+    nav.press('discover');
+    nav.press('connections');
+    nav.press('likes');
+    assert.equal(
+      nav.displayPage(),
+      'likes',
+      'ADV-1 displayPage must track the LAST pressed tab during a rapid burst (not the first, not a middle one)'
+    );
+    assert.equal(nav.currentPage, 'home', 'ADV-1 currentPage has not committed yet');
+
+    // startTransition may coalesce/skip intermediates and land currentPage on 'likes' directly.
+    nav.commitCurrentPage('likes');
+    assert.equal(nav.pendingPage, null, 'ADV-1 reconcile clears pending once currentPage catches up to the last tap');
+    assert.equal(
+      nav.displayPage(),
+      'likes',
+      'ADV-1 displayPage must remain the last-tapped tab after reconcile (now sourced from currentPage), never strand'
+    );
+
+    // Realistic interleave variant: currentPage lands on an INTERMEDIATE page first.
+    const nav2 = createFaithfulNav('home', LAYOUTS);
+    nav2.press('discover');
+    nav2.press('connections');
+    nav2.press('likes'); // displayPage === 'likes'
+    nav2.commitCurrentPage('connections'); // an earlier transition wins first
+    // The reconcile fired (currentPage changed home→connections) and CLEARED pending.
+    assert.equal(nav2.pendingPage, null, 'ADV-1 intermediate commit fires reconcile and clears the optimistic lead');
+    assert.equal(
+      nav2.displayPage(),
+      'connections',
+      'ADV-1 once reconciled, displayPage follows the AUTHORITATIVE currentPage — it must NOT strand on the stale last-tap (likes)'
+    );
+    // And when the final transition commits, the highlight follows it too — no resurrection.
+    nav2.commitCurrentPage('likes');
+    assert.equal(
+      nav2.displayPage(),
+      'likes',
+      'ADV-1 final commit moves displayPage to likes via currentPage; no stale-pending resurrection'
+    );
+  }
+
+  // ===== ADV-2: programmatic nav to the SAME page a stale lead points to → no stuck pending ==
+  {
+    const nav = createFaithfulNav('home', LAYOUTS);
+    nav.press('connections'); // optimistic lead === connections
+    assert.equal(nav.pendingPage, 'connections', 'ADV-2 precondition: pending is set');
+
+    // A push notification routes to 'connections' too (same page the user optimistically chose).
+    nav.commitCurrentPage('connections');
+    // currentPage changed home→connections → reconcile fired → pending cleared.
+    assert.equal(
+      nav.pendingPage,
+      null,
+      'ADV-2 reconcile must clear pending even when programmatic nav matches the optimistic page (no stuck non-null pending)'
+    );
+    assert.equal(nav.displayPage(), 'connections', 'ADV-2 displayPage correct after match');
+
+    // PROOF the highlight is not deadlocked: a later programmatic nav to a DIFFERENT page works.
+    nav.commitCurrentPage('profile');
+    assert.equal(
+      nav.displayPage(),
+      'profile',
+      'ADV-2 a subsequent programmatic nav must move the highlight — proves pending did not stick and block reconcile'
+    );
+  }
+
+  // ===== ADV-3: reduceMotion geometry lands at displayPage's tab during an optimistic lead =====
+  {
+    const nav = createFaithfulNav('home', LAYOUTS);
+    nav.press('profile'); // optimistic lead; currentPage still 'home'
+    const target = nav.spotlightTarget();
+    // Under reduceMotion the component instant-sets spotlightX/Width to exactly this target.
+    assert.deepEqual(
+      target,
+      { x: LAYOUTS.profile.x + SPOTLIGHT_INSET, width: LAYOUTS.profile.width - SPOTLIGHT_INSET * 2 },
+      'ADV-3 spotlight geometry (reduce-motion instant-set) must be computed from displayPage=profile, NOT currentPage=home'
+    );
+    assert.notDeepEqual(
+      target,
+      { x: LAYOUTS.home.x + SPOTLIGHT_INSET, width: LAYOUTS.home.width - SPOTLIGHT_INSET * 2 },
+      'ADV-3 geometry must NOT land on the old currentPage tab while an optimistic lead is active'
+    );
+  }
+}
+
+// ===========================================================================
+// SOURCE-WIRING GUARDS — bind the faithful model to the real component so the model can't
+// drift from production semantics. These are the fails-on-revert keys for the tester test.
+// ===========================================================================
+function runWiringGuards() {
+  const nav = readSource('src/components/GlassBottomNav.tsx');
+
+  // ADV-W1: reconcile is keyed on [currentPage] (NOT [displayPage] / [] / [pendingPage]).
+  // The whole "fires only when currentPage changes" model rests on this exact dep array.
+  assert.match(
+    nav,
+    /useEffect\(\s*\(\)\s*=>\s*\{\s*setPendingPage\(null\)\s*;?\s*\},\s*\[currentPage\]\s*\)/,
+    'ADV-W1 reconcile effect must be `useEffect(() => { setPendingPage(null); }, [currentPage])` — keyed ONLY on currentPage'
+  );
+
+  // ADV-W2: the spotlight geometry effect reads displayPage's layout (so an optimistic lead
+  // moves the pill to the tapped tab, the basis of ADV-1/ADV-3).
+  assert.match(
+    nav,
+    /const\s+layout\s*=\s*tabLayoutsRef\.current\[displayPage\]\s*;/,
+    'ADV-W2 spotlight geometry must be read from tabLayoutsRef.current[displayPage]'
+  );
+
+  // ADV-W3: re-tap guard compares against displayPage (optimistic-aware), so a rapid burst
+  // mid-flight isn't blocked by the stale currentPage closure (basis of ADV-1 burst).
+  assert.match(
+    nav,
+    /if\s*\(\s*key\s*===\s*displayPage\s*\)\s*return\s*;/,
+    'ADV-W3 onPress re-tap guard must compare key === displayPage (optimistic), not currentPage'
+  );
+
+  // ADV-W4: active flag derives from displayPage → icon color + label + a11y.selected all
+  // follow the optimistic lead (ADV-1 expects the LAST tap to read as active).
+  assert.match(
+    nav,
+    /const\s+active\s*=\s*key\s*===\s*displayPage\s*;/,
+    'ADV-W4 active flag must be `key === displayPage`'
+  );
+}
+
+function runAll() {
+  runBehavioralAdversarial();
+  runWiringGuards();
+}
+
+if (require.main === module) {
+  try {
+    runAll();
+    console.log(
+      'PASS ADV-1..ADV-3 + ADV-W1..ADV-W4 ORCH-0995 tester adversarial — optimistic-nav desync edge cases (rapid multi-tap, programmatic-same-page reconcile, reduce-motion geometry) hold against a faithful effect-timing model wired to the real component'
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = { runBehavioralAdversarial, runWiringGuards, runAll, createFaithfulNav };


### PR DESCRIPTION
## ORCH-0995 — Android tab navigation lag → iPhone-fluid

**Root causes fixed (proven on physical Galaxy A72):**
1. Tab spotlight pill animated `left`+`width` with `useNativeDriver:false` → JS-thread spring → Android frame drops. Now animates on the UI thread via react-native-reanimated (already installed; OTA-safe).
2. Tap feedback was hostage to the destination screen mount — highlight couldn't move until the heavy screen finished mounting. Now: GlassBottomNav optimistic `pendingPage`/`displayPage` moves the highlight on the tap frame; `setCurrentPage` wrapped in `React.startTransition` so the heavy mount no longer blocks feedback; `closeProfileOverlays()` kept urgent.

**Verified:** operator confirmed smooth on Galaxy A72; device screenshot proved highlight jumps to tapped tab while old screen still drawn. Only active tab mounts (CI gate `check-active-tab-only.sh` passes). reduceMotion + layoutTick preserved. No new native dep.

**Step 0.5:** implementor happy-path `orch-0995-bottom-nav-spotlight-ui-thread` + `orch-0995-impl2-optimistic-tab-feedback`; tester adversarial `orch-0995-tester-optimistic-desync-adversarial` (rapid multi-tap, programmatic-nav-during-pending, reduceMotion geometry). fails-on-revert proven.

QA: PASS (0 P0/P1). Reports in `Mingla_Artifacts/reports/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)