### PR TITLE
[deploy] Close ORCH-1001: fix business-web white-page crash

### DIFF
--- a/.github/scripts/strict-grep/orch-0978-video-cap-29s.mjs
+++ b/.github/scripts/strict-grep/orch-0978-video-cap-29s.mjs
@@ -29,6 +29,12 @@ const walkFiles = (dirPath) => {
 };
 
 const coverPickerPath = "mingla-business/src/components/ui/CoverPicker.tsx";
+// ORCH-1001: the native trim wiring (react-native-video-trim import + showEditor
+// + cancel handler) moved out of CoverPicker.tsx into a Metro platform-split
+// module so the native-only package never lands in the web bundle (white-page
+// crash). C1/C12 below check that wiring in the split module; CoverPicker.tsx
+// still owns the video picker, the source ceiling, and the trimmed-upload build.
+const trimEditorPath = "mingla-business/src/components/ui/coverPickerVideoTrimEditor.ts";
 const processingServicePath =
   "mingla-business/src/services/eventCoverVideoProcessingService.ts";
 const mediaRulesPath = "mingla-business/src/utils/eventCoverMediaRules.ts";
@@ -38,8 +44,15 @@ const uploadIntentPath = "supabase/functions/event-cover-video-upload-intent/ind
 const webhookPath = "supabase/functions/event-cover-video-webhook/index.ts";
 
 const coverPicker = read(coverPickerPath);
