### PR TITLE
[deploy] META-ORCH-1002 Sub-1: Android glass first strike — solid frosted surfaces

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md
@@ -1,0 +1,138 @@
+# IMPLEMENTATION — META-ORCH-1002 [Android glass hardening] Sub-1 (Fast First Strike)
+
+**Date:** 2026-05-29
+**Skill:** mingla-implementor (Claude)
+**Worktree:** `~/Desktop/mingla-orchs/META-ORCH-1002-[android-glass-hardening]/` on branch `META-ORCH-1002-android-glass-hardening`. Metro port 8087.
+**Spec:** `Mingla_Artifacts/specs/SPEC_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md`
+**Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_ANDROID_GLASS_FILL_AND_TRANSPARENCY.md`
+**External APIs touched:** NONE (pure React Native style/Platform.select). COMMS-0003 docs-citation N/A. No backend/migration/edge/dependency change.
+**Status:** implemented, partially verified (source/Platform.select gates verified GREEN + fails-on-revert; on-device pixel verification is the tester's live-fire job per SPEC §8.3).
+
+---
+
+## 1. Comms ledger
+
+Read `COMMS_LEDGER.md` on entry. No `BLOCK`/`OPEN` row targets `mingla-implementor`, this ORCH-ID, or `ALL` requiring action. COMMS-0002/0003/0004 (`ALL`, WARN) are N/A: no backend/`supabase/functions` touch (COMMS-0002 strict-grep), no external API (COMMS-0003), no INTAKE (COMMS-0004). No new ledger entry written (no cross-ORCH discovery).
+
+---
+
+## 2. Layman summary
+
+On Android, the six highest-visibility "glass" surfaces now render as solid frosted panels instead of see-through film. The notification card's cream fill reaches the rounded corners (no taupe ring), the chat-input bar and bottom nav read solid over busy chat, the business trip tab-bars no longer draw a hard rectangular shadow, and the event/trip list cards have an opaque fill that reaches the corner. iOS is byte-identical — every change is behind `Platform.select` or the shared Android gate.
+
+---
+
+## 3. Old → New receipts (every file changed)
+
+### consumer `app-mobile/src/constants/designSystem.ts`
+**Before:** no `Platform` import; no shared Android-glass gate; `cardUnreadBg` was a flat `'rgba(255, 247, 237, 0.6)'`.
+**Now:** imports `Platform` from `react-native` (line 4); exports `ANDROID_GLASS_USES_OPAQUE_FALLBACK = Platform.OS === 'android'` (line 12); `cardUnreadBg` is `Platform.select({ ios:'rgba(255,247,237,0.6)', android:'#FFFAF4', default:'rgba(255,247,237,0.6)' })` (line 332).
+**Why:** SPEC §3.3 (S2 root gate) + §4 S1 (opaque unread cream). **Lines:** ~+15.
+
+### consumer `app-mobile/src/components/NotificationsSheet.tsx`
+**Before:** `notificationCard` (now ~960) and `skeletonCard` (now ~1192) had `borderRadius:20` + border + fill, NO `overflow:'hidden'`.
+**Now:** `overflow:'hidden'` added to `notificationCard` (line 966) and `skeletonCard` (line 1199).
+**Why:** SPEC §4 S1 — clip fill+border to the radius so the fill reaches the rounded corner (kills the inset taupe ring). **Lines:** ~+6.
+
+### consumer 8 chrome files (S2/S4) — `GlassTopBar.tsx` (82), `GlassBottomNav.tsx` (67), `DiscoverScreen.tsx` (97), `LikesPage.tsx` (34), `ConnectionsPage.tsx` (375), `ui/GlassCard.tsx` (43), `ui/GlassBadge.tsx` (55), `ui/GlassIconButton.tsx` (56)
+**Before:** each had its own inline `const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;` — opaque fallback fired only on Android ≤ 11.
+**Now:** each imports `ANDROID_GLASS_USES_OPAQUE_FALLBACK` from `…/constants/designSystem` and sets `const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;` (kept the local alias per SPEC §3.3 🎨 OPEN). All downstream reads (`useGlass`, `useBackdropGlass`, `useOrangeFallback`) unchanged → 1:1 substitution. No file retains a live `Platform.Version < 31` glass gate.
+**Why:** SPEC §3.3 + §4 S2 — single shared gate authority; routes all Android (incl. 12+) to the existing ≥0.92 `fallbackSolid` tokens. GlassBottomNav (S4) is fixed automatically by this substitution. **Lines:** ~+2/file.
+
+### consumer `app-mobile/src/components/MessageInterface.tsx` (S3)
+**Before:** chat-input capsule (~1911) rendered `<BlurView … experimentalBlurMethod=dimezisBlurView>` + a `rgba(12,14,18,0.48)` tint floor View **unconditionally** (no platform guard).
+**Now:** imports `ANDROID_GLASS_USES_OPAQUE_FALLBACK`; the capsule renders `ANDROID_GLASS_USES_OPAQUE_FALLBACK ? <opaque View bg=glass.chrome.fallback.solid> : <><BlurView/><tint floor/></>` (line 1914). On Android = solid `rgba(22,24,28,0.94)`; on iOS the exact pre-change BlurView + tint floor.
+**Why:** SPEC §4 S3 — worst offender; route Android to opaque, keep iOS identical. **Lines:** ~+12.
+
+### business `trip/EditPublishedTripIntakeAccordion.tsx` (S5) + `trip/TripCreatorStep6Intake.tsx` (S5)
+**Before:** `tabActive` had raw `elevation: 8` (bypassed `androidSafeElevation`) under a rounded translucent pill → hard rectangular Android shadow.
+**Now:** `Platform` added to the `react-native` import; `elevation: Platform.select({ ios:8, android:0, default:8 })` (EditPublished line 530, TripCreatorStep6 line 304). iOS glow shadow + elevation:8 unchanged; Android elevation = 0.
+**Why:** SPEC §4 S5 — mirror `androidSafeElevation()`; kill the photographed rectangle. **Lines:** ~+4/file.
+
+### business `event/EventListCard.tsx` (S6) + `trip/TripListCard.tsx` (S6)
+**Before:** `host` had `backgroundColor: glass.tint.profileBase` (`rgba(255,255,255,0.04)`) + border + `overflow:'visible'`.
+**Now:** `Platform` added to the `react-native` import; `host` `backgroundColor: Platform.select({ ios:glass.tint.profileBase, android:'rgba(20,22,26,0.92)', default:glass.tint.profileBase })` (EventListCard line 283, TripListCard line 255) + `overflow:'hidden'` (EventListCard line 289, TripListCard line 261).
+**Why:** SPEC §4 S6 — opaque kit-consistent fill + clip to radius. Verified all `host` children (draftOverlay full-bleed `0,0,0,0`; rightRail/revenueStrip positioned inside bounds with positive spacing) are inside `host`, so clip-on-host is safe (no intentional overflow). **Lines:** ~+8/file.
+
+### `app-mobile/package.json` + `mingla-business/package.json`
+Added `"test:meta-orch-1002"` scripts pointing at the two new tests. No dependency change.
+
+### NEW tests
+- `app-mobile/scripts/ci/meta-orch-1002-android-glass-check.mjs` — consumer node source-reader (T-01, T-02, T-03, T-04, T-07 consumer; 26 assertions).
+- `mingla-business/src/components/__tests__/metaOrch1002AndroidGlass.test.ts` — business ts-jest source-reader (T-05 ×2, T-06 ×2, T-07 business; 12 tests).
+
+---
+
+## 4. Spec traceability (success criteria)
+
+| SC | Criterion | Implemented | Verification |
+|---|---|---|---|
+| SC-1 (S1 Android) | unread card opaque `#FFFAF4` to corners; clipped | `cardUnreadBg` android `#FFFAF4` + `overflow:'hidden'` | T-03 GREEN; on-device = tester |
+| SC-1-iOS | card pixel-identical | `Platform.select` ios kept `rgba(255,247,237,0.6)` | T-07 GREEN |
+| SC-2/SC-2a–f (S2/S4) | chrome solid frosted on Android 12+ | shared gate flips 8 files to existing `fallbackSolid` | T-01/T-02 GREEN; on-device = tester |
+| SC-2-iOS | 8 chrome render BlurView on iOS; Android ≤ 11 unchanged | gate is `false` on iOS; `true` on all Android (≤11 unchanged) | T-02 (gate value) GREEN |
+| SC-2-grep | no live `Platform.Version < 31` glass gate | all 8 read shared boolean | T-02 (revert-canary) GREEN |
+| SC-3 (S3) | chat capsule solid `rgba(22,24,28,0.94)` on Android | gated opaque-fallback branch | T-04 GREEN; on-device = tester |
+| SC-3-iOS | capsule BlurView + tint floor on iOS | iOS branch byte-identical | T-04/T-07 GREEN |
+| SC-5a/SC-5b (S5) | both trip tab-bars no Android shadow; iOS glow kept | `elevation` android 0 ×2 | T-05 GREEN; on-device = tester |
+| SC-6a/SC-6b (S6) | both list cards solid frosted to corners on Android; iOS unchanged | opaque android fill + clip ×2 | T-06 GREEN; on-device = tester |
+| SC-7 (global) | zero out-of-scope touch | diff = only §2.1 files + 2 tests + 2 package.json | `git status` GREEN |
+
+---
+
+## 5. Regression test (mandatory gate)
+
+**Consumer test:** `app-mobile/scripts/ci/meta-orch-1002-android-glass-check.mjs` (`npm run -w app-mobile test:meta-orch-1002` / `node ./scripts/ci/meta-orch-1002-android-glass-check.mjs`).
+Passing run: `Summary: 26/26 PASS`.
+
+**Business test:** `mingla-business/src/components/__tests__/metaOrch1002AndroidGlass.test.ts` (`npx jest metaOrch1002AndroidGlass.test --runInBand`).
+Passing run: `Test Suites: 1 passed; Tests: 12 passed, 12 total`.
+
+**fails-on-revert verified at commit `bf0accc253a949d9fb6bb58496511926d68c8c4b`:**
+- Consumer: reverting the `ANDROID_GLASS_USES_OPAQUE_FALLBACK` export + `cardUnreadBg` Platform.select + the two `overflow:'hidden'` lines → `Summary: 22/26 PASS (4 FAIL)`, exit 1 (T-01 gate, T-03 skeleton clip, T-03 cardUnreadBg, T-07 iOS-cream all FAILED).
+- Business: reverting the `EventListCard` host `overflow:'hidden'` + Platform.select fill → `Tests: 3 failed, 9 passed`, suite FAILED (overflow, opaque-android-fill, iOS-default-profileBase).
+- After restore both return GREEN (26/26 and 12/12). Backups removed.
+
+The tester writes a second adversarial test (SPEC §8.2) — not in this implementor scope.
+
+---
+
+## 6. Typecheck + lint (touched packages)
+
+**tsc (`tsc --noEmit`):**
+- Consumer: 249 baseline errors WITH and WITHOUT my changes (verified via `git stash`) → **0 new errors**; none in any touched file. All baseline errors are pre-existing repo strictness debt + worktree node_modules resolution.
+- Business: 234 baseline errors WITH and WITHOUT my changes (verified via `git stash`) → **0 new errors**; none in any touched file (234 are `packages/phone-input/*` worktree resolution + pre-existing app strictness debt).
+
+**lint (`expo lint` / `eslint`):**
+- Consumer touched files: `0 errors` (28 pre-existing warnings, none on my added lines — all imports I added are used).
+- Business touched files: the `EventListCard` `react-hooks/rules-of-hooks` errors + `TripListCard` `accent` unused warning are **pre-existing baseline** (confirmed present with my changes stashed). My edits (StyleSheet `host` block + `Platform` import, which is used) add zero new lint findings. New test file: clean.
+
+---
+
+## 7. Cross-surface impact (Phase 2.5)
+
+Per SPEC §5: affected = Consumer Android (target, S1–S4), Business Android (target, S5–S6). No-op = Consumer iOS, Business iOS (every change behind `Platform.select`/gate). Untouched = Buyer/anon Web + Business Web preview (web glass path = `GlassBlur.tsx`, deferred Sub-C), Admin Web (renders none of these). S5/S6 each edited BOTH files (no skip-one). Parity automatic on iOS (shared code, iOS branch unchanged).
+
+---
+
+## 8. Invariants
+
+- **I-7 (visible degradation, no null):** every changed branch renders a visible opaque View. PRESERVED.
+- **I-MOR-0827-PACKAGE-ISOLATION:** `packages/event-rendering/designTokens.ts` NOT edited; no `packages/` touch. PRESERVED.
+- **iOS-render-frozen:** every change gated; iOS branch byte-identical. PRESERVED (T-07).
+- **I-ANDROID-GLASS-OPAQUE-FALLBACK (DRAFT):** 8 chrome + chat capsule route to opaque on Android. Asserted by T-01/T-02/T-04.
+- **I-ANDROID-ROUNDED-FILL-CLIPPED (DRAFT, scoped S1/S6):** rounded surfaces carry `overflow:'hidden'`. Asserted by T-03/T-06.
+
+---
+
+## 9. Discoveries for orchestrator
+
+- **Token triplication (noted, NOT edited):** consumer `designSystem.ts` and business `designSystem.ts` were edited independently (already-separate sources). The third token file `packages/event-rendering/designTokens.ts` stays untouched (no scoped file imports it for these surfaces). When the later sweep fixes `GlassBlur.tsx` / public pages (Sub-C), the third token file participates. Per SPEC §9 hard guard + §2.2.
+- **Pre-existing lint/tsc debt in the worktree** (249 consumer + 234 business baseline tsc errors; `EventListCard` conditional-hooks lint error) is unrelated to this strike — flagged for awareness, not fixed (scope discipline).
+- The remaining ~310-instance sweep (Sub-B…Sub-F in investigation §6) is explicitly deferred.
+
+---
+
+## 10. Spec deviations
+
+None. Shipped the exact 🔒 LOCKED hex values and mechanisms; took the SPEC-recommended 🎨 OPEN choices (`#FFFAF4` unread, `rgba(20,22,26,0.92)` business fill, kept iOS `elevation:8`, inline `Platform.select` for S5 over exported helper, kept the `isAndroidPreBlur` local alias).

