### PR TITLE
[deploy] Close ORCH-1003: immutable caching for hashed business-web assets

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1003_BIZ_WEB_ASSET_CACHING.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1003_BIZ_WEB_ASSET_CACHING.md
@@ -1,0 +1,46 @@
+# ORCH-1003 — Business web asset caching (speed)
+
+**Severity:** S2-medium · **Class:** `performance`
+**Affected Surfaces:** business-web + buyer-web (the `mingla-business` Vercel deployment). NOT in scope: native apps, admin-web, supabase.
+**Parent:** the speed/reliability program proposed as META-ORCH-1002 (that ID was already taken by android-glass-hardening; renumbered to ORCH-1003 per COMMS-0004). The dropdown/empty-page reliability investigation is a separate follow-on ORCH.
+
+## Problem
+
+Expo's web export emits content-hashed asset filenames under `/_expo/static/` (e.g. `index-d7283047….js`) — the filename changes whenever the content changes, so the file is safe to cache forever. But Vercel served them with its default `cache-control: public, max-age=0, must-revalidate`, forcing the browser to re-validate the full ~8.8 MB bundle on **every** page load. That round-trip is the primary cause of the slow loads, and on flaky connections a failed revalidation can yield a blank/partial page (a likely contributor to the "had to refresh multiple times" reports).
+
+## Fix
+
+One header rule added to `mingla-business/vercel.json`:
+
+```json
+{ "source": "/_expo/static/(.*)",
+  "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }] }
+```
+
+Docs: Vercel headers config — https://vercel.com/docs/projects/project-configuration#headers
+
+## Why updates still reach users (no staleness risk)
+
+- The HTML shell is **not** under `/_expo/static/`, so it keeps Vercel's default `max-age=0, must-revalidate` and is re-checked on every load.
+- A deploy changes asset contents → changes the hash → changes the filename. The fresh HTML references the new filename, which the browser has never cached → it downloads the new bundle. Verified live on the ORCH-1001 deploy (`a5d93c70…` → `d7283047…`).
+- The catch-all rewrite `/(.*) → /` does NOT swallow real static files — Vercel serves an existing file before applying SPA-fallback rewrites — so the header attaches to the served asset correctly.
+- No service worker is in play (Expo web export adds none); the browser HTTP cache is the only cache and obeys these headers exactly.
+
+Net effect: returning visitors with unchanged code fetch **zero bytes** for the bundle (instant); a real deploy auto-busts via the new filename.
+
+## Dependency walk (config-layer: vercel.json)
+
+- `orch-0964-well-known-json-content-type.mjs` — matches the `.well-known` rules by content via `.some()`, not by index/length → unaffected (verified: exit 0).
+- `orch-0891-marketing-performance-budget.mjs` — verified exit 0.
+- `playwright/meta-orch-0952-static-server.mjs` — a local static file server; does not read vercel.json headers → unaffected.
+- Vercel build/serve — the consumer; the new rule sits alongside the existing `headers` entries and is independent of `rewrites`.
+
+## Step 0.5 regression tests
+
+- Happy-path `__tests__/orch1003.assetCaching.test.ts` — asserts the `/_expo/static/(.*)` rule with `public, max-age=31536000, immutable` (fails-on-revert).
+- Adversarial `__tests__/orch1003.assetCaching.adversarial.test.ts` — DIFFERENT angle: asserts we did NOT over-cache (no immutable/long max-age on the HTML shell or `/(.*)`), immutable caching is scoped only to the hashed-asset path, the SPA catch-all rewrite survives and stays last, and the `.well-known` content-type rules are preserved.
+
+## Live verification (post-deploy)
+
+- `GET /_expo/static/js/web/index-<hash>.js` → `Cache-Control: public, max-age=31536000, immutable`.
+- `GET /` (HTML) → still `max-age=0, must-revalidate`, and points at the current hashed bundle filename.