-if (!coverPicker.includes("maxDuration: EVENT_COVER_MAX_VIDEO_DURATION_MS")) {
-  fail("C1", `${coverPickerPath} must pass EVENT_COVER_MAX_VIDEO_DURATION_MS to showEditor`);
+const trimEditor = read(trimEditorPath);
+if (
+  !coverPicker.includes(
+    "trimVideoWithDedicatedEditor(asset.uri, EVENT_COVER_MAX_VIDEO_DURATION_MS)",
+  )
+) {
+  fail("C1", `${coverPickerPath} must pass EVENT_COVER_MAX_VIDEO_DURATION_MS to the trim editor`);
+} else if (!trimEditor.includes("maxDuration: maxDurationMs")) {
+  fail("C1", `${trimEditorPath} must forward the duration cap to showEditor`);
 } else if (coverPicker.includes("videoMaxDuration")) {
   fail("C1", `${coverPickerPath} must not rely on ImagePicker videoMaxDuration`);
 } else {
@@ -191,12 +204,12 @@ if (videoPickerCall === undefined) {
   fail("C12", `${coverPickerPath} video picker must not pass allowsEditing`);
 } else if (videoPickerCall.includes("videoMaxDuration")) {
   fail("C12", `${coverPickerPath} video picker must not pass videoMaxDuration`);
-} else if (!coverPicker.includes('from "react-native-video-trim"')) {
-  fail("C12", `${coverPickerPath} must import react-native-video-trim`);
-} else if (!coverPicker.includes("showEditor(uri")) {
-  fail("C12", `${coverPickerPath} must call showEditor for the native trim flow`);
-} else if (!coverPicker.includes("onCancelTrimming")) {
-  fail("C12", `${coverPickerPath} must handle trimmer cancel`);
+} else if (!trimEditor.includes('from "react-native-video-trim"')) {
+  fail("C12", `${trimEditorPath} must import react-native-video-trim`);
+} else if (!trimEditor.includes("showEditor(uri")) {
+  fail("C12", `${trimEditorPath} must call showEditor for the native trim flow`);
+} else if (!trimEditor.includes("onCancelTrimming")) {
+  fail("C12", `${trimEditorPath} must handle trimmer cancel`);
 } else if (!coverPicker.includes("buildTrimmedVideoUploadFile")) {
   fail("C12", `${coverPickerPath} must build uploads from the trimmed outputPath`);
 } else {

--- a/.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs
+++ b/.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1001 [Business web white-page crash] — native TurboModule web-bundle gate.
+ *
+ * WHY: `react-native-video-trim` (and peers) ship a TurboModule whose module
+ * body runs `TurboModuleRegistry.getEnforcing('<Name>')` at IMPORT-EVAL time.
+ * An eager top-level `import` of such a package in a web-reachable file gets
+ * evaluated the instant the web bundle loads, `getEnforcing` throws (no native
+ * runtime on web), and the entire app crashes to a blank #root (white page).
+ * That is exactly what shipped with ORCH-0989 and blanked business.usemingla.com.
+ *
+ * RULE: a native-only package on the denylist may be EAGERLY imported only from
+ *   (a) a `*.native.ts|tsx|js|jsx` file (Metro never bundles it on web), or
+ *   (b) a base `foo.ts|tsx` file that HAS a sibling `foo.web.ts|tsx` stub
+ *       (Metro resolves the web stub on web, so the native pkg is excluded).
+ * Any other eager import is a FAIL — it would land in, and crash, the web bundle.
+ *
+ * Lazy, runtime-gated `require("pkg")` (e.g. react-native-compressor behind a
+ * `Platform.OS === "web"` early-return) is NOT flagged: Metro registers the
+ * factory but never executes its body on web, so `getEnforcing` never runs.
+ * This gate targets EAGER `import` / top-level `import()` only.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? path.resolve(process.cwd(), "..")
+  : process.cwd();
+
+const checkedRoots = ["mingla-business/app", "mingla-business/src"];
+
+// Native-only packages whose module body calls TurboModuleRegistry.getEnforcing
+// at import-eval time. Add a package here the moment it enters the dep tree.
+const nativeOnlyPackages = ["react-native-video-trim", "react-native-compressor"];
+
+const eagerImportPattern = (pkg) => {
+  const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // eager: `import ... from "pkg"`, side-effect `import "pkg"`, or top-level `import("pkg")`.
+  // NOT matched: `require("pkg")` (lazy factory — safe when runtime-gated).
+  return new RegExp(
+    `(?:^|\\n)\\s*import\\s+(?:[^;\\n]*?\\s+from\\s+)?["']${escaped}["']` +
+      `|(?:^|\\n)\\s*import\\(\\s*["']${escaped}["']\\s*\\)`,
+  );
+};
+
+const hasWebSibling = (absolutePath) => {
+  const dir = path.dirname(absolutePath);
+  const base = path.basename(absolutePath).replace(/\.(ts|tsx|js|jsx)$/, "");
+  return [".web.ts", ".web.tsx", ".web.js", ".web.jsx"].some((ext) =>
+    fs.existsSync(path.join(dir, `${base}${ext}`)),
+  );
+};
+
+const isNativeSuffixed = (absolutePath) =>
+  /\.native\.(ts|tsx|js|jsx)$/.test(absolutePath);
+
+const failures = [];
+
+const walk = (directory) => {
+  if (!fs.existsSync(directory)) return;
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walk(absolutePath);
+      continue;
+    }
+    if (!/\.(ts|tsx|js|jsx)$/.test(entry.name)) continue;
+    const relativePath = path.relative(root, absolutePath);
+    const source = fs.readFileSync(absolutePath, "utf8");
+    for (const pkg of nativeOnlyPackages) {
+      if (!eagerImportPattern(pkg).test(source)) continue;
+      if (isNativeSuffixed(absolutePath)) continue; // .native.* — web-excluded
+      if (hasWebSibling(absolutePath)) continue; // platform split — web gets stub
+      failures.push(
+        `${relativePath}: eager top-level import of native-only "${pkg}" in a web-reachable file. ` +
+          `Move it behind a Metro platform split — a "${path.basename(relativePath).replace(/\.(ts|tsx|js|jsx)$/, "")}.web.ts" stub sibling, ` +
+          `or a ".native.ts" file. An eager import here runs getEnforcing() at web-eval time and white-pages the app.`,
+      );
+    }
+  }
+};
+
+// ---- Self-test (run with --self-test): proves the gate actually catches the bug.
+if (process.argv.includes("--self-test")) {
+  const selfFailures = [];
+  const probe = (label, source, file, expectFail) => {
+    const fakeRoot = "/tmp/orch1001-selftest";
+    const abs = path.join(fakeRoot, file);
+    const pat = eagerImportPattern("react-native-video-trim");
+    const matched = pat.test(source);
+    const wouldFail =
+      matched && !isNativeSuffixed(abs) && !(file.includes("HASWEB"));
+    if (wouldFail !== expectFail) {
+      selfFailures.push(`SELF-TEST "${label}": expected fail=${expectFail}, got ${wouldFail}`);
+    }
+  };
+  probe("eager import in plain file", 'import Foo from "react-native-video-trim";', "Bad.ts", true);
+  probe("side-effect import", 'import "react-native-video-trim";', "Bad.ts", true);
+  probe(".native suffixed", 'import Foo from "react-native-video-trim";', "Ok.native.ts", false);
+  probe("lazy require (not eager)", 'const x = require("react-native-video-trim");', "Ok.ts", false);
+  probe("unrelated file", 'import { View } from "react-native";', "Ok.ts", false);
+  if (selfFailures.length) {
+    console.error("ORCH-1001 gate SELF-TEST FAILED:");
+    selfFailures.forEach((f) => console.error("  - " + f));
+    process.exit(1);
+  }
+  console.log("ORCH-1001 gate self-test PASS (5/5 cases).");
+  process.exit(0);
+}
+
+// ---- npm wiring check: the gate must be wired into package.json.
+const checkNpmWiring = () => {
+  const packageJsonPath = path.join(root, "mingla-business/package.json");
+  let packageJson;
+  try {
+    packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  } catch (error) {
+    failures.push(`ORCH-1001 wiring: mingla-business/package.json parse failed: ${error.message}`);
+    return;
+  }
+  const script = packageJson.scripts?.["test:orch-1001"];
+  if (
+    typeof script !== "string" ||
+    !script.includes("orch-1001-no-native-turbomodule-in-web-bundle.mjs")
+  ) {
+    failures.push(
+      `ORCH-1001 wiring: mingla-business/package.json missing scripts["test:orch-1001"] pointing at the gate script.`,
+    );
+  }
+};
+
+checkedRoots.forEach((relativeRoot) => walk(path.join(root, relativeRoot)));
+checkNpmWiring();
+
+if (failures.length) {
+  console.error("ORCH-1001 native-TurboModule web-bundle gate FAILED:");
+  failures.forEach((failure) => console.error("  - " + failure));
+  process.exit(1);
+}
+console.log(
+  `ORCH-1001 gate PASS: no eager native-only TurboModule imports in web-reachable mingla-business code (${nativeOnlyPackages.join(", ")}).`,
+);

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -709,6 +709,19 @@ jobs:
       - name: Run ORCH-0778 gate
         run: node .github/scripts/strict-grep/orch-0778-web-stripe-native-import-gate.mjs
 
+  orch-1001-no-native-turbomodule-in-web-bundle:
+    name: "ORCH-1001: native TurboModules stay out of the web bundle"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1001 gate self-test
+        run: node .github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs --self-test
+      - name: Run ORCH-1001 gate
+        run: node .github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs
+
   meta-orch-0827-package-isolation:
     name: "META-ORCH-0827: packages/ pure-presentational isolation"
     runs-on: ubuntu-latest

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1001_BIZ_WEB_WHITE_PAGE_CRASH.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1001_BIZ_WEB_WHITE_PAGE_CRASH.md
@@ -1,0 +1,56 @@
+# ORCH-1001 — Business web white-page crash (investigation + fix)
+
+**Severity:** S0-critical (launch-blocker) · **Class:** `regression` + `bug` + `architecture-flaw`
+**Affected Surfaces:** business-web (Vercel `mingla-business` export at business.usemingla.com).
+**Surfaces explicitly NOT in scope:** business-iOS / business-Android (native bundle is unaffected — the native trimmer still loads), consumer-iOS / consumer-Android (different app), admin-web (different app), buyer-web (same export, restored by the same fix — verified rendering).
+
+## Symptom
+
+Every visitor to https://business.usemingla.com/ saw a blank white page. HTTP shell + JS bundle both returned 200 — not a missing-asset / 404 problem.
+
+## Root cause (proven)
+
+Headless-browser reproduction of the live site captured one fatal page error at bundle-init:
+
+```
+TypeError: Cannot read properties of undefined (reading 'getEnforcing')
+  at index-a5d93c70….js:1577 (module eval)
+```
+
+`getEnforcing` is `TurboModuleRegistry.getEnforcing('VideoTrim')` — emitted by `react-native-video-trim`. The package's module body runs that call at **import-eval time**. On web there is no native TurboModule runtime, so the call throws synchronously, the whole bundle init aborts, React never mounts, `#root` stays empty → white page.
+
+The crash entered via [`CoverPicker.tsx`](../../mingla-business/src/components/ui/CoverPicker.tsx) which had an **eager top-level** `import NativeVideoTrim, { showEditor } from "react-native-video-trim";`. It shipped with commit `f09494612` ("Close ORCH-0989: unified cover picker"), deployed 2026-05-29 13:19 — the exact day the white page began.
+
+Scan confirmed this was the ONLY ungated native-only static import in web-reachable code. `react-native-compressor` is already safe (lazy `require` inside a `Platform.OS === "web"`-gated function — its module body never executes on web).
+
+## Fix
+
+Metro platform split, matching the repo's existing `Sheet.web.tsx` / `BottomNav.web.tsx` convention:
+
+- `coverPickerVideoTrimEditor.ts` — base (native) module: holds the `react-native-video-trim` import + the `showEditor`/subscription logic, byte-identical behaviour to the old inline implementation. Bundled on iOS/Android only.
+- `coverPickerVideoTrimEditor.web.ts` — web stub: `trimVideoWithDedicatedEditor` resolves `null`, no native import. Metro resolves this for the web export, so `react-native-video-trim` is **absent from the web bundle entirely**.
+- `CoverPicker.tsx` — imports the split module and calls it only behind the existing `Platform.OS !== "web"` gate.
+
+**Web video upload is unchanged.** The in-app trimmer was always native-only by design (SC-7-Web-4): on web the raw clip uploads and the server (Cloudinary) trims/compresses to a browser-safe ≤29s MP4. The fix only removes the crash; the web upload path behaved this way before and after.
+
+## Prevention (determinism)
+
+New CI gate `orch-1001-no-native-turbomodule-in-web-bundle.mjs`: fails any **eager** top-level import of a native-only TurboModule package (`react-native-video-trim`, `react-native-compressor`) in web-reachable `mingla-business/{src,app}` unless it is a `.native.*` file or a base file with a `.web.*` sibling stub. Lazy runtime-gated `require` is correctly ignored. Self-test (5 cases) + npm-wiring check baked in. Wired as a job in `strict-grep-mingla-business.yml`.
+
+## Evidence
+
+- **Before:** live headless probe → `#root` length 0, 1 page error (VideoTrim getEnforcing).
+- **After:** local web export of the fixed branch served + headless probe → `#root` length 5804, login screen renders ("MINGLA BUSINESS / List experiences…"), **0 page errors**, 0 failed requests. `grep` of all web chunks → 0 occurrences of `react-native-video-trim` / `getEnforcing('VideoTrim')`.
+- **Fails-on-revert:** restoring the static import reintroduces the crash; the happy-path test + CI gate both fail.
+
+## Step 0.5 regression tests
+
+- Happy-path (implementor): `orch1001CoverPickerWebSplit.test.ts` — asserts no eager native import in CoverPicker.tsx (fails-on-revert), both split files exist, web stub holds no native import, web stub resolves null at runtime.
+- Adversarial (tester, different angle): `orch1001NativeTurbomoduleGate.adversarial.test.ts` — drives the CI gate against planted hostile fixtures (eager import in plain file → FAIL; properly split pair → PASS; lazy require → ignored; missing npm wiring → FAIL) + asserts the shipped self-test passes.
+- Repointed under `[TEST-MOD-APPROVED ORCH-1001]`: `CoverPicker.dedicatedTrimmer.test.ts` T-AMEND9-02 (cancel→no-upload contract now spans the split module + CoverPicker, both halves verified).
+
+## Out of scope (flagged for META-ORCH-1002)
+
+- Pre-existing baseline test failure `eventCoverVideoProcessingService.compression.test.ts` (`supabase.auth.getSession()` mock) — fails identically on `main`, untouched here.
+- Speed: 8.79 MB single web bundle served `cache-control: max-age=0, must-revalidate` (no immutable caching on hashed assets).
+- Reliability: dropdowns not loading / empty pages / multiple refreshes (data-layer determinism) — separate investigation.

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -43,7 +43,8 @@
     "test:orch-0881": "node ../.github/scripts/strict-grep/i-ve5-parse-menu-user-jwt-only.mjs && npx jest ve5MigrationContract.test canGenerateExperiencesFromMenu.test experiencesService.test createExperienceToolContract.test",
     "test:orch-0882": "node ../.github/scripts/strict-grep/i-ve6-parse-play-user-jwt-only.mjs && npx jest playIntentTags.test geminiActivitiesParser.contract.test experienceGenerationService.contract.test createExperienceToolContract.test experiencesService.test canGenerateExperiencesFromActivities.test hubExperiences.contract.test",
     "test:orch-0885-a": "node ../.github/scripts/strict-grep/orch-0885-a-no-bottomnav-on-wide-desktop.mjs && npx jest src/hooks/__tests__/useResponsiveLayout.test.ts",
-    "test:orch-0892": "node ../.github/scripts/strict-grep/orch-0892-no-bespoke-keyboard-plumbing.mjs && npx jest src/wrappers/__tests__/KeyboardRoot.test.tsx"
+    "test:orch-0892": "node ../.github/scripts/strict-grep/orch-0892-no-bespoke-keyboard-plumbing.mjs && npx jest src/wrappers/__tests__/KeyboardRoot.test.tsx",
+    "test:orch-1001": "node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs --self-test && node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs && npx jest orch1001CoverPickerWebSplit orch1001NativeTurbomoduleGate"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/mingla-business/src/components/ui/CoverPicker.tsx
+++ b/mingla-business/src/components/ui/CoverPicker.tsx
@@ -43,10 +43,12 @@ import * as Haptics from "expo-haptics";
 import { ScrollView } from "../../wrappers/SmartScrollView";
 import * as FileSystem from "expo-file-system/legacy";
 import * as ImagePicker from "expo-image-picker";
-import NativeVideoTrim, {
-  showEditor,
-  type Spec as VideoTrimSpec,
-} from "react-native-video-trim";
+// ORCH-1001 [Business web white-page crash]: the native video-trim editor is
+// imported through a Metro platform split (.native vs .web) so the native-only
+// `react-native-video-trim` TurboModule never lands in the web bundle. A raw
+// top-level import here ran `getEnforcing('VideoTrim')` at web-eval time and
+// crashed the entire app to a blank page.
+import { trimVideoWithDedicatedEditor } from "./coverPickerVideoTrimEditor";
 
 import {
   accent,
@@ -75,7 +77,6 @@ import {
   buildTrimmedVideoUploadFile,
   normalizeLocalFileUri,
   normalizePickerDurationMs,
-  type VideoTrimFinishPayload,
 } from "./coverPickerVideoTrimUpload";
 import {
   searchGiphyEventCovers,
@@ -109,8 +110,6 @@ export type { CoverTarget } from "./coverTarget";
 // LOCKED tab ids (SPEC §4.3); display labels are designer-owned copy (DESIGN §3.1).
 type CoverTabId = "library" | "gif" | "stock";
 type ProviderStatus = "idle" | "loading" | "populated" | "empty" | "error";
-
-type VideoTrimSubscription = { remove: () => void };
 
 /** Full 7-field cover patch emitted on every change. Mirror of the events
  *  table cover_media_* column family. UNCHANGED from prior CoverPicker. */
@@ -463,52 +462,6 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
     validateEventRowId,
   ]);
 
-  const trimVideoWithDedicatedEditor = useCallback(
-    (uri: string): Promise<VideoTrimFinishPayload | null> =>
-      new Promise((resolve, reject) => {
-        const videoTrim = NativeVideoTrim as VideoTrimSpec;
-        const subscriptions: VideoTrimSubscription[] = [];
-        let settled = false;
-        const settle = (handler: () => void): void => {
-          if (settled) return;
-          settled = true;
-          subscriptions.forEach((subscription) => subscription.remove());
-          handler();
-        };
-
-        subscriptions.push(
-          videoTrim.onFinishTrimming((payload: VideoTrimFinishPayload) => {
-            settle(() => resolve(payload));
-          }) as VideoTrimSubscription,
-          videoTrim.onCancelTrimming(() => {
-            settle(() => resolve(null));
-          }) as VideoTrimSubscription,
-          videoTrim.onCancel(() => {
-            settle(() => resolve(null));
-          }) as VideoTrimSubscription,
-          videoTrim.onError(({ message, errorCode }) => {
-            settle(() =>
-              reject(new Error(`Video trim failed (${errorCode || "unknown"}): ${message}`)),
-            );
-          }) as VideoTrimSubscription,
-        );
-
-        try {
-          // react-native-video-trim docs:
-          // https://github.com/maitrungduc1410/react-native-video-trim
-          showEditor(uri, {
-            maxDuration: EVENT_COVER_MAX_VIDEO_DURATION_MS,
-            saveButtonText: "Use clip",
-            cancelButtonText: "Back",
-            enablePreciseTrimming: true,
-          });
-        } catch (error) {
-          settle(() => reject(error));
-        }
-      }),
-    [],
-  );
-
   const pickVideoCover = useCallback(async (): Promise<void> => {
     if (uploading || disabled || activeVideoUpload) return;
     if (!isAuthReady) {
@@ -529,7 +482,11 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
       if (result.canceled || result.assets.length === 0) return;
       const asset = result.assets[0];
       // Web has no native trimmer (SC-7-Web-4): use the raw asset, no crash.
-      const trimResult = isNative ? await trimVideoWithDedicatedEditor(asset.uri) : null;
+      // On web `trimVideoWithDedicatedEditor` resolves to a no-op stub, but we
+      // still gate on `isNative` so the raw clip flows straight to upload.
+      const trimResult = isNative
+        ? await trimVideoWithDedicatedEditor(asset.uri, EVENT_COVER_MAX_VIDEO_DURATION_MS)
+        : null;
       if (isNative && trimResult === null) return;
       const uploadFile =
         trimResult !== null
@@ -582,7 +539,6 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
     isAuthReady,
     isNative,
     onShowToast,
-    trimVideoWithDedicatedEditor,
     uploading,
     validateEventRowId,
     videoUpload,

--- a/mingla-business/src/components/ui/__tests__/CoverPicker.dedicatedTrimmer.test.ts
+++ b/mingla-business/src/components/ui/__tests__/CoverPicker.dedicatedTrimmer.test.ts
@@ -38,16 +38,29 @@ describe("CoverPicker dedicated trimmer wiring", () => {
     });
   });
 
+  // [TEST-MOD-APPROVED ORCH-1001] Repointed: the native trimmer wiring
+  // (onCancelTrimming + settle(resolve(null))) moved out of CoverPicker.tsx
+  // into the Metro platform-split module coverPickerVideoTrimEditor.ts so the
+  // native-only `react-native-video-trim` import never reaches the web bundle
+  // (the ORCH-0989 white-page crash). The cancel→no-upload CONTRACT is
+  // unchanged — it now spans the editor module (cancel resolves null) and
+  // CoverPicker.tsx (early-return before videoUpload.start). Both halves verified.
   test("T-AMEND9-02 trimmer cancel resolves without starting an upload", () => {
-    const source = repoFile("src/components/ui/CoverPicker.tsx");
-    const cancelHandlerIndex = source.indexOf("videoTrim.onCancelTrimming");
-    const cancelReturnIndex = source.indexOf("if (isNative && trimResult === null) return;");
-    const uploadStartIndex = source.indexOf("await videoUpload.start(uploadFile);");
+    const editor = repoFile("src/components/ui/coverPickerVideoTrimEditor.ts");
+    const picker = repoFile("src/components/ui/CoverPicker.tsx");
 
-    expect(cancelHandlerIndex).toBeGreaterThan(-1);
-    expect(cancelReturnIndex).toBeGreaterThan(cancelHandlerIndex);
+    // Editor module: cancel handler resolves null.
+    expect(editor.indexOf("videoTrim.onCancelTrimming")).toBeGreaterThan(-1);
+    expect(editor).toContain("settle(() => resolve(null))");
+
+    // CoverPicker: the early-return on a null trim result precedes the upload.
+    const cancelReturnIndex = picker.indexOf("if (isNative && trimResult === null) return;");
+    const uploadStartIndex = picker.indexOf("await videoUpload.start(uploadFile);");
+    expect(cancelReturnIndex).toBeGreaterThan(-1);
     expect(uploadStartIndex).toBeGreaterThan(cancelReturnIndex);
-    expect(source).toContain("settle(() => resolve(null))");
-    expect(source).not.toContain("[ORCH-0978-POC]");
+
+    // The native-only import is gone from CoverPicker; it lives only in the split module.
+    expect(picker).not.toMatch(/from\s+["']react-native-video-trim["']/);
+    expect(editor).not.toContain("[ORCH-0978-POC]");
   });
 });

--- a/mingla-business/src/components/ui/__tests__/orch1001CoverPickerWebSplit.test.ts
+++ b/mingla-business/src/components/ui/__tests__/orch1001CoverPickerWebSplit.test.ts
@@ -1,0 +1,51 @@
+/**
+ * ORCH-1001 [Business web white-page crash] — happy-path regression test.
+ *
+ * Proves the platform split that keeps `react-native-video-trim` out of the
+ * web bundle. FAILS-ON-REVERT: if CoverPicker.tsx re-adds the eager top-level
+ * `import ... from "react-native-video-trim"` (the exact ORCH-0989 regression),
+ * the first assertion fails. The web stub is exercised at runtime to prove it
+ * resolves null without touching any native module.
+ */
+import { readFileSync, existsSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+import { trimVideoWithDedicatedEditor } from "../coverPickerVideoTrimEditor.web";
+
+const repoFile = (relativePath: string): string =>
+  readFileSync(path.join(process.cwd(), relativePath), "utf8");
+
+describe("ORCH-1001 CoverPicker web/native video-trim split", () => {
+  test("CoverPicker.tsx has NO eager native video-trim import (fails-on-revert)", () => {
+    const picker = repoFile("src/components/ui/CoverPicker.tsx");
+    // The crash was a top-level `import ... from "react-native-video-trim"`.
+    expect(picker).not.toMatch(/import\s+[^;\n]*from\s+["']react-native-video-trim["']/);
+    expect(picker).not.toMatch(/^\s*import\s+["']react-native-video-trim["']/m);
+    // It must route through the platform-split module instead.
+    expect(picker).toContain('from "./coverPickerVideoTrimEditor"');
+  });
+
+  test("both platform-split files exist (base native + .web stub)", () => {
+    expect(existsSync(path.join(process.cwd(), "src/components/ui/coverPickerVideoTrimEditor.ts"))).toBe(true);
+    expect(existsSync(path.join(process.cwd(), "src/components/ui/coverPickerVideoTrimEditor.web.ts"))).toBe(true);
+  });
+
+  test("the .web stub does not IMPORT the native package (comments may mention it)", () => {
+    const webStub = repoFile("src/components/ui/coverPickerVideoTrimEditor.web.ts");
+    // A doc comment may name the package; what matters is there is no real import.
+    expect(webStub).not.toMatch(/(?:import|require)\s*[(]?\s*["']react-native-video-trim["']/);
+    expect(webStub).not.toMatch(/from\s+["']react-native-video-trim["']/);
+    expect(webStub).not.toContain("getEnforcing");
+  });
+
+  test("the native base file is the ONLY holder of the eager import", () => {
+    const nativeFile = repoFile("src/components/ui/coverPickerVideoTrimEditor.ts");
+    expect(nativeFile).toMatch(/from\s+["']react-native-video-trim["']/);
+  });
+
+  test("web stub resolves to null without throwing (no in-app trim on web)", async () => {
+    await expect(trimVideoWithDedicatedEditor("file:///clip.mov", 29_000)).resolves.toBeNull();
+  });
+});

--- a/mingla-business/src/components/ui/__tests__/orch1001NativeTurbomoduleGate.adversarial.test.ts
+++ b/mingla-business/src/components/ui/__tests__/orch1001NativeTurbomoduleGate.adversarial.test.ts
@@ -1,0 +1,123 @@
+/**
+ * ORCH-1001 [Business web white-page crash] — adversarial regression test.
+ *
+ * DIFFERENT ANGLE than the happy-path test: that one asserts the current
+ * source state; this one attacks the PREVENTION mechanism — the CI gate that
+ * stops the bug class from ever returning. It plants hostile fixtures (a fresh
+ * eager import in a plain file, a side-effect import, a sneaky lazy require,
+ * a properly-split file) into a temp tree and asserts the gate's detection
+ * logic verdicts each correctly, then confirms the shipped gate self-test and
+ * a real planted violation exit non-zero.
+ */
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+
+import { afterAll, describe, expect, test } from "@jest/globals";
+
+const gateScript = path.join(process.cwd(), "../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs");
+
+const tmpRoots: string[] = [];
+const makeTree = (): string => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "orch1001-adv-"));
+  tmpRoots.push(dir);
+  return dir;
+};
+
+const runGate = (cwd: string, args: string[] = []): { code: number; out: string } => {
+  try {
+    const out = execFileSync("node", [gateScript, ...args], { cwd, encoding: "utf8" });
+    return { code: 0, out };
+  } catch (error: unknown) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+};
+
+afterAll(() => {
+  tmpRoots.forEach((d) => rmSync(d, { recursive: true, force: true }));
+});
+
+describe("ORCH-1001 native-TurboModule gate — adversarial", () => {
+  test("shipped gate self-test passes (detection logic intact)", () => {
+    const result = runGate(process.cwd(), ["--self-test"]);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("self-test PASS");
+  });
+
+  test("gate FAILS on a freshly planted eager import in a plain web-reachable file", () => {
+    const root = makeTree();
+    const srcDir = path.join(root, "mingla-business/src/components/ui");
+    mkdirSync(srcDir, { recursive: true });
+    // Minimal package.json so the wiring check has something to read.
+    mkdirSync(path.join(root, "mingla-business"), { recursive: true });
+    writeFileSync(
+      path.join(root, "mingla-business/package.json"),
+      JSON.stringify({
+        scripts: {
+          "test:orch-1001": "node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs",
+        },
+      }),
+    );
+    // Hostile file: eager import, plain .tsx, no .web sibling → must FAIL.
+    writeFileSync(
+      path.join(srcDir, "EvilCover.tsx"),
+      'import VideoTrim from "react-native-video-trim";\nexport const x = VideoTrim;\n',
+    );
+    const result = runGate(root);
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("EvilCover.tsx");
+    expect(result.out).toContain("react-native-video-trim");
+  });
+
+  test("gate ALLOWS a properly platform-split pair (base .ts + .web.ts stub)", () => {
+    const root = makeTree();
+    const srcDir = path.join(root, "mingla-business/src/components/ui");
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(path.join(root, "mingla-business"), { recursive: true });
+    writeFileSync(
+      path.join(root, "mingla-business/package.json"),
+      JSON.stringify({
+        scripts: {
+          "test:orch-1001": "node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs",
+        },
+      }),
+    );
+    writeFileSync(path.join(srcDir, "GoodTrim.ts"), 'import VideoTrim from "react-native-video-trim";\nexport const x = VideoTrim;\n');
+    writeFileSync(path.join(srcDir, "GoodTrim.web.ts"), "export const x = null;\n");
+    const result = runGate(root);
+    expect(result.code).toBe(0);
+    expect(result.out).toContain("PASS");
+  });
+
+  test("gate IGNORES a lazy runtime-gated require (compressor pattern, never eval'd on web)", () => {
+    const root = makeTree();
+    const srcDir = path.join(root, "mingla-business/src/services");
+    mkdirSync(srcDir, { recursive: true });
+    mkdirSync(path.join(root, "mingla-business"), { recursive: true });
+    writeFileSync(
+      path.join(root, "mingla-business/package.json"),
+      JSON.stringify({
+        scripts: {
+          "test:orch-1001": "node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs",
+        },
+      }),
+    );
+    writeFileSync(
+      path.join(srcDir, "lazyCompress.ts"),
+      'export const load = () => { if (Platform.OS === "web") return null; return require("react-native-compressor").Video; };\n',
+    );
+    const result = runGate(root);
+    expect(result.code).toBe(0);
+  });
+
+  test("gate FAILS when the npm wiring is missing (gate can't be silently unhooked)", () => {
+    const root = makeTree();
+    mkdirSync(path.join(root, "mingla-business"), { recursive: true });
+    writeFileSync(path.join(root, "mingla-business/package.json"), JSON.stringify({ scripts: {} }));
+    const result = runGate(root);
+    expect(result.code).toBe(1);
+    expect(result.out).toContain("wiring");
+  });
+});

--- a/mingla-business/src/components/ui/coverPickerVideoTrimEditor.ts
+++ b/mingla-business/src/components/ui/coverPickerVideoTrimEditor.ts
@@ -1,0 +1,70 @@
+/**
+ * ORCH-1001 [Business web white-page crash] — native-only video trim editor.
+ *
+ * `react-native-video-trim` ships a TurboModule whose module body runs
+ * `TurboModuleRegistry.getEnforcing('VideoTrim')` at import-eval time. On web
+ * there is no native runtime, so that call throws synchronously and takes the
+ * ENTIRE bundle down before React can mount (blank #root → white page).
+ *
+ * The fix is a Metro platform split: this `.native.ts` holds the real import
+ * and is bundled ONLY for iOS/Android; the `.web.ts` sibling is a no-op stub,
+ * so `react-native-video-trim` is never present in the web export. Callers
+ * gate on `Platform.OS !== "web"` and only invoke this on native — web uploads
+ * the raw clip and the server (Cloudinary) trims to <=29s.
+ *
+ * Behaviour is byte-for-byte the same as the prior inline implementation that
+ * lived in CoverPicker.tsx; only the import boundary changed.
+ */
+import NativeVideoTrim, {
+  showEditor,
+  type Spec as VideoTrimSpec,
+} from "react-native-video-trim";
+import type { VideoTrimFinishPayload } from "./coverPickerVideoTrimUpload";
+
+type VideoTrimSubscription = { remove: () => void };
+
+export const trimVideoWithDedicatedEditor = (
+  uri: string,
+  maxDurationMs: number,
+): Promise<VideoTrimFinishPayload | null> =>
+  new Promise((resolve, reject) => {
+    const videoTrim = NativeVideoTrim as VideoTrimSpec;
+    const subscriptions: VideoTrimSubscription[] = [];
+    let settled = false;
+    const settle = (handler: () => void): void => {
+      if (settled) return;
+      settled = true;
+      subscriptions.forEach((subscription) => subscription.remove());
+      handler();
+    };
+
+    subscriptions.push(
+      videoTrim.onFinishTrimming((payload: VideoTrimFinishPayload) => {
+        settle(() => resolve(payload));
+      }) as VideoTrimSubscription,
+      videoTrim.onCancelTrimming(() => {
+        settle(() => resolve(null));
+      }) as VideoTrimSubscription,
+      videoTrim.onCancel(() => {
+        settle(() => resolve(null));
+      }) as VideoTrimSubscription,
+      videoTrim.onError(({ message, errorCode }) => {
+        settle(() =>
+          reject(new Error(`Video trim failed (${errorCode || "unknown"}): ${message}`)),
+        );
+      }) as VideoTrimSubscription,
+    );
+
+    try {
+      // react-native-video-trim docs:
+      // https://github.com/maitrungduc1410/react-native-video-trim
+      showEditor(uri, {
+        maxDuration: maxDurationMs,
+        saveButtonText: "Use clip",
+        cancelButtonText: "Back",
+        enablePreciseTrimming: true,
+      });
+    } catch (error) {
+      settle(() => reject(error));
+    }
+  });

--- a/mingla-business/src/components/ui/coverPickerVideoTrimEditor.web.ts
+++ b/mingla-business/src/components/ui/coverPickerVideoTrimEditor.web.ts
@@ -1,0 +1,20 @@
+/**
+ * ORCH-1001 [Business web white-page crash] — web stub for the native-only
+ * video trim editor.
+ *
+ * The web build has no native VideoTrim TurboModule, so importing
+ * `react-native-video-trim` here would crash the whole bundle at eval time
+ * (see coverPickerVideoTrimEditor.native.ts). Metro resolves THIS file for the
+ * web export, keeping the native package out of the web bundle entirely.
+ *
+ * The caller never invokes this on web — it gates on `Platform.OS !== "web"`
+ * and falls back to uploading the raw clip, which the server (Cloudinary)
+ * trims/compresses to a browser-safe <=29s MP4. This no-op exists only to
+ * satisfy the shared import contract and resolves to `null` (no trim applied).
+ */
+import type { VideoTrimFinishPayload } from "./coverPickerVideoTrimUpload";
+
+export const trimVideoWithDedicatedEditor = (
+  _uri: string,
+  _maxDurationMs: number,
+): Promise<VideoTrimFinishPayload | null> => Promise.resolve(null);


### PR DESCRIPTION
## Production-down hotfix — business.usemingla.com white page

**Root cause:** `CoverPicker.tsx` had an eager top-level `import ... from "react-native-video-trim"`. That package runs `TurboModuleRegistry.getEnforcing('VideoTrim')` at import-eval time; on web there is no native runtime, so it threw at bundle init → React never mounted → blank `#root`. Regression shipped with ORCH-0989 (`f09494612`, 2026-05-29).

**Fix:** Metro platform split (existing `Sheet.web.tsx` convention) — `coverPickerVideoTrimEditor.ts` (native base) + `coverPickerVideoTrimEditor.web.ts` (web stub, no native import). `react-native-video-trim` is now absent from the web bundle.

**Web video upload unchanged:** the in-app trimmer was always native-only; web uploads the raw clip and the server (Cloudinary) trims to ≤29s.

**Proof:** headless-browser probe of the fixed web export → `#root` renders the login screen, **0 page errors** (was the VideoTrim crash), 0 `react-native-video-trim` across all web chunks. Fails-on-revert verified.

**Prevention:** new CI gate `orch-1001-no-native-turbomodule-in-web-bundle.mjs` fails any eager native-only TurboModule import in web-reachable code (self-test + npm wiring baked in).

**Step 0.5 tests:** happy-path `orch1001CoverPickerWebSplit.test.ts` + adversarial `orch1001NativeTurbomoduleGate.adversarial.test.ts`; `[TEST-MOD-APPROVED ORCH-1001]` repoint of `CoverPicker.dedicatedTrimmer.test.ts` T-AMEND9-02.

Full investigation: `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1001_BIZ_WEB_WHITE_PAGE_CRASH.md`