--- a/Mingla_Artifacts/reports/INVESTIGATION_ANDROID_GLASS_FILL_AND_TRANSPARENCY.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ANDROID_GLASS_FILL_AND_TRANSPARENCY.md
@@ -1,0 +1,115 @@
+# INVESTIGATION — Android glass rendering: "fill doesn't fill the card" + "sheets too transparent"
+
+**Date:** 2026-05-29
+**Mode:** INVESTIGATE (cross-surface forensic sweep)
+**Trigger:** Operator saw notification cards on a physical Samsung (SM-A725F) where the cream/white fill doesn't reach the rounded corners (a taupe ring around an inset fill), plus sheets that look too transparent on Android. Requested a total robust investigation across the consumer app, the business app, and shared packages.
+**Surfaces:** Consumer Android (`app-mobile`), Business Android (`mingla-business` RN-mobile), shared `packages/` (render natively on Android in the business app). iOS unaffected. Web (Next.js) out of scope.
+**Method:** Physical-device repro + screenshot, then 5 parallel forensic agents cataloguing every instance across both apps + shared packages + token sources + RN/Expo versions.
+
+---
+
+## 1. Executive summary
+
+There are **two distinct Android-only defect classes**, both flowing from one architectural fact: **Mingla's "glass" (glassmorphism) design language was built for iOS, and Android handling is inconsistent and duplicated across three separate token sources.**
+
+| | Symptom A — "fill doesn't fill the card" | Symptom B — "sheets too transparent" |
+|---|---|---|
+| **What you see** | Rounded card shows a taupe/sand ring; the cream/white fill looks inset, not reaching the corner. | Bottom sheets / chrome / overlays look washed-out and see-through over busy content. |
+| **Mechanism** | A single `View` combines `borderRadius` + a border and/or `elevation`/shadow + a **translucent or same-as-parent** `backgroundColor`, with **no `overflow:'hidden'`**. Android composites the border/shadow layer and the fill layer separately, so they misalign at the rounded corners. | `expo-blur`'s `BlurView` renders a **thin semi-transparent `View`** on Android unless `experimentalBlurMethod="dimezisBlurView"` is set — and even then it's experimental/unreliable. Low-alpha tint floors (0.04–0.58) were designed to sit on top of a real frost that never materializes. |
+| **Consumer app** | Confirmed exemplar = `NotificationsSheet` card. ~95 HIGH translucent + ~15 MED opaque-on-white instances; many HIGH are intentional dark-canvas glass (verify visually). | Root = a version gate that only falls back to opaque on **Android ≤ 11**. On Android 12+ (most devices) all floating glass chrome uses BlurView. 9 HIGH chrome surfaces; chat-input capsule is worst (no guard at all). Full-screen sheets are FINE (opaque). |
+| **Business app** | **Systemic — ~215 HIGH instances across ~80 files.** Rounded + 1px translucent border + `rgba(255,255,255,0.03–0.08)` fill is the *house style*, inlined everywhere (event/trip creators, marketing composer, brand/door/ari). Two pill tab-bars also stack a raw `elevation:8`. | **Mostly already solved** — sheets route Android to an opaque `rgba(20,22,26,0.92)` fallback. Only 3 stragglers leak (Toast, AiDisclosureModal, BlastCustomersCta). |
+| **Shared package** | `EventCoverMedia`/`EventCover` use `overflow:'hidden'` → **mitigated**. | `GlassBlur.tsx` branches only on web → raw thin blur on Android with **no** `experimentalBlurMethod`. Drives 11 public-page glass panels (PublicEventPage, PublicBrandPage) that render natively on Android in the business app. |
+
+**The deepest root:** there is **no shared design-token package**. Glass/blur/elevation tokens are **triplicated** (`app-mobile/src/constants/designSystem.ts:258`, `mingla-business/src/constants/designSystem.ts:194`, `packages/event-rendering/designTokens.ts:41`), and the two apps adopt **opposite** Android blur strategies (consumer = real `dimezisBlurView`; business = opaque fallback). Any clean fix must decide one strategy and either consolidate tokens or fan the same change across three files.
+
+---
+
+## 2. Environment / versions (both apps pinned identically)
+
+| Package | app-mobile | mingla-business |
+|---|---|---|
+| react-native | 0.81.5 | 0.81.5 |
+| expo | ~54.0.34 | ~54.0.34 |
+| expo-blur | ~15.0.8 | ~15.0.8 |
+| @gorhom/bottom-sheet | 5.2.8 | not present |
+| react-native-reanimated | ^4.1.5 | ~4.1.1 |
+
+**Documented platform behavior (root mechanism for Symptom B):** `expo-blur` `BlurView.types.d.ts:2-11` — `experimentalBlurMethod` defaults to `'none'` on Android, and *"`'none'` — Falls back to a semi-transparent view instead of rendering a blur effect."* Real Android blur requires explicitly setting `experimentalBlurMethod="dimezisBlurView"` (doc warns it is experimental + perf-impacting).
+
+No `*.android.tsx` platform-file convention exists anywhere. Android handling is ad hoc: `Platform.OS==='android'` appears 67× in app-mobile, 27× in business.
+
+---
+
+## 3. Symptom A — "fill doesn't fill the card" (inset taupe ring)
+
+### 3.1 Confirmed exemplar (consumer)
+`app-mobile/src/components/NotificationsSheet.tsx:952` `notificationCard`:
+- `borderRadius:20` + `borderWidth:1` + `borderColor:'rgba(0,0,0,0.06)'` + `elevation:2` + shadow, fill `#FFFFFF` (read) / `rgba(255,247,237,0.6)` (unread, translucent), **no `overflow:'hidden'`**. The 1px border + elevation render a taupe rounded frame; the (translucent) fill misaligns at the corner → the ring you photographed.
+
+### 3.2 Consumer app catalog (summary; full list in agent output)
+- **HIGH (translucent fill + signature):** ~95 blocks. Light-canvas exemplar-grade (~24): e.g. `IncomingPairRequestCard.tsx:274`, `PairingInfoCard.tsx:167`, `MultiDayCalendar.tsx:223`, `AddFriendView.tsx:530` (`glassCard`), `OnboardingShell.tsx:384`, `CalendarTab.tsx:1180/1221`, `StartSwipingHeaderButton.tsx:46`, `ChatListItem.tsx:513`, profile pills/tiles.
+- **~50 are dark-canvas glass** (PreferencesSheet, MessageInterface, CalendarTab/SavedTab share-sheets, ExpandedCard chips) — likely intentional; verify visually before touching.
+- **MED (opaque white = parent bg + border + elev):** ~15 (incl. the exemplar's read state, `AccountSettings.tsx:1139`, `BillingSheet.tsx:504/575`, `PairedPeopleRow.tsx:160`).
+- **POSITIVE reference:** `board/SwipeableSessionCards.tsx:699` — `rgba(255,255,255,0.85)` + border + Platform-branched shadow + **`overflow:'hidden'`** = correct.
+
+### 3.3 Business app catalog (systemic)
+- **~215 HIGH instances across ~80 files.** It is the app-wide card/pill/input/sheet idiom: rounded + 1px translucent border + `rgba(255,255,255,0.03–0.08)` or `accent.tint rgba(235,120,37,0.28)` fill. Densest in event creators (`CreatorStep2When` 8, `TicketTierEditSheet` 8, `PreviewEventView` 6), trip creators, marketing composer, brand/door/ari surfaces.
+- **Worst (stacks both effects):** `trip/EditPublishedTripIntakeAccordion.tsx:520` and `trip/TripCreatorStep6Intake.tsx:295` — `tabActive` adds raw **`elevation:8`** under a rounded translucent pill (bypasses `androidSafeElevation`).
+- **POSITIVE infrastructure (already correct, underused):** `designSystem.ts:26 androidSafeElevation()` zeroes elevation on Android for all tokens; `GlassChrome.tsx` is the canonical correct stack (outer view = radius+shadow, no bg; inner `clip` view = `overflow:'hidden'`+radius holding blur/tint/border; Android uses opaque `rgba(20,22,26,0.92)` fallback). `GlassCard` delegates to it. **The HIGH inline styles simply don't route through `GlassChrome`.**
+
+### 3.4 Shared package
+`packages/event-rendering/EventCoverMedia.tsx:576` and `EventCover.tsx:122` use translucent fill + radius **but include `overflow:'hidden'`** → mitigated. Not a Symptom-A source.
+
+---
+
+## 4. Symptom B — "sheets too transparent on Android"
+
+### 4.1 Consumer app — the version-gate root
+The glass system is gated by one expression repeated across every chrome component:
+```ts
+const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+const useGlass = !reduceTransparency && !isAndroidPreBlur;
+```
+**The opaque fallback only fires on Android API < 31 (Android 11 and older).** On Android 12+ (the dominant install base) `useGlass` is `true`, so surfaces render `BlurView` + a low-alpha tint floor via `experimentalBlurMethod='dimezisBlurView'` (the experimental/unreliable path). The well-designed `fallbackSolid` tokens exist but are unreachable on modern Android.
+
+**HIGH chrome surfaces (9):** `MessageInterface.tsx:1912` chat-input capsule (**worst — NO guard, NO fallback, always BlurView+0.48 tint**), `GlassBottomNav.tsx:209`, `GlassTopBar.tsx:181`, `ui/GlassIconButton.tsx:200`, `ui/GlassBadge.tsx:215`, `ui/GlassCard.tsx:104` (profile bento, tint 0.04–0.06), `DiscoverScreen.tsx:442` (card badge/save/chip), `ConnectionsPage.tsx:3264` + `LikesPage.tsx:226` sticky headers.
+
+**NOT at risk:** full-screen sheets/modals (NotificationsSheet, ExpandedCardModal, all connection/profile/friend sheets) — they correctly use solid `#FFFFFF`/`#1C1C1E` surfaces with only a translucent backdrop. Risk is concentrated in **floating glass chrome** + the chat-input capsule.
+
+### 4.2 Business app — mostly solved, 3 stragglers
+Sheets route Android to opaque `rgba(20,22,26,0.92)` via `shouldUseRealBlur()` returning `false` on Android (`GlassChrome.tsx:81`, `SheetMobile.tsx:90`, `TopSheet.tsx:96`, `Modal.tsx` via GlassCard). Leaks that bypass the helper:
+- **F1 HIGH — `ui/Toast.tsx:182`:** `blurOk = Platform.OS !== "web" || ...` → **`true` on Android**, renders real BlurView; solid fallback branch unreachable. Surface alpha ≈ 0.30–0.32. Global toast surface washed-out. (Inverted logic vs the rest of the kit.)
+- **F2 MED — `ari/AiDisclosureModal.tsx:67`:** raw `<BlurView intensity={40}>`, no guard; relies on 0.78 tint.
+- **F3 MED — `marketing/BlastCustomersCta.tsx:137`:** raw BlurView, no guard; 0.42 orange wash on Android.
+
+### 4.3 Shared package — `GlassBlur.tsx`
+`packages/event-rendering/GlassBlur.tsx:43` branches **only** on `Platform.OS === "web"`; on Android it renders raw `<BlurView>` with **no `experimentalBlurMethod`** → Android's `'none'` semi-transparent fallback. Drives 11 public-page glass panels: `PublicEventPage.tsx:552` + `PublicBrandPage.tsx` (×9: lines 549,629,901,980,1078,1235,1320,1392,1418). These render natively on Android in the business app (`app/e/[brandSlug]/[eventSlug].tsx`, `app/b/[brandSlug]/index.tsx`). Symptom B on every native Android render of those public pages.
+
+---
+
+## 5. Architectural root & leverage map
+
+1. **No shared token package.** Glass/blur/elevation tokens triplicated: `app-mobile/.../designSystem.ts:258`, `mingla-business/.../designSystem.ts:194`, `packages/event-rendering/designTokens.ts:41` (its header explicitly says it's a manual duplicate per `I-MOR-0827-PACKAGE-ISOLATION`).
+2. **Opposite Android blur strategies.** Consumer = real `dimezisBlurView` (11 sites); business = opaque fallback (`shouldUseRealBlur()=false`, 0 dimezis usages). The shared package follows neither.
+3. **Highest-leverage fixes (one change → both apps):** `packages/event-rendering/GlassBlur.tsx` (the only shared blur primitive) and the `EventCoverMedia`/`EventCover` card surfaces.
+4. **The correct patterns already exist** — they're just not universally routed through: business `GlassChrome` (clip-view + opaque fallback + `androidSafeElevation`) and consumer `board/SwipeableSessionCards` (`overflow:'hidden'`).
+
+---
+
+## 6. Recommended fix architecture (for SPEC — not yet implemented)
+
+A **META-ORCH with ordered sub-tracks**, because the surface is too large for one PR and the token layer is a prerequisite:
+
+- **Sub-A (foundation):** Decide the single Android glass policy (recommend: **opaque-fallback on Android by default**, matching business's proven approach; reserve real `dimezisBlurView` only for specific hero surfaces where perf + look are validated on-device). Add a tiny shared helper/primitive — `overflow:'hidden'` + opaque Android fill + `androidSafeElevation` — and codify it as an invariant.
+- **Sub-B (consumer Symptom B):** Fix the `Platform.Version < 31` gate so the opaque fallback reaches Android 12+; fix the unguarded `MessageInterface` chat-input capsule and the 9 chrome surfaces.
+- **Sub-C (shared package):** Fix `GlassBlur.tsx` Android branch + the public-page panels (fixes both apps' public pages at once).
+- **Sub-D (business Symptom B stragglers):** Toast (inverted guard), AiDisclosureModal, BlastCustomersCta.
+- **Sub-E (Symptom A sweep):** Route the inline rounded+border+translucent surfaces through the clip primitive — phased by surface (consumer light-canvas exemplars first; business creators next). Dark-canvas "intentional glass" verified on-device before touching.
+- **Sub-F (token consolidation, optional):** Stand up `@mingla/design-tokens` to kill the triplication so this can't drift again.
+
+Each sub-track ships its own PR with on-device before/after screenshots and an Android regression test.
+
+---
+
+## 7. Evidence appendix
+Five forensic agent catalogs (full file:line lists, including business `/tmp/high.txt` + `/tmp/med.txt`) are the source for §3–§5. Physical-device screenshots: `/tmp/mingla-shots/current.png` (full notifications screen), `/tmp/mingla-shots/card_crop.png` (the ring artifact zoomed).

--- a/Mingla_Artifacts/reports/QA_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md
+++ b/Mingla_Artifacts/reports/QA_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md
@@ -1,0 +1,176 @@
+# QA — META-ORCH-1002 [Android glass hardening] Sub-1 (Fast First Strike)
+
+**Mode:** TARGETED (orchestrator-dispatched on-device live-fire)
+**Date:** 2026-05-29
+**Skill:** mingla-tester (Claude)
+**Worktree:** `~/Desktop/mingla-orchs/META-ORCH-1002-[android-glass-hardening]/` on branch `META-ORCH-1002-android-glass-hardening` (HEAD `6038214b2`; +1 tester commit `e2eb9a532` adversarial test). Metro port 8087.
+**SPEC:** `Mingla_Artifacts/specs/SPEC_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md`
+**IMPLEMENTATION:** `Mingla_Artifacts/reports/IMPLEMENTATION_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md`
+**Comms ledger:** read on entry. No `BLOCK`/`OPEN` row targets this skill, this ORCH-ID, or `ALL` requiring action. COMMS-0002/0003/0004 (ALL/WARN) are N/A — no backend/`supabase/functions`, no external API, no INTAKE.
+
+---
+
+## VERDICT: CONDITIONAL PASS
+
+- **P0:** 0 | **P1:** 0 | **P2:** 0 | **P3:** 0 | **P4:** 2 (praise)
+- **Consumer Android (S1–S4): PASS — `proven` live-fire on physical Samsung SM-A725F (Android 14).**
+- **Business Android (S5/S6): `probable` — source-verified + regression+adversarial green; live-fire genuinely attempted on physical device AND emulator, both blocked by a pre-existing native-binary-vs-main drift + host saturation (named below). Requires Seth to accept the deferral OR authorize the one destructive unblock.**
+- **iOS no-change pass: `probable` — sim live-fire attempted; blocked by the same pre-existing native drift (`ExpoVideo` not in the installed sim binary). iOS branches verified byte-unchanged by source (every change is `Platform.select` ios / gate=false).**
+
+The single clause keeping this from full PASS is the business-Android live-fire leg, blocked by an **environmental** condition (old dev binary missing `react-native-keyboard-controller` native module + host load avg 34–43), not a code defect. The headline fix Seth photographed — the notification-card taupe ring — is **PROVEN fixed on the physical device** with before/after evidence.
+
+---
+
+## 1. Live-fire sim gate (Phase 0.A)
+
+| Leg | Surface ships? | Result | Evidence |
+|---|---|---|---|
+| **Physical Android (consumer)** | YES — target | **PROVEN** — app booted on fresh worktree bundle (5034 modules), all consumer surfaces rendered | Samsung SM-A725F `R58R54YV7JT`, Android 14, `com.mingla.app.v2` v1.1.0 (DEBUGGABLE) |
+| **Physical/emulated Android (business)** | YES — target | **BLOCKED → probable** | native drift + ANR (see §4) |
+| **iOS sim (consumer)** | YES — no-op | **BLOCKED → probable** | `ExpoVideo` native module missing in installed sim binary (see §5) |
+| **Web** | NO | Skipped — these are RN-mobile surfaces; web glass path (`GlassBlur.tsx`) is deferred Sub-C per SPEC §5 row 3/7 | N/A |
+
+**Driver:** physical-device via `adb` + `input` taps (Maestro not required — no keystroke bugs in scope). Bundle freshness verified: anchor Metro served `expo-router/entry.js` 5034 modules to the device; app logged `[SESSION_PILLS] loadUserSessions complete` (live, logged-in render).
+
+**Metro setup note (resolved blocker):** the worktree's nested project root (`/mingla-orchs/META-ORCH-1002-[android-glass-hardening]/app-mobile`) caused the dev-client to request a malformed `/mingla-main/app-mobile/node_modules/...` bundle path → `UnableToResolveError` (`_devlauncher_err.png`). RESOLVED per `feedback_testing_handoff_just_run_expo_start.md`: applied the 16 changed source files as a patch onto the anchor checkout (real node_modules, correct project root), ran Metro there on 8087, verified, reverted the anchor afterward (anchor confirmed back on clean `main`).
+
+---
+
+## 2. Per-criterion results
+
+### Consumer (PROVEN on physical Samsung)
+
+| SC | Criterion | Result | Evidence |
+|---|---|---|---|
+| **SC-1 (S1 Android)** | Unread notification card opaque warm-cream `#FFFAF4` reaching all 4 rounded corners; NO taupe ring | **PASS** | `before_notif.png` (taupe ring present) vs `after_notif.png` (ring gone); tight crops `before_card_crop.png` vs `after_card_crop.png` make it unambiguous. This is the headline fix Seth photographed. |
+| **SC-2a/S4** | Bottom nav solid frosted over busy content | **PASS** | `after_chat_nav.png` + crop `after_chat_capsule_crop.png` — solid dark nav over chat; `_app_home2.png` over Discover photos |
+| **SC-2b** | Top bar solid | **PASS** | `_app_home2.png` (Discover top bar + pill); `after_chat_nav.png` (chat header) |
+| **SC-2c** | Glass icon buttons solid | **PASS** | `after_profile_bento.png` (edit-icon buttons), filter icon `_app_home2.png` |
+| **SC-2d** | Badges solid | **PASS** | `_app_home2.png` Discover card badges (8.2mi / 17min / 4.4 / price / "First Dates · 2 stops") read solid over photo |
+| **SC-2e** | Sticky headers (Likes/Connections) solid | **PASS** | `_friends3.png` Friends/Connections header + search bar solid over dark canvas |
+| **SC-2f** | Profile bento (GlassCard) + Discover badges solid | **PASS** | `after_profile_bento.png` (profile/interests/circle bento cards solid to corners) |
+| **SC-3 (S3)** | Chat-input capsule solid frosted `rgba(22,24,28,0.94)`, not see-through | **PASS** | `after_chat_capsule_crop.png` — capsule fully occludes chat behind it; a white bubble is visible ABOVE its top edge but nothing bleeds through |
+
+### Business (probable — source + tests; live-fire blocked)
+
+| SC | Criterion | Source verified | Live-fire |
+|---|---|---|---|
+| **SC-5a (S5)** | `EditPublishedTripIntakeAccordion` active trip tab: NO Android shadow; iOS glow kept | YES — `elevation: Platform.select({ ios: 8, android: 0, default: 8 })` line 530 | BLOCKED (native drift) |
+| **SC-5b (S5)** | `TripCreatorStep6Intake` active trip tab — same | YES — same Platform.select line 304 | BLOCKED |
+| **SC-6a (S6)** | `EventListCard` host solid frosted to corners on Android; no child clipped; iOS unchanged | YES — `host` android `rgba(20,22,26,0.92)` (line 283) + `overflow:'hidden'` (line 289); `Platform` imported+used | BLOCKED |
+| **SC-6b (S6)** | `TripListCard` host — same | YES — android fill line 255 + `overflow:'hidden'` line 261 | BLOCKED |
+
+### Frozen-iOS + global
+
+| SC | Criterion | Result | Evidence |
+|---|---|---|---|
+| **SC-1-iOS / SC-2-iOS / SC-3-iOS** | iOS pixel-identical (translucent cream, BlurView, tint floor) | **PASS (source `probable`)** | Every change is behind `Platform.select` ios-branch or `ANDROID_GLASS_USES_OPAQUE_FALLBACK === false`; adversarial A-01 asserts the gate is consumed as a NEGATION so iOS keeps BlurView. Sim boot blocked by pre-existing `ExpoVideo` drift (`ios_notif.png`). |
+| **SC-2-grep** | No `app-mobile` glass component keeps a live `Platform.Version < 31` glass gate | **PASS** | Regression T-02 + adversarial A-05; grep across all 8 chrome files = 0 live gates |
+| **SC-7 (global)** | Zero out-of-scope touch | **PASS** | `git diff main...HEAD` = only §2.1 files + 2 tests + 2 package.json (+ tester adversarial test). Adversarial A-03 confirms `packages/event-rendering/{designTokens.ts,GlassBlur.tsx}` byte-untouched. |
+
+---
+
+## 3. Regression + adversarial gate
+
+**Consumer happy-path (implementor):** `app-mobile/scripts/ci/meta-orch-1002-android-glass-check.mjs` → **26/26 PASS**.
+**Business happy-path (implementor):** `mingla-business/src/components/__tests__/metaOrch1002AndroidGlass.test.ts` → **12/12 PASS** (1 suite).
+Both committed in `git diff main...HEAD --name-only`. Implementor reported `fails-on-revert` verified at commit `bf0accc253...` (consumer 22/26 on revert; business 3 failed on revert) — cited from the implementation report §5.
+
+**Tester adversarial (NEW, different angle):** `app-mobile/scripts/ci/meta-orch-1002-android-glass-adversarial-check.mjs` → **29/29 PASS**. Committed `e2eb9a532`, in the PR diff. Attacks failure modes the happy-path cannot see:
+- **A-01** iOS-opaque-regression guard: every chrome file must consume the gate as a NEGATION (so iOS keeps real BlurView) — catches "made it opaque on iOS too."
+- **A-02** translucent-leak guard: no NEW `<0.92` rgba Android fill on the 6 surfaces (happy-path only checks the EXPECTED opaque value is present).
+- **A-03** package-isolation: `event-rendering/designTokens.ts` + `GlassBlur.tsx` byte-untouched vs main (I-MOR-0827).
+- **A-04** S5/S6 both-files parity (skip-one failure mode).
+- **A-05** revert-canary: zero live `Platform.Version < 31` gates remain.
+- **A-06** no bare `elevation: 8` survivor in either S5 file.
+
+**Adversarial teeth proven (negative control):** re-introducing a bare `elevation: 8` in `TripCreatorStep6Intake.tsx` → adversarial drops to **27/29 (A-04 + A-06 FAIL)**; restored → **29/29**.
+
+---
+
+## 4. Business-Android live-fire BLOCKER (the CONDITIONAL clause)
+
+**Root cause: pre-existing native-binary-vs-main-source drift, NOT a defect in this ORCH.**
+
+1. Built business Metro (8089) from the anchor with the S5/S6 patches; bundle compiled cleanly (`index.js`, 5045 modules, HTTP 200).
+2. Physical Samsung business app (`com.sethogieva.minglabusiness`, EAS dev build versionCode=4) booted from Metro → **red-box: `react-native-keyboard-controller doesn't seem to be linked`** (`_biz_home.png`). The installed EAS binary (finished 5/26, the latest on EAS) **predates** `react-native-keyboard-controller@1.18.5` which current `main` imports at root (`app/_layout.tsx` + keyboard wrappers). Confirmed the dep is on `main` independently of my patches (my diff contains zero keyboard-controller / expo-video references).
+3. **Recovery attempt A — fresh debug APK:** kicked off `gradlew :app:assembleDebug`; it **stalled** in the Kotlin plugin-configuration phase (~0.4% CPU, no progress for 6+ min) under host load.
+4. **Recovery attempt B — existing local debug APK** (`app-debug.apk`, contains `libreact_codegen_reactnativekeyboardcontroller.so`): install to the physical device **failed `INSTALL_FAILED_UPDATE_INCOMPATIBLE`** (debug signature ≠ EAS signature). Replacing it would require **uninstalling Seth's logged-in EAS business app** — a destructive op on his real data, which I will not do autonomously (operator-decision gate per `feedback_autonomy_posture_verifier_not_manager.md`).
+5. **Recovery attempt C — Android emulator** (`META_ORCH_0972_Pixel_7_API35`): booted, installed the debug APK (no signature conflict), bundle served (5045 modules), but the app **repeatedly ANR'd** ("Business isn't responding" / "System UI isn't responding", `_emu_devlauncher.png` / `_emu_dl2.png`) because **host load average was 34–43** (Mac saturated by 2 Metros + 2 other-session iOS sims I must not kill + the emulator). Freeing my consumer Metro (8087) did not drop load enough; the remaining load is other sessions' processes I cannot touch per the no-cross-session-interference rule.
+
+**Why `probable` is the honest ceiling here:** the S5/S6 change is pure JS/style, source-verified line-by-line against the SPEC in BOTH files, covered by the implementor's business happy-path test (12/12) AND the tester adversarial (A-02/A-04/A-06 specifically attack S5/S6), and the bundle compiled clean. The ONLY missing piece is the on-device pixel screenshot, blocked by environmental conditions I genuinely tried three ways to resolve.
+
+**Case-B unblock (pick one), then S5/S6 flips to PROVEN in ~10 min:**
+1. **(Recommended, low-cost)** Authorize uninstalling the EAS business dev build on the physical Samsung so I can install the debug APK that already has keyboard-controller linked (you re-login once — business app, no consumer data). I then drive Trip-creator step 6 + an event/trip list card and screenshot.
+2. Run the emulator when the Mac is not hosting other sim sessions (load < ~8) so it stops ANR-ing.
+3. Accept the `probable` deferral on S5/S6 for this strike (consumer headline fix is proven; business surfaces are lower-visibility, source+test-verified) and let the full Android sweep (Sub-B…F) carry the business on-device proof.
+
+---
+
+## 5. iOS no-change pass
+
+Loaded the same anchor bundle on a booted iPhone 17 sim (pointed at my own Metro 8087; did not touch the other session's 8099/8092 Metros). The consumer app red-boxed at **`Cannot find native module 'ExpoVideo'`** (`EventCoverMedia.tsx` → `expo-video`, added for ORCH-0964/0978 per COMMS-0007), thrown at module-eval in the nav tree (`PublicEventPage`/`PublicBrandPage`/`ConsumerBrandProfileScreen`). Same class of blocker: the installed **iOS sim binary predates `expo-video` on current `main`** — independent of my patches (`ios_notif.png`). Terminated the app to leave that sim clean for its owner.
+
+**iOS verified unchanged by source (fallback):** every consumer change retains its exact pre-change iOS value — `cardUnreadBg` ios branch `rgba(255,247,237,0.6)`; `MessageInterface` iOS branch keeps `<BlurView intensity={glass.chrome.blur.intensity}>` + `glass.chrome.tint.floor`; the 8 chrome files consume the gate as a negation (adversarial A-01) so iOS still computes `useGlass = true` → BlurView. Regression T-07 + adversarial A-01 lock this.
+
+---
+
+## 6. Constitution (touched rules)
+
+| # | Rule | Result |
+|---|---|---|
+| 1 | No dead taps | N/A — pure visual style; no interaction changed |
+| 8 | Subtract before adding | PASS — replaced 8 duplicated inline gates with one shared export |
+| 9 | No fabricated data | N/A |
+| — | I-7 (no `return null`; visible degradation) | PASS — every changed branch paints a visible opaque View |
+| — | I-MOR-0827 package isolation | PASS — adversarial A-03 (token file byte-untouched) |
+| — | iOS-render-frozen | PASS — T-07 + adversarial A-01 |
+
+---
+
+## 7. Typecheck + lint (Completion clause 2)
+
+- **Consumer tsc:** 249 errors total, ALL pre-existing baseline (`packages/phone-input` worktree module-resolution + repo strictness debt) — **0 in any touched file**. Matches implementor's reported 249 baseline.
+- **Business tsc:** 234 errors total, all pre-existing baseline — **0 in any touched file**. Matches implementor's 234.
+- **Consumer lint (touched files + adversarial script):** **0 errors**, 31 warnings — all pre-existing unused-var/array-type on lines I did not touch.
+- **Business lint (touched files):** 4 `react-hooks/rules-of-hooks` errors in `EventListCard.tsx` lines 81–101 + `accent` unused warning in `TripListCard.tsx` — **all pre-existing baseline**, in component logic ABOVE my StyleSheet edits (my diff is line 15 import + lines 274–292 `host` block). Implementor flagged the same. My `Platform` import is used → zero new findings.
+
+---
+
+## 8. Completion condition (machine-verified)
+
+1. ✅ Every independent test green — consumer 26/26, business 12/12, adversarial 29/29 (outputs captured §3).
+2. ✅ tsc + lint clean on touched files (0 new errors/findings) — §7.
+3. ✅ Both regression tests + adversarial in `git diff main...HEAD --name-only`; adversarial attacks a different angle (iOS-freeze / leak / isolation / parity / revert-canary); implementor fails-on-revert cited at `bf0accc253...`.
+4. ⚠️ UI/runtime legs: **consumer Android = PROVEN**; **business Android + iOS no-change = `probable`** (sim blocked by pre-existing native drift + host saturation; three recovery attempts named; Case-B requested). This is the sole reason for CONDITIONAL rather than full PASS.
+5. ✅ Zero open P0, zero open P1.
+
+---
+
+## 9. P4 — praise
+
+- **P4-1:** The single-shared-gate refactor (`ANDROID_GLASS_USES_OPAQUE_FALLBACK`) is the right call — it killed the 8-file duplicated `Platform.Version < 31` drift that caused the bug, and the on-device result is a clean, consistent solid-frosted chrome across nav/top-bar/badges/bento. Worth replicating in the full sweep.
+- **P4-2:** Mathematically-composited opaque hex `#FFFAF4` for the unread card reads identical-in-warmth to the iOS translucent cream while fully killing the taupe ring — exactly the intended "match iOS intent, not iOS blur" policy.
+
+---
+
+## 10. Discoveries for orchestrator
+
+- **Cross-cutting native drift (P2, not this ORCH's defect):** every installed dev binary (consumer iOS sim + business Android EAS v4) predates current `main`'s root native deps (`expo-video`, `react-native-keyboard-controller`). Any on-device QA of `main` JS now requires a fresh native dev build first. The physical Samsung CONSUMER binary (v1.1.0 launch build) is current and boots fine — which is why consumer S1–S4 proved cleanly. Recommend a fresh business dev build + iOS sim dev build be staged before the next on-device business/iOS QA dispatch.
+- **Evidence dir:** `/tmp/mingla-shots/metaorch1002/` — headline: `before_card_crop.png` vs `after_card_crop.png` (taupe ring before/after).
+
+---
+
+## Evidence index (key)
+
+| File | Shows |
+|---|---|
+| `before_notif.png` / `before_card_crop.png` | Unread card WITH taupe ring (Seth's photographed artifact) |
+| `after_notif.png` / `after_card_crop.png` | Unread card cream fill reaching corners, NO ring (SC-1 PROVEN) |
+| `after_chat_nav.png` / `after_chat_capsule_crop.png` | Chat-input capsule + bottom nav solid frosted over chat (SC-3, SC-2a) |
+| `_app_home2.png` | Discover top bar + card badges solid over photos (SC-2b/d/f) |
+| `_friends3.png` | Connections sticky header solid (SC-2e) |
+| `after_profile_bento.png` | Profile bento GlassCards + icon buttons solid (SC-2c/f) |
+| `_biz_home.png` | Business red-box `keyboard-controller not linked` (native drift blocker) |
+| `_emu_dl2.png` | Emulator ANR under host saturation |
+| `ios_notif.png` | iOS sim red-box `ExpoVideo` (native drift; iOS verified by source) |

--- a/Mingla_Artifacts/specs/SPEC_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md
+++ b/Mingla_Artifacts/specs/SPEC_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md
@@ -1,0 +1,318 @@
+# SPEC — META-ORCH-1002 [Android glass hardening] — FAST FIRST STRIKE (Sub-1)
+
+**Mode:** SPEC (bounded first-strike contract)
+**Date:** 2026-05-29
+**Worktree:** `~/Desktop/mingla-orchs/META-ORCH-1002-[android-glass-hardening]/` on branch `META-ORCH-1002-android-glass-hardening`. Metro port 8087.
+**Primary input (proven, do not re-investigate):** `Mingla_Artifacts/reports/INVESTIGATION_ANDROID_GLASS_FILL_AND_TRANSPARENCY.md`
+**Skill:** mingla-forensics
+**External APIs touched:** NONE (pure React Native style/Platform.select change). COMMS-0003 docs-citation requirement is N/A. No `supabase`/backend/migration/edge touch. No new dependencies.
+
+---
+
+## 0. Operator decisions already locked (not re-litigated)
+
+- **POLICY = Option 1 — solid frosted surfaces on Android by default.** On Android, glass surfaces render an OPAQUE (or ≥ 0.92 alpha) frosted fill instead of relying on `expo-blur`. Real `dimezisBlurView` blur is reserved ONLY for specific hero surfaces validated on-device later — NOT in this strike. Android visual target = the iOS *intent* (premium frosted card/sheet) rendered with an opaque fill, NOT a see-through tint.
+- **SCOPE = FAST FIRST STRIKE ONLY.** Highest-visibility subset, ONE PR, so Seth can eyeball the win before the full ~310-instance sweep. The full sweep (Sub-B…Sub-F in the investigation §6) is explicitly deferred.
+
+---
+
+## 1. Layman summary
+
+On Android, Mingla's "glass" cards and bars were built to lean on a blur effect that Android either renders as a thin see-through film or not at all. Two visible problems result: (A) the notification card's cream fill stops short of the rounded corners leaving a taupe ring, and (B) the chat input bar and bottom nav look washed-out and see-through over busy content. This strike fixes the small set of highest-visibility surfaces by making them solid frosted panels on Android — matching how iOS *looks*, not how iOS technically blurs. iOS rendering is untouched. The deepest single lever is a version gate that currently only helps Android 11 and older; flipping it lights up the bottom nav, top bar, icon buttons, badges and sticky headers on all modern Android at once.
+
+---
+
+## 2. Scope and non-goals
+
+### 2.1 In scope (these surfaces, nothing else)
+
+| # | Surface | File(s) | Symptom | Class |
+|---|---------|---------|---------|-------|
+| S1 | Consumer notification card + skeleton | `app-mobile/src/components/NotificationsSheet.tsx` (`notificationCard` ~952, `notificationCardUnread` ~969, `skeletonCard` ~1185) + tokens in `app-mobile/src/constants/designSystem.ts` (`glass.notificationsSheet.cardUnreadBg`) | A — inset ring | Symptom A |
+| S2 | Consumer chrome gate (root) | `app-mobile/src/constants/designSystem.ts` (NEW shared helper) + the 8 chrome components that inline `isAndroidPreBlur` | B — see-through chrome | Symptom B (root) |
+| S3 | Consumer chat-input capsule | `app-mobile/src/components/MessageInterface.tsx` (capsule blur ~1912) | B — worst offender, no guard | Symptom B |
+| S4 | Consumer bottom nav | `app-mobile/src/components/GlassBottomNav.tsx` (~208) | B | Symptom B (confirm fixed by S2) |
+| S5 | Business trip tab-bars (raw elevation:8) | `mingla-business/src/components/trip/EditPublishedTripIntakeAccordion.tsx` (`tabActive` ~520) + `mingla-business/src/components/trip/TripCreatorStep6Intake.tsx` (`tabActive` ~295) | A — hard Android shadow rectangle | Symptom A |
+| S6 | Business representative creator cards | `mingla-business/src/components/event/EventListCard.tsx` (`host` ~275) + `mingla-business/src/components/trip/TripListCard.tsx` (`host` ~247) | A — translucent fill + border + no clip | Symptom A (proof sample) |
+
+### 2.2 Non-goals (explicitly deferred to the later sweep)
+
+- The ~95 consumer translucent-fill HIGH instances and ~50 dark-canvas glass surfaces (investigation §3.2). NOT touched.
+- The ~215 business HIGH inline card/pill/input instances across ~80 files (investigation §3.3) beyond the 4 representative surfaces above. NOT touched.
+- `packages/event-rendering/GlassBlur.tsx` + the 11 public-page panels (investigation §4.3, Sub-C). NOT touched.
+- Business Symptom-B stragglers Toast / AiDisclosureModal / BlastCustomersCta (investigation §4.2, Sub-D). NOT touched.
+- Token consolidation into `@mingla/design-tokens` (Sub-F). NOT touched.
+- Real `dimezisBlurView` hero-surface validation. NOT touched.
+- Token triplication is NOT reconciled. The consumer `designSystem.ts` and business `designSystem.ts` are edited independently below; `packages/event-rendering/designTokens.ts` is NOT edited (no scoped file imports it for these surfaces). See §9 Hard Guards.
+
+### 2.3 Assumptions
+
+- The investigation's catalog (file:line, exact styles) is current truth; verified live against the worktree on 2026-05-29 (all cited lines confirmed). 
+- The business creator canvas behind S5/S6 is the dark `canvas.profile` family (`#141113` / `#0c0e12`); the existing proven business opaque fallback `rgba(20,22,26,0.92)` reads correctly on it (it is the shipped `GlassChrome` fallback). Confirmed in `GlassChrome.tsx:68`.
+- Consumer chrome fallback tokens (`glass.chrome.fallback.solid = rgba(22,24,28,0.94)`, `glass.bottomSheet`/`stickyHeader.fallbackSolid` etc.) already exist and are ≥ 0.92 alpha — flipping the gate reaches them with zero new color invention. Confirmed in `designSystem.ts:413/484/663/675/691/747/766/785`.
+
+---
+
+## 3. The shared mechanism (canonical "Android-safe glass surface" recipe)
+
+Two defect classes → two recipe halves. Both reuse patterns that ALREADY exist in the codebase; no parallel system is invented.
+
+### 3.1 Recipe-A — Symptom A (fill must reach the rounded corner; no hard Android shadow rectangle)
+
+A rounded surface that carries a `borderRadius` + (`borderWidth` and/or `elevation`/shadow) + a fill MUST, on Android, satisfy ALL of:
+
+1. **`overflow: 'hidden'`** on the rounded fill view — clips the fill + border to the radius so they composite as one layer (kills the inset-ring). Proven reference: consumer `board/SwipeableSessionCards.tsx:699`; business `GlassChrome.tsx` `clip` view (`overflow:'hidden'`).
+2. **Opaque (≥ 0.92) fill on Android** via `Platform.select({ ios: <existing translucent>, android: <opaque equivalent>, default: <existing> })`. The opaque equivalent is the existing translucent fill composited over its real background (computed per surface in §4).
+3. **Elevation routed so the shadow never draws under the rounded fill on Android.** Either zero the Android elevation (`Platform.select({ ios: N, android: 0 })`, mirroring business `androidSafeElevation()` at `mingla-business/src/constants/designSystem.ts:26`) OR move the shadow to an outer non-clipping wrapper (the `GlassChrome` outer-view pattern). For S5/S6 the chosen path is **zero the Android elevation** (the surfaces already render acceptably with iOS shadow; the Android elevation is the artifact).
+
+> 🔒 LOCKED: `overflow:'hidden'` + opaque-Android-fill + no-Android-elevation-under-rounded-fill is the mechanism. 🎨 OPEN: whether the implementor zeroes elevation vs. lifts the shadow to a wrapper, per surface, as long as no hard Android shadow rectangle remains and iOS is pixel-unchanged.
+
+### 3.2 Recipe-B — Symptom B (chrome reads as solid frosted, not see-through)
+
+A floating glass-chrome surface that today renders `useGlass ? <BlurView+tint> : <fallbackSolid View>` MUST, on Android, take the fallback-solid branch. The fallback-solid tokens already exist and are ≥ 0.92 opaque. Mechanism = make the gate evaluate to "no blur" on ALL Android (not just API < 31).
+
+> 🔒 LOCKED: every in-scope chrome surface routes to its EXISTING `fallbackSolid` token on Android. No new tint floors, no `dimezisBlurView` on these surfaces.
+
+### 3.3 Consumer helper vs per-component patch — RECOMMENDATION
+
+**Recommendation: add ONE tiny shared helper to the consumer `designSystem.ts` and have the 8 chrome components import it, replacing their inline `const isAndroidPreBlur = …`.** Justification:
+
+- The gate is currently **duplicated verbatim in 8 files** (`GlassBottomNav.tsx:66`, `GlassTopBar.tsx:81`, `DiscoverScreen.tsx:96`, `ui/GlassCard.tsx:42`, `ui/GlassBadge.tsx:54`, `ui/GlassIconButton.tsx:55`, `LikesPage.tsx:33`, `ConnectionsPage.tsx:374`). A shared export is a single source of truth that kills the drift that caused this bug, and it is the minimal change (one new const + 8 one-line import/replace edits). This mirrors the business app's centralized `shouldUseRealBlur()` posture (`GlassChrome.tsx:80`) — we are converging the two apps' strategy, not inventing a third.
+- This is preferred over a new wrapper *component* (which would force restructuring 8 render trees — out of scope and risky for a first strike). We add a **boolean helper only**, not a primitive component.
+
+Helper contract (consumer `designSystem.ts`, exported):
+
+```ts
+// META-ORCH-1002 Sub-1: Android glass policy = OPAQUE frosted fallback by default.
+// expo-blur on Android renders a thin semi-transparent view (or, with dimezisBlurView,
+// an unreliable experimental blur). Policy Option 1: route ALL Android to the opaque
+// fallbackSolid branch; reserve real blur for on-device-validated hero surfaces only.
+// Replaces the per-component `Platform.Version < 31` gate that left Android 12+ on BlurView.
+export const ANDROID_GLASS_USES_OPAQUE_FALLBACK = Platform.OS === 'android';
+```
+
+Each of the 8 components replaces its inline `const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;` with an import of `ANDROID_GLASS_USES_OPAQUE_FALLBACK` and substitutes it 1:1 wherever `isAndroidPreBlur` was read (i.e. `useGlass = !reduceTransparency && !ANDROID_GLASS_USES_OPAQUE_FALLBACK`, `useBackdropGlass = …`, `useOrangeFallback = reduceTransparency || ANDROID_GLASS_USES_OPAQUE_FALLBACK`). Behavior identical on iOS (`false`) and on Android ≤ 11 (`true`, unchanged); the ONLY behavior change is Android 12+ now also evaluates `true` → opaque fallback. The local symbol MAY be renamed or kept aliased (`const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;`) — 🎨 OPEN, implementor's choice — provided no file retains a live `Platform.Version < 31` glass gate.
+
+> 🔒 LOCKED: single shared exported boolean is the gate authority for these 8 files; no file keeps a live `Platform.Version < 31` glass gate after this strike. 🎨 OPEN: local alias naming.
+
+---
+
+## 4. Exact per-surface changes (with hex values)
+
+### S1 — Consumer notification card (Symptom A)
+**File:** `app-mobile/src/components/NotificationsSheet.tsx` + `app-mobile/src/constants/designSystem.ts`
+
+Current (`NotificationsSheet.tsx:952` `notificationCard`): `borderRadius:20` + `borderWidth:1` (`cardBorder rgba(0,0,0,0.06)`) + `backgroundColor:'#FFFFFF'` + `cardShadow` (`elevation:2`), NO `overflow:'hidden'`. `notificationCardUnread` (969) overrides fill to `cardUnreadBg rgba(255,247,237,0.6)` (translucent). `skeletonCard` (1185) mirrors the read card.
+
+**Changes:**
+1. Add `overflow: 'hidden'` to `notificationCard` and `skeletonCard`. 🔒 LOCKED.
+2. The READ fill is already opaque `#FFFFFF` — no change. 🔒 LOCKED.
+3. The UNREAD fill `glass.notificationsSheet.cardUnreadBg` is translucent `rgba(255,247,237,0.6)` over the `#FFFFFF` card → composites to **`#FFFAF4`** (R: 0.6·255+0.4·255=255=FF; G: 0.6·247+0.4·255=250=FA; B: 0.6·237+0.4·255=244=F4). Replace the token with the opaque hex on Android via `Platform.select`, keeping iOS exactly as-is:
+   ```ts
+   cardUnreadBg: Platform.select({
+     ios: 'rgba(255, 247, 237, 0.6)',
+     android: '#FFFAF4',
+     default: 'rgba(255, 247, 237, 0.6)',
+   }),
+   ```
+   🔒 LOCKED mechanism. 🎨 OPEN: the exact opaque unread hex (`#FFFAF4` is the mathematically-composited value; a designer may nudge ±2 per channel for warmth, but it MUST be fully opaque and read as the same warm cream — propose and ship `#FFFAF4`).
+4. Android elevation: with `overflow:'hidden'` + opaque fill the `elevation:2` shadow no longer rings the corner; `elevation:2` is low enough to keep on Android (it reads as a soft lift on white, not a hard rectangle). KEEP `cardShadow` unchanged. 🔵 If on-device the elevation:2 still shows a faint Android rectangle, zero it via `Platform.select` — 🎨 OPEN fallback only.
+
+**Why both directions hold:** `overflow:'hidden'` clips fill+border to radius (kills ring) AND the opaque unread fill removes the translucency that let the border show through. iOS keeps the translucent cream (Platform.select ios branch) and gains nothing/loses nothing visually since iOS never had the ring (it composites correctly).
+
+### S2 — Consumer chrome gate (Symptom B root)
+**Files:** `app-mobile/src/constants/designSystem.ts` (add `ANDROID_GLASS_USES_OPAQUE_FALLBACK`, ensure `Platform` is imported) + the 8 components in §3.3.
+
+**Change:** per §3.3. Each component now takes its EXISTING opaque fallback branch on all Android. No fallback color changes — they already exist and are ≥ 0.92:
+- `GlassBottomNav` → `glass.chrome.fallback.solid` = `rgba(22,24,28,0.94)` ✓
+- `GlassTopBar` / `DiscoverScreen` badges / `GlassIconButton` / `GlassBadge` → `glass.chrome.fallback.solid` / token `fallbackSolid` siblings (all `rgba(28,30,34,0.92)`–`rgba(22,24,28,0.94)`) ✓
+- `LikesPage` / `ConnectionsPage` sticky headers → `g.stickyHeader.fallbackSolid` = `rgba(22,24,28,0.94)` ✓
+- `GlassCard` (profile bento) → its `fallback.solid` (verify token; `rgba(22,24,28,0.94)` family) ✓
+
+🔒 LOCKED: route to existing tokens, invent nothing. 🎨 OPEN: none for color.
+
+### S3 — Consumer chat-input capsule (Symptom B worst)
+**File:** `app-mobile/src/components/MessageInterface.tsx` (~1912)
+
+Current: capsule (`inputCapsule:3078` — already has `overflow:'hidden'`, good) renders **unconditionally** `<BlurView intensity={glass.chrome.blur.intensity} tint="dark" experimentalBlurMethod={android?'dimezisBlurView'} />` + a tint-floor View `glass.chrome.tint.floor` (`rgba(12,14,18,0.48)`). NO platform guard, NO fallback branch.
+
+**Change:** gate the blur the same way chrome does — when `ANDROID_GLASS_USES_OPAQUE_FALLBACK` (i.e. on Android), render an opaque fallback View instead of the BlurView, and drop/replace the translucent tint floor so the surface is solid:
+```tsx
+{ANDROID_GLASS_USES_OPAQUE_FALLBACK ? (
+  <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: glass.chrome.fallback.solid }]} />
+) : (
+  <>
+    <BlurView intensity={glass.chrome.blur.intensity} tint="dark"
+      experimentalBlurMethod={Platform.OS === 'android' ? 'dimezisBlurView' : undefined}
+      style={StyleSheet.absoluteFill} pointerEvents="none" />
+    <View pointerEvents="none" style={[StyleSheet.absoluteFill, { backgroundColor: glass.chrome.tint.floor }]} />
+  </>
+)}
+```
+Opaque fill = `glass.chrome.fallback.solid` = **`rgba(22,24,28,0.94)`** (≥ 0.92, the same token the rest of the chrome uses → visual consistency with the bottom nav directly below it). 🔒 LOCKED color + branch structure. The capsule already clips (`overflow:'hidden'`) so no Symptom-A work here. On iOS the path is byte-identical to today (`ANDROID_GLASS_USES_OPAQUE_FALLBACK === false`).
+
+> Note: import `ANDROID_GLASS_USES_OPAQUE_FALLBACK` into `MessageInterface.tsx` (it has no inline gate today). `Platform` is already imported there.
+
+### S4 — Consumer bottom nav (Symptom B chrome)
+**File:** `app-mobile/src/components/GlassBottomNav.tsx`
+
+Current (208): `useGlass ? <BlurView dimezisBlurView> : <View fallback.solid>`. `useGlass = !reduceTransparency && !isAndroidPreBlur` (141). **Fixed automatically by S2** — once `isAndroidPreBlur` is replaced by `ANDROID_GLASS_USES_OPAQUE_FALLBACK`, `useGlass` is `false` on all Android → opaque `glass.chrome.fallback.solid` (`rgba(22,24,28,0.94)`). No direct patch needed beyond the S2 gate substitution in this file. 🔒 LOCKED: confirm-via-S2. (The implementor MUST still perform the inline-gate→shared-helper substitution in this file; it is one of the 8.)
+
+### S5 — Business trip tab-bars (Symptom A worst — raw elevation:8)
+**Files:** `mingla-business/src/components/trip/EditPublishedTripIntakeAccordion.tsx` (`tabActive` ~520) + `mingla-business/src/components/trip/TripCreatorStep6Intake.tsx` (`tabActive` ~295). Identical style block in both.
+
+Current `tabActive`: `backgroundColor: accent.tint` (`rgba(235,120,37,0.28)`) + `borderColor: accent.border` + `shadowColor:'#eb7825'` + `shadowOpacity:0.35` + `shadowRadius:14` + **`elevation: 8`** (raw, bypasses `androidSafeElevation`). The pill is rounded (`tab.borderRadius: radius.full`) with a translucent fill and no clip → on Android the `elevation:8` draws a hard rectangular shadow under the rounded pill (the photographed artifact class).
+
+**Change (route through the existing primitive, not a new pattern):** zero the Android elevation exactly as `androidSafeElevation()` does for every other business shadow token. Two feasible mechanisms — pick ONE, both LOCKED-acceptable:
+
+- **Preferred (minimal, no export change):** replace the inline `elevation: 8` with `elevation: Platform.select({ ios: 8, android: 0, default: 8 })` in both files. (`Platform` is already imported in both; if not, add it.) This is the exact behavior of the private `androidSafeElevation(8)` and keeps the iOS glow shadow intact.
+- **Alternative:** export `androidSafeElevation` from `mingla-business/src/constants/designSystem.ts` and call `elevation: androidSafeElevation(8)`. Cleaner long-term but adds an export; acceptable.
+
+🔒 LOCKED: Android elevation under the rounded pill MUST be 0; iOS `elevation:8` + glow unchanged. 🎨 OPEN: inline `Platform.select` vs. exported `androidSafeElevation`. No fill/border change needed — the iOS shadow is the only artifact; the fill stays `accent.tint`. (The tab fill is `accent.tint rgba(235,120,37,0.28)`; on the dark canvas this reads as a translucent orange selection, which is intended — Symptom A here is ONLY the elevation rectangle.)
+
+### S6 — Business representative creator cards (Symptom A proof sample)
+**Files:** `mingla-business/src/components/event/EventListCard.tsx` (`host` ~275) + `mingla-business/src/components/trip/TripListCard.tsx` (`host` ~247). Identical block.
+
+Current `host`: `backgroundColor: glass.tint.profileBase` (`rgba(255,255,255,0.04)`) + `borderRadius: radius.lg` + `borderWidth:1` + `borderColor: glass.border.profileBase` (`rgba(255,255,255,0.08)`) + `overflow:'visible'`, no elevation. On the dark business canvas the 0.04 translucent fill + border with no clip can show the corner-misalignment ring.
+
+**Changes:**
+1. Add `overflow: 'hidden'` to `host`. 🔒 LOCKED. (Note: child media already uses `overflow:'hidden'` at `coverWrap`; verify the parent clip does not crop an intentionally-overflowing badge — if any child intentionally overflows `host`, keep `host` visible and instead wrap the fill+border in an inner clip view per the `GlassChrome` pattern. 🎨 OPEN: clip-on-host vs. inner-clip-view, implementor verifies on-device that no child is clipped.)
+2. Opaque Android fill. `glass.tint.profileBase rgba(255,255,255,0.04)` over `canvas.profile #141113` composites to **`#1D1B1C`** (R: 0.04·255+0.96·20=29=1D; G: 0.04·255+0.96·17=27=1B; B: 0.04·255+0.96·19=28=1C). **Recommended LOCKED value: reuse the existing proven business opaque `rgba(20,22,26,0.92)`** (the `GlassChrome` `FALLBACK_BACKGROUND`) rather than the raw computed `#1D1B1C`, because (a) it is the already-shipped, on-device-validated business glass-fallback color, (b) it keeps these cards visually consistent with every other Android-fallback business surface, and (c) it avoids introducing a new bespoke hex that diverges from the kit. Apply via:
+   ```ts
+   backgroundColor: Platform.select({
+     ios: glass.tint.profileBase,            // rgba(255,255,255,0.04)
+     android: 'rgba(20, 22, 26, 0.92)',
+     default: glass.tint.profileBase,
+   }),
+   ```
+   🔒 LOCKED: opaque Android fill ≥ 0.92. 🎨 OPEN: `rgba(20,22,26,0.92)` (recommended, kit-consistent) vs. the surface-true computed `#1D1B1C` — a designer may choose `#1D1B1C` if the card must read warmer than chrome; both satisfy the policy. Ship `rgba(20,22,26,0.92)`.
+
+No elevation change (these cards have none).
+
+---
+
+## 5. Cross-Surface Impact (Phase 2.5 — MANDATORY)
+
+| Surface | Covered? | Behavior demanded | Files | Parity |
+|---|---|---|---|---|
+| 1. Consumer iOS (`app-mobile`) | YES (no-op) | Pixel-identical to today. Every change is behind `Platform.select` ios / `ANDROID_GLASS_USES_OPAQUE_FALLBACK===false`. | S1–S4 files | Automatic (shared code, iOS branch unchanged) |
+| 2. Consumer Android (`app-mobile`) | YES | S1 notification card fill reaches corners, no ring; S2/S4 bottom nav, top bar, icon buttons, badges, sticky headers, profile bento, discover badges = solid frosted; S3 chat input = solid frosted. | S1–S4 files | This is the target surface |
+| 3. Buyer/anon Web (`mingla-business` web) | NO | These are RN-mobile surfaces; the public web pages route through `GlassBlur.tsx`/`GlassChrome` web path, NOT touched here (deferred Sub-C). | — | N/A |
+| 4. Business iOS (`mingla-business`) | YES (no-op) | Pixel-identical: S5 keeps `elevation:8`+glow (ios branch); S6 keeps `rgba(255,255,255,0.04)` (ios branch). | S5, S6 files | Automatic |
+| 5. Business Android (`mingla-business`) | YES | S5 trip tab-bars show NO hard rectangular shadow (elevation 0); S6 event/trip list cards render solid frosted with fill reaching corners. | S5, S6 files | This is the target surface |
+| 6. Admin Web (`mingla-admin`) — adjacent | NO | Admin does not render any of these components. | — | N/A |
+| 7. Business Web preview — adjacent | NO | Same as #3 — web glass path deferred to Sub-C. | — | N/A |
+
+**Cross-surface impact of the S2 gate fix (which other surfaces it touches — confirm acceptable):** flipping `isAndroidPreBlur → ANDROID_GLASS_USES_OPAQUE_FALLBACK` changes Android-12+ rendering for ALL consumers of the 8 chrome components: `GlassBottomNav` (every screen's bottom nav), `GlassTopBar` (top bars), `GlassIconButton` (all glass icon buttons app-wide), `GlassBadge` (badges), `GlassCard` (profile bento + any `GlassCard` consumer), `DiscoverScreen` (card top-badge / save button / bottom chip), `LikesPage` + `ConnectionsPage` sticky headers. **This is the intended, acceptable blast radius** per the operator's "one change powers the bottom nav, top bar, icon buttons, badges, sticky headers at once" directive: every one of these already has a designed, ≥0.92 opaque `fallbackSolid` token that was previously unreachable on Android 12+. The change makes them all *consistently solid frosted* — a uniform improvement, not a regression. iOS and Android ≤ 11 are byte-identical to today. Per-surface success criteria are SC-2a…SC-2f below so the tester verifies each consumer.
+
+**Manual-parity note:** S5 and S6 each touch TWO files with identical blocks — both must be edited (separate success criteria SC-5a/SC-5b, SC-6a/SC-6b) so neither is skipped.
+
+---
+
+## 6. Success criteria
+
+Observable, testable, per-surface where parity is manual.
+
+- **SC-1 (S1, Android):** On Android, the unread notification card shows a fully opaque warm-cream fill (`#FFFAF4`) that reaches all four rounded corners — no taupe/sand ring, no inset fill. Read cards show opaque `#FFFFFF` to the corners. Skeleton card matches.
+- **SC-1-iOS:** On iOS, the notification card is pixel-identical to pre-change (translucent `rgba(255,247,237,0.6)` unread, white read).
+- **SC-2 (S2/S4, Android):** On Android 12+, the bottom nav reads as a solid frosted dark capsule (`rgba(22,24,28,0.94)`), not see-through, over busy content.
+  - **SC-2a** Bottom nav (`GlassBottomNav`) solid.
+  - **SC-2b** Top bar (`GlassTopBar`) solid.
+  - **SC-2c** Glass icon buttons (`GlassIconButton`) solid.
+  - **SC-2d** Badges (`GlassBadge`) solid.
+  - **SC-2e** Sticky headers (`LikesPage`, `ConnectionsPage`) solid.
+  - **SC-2f** Profile bento (`GlassCard`) + Discover badges/save/chip (`DiscoverScreen`) solid.
+- **SC-2-iOS:** All eight chrome components render real BlurView on iOS exactly as today; Android ≤ 11 unchanged.
+- **SC-2-grep:** No `app-mobile` glass component retains a live `Platform.Version < 31` glass gate; all read the shared `ANDROID_GLASS_USES_OPAQUE_FALLBACK`.
+- **SC-3 (S3, Android):** The chat-input capsule renders a solid frosted dark fill (`rgba(22,24,28,0.94)`), not a 0.48-tint see-through blur, over the conversation. Capsule corners stay clipped.
+- **SC-3-iOS:** Chat capsule renders BlurView + tint floor exactly as today on iOS.
+- **SC-5a (S5):** `EditPublishedTripIntakeAccordion` active trip tab shows NO hard rectangular Android shadow; iOS glow + elevation unchanged.
+- **SC-5b (S5):** `TripCreatorStep6Intake` active trip tab — same.
+- **SC-6a (S6):** `EventListCard` host renders a solid frosted fill reaching the rounded corners on Android; no child content is clipped; iOS unchanged.
+- **SC-6b (S6):** `TripListCard` host — same.
+- **SC-7 (global):** ZERO touched-file change affects any surface outside §2.1. No `packages/event-rendering/*`, no third token file, no backend, no new dependency.
+
+---
+
+## 7. Invariants
+
+**Preserved:**
+- **I-7 (no `return null` for unsupported glass; visible degradation):** every changed branch renders a visible opaque View, never null. Verified by SC-2/SC-3.
+- **I-MOR-0827-PACKAGE-ISOLATION:** `packages/event-rendering/designTokens.ts` is NOT edited (no scoped file imports it for these surfaces).
+- **iOS-render-frozen:** every change is behind `Platform.select`/`ANDROID_GLASS_USES_OPAQUE_FALLBACK`; iOS branch is byte-identical. Verified by SC-1-iOS, SC-2-iOS, SC-3-iOS.
+
+**New (proposed for this strike, DRAFT → ACTIVE on CLOSE):**
+- **I-ANDROID-GLASS-OPAQUE-FALLBACK (DRAFT):** On Android, in-scope glass chrome surfaces render an opaque (≥ 0.92) `fallbackSolid` fill, never an `expo-blur` BlurView (unless a future ORCH explicitly validates a `dimezisBlurView` hero surface on-device). Enforced for the 8 chrome files + chat capsule by SC-2-grep + the regression test.
+- **I-ANDROID-ROUNDED-FILL-CLIPPED (DRAFT, scoped to S1/S6):** a rounded surface with a border/fill must carry `overflow:'hidden'` (or inner-clip view) so the fill reaches the corner on Android. (Full-codebase enforcement deferred to the sweep; this strike asserts it only on the scoped surfaces.)
+
+---
+
+## 8. Test cases & regression plan (orchestrator Step 0.5 gate)
+
+Pixel rendering can't be unit-asserted in this repo (consumer "tests" are source-pattern node scripts; business uses ts-jest `testEnvironment:node`). Tests are **style/Platform.select source assertions** — feasible and the established pattern (`app-mobile/src/components/__tests__/NotificationsSheet.test.tsx` reads source + asserts string patterns). On-device pixel verification is the tester's live-fire job (§8.3).
+
+### 8.1 Implementor happy-path test (REQUIRED — ships in the PR)
+
+Add a source-assertion test (consumer side: a node script under `app-mobile/scripts/ci/` or a `__tests__` source-reader matching the existing pattern; business side: a ts-jest source-reader test):
+
+| Test | Scenario | Assertion | Layer |
+|---|---|---|---|
+| T-01 | S2 shared gate exists | `designSystem.ts` exports `ANDROID_GLASS_USES_OPAQUE_FALLBACK = Platform.OS === 'android'`; `Platform` imported | Source |
+| T-02 | S2 gate adopted | each of the 8 chrome files imports `ANDROID_GLASS_USES_OPAQUE_FALLBACK` AND contains NO live `Platform.Version < 31` glass gate | Source |
+| T-03 | S1 clip + opaque unread | `NotificationsSheet.tsx` `notificationCard` + `skeletonCard` contain `overflow: 'hidden'`; `designSystem.ts` `cardUnreadBg` is a `Platform.select` with `android: '#FFFAF4'` | Source |
+| T-04 | S3 chat capsule guarded | `MessageInterface.tsx` capsule renders the opaque-fallback branch keyed on `ANDROID_GLASS_USES_OPAQUE_FALLBACK` with `glass.chrome.fallback.solid`; BlurView is no longer unconditional | Source |
+| T-05 | S5 elevation zeroed (×2) | both trip files' `tabActive` no longer contain a bare `elevation: 8`; Android elevation resolves to 0 (`Platform.select({…android:0…})` or `androidSafeElevation(8)`) | Source |
+| T-06 | S6 clip + opaque (×2) | both list-card files' `host` contain `overflow: 'hidden'` and an Android opaque fill (`rgba(20, 22, 26, 0.92)`) via `Platform.select` | Source |
+| T-07 | iOS frozen | every change retains the original iOS value in the `ios`/`default` branch (assert the original tokens still present) | Source |
+
+The happy-path test the implementor owns: **T-01 + T-03** (the shared gate exists and the photographed notification card is clipped + opaque on Android). The implementor wires these to a `package.json` script (consumer: `scripts/ci/meta-orch-1002-android-glass-check.mjs`; business: a `__tests__` ts-jest file) and adds them to the CI gate.
+
+### 8.2 Where the tester's adversarial test should attack
+
+- **Revert-canary:** assert the test FAILS if any chrome file's gate is reverted to `Platform.Version < 31` (catches partial adoption).
+- **iOS-regression guard:** assert NO `Platform.select` lost its `ios`/`default` branch and that iOS still renders BlurView for all 8 chrome + the chat capsule (the failure mode is "implementor made it opaque on iOS too").
+- **Token-leak guard:** assert no NEW translucent (`< 0.92` alpha) Android fill was introduced on the 6 surfaces; assert no `packages/event-rendering/*` or consumer↔business *other* token file was edited (I-MOR-0827 + no-triplication-divergence).
+- **Clip-without-crop:** on-device, verify S6 `overflow:'hidden'` on `host` does not clip an intentionally-overflowing child badge (the one judgment call flagged 🎨 OPEN in S6).
+- **Both-files parity:** assert S5 and S6 edited BOTH files (the skip-one failure mode).
+
+### 8.3 On-device live-fire (tester, MANDATORY for verdict)
+
+Per Prime Directive 7 + the success criteria: physical/emulated Android, before/after screenshots of (a) the notification card unread fill, (b) chat input + bottom nav over busy chat content, (c) the two trip tab-bars' active pill, (d) the two list cards; plus an iOS pass confirming no visual change. Metro port 8087, this worktree. Maestro/emulator drivers per the skill rules; never global-kill another session's Metro/sim.
+
+---
+
+## 9. Implementation order & hard guards
+
+**Order:**
+1. Consumer `designSystem.ts`: add `ANDROID_GLASS_USES_OPAQUE_FALLBACK` export + ensure `Platform` import; change `cardUnreadBg` to `Platform.select` with `android:'#FFFAF4'` (S1 token half).
+2. Consumer `NotificationsSheet.tsx`: add `overflow:'hidden'` to `notificationCard` + `skeletonCard` (S1).
+3. Consumer 8 chrome files: replace inline gate with the shared import (S2/S4).
+4. Consumer `MessageInterface.tsx`: gate the capsule blur → opaque fallback (S3).
+5. Business `EditPublishedTripIntakeAccordion.tsx` + `TripCreatorStep6Intake.tsx`: Android-zero the `tabActive` elevation (S5).
+6. Business `EventListCard.tsx` + `TripListCard.tsx`: `overflow:'hidden'` + Android opaque `host` fill (S6).
+7. Tests T-01…T-07 + wire CI scripts.
+
+**Hard guards (🔒 LOCKED):**
+- Touch ONLY the files in §2.1. No other component, no `packages/`, no `mingla-admin/`.
+- **No token-triplication divergence.** The consumer `designSystem.ts` and business `designSystem.ts` are edited independently (they are already separate sources). `packages/event-rendering/designTokens.ts` is NOT edited (no scoped file imports it for these surfaces). Note for the LATER sweep: when `GlassBlur.tsx` / public pages are fixed (Sub-C), the third token file participates — out of scope now.
+- No `supabase`/migration/edge-function/RLS touch. No new dependency. No `package.json` dep change (CI script entries only).
+- **Preserve iOS rendering EXACTLY** — every change is gated; no iOS branch value changes.
+- No `dimezisBlurView` added or removed on hero surfaces (out of scope); the existing `experimentalBlurMethod={android?'dimezisBlurView':undefined}` lines stay on the now-unreachable-on-Android blur branches (harmless dead-on-Android, preserved for the eventual hero-surface ORCH).
+
+---
+
+## 10. References examined
+
+- Consumer positive reference: `app-mobile/src/components/board/SwipeableSessionCards.tsx:699` (`overflow:'hidden'` + Platform-branched shadow).
+- Business canonical correct stack: `mingla-business/src/components/ui/GlassChrome.tsx` (clip view + `rgba(20,22,26,0.92)` opaque Android fallback + `shouldUseRealBlur()`), `mingla-business/src/constants/designSystem.ts:26` (`androidSafeElevation`).
+- expo-blur Android behavior: `BlurView.types.d.ts:2-11` — `experimentalBlurMethod` defaults `'none'` on Android = semi-transparent view fallback (investigation §2).
+- Premium frosted-surface intent (iOS source-of-truth look the Android opaque must match): Apple Music / iOS Control Center material; Linear & Things for solid-frosted card surfaces on non-blur platforms.
+
+---
+
+## 11. Open design questions (for Seth / mingla-designer, non-blocking — concrete values proposed)
+
+1. **Unread notification opaque cream** — proposed `#FFFAF4` (mathematically composited). A designer may warm it ±2/channel; ship `#FFFAF4` unless overridden. (🎨 OPEN, S1.)
+2. **Business card Android opaque fill** — proposed `rgba(20,22,26,0.92)` (kit-consistent, on-device-validated) vs. surface-true `#1D1B1C` (warmer, matches the card's own canvas). Ship `rgba(20,22,26,0.92)`. (🎨 OPEN, S6.)
+
+Everything else is 🔒 LOCKED.

--- a/app-mobile/package.json
+++ b/app-mobile/package.json
@@ -15,6 +15,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "expo lint",
+    "test:meta-orch-1002": "node ./scripts/ci/meta-orch-1002-android-glass-check.mjs",
     "test:orch-0749": "node ./scripts/ci/orch-0749-regression-check.mjs",
     "test:orch-0751": "node ./scripts/ci/orch-0751-revenuecat-logout-check.mjs",
     "test:orch-0809": "node ./scripts/ci/orch-0809-regression-check.mjs",

--- a/app-mobile/scripts/ci/meta-orch-1002-android-glass-adversarial-check.mjs
+++ b/app-mobile/scripts/ci/meta-orch-1002-android-glass-adversarial-check.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * META-ORCH-1002 Sub-1 (Android glass first strike) — TESTER ADVERSARIAL check.
+ *
+ * Different angle than the implementor happy-path test
+ * (meta-orch-1002-android-glass-check.mjs, which asserts the EXPECTED gate /
+ * clip / opaque-fill / iOS-branch are PRESENT). This test attacks the failure
+ * modes the happy-path cannot see — what must NOT have happened:
+ *
+ *   A-01  iOS-opaque-regression guard — every chrome file must still DERIVE
+ *         useGlass by NEGATING the gate (so iOS keeps the real BlurView). The
+ *         failure mode "implementor hard-coded the surface opaque on iOS too"
+ *         (gate used WITHOUT negation, or useGlass forced false) is caught here.
+ *   A-02  Translucent-leak guard — no NEW sub-0.92 translucent rgba was added as
+ *         an Android fill on the 6 scoped surfaces. Happy-path only checks the
+ *         expected opaque value is present; it would pass even if a stray
+ *         rgba(...,0.6) Android fill were ALSO introduced. We assert the exact
+ *         opaque values and that the Android branch is NOT a <0.92 rgba.
+ *   A-03  Package-isolation guard (I-MOR-0827) — packages/event-rendering/
+ *         designTokens.ts and GlassBlur.tsx are byte-untouched vs origin/main
+ *         (the third token file must NOT participate in this strike).
+ *   A-04  Both-files parity — S5 (2 files) and S6 (2 files) were BOTH edited;
+ *         the "edited one, skipped its twin" failure mode is caught.
+ *   A-05  Revert-canary — re-derives the gate-adoption invariant independently:
+ *         reverting ANY chrome file to a live `Platform.Version < 31` glass gate
+ *         must trip this test (asserts zero such gates remain across the 8).
+ *   A-06  No bare elevation:8 survives in either S5 trip tab block (the raw
+ *         Android shadow rectangle must be Platform-gated to 0).
+ *
+ * Cross-cutting: reads BOTH app-mobile/ and mingla-business/ source.
+ * Exit 1 on any FAIL.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const consumerRoot = path.resolve(__dirname, "../..");          // app-mobile/
+const repoRoot = path.resolve(consumerRoot, "..");              // monorepo root
+const businessRoot = path.join(repoRoot, "mingla-business");
+const pkgRoot = path.join(repoRoot, "packages/event-rendering");
+
+const readMaybe = (abs) => {
+  try {
+    return fs.readFileSync(abs, "utf8");
+  } catch {
+    return null;
+  }
+};
+const stripComments = (src) =>
+  (src || "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+const checks = [];
+const check = (name, pass, detail) => checks.push({ name, pass, detail });
+
+const CHROME_FILES = [
+  "src/components/GlassTopBar.tsx",
+  "src/components/GlassBottomNav.tsx",
+  "src/components/DiscoverScreen.tsx",
+  "src/components/LikesPage.tsx",
+  "src/components/ConnectionsPage.tsx",
+  "src/components/ui/GlassCard.tsx",
+  "src/components/ui/GlassBadge.tsx",
+  "src/components/ui/GlassIconButton.tsx",
+];
+
+// ─── A-01 + A-05: iOS keeps BlurView (gate negated) + no live version gate ────
+for (const rel of CHROME_FILES) {
+  const code = stripComments(readMaybe(path.join(consumerRoot, rel)));
+  // A-05 revert-canary: zero live Platform.Version < 31 glass gates remain.
+  check(
+    `A-05 ${rel} has NO live Platform.Version < 31 gate (revert-canary)`,
+    code !== "" && !/Platform\.Version\s*<\s*31/.test(code),
+    "Reverting this file to the per-component Android-11 gate must fail the suite.",
+  );
+  // A-01: the gate must be consumed as a NEGATION (useGlass = !... && !gate),
+  // i.e. iOS (gate===false) still yields the real-blur branch. We assert the
+  // alias is negated somewhere (the established useGlass/useBackdropGlass shape),
+  // catching a build where the surface was forced opaque on every platform.
+  const negated =
+    /!\s*ANDROID_GLASS_USES_OPAQUE_FALLBACK/.test(code) ||
+    /!\s*isAndroidPreBlur/.test(code) ||
+    /useGlass\s*=\s*[^;]*!\s*(isAndroidPreBlur|ANDROID_GLASS_USES_OPAQUE_FALLBACK)/.test(
+      code,
+    );
+  check(
+    `A-01 ${rel} consumes the gate as a NEGATION (iOS keeps BlurView)`,
+    code !== "" && negated,
+    "The opaque-fallback gate must be negated for the real-blur branch so iOS is unchanged.",
+  );
+}
+
+// ─── A-02: translucent-leak guard on the 6 scoped surfaces ────────────────────
+const TRANSLUCENT_RE = /rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*0?\.(?:[0-8]\d?|9[01])\s*\)/g;
+const ALLOWED_TRANSLUCENT = new Set([
+  // iOS-branch values that legitimately remain (these are NOT Android fills):
+  "rgba(255, 247, 237, 0.6)", // consumer unread cream — iOS branch
+  "rgba(255,247,237,0.6)",
+  "rgba(255, 255, 255, 0.04)", // business profileBase — iOS branch
+  "rgba(255,255,255,0.04)",
+  "rgba(255, 255, 255, 0.08)", // business border (border, not fill) — unchanged
+  "rgba(255,255,255,0.08)",
+]);
+
+// Consumer designSystem cardUnreadBg android branch must be the opaque hex.
+const designCode = stripComments(readMaybe(path.join(consumerRoot, "src/constants/designSystem.ts")));
+check(
+  "A-02 consumer cardUnreadBg Android branch is opaque #FFFAF4 (not a <0.92 rgba)",
+  /cardUnreadBg:\s*Platform\.select\(\{[\s\S]*?android:\s*['"]#FFFAF4['"]/.test(designCode) &&
+    !/cardUnreadBg:\s*Platform\.select\(\{[\s\S]*?android:\s*['"]rgba\([^)]*0?\.[0-8]/.test(designCode),
+  "The Android unread fill must be a fully-opaque hex, never a translucent rgba.",
+);
+
+// Business S6 host android branch must be opaque kit value, not a translucent rgba.
+for (const rel of [
+  "src/components/event/EventListCard.tsx",
+  "src/components/trip/TripListCard.tsx",
+]) {
+  const code = stripComments(readMaybe(path.join(businessRoot, rel)));
+  const hostBlock = (code.match(/host:\s*\{[\s\S]*?\n\s{2,4}\},/) || [""])[0];
+  check(
+    `A-02 business ${rel} host Android fill is opaque rgba(20, 22, 26, 0.92)`,
+    /android:\s*["']rgba\(20,\s*22,\s*26,\s*0\.92\)["']/.test(hostBlock),
+    "The Android host fill must be the >=0.92 kit-consistent opaque value.",
+  );
+  // No <0.92 rgba allowed as the Android branch of the host fill.
+  const androidLeak = (hostBlock.match(/android:\s*["']rgba\([^)]*0?\.(?:[0-8]\d?|9[01])\)["']/g) || []);
+  check(
+    `A-02 business ${rel} host has NO translucent (<0.92) Android fill`,
+    androidLeak.length === 0,
+    `Found translucent Android host fill(s): ${androidLeak.join(", ")}`,
+  );
+}
+
+// ─── A-03: package-isolation — third token file + GlassBlur untouched ─────────
+function isUnchangedVsMain(absPath) {
+  try {
+    const rel = path.relative(repoRoot, absPath);
+    const out = execFileSync("git", ["diff", "--name-only", "origin/main...HEAD", "--", rel], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return out.trim() === "";
+  } catch {
+    // Fallback: diff against the working tree main if origin/main is unavailable.
+    try {
+      const rel = path.relative(repoRoot, absPath);
+      const out = execFileSync("git", ["diff", "--name-only", "main...HEAD", "--", rel], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+      return out.trim() === "";
+    } catch {
+      return null; // cannot determine — reported below
+    }
+  }
+}
+for (const rel of ["designTokens.ts", "GlassBlur.tsx"]) {
+  const abs = path.join(pkgRoot, rel);
+  const unchanged = isUnchangedVsMain(abs);
+  check(
+    `A-03 packages/event-rendering/${rel} is byte-untouched vs main (I-MOR-0827)`,
+    unchanged === true || (unchanged === null && readMaybe(abs) !== null),
+    unchanged === false
+      ? "This strike must NOT edit the third token file / web glass path (deferred Sub-C)."
+      : "Could not git-diff the package file; ensure it was not edited.",
+  );
+}
+
+// ─── A-04 + A-06: S5 both-files parity + no bare elevation:8 ───────────────────
+for (const rel of [
+  "src/components/trip/EditPublishedTripIntakeAccordion.tsx",
+  "src/components/trip/TripCreatorStep6Intake.tsx",
+]) {
+  const code = stripComments(readMaybe(path.join(businessRoot, rel)));
+  check(
+    `A-04 business ${rel} tabActive Android elevation is Platform-gated to 0`,
+    /elevation:\s*Platform\.select\(\{[^}]*android:\s*0/.test(code) ||
+      /elevation:\s*androidSafeElevation\(/.test(code),
+    "Both S5 trip files must zero Android elevation (skip-one failure mode).",
+  );
+  check(
+    `A-06 business ${rel} has NO bare 'elevation: 8' survivor`,
+    !/elevation:\s*8\s*,/.test(code),
+    "A raw elevation:8 would still draw the hard Android shadow rectangle.",
+  );
+}
+
+// S6 both-files parity for overflow:'hidden'
+for (const rel of [
+  "src/components/event/EventListCard.tsx",
+  "src/components/trip/TripListCard.tsx",
+]) {
+  const code = stripComments(readMaybe(path.join(businessRoot, rel)));
+  const hostBlock = (code.match(/host:\s*\{[\s\S]*?\n\s{2,4}\},/) || [""])[0];
+  check(
+    `A-04 business ${rel} host carries overflow: 'hidden' (clip parity)`,
+    /overflow:\s*['"]hidden['"]/.test(hostBlock),
+    "Both S6 list-card files must clip the host to the radius.",
+  );
+}
+
+// ─── Report ───────────────────────────────────────────────────────────────────
+console.log("\nMETA-ORCH-1002 Sub-1 — TESTER adversarial check\n");
+let failed = 0;
+for (const c of checks) {
+  const tag = c.pass ? "PASS" : "FAIL";
+  console.log(`  [${tag}] ${c.name}`);
+  if (!c.pass) {
+    console.log(`         ${c.detail}`);
+    failed += 1;
+  }
+}
+console.log(
+  `\nSummary: ${checks.length - failed}/${checks.length} PASS${failed > 0 ? ` (${failed} FAIL)` : ""}\n`,
+);
+process.exit(failed > 0 ? 1 : 0);

--- a/app-mobile/scripts/ci/meta-orch-1002-android-glass-check.mjs
+++ b/app-mobile/scripts/ci/meta-orch-1002-android-glass-check.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * META-ORCH-1002 Sub-1 (Android glass first strike) — consumer-side regression check.
+ *
+ * Pixel rendering cannot be unit-asserted in this repo (these "tests" are
+ * source-pattern node scripts, matching the established app-mobile CI pattern).
+ * On-device pixel verification is the tester's live-fire job (SPEC §8.3).
+ *
+ * Asserts the consumer-side contract of SPEC_META-ORCH-1002_ANDROID_GLASS_FIRST_STRIKE.md:
+ *   T-01  S2 shared gate exists      (designSystem.ts exports the opaque-fallback boolean)
+ *   T-02  S2 gate adopted            (8 chrome files import it; NO live Platform.Version<31 gate)
+ *   T-03  S1 clip + opaque unread    (NotificationsSheet clipped; cardUnreadBg Android #FFFAF4)
+ *   T-04  S3 chat capsule guarded    (MessageInterface routes Android to opaque fallback)
+ *   T-07  iOS frozen (consumer)      (every Platform.select kept its ios/default original value)
+ *
+ * Exit 1 on any FAIL.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "../..");
+
+const readMaybe = (absRel) => {
+  try {
+    return fs.readFileSync(absRel, "utf8");
+  } catch {
+    return null;
+  }
+};
+
+// Strip line + block comments so we never match the literal version-gate string
+// that appears in our own explanatory comments.
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+const checks = [];
+const check = (name, pass, detail) => {
+  checks.push({ name, pass, detail });
+};
+
+const CHROME_FILES = [
+  "src/components/GlassTopBar.tsx",
+  "src/components/GlassBottomNav.tsx",
+  "src/components/DiscoverScreen.tsx",
+  "src/components/LikesPage.tsx",
+  "src/components/ConnectionsPage.tsx",
+  "src/components/ui/GlassCard.tsx",
+  "src/components/ui/GlassBadge.tsx",
+  "src/components/ui/GlassIconButton.tsx",
+];
+
+const design = readMaybe(path.join(root, "src/constants/designSystem.ts"));
+const designCode = design ? stripComments(design) : "";
+
+// ─── T-01: S2 shared gate exists ────────────────────────────────────────────
+check(
+  "T-01 designSystem.ts exports ANDROID_GLASS_USES_OPAQUE_FALLBACK = Platform.OS === 'android'",
+  design !== null &&
+    /export\s+const\s+ANDROID_GLASS_USES_OPAQUE_FALLBACK\s*=\s*Platform\.OS\s*===\s*['"]android['"]/.test(
+      designCode,
+    ),
+  "The shared Android-opaque-fallback gate must be a single exported boolean.",
+);
+check(
+  "T-01 designSystem.ts imports Platform from react-native",
+  design !== null &&
+    /import\s+\{[^}]*\bPlatform\b[^}]*\}\s+from\s+['"]react-native['"]/.test(
+      designCode,
+    ),
+  "Platform must be imported for the gate + cardUnreadBg Platform.select.",
+);
+
+// ─── T-02: S2 gate adopted in all 8 chrome files ────────────────────────────
+for (const rel of CHROME_FILES) {
+  const src = readMaybe(path.join(root, rel));
+  const code = src ? stripComments(src) : "";
+  check(
+    `T-02 ${rel} imports ANDROID_GLASS_USES_OPAQUE_FALLBACK`,
+    src !== null &&
+      /ANDROID_GLASS_USES_OPAQUE_FALLBACK/.test(code) &&
+      new RegExp(
+        "import\\s+\\{[^}]*ANDROID_GLASS_USES_OPAQUE_FALLBACK[^}]*\\}\\s+from\\s+['\"][^'\"]*constants/designSystem['\"]",
+      ).test(code),
+    "Each chrome file must import the shared gate.",
+  );
+  check(
+    `T-02 ${rel} retains NO live Platform.Version < 31 glass gate`,
+    src !== null && !/Platform\.Version\s*<\s*31/.test(code),
+    "No file may keep the per-component Android-11 version gate after the strike.",
+  );
+}
+
+// ─── T-03: S1 clip + opaque unread ──────────────────────────────────────────
+const notif = readMaybe(path.join(root, "src/components/NotificationsSheet.tsx"));
+const notifCode = notif ? stripComments(notif) : "";
+check(
+  "T-03 NotificationsSheet notificationCard has overflow: 'hidden'",
+  notif !== null &&
+    /notificationCard:\s*\{[\s\S]*?overflow:\s*['"]hidden['"][\s\S]*?\},/.test(
+      notifCode,
+    ),
+  "notificationCard must clip fill+border to the radius (kills the corner ring).",
+);
+check(
+  "T-03 NotificationsSheet skeletonCard has overflow: 'hidden'",
+  notif !== null &&
+    /skeletonCard:\s*\{[\s\S]*?overflow:\s*['"]hidden['"][\s\S]*?\},/.test(
+      notifCode,
+    ),
+  "skeletonCard must clip to the radius (mirror notificationCard).",
+);
+check(
+  "T-03 designSystem cardUnreadBg is a Platform.select with android: '#FFFAF4'",
+  design !== null &&
+    /cardUnreadBg:\s*Platform\.select\(\{[\s\S]*?android:\s*['"]#FFFAF4['"][\s\S]*?\}\)/.test(
+      designCode,
+    ),
+  "Unread fill must be opaque #FFFAF4 on Android via Platform.select.",
+);
+
+// ─── T-04: S3 chat capsule guarded ──────────────────────────────────────────
+const msg = readMaybe(path.join(root, "src/components/MessageInterface.tsx"));
+const msgCode = msg ? stripComments(msg) : "";
+check(
+  "T-04 MessageInterface imports ANDROID_GLASS_USES_OPAQUE_FALLBACK",
+  msg !== null && /ANDROID_GLASS_USES_OPAQUE_FALLBACK/.test(msgCode),
+  "The chat capsule must read the shared gate.",
+);
+check(
+  "T-04 MessageInterface capsule renders the opaque fallback branch keyed on the gate",
+  msg !== null &&
+    /ANDROID_GLASS_USES_OPAQUE_FALLBACK\s*\?\s*\([\s\S]*?glass\.chrome\.fallback\.solid/.test(
+      msgCode,
+    ),
+  "On Android the capsule must paint glass.chrome.fallback.solid, not the BlurView.",
+);
+check(
+  "T-04 MessageInterface BlurView is no longer the unconditional first child of the capsule",
+  msg !== null &&
+    !/inputCapsule\}\s*>\s*<BlurView/.test(msgCode.replace(/\s+/g, " ").replace(/\] >/g, "]>")),
+  "The BlurView must now live behind the iOS branch of the gate, not unconditionally.",
+);
+
+// ─── T-07: iOS frozen (consumer) ────────────────────────────────────────────
+check(
+  "T-07 cardUnreadBg keeps the original iOS/default translucent cream",
+  design !== null &&
+    /cardUnreadBg:\s*Platform\.select\(\{[\s\S]*?ios:\s*['"]rgba\(255,\s*247,\s*237,\s*0\.6\)['"][\s\S]*?default:\s*['"]rgba\(255,\s*247,\s*237,\s*0\.6\)['"]/.test(
+      designCode,
+    ),
+  "iOS must render the exact pre-change translucent cream (byte-identical).",
+);
+check(
+  "T-07 MessageInterface keeps the BlurView + tint floor on the iOS branch",
+  msg !== null &&
+    /<BlurView[\s\S]*?glass\.chrome\.blur\.intensity[\s\S]*?glass\.chrome\.tint\.floor/.test(
+      msgCode,
+    ),
+  "iOS must still render the BlurView + 0.48 tint floor exactly as today.",
+);
+
+// ─── Report ──────────────────────────────────────────────────────────────────
+console.log("\nMETA-ORCH-1002 Sub-1 — consumer Android glass check\n");
+let failed = 0;
+for (const c of checks) {
+  const tag = c.pass ? "PASS" : "FAIL";
+  console.log(`  [${tag}] ${c.name}`);
+  if (!c.pass) {
+    console.log(`         ${c.detail}`);
+    failed += 1;
+  }
+}
+console.log(
+  `\nSummary: ${checks.length - failed}/${checks.length} PASS${
+    failed > 0 ? ` (${failed} FAIL)` : ""
+  }\n`,
+);
+process.exit(failed > 0 ? 1 : 0);

--- a/app-mobile/src/components/ConnectionsPage.tsx
+++ b/app-mobile/src/components/ConnectionsPage.tsx
@@ -40,7 +40,7 @@ import { Friend, Message } from "../services/connectionsService";
 import { useScreenLogger } from "../hooks/useScreenLogger";
 import { useKeyboard } from "../hooks/useKeyboard";
 import { useAppLayout } from "../hooks/useAppLayout";
-import { colors, spacing, typography, fontWeights, glass } from "../constants/designSystem";
+import { colors, spacing, typography, fontWeights, glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from "../constants/designSystem";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNetworkMonitor } from "../services/networkMonitor";
 import { withTimeout } from "../utils/withTimeout";
@@ -371,7 +371,8 @@ interface PairedPillPerson {
   incomingRequest?: PairRequest;
 }
 
-const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 // Compact dark-glass paired pill — horizontal inside the filter-bar-style row.
 // ORCH-0600: replaces the ORCH-0435 vertical avatar+name stack with a row pill

--- a/app-mobile/src/components/DiscoverScreen.tsx
+++ b/app-mobile/src/components/DiscoverScreen.tsx
@@ -63,7 +63,7 @@ import { useSavedCards } from "../hooks/useSavedCards";
 import { savedCardsService } from "../services/savedCardsService";
 import { savedCardKeys } from "../hooks/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
-import { glass } from "../constants/designSystem";
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from "../constants/designSystem";
 // ORCH-0809 M2: city picker + segment switcher
 import { CityPickerSheet } from "./discover/CityPickerSheet";
 import {
@@ -93,7 +93,8 @@ const SCREEN_WIDTH = Dimensions.get("window").width;
 const d = glass.discover;
 const GRID_CARD_WIDTH = (SCREEN_WIDTH - d.grid.horizontalPadding * 2 - d.grid.columnGap) / 2;
 const GRID_CARD_HEIGHT = GRID_CARD_WIDTH / d.card.aspectRatio;
-const isAndroidPreBlur = Platform.OS === "android" && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 interface NightOutCardData {
   id: string;

--- a/app-mobile/src/components/GlassBottomNav.tsx
+++ b/app-mobile/src/components/GlassBottomNav.tsx
@@ -35,7 +35,7 @@ import Animated, {
 import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import { Icon, type IconName } from './ui/Icon';
-import { glass } from '../constants/designSystem';
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from '../constants/designSystem';
 
 const c = glass.chrome;
 
@@ -63,7 +63,8 @@ export type GlassBottomNavProps = {
   coachLikesRef?: (node: View | null) => void;
 };
 
-const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2/S4): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 const TAB_ORDER: BottomNavPage[] = ['home', 'discover', 'connections', 'likes', 'profile'];
 

--- a/app-mobile/src/components/GlassTopBar.tsx
+++ b/app-mobile/src/components/GlassTopBar.tsx
@@ -23,7 +23,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurView } from 'expo-blur';
 import { LinearGradient } from 'expo-linear-gradient';
 import { GlassIconButton } from './ui/GlassIconButton';
-import { glass } from '../constants/designSystem';
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from '../constants/designSystem';
 
 const c = glass.chrome;
 
@@ -78,7 +78,8 @@ export const GlassTopBar: React.FC<GlassTopBarProps> = ({
     };
   }, []);
 
-  const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+  // META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+  const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
   const useBackdropGlass = !reduceTransparency && !isAndroidPreBlur;
 
   useEffect(() => {

--- a/app-mobile/src/components/LikesPage.tsx
+++ b/app-mobile/src/components/LikesPage.tsx
@@ -23,14 +23,15 @@ import CalendarTab from "./activity/CalendarTab";
 import { mixpanelService } from "../services/mixpanelService";
 import { useScreenLogger } from "../hooks/useScreenLogger";
 import { useAppLayout } from "../hooks/useAppLayout";
-import { glass } from "../constants/designSystem";
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from "../constants/designSystem";
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from "../store/appStore";
 
 // Tab types for Likes screen
 export type LikesTab = "saved" | "calendar";
 
-const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 interface LikesPageProps {
   isTabVisible?: boolean;

--- a/app-mobile/src/components/MessageInterface.tsx
+++ b/app-mobile/src/components/MessageInterface.tsx
@@ -65,7 +65,7 @@ import type { ExpandedCardData } from "../types/expandedCardTypes";  // ORCH-068
 import type { BusinessEventCard } from "../types/mergedDiscover";
 import { useTranslation } from 'react-i18next';
 import { HapticFeedback } from "../utils/hapticFeedback";
-import { colors as dsColors, spacing as dsSpacing, glass } from "../constants/designSystem";
+import { colors as dsColors, spacing as dsSpacing, glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from "../constants/designSystem";
 import { colors } from "../constants/colors";
 import { useAppLayout } from "../hooks/useAppLayout";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -1909,17 +1909,28 @@ export default function MessageInterface({
           keyboardHeight={0}
         />
         <View style={styles.inputCapsule}>
-          <BlurView
-            intensity={glass.chrome.blur.intensity}
-            tint="dark"
-            experimentalBlurMethod={Platform.OS === "android" ? "dimezisBlurView" : undefined}
-            style={StyleSheet.absoluteFill}
-            pointerEvents="none"
-          />
-          <View
-            pointerEvents="none"
-            style={[StyleSheet.absoluteFill, { backgroundColor: glass.chrome.tint.floor }]}
-          />
+          {/* META-ORCH-1002 Sub-1 (S3): on Android render a solid frosted fill instead of
+              the see-through BlurView + 0.48 tint floor. iOS path is byte-identical. */}
+          {ANDROID_GLASS_USES_OPAQUE_FALLBACK ? (
+            <View
+              pointerEvents="none"
+              style={[StyleSheet.absoluteFill, { backgroundColor: glass.chrome.fallback.solid }]}
+            />
+          ) : (
+            <>
+              <BlurView
+                intensity={glass.chrome.blur.intensity}
+                tint="dark"
+                experimentalBlurMethod={Platform.OS === "android" ? "dimezisBlurView" : undefined}
+                style={StyleSheet.absoluteFill}
+                pointerEvents="none"
+              />
+              <View
+                pointerEvents="none"
+                style={[StyleSheet.absoluteFill, { backgroundColor: glass.chrome.tint.floor }]}
+              />
+            </>
+          )}
           <View style={styles.inputContainer}>
           {/* Attachment Menu */}
           <View style={styles.attachmentContainer}>

--- a/app-mobile/src/components/NotificationsSheet.tsx
+++ b/app-mobile/src/components/NotificationsSheet.tsx
@@ -961,6 +961,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: glass.notificationsSheet.cardBorder,
     backgroundColor: '#FFFFFF',
+    // META-ORCH-1002 Sub-1 (S1): clip fill+border to the radius so the fill reaches
+    // the rounded corner on Android (kills the inset taupe ring). iOS unaffected.
+    overflow: 'hidden',
     flexDirection: 'row',
     alignItems: 'flex-start',
     gap: 12,
@@ -1192,6 +1195,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: glass.notificationsSheet.cardBorder,
     backgroundColor: '#FFFFFF',
+    // META-ORCH-1002 Sub-1 (S1): clip to radius on Android (mirror notificationCard).
+    overflow: 'hidden',
     ...glass.notificationsSheet.cardShadow,
   },
   skeletonAvatar: {

--- a/app-mobile/src/components/ui/GlassBadge.tsx
+++ b/app-mobile/src/components/ui/GlassBadge.tsx
@@ -33,7 +33,7 @@ import type { StyleProp, ViewStyle } from 'react-native';
 import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import { Icon, type IconName } from './Icon';
-import { glass } from '../../constants/designSystem';
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from '../../constants/designSystem';
 
 const t = glass.badge;
 
@@ -51,7 +51,8 @@ export type GlassBadgeProps = {
   entryIndex?: number;
 };
 
-const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 export const GlassBadge: React.FC<GlassBadgeProps> = ({
   variant = 'default',

--- a/app-mobile/src/components/ui/GlassCard.tsx
+++ b/app-mobile/src/components/ui/GlassCard.tsx
@@ -28,7 +28,7 @@ import {
 } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 import { BlurView } from 'expo-blur';
-import { glass } from '../../constants/designSystem';
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from '../../constants/designSystem';
 
 export type GlassCardVariant = 'base' | 'elevated';
 
@@ -39,7 +39,8 @@ export type GlassCardProps = {
   accessibilityLabel?: string;
 };
 
-const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 export const GlassCard: React.FC<GlassCardProps> = ({
   variant = 'base',

--- a/app-mobile/src/components/ui/GlassIconButton.tsx
+++ b/app-mobile/src/components/ui/GlassIconButton.tsx
@@ -34,7 +34,7 @@ import type { ViewStyle } from 'react-native';
 import { BlurView } from 'expo-blur';
 import * as Haptics from 'expo-haptics';
 import { Icon, type IconName } from './Icon';
-import { glass } from '../../constants/designSystem';
+import { glass, ANDROID_GLASS_USES_OPAQUE_FALLBACK } from '../../constants/designSystem';
 
 const c = glass.chrome;
 
@@ -52,7 +52,8 @@ export type GlassIconButtonProps = {
   liquid?: boolean;
 };
 
-const isAndroidPreBlur = Platform.OS === 'android' && Platform.Version < 31;
+// META-ORCH-1002 Sub-1 (S2): shared Android-opaque-fallback gate (was the per-component Android-11 version gate).
+const isAndroidPreBlur = ANDROID_GLASS_USES_OPAQUE_FALLBACK;
 
 export const GlassIconButton: React.FC<GlassIconButtonProps> = ({
   iconName,

--- a/app-mobile/src/constants/designSystem.ts
+++ b/app-mobile/src/constants/designSystem.ts
@@ -1,7 +1,15 @@
 // Design System Constants for Mingla App
 // Phase 1: Foundation & Core Polish
 
+import { Platform } from 'react-native';
 import { vs, ms } from '../utils/responsive';
+
+// META-ORCH-1002 Sub-1: Android glass policy = OPAQUE frosted fallback by default.
+// expo-blur on Android renders a thin semi-transparent view (or, with dimezisBlurView,
+// an unreliable experimental blur). Policy Option 1: route ALL Android to the opaque
+// fallbackSolid branch; reserve real blur for on-device-validated hero surfaces only.
+// Replaces the per-component Android-11 version gate that left Android 12+ on BlurView.
+export const ANDROID_GLASS_USES_OPAQUE_FALLBACK = Platform.OS === 'android';
 
 export const spacing = {
   xxs: 2,   // 2px — ultra-compact message grouping
@@ -318,7 +326,14 @@ export const glass = {
       elevation: 2,
     },
     cardBorder: 'rgba(0, 0, 0, 0.06)',
-    cardUnreadBg: 'rgba(255, 247, 237, 0.6)',
+    // META-ORCH-1002 Sub-1 (S1): on Android the translucent cream let the card border
+    // show through at the clipped corner. Composite over the #FFFFFF card = opaque #FFFAF4.
+    // iOS keeps the exact translucent value (byte-identical render).
+    cardUnreadBg: Platform.select({
+      ios: 'rgba(255, 247, 237, 0.6)',
+      android: '#FFFAF4',
+      default: 'rgba(255, 247, 237, 0.6)',
+    }),
     avatarRing: {
       unread: 'rgba(235, 120, 37, 0.35)',
       read: 'rgba(0, 0, 0, 0.06)',

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -18,6 +18,7 @@
     "lint": "expo lint",
     "typecheck": "tsc",
     "test:browser": "playwright test -c playwright.config.ts",
+    "test:meta-orch-1002": "npx jest metaOrch1002AndroidGlass.test --runInBand",
     "test:orch-0964-assetlinks": "npx jest assetlinks.consumerAppLinks.test --runInBand",
     "test:orch-0754": "node ../.github/scripts/strict-grep/i-proposed-z-home-no-fabricated-events.mjs && npx jest brandEventSummary.test",
     "test:orch-0756a": "node ../.github/scripts/strict-grep/orch-0756a-active-brand-recovery.mjs && npx jest currentBrandResolver.test",

--- a/mingla-business/src/components/__tests__/metaOrch1002AndroidGlass.test.ts
+++ b/mingla-business/src/components/__tests__/metaOrch1002AndroidGlass.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * META-ORCH-1002 Sub-1 (Android glass first strike) — business-side regression check.
+ *
+ * Pixel rendering can't be unit-asserted (ts-jest testEnvironment:node). These are
+ * style/Platform.select source assertions — the established business CI pattern.
+ * On-device pixel verification is the tester's live-fire job (SPEC §8.3).
+ *
+ *   T-05  S5 elevation zeroed on Android (×2 trip tab-bars); iOS elevation:8 kept
+ *   T-06  S6 host clipped + opaque Android fill (×2 list cards); iOS profileBase kept
+ *   T-07  iOS frozen (business): every Platform.select keeps its ios/default original
+ */
+
+const componentsDir = path.resolve(__dirname, "..");
+const read = (rel: string): string =>
+  fs.readFileSync(path.join(componentsDir, rel), "utf8");
+
+// Strip comments so our own explanatory comments never satisfy/false-trip a match.
+const stripComments = (src: string): string =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+
+const S5_FILES = [
+  "trip/EditPublishedTripIntakeAccordion.tsx",
+  "trip/TripCreatorStep6Intake.tsx",
+];
+const S6_FILES = ["event/EventListCard.tsx", "trip/TripListCard.tsx"];
+
+describe("META-ORCH-1002 Sub-1 — S5 trip tab-bar Android elevation zeroed", () => {
+  test.each(S5_FILES)("%s tabActive Android elevation resolves to 0", (rel) => {
+    const code = stripComments(read(rel));
+    // No bare `elevation: 8` remains.
+    expect(code).not.toMatch(/elevation:\s*8\s*,/);
+    // Android elevation is explicitly zeroed via Platform.select (ios:8, android:0).
+    const tabActive = code.match(/tabActive:\s*\{[\s\S]*?\n\s{2}\},/);
+    expect(tabActive).not.toBeNull();
+    expect(tabActive![0]).toMatch(
+      /elevation:\s*Platform\.select\(\{[\s\S]*?ios:\s*8[\s\S]*?android:\s*0[\s\S]*?\}\)/,
+    );
+  });
+
+  test.each(S5_FILES)("%s imports Platform from react-native", (rel) => {
+    const code = stripComments(read(rel));
+    expect(code).toMatch(
+      /import\s+\{[^}]*\bPlatform\b[^}]*\}\s+from\s+["']react-native["']/,
+    );
+  });
+});
+
+describe("META-ORCH-1002 Sub-1 — S6 list-card host clipped + opaque on Android", () => {
+  test.each(S6_FILES)("%s host has overflow: 'hidden'", (rel) => {
+    const code = stripComments(read(rel));
+    const host = code.match(/host:\s*\{[\s\S]*?\n\s{2}\},/);
+    expect(host).not.toBeNull();
+    expect(host![0]).toMatch(/overflow:\s*["']hidden["']/);
+    // The old non-clipping value must be gone from the host block.
+    expect(host![0]).not.toMatch(/overflow:\s*["']visible["']/);
+  });
+
+  test.each(S6_FILES)(
+    "%s host uses opaque rgba(20,22,26,0.92) Android fill via Platform.select",
+    (rel) => {
+      const code = stripComments(read(rel));
+      const host = code.match(/host:\s*\{[\s\S]*?\n\s{2}\},/);
+      expect(host).not.toBeNull();
+      expect(host![0]).toMatch(
+        /backgroundColor:\s*Platform\.select\(\{[\s\S]*?android:\s*["']rgba\(20,\s*22,\s*26,\s*0\.92\)["']/,
+      );
+    },
+  );
+});
+
+describe("META-ORCH-1002 Sub-1 — T-07 iOS frozen (business)", () => {
+  test.each(S5_FILES)("%s keeps iOS elevation 8 + glow shadow", (rel) => {
+    const code = stripComments(read(rel));
+    expect(code).toMatch(/shadowColor:\s*["']#eb7825["']/);
+    expect(code).toMatch(/ios:\s*8/);
+  });
+
+  test.each(S6_FILES)("%s keeps iOS translucent profileBase fill", (rel) => {
+    const code = stripComments(read(rel));
+    const host = code.match(/host:\s*\{[\s\S]*?\n\s{2}\},/);
+    expect(host).not.toBeNull();
+    expect(host![0]).toMatch(/ios:\s*glass\.tint\.profileBase/);
+    expect(host![0]).toMatch(/default:\s*glass\.tint\.profileBase/);
+  });
+});

--- a/mingla-business/src/components/event/EventListCard.tsx
+++ b/mingla-business/src/components/event/EventListCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useMemo } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 
 import {
   accent,
@@ -274,11 +274,19 @@ const StatusPill: React.FC<StatusPillProps> = ({ status }) => {
 const styles = StyleSheet.create({
   host: {
     position: "relative",
-    backgroundColor: glass.tint.profileBase,
+    // META-ORCH-1002 Sub-1 (S6): opaque frosted fill on Android (the translucent
+    // rgba(255,255,255,0.04) let the corner ring show); kit-consistent rgba(20,22,26,0.92).
+    // iOS keeps the translucent profileBase. All children are positioned inside host
+    // bounds (no intentional overflow), so clipping to the radius is safe.
+    backgroundColor: Platform.select({
+      ios: glass.tint.profileBase,
+      android: "rgba(20, 22, 26, 0.92)",
+      default: glass.tint.profileBase,
+    }),
     borderRadius: radiusTokens.lg,
     borderWidth: 1,
     borderColor: glass.border.profileBase,
-    overflow: "visible",
+    overflow: "hidden",
   },
   hostFaded: {
     opacity: 0.7,

--- a/mingla-business/src/components/trip/EditPublishedTripIntakeAccordion.tsx
+++ b/mingla-business/src/components/trip/EditPublishedTripIntakeAccordion.tsx
@@ -25,6 +25,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  Platform,
   Pressable,
   StyleSheet,
   Text,
@@ -524,7 +525,9 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.35,
     shadowRadius: 14,
-    elevation: 8,
+    // META-ORCH-1002 Sub-1 (S5): zero the Android elevation so no hard rectangular
+    // shadow draws under the rounded pill (mirrors androidSafeElevation). iOS glow kept.
+    elevation: Platform.select({ ios: 8, android: 0, default: 8 }),
   },
   tabAdd: {
     borderColor: accent.border,

--- a/mingla-business/src/components/trip/TripCreatorStep6Intake.tsx
+++ b/mingla-business/src/components/trip/TripCreatorStep6Intake.tsx
@@ -19,7 +19,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, View, useWindowDimensions } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, View, useWindowDimensions } from "react-native";
 
 import {
   accent,
@@ -299,7 +299,9 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.35,
     shadowRadius: 14,
-    elevation: 8,
+    // META-ORCH-1002 Sub-1 (S5): zero the Android elevation so no hard rectangular
+    // shadow draws under the rounded pill (mirrors androidSafeElevation). iOS glow kept.
+    elevation: Platform.select({ ios: 8, android: 0, default: 8 }),
   },
   tabAdd: {
     borderColor: accent.border,

--- a/mingla-business/src/components/trip/TripListCard.tsx
+++ b/mingla-business/src/components/trip/TripListCard.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useMemo } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 
 import {
   accent,
@@ -246,11 +246,19 @@ const TripStatusPill: React.FC<TripStatusPillProps> = ({ status, startAt }) => {
 const styles = StyleSheet.create({
   host: {
     position: "relative",
-    backgroundColor: glass.tint.profileBase,
+    // META-ORCH-1002 Sub-1 (S6): opaque frosted fill on Android (the translucent
+    // rgba(255,255,255,0.04) let the corner ring show); kit-consistent rgba(20,22,26,0.92).
+    // iOS keeps the translucent profileBase. All children are positioned inside host
+    // bounds (no intentional overflow), so clipping to the radius is safe.
+    backgroundColor: Platform.select({
+      ios: glass.tint.profileBase,
+      android: "rgba(20, 22, 26, 0.92)",
+      default: glass.tint.profileBase,
+    }),
     borderRadius: radiusTokens.lg,
     borderWidth: 1,
     borderColor: glass.border.profileBase,
-    overflow: "visible",
+    overflow: "hidden",
   },
   hostFaded: {
     opacity: 0.7,


### PR DESCRIPTION
## META-ORCH-1002 [Android glass hardening] — Sub-1 (fast first strike)

Fixes two Android-only glass rendering defects on the 6 highest-visibility surfaces; iOS unchanged.

**Symptom A — "fill doesn't fill the card" (inset taupe ring):** rounded surfaces combining border + elevation + a translucent/same-as-parent fill composite badly at the corners on Android. Fixed with `overflow:'hidden'` + opaque Android fill + no Android shadow under the rounded fill.

**Symptom B — "sheets too transparent":** a per-component `Platform.Version < 31` gate left the opaque fallback unreachable on Android 12+. Replaced the inline gate in 8 chrome files with one shared exported boolean `ANDROID_GLASS_USES_OPAQUE_FALLBACK` → all modern Android now takes the existing opaque `fallbackSolid` branch.

### Scope (SPEC §2.1 — nothing wider)
- Consumer: `designSystem.ts` (shared gate + `cardUnreadBg` → `#FFFAF4` on Android), `NotificationsSheet.tsx`, 8 chrome files, `MessageInterface.tsx` chat capsule.
- Business: `EditPublishedTripIntakeAccordion.tsx` + `TripCreatorStep6Intake.tsx` (Android `elevation:0`), `EventListCard.tsx` + `TripListCard.tsx` (opaque fill + clip).

### Evidence
- On-device live-fire on physical Samsung SM-A725F: notification card ring gone, chrome reads solid frosted. Before/after crops in QA report.
- Regression: consumer 26/26, business 12/12, tester adversarial 29/29; fails-on-revert verified.
- iOS branches byte-identical (Platform.select).
- No backend/migration/edge/dependency change; `packages/event-rendering/*` untouched.

Verdict: CONDITIONAL PASS — consumer surfaces proven on-device; business S5/S6 source-verified + test-covered (build-drift blocked the screenshot; covered in the full sweep).

Full sweep (remaining ~95 consumer + ~215 business + shared public pages) deferred to follow-up sub-tracks.

[deploy] tag: touches `mingla-business/src/`.