--- a/mingla-business/__tests__/orch1003.assetCaching.adversarial.test.ts
+++ b/mingla-business/__tests__/orch1003.assetCaching.adversarial.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ORCH-1003 [Business web asset caching] — adversarial regression test.
+ *
+ * DIFFERENT ANGLE than the happy-path: that one proves the static assets ARE
+ * cached. This one proves we did NOT over-cache (which would strand users on
+ * stale code) and did NOT break SPA routing. The freshness guarantee depends on
+ * the HTML shell staying uncached and the SPA catch-all rewrite surviving.
+ */
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+type HeaderRule = { source: string; headers: { key: string; value: string }[] };
+const vercel = JSON.parse(
+  readFileSync(path.join(process.cwd(), "vercel.json"), "utf8"),
+) as { headers: HeaderRule[]; rewrites: { source: string; destination: string }[] };
+
+const cacheControlFor = (source: string): string | undefined =>
+  vercel.headers
+    .find((r) => r.source === source)
+    ?.headers.find((h) => h.key === "Cache-Control")?.value;
+
+describe("ORCH-1003 caching did not over-reach", () => {
+  test("no header rule applies immutable/long caching to the HTML shell or catch-all", () => {
+    const dangerousSources = ["/", "/(.*)", "/index.html"];
+    for (const src of dangerousSources) {
+      const value = cacheControlFor(src);
+      if (value) {
+        expect(value).not.toContain("immutable");
+        expect(value).not.toMatch(/max-age=(?!0\b)\d{3,}/); // no long max-age on HTML
+      }
+    }
+  });
+
+  test("immutable caching is scoped ONLY to the hashed-asset path, never a broad glob", () => {
+    const immutableRules = vercel.headers.filter((r) =>
+      r.headers.some((h) => h.key === "Cache-Control" && h.value.includes("immutable")),
+    );
+    expect(immutableRules.length).toBeGreaterThan(0);
+    for (const rule of immutableRules) {
+      // Must target the Expo static dir — never a catch-all that would pin the HTML.
+      expect(rule.source.startsWith("/_expo/static")).toBe(true);
+      expect(rule.source).not.toBe("/(.*)");
+      expect(rule.source).not.toBe("/");
+    }
+  });
+
+  test("the SPA catch-all rewrite still exists and is the LAST rewrite", () => {
+    const last = vercel.rewrites[vercel.rewrites.length - 1];
+    expect(last.source).toBe("/(.*)");
+    expect(last.destination).toBe("/");
+  });
+
+  test("the .well-known JSON content-type rules are preserved (not clobbered)", () => {
+    const wellKnown = vercel.headers.filter((r) => r.source.startsWith("/.well-known/"));
+    expect(wellKnown.length).toBeGreaterThanOrEqual(2);
+    for (const rule of wellKnown) {
+      expect(rule.headers.some((h) => h.key === "Content-Type" && h.value === "application/json")).toBe(true);
+    }
+  });
+});

--- a/mingla-business/__tests__/orch1003.assetCaching.test.ts
+++ b/mingla-business/__tests__/orch1003.assetCaching.test.ts
@@ -1,0 +1,31 @@
+/**
+ * ORCH-1003 [Business web asset caching] — happy-path regression test.
+ *
+ * Asserts vercel.json caches the content-hashed Expo web assets under
+ * /_expo/static immutably for a year. FAILS-ON-REVERT: remove or weaken the
+ * rule and this fails.
+ */
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+type HeaderRule = { source: string; headers: { key: string; value: string }[] };
+const vercel = JSON.parse(
+  readFileSync(path.join(process.cwd(), "vercel.json"), "utf8"),
+) as { headers: HeaderRule[]; rewrites: { source: string; destination: string }[] };
+
+const staticRule = (): HeaderRule | undefined =>
+  vercel.headers.find((r) => r.source === "/_expo/static/(.*)");
+
+describe("ORCH-1003 immutable caching for hashed web assets", () => {
+  test("vercel.json caches /_expo/static immutably for a year", () => {
+    const rule = staticRule();
+    expect(rule).toBeDefined();
+    const cacheControl = rule!.headers.find((h) => h.key === "Cache-Control");
+    expect(cacheControl).toBeDefined();
+    expect(cacheControl!.value).toContain("immutable");
+    expect(cacheControl!.value).toContain("max-age=31536000");
+    expect(cacheControl!.value).toContain("public");
+  });
+});

--- a/mingla-business/vercel.json
+++ b/mingla-business/vercel.json
@@ -48,6 +48,12 @@
   ],
   "headers": [
     {
+      "source": "/_expo/static/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
       "source": "/.well-known/apple-app-site-association",
       "headers": [
         { "key": "Content-Type", "value": "application/json" }


### PR DESCRIPTION
## Speed: cache hashed Expo web assets immutably

**Problem:** `/_expo/static/` assets (incl. the ~8.8 MB JS bundle) were served `max-age=0, must-revalidate`, forcing a full re-validation on every page load — the main slowness, and a likely contributor to flaky/blank loads.

**Fix:** one `vercel.json` header rule — `/_expo/static/(.*)` → `public, max-age=31536000, immutable`.

**Updates still land on refresh (no staleness):** content-hashed filenames mean a deploy renames the bundle; the HTML shell stays uncached (`max-age=0`) and points at the new filename, so the browser fetches fresh code automatically. The catch-all SPA rewrite doesn't swallow real static files; no service worker in play.

**Dependency walk (vercel.json config-layer):** `orch-0964` + `orch-0891` gates pass (content-match, not index); local static server unaffected; rule independent of rewrites.

**Step 0.5:** happy-path `orch1003.assetCaching.test.ts` (fails-on-revert) + adversarial `orch1003.assetCaching.adversarial.test.ts` (different angle — proves we did NOT over-cache the HTML/catch-all and SPA routing survives).

Report: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1003_BIZ_WEB_ASSET_CACHING.md`