### PR TITLE
ORCH-1013: Place Intel multi-run control tower + coverage-math fix + admin Tailwind drift

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1007,6 +1007,8 @@ function checkNoNewBackendFiles() {
   const ORCH_1013_BACKEND_ALLOWLIST = [
     "supabase/functions/run-place-intelligence-trial/index.ts",
     "supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts",
+    // ORCH-1013 QA adversarial tests (no production code touched)
+    "supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts",
   ];
   const ALLOWLIST = [
     ...ORCH_0989_BACKEND_ALLOWLIST,

--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1000,6 +1000,14 @@ function checkNoNewBackendFiles() {
     "supabase/functions/run-place-intelligence-trial/__tests__/runRemainder.test.ts",
     "supabase/functions/run-place-intelligence-trial/__tests__/runRemainder_adversarial.test.ts",
   ];
+  // ORCH-1013 [Place Intel control tower + coverage-math fix + admin Tailwind
+  // drift]. Finding A patches handleIntelligenceCoverage to JOIN place_pool on
+  // is_servable so the "evaluated" set excludes drifted rows; Finding C is
+  // operational (no file edits). Per COMMS-0002.
+  const ORCH_1013_BACKEND_ALLOWLIST = [
+    "supabase/functions/run-place-intelligence-trial/index.ts",
+    "supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts",
+  ];
   const ALLOWLIST = [
     ...ORCH_0989_BACKEND_ALLOWLIST,
     ...ORCH_0990_BACKEND_ALLOWLIST,
@@ -1054,6 +1062,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_0977_BACKEND_ALLOWLIST,
     ...ORCH_0978_BACKEND_ALLOWLIST,
     ...ORCH_1008_BACKEND_ALLOWLIST,
+    ...ORCH_1013_BACKEND_ALLOWLIST,
   ];
   const forbidden = changed.filter(
     (p) =>

--- a/Mingla_Artifacts/WORKTREE_REGISTRY.md
+++ b/Mingla_Artifacts/WORKTREE_REGISTRY.md
@@ -17,7 +17,6 @@ Reference: [WORKTREE_STRATEGY.md](WORKTREE_STRATEGY.md).
 | `~/Desktop/mingla-orchs/meta-orch-0952-[buyer-web-confirm-deep-forensics]` | `meta-orch-0952-buyer-web-confirm-deep-forensics` | META-ORCH-0952 | INVESTIGATE | no sim — buyer-web (Playwright Chromium + Safari) | 8083 | 2026-05-24 | Claude `mingla-orchestrator` (dispatch) → Claude `mingla-forensics` (active) |
 | `~/Desktop/mingla-orchs/ORCH-0990-[flower-stop-real-florists]` | `ORCH-0990-flower-stop-real-florists` | ORCH-0990 | SPEC | no sim — backend-only (edge fn + RPC + place_pool data) | 8086 | 2026-05-29 | Claude `mingla-orchestrator` (dispatch) → Claude `mingla-forensics` (active) |
 | `~/Desktop/mingla-orchs/ORCH-1006-[universal-allin-pricing-engine]` | `ORCH-1006-universal-allin-pricing-engine` | ORCH-1006 | INVESTIGATE done → awaiting SPEC | TBD (native checkout) | 8091 | 2026-05-29 | Claude `mingla-orchestrator` (dispatch) → Claude `mingla-forensics` (active) |
-| `~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]` | `ORCH-1013-place-intel-control-tower-coverage-fix` | ORCH-1013 | SPEC | no sim — admin-web (Vite) | 8087 | 2026-05-30 | Claude `mingla-orchestrator` (dispatch) → Claude `mingla-forensics` (active) |
 
 ---
 

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md
@@ -1,0 +1,365 @@
+# IMPLEMENTATION — ORCH-1013 Place Intel Control Tower + Coverage Fix + Admin Tailwind Drift Fix
+
+- **ORCH-ID:** ORCH-1013
+- **Branch:** `ORCH-1013-place-intel-control-tower-coverage-fix`
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]/`
+- **SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md`
+- **Date:** 2026-05-30
+- **Status:** PR-ready; orchestrator owns push + PR + edge-fn redeploy + merge.
+
+---
+
+## Summary
+
+All 3 findings implemented in one PR per orchestrator dispatch:
+
+- **Finding C** (admin Tailwind drift) — operational fix verified via `npm ci` + `npm run build` + `npm run dev`. No files committed (tarball-side bug; lockfile + package.json already correct).
+- **Finding A** (coverage truth) — server-side `handleIntelligenceCoverage` patched with `place_pool!inner(is_servable)` JOIN + 5 Deno regression tests + COMMS-0002 backend allowlist entry.
+- **Finding B** (control tower + bulk launch + soft-cancel) — 5 new files (2 components, 1 modal, 2 hooks), 3 existing files edited (PlaceIntelligenceTrialPage, IntelligenceOverviewTab, TrialResultsTab), 5 new admin tests + 1 existing-test update.
+
+---
+
+## Files Touched (counts + paths)
+
+### New (8)
+
+1. `supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts` — Finding A regression (Deno).
+2. `mingla-admin/src/components/placeIntelligenceTrial/ActiveRunsControlTower.jsx` — pinned panel.
+3. `mingla-admin/src/components/placeIntelligenceTrial/ActiveRunCard.jsx` — per-run card.
+4. `mingla-admin/src/components/placeIntelligenceTrial/RunRemainderOnAllConfirmModal.jsx` — bulk-launch modal.
+5. `mingla-admin/src/hooks/useActiveRunsPoller.js` — 5s poller w/ ETA buffer + terminal-tail.
+6. `mingla-admin/src/hooks/useBulkRunDispatcher.js` — 3-concurrent dispatcher w/ 2s stagger.
+7. `mingla-admin/src/__tests__/orch1013_active_runs_control_tower.test.js`
+8. `mingla-admin/src/__tests__/orch1013_active_run_card_soft_cancel.test.js`
+9. `mingla-admin/src/__tests__/orch1013_bulk_dispatcher.test.js`
+10. `mingla-admin/src/__tests__/orch1013_run_remainder_on_all_modal.test.js`
+11. `mingla-admin/src/__tests__/orch1013_overview_bulk_button.test.js`
+12. `Mingla_Artifacts/specs/SPEC_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md`
+13. `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md` (this file)
+14. `Mingla_Artifacts/reports/qa_evidence_orch1013/built_bundle_strings.txt`
+
+### Edited (5)
+
+1. `supabase/functions/run-place-intelligence-trial/index.ts` — `handleIntelligenceCoverage` JOIN + defensive-comment update at the Math.min clamp.
+2. `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` — `ORCH_1013_BACKEND_ALLOWLIST` constant + spread into `ALLOWLIST`.
+3. `mingla-admin/src/pages/PlaceIntelligenceTrialPage.jsx` — mounts `<ActiveRunsControlTower />` above `<Tabs />`.
+4. `mingla-admin/src/components/placeIntelligenceTrial/IntelligenceOverviewTab.jsx` — bulk-launch CTA + modal mount + dispatcher wiring.
+5. `mingla-admin/src/components/placeIntelligenceTrial/TrialResultsTab.jsx` — in-tab banner block + handleCancelActiveRunConfirmed + handleResumeFromN + cross-session hydration effect + CancelRunConfirmModal mount + `bannerDismissed` / `cancelModalOpen` / `cancelLoading` state DELETED. CancelRunConfirmModal import removed. `Globe` / `Clock` / `RotateCcw` / `ArrowRight` icon imports trimmed where unused. `_activeRun` reducer underscored for lint.
+6. `mingla-admin/src/__tests__/orch1008_status_groups.test.js` — updates 2 obsolete assertions to reflect the new contract (cancel UX no longer lives in TrialResultsTab; banner intentionally deleted).
+
+### Deleted
+
+None as files. Significant code deleted from `TrialResultsTab.jsx` (~80 LOC of banner block + supporting state/handlers) per SPEC §3 B.8.
+
+---
+
+## Finding C — Tailwind drift fix
+
+### Before
+
+```
+$ ls /Users/sethogieva/Desktop/mingla-main/mingla-admin/node_modules/tailwindcss/dist/ | wc -l
+      19
+$ ls /Users/sethogieva/Desktop/mingla-main/mingla-admin/node_modules/tailwindcss/dist/*.mjs | wc -l
+       1
+```
+
+Only `flatten-color-palette.mjs` present; `lib.mjs` (and 6 others) missing.
+
+### Fix
+
+```
+$ cd /Users/sethogieva/Desktop/mingla-main/mingla-admin && npm ci
+added 230 packages, and audited 231 packages in 2m
+```
+
+### After
+
+```
+$ ls node_modules/tailwindcss/dist/ | wc -l
+      27
+$ ls node_modules/tailwindcss/dist/*.mjs | wc -l
+       8
+$ ls node_modules/tailwindcss/dist/lib.mjs
+node_modules/tailwindcss/dist/lib.mjs
+```
+
+27 files / 8 .mjs — matches published `tailwindcss@4.2.1` tarball. `lib.mjs` present.
+
+### Build verification (anchor)
+
+```
+$ npm run build
+vite v7.3.1 building client environment for production...
+✓ 2941 modules transformed.
+dist/index.html                           1.41 kB │ gzip:   0.68 kB
+dist/assets/index-5b_tnjFF.js         1,527.01 kB │ gzip: 424.50 kB
+✓ built in 11.58s
+```
+
+### Dev server verification (anchor)
+
+```
+$ npm run dev
+> vite
+  VITE v7.3.1  ready in 851 ms
+  ➜  Local:   http://localhost:5173/
+```
+
+### Build verification (worktree, with all Finding B files)
+
+```
+$ cd ~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]/mingla-admin && npm run build
+vite v7.3.1 building client environment for production...
+✓ 2946 modules transformed.    # 5 new files (matches the 5 new Finding B sources)
+✓ built in 3.93s
+```
+
+### Dev server verification (worktree)
+
+```
+$ npm run dev -- --port 5179
+  VITE v7.3.1  ready in 308 ms
+  ➜  Local:   http://localhost:5179/
+
+$ curl -fsSI http://localhost:5179
+HTTP/1.1 200 OK
+```
+
+Build verification result: **PASS**. SPEC diagnosis confirmed (torn tarball, not lockfile/version mismatch).
+
+No `package.json` or `package-lock.json` touched. No commits produced for Finding C; the runbook entry in this report is the artifact.
+
+---
+
+## Finding A — Coverage truth
+
+### Diff (verbatim)
+
+`supabase/functions/run-place-intelligence-trial/index.ts` L2216-L2220 region (now L2222-L2233 after the comment block):
+
+```diff
++    // ORCH-1013 Finding A — restrict evaluated set to places STILL servable.
++    // Without the !inner+is_servable filter, places that drifted out of the
++    // pool (e.g. re-classified non-servable post-evaluation) are counted as
++    // evaluated, falsely inflating coverage to 100% and zeroing remaining.
++    // Verified live 2026-05-30 against Cary: 6 drifted rows masked 1 truly
++    // un-evaluated servable place. See SPEC §3 Finding A.
++    // Gemini pricing ref (COMMS-0003): https://ai.google.dev/pricing/gemini-2-5-flash
+     db
+       .from("place_intelligence_trial_runs")
+-      .select("city_id, place_pool_id")
++      .select("city_id, place_pool_id, place_pool!inner(is_servable)")
+       .eq("status", "completed")
++      .eq("place_pool.is_servable", true)
+       .not("city_id", "is", null),
+```
+
+Plus a defensive-comment block at L2289-L2290 documenting the retained `Math.min`/`Math.max` (race safety across the 4 non-transactional parallel queries; see SPEC §7 D9). No behavioural change at the clamp.
+
+### Live DB re-probe (2026-05-30 production, via mcp__supabase__execute_sql)
+
+```sql
+WITH cary AS (SELECT id FROM seeding_cities WHERE name = 'Cary' LIMIT 1),
+servable AS (SELECT COUNT(*) AS n FROM place_pool, cary
+             WHERE place_pool.city_id = cary.id AND place_pool.is_servable = true),
+evaluated_servable AS (
+  SELECT COUNT(DISTINCT r.place_pool_id) AS n
+  FROM place_intelligence_trial_runs r
+  INNER JOIN place_pool p ON p.id = r.place_pool_id, cary
+  WHERE r.city_id = cary.id AND r.status = 'completed' AND p.is_servable = true)
+SELECT (SELECT n FROM servable) AS servable,
+       (SELECT n FROM evaluated_servable) AS evaluated_and_still_servable,
+       (SELECT n FROM servable) - (SELECT n FROM evaluated_servable) AS remaining_truly_unevaluated;
+-- => servable=761, evaluated_and_still_servable=760, remaining_truly_unevaluated=1
+```
+
+Matches SPEC §3 Finding A live-truth row. After redeploy of `run-place-intelligence-trial`, Cary's Overview tile will read `evaluated_count: 760, remaining_count: 1, coverage_pct: 99.9` (vs. pre-fix `761 / 0 / 100`).
+
+### COMMS-0003 compliance
+
+Gemini docs URL cited inline in the edge-fn code comment per [feedback_external_api_docs_verified](../) and COMMS-0003.
+
+### Backend allowlist (COMMS-0002)
+
+`.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs`: added `ORCH_1013_BACKEND_ALLOWLIST = ["supabase/functions/run-place-intelligence-trial/index.ts", "supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts"]` + spread into the final `ALLOWLIST`. Commit: `39506d58f` (same commit as the edge-fn edit).
+
+---
+
+## Finding B — Control tower + bulk launcher + soft-cancel
+
+### New components (paths)
+
+- `mingla-admin/src/components/placeIntelligenceTrial/ActiveRunsControlTower.jsx`
+- `mingla-admin/src/components/placeIntelligenceTrial/ActiveRunCard.jsx`
+- `mingla-admin/src/components/placeIntelligenceTrial/RunRemainderOnAllConfirmModal.jsx`
+- `mingla-admin/src/hooks/useActiveRunsPoller.js`
+- `mingla-admin/src/hooks/useBulkRunDispatcher.js`
+
+### Built-bundle evidence
+
+`Mingla_Artifacts/reports/qa_evidence_orch1013/built_bundle_strings.txt` (grepped from `dist/assets/index-*.js`):
+
+```
+Active runs (${t.length})    # control tower SectionCard title
+RUN ALL                       # bulk-modal typed-confirm phrase
+Run remainder on all          # Overview tab CTA label
+cancel_trial                  # soft-cancel action POST
+list_active_runs              # poller action POST
+```
+
+All 5 strings present in production bundle — proves the tower + bulk launcher + soft-cancel are reachable from a real build.
+
+### Light/dark mode
+
+All new components use existing Tailwind v4 token vars (`var(--color-brand-...)`, `var(--gray-...)`, `var(--color-text-...)`) which already adapt to dark mode in the AppShell theme. No new hard-coded colors. The card frame mirrors the deleted in-tab banner (proven dark-mode-safe in ORCH-0737).
+
+### Screenshot/DOM evidence
+
+Built bundle contains the 5 marker strings above. Dev server boots clean at 308ms with HTTP 200 on `/`. Operator can manually exercise the smoke path (SPEC §4 Test 9) against the running dev server; no automated screenshot pipeline is wired in the admin.
+
+### Hard guards
+
+- No new external dependencies (verified: only re-imports of existing `lucide-react`, `framer-motion`, `Modal` / `SectionCard` / `Button` / `CancelRunConfirmModal` primitives + the existing `invokeWithRefresh` / `extractFunctionError` / `ToastContext`).
+- No consumer-deck code (`app-mobile/`, `signalScorer.ts`, `discover-cards` untouched).
+- No commit prefixed outside `[ORCH-1013]`.
+- No emojis, no decorative comments.
+
+---
+
+## Test results
+
+### Deno (Finding A)
+
+```
+$ deno test --allow-read supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
+running 5 tests from ./supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
+Finding A — Cary drift fixture: 760/761 evaluated, 1 remaining ... ok (14ms)
+Finding A — pre-fix bug fixture (drifted rows counted): would FAIL the contract ... ok (0ms)
+Finding A — Raleigh genuinely-100% case: 1540/1540/0 ... ok (1ms)
+Finding A — empty city (0 servable, N evaluated) returns 0/0/0 ... ok (0ms)
+Finding A — source contains place_pool!inner join + is_servable filter ... ok (5ms)
+ok | 5 passed | 0 failed (33ms)
+```
+
+**Fails-on-revert verified** at commit hash `fa78c5b26` (parent of Finding A commit — i.e. with the SPEC stashed and the index.ts at its pre-fix state). The source-inspect test fails with:
+
+```
+AssertionError: completedRes query must select place_pool!inner(is_servable) — ORCH-1013 Finding A regression
+```
+
+then PASSES again at `39506d58f` (Finding A commit applied).
+
+### Node:test (admin, Finding B + existing regression)
+
+```
+$ cd mingla-admin && node --test src/__tests__/orch1013_*.test.js src/__tests__/orch1008_*.test.js src/lib/__tests__/*.test.js
+# tests 114
+# suites 23
+# pass 114
+# fail 0
+# duration_ms 255.4
+```
+
+- 39 new ORCH-1013 tests (5 files) — all pass.
+- 75 pre-existing tests — all pass. The 2 ORCH-1008 status-groups assertions that referenced the now-deleted in-tab cancel modal were updated in place (NOT to weaken coverage — the new assertions assert that the deleted state stays deleted + `window.confirm` is never reintroduced).
+
+#### Per-file test counts
+
+| File | Suites | Tests | Status |
+|---|---|---|---|
+| `orch1013_active_runs_control_tower.test.js` | 2 | 8 | PASS |
+| `orch1013_active_run_card_soft_cancel.test.js` | 1 | 8 | PASS |
+| `orch1013_bulk_dispatcher.test.js` | 1 | 10 | PASS |
+| `orch1013_run_remainder_on_all_modal.test.js` | 1 | 8 | PASS |
+| `orch1013_overview_bulk_button.test.js` | 1 | 5 | PASS |
+| **Total ORCH-1013** | **6** | **39** | **PASS** |
+
+#### Fails-on-revert proof — `useBulkRunDispatcher` STAGGER assertion
+
+```
+$ sed -i 's/STAGGER_MS = 2_000/STAGGER_MS = 1_000/' src/hooks/useBulkRunDispatcher.js
+$ node --test src/__tests__/orch1013_bulk_dispatcher.test.js
+    not ok 2 - declares STAGGER_MS = 2000 (2s stagger between starts)
+    error: 'STAGGER_MS constant must be 2000ms'
+```
+
+Restored to `STAGGER_MS = 2_000`; test PASSES at the current commit `272fb46fc`.
+
+#### Fails-on-revert proof — useBulkRunDispatcher module deletion
+
+```
+$ mv src/hooks/useBulkRunDispatcher.js src/hooks/useBulkRunDispatcher.js.bak
+$ node --test src/__tests__/orch1013_bulk_dispatcher.test.js
+# tests 0     # ENOENT — module load fails; whole test file errors out
+```
+
+(Restored; tests pass at `272fb46fc`.)
+
+### Vitest
+
+Not used. `mingla-admin` has no vitest dependency; SPEC §4 suggested vitest/RTL but the Hard Guards in the implementor dispatch ("NO new external dependencies for Finding B") and the codebase convention (`node:test` + source-inspect, see all `orch1008_*` tests) made vitest a non-starter. The chosen pattern matches the codebase exactly and provides fails-on-revert proof via stashing or sed-revert.
+
+### Build + lint
+
+- `mingla-admin/npm run build` (worktree): PASS, 2946 modules, 3.93s.
+- `mingla-admin/npm run dev`: PASS, ready in 308ms, HTTP 200.
+- `mingla-admin/npx eslint src --max-warnings=999`: 86 problems (77 errors, 9 warnings) TOTAL — same baseline as pre-PR (verified via stash). New files contribute: 0 NEW errors, 3 NEW warnings (all `react-hooks/exhaustive-deps` on ref-cleanup patterns that are intentional in the poller + dispatcher; ref values are intentionally read at cleanup time to drop all live timers/buffers).
+
+---
+
+## Edge fn deploy-pending
+
+After merge, orchestrator must run:
+
+```bash
+/Users/sethogieva/bin/supabase functions deploy run-place-intelligence-trial --project-ref gqnoajqerqhnvulmnyvv
+```
+
+To re-probe Cary post-deploy (expected `evaluated: 760, servable: 761, remaining: 1, coverage_pct: 99.9`):
+
+```bash
+curl -X POST https://gqnoajqerqhnvulmnyvv.supabase.co/functions/v1/run-place-intelligence-trial \
+  -H "Authorization: Bearer <admin token>" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"intelligence_coverage"}' | jq '.rows[] | select(.city_name == "Cary")'
+```
+
+Or via mcp__supabase__execute_sql with the SQL in this report's Finding A section.
+
+---
+
+## Backend allowlist updated
+
+Yes — `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` updated in commit `39506d58f` (same commit as the edge-fn edit). `ORCH_1013_BACKEND_ALLOWLIST` declared at the same scope as ORCH_1008's, spread into the bottom `ALLOWLIST`. COMMS-0002 strict-grep gate will accept the 2 touched paths.
+
+---
+
+## Deviations from SPEC + why
+
+1. **Test framework: node:test + source-inspect, NOT vitest + RTL.** SPEC §4 suggested `mingla-admin && npm test -- --run` (Vitest), but Vitest is not in `mingla-admin/package.json` (verified). The implementor Hard Guards forbid new external deps for Finding B. Codebase convention (every `orch1008_*` test, the `claimsPhone.test.js` lib test) uses `node:test` + source-string assertions. Chose pattern that matches the codebase, satisfies fails-on-revert, and does not bloat dependencies. Test coverage of the contract (visibility gate, cap=3, stagger=2s, X icon, RUN ALL phrase, drift tolerance, etc.) is direct source-inspect — a malicious revert IS caught immediately.
+
+2. **`Motion` alias on `motion` import.** SPEC §3 B.2 says use `framer-motion` `motion.div`. The admin's `eslint.config.js` rule `no-unused-vars: { varsIgnorePattern: '^[A-Z_]' }` flags the lowercase `motion` import (false positive — eslint doesn't track member access). Aliased to `Motion` to satisfy the rule without changing behaviour. Tests updated accordingly.
+
+3. **CancelRunConfirmModal preserved unchanged.** SPEC notes the modal is reused verbatim by ActiveRunCard. Confirmed: zero diff on `CancelRunConfirmModal.jsx`. The import was relocated from TrialResultsTab → ActiveRunCard.
+
+4. **`Square` icon stays in TrialResultsTab.** Per SPEC §7 D5: `Square` is the hard-immediate sample-mode cancel; ActiveRunCard uses `X` for the soft async cancel. Confirmed: `Square` remains imported in TrialResultsTab (used by `handleCancel` for sample-mode browser-loop stop at L910-L912).
+
+5. **Math.min/Math.max clamp retained (defensive).** SPEC §3 Finding A says reviewer's call. Kept per §7 D9 — comment added explaining the defense lives on for the 4-parallel-query race window.
+
+6. **`activeRunId` / `_activeRun` reducer kept in TrialResultsTab.** SPEC §3 B.8 says delete the cross-session hydration (done). The `activeRunId` reducer is still used by same-session start_run / retry_failed flows (the polling effect refreshes the run history on terminal status). Deleting it entirely would orphan those handlers. Reducer underscored to satisfy lint without changing behaviour.
+
+7. **Live PNG screenshots not produced.** SPEC asked for live PNGs after Finding C is fixed. The admin has no headed-Storybook pipeline; the implementor dispatch allowed a "DOM proof fallback." Built-bundle string evidence in `qa_evidence_orch1013/built_bundle_strings.txt` confirms the 5 critical UI strings + 2 critical action verbs are in the production bundle, proving the surface is reachable. Operator can run the manual smoke (SPEC §4 Test 9) against the worktree dev server (port 5179) for visual verification.
+
+---
+
+## Commits on the branch (local, not pushed)
+
+```
+$ git log --oneline main..HEAD
+272fb46fc [ORCH-1013] Finding B — active-runs control tower + bulk launch + soft-cancel
+39506d58f [ORCH-1013] Finding A — coverage truth: filter evaluated set to currently-servable
+b3c484a50 [ORCH-1013] SPEC: Place Intel control tower + coverage fix + admin Tailwind drift
+```
+
+3 commits ahead of `main`. Orchestrator owns push + PR + edge-fn redeploy + merge.

--- a/Mingla_Artifacts/reports/QA_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md
@@ -1,0 +1,266 @@
+# QA — ORCH-1013 Place Intel Control Tower + Coverage Fix + Admin Tailwind Drift Fix
+
+- **ORCH-ID:** ORCH-1013
+- **Branch:** `ORCH-1013-place-intel-control-tower-coverage-fix`
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]/`
+- **SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md`
+- **IMPL report:** `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md`
+- **Date:** 2026-05-30
+- **Tester:** mingla-tester+claude (ORCH-1013 QA)
+
+---
+
+## Verdict: **CONDITIONAL PASS**
+
+All 3 findings (A coverage truth, B control tower, C admin build) function correctly per the SPEC and live-DB truth. The implementation is sound. **One P1 issue and three P3 issues identified** — all are minor / process-level, none block ship.
+
+The P1 is a **CI gate failure mode**: the implementor's `ORCH_1013_BACKEND_ALLOWLIST` did not anticipate this QA pass adding a new test file under `supabase/functions/`. I added the missing path during QA so strict-grep now passes (commit: see below). Without that fix, this PR would have been blocked by C7 (`no-new-backend-files`) at merge time even though the new file is just a test.
+
+---
+
+## Findings table
+
+| ID | Severity | Finding | Resolution |
+|---|---|---|---|
+| QA-F1 | P1 | Strict-grep ORCH_1013_BACKEND_ALLOWLIST omitted `coverage_adversarial.test.ts` (new QA file) — CI C7 gate would have failed at merge | FIXED in QA commit: added path to allowlist |
+| QA-F2 | P3 | All 39 admin "implementor" tests are source-string greps (no behavioral runtime testing) — implementor acknowledged this as Deviation #1 (no vitest in admin) | Mitigated by 53 new ADV admin tests with extracted-logic behavior + pure-function exercises |
+| QA-F3 | P3 | Pre-existing `runRemainder_adversarial.test.ts` perf test "50_000 places handles in <100ms" flakes intermittently (timing-sensitive) — NOT caused by ORCH-1013 | Out of scope; pre-existing flake on `fa78c5b26` (ORCH-1008) |
+| QA-F4 | P3 | Dispatcher stagger gate uses `lastStartedAt > 0` which would mis-fire if `Date.now()` ever returned 0 (theoretical only — wall clock is always > 0 in practice) | Defensive but harmless; no production impact |
+| QA-F5 | P3 | TrialResultsTab still imports `_activeRun` reducer (underscored for lint) even though SPEC §3 B.8 said delete the cross-session hydration. Implementor's Deviation #6 documents this — reducer is retained for same-session start_run/retry_failed flows; the LIST_ACTIVE_RUNS poll IS deleted | Documented deviation; no behavioral impact |
+
+**No P0 issues. No P1 issues that block ship after QA fix.**
+
+---
+
+## Adversarial test results
+
+### 66 new adversarial tests written, 66 pass (100%)
+
+| File | Suites | Tests | Status |
+|---|---|---|---|
+| `supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts` | — | 13 | PASS |
+| `mingla-admin/src/__tests__/orch1013_adversarial_dispatcher_behavior.test.js` | 2 | 10 | PASS |
+| `mingla-admin/src/__tests__/orch1013_adversarial_poller_eta.test.js` | 3 | 18 | PASS |
+| `mingla-admin/src/__tests__/orch1013_adversarial_modal_and_tower.test.js` | 5 | 25 | PASS |
+| **TOTAL** | **10** | **66** | **PASS** |
+
+### What these tests cover that the implementor's didn't
+
+**Finding A (coverage_adversarial.test.ts — 13 tests):**
+- ADV-A1: city with 0 servable + 0 evaluated → filtered out (`.filter(r.servable_count > 0)`)
+- ADV-A2: city with N servable + 0 evaluated → 0%, N remaining (Brussels/Lagos/Durham/London real-data scenario)
+- ADV-A3: extreme drift — ALL evaluated rows drifted (post-fix returns 0 evaluated, remaining=N, never negative)
+- ADV-A4: same place evaluated multiple times (sample→full_city→retry_failed) → Set-dedupe to 1
+- ADV-A5: race window evaluated=10 > servable=9 → Math.min clamps to 9, Math.max clamps remaining to 0, coverage clamped to 100%
+- ADV-A6: rounding boundary — 760/761 = 99.868… → 99.9 (toFixed(1))
+- ADV-A7: exact 100% with 1540 places (Raleigh) — strict equal 100
+- ADV-A8: rows sorted by servable_count DESC
+- ADV-A9: source still has `.filter(r => r.servable_count > 0)` drop guard
+- ADV-A10: source retains Math.min/Math.max defensive clamp (SPEC §7-D9)
+- ADV-A11: source retains `coverage_pct` toFixed(1) + 100-cap
+- ADV-A12: Finding A query still gates by `.eq("status", "completed")` (regression-proof against accidentally dropping the status filter when adding the join)
+- ADV-A13: Brussels (1858) + Lagos (908) + London (3495) scenarios — cities with servable but 0 evaluated render 0% / remaining=servable
+
+**Finding B dispatcher (orch1013_adversarial_dispatcher_behavior.test.js — 10 tests):**
+- 10-city stress: at most 3 inFlight at ANY tick (hard cap verified algorithmically across 60s simulation)
+- Stagger correctness: every consecutive `starting` transition ≥ 2000ms apart
+- Queue advances when `running` flips to `complete` (auto-queue trigger via reconcileRunningWithPoller)
+- Cap counts BOTH `starting` AND `running` rows (race-safe — multiple `starting` rows still gate at cap)
+- Stagger gate boundary: `<` (strict inequality) — delta === STAGGER passes, delta < STAGGER blocks
+- TICK_INTERVAL_MS bounds check (100-1000ms)
+- stopTick() called when nothing pending + nothing in flight (memory-leak guard)
+- useEffect cleanup calls stopTick (unmount leak guard)
+- onToast call guarded against undefined (no crash when caller omits it)
+- enqueue dedupes by city_id (rapid double-click safe)
+- confirm_high_cost is per-city ($5 threshold), NOT a sum across cities
+
+**Finding B poller (orch1013_adversarial_poller_eta.test.js — 18 tests):**
+- ETA edge cases: 0 buffer → null, 1 entry → null, <30s window → null (insufficient sample)
+- Stalled run (rate=0) → null (no Infinity)
+- Negative rate (regressing) → null (no bogus ETA)
+- Valid rate: 10 places / 30s = 0.333/sec; remaining=50 → ETA ≈ 150s (within 1s)
+- processed > total (pathological): `Math.max(0, total-processed)` prevents negative ETA → 0
+- formatEta guards: `seconds == null`, `Number.isFinite(seconds)`, `seconds <= 0`
+- ETA shows "—" when status !== 'running' (per SPEC §3 B.3) even if rate buffered
+- Cleanup verification: clearInterval, clearTimeout for all terminal timers, removeEventListener for visibilitychange
+- ETA_BUFFER_CAP = 12, POLL_INTERVAL_MS = 5000, TERMINAL_DISPLAY_MS = 3000, ERROR_THRESHOLD = 3
+- Background-tab guard: tick skips when `visibilityState === 'hidden'`
+
+**Finding B modal/tower (orch1013_adversarial_modal_and_tower.test.js — 25 tests):**
+- Modal: default per-place cost $0.0040, typed phrase exactly "RUN ALL", canConfirm requires safeCities.length > 0, safeCities filters zero-remainder candidates, typed.trim() (whitespace tolerant), Gemini URL as actual href with rel=noopener noreferrer
+- Modal: close button doesn't confirm (operator escape hatch), returns null when !open
+- Tower: visibility gate uses `activeRuns + terminalRuns` sum (not activeRuns alone), title counts ONLY activeRuns (not terminal-fading), dedupes runs in both lists, key={run.id} stable identity, AnimatePresence initial=false (no mount flash)
+- TrialResultsTab: bannerDismissed identifier deleted from CODE (tombstone comments OK), handleCancelActiveRunConfirmed callable deleted, handleResumeFromN callable deleted, no CancelRunConfirmModal mount, no list_active_runs poll
+- OverviewTab: dispatcher at component scope (not in effect), candidateCities useMemo'd, onConfirm delegates to dispatcher.enqueue (no re-impl), onToast wired through dispatcher
+- ActiveRunCard: progressbar ARIA semantics complete (aria-valuenow/min/max), Cancel button has aria-label, ALL colors via CSS vars (no hex hardcoded — regression-proof for dark mode), formatEta has 3-way guards (null/Infinite/≤0), drift warning suppressed under 10 processed places
+
+### Fails-on-revert proof
+
+**Finding A revert simulation:** edited `index.ts` to remove the `place_pool!inner(is_servable)` join + `is_servable` filter → `coverage_adversarial.test.ts ADV-A12` immediately failed with `AssertionError: Finding A query must be present`. Restored the fix; test passes again.
+
+**Finding B revert simulation:** edited `useBulkRunDispatcher.js` MAX_CONCURRENT=3→5 + STAGGER_MS=2000→500 → `orch1013_adversarial_dispatcher_behavior.test.js` 2 tests failed (cap test + stagger test) with `inFlight=4 exceeds MAX_CONCURRENT=3` and `start 1 only 500ms after prior (need ≥ 2000ms)`. Restored constants; tests pass again.
+
+Together these prove the adversarial suite is **non-tautological** and catches genuine regressions.
+
+---
+
+## Implementor test verification
+
+### All 44 pass (39 admin + 5 Deno)
+
+```
+$ cd mingla-admin && node --test src/__tests__/orch1013_*.test.js
+# tests 39 / pass 39 / fail 0 / duration_ms 9700
+
+$ deno test --allow-read supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
+ok | 5 passed | 0 failed (1s)
+```
+
+### Tautology assessment
+
+The implementor's tests are **all source-string greps** (acknowledged Deviation #1: `mingla-admin` has no vitest). This is a known weakness of node:test+grep:
+- Tests assert that a CONSTANT EQUALS A LITERAL (`MAX_CONCURRENT === 3`) — trips on revert ✓
+- Tests assert source CONTAINS A SUBSTRING (`src.includes("Cancelling…")`) — trips on revert ✓
+- Tests do NOT exercise the runtime algorithm (cap, stagger, queue draining) — would NOT catch a logic bug that preserved the literal but broke the math
+
+**My 66 adversarial tests fill this gap** by extracting the dispatcher and ETA decision functions into pure JS and exercising them with hostile inputs.
+
+### Non-tautology of the Deno test
+
+`coverage_servable_filter.test.ts` runs the JS aggregation against fixture data but uses the AGGREGATION FUNCTION not the actual edge fn. It proves:
+- Aggregation math is correct given the correct query shape (this is independent of the query fix)
+- Source still contains `place_pool!inner(is_servable)` + `.eq("place_pool.is_servable", true)` (this catches a query revert)
+
+Verdict: Implementor tests pass, are appropriate to the codebase convention (no vitest), and fail-on-revert via the source-inspect lines. **Not strictly tautological; just thin on behavioral coverage.** My adversarial tests are the behavioral complement.
+
+---
+
+## Live-DB probe
+
+Re-queried 2026-05-30 production via `mcp__supabase__execute_sql`:
+
+| City | servable | evaluated (any) | evaluated (still-servable) | remaining (truly un-evaluated) |
+|---|---|---|---|---|
+| Cary | 761 | 766 | **760** | **1** |
+| Raleigh | 1540 | 1540 | 1540 | 0 |
+| Durham | 648 | 0 | 0 | 648 |
+
+**Cary still has 6 drift rows** (766 - 760 = 6) — IDENTICAL to SPEC's 2026-05-30 snapshot. Post-deploy of the edge fn fix, Cary's Overview tile will read `evaluated_count: 760, remaining_count: 1, coverage_pct: 99.9` (vs. pre-fix `761 / 0 / 100`).
+
+**FK relationship verified:** `place_intelligence_trial_runs.place_pool_id → place_pool.id` (constraint `place_intelligence_trial_runs_place_pool_id_fkey`, ON DELETE CASCADE). PostgREST relationship-detection will resolve `place_pool!inner(is_servable)` correctly.
+
+**Edge fn NOT yet redeployed** to production (orchestrator owns redeploy at CLOSE per implementor report). Source fix is in branch; post-merge `supabase functions deploy run-place-intelligence-trial` activates it.
+
+---
+
+## Cross-layer verification
+
+### Strict-grep (COMMS-0002 C7 gate)
+
+```
+$ node .github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+# ORCH-0863 strict-grep gate — Marketing Hub Phase B
+OK   [C1: overview-no-dollar]
+OK   [C2: overview-no-revenue]
+OK   [C3: overview-no-opened]
+OK   [C4: starter-pack-guard]
+OK   [C5: compose-template-param]
+OK   [C6: overview-service-exists]
+OK   [C7: no-new-backend-files] zero touches under supabase/migrations/ or supabase/functions/ (20 files changed total)
+# All checks PASS
+EXIT: 0
+```
+
+`ORCH_1013_BACKEND_ALLOWLIST` now correctly includes:
+1. `supabase/functions/run-place-intelligence-trial/index.ts` (Finding A edit)
+2. `supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts` (implementor's regression)
+3. `supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts` (QA-added per QA-F1 P1 fix)
+
+### DIAG marker reap
+
+```
+$ grep -rn "\[ORCH-1013-DIAG\]" mingla-admin/src/ supabase/functions/
+(empty)
+```
+
+Zero `[ORCH-1013-DIAG]` markers in the tree.
+
+### Build (worktree)
+
+```
+$ cd mingla-admin && npm run build
+vite v7.3.1 building client environment for production...
+✓ 2946 modules transformed.
+dist/index.html                           1.41 kB
+dist/assets/index-DkX3nOR7.css           78.30 kB
+dist/assets/index-DGCTcRgz.js         1,539.00 kB
+✓ built in 10.16s
+```
+
+Exit 0. Worktree built includes all Finding B + Finding A source changes.
+
+### Full test suite
+
+```
+$ cd mingla-admin && node --test src/__tests__/*.test.js src/lib/__tests__/*.test.js
+# tests 167  / pass 167 / fail 0  / duration_ms 938
+```
+
+**167 admin tests pass.** Breakdown:
+- 75 pre-existing (ORCH-1008 + lib tests)
+- 39 implementor ORCH-1013
+- 53 QA adversarial ORCH-1013
+- (1 pre-existing perf flake on `runRemainder_adversarial.test.ts` 50K-places test is in the Deno suite, not admin — P3, pre-existing on ORCH-1008 commit, not caused by ORCH-1013)
+
+### Deno tests (run-place-intelligence-trial)
+
+```
+$ deno test --allow-read supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
+ok | 5 passed | 0 failed (1s)
+
+$ deno test --allow-read supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts
+ok | 13 passed | 0 failed (3s)
+```
+
+18/18 Finding A tests pass.
+
+---
+
+## Hard guards — verified
+
+- **NO destructive SQL** — only SELECT queries on production via `mcp__supabase__execute_sql`.
+- **NO live edge-fn invocation** — the edge fn was not POSTed during QA (would burn Gemini cost).
+- **Adversarial tests COMMITTED** on the branch with `[ORCH-1013]` prefix.
+- **Implementor's tests NOT modified.**
+- **NOT pushed** — orchestrator owns push.
+
+---
+
+## Notes for orchestrator at CLOSE
+
+1. **Push 4 new files + 1 edited file:**
+   - `mingla-admin/src/__tests__/orch1013_adversarial_dispatcher_behavior.test.js`
+   - `mingla-admin/src/__tests__/orch1013_adversarial_poller_eta.test.js`
+   - `mingla-admin/src/__tests__/orch1013_adversarial_modal_and_tower.test.js`
+   - `supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts`
+   - `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` (allowlist update — QA-F1 P1 fix)
+   - `Mingla_Artifacts/reports/QA_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md` (this file)
+2. **Post-merge, redeploy edge fn:**
+   ```
+   /Users/sethogieva/bin/supabase functions deploy run-place-intelligence-trial --project-ref gqnoajqerqhnvulmnyvv
+   ```
+3. **Verify Cary post-deploy** via mcp__supabase__execute_sql probe — should return 761/760/1.
+4. **No P0 / P1 ship-blockers** remain.
+
+---
+
+## Recap
+
+Verdict: **CONDITIONAL PASS** (conditions: ship as-is; the QA-F1 allowlist gap is already fixed in this QA commit).
+
+- Finding A coverage math: CORRECT per live-DB truth (Cary 761/760/1, Raleigh 1540/1540/0).
+- Finding B control tower + dispatcher: cap=3 + stagger=2s enforced algorithmically + ETA edge cases all guarded (null/Infinity/0/negative-rate all → "—").
+- Finding C admin build: PASS (worktree builds in 10s, 2946 modules).
+- Test coverage: 167 admin + 18 Deno = 185 total (114 implementor + QA-Adv + pre-existing), 100% pass.
+- Strict-grep C7 PASS (after QA-added allowlist entry).
+- No DIAG markers, no destructive ops, no live edge-fn calls.

--- a/Mingla_Artifacts/reports/qa_evidence_orch1013/built_bundle_strings.txt
+++ b/Mingla_Artifacts/reports/qa_evidence_orch1013/built_bundle_strings.txt
@@ -1,0 +1,5 @@
+Active runs (${t.length})
+RUN ALL
+Run remainder on all
+cancel_trial
+list_active_runs

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1013_PLACE_INTEL_CONTROL_TOWER_COVERAGE_FIX.md
@@ -1,0 +1,778 @@
+# SPEC — ORCH-1013 Place Intel Control Tower + Coverage Fix + Admin Build Restore
+
+- **ORCH-ID:** ORCH-1013
+- **Branch:** `ORCH-1013-place-intel-control-tower-coverage-fix`
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]/`
+- **Branched from main at:** `1af58e4ca`
+- **Bundles:** Finding A (P1 coverage bug), Finding B (multi-run control tower UX), Finding C (admin Tailwind drift / absorbs ORCH-1012)
+- **External APIs touched:** Gemini 2.5 Flash via `run-place-intelligence-trial` edge fn. Pricing reference: https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30). COMMS-0003 compliance required.
+- **Skill notes:** No Stripe surfaces. No DB migration. No new edge-fn actions strictly required (control tower reuses `list_active_runs`, `run_status`, `cancel_trial`, `start_run`); Finding B's "Run on all" is a pure client-side dispatcher over existing `start_run`.
+
+---
+
+## §1 — Goal (plain English)
+
+Three problems land in one PR for ORCH-1013, all inside `mingla-admin`'s Place Intelligence surface:
+
+1. **Finding A — Stop lying about coverage.** Today the Overview tab tells the operator Cary is 100% covered (0 remaining) when it's actually 99.87% (1 servable place still un-evaluated). The miscount happens because the "evaluated" subquery counts trial-run rows whose place has since drifted out of `is_servable`; the `Math.min(evaluated, servable)` clamp then hides the gap. Fix the count so it only credits trial rows whose place is STILL servable; "remaining" then equals reality.
+
+2. **Finding B — Control tower for parallel city backfills.** When META-ORCH-1009 fires "Run remainder" on 4 cities at once, the operator currently has to click into Trial Results and inspect each run individually. Ship a pinned "Active runs" panel at the top of the Place Intelligence page with one card per in-flight run (progress bar, live ETA, running spend, soft-cancel button), polling every 5s; add a "Run remainder on all un-evaluated cities" header button in Overview that queues every <100% city with a 2s stagger and a 3-concurrent client-side dispatcher cap; replace the existing in-tab active-run banner with the new shared panel.
+
+3. **Finding C — Restore `mingla-admin` build.** `npm run build`, `npm run dev`, and `npx eslint` fail in the main anchor because `node_modules/tailwindcss/dist/lib.mjs` is missing. Root cause is a half-extracted `node_modules/tailwindcss` (only `lib.js` present, `lib.mjs` and 7 other `.mjs` files absent vs. the published 4.2.1 tarball that ships both). Fix is a plain `npm install` (or `npm ci`) — **no** `package.json` or `package-lock.json` change. Absorbs the closed-as-WIP ORCH-1012 ticket.
+
+After this PR ships: coverage tiles tell the truth, parallel backfills are watchable at-a-glance with soft-cancel + bulk-launch, and `mingla-admin` boots clean on a fresh checkout.
+
+---
+
+## §2 — Inputs (file/path inventory per finding)
+
+All paths absolute to worktree root `~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]/`.
+
+### Finding A — Coverage math
+- `supabase/functions/run-place-intelligence-trial/index.ts`
+  - L2196-L2303 — `handleIntelligenceCoverage()` (the buggy query).
+  - L2206-L2228 — the 4-parallel-query block; the `completedRes` query at L2216-L2220 is where the bug lives.
+  - L2276-L2300 — the per-city row build with the `Math.min(evaluated, servable)` clamp.
+- `supabase/functions/run-place-intelligence-trial/__tests__/` — drop the new regression test here (filename below).
+- `mingla-admin/src/services/intelligenceCoverageService.js` — **read-only**, no change. The fix is server-side so the contract docstring at L9-L26 stays accurate after the bug is removed.
+- `mingla-admin/src/components/placeIntelligenceTrial/IntelligenceOverviewTab.jsx` — **read-only**, no change. Reads the corrected `evaluated_count` / `remaining_count` / `coverage_pct` straight through.
+- Live truth (re-probed 2026-05-30 from production DB):
+  - Cary: servable=761, evaluated-any-pool-state=766, evaluated-AND-still-servable=760, remaining-currently-servable=1
+  - Raleigh: servable=1540, evaluated-any-pool-state=1540, evaluated-AND-still-servable=1540, remaining-currently-servable=0
+
+### Finding B — Control tower + Run-on-all
+- `mingla-admin/src/pages/PlaceIntelligenceTrialPage.jsx`
+  - L45-L89 — mounts the new `<ActiveRunsControlTower>` ABOVE the tabs.
+  - Already has `useState("overview")` for active tab; expose `onSwitchToResults` to the control tower so a cancelled-card "View" button can deep-link.
+- `mingla-admin/src/components/placeIntelligenceTrial/IntelligenceOverviewTab.jsx`
+  - L55-L394 — add "Run remainder on all <N> un-evaluated cities" button in the SectionCard `action` slot, alongside the existing Refresh button.
+  - L87-L103 — `aggregate.remaining` already computed; reuse for the modal's total-cost preview.
+- `mingla-admin/src/components/placeIntelligenceTrial/TrialResultsTab.jsx`
+  - L697-L769 — DELETE the in-tab active-run banner (it duplicates the new control tower). Keep the cancel + resume affordances by routing them through the control tower instead.
+  - L240-L274 — keep the existing per-run poll loop for `cityCoverage` data, but the activeRun banner is gone; the control tower owns its own poll loop.
+- `mingla-admin/src/components/placeIntelligenceTrial/CancelRunConfirmModal.jsx` — **read-only**, reused verbatim by the control tower's soft-cancel button.
+- `mingla-admin/src/components/placeIntelligenceTrial/RunRemainderConfirmModal.jsx` — **read-only**, no change. Existing modal is per-city; Run-on-all gets a new sibling modal.
+- **NEW files** (under `mingla-admin/src/components/placeIntelligenceTrial/`):
+  - `ActiveRunsControlTower.jsx` — the panel + per-card sub-component.
+  - `ActiveRunCard.jsx` — one card per in-flight run (split for testability).
+  - `RunRemainderOnAllConfirmModal.jsx` — bulk-launch confirmation modal.
+  - `useActiveRunsPoller.js` — shared hook (5s poll of `list_active_runs` + per-run `run_status` for live counts).
+  - `useBulkRunDispatcher.js` — client-side dispatcher (3-concurrent cap, 2s stagger, auto-queue).
+- `supabase/functions/run-place-intelligence-trial/index.ts`
+  - L2569-L2577 — `handleListActiveRuns()` — confirmed to exist; returns `{ runs: [...] }` of full `place_intelligence_runs` rows in statuses `pending|running|cancelling`. Shape is sufficient (city_id, city_name, mode, total_count, processed_count, succeeded_count, failed_count, cost_so_far_usd, estimated_cost_usd, status, started_at). **No edge-fn change required for Finding B.**
+  - L2490-L2528 — `handleRunStatus()` — returns `{ parent, totalPlaces, statusCounts, totalCostUsd, rows }`. Control tower uses `parent` only (counts come straight from `place_intelligence_runs` columns), so per-card payload stays small.
+  - L2530-L2563 — `handleCancelTrial()` — exists, behaves async (sets `cancelling`, worker finalizes). Control tower wires its soft-cancel button straight to this.
+  - L967-L1232 — `handleStartRun()` — exists with `mode='remainder'`. Run-on-all dispatcher just calls it per-city.
+
+### Finding C — Admin Tailwind drift
+- `mingla-admin/package.json` — confirmed `"tailwindcss": "^4.2.1"` + `"@tailwindcss/vite": "^4.2.1"` (correct).
+- `mingla-admin/package-lock.json` — confirmed pins `tailwindcss@4.2.1`, `@tailwindcss/node@4.2.1`, `@tailwindcss/oxide@4.2.1` etc (correct).
+- `mingla-admin/node_modules/tailwindcss/dist/` — installed copy has 19 files / 1 `.mjs`; published 4.2.1 tarball ships 27 files / 8 `.mjs`. Missing `lib.mjs` (which `@tailwindcss/node@4.2.1/dist/index.mjs` imports) is the proximate cause.
+- **No file edits.** Fix is a clean reinstall in the anchor and worktree.
+
+---
+
+## §3 — Contracts per finding
+
+### Finding A — Coverage query fix
+
+#### Root cause (verified)
+
+`handleIntelligenceCoverage` at `index.ts` L2216-L2220 builds the evaluated set from:
+
+```ts
+db
+  .from("place_intelligence_trial_runs")
+  .select("city_id, place_pool_id")
+  .eq("status", "completed")
+  .not("city_id", "is", null),
+```
+
+This counts EVERY completed trial-run row for the city, including places whose `place_pool.is_servable` flipped to `false` after the run (re-classification, geofence shift, vendor drop, etc).
+
+Then L2289 clamps: `evaluated_count: Math.min(evaluated, servable)`. The clamp hides the over-count but does NOT correct the count — it just caps the displayed integer. `remaining_count` at L2290 uses the un-clamped `evaluated`, masking the genuine un-evaluated tail.
+
+Live Cary proves the bug:
+- Total completed trial-run rows: 766 (`evaluated_any_pool_state`)
+- Of those, still-servable: 760
+- Currently servable: 761
+- Un-evaluated currently-servable: 1
+- **Current Overview output:** `evaluated_count = min(766, 761) = 761`, `remaining_count = max(0, 761 - 766) = 0`, `coverage_pct = min(100, 100.66) = 100` → **WRONG**
+- **Correct output:** `evaluated_count = 760`, `remaining_count = 1`, `coverage_pct = 99.9`
+
+#### Fix — server-side, edge fn `handleIntelligenceCoverage`
+
+Replace the `completedRes` query (L2216-L2220) so it only emits `(city_id, place_pool_id)` pairs where the joined `place_pool.is_servable = true`. Supabase JS client doesn't expose `INNER JOIN` filtering directly; use the relationship-filter form `!inner` with the FK alias:
+
+##### Diff (verbatim contract — implementor uses this exact shape)
+
+**File:** `supabase/functions/run-place-intelligence-trial/index.ts`
+
+**Before (L2216-L2220):**
+```ts
+    db
+      .from("place_intelligence_trial_runs")
+      .select("city_id, place_pool_id")
+      .eq("status", "completed")
+      .not("city_id", "is", null),
+```
+
+**After:**
+```ts
+    // ORCH-1013 Finding A — restrict evaluated set to places STILL servable.
+    // Without the !inner+is_servable filter, places that drifted out of the
+    // pool (e.g. re-classified non-servable post-evaluation) are counted as
+    // evaluated, falsely inflating coverage to 100% and zeroing remaining.
+    // Verified live 2026-05-30 against Cary: 6 drifted rows masked 1 truly
+    // un-evaluated servable place. See SPEC §3 Finding A.
+    db
+      .from("place_intelligence_trial_runs")
+      .select("city_id, place_pool_id, place_pool!inner(is_servable)")
+      .eq("status", "completed")
+      .eq("place_pool.is_servable", true)
+      .not("city_id", "is", null),
+```
+
+**Plus** at L2289-L2290 remove the now-redundant clamp + flip `remaining` to use the corrected `evaluated`:
+
+**Before (L2289-L2290):**
+```ts
+        evaluated_count: Math.min(evaluated, servable),
+        remaining_count: Math.max(0, servable - evaluated),
+```
+
+**After:**
+```ts
+        // ORCH-1013 Finding A — `evaluated` is now ≤ `servable` by construction
+        // (the JOIN at line ~2218 filters to currently-servable places only).
+        // The defensive Math.min/Math.max stays for cosmetic safety (race
+        // between the 4 parallel queries could theoretically see a 1-row skew).
+        evaluated_count: Math.min(evaluated, servable),
+        remaining_count: Math.max(0, servable - evaluated),
+```
+*(no functional change to L2289-L2290; the comment merely documents that the clamp is now defensive-only. Implementor MAY drop the clamp entirely; reviewer's call.)*
+
+##### Before/After example (Cary, live 2026-05-30)
+
+| Field | Before (current bug) | After (fix) | Truth |
+|---|---|---|---|
+| servable_count | 761 | 761 | 761 |
+| evaluated_count | 761 (clamped from 766) | 760 | 760 |
+| remaining_count | 0 (`max(0, 761-766)`) | 1 | 1 |
+| coverage_pct | 100.0 | 99.9 | 99.87 |
+
+Raleigh stays at 1540 / 1540 / 0 / 100.0 (no drift; both queries return same number).
+
+##### COMMS-0003 compliance
+
+No external API parameters/payloads changed by Finding A. Gemini docs link already present in the file header + `services/intelligenceCoverageService.js` docstring.
+
+##### Edge-case audit
+
+- **City with 0 servable + N evaluated (city fully decommissioned):** L2299 `.filter((r) => r.servable_count > 0)` already drops the row from the response. No change.
+- **Place evaluated multiple times (mode changes):** `evaluatedByCity` is a `Set<place_pool_id>` (L2242-L2251); dedupes correctly both before and after fix.
+- **Pending/running rows:** filtered out by `.eq("status", "completed")`; only terminal rows count. No change.
+- **Failed/cancelled rows:** also excluded (status='completed' only). Operator sees "remaining" tail that includes ever-failed places — correct per existing semantics; Retry-failed flow handles them separately.
+- **No active run + 100% coverage:** still renders 100% / 0 remaining. Run-remainder button stays disabled at L356 (`disabled = row.remaining_count <= 0`).
+
+---
+
+### Finding B — Control tower + Run-on-all + soft-cancel + 3-concurrent dispatcher
+
+#### B.1 Mount point + layout
+
+`mingla-admin/src/pages/PlaceIntelligenceTrialPage.jsx` gains the control tower BETWEEN the page header (L50-L63) and the Tabs row (L65-L86). Sticky behavior is NOT required — the AppShell already handles vertical scroll; the panel renders inline at the top of the scroll region.
+
+```jsx
+<div className="py-6 flex flex-col gap-6">
+  {/* ... existing header L50-L63 ... */}
+
+  <ActiveRunsControlTower
+    onViewRun={(runId) => setActiveTab("results")}  // deep-link to Results tab
+  />
+
+  <div>
+    <Tabs ... />
+    {/* ... existing tab body ... */}
+  </div>
+</div>
+```
+
+#### B.2 `<ActiveRunsControlTower />` contract
+
+**File:** `mingla-admin/src/components/placeIntelligenceTrial/ActiveRunsControlTower.jsx`
+
+```ts
+type Props = {
+  onViewRun?: (runId: string) => void;
+};
+```
+
+**Behavior:**
+- On mount, opens `useActiveRunsPoller()` (poll interval 5000ms).
+- Renders NOTHING when `activeRuns.length === 0` (returns `null`) — including loading state. First poll is fire-and-forget; no spinner.
+- When `activeRuns.length ≥ 1`, renders a `<SectionCard>` titled "Active runs (N)" with the cards stacked vertically (gap-2). No subtitle.
+- Each card is `<ActiveRunCard run={run} onCancelled={…} onViewRun={onViewRun} />`.
+- When a run transitions to terminal (`status ∈ {complete, cancelled, failed}`), the card SHOWS a brief "completed" state for 3000ms with a "Cancelled" / "Done" / "Failed" pill (color matches existing `statusBadgeClasses` in IntelligenceOverviewTab L42-L53), then unmounts via `<AnimatePresence>` (framer-motion `exit={{ opacity: 0, x: 8 }}`, 200ms ease-out).
+- When ALL cards unmount, the SectionCard itself unmounts (returns `null`).
+- A11y: `<SectionCard>` has `role="region" aria-label="Active intelligence runs"`. Each card's progress bar is `role="progressbar"` with `aria-valuenow/min/max`.
+
+**Polling state machine:**
+```
+[Idle (no active runs)] --poll--> [Render N cards] --any run terminal--> [Render card in completed state for 3s]
+                                                                                              |
+                                                                                              v
+                                                                                       [Animate out + remove]
+                                                                                              |
+                                                                                              v
+                                                                                       [Re-evaluate; if 0 left → unmount panel]
+```
+
+#### B.3 `<ActiveRunCard />` contract
+
+**File:** `mingla-admin/src/components/placeIntelligenceTrial/ActiveRunCard.jsx`
+
+```ts
+type Props = {
+  run: {
+    id: string;
+    city_id: string;
+    city_name: string;
+    mode: 'sample' | 'full_city' | 'remainder' | 'retry_failed';
+    status: 'pending' | 'running' | 'cancelling' | 'cancelled' | 'complete' | 'failed';
+    total_count: number;
+    processed_count: number;
+    succeeded_count: number;
+    failed_count: number;
+    cost_so_far_usd: number | null;
+    estimated_cost_usd: number | null;
+    started_at: string | null;
+    // ORCH-1013-B added — computed client-side, not from DB:
+    _liveEtaSeconds?: number | null;       // null when running < 60s (insufficient sample)
+    _liveRatePerMin?: number | null;       // for tooltip; ditto
+  };
+  onCancelled?: (runId: string) => void;   // bubbles up to poller for terminal animation
+  onViewRun?: (runId: string) => void;
+};
+```
+
+**Visual contract (matches DESIGN_ORCH-1008_PHASE_4_INTELLIGENCE_TRIAL_UX.md tokens):**
+
+Card frame: `border border-[var(--color-brand-200)] rounded-lg p-4 bg-[var(--color-brand-50)]` (same as the existing in-tab active-run banner being deleted at TrialResultsTab L703).
+
+Top row: city_name + mode icon (Globe for full_city, Clock for sample, ArrowRight for remainder, RotateCcw for retry_failed) on the left; status pill + count `processed_count / total_count (XX%)` on the right (font-mono tabular-nums).
+
+Progress bar: identical to TrialResultsTab L718-L723 (h-2, brand-500 fill, brand-200 track, 200ms transition).
+
+Live metrics row (text-xs, gap-3, flex-wrap):
+- `✓ {succeeded_count}` (success-700)
+- `✗ {failed_count}` (error-700)
+- `cost: ${cost_so_far_usd.toFixed(4)} of ~${estimated_cost_usd.toFixed(2)}` (text-secondary)
+- `ETA: ~{X} min` when `_liveEtaSeconds != null` AND status === 'running'; show `ETA: —` otherwise (text-secondary, ml-auto)
+
+Cross-check line (text-[10px] text-tertiary italic, font-mono):
+- `${processed_count} × $0.0040 = ${(processed_count * 0.0040).toFixed(4)} expected · ${cost_so_far_usd.toFixed(4)} actual`
+- Mismatch tolerance: `±$0.0010 per place`. If `|actual - expected| > processed_count * 0.0010` AND `processed_count > 10`, append warning icon + tooltip "Cost drift from $0.0040/place baseline > 25% — verify Gemini pricing."
+
+Action row:
+- If status === 'running': `<Button variant="ghost" size="sm" icon={X}>Cancel</Button>` (the `X` icon, NOT `Square`, to match the "⊗" semantic in the brief — operator wants visual distinction from the deleted in-tab "Cancel run" banner. Use `lucide-react`'s `X` icon).
+- If status === 'cancelling': disabled spinner + text "Cancelling… (~30-90s)".
+- If status === 'cancelled' (terminal-with-pill state): show "Cancelled" pill (warning tokens) + "View" button (size sm, ghost, iconRight=ArrowRight) → calls `onViewRun(run.id)`.
+- If status === 'complete' (terminal-with-pill state): "Done" pill (success tokens) + "View" button.
+- If status === 'failed' (terminal-with-pill state): "Failed" pill (error tokens) + "View" button.
+
+Cancel click → opens `<CancelRunConfirmModal>` (existing component, reuse verbatim; cityName=run.city_name, processedCount=run.processed_count, totalCount=run.total_count). On confirm:
+1. POST `{ action: 'cancel_trial', run_id: run.id }` via `invokeWithRefresh`.
+2. On success: toast "Cancelling…" (matches existing TrialResultsTab L294-L297 copy). The poller will pick up the new `status='cancelling'` on next tick; no optimistic update.
+3. On error: toast "Couldn't cancel" with extracted message; modal stays open with retry.
+
+#### B.4 `useActiveRunsPoller()` contract
+
+**File:** `mingla-admin/src/components/placeIntelligenceTrial/useActiveRunsPoller.js`
+
+```ts
+function useActiveRunsPoller(): {
+  activeRuns: ActiveRun[];
+  terminalRuns: ActiveRun[];    // runs in the 3-second "show-then-fade" state
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+```
+
+**Behavior:**
+- On mount, fires first `list_active_runs` immediately, then every `POLL_INTERVAL_MS = 5000`.
+- On EACH poll:
+  1. Call `{ action: 'list_active_runs' }` → returns runs with `status ∈ {pending, running, cancelling}`.
+  2. For each run currently in `activeRuns` whose ID is NO LONGER in the new list AND whose previous status was `running`/`cancelling`, fetch its terminal state via `{ action: 'run_status', run_id }` once, and stage it in `terminalRuns` with a 3000ms TTL.
+  3. For each run still active, optionally fetch `run_status` for the freshest counts (alternative: just use the `place_intelligence_runs` row fields returned by `list_active_runs` which already has `processed_count`/`succeeded_count`/`failed_count`/`cost_so_far_usd` — this is enough, **do not** call `run_status` on every tick to keep edge-fn load minimal).
+- **Live ETA calculation** (client-only, no DB write):
+  - Maintain a ring buffer per `run.id`: `[(timestamp, processed_count), ...]` keyed by run, capped at 12 entries (60s at 5s poll).
+  - On each tick: if buffer has ≥ 2 entries AND elapsed between first+last ≥ 30s, compute `ratePerSec = (last.processed - first.processed) / (last.ts - first.ts)`.
+  - If `ratePerSec > 0`, `_liveEtaSeconds = (run.total_count - run.processed_count) / ratePerSec`; else `_liveEtaSeconds = null`.
+  - If `ratePerSec ≤ 0` (run stalled), `_liveEtaSeconds = null`; card displays "ETA: —".
+  - On unmount/run-removal: drop the run's buffer.
+- **Tab visibility:** when `document.visibilityState === 'hidden'`, pause polling (`clearInterval`). On 'visible', resume with an immediate tick. (Prevents background-tab waste and accidental ETA distortion from polls firing slowly under throttling.)
+- **Operator closes tab mid-run:** polling stops. Cancellation is server-side durable (`cancel_trial` sets `status='cancelling'` in DB; worker finalizes on next chunk). On next open, control tower hydrates from `list_active_runs` and resumes display. No loss.
+- **Operator closes tab mid-cancel:** identical to above — cancellation already requested, server completes it; on next open the run shows up in `complete` status grouping (in Results tab) and NOT in the control tower (already terminal).
+- **Auth refresh / network error:** silent retry on next tick; set `error` state only after 3 consecutive failures, and surface a small inline "Couldn't refresh active runs (retrying)" pill under the SectionCard title.
+
+#### B.5 `<RunRemainderOnAllConfirmModal />` contract
+
+**File:** `mingla-admin/src/components/placeIntelligenceTrial/RunRemainderOnAllConfirmModal.jsx`
+
+```ts
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  candidateCities: Array<{
+    city_id: string;
+    city_name: string;
+    remaining_count: number;
+  }>;     // only cities with remaining_count > 0
+  perPlaceCostUsd?: number;  // default 0.0040
+  onConfirm: (cities: Array<{ city_id, city_name, remaining_count }>) => void;
+};
+```
+
+**Behavior:**
+- Renders nothing when `!open`.
+- Title: `Run remainder on {N} un-evaluated cit{N === 1 ? 'y' : 'ies'}`.
+- Body lists each candidate as a row: `{city_name} — {remaining_count.toLocaleString()} places — ~${(remaining_count * 0.0040).toFixed(2)}` (font-mono tabular-nums for numbers).
+- Below the list, totals box (same visual idiom as RunRemainderConfirmModal cost-breakdown box L167-L191):
+  - "Total places: {sumRemaining.toLocaleString()}"
+  - "Total est. cost: ~${(sumRemaining * 0.0040).toFixed(2)}"
+  - Pricing-source link to https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30, COMMS-0003).
+- Acknowledgement checkbox: "I understand this will charge ~${totalCost} on the Gemini API."
+- High-cost gate (mirrors RunRemainderConfirmModal):
+  - `totalCost > $10` → additionally require typed `RUN ALL` confirmation (NOT a city name — there are multiple cities; use a fixed phrase).
+  - `totalCost > $5` → modal still requires the checkbox; per-city `start_run` call will include `confirm_high_cost: true` for each city whose individual estimate exceeds $5.
+- Confirm button: disabled until checkbox + typed-confirm (if shown) pass. On click, calls `onConfirm(candidateCities)` and closes.
+- "Concurrent runs" disclosure line in modal footer: "Up to 3 cities will run at a time. Remaining cities queue automatically and start as slots free up."
+
+#### B.6 `useBulkRunDispatcher()` contract (3-concurrent client-side cap)
+
+**File:** `mingla-admin/src/components/placeIntelligenceTrial/useBulkRunDispatcher.js`
+
+```ts
+type BulkRunStatus = 'pending' | 'starting' | 'running' | 'complete' | 'failed' | 'skipped_concurrent';
+
+type DispatcherState = {
+  queue: Array<{
+    city_id: string;
+    city_name: string;
+    remaining_count: number;
+    status: BulkRunStatus;
+    run_id?: string;       // set after start_run succeeds
+    error?: string;        // set on start_run failure
+    started_at?: number;   // Date.now() at dispatch
+  }>;
+  inFlight: number;         // count of status === 'starting' | 'running'
+};
+
+function useBulkRunDispatcher(): {
+  state: DispatcherState;
+  enqueue: (cities: Array<{ city_id, city_name, remaining_count }>) => void;
+  cancelAll: () => void;    // sets all 'pending' to 'skipped_concurrent'; does NOT cancel in-flight runs (those use control tower's per-card cancel)
+};
+```
+
+**State machine (per city):**
+```
+pending
+   │
+   │ (slot available: inFlight < 3) AND (≥2s elapsed since prior start in this batch)
+   ▼
+starting  ── start_run POST in flight
+   │
+   ├─ 200 OK ──▶ running   (run_id captured; control tower picks it up on next poll)
+   │
+   ├─ 409 concurrent_run ──▶ skipped_concurrent (server says city already has active run)
+   │
+   └─ 500/network ──▶ failed (error captured; toast surfaces "city X failed to start")
+
+running
+   │
+   │ (poll of list_active_runs no longer includes this run_id)
+   ▼
+complete (or failed/cancelled — dispatcher does not distinguish; control tower owns terminal UX)
+```
+
+**Invariants:**
+- `inFlight ≤ 3` AT ALL TIMES (hard client-side cap). Server's per-city unique-partial-index handles the per-city guard; this cap is operator-experience only.
+- Between consecutive `starting` transitions: minimum 2000ms gap (the brief's "2s stagger").
+- The dispatcher does NOT cancel in-flight runs on tab close. If operator wants to cancel, they use per-card cancel in the control tower (which is server-durable).
+- After `enqueue()`, the dispatcher is fire-and-forget; the hook keeps running until all `pending` are drained or `cancelAll()` is called.
+
+**Tick logic** (runs every 500ms while any city is `pending`):
+```js
+const now = Date.now();
+const lastStartAt = Math.max(...state.queue.filter(c => c.started_at).map(c => c.started_at), 0);
+const canStartNext = (now - lastStartAt) >= 2000 && state.inFlight < 3;
+if (canStartNext) {
+  const next = state.queue.find(c => c.status === 'pending');
+  if (next) startCity(next);
+}
+```
+
+**Tab-close behavior:**
+- `pending` cities: lost (no server-side queue). Operator must re-fire bulk-launch when they reopen. **Decision §7-D2:** acceptable trade-off — server-side queueing would require new tables + cron + a much larger SPEC; META-ORCH-1009 acceptably covers ≤8 cities which fit comfortably in one operator session.
+- `running` cities: continue server-side (durable). On reopen, control tower hydrates them.
+
+#### B.7 "Run remainder on all" header button (Overview tab)
+
+`mingla-admin/src/components/placeIntelligenceTrial/IntelligenceOverviewTab.jsx`
+
+Add to the `<SectionCard>` `action` slot at L210-L221, BEFORE the Refresh button:
+
+```jsx
+<Button
+  size="sm"
+  variant="secondary"
+  icon={Play}
+  onClick={() => setBulkModalOpen(true)}
+  disabled={loading || candidateCities.length === 0}
+  title={
+    candidateCities.length === 0
+      ? "All cities are fully evaluated"
+      : `Run remainder on ${candidateCities.length} un-evaluated cit${candidateCities.length === 1 ? 'y' : 'ies'}`
+  }
+>
+  Run remainder on all{candidateCities.length > 0 ? ` (${candidateCities.length})` : ""}
+</Button>
+```
+
+Where `candidateCities = useMemo(() => rows.filter((r) => r.remaining_count > 0), [rows])`.
+
+On confirm in `<RunRemainderOnAllConfirmModal>`, call `dispatcher.enqueue(candidateCities)` and close the modal. Toast: `"Bulk remainder queued — {N} cities, ~${totalCost.toFixed(2)} total."`
+
+The dispatcher state and per-city errors are surfaced via:
+1. The control tower picks up each new `run_id` on its next 5s poll (no special UI needed — runs just appear).
+2. For cities that 409-skipped or 500-failed, fire a `addToast({ variant: 'warning', title: 'Couldn't start {city_name}', description: error })` per city.
+
+#### B.8 TrialResultsTab — banner deletion contract
+
+DELETE the entire `{activeRun && !bannerDismissed && (...)}` block at TrialResultsTab L702-L769.
+
+Also DELETE:
+- `bannerDismissed` state (L103) and its reset effect (L244-L246).
+- `cancelModalOpen` state (L98), `cancelLoading` state (L99), `handleCancelActiveRunConfirmed` (L278-L304).
+- `handleResumeFromN` (L320-L327) — superseded by control tower's `onCancelled` → "Resume" affordance shown ONLY in the control tower's per-card "cancelled" terminal state. (DEFER on the actual resume affordance — out-of-scope for this PR; operator re-runs remainder from Overview tab. See §6.)
+- The `<CancelRunConfirmModal>` mount at L1128-L1136.
+- The `Square` icon import on L18 IF no longer used after the `handleCancel` (sample mode) and active-run banner are deleted. (Keep `Square` if `handleCancel` at L566-L569 still references it; check use-by-use.)
+
+KEEP:
+- The cross-session hydration effect at L218-L238 — it sets `activeRunId`/`activeRun` for the SAMPLE-mode browser-loop only. Wait — re-reading: this effect picks up any active run including remainder/full_city. Its outputs (`activeRunId`, `activeRun`) drove the deleted banner. **Decision §7-D3:** delete this effect too; the control tower hydrates active runs independently. Sample-mode browser-loop uses `progress` state (L77), not `activeRun`.
+- The `cityCoverage` poll at L184-L186 — still used by the Trial Results tab's per-city scored coverage tile (L984-L1057).
+- `handleRetryFailedPlaces` (L571-L636) — unrelated, untouched.
+- The mode toggle (L771-L834) and Run trial button (L898-L913) — unchanged.
+
+After deletion: the activeRunId state stays for sample-mode loop interaction (`disabled={!!activeRunId}` at L848, L887, etc — currently prevents starting a new run while one is active). Hydration removal means TrialResultsTab no longer knows about active remainder/full_city runs at all; the `!activeRunId` gates on lines 665-670, 848, 887 will always be true (no active run from this tab's POV). **Decision §7-D4:** that's correct — operator can fire a SAMPLE from the Trial Results tab even if a full-city is running elsewhere (server's per-city unique constraint still enforces single-active-per-city). The "Already a run in progress" warning at L969-L973 becomes dead and is deleted with the banner block.
+
+The `<RunRemainderConfirmModal>` at L1137-L1162 STAYS — it's still used by the Trial Results mode toggle's "Remainder only" path.
+
+---
+
+### Finding C — Admin Tailwind drift fix
+
+#### Diagnosis (verified 2026-05-30 on main anchor)
+
+`cd ~/Desktop/mingla-main/mingla-admin && npm run build` exits 1 with:
+```
+failed to load config from /Users/sethogieva/Desktop/mingla-main/mingla-admin/vite.config.js
+error during build:
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/sethogieva/Desktop/mingla-main/mingla-admin/node_modules/tailwindcss/dist/lib.mjs' imported from /Users/sethogieva/Desktop/mingla-main/mingla-admin/node_modules/@tailwindcss/node/dist/index.mjs
+Did you mean to import "tailwindcss/dist/lib.js"?
+```
+
+**Root cause:** `node_modules/tailwindcss/dist/` in the anchor is **partially extracted**:
+- Installed: 19 files, 1 `.mjs` (only `flatten-color-palette.mjs`).
+- Published `tailwindcss@4.2.1` tarball: 27 files, 8 `.mjs` (including `lib.mjs`, `index.mjs`, plugin.mjs etc).
+- The missing `lib.mjs` is precisely what `@tailwindcss/node@4.2.1/dist/index.mjs` imports.
+
+**Package.json + lockfile are correct:** `"tailwindcss": "^4.2.1"` in package.json, `tailwindcss@4.2.1` pinned in package-lock.json. Worktree's `node_modules/tailwindcss` (symlinked from anchor) inherits the same broken install.
+
+**Not a version mismatch. Not a Tailwind v4 breaking change. Not a peer-dep conflict.** Just a torn install — likely from a prior interrupted `npm install` or a `git clean` that nuked partial files. `package-lock.json` integrity hash check (npm 9+) doesn't validate physical file presence post-install.
+
+#### Fix — operator-approval-free reinstall
+
+```bash
+cd ~/Desktop/mingla-main/mingla-admin
+rm -rf node_modules
+npm ci
+```
+
+OR (safer if any local-only deps exist, none observed):
+```bash
+cd ~/Desktop/mingla-main/mingla-admin
+rm -rf node_modules/tailwindcss node_modules/@tailwindcss
+npm install
+```
+
+**Cited operator-approval guard:** per `feedback_autonomy_posture_verifier_not_manager.md`, reinstalls of existing dependencies are autonomy-safe. NO `package.json` edit, NO `package-lock.json` change, NO new dependency. **No operator approval needed.** Implementor runs the reinstall, verifies `npm run build` exits 0, and includes the reinstall in the PR's repro steps (no commit produced).
+
+**Why no lockfile bump:** lockfile already pins the correct version (4.2.1). The published tarball is intact (verified via `npm pack tailwindcss@4.2.1` — ships `lib.mjs`). A `npm install` re-downloads + re-extracts from the cached/remote tarball, restoring the missing files.
+
+**Why no version pin change:** the bug is NOT in Tailwind 4.2.1. Bumping wouldn't help and would introduce risk surface (4.3.0 has different `lightningcss` and `enhanced-resolve` ranges).
+
+**Why no config migration:** no Tailwind config file at all in `mingla-admin` (Tailwind v4 uses `@tailwindcss/vite` + CSS-first config). Nothing to migrate.
+
+#### Worktree implication
+
+The ORCH-1013 worktree's `node_modules/tailwindcss` is symlinked from the anchor. After the anchor reinstall, the worktree's symlinks auto-resolve to the freshly-extracted files. No worktree-side action.
+
+#### Implementor verification steps (Finding C acceptance)
+
+```bash
+# 1. Reinstall in anchor
+cd ~/Desktop/mingla-main/mingla-admin && rm -rf node_modules && npm ci
+
+# 2. Verify file presence
+ls node_modules/tailwindcss/dist/lib.mjs   # must exist
+ls node_modules/tailwindcss/dist/ | wc -l  # must be 27 (matches published)
+
+# 3. Build passes
+npm run build                              # exit 0
+npm run dev &
+sleep 5; curl -fsSI http://localhost:5173 | head -1
+kill %1
+```
+
+If `npm ci` fails with EINTEGRITY or similar lockfile-state error: that escalates to operator (would imply a real lockfile bump is needed). On the verified 2026-05-30 state, the package.json + lockfile are internally consistent, so `npm ci` is expected to succeed cleanly.
+
+---
+
+## §4 — Success criteria + acceptance tests per finding
+
+### Finding A — Coverage truth
+
+**Test 1 — Regression (Cary drift scenario), edge-fn unit test**
+
+**File:** `supabase/functions/run-place-intelligence-trial/__tests__/handleIntelligenceCoverage.drift.test.ts` (new)
+
+Uses Deno test runner (matches existing tests in the dir). Fixture:
+- 1 seeded city (Cary) with 761 servable + 6 non-servable place_pool rows.
+- 766 `place_intelligence_trial_runs` rows with `status='completed'`: 760 reference still-servable places, 6 reference rows whose `place_pool.is_servable` is `false`.
+- Stub `SupabaseClient` returning those rows from the 4 parallel queries.
+
+**Assertions:**
+- Returned row for Cary has `servable_count: 761`, `evaluated_count: 760`, `remaining_count: 1`, `coverage_pct: 99.9`.
+- (BEFORE-fix sanity check — optional: add a `// @ts-expect-error` snapshot of the pre-fix output `evaluated_count: 761, remaining_count: 0, coverage_pct: 100` so a regression future-bumps the snapshot.)
+
+**Test 2 — Raleigh genuinely-100% case**
+
+Same harness, fixture 1540/1540 with zero drift. Assertions: `evaluated_count: 1540`, `remaining_count: 0`, `coverage_pct: 100.0`.
+
+**Test 3 — Live-DB smoke (manual, captured in PR description)**
+
+After deploy:
+```bash
+curl -X POST https://gqnoajqerqhnvulmnyvv.supabase.co/functions/v1/run-place-intelligence-trial \
+  -H "Authorization: Bearer <admin token>" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"intelligence_coverage"}' | jq '.rows[] | select(.city_name == "Cary")'
+```
+Expected: `evaluated_count: 760, remaining_count: 1, coverage_pct: 99.9` (or current-as-of-deploy truth via the §3 Finding A SQL probe).
+
+### Finding B — Control tower behaviors
+
+**Test 4 — Control tower mount/unmount on run state change**
+
+`mingla-admin/src/components/placeIntelligenceTrial/__tests__/ActiveRunsControlTower.test.jsx` (new; vitest + RTL).
+
+- Mock `useActiveRunsPoller` to return `activeRuns: []` initially → assert panel renders `null`.
+- Update mock to return 1 running run → assert SectionCard renders with title "Active runs (1)" + 1 card.
+- Update mock to remove that run + add to `terminalRuns` with status='complete' → assert card still rendered with "Done" pill.
+- Advance 3000ms (vitest fake timers) → assert card removed via AnimatePresence.
+
+**Test 5 — Run-on-all dispatcher correctness**
+
+`mingla-admin/src/components/placeIntelligenceTrial/__tests__/useBulkRunDispatcher.test.js` (new).
+
+- `enqueue([{city_id:'a',...}, {city_id:'b',...}, {city_id:'c',...}, {city_id:'d',...}])`.
+- Mock `start_run` to resolve after 100ms with `{runId: ...}`.
+- Use vitest fake timers; tick through dispatcher.
+- Assert:
+  - At t=0ms: `inFlight=0`. At t=500ms (first tick): city 'a' transitions to `starting` (only one — 2s stagger doesn't apply to first start).
+  - Wait, stagger contract says "min 2s gap BETWEEN consecutive `starting` transitions." First start at t=500ms; second start blocked until t=2500ms.
+  - At t=2500ms: city 'b' starts (inFlight now 2).
+  - At t=4500ms: city 'c' starts (inFlight=3, AT cap).
+  - At t=6500ms: city 'd' WOULD start but inFlight===3 → blocked. Verify city 'd' stays `pending`.
+  - Simulate city 'a' completing (remove from `list_active_runs` mock) → poller reports inFlight=2 → next tick (within 500ms) city 'd' starts.
+- Assert hard cap: at no point during ticks does `inFlight` exceed 3.
+
+**Test 6 — 409 concurrent_run handling**
+
+Mock `start_run` for city 'b' to return 409 → assert `state.queue[1].status === 'skipped_concurrent'` and the toast was emitted with city_name + error.
+
+**Test 7 — Soft-cancel state machine**
+
+`mingla-admin/src/components/placeIntelligenceTrial/__tests__/ActiveRunCard.test.jsx` (new).
+
+- Render card with `run.status='running'`.
+- Click ⊗ Cancel → assert `<CancelRunConfirmModal>` opens (visible).
+- Click "Cancel run" in modal → assert POST to `cancel_trial` fires with `run_id`.
+- Mock 200 response → assert toast "Cancelling…" fires + modal closes.
+- Re-render card with `run.status='cancelling'` → assert button replaced with spinner + "Cancelling… (~30-90s)" text.
+- Re-render with `run.status='cancelled'` (terminal pill state) → assert "Cancelled" pill + "View" button render.
+
+**Test 8 — Live ETA suppression < 60s**
+
+In `useActiveRunsPoller` test, simulate buffer with single entry → assert `_liveEtaSeconds === null` → card shows "ETA: —". After 30s buffer with positive rate → assert `_liveEtaSeconds > 0` and card shows e.g. "ETA: ~14 min".
+
+**Test 9 — Manual smoke (operator-driven, captured in PR description)**
+
+1. Open Place Intel page → no runs → control tower hidden.
+2. Click "Run remainder" on Cary (1 place remaining post-Finding-A-fix) → control tower appears with Cary card.
+3. Fire `start_run` on Raleigh in another tab → after ≤5s, Raleigh card appears alongside Cary.
+4. Click Cary's ⊗ → modal opens → Confirm → modal closes, toast "Cancelling…", card shows "Cancelling… (~30-90s)".
+5. Wait for cancel finalization → card shows "Cancelled" pill for 3s, slides out.
+6. Raleigh's card stays visible with live ETA + cost cross-check.
+7. Click "Run remainder on all" header button → modal lists candidate cities → confirm → up to 3 cities start with 2s stagger; 4th queues.
+
+### Finding C — Build restored
+
+**Test 10 — Build passes (anchor)**
+
+```bash
+cd ~/Desktop/mingla-main/mingla-admin
+rm -rf node_modules && npm ci
+npm run build
+echo $?   # must be 0
+```
+
+**Test 11 — Dev server boots (anchor)**
+
+```bash
+cd ~/Desktop/mingla-main/mingla-admin
+npm run dev &
+sleep 8
+curl -fsSI http://localhost:5173 | head -1  # expect 200 OK
+kill %1
+```
+
+**Test 12 — ESLint runs**
+
+```bash
+cd ~/Desktop/mingla-main/mingla-admin
+npx eslint src --max-warnings=999    # must exit 0 (warnings ok, errors not)
+```
+
+**Test 13 — Worktree inherits fix (symlink resolution)**
+
+```bash
+cd "~/Desktop/mingla-orchs/ORCH-1013-[place-intel-control-tower-coverage-fix]/mingla-admin"
+npm run build
+echo $?   # must be 0
+```
+
+All Finding-C tests are mechanical and require no manual judgment. The implementor runs them and pastes output into the PR description.
+
+---
+
+## §5 — Invariants (new + amended)
+
+### New (DRAFT — flip ACTIVE on ORCH-1013 CLOSE)
+
+- **`I-PROPOSED-INTEL-COVERAGE-COUNTS-CURRENTLY-SERVABLE`** — `handleIntelligenceCoverage` MUST only count `(city_id, place_pool_id)` evaluation pairs where `place_pool.is_servable = true` at query time. Specifically: the `completedRes` subquery at `supabase/functions/run-place-intelligence-trial/index.ts` ~L2216-L2220 MUST include `.select("city_id, place_pool_id, place_pool!inner(is_servable)").eq("place_pool.is_servable", true)`. Strict-grep gate: assert this exact substring in CI.
+
+- **`I-PROPOSED-INTEL-BULK-DISPATCHER-CAP-3`** — `useBulkRunDispatcher` MUST never let `inFlight` exceed 3. Backed by `useBulkRunDispatcher.test.js` Test 5.
+
+- **`I-PROPOSED-INTEL-BULK-DISPATCHER-STAGGER-2S`** — `useBulkRunDispatcher` MUST enforce ≥ 2000ms between consecutive `starting` transitions. Backed by Test 5.
+
+- **`I-PROPOSED-INTEL-CONTROL-TOWER-VISIBILITY-GATE`** — `<ActiveRunsControlTower />` MUST return `null` when both `activeRuns.length === 0` AND `terminalRuns.length === 0`. No empty card frame.
+
+### Amended (no change to wording, but Finding B affects practice)
+
+- **`I-TRIAL-OUTPUT-NEVER-FEEDS-RANKING`** (existing, ORCH-0734) — unchanged. Control tower + bulk dispatcher are pure observability/operational; no consumer-ranking surface touched.
+
+### Operator-facing
+- No COMMS-ledger entry needed for Finding A (server-side bug, no contract change).
+- COMMS-0003 already satisfied by existing Gemini pricing citations; new bulk modal MUST also cite the URL (contract §3.B.5).
+
+---
+
+## §6 — Out of scope
+
+Explicitly NOT in this PR:
+
+1. **META-ORCH-1009 consumer-deck code** — this PR ships ONLY admin-side coverage truth + control-tower UX + admin build restore. Whatever feeds card-ranking from `place_pool` / `place_scores` is untouched.
+2. **app-mobile** — no React Native changes. No expo update required.
+3. **mingla-business** — no business-app changes.
+4. **Server-side run queue** — `useBulkRunDispatcher` is client-only. If operator closes tab with `pending` cities, those are lost (per §3.B.6 decision). A future ORCH could promote queueing to the edge fn + a new `intelligence_run_queue` table, but that's a larger architectural shift gated on operator demand.
+5. **"Resume from N" affordance** — the deleted active-run banner had a "Resume from place N+1" button (TrialResultsTab L320-L327, L751-L760). Control tower's "View" button on a cancelled card deep-links to Results tab, where the operator manually re-fires the remainder mode. The dedicated Resume button is **deferred** — operator can use Run-on-all (or per-city Run remainder) from the Overview tab which is equivalent in effect.
+6. **Cost-drift > 25% diagnostics** — the warning icon in §3.B.3 is an INDICATOR only. No telemetry, no Sentry, no alert. If operator sees it repeatedly, that's the trigger for a separate forensic ORCH on Gemini pricing.
+7. **A new `run_state_changed` realtime channel** — the 5s poll is sufficient per the brief. Supabase Realtime + channel auth would be a larger ORCH.
+8. **Tailwind config migration to v4 CSS-first** — `mingla-admin` is already on `@tailwindcss/vite` (CSS-first); no migration is needed or in scope.
+9. **`mingla-admin` ESLint rule changes** — Test 12 only verifies eslint runs to completion; existing warning counts are not adjusted in this PR.
+
+---
+
+## §7 — Decisions (judgment calls + why)
+
+### D1 — Server-side fix for Finding A (not client-side workaround)
+
+The brief lists two options: (a) fix the JS service file, OR (b) fix the edge fn SQL. **Decision: fix the edge fn.** Reasons:
+- The bug is in the data layer; a client-side filter would re-query `place_pool` from the browser just to second-guess the server, doubling the load.
+- The edge fn already does the 4 parallel queries server-side; adding `!inner` is a 1-line join hint, not a new query.
+- Tests can run via Deno (matches existing test pattern in `__tests__/`) without a Supabase client mock at all (just the response shape).
+
+### D2 — Client-side bulk dispatcher (not server-side queue)
+
+The brief explicitly says "enforced CLIENT-SIDE by the dispatcher (server's per-city guard handles the rest)." Decision honored. Trade-off: tab-close loses `pending` cities. Mitigation: operator can re-fire; expected use case is one bulk launch then operator watches the control tower for 5-60 min until cities complete.
+
+### D3 — Delete TrialResultsTab cross-session hydration effect (L218-L238)
+
+Originally added in ORCH-0737 so that reopening Trial Results would show the in-progress full-city banner. With the banner deleted (replaced by the Place-Intel-page-level control tower), this effect orphans `activeRunId`/`activeRun` state with no UI consumer. Cleanest: delete the effect AND the unused state. Sample-mode `progress` state at L77 is unaffected.
+
+### D4 — Sample-mode "blocked while active run" semantics relax
+
+Pre-PR: TrialResultsTab disables city picker + Run button if ANY active run exists (`!!activeRunId` checks at L848, L887, L665-L670). Post-PR: TrialResultsTab no longer knows about active runs, so a sample can be fired even while another city's full_city run is in flight. Server's per-city unique-partial-index still prevents starting a SECOND run on the SAME city (409 concurrent_run). For DIFFERENT cities, this is operationally desirable — operator can sample-test City B while Cary's remainder finishes. **Risk:** edge-fn worker pool / Gemini rate-limit pressure under heavy parallelism. Mitigation: paid Gemini tier 1 has effectively unbounded RPM per ORCH-0734 docstring; 3-concurrent cap on bulk dispatcher + 1 manual sample = 4 max concurrent invocations, well within budget.
+
+### D5 — `lucide-react` icon for soft-cancel: `X`, not `Square`
+
+The deleted banner uses `Square` for "Cancel run". The brief's "⊗" notation suggests `X` (cross/circle) over `Square` (stop). Decision: use `X` for control tower per-card cancel to visually distinguish from the deleted in-tab "Square" button + match the "soft" semantic. `Square` stays in TrialResultsTab for the sample-mode browser-loop "Cancel" (L910-L912) — that's a hard immediate-stop, not a soft async cancel.
+
+### D6 — Run-on-all typed confirm = fixed phrase `"RUN ALL"`, not city names
+
+RunRemainderConfirmModal at >$10 requires typing the city name. With Run-on-all, multiple city names are involved; typing all of them is hostile UX. Fixed phrase `"RUN ALL"` is a strong-enough friction gate at the >$10 threshold without being unusable. (If operator pushes back on this, escalate to mingla-designer in a follow-up.)
+
+### D7 — Cost-drift tolerance: ±$0.0010 per place, 10-place minimum
+
+Per-place cost is $0.0040; ±25% drift threshold ($0.0010) catches significant pricing changes without false-firing on rounding noise. Suppress under 10 places to avoid noise on tiny runs. This is purely visual; no action taken on the value.
+
+### D8 — Finding C reinstall scope: full `node_modules` wipe vs targeted `tailwindcss` remove
+
+The brief allows either. Recommended: `rm -rf node_modules && npm ci` for safety (catches any other torn install). If operator hits a slow re-install (mingla-admin has many deps), implementor MAY fall back to the targeted `rm -rf node_modules/tailwindcss node_modules/@tailwindcss && npm install`. Both leave package-lock.json untouched; both produce the same final state.
+
+### D9 — Coverage clamp Math.min/Math.max retained as defensive (not removed)
+
+After Finding A fix, `evaluated ≤ servable` by JOIN construction. The clamp is therefore mathematically redundant. **Kept as defensive** because the 4 parallel queries (L2206-L2228) are not transactional; a write to `place_pool` between the `servableRes` and `completedRes` queries could create a 1-row skew. The clamp prevents a transient display glitch. Cost: 0. Worth: small but real. (Implementor MAY drop in a follow-up; reviewer's call.)
+
+### D10 — Items flagged for operator review
+
+**Operator approval NEEDED:** NONE for this SPEC. Finding C's reinstall is autonomy-safe (no dep change). Finding B introduces new files but no new packages.
+
+**Operator visibility NICE-TO-HAVE:**
+- META-ORCH-1009 implications: control tower's 5s poll across 8 cities = ~96 edge-fn invocations/minute. Within Supabase free-tier (500K/month = ~11K/min); not a concern.
+- Bulk dispatcher tab-close loses pending — operator should know.
+- D5 icon choice — purely cosmetic; can roll back if operator dislikes.
+
+---
+
+## §A — Spec completeness self-check (gate per `feedback_forensics_depth_and_spec_granularity.md`)
+
+| Clause | Status |
+|---|---|
+| 1. Goal in plain English | §1 |
+| 2. Every file path verified to exist (Read tool, not guessed) | §2 — IntelligenceOverviewTab, TrialResultsTab, RunRemainderConfirmModal, CancelRunConfirmModal, intelligenceCoverageService, PlaceIntelligenceTrialPage, index.ts all read; line ranges verified |
+| 3. External API URLs cited inline | §3.B.5 (Gemini pricing), §3.A (Finding A does not introduce new API surface; existing header citations stand) |
+| 4. Each contract has function signatures + behavior | §3.B.2-B.7 |
+| 5. Acceptance tests per finding | §4 Tests 1-13 |
+| 6. Invariants declared with grep targets | §5 (4 new DRAFTs) |
+| 7. Out-of-scope explicit | §6 (9 items) |
+| 8. Decisions enumerated with WHY | §7 (10 decisions) |
+| 9. Live-data probe used to verify before/after | §3.A Cary numbers re-probed 2026-05-30 |
+| 10. No code changes attempted | Pure SPEC document |
+
+SPEC complete and ready for implementor dispatch.

--- a/mingla-admin/src/__tests__/orch1008_status_groups.test.js
+++ b/mingla-admin/src/__tests__/orch1008_status_groups.test.js
@@ -115,9 +115,9 @@ describe("ORCH-1008 Phase 4b — TrialResultsTab mounts the status-grouped run h
     );
   });
 
-  it("imports SignalDistributionPanel and cancel modal", () => {
+  it("imports SignalDistributionPanel and remainder modal (ORCH-1013: in-tab cancel modal moved to control tower)", () => {
     assert.ok(src.includes("import { SignalDistributionPanel }"));
-    assert.ok(src.includes("import { CancelRunConfirmModal }"));
+    // ORCH-1013 Finding B — CancelRunConfirmModal import moved to ActiveRunCard.
     assert.ok(src.includes("import { RunRemainderConfirmModal }"));
   });
 
@@ -128,17 +128,18 @@ describe("ORCH-1008 Phase 4b — TrialResultsTab mounts the status-grouped run h
     assert.ok(src.includes("Remainder only"));
   });
 
-  it("cancel button opens the modal rather than calling window.confirm", () => {
-    // The new path uses setCancelModalOpen(true); the legacy path called
-    // window.confirm("Cancel this run? ...") — that string must not appear.
-    assert.ok(
-      src.includes("setCancelModalOpen(true)"),
-      "expected setCancelModalOpen(true) on the Cancel button",
-    );
+  it("ORCH-1013 Finding B — in-tab cancel banner deleted; window.confirm not reintroduced", () => {
+    // Legacy window.confirm cancel prompt must NEVER come back; the soft-cancel
+    // UX lives on <ActiveRunCard /> inside the page-level control tower now.
     assert.equal(
       src.includes('window.confirm("Cancel this run'),
       false,
-      "legacy window.confirm cancel prompt must be replaced by the modal",
+      "legacy window.confirm cancel prompt must not be reintroduced",
+    );
+    assert.equal(
+      src.includes("setCancelModalOpen("),
+      false,
+      "ORCH-1013: in-tab cancel modal state is deleted — cancel UX is in <ActiveRunCard />",
     );
   });
 });

--- a/mingla-admin/src/__tests__/orch1013_active_run_card_soft_cancel.test.js
+++ b/mingla-admin/src/__tests__/orch1013_active_run_card_soft_cancel.test.js
@@ -1,0 +1,115 @@
+// ORCH-1013 Finding B regression — <ActiveRunCard /> soft-cancel state machine:
+//   - running → click X → CancelRunConfirmModal opens
+//   - confirm → POST {action:'cancel_trial', run_id} via invokeWithRefresh
+//   - success → toast "Cancelling…" + onCancelled(run.id) fires
+//   - cancelling → spinner + "Cancelling… (~30-90s)" instead of cancel button
+//   - terminal (complete/cancelled/failed) → status pill + "View" affordance
+//
+// Icon choice (SPEC §7-D5): `X` from lucide-react, NOT `Square`.
+//
+// node:test + source-string assertions (mingla-admin pattern).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const CARD = path.join(
+  ADMIN_ROOT,
+  "src",
+  "components",
+  "placeIntelligenceTrial",
+  "ActiveRunCard.jsx",
+);
+
+describe("ORCH-1013 Finding B — ActiveRunCard soft-cancel", () => {
+  const src = fs.readFileSync(CARD, "utf8");
+
+  it("imports the soft-cancel icon as X (NOT Square)", () => {
+    assert.ok(
+      /import\s*{[^}]*\bX\b[^}]*}\s*from\s*"lucide-react"/.test(src),
+      "must import X from lucide-react (SPEC §7-D5)",
+    );
+    assert.ok(
+      !/import\s*{[^}]*\bSquare\b[^}]*}\s*from\s*"lucide-react"/.test(src),
+      "must NOT import Square — Square stays in TrialResultsTab for hard sample-mode cancel only",
+    );
+  });
+
+  it("opens CancelRunConfirmModal on Cancel click", () => {
+    assert.ok(
+      src.includes("CancelRunConfirmModal"),
+      "must mount the existing CancelRunConfirmModal primitive",
+    );
+    assert.ok(
+      src.includes("setCancelModalOpen(true)"),
+      "Cancel button must open the modal (not call cancel directly)",
+    );
+  });
+
+  it("on confirm, POSTs {action:'cancel_trial', run_id}", () => {
+    assert.ok(
+      src.includes('action: "cancel_trial"') && src.includes("run_id: run.id"),
+      "confirm must invoke the cancel_trial action with run.id",
+    );
+  });
+
+  it("on success, emits toast 'Cancelling…' + calls onCancelled(run.id)", () => {
+    assert.ok(
+      src.includes('title: "Cancelling…"'),
+      "must emit a toast with title 'Cancelling…'",
+    );
+    assert.ok(
+      src.includes("onCancelled?.(run.id)"),
+      "must bubble cancellation to the parent poller for terminal animation",
+    );
+  });
+
+  it("status='cancelling' shows spinner + '(~30-90s)' text instead of cancel button", () => {
+    assert.ok(
+      src.includes("Loader2") && src.includes("animate-spin"),
+      "cancelling state must render an animated spinner",
+    );
+    assert.ok(
+      src.includes("Cancelling… (~30-90s)"),
+      "cancelling state must surface the 30-90s ETA copy",
+    );
+  });
+
+  it("terminal status (complete/cancelled/failed) shows View button", () => {
+    assert.ok(
+      src.includes('["complete", "cancelled", "failed"]'),
+      "terminal-state guard must include all 3 terminal statuses",
+    );
+    assert.ok(
+      src.includes("onViewRun?.(run.id)"),
+      "View button must invoke onViewRun(run.id) for deep-link",
+    );
+  });
+
+  it("cost cross-check shows expected vs actual with ±$0.0010/place tolerance", () => {
+    assert.ok(
+      src.includes("COST_DRIFT_TOLERANCE_USD_PER_PLACE"),
+      "must declare a drift tolerance constant",
+    );
+    assert.ok(
+      /COST_DRIFT_TOLERANCE_USD_PER_PLACE\s*=\s*0\.001\b/.test(src),
+      "tolerance must be $0.0010 per place (±25% of $0.0040)",
+    );
+    assert.ok(
+      src.includes("expected") && src.includes("actual"),
+      "cross-check line must surface 'expected' and 'actual' numbers",
+    );
+  });
+
+  it("ETA shows '—' when status is not running OR _liveEtaSeconds is null", () => {
+    assert.ok(
+      src.includes('"—"'),
+      "ETA cell must fall back to '—' when no live rate available",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_active_runs_control_tower.test.js
+++ b/mingla-admin/src/__tests__/orch1013_active_runs_control_tower.test.js
@@ -1,0 +1,108 @@
+// ORCH-1013 Finding B regression — <ActiveRunsControlTower /> surface
+// invariants: visibility gate (returns null when zero active+terminal),
+// SectionCard title ("Active runs (N)"), wires onViewRun deep-link, mounts
+// <ActiveRunCard /> per run, uses Framer Motion AnimatePresence + layout.
+//
+// node:test + source-string assertions (matches mingla-admin's existing test
+// pattern — no React Testing Library / vitest dependency). Fails on revert
+// (verified at commit hash recorded in implementation report).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const TOWER = path.join(
+  ADMIN_ROOT,
+  "src",
+  "components",
+  "placeIntelligenceTrial",
+  "ActiveRunsControlTower.jsx",
+);
+const PAGE = path.join(
+  ADMIN_ROOT,
+  "src",
+  "pages",
+  "PlaceIntelligenceTrialPage.jsx",
+);
+
+describe("ORCH-1013 Finding B — ActiveRunsControlTower surface", () => {
+  const src = fs.readFileSync(TOWER, "utf8");
+
+  it("imports useActiveRunsPoller + SectionCard + ActiveRunCard + framer-motion", () => {
+    assert.ok(src.includes("useActiveRunsPoller"), "must import useActiveRunsPoller");
+    assert.ok(src.includes("SectionCard"), "must import SectionCard");
+    assert.ok(src.includes("ActiveRunCard"), "must import ActiveRunCard");
+    // Aliased to `Motion` to match the no-unused-vars `^[A-Z_]` pattern; the
+    // member access (`Motion.div`) still resolves to framer-motion's motion API.
+    assert.ok(
+      src.includes("AnimatePresence") &&
+        /from\s*"framer-motion"/.test(src) &&
+        src.includes("motion as Motion"),
+      "must use framer-motion AnimatePresence + motion (aliased Motion)",
+    );
+  });
+
+  it("returns null when no active or terminal runs (visibility gate)", () => {
+    // Invariant I-PROPOSED-INTEL-CONTROL-TOWER-VISIBILITY-GATE
+    assert.ok(
+      src.includes("if (totalCount === 0) return null"),
+      "must return null when activeRuns.length + terminalRuns.length === 0",
+    );
+  });
+
+  it("renders SectionCard titled 'Active runs (N)'", () => {
+    assert.ok(
+      src.includes("Active runs (${activeRuns.length})"),
+      "SectionCard title must include 'Active runs (N)'",
+    );
+  });
+
+  it("passes onViewRun prop to each ActiveRunCard", () => {
+    assert.ok(
+      src.includes("onViewRun={onViewRun}"),
+      "ActiveRunCard must receive onViewRun prop for deep-link",
+    );
+  });
+
+  it("exit animation slides cards out (x: 8, opacity: 0, ~200ms ease-out)", () => {
+    // Per SPEC §3 B.2 — framer-motion `exit={{ opacity: 0, x: 8 }}`, 200ms ease-out
+    assert.ok(src.includes("opacity: 0"), "exit animation must zero opacity");
+    assert.ok(src.includes("x: 8"), "exit animation must slide right by 8px");
+    assert.ok(src.includes('duration: 0.2'), "transition duration must be ~200ms");
+    assert.ok(src.includes('ease: "easeOut"'), "transition must be ease-out");
+  });
+});
+
+describe("ORCH-1013 Finding B — PlaceIntelligenceTrialPage mounts the control tower", () => {
+  const src = fs.readFileSync(PAGE, "utf8");
+
+  it("imports ActiveRunsControlTower", () => {
+    assert.ok(
+      src.includes("ActiveRunsControlTower"),
+      "page must import the control tower",
+    );
+  });
+
+  it("mounts <ActiveRunsControlTower /> above the Tabs", () => {
+    const towerIdx = src.indexOf("<ActiveRunsControlTower");
+    const tabsIdx = src.indexOf("<Tabs ");
+    assert.ok(towerIdx > 0, "must mount ActiveRunsControlTower");
+    assert.ok(tabsIdx > 0, "must have Tabs row");
+    assert.ok(
+      towerIdx < tabsIdx,
+      "ActiveRunsControlTower must mount before the Tabs row in JSX",
+    );
+  });
+
+  it("control tower deep-links 'View' to the Results tab", () => {
+    assert.ok(
+      src.includes('setActiveTab("results")'),
+      "onViewRun must switch the page to the Results tab",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_adversarial_dispatcher_behavior.test.js
+++ b/mingla-admin/src/__tests__/orch1013_adversarial_dispatcher_behavior.test.js
@@ -1,0 +1,253 @@
+// ORCH-1013 ADVERSARIAL — useBulkRunDispatcher BEHAVIORAL tests.
+//
+// The implementor's tests are all source-string greps. They prove the source
+// CONTAINS certain constants/strings, but never exercise the tick algorithm,
+// the cap, the stagger, or the queue draining. This file is the runtime
+// behavioral counterpart: it re-extracts the dispatcher's pure decision
+// function (faithful to useBulkRunDispatcher.js) and asserts the contract
+// holds across the hostile inputs the implementor's tests can't reach:
+//
+//   - 10-city stress: exactly 3 fire immediately-eligible, rest queue
+//   - stagger correctness with fake-time stepping
+//   - cap hard-enforced under simulated network races
+//   - reconciliation pops `running` → `complete` and the next pending starts
+//   - dedup on enqueue (same city_id twice → 1 entry)
+//   - cancelAll only affects `pending`, leaves `running` alone
+//   - rapid double-enqueue does not double-start the same city
+//
+// If the implementor changes constants or logic, these tests must trip.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const HOOK = path.join(ADMIN_ROOT, "src", "hooks", "useBulkRunDispatcher.js");
+const src = fs.readFileSync(HOOK, "utf8");
+
+// Re-extract dispatcher constants from source so the test is automatically
+// in sync with the contract (if the source bumps them, behavior tests run
+// against the new value but the source-grep tests in
+// orch1013_bulk_dispatcher.test.js will trip on the wrong constant).
+function num(name) {
+  const m = src.match(new RegExp(`${name}\\s*=\\s*([0-9_]+)`));
+  if (!m) throw new Error(`could not extract ${name} from useBulkRunDispatcher.js`);
+  return parseInt(m[1].replace(/_/g, ""), 10);
+}
+const MAX_CONCURRENT = num("MAX_CONCURRENT");
+const STAGGER_MS = num("STAGGER_MS");
+
+// ──────────────────────────────────────────────────────────────────────
+// Faithful re-implementation of the tick decision logic in
+// useBulkRunDispatcher.js. Pure function: given queue + clock, returns
+// the next city to start (or null). Mirrors lines 178-208.
+// ──────────────────────────────────────────────────────────────────────
+
+function countInFlight(queue) {
+  return queue.filter((c) => c.status === "starting" || c.status === "running")
+    .length;
+}
+
+function pickNext(queue, nowMs) {
+  const inFlight = countInFlight(queue);
+  if (inFlight >= MAX_CONCURRENT) return null;
+  const lastStartedAt = queue.reduce((max, c) => {
+    const ts = Number(c.started_at || 0);
+    return ts > max ? ts : max;
+  }, 0);
+  if (lastStartedAt > 0 && nowMs - lastStartedAt < STAGGER_MS) return null;
+  return queue.find((c) => c.status === "pending") ?? null;
+}
+
+function startCity(queue, city, nowMs) {
+  const idx = queue.findIndex((c) => c.city_id === city.city_id);
+  queue[idx] = { ...queue[idx], status: "running", started_at: nowMs };
+}
+
+describe("ORCH-1013 ADVERSARIAL — dispatcher behavior under load", () => {
+  it("10 cities → at most 3 inFlight at any time, no batch-fire", () => {
+    const cities = Array.from({ length: 10 }, (_v, i) => ({
+      city_id: `c${i}`,
+      city_name: `City ${i}`,
+      remaining_count: 50,
+      status: "pending",
+    }));
+    // Realistic ms-since-epoch base so the `lastStartedAt > 0` gate engages
+    // after the first start (the source uses Date.now() which is always > 0).
+    const BASE = 1_700_000_000_000;
+    let now = BASE;
+    let maxObservedInFlight = 0;
+    // Simulate 60 seconds at 500ms ticks
+    for (let t = 0; t < 120; t++) {
+      now = BASE + t * 500;
+      const next = pickNext(cities, now);
+      if (next) startCity(cities, next, now);
+      const inFlight = countInFlight(cities);
+      maxObservedInFlight = Math.max(maxObservedInFlight, inFlight);
+      assert.ok(
+        inFlight <= MAX_CONCURRENT,
+        `inFlight=${inFlight} exceeds MAX_CONCURRENT=${MAX_CONCURRENT} at t=${now}ms`,
+      );
+    }
+    assert.equal(
+      maxObservedInFlight,
+      MAX_CONCURRENT,
+      "should saturate at exactly MAX_CONCURRENT (3) under 10-city load",
+    );
+    // After 60s, 3 should have started; 7 still pending (no runs ever completed)
+    assert.equal(
+      cities.filter((c) => c.status === "running").length,
+      MAX_CONCURRENT,
+      "exactly 3 cities should be running after 60s of no completions",
+    );
+    assert.equal(
+      cities.filter((c) => c.status === "pending").length,
+      10 - MAX_CONCURRENT,
+      "remaining 7 cities should stay pending",
+    );
+  });
+
+  it("stagger enforced: consecutive starts at minimum STAGGER_MS apart", () => {
+    const cities = Array.from({ length: 5 }, (_v, i) => ({
+      city_id: `s${i}`,
+      city_name: `S${i}`,
+      remaining_count: 10,
+      status: "pending",
+    }));
+    const BASE = 1_700_000_000_000;
+    let now = BASE;
+    const startTimes = [];
+    for (let t = 0; t < 30; t++) {
+      now = BASE + t * 500;
+      const next = pickNext(cities, now);
+      if (next) {
+        startTimes.push(now);
+        startCity(cities, next, now);
+      }
+    }
+    // First start at t=BASE (lastStartedAt=0 in queue; gate is
+    // `lastStartedAt > 0`, so first start always fires immediately).
+    // Subsequent starts must be ≥ STAGGER_MS apart.
+    for (let i = 1; i < startTimes.length; i++) {
+      const gap = startTimes[i] - startTimes[i - 1];
+      assert.ok(
+        gap >= STAGGER_MS,
+        `start ${i} at ${startTimes[i]}ms is only ${gap}ms after prior start (need ≥ ${STAGGER_MS}ms)`,
+      );
+    }
+  });
+
+  it("queue advances when a `running` city flips to `complete`", () => {
+    // Saturate the cap, then complete one, then verify the 4th city starts.
+    const BASE = 1_700_000_000_000;
+    const cities = [
+      { city_id: "a", city_name: "A", remaining_count: 10, status: "running", started_at: BASE },
+      { city_id: "b", city_name: "B", remaining_count: 10, status: "running", started_at: BASE + 2000 },
+      { city_id: "c", city_name: "C", remaining_count: 10, status: "running", started_at: BASE + 4000 },
+      { city_id: "d", city_name: "D", remaining_count: 10, status: "pending" },
+    ];
+    // At t=BASE+5000 (cap saturated): no new start
+    assert.equal(pickNext(cities, BASE + 5000), null, "should be capped at 3 inFlight");
+    // City 'a' completes (reconciler flips it)
+    cities[0].status = "complete";
+    // At t=BASE+6000 (only 2000ms since last start at BASE+4000 — wait, that's
+    // EXACTLY STAGGER, gate is `<`, so 2000 === STAGGER is NOT blocked).
+    // Actually the gate is `now - lastStartedAt < STAGGER_MS`, so at delta=2000
+    // exactly, condition is `2000 < 2000` = false, gate passes. Verify the
+    // 'd' city is picked.
+    const pickedExactly = pickNext(cities, BASE + 6000);
+    assert.ok(pickedExactly, "stagger gate uses '<', so delta === STAGGER passes");
+    assert.equal(pickedExactly.city_id, "d", "FIFO-next pending city ('d') picked");
+    // Add a stricter sub-case: delta just under STAGGER must be blocked.
+    cities[3].status = "pending"; // reset
+    assert.equal(
+      pickNext(cities, BASE + 5500),
+      null,
+      "delta=1500ms < STAGGER=2000ms must block (only 1.5s since last start)",
+    );
+  });
+
+  it("cap never breached even if multiple ticks see `pending` simultaneously", () => {
+    // Hostile race: pickNext is called twice within the same tick window
+    // before the first `starting` transition is reflected. The startingInFlightRef
+    // guard in the real hook prevents this; we test that the algorithm itself
+    // (counting `running`/`starting`) is correct.
+    const cities = [
+      { city_id: "a", city_name: "A", remaining_count: 10, status: "starting", started_at: 0 },
+      { city_id: "b", city_name: "B", remaining_count: 10, status: "starting", started_at: 1 },
+      { city_id: "c", city_name: "C", remaining_count: 10, status: "starting", started_at: 2 },
+      { city_id: "d", city_name: "D", remaining_count: 10, status: "pending" },
+    ];
+    // Even though stagger would allow a new start (>2s passed), cap blocks
+    assert.equal(
+      pickNext(cities, 10_000),
+      null,
+      "cap must count `starting` rows toward inFlight",
+    );
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — dispatcher source-level invariants beyond grep", () => {
+  it("TICK_INTERVAL_MS is set to 500 (drives auto-queue latency)", () => {
+    const m = src.match(/TICK_INTERVAL_MS\s*=\s*([0-9_]+)/);
+    assert.ok(m, "TICK_INTERVAL_MS constant must be declared");
+    const tickMs = parseInt(m[1].replace(/_/g, ""), 10);
+    assert.ok(
+      tickMs <= 1000,
+      `TICK_INTERVAL_MS=${tickMs}ms is too slow (>1s would make queue feel laggy)`,
+    );
+    assert.ok(
+      tickMs >= 100,
+      `TICK_INTERVAL_MS=${tickMs}ms is too aggressive (<100ms wastes CPU)`,
+    );
+  });
+
+  it("tick clears the interval when nothing pending and nothing in flight (no leak)", () => {
+    assert.ok(
+      src.includes("stopTick()") && src.includes("inFlight === 0"),
+      "tick must call stopTick() when nothing pending and nothing in flight (memory-leak guard)",
+    );
+  });
+
+  it("useEffect cleanup stops the tick interval on unmount (no leak)", () => {
+    const cleanupMatch = src.match(/return\s*\(\)\s*=>\s*\{[^}]*stopTick\(\)/);
+    assert.ok(
+      cleanupMatch,
+      "useEffect cleanup must call stopTick() on unmount to prevent timer leak",
+    );
+  });
+
+  it("startCity uses optional chaining when onToast is undefined (no crash without parent toast)", () => {
+    // The hook accepts `{ onToast } = {}` — if operator forgets to pass it,
+    // the toast call must be guarded.
+    assert.ok(
+      src.includes("if (onToast)") || src.includes("onToast?."),
+      "onToast call must be guarded (otherwise crash when caller omits it)",
+    );
+  });
+
+  it("enqueue dedupes by city_id (rapid double-click does not double-start)", () => {
+    assert.ok(
+      src.includes("existingIds.has(c.city_id)"),
+      "enqueue must skip duplicate city_ids",
+    );
+  });
+
+  it("confirm_high_cost threshold ($5) is per-city, not summed", () => {
+    // SPEC §3 B.5: per-city start_run call MUST include confirm_high_cost when
+    // ITS OWN estimate > $5. Verify the hook does per-city calc, not aggregate.
+    assert.ok(
+      src.includes("estCost > 5") || src.includes("estCost > 5_"),
+      "per-city confirm_high_cost threshold must be $5 per city",
+    );
+    // The hook must NOT sum across cities for this gate.
+    assert.ok(
+      !/sumRemaining|totalRemaining/i.test(src),
+      "per-city gate must NOT use any sum/total variable",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_adversarial_modal_and_tower.test.js
+++ b/mingla-admin/src/__tests__/orch1013_adversarial_modal_and_tower.test.js
@@ -1,0 +1,271 @@
+// ORCH-1013 ADVERSARIAL — RunRemainderOnAllConfirmModal + ActiveRunsControlTower
+// + TrialResultsTab banner-deletion verification.
+//
+// Goes beyond grep: tests boundary conditions on cost gating, dedupe semantics
+// in candidateCities, and asserts the OLD in-tab banner is GONE from
+// TrialResultsTab (regression-proofing the SPEC §3 B.8 deletion).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const COMP = path.join(ADMIN_ROOT, "src", "components", "placeIntelligenceTrial");
+const MODAL = path.join(COMP, "RunRemainderOnAllConfirmModal.jsx");
+const TOWER = path.join(COMP, "ActiveRunsControlTower.jsx");
+const RESULTS_TAB = path.join(COMP, "TrialResultsTab.jsx");
+const OVERVIEW_TAB = path.join(COMP, "IntelligenceOverviewTab.jsx");
+const CARD = path.join(COMP, "ActiveRunCard.jsx");
+
+describe("ORCH-1013 ADVERSARIAL — RunRemainderOnAllConfirmModal cost gates", () => {
+  const src = fs.readFileSync(MODAL, "utf8");
+
+  it("perPlaceCostUsd default matches the SPEC ($0.0040)", () => {
+    assert.ok(
+      /DEFAULT_PER_PLACE_COST_USD\s*=\s*0\.004\b/.test(src),
+      "default per-place cost must be $0.0040 (SPEC §3 B.5)",
+    );
+  });
+
+  it("typed-confirm phrase is exactly 'RUN ALL' (not city names)", () => {
+    // SPEC §7-D6: typed phrase MUST be a fixed phrase because typing N city
+    // names is hostile UX. Regression-proof against future "improvements".
+    assert.ok(
+      /TYPED_CONFIRM_PHRASE\s*=\s*"RUN ALL"/.test(src),
+      "typed-confirm phrase must be the fixed string 'RUN ALL' per SPEC §7-D6",
+    );
+  });
+
+  it("guards against empty candidate list: canConfirm requires safeCities.length > 0", () => {
+    assert.ok(
+      src.includes("safeCities.length > 0"),
+      "canConfirm must require ≥ 1 candidate city",
+    );
+  });
+
+  it("safeCities filters out rows with remaining_count ≤ 0", () => {
+    assert.ok(
+      src.includes("candidateCities.filter((c) => c?.remaining_count > 0)"),
+      "modal must defensively filter zero-remainder candidates",
+    );
+  });
+
+  it("typedMatches strict-trims (whitespace tolerant on either side)", () => {
+    assert.ok(
+      src.includes("typed.trim() === TYPED_CONFIRM_PHRASE"),
+      "typed comparison must trim whitespace (operator may hit space)",
+    );
+  });
+
+  it("Gemini pricing URL is linked, not just text", () => {
+    assert.ok(
+      /href=["']https:\/\/ai\.google\.dev\/pricing\/gemini-2-5-flash/.test(src),
+      "Gemini pricing must be an actual href, not a string literal",
+    );
+    assert.ok(
+      src.includes('target="_blank"') && src.includes('rel="noopener noreferrer"'),
+      "external link must be target=_blank with rel=noopener noreferrer",
+    );
+  });
+
+  it("close button calls onClose without confirming (operator escape hatch)", () => {
+    // Cancel button at modal footer must NOT call onConfirm
+    const footerSlice = src.slice(src.indexOf("ModalFooter"), src.indexOf("</ModalFooter>"));
+    assert.ok(
+      footerSlice.includes("onClick={onClose}"),
+      "footer Cancel button must invoke onClose only",
+    );
+  });
+
+  it("modal returns null when !open (no rendering when closed)", () => {
+    assert.ok(
+      src.includes("if (!open) return null"),
+      "modal must early-return null when not open",
+    );
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — ActiveRunsControlTower zero-renders", () => {
+  const src = fs.readFileSync(TOWER, "utf8");
+
+  it("uses totalCount (active + terminal) not activeRuns alone for visibility gate", () => {
+    // I-PROPOSED-INTEL-CONTROL-TOWER-VISIBILITY-GATE: must check BOTH lists
+    assert.ok(
+      src.includes("activeRuns.length + terminalRuns.length"),
+      "visibility gate must sum active + terminal counts",
+    );
+  });
+
+  it("SectionCard title counts ONLY active runs (not terminal-fading)", () => {
+    // The title "Active runs (N)" should reflect only the live count;
+    // terminal-fading cards should not inflate the badge.
+    assert.ok(
+      src.includes("Active runs (${activeRuns.length})"),
+      "title must use activeRuns.length, not allRuns or totalCount",
+    );
+  });
+
+  it("dedupes terminal-fading entries that are still in activeRuns", () => {
+    // If a run is in BOTH lists (race condition between poll + terminal stage),
+    // it must render once, not twice.
+    assert.ok(
+      src.includes("!activeRuns.some((a) => a.id === t.id)"),
+      "terminal-fading entries already in activeRuns must NOT double-render",
+    );
+  });
+
+  it("each ActiveRunCard uses run.id as React key (stable identity)", () => {
+    assert.ok(
+      src.includes("key={run.id}"),
+      "React key must be the stable run.id (not array index)",
+    );
+  });
+
+  it("AnimatePresence initial={false} (no in-animation on mount)", () => {
+    assert.ok(
+      src.includes("initial={false}"),
+      "AnimatePresence must skip mount-animation to prevent first-load flash",
+    );
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — TrialResultsTab in-tab banner DELETED", () => {
+  const src = fs.readFileSync(RESULTS_TAB, "utf8");
+  // Strip comments before identifier-deletion checks (implementor left
+  // tombstone comments referencing the deleted names for traceability;
+  // those are intentional and should not trip the regression).
+  const stripped = src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
+
+  it("no longer renders the 'Cancel run' banner (SPEC §3 B.8 deletion)", () => {
+    // The deleted block used these idioms — assert they're gone in CODE
+    // (comments tombstoning the deletion are OK).
+    assert.ok(
+      !stripped.includes("bannerDismissed"),
+      "bannerDismissed state must be DELETED per SPEC §3 B.8",
+    );
+    assert.ok(
+      !/handleCancelActiveRunConfirmed\s*\(/.test(stripped),
+      "handleCancelActiveRunConfirmed CALLABLE must be DELETED (tombstone comment ok)",
+    );
+    assert.ok(
+      !/handleResumeFromN\s*\(/.test(stripped),
+      "handleResumeFromN CALLABLE must be DELETED (deferred per SPEC §6)",
+    );
+  });
+
+  it("CancelRunConfirmModal no longer mounted from TrialResultsTab", () => {
+    assert.ok(
+      !src.includes("<CancelRunConfirmModal"),
+      "CancelRunConfirmModal must only mount from ActiveRunCard now",
+    );
+  });
+
+  it("Cross-session hydration effect for activeRunId is DELETED (SPEC §7-D3)", () => {
+    // The hydration that orphaned activeRun state with no UI consumer was deleted.
+    assert.ok(
+      !src.includes("list_active_runs"),
+      "TrialResultsTab no longer polls list_active_runs — control tower owns it",
+    );
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — IntelligenceOverviewTab bulk wiring", () => {
+  const src = fs.readFileSync(OVERVIEW_TAB, "utf8");
+
+  it("dispatcher hook is consumed at component scope (not inside a useEffect)", () => {
+    assert.ok(
+      /const\s+dispatcher\s*=\s*useBulkRunDispatcher/.test(src),
+      "useBulkRunDispatcher must be called at component scope",
+    );
+  });
+
+  it("candidateCities is memoized (avoids re-creating array on every render)", () => {
+    assert.ok(
+      src.includes("const candidateCities = useMemo("),
+      "candidateCities must be useMemo'd to prevent unnecessary modal re-renders",
+    );
+  });
+
+  it("bulk modal passes the dispatcher's enqueue, not a re-implementation", () => {
+    assert.ok(
+      src.includes("dispatcher.enqueue(cities)"),
+      "onConfirm must delegate to dispatcher.enqueue (single source of truth)",
+    );
+  });
+
+  it("onToast is wired into the dispatcher (per-city failures surface)", () => {
+    assert.ok(
+      src.includes("useBulkRunDispatcher({ onToast: addToast })"),
+      "dispatcher must receive the toast emitter for 409/500 surfacing",
+    );
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — ActiveRunCard accessibility + tokens", () => {
+  const src = fs.readFileSync(CARD, "utf8");
+
+  it("progress bar has role='progressbar' + aria-valuenow/min/max", () => {
+    assert.ok(
+      src.includes('role="progressbar"') &&
+        src.includes("aria-valuenow") &&
+        src.includes("aria-valuemin={0}") &&
+        src.includes("aria-valuemax={100}"),
+      "progress bar must have full ARIA progressbar semantics",
+    );
+  });
+
+  it("cancel button has aria-label for screen readers", () => {
+    assert.ok(
+      src.includes('aria-label="Cancel run"'),
+      "Cancel icon button needs an aria-label",
+    );
+  });
+
+  it("uses CSS variable tokens (not hard-coded colors) for dark-mode safety", () => {
+    // SPEC §3 B.3 visual contract: tokens only.
+    assert.ok(
+      src.includes("var(--color-brand-200)") &&
+        src.includes("var(--color-brand-500)") &&
+        src.includes("var(--color-brand-50)"),
+      "card frame must use brand-* CSS variables (dark-mode adaptive)",
+    );
+    // Check no hard-coded hex/rgb colors snuck in
+    assert.ok(
+      !/#[0-9a-fA-F]{3,6}\b/.test(src.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "")),
+      "no hard-coded hex colors allowed in ActiveRunCard (must use tokens)",
+    );
+  });
+
+  it("formatEta has guards against null AND Number.isFinite (no 'NaN min' or 'Infinity min')", () => {
+    const formatEtaSlice = src.slice(src.indexOf("function formatEta"), src.indexOf("export function"));
+    assert.ok(
+      formatEtaSlice.includes("seconds == null"),
+      "must guard against null seconds",
+    );
+    assert.ok(
+      formatEtaSlice.includes("Number.isFinite(seconds)"),
+      "must guard against Infinity/NaN seconds",
+    );
+    assert.ok(
+      formatEtaSlice.includes("seconds <= 0"),
+      "must guard against zero/negative seconds",
+    );
+  });
+
+  it("cost cross-check warning only fires above 10-place threshold (avoids noise on small runs)", () => {
+    assert.ok(
+      /COST_DRIFT_MIN_PROCESSED\s*=\s*10\b/.test(src),
+      "drift warning must suppress under 10 processed places (SPEC §7-D7)",
+    );
+    assert.ok(
+      src.includes("processed < COST_DRIFT_MIN_PROCESSED"),
+      "drift calculation must short-circuit under the minimum",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_adversarial_poller_eta.test.js
+++ b/mingla-admin/src/__tests__/orch1013_adversarial_poller_eta.test.js
@@ -1,0 +1,203 @@
+// ORCH-1013 ADVERSARIAL — useActiveRunsPoller ETA + lifecycle.
+//
+// The implementor's poller tests assert constants only ("declares POLL_INTERVAL_MS = 5000").
+// This file tests the ACTUAL ETA computation algorithm + the edge cases the
+// spec calls out: 0-progress (no NaN/Infinity), stalled run (rate ≤ 0),
+// buffer cap, terminal-tail TTL.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const HOOK = path.join(ADMIN_ROOT, "src", "hooks", "useActiveRunsPoller.js");
+const CARD = path.join(
+  ADMIN_ROOT,
+  "src",
+  "components",
+  "placeIntelligenceTrial",
+  "ActiveRunCard.jsx",
+);
+const src = fs.readFileSync(HOOK, "utf8");
+const cardSrc = fs.readFileSync(CARD, "utf8");
+
+// Mirror the ETA computation block from useActiveRunsPoller.js (~L91-L117).
+const ETA_BUFFER_CAP = 12;
+const ETA_MIN_WINDOW_MS = 30_000;
+
+function computeEta(buffer, run) {
+  if (buffer.length < 2) return { liveEtaSeconds: null, liveRatePerMin: null };
+  const first = buffer[0];
+  const last = buffer[buffer.length - 1];
+  const dtMs = last.ts - first.ts;
+  if (dtMs < ETA_MIN_WINDOW_MS) return { liveEtaSeconds: null, liveRatePerMin: null };
+  const dProcessed = last.processed - first.processed;
+  const ratePerSec = dProcessed / (dtMs / 1000);
+  if (ratePerSec <= 0) return { liveEtaSeconds: null, liveRatePerMin: null };
+  const remaining = Math.max(0, Number(run.total_count || 0) - Number(run.processed_count || 0));
+  return {
+    liveEtaSeconds: remaining / ratePerSec,
+    liveRatePerMin: ratePerSec * 60,
+  };
+}
+
+describe("ORCH-1013 ADVERSARIAL — ETA computation edge cases", () => {
+  it("0 buffer entries → null (no division by zero)", () => {
+    const { liveEtaSeconds } = computeEta([], { total_count: 100, processed_count: 0 });
+    assert.equal(liveEtaSeconds, null);
+  });
+
+  it("1 buffer entry → null (insufficient sample)", () => {
+    const { liveEtaSeconds } = computeEta(
+      [{ ts: 0, processed: 10 }],
+      { total_count: 100, processed_count: 10 },
+    );
+    assert.equal(liveEtaSeconds, null, "single sample cannot extrapolate rate");
+  });
+
+  it("2 entries but <30s apart → null (under min window)", () => {
+    const { liveEtaSeconds } = computeEta(
+      [{ ts: 0, processed: 10 }, { ts: 20_000, processed: 30 }],
+      { total_count: 100, processed_count: 30 },
+    );
+    assert.equal(liveEtaSeconds, null, "20s sample is under 30s min window");
+  });
+
+  it("stalled run (rate = 0) → null (avoid Infinity)", () => {
+    const { liveEtaSeconds } = computeEta(
+      [{ ts: 0, processed: 50 }, { ts: 30_000, processed: 50 }],
+      { total_count: 100, processed_count: 50 },
+    );
+    assert.equal(liveEtaSeconds, null, "stalled run must NOT render Infinity");
+  });
+
+  it("regressing rate (rate < 0) → null", () => {
+    // Pathological: processed count went backward (shouldn't happen, but defend)
+    const { liveEtaSeconds } = computeEta(
+      [{ ts: 0, processed: 60 }, { ts: 30_000, processed: 50 }],
+      { total_count: 100, processed_count: 50 },
+    );
+    assert.equal(liveEtaSeconds, null, "negative rate must NOT render bogus ETA");
+  });
+
+  it("valid rate at 30s window: 10 places/30s = 0.333/sec; remaining=50 → ETA ≈ 150s", () => {
+    const { liveEtaSeconds, liveRatePerMin } = computeEta(
+      [{ ts: 0, processed: 40 }, { ts: 30_000, processed: 50 }],
+      { total_count: 100, processed_count: 50 },
+    );
+    assert.ok(liveEtaSeconds !== null);
+    assert.ok(Math.abs(liveEtaSeconds - 150) < 1, `expected ~150s, got ${liveEtaSeconds}`);
+    assert.ok(Math.abs(liveRatePerMin - 20) < 0.1, `expected ~20/min, got ${liveRatePerMin}`);
+  });
+
+  it("0% progress baseline: processed=0, no buffer history → null", () => {
+    const { liveEtaSeconds } = computeEta([], { total_count: 100, processed_count: 0 });
+    assert.equal(liveEtaSeconds, null);
+  });
+
+  it("processed > total (pathological): remaining=Max(0,..) prevents negative ETA", () => {
+    const { liveEtaSeconds } = computeEta(
+      [{ ts: 0, processed: 90 }, { ts: 30_000, processed: 110 }],
+      { total_count: 100, processed_count: 110 },
+    );
+    // rate=0.667/s, remaining=Max(0, 100-110)=0, ETA=0
+    assert.equal(liveEtaSeconds, 0, "remaining clamped via Max(0,...)");
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — formatEta in ActiveRunCard", () => {
+  // Re-extract the formatEta function from ActiveRunCard source. It's a pure
+  // function — we can require() it via dynamic import, but the file is JSX.
+  // Instead: assert the contract via grep + recreate.
+  it("formatEta(null) returns '—' (not 'NaN min')", () => {
+    assert.ok(
+      cardSrc.includes('"—"') && cardSrc.includes("formatEta"),
+      "formatEta must fall back to em-dash on null/non-finite",
+    );
+    // Verify the null guard is present
+    assert.ok(
+      /seconds\s*==\s*null/.test(cardSrc) ||
+        /seconds\s*===\s*null/.test(cardSrc) ||
+        cardSrc.includes("seconds == null"),
+      "formatEta must check for null seconds",
+    );
+    assert.ok(
+      cardSrc.includes("Number.isFinite(seconds)"),
+      "formatEta must reject Infinity/NaN via Number.isFinite",
+    );
+  });
+
+  it("ETA displays '—' when status !== 'running' even if liveEtaSeconds is positive", () => {
+    // SPEC §3 B.3: 'ETA: —' otherwise. Source must guard on isRunning.
+    assert.ok(
+      cardSrc.includes("isRunning ? formatEta(run._liveEtaSeconds) : \"—\""),
+      "ETA must show '—' when not running, regardless of buffered rate",
+    );
+  });
+});
+
+describe("ORCH-1013 ADVERSARIAL — poller lifecycle + leak protection", () => {
+  it("clearInterval is called in cleanup", () => {
+    assert.ok(
+      src.includes("clearInterval(interval)"),
+      "useEffect cleanup must call clearInterval to prevent leak",
+    );
+  });
+
+  it("clearTimeout is called for all terminal-display timers on unmount", () => {
+    assert.ok(
+      src.includes("for (const handle of terminalTimersRef.current.values()) clearTimeout(handle)"),
+      "all pending 3s terminal-display timers must be cleared on unmount",
+    );
+  });
+
+  it("visibilitychange listener is removed on unmount", () => {
+    assert.ok(
+      src.includes('document.removeEventListener("visibilitychange"'),
+      "visibilitychange listener must be removed on unmount",
+    );
+  });
+
+  it("ETA buffer cap = 12 (60s at 5s poll)", () => {
+    const m = src.match(/ETA_BUFFER_CAP\s*=\s*([0-9_]+)/);
+    assert.ok(m, "ETA_BUFFER_CAP constant must be declared");
+    assert.equal(parseInt(m[1].replace(/_/g, ""), 10), 12);
+  });
+
+  it("poll interval = 5000ms (SPEC §3 B.4)", () => {
+    const m = src.match(/POLL_INTERVAL_MS\s*=\s*([0-9_]+)/);
+    assert.ok(m);
+    assert.equal(parseInt(m[1].replace(/_/g, ""), 10), 5000);
+  });
+
+  it("terminal display TTL = 3000ms (SPEC §3 B.2)", () => {
+    const m = src.match(/TERMINAL_DISPLAY_MS\s*=\s*([0-9_]+)/);
+    assert.ok(m);
+    assert.equal(parseInt(m[1].replace(/_/g, ""), 10), 3000);
+  });
+
+  it("background-tab guard: tick early-returns on document.visibilityState === 'hidden'", () => {
+    assert.ok(
+      src.includes('document.visibilityState === "hidden"'),
+      "tick must skip polling when tab is hidden (quota + ETA preservation)",
+    );
+  });
+
+  it("error state surfaces only after 3 consecutive failures (not on first transient)", () => {
+    const m = src.match(/ERROR_THRESHOLD\s*=\s*([0-9_]+)/);
+    assert.ok(m, "ERROR_THRESHOLD must be declared");
+    assert.equal(parseInt(m[1].replace(/_/g, ""), 10), 3);
+    assert.ok(
+      src.includes("consecutiveErrorsRef.current += 1"),
+      "must increment consecutive error counter",
+    );
+    assert.ok(
+      src.includes("consecutiveErrorsRef.current = 0"),
+      "must reset counter on success",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_bulk_dispatcher.test.js
+++ b/mingla-admin/src/__tests__/orch1013_bulk_dispatcher.test.js
@@ -1,0 +1,117 @@
+// ORCH-1013 Finding B regression — useBulkRunDispatcher invariants:
+//   - hard cap inFlight ≤ 3 (I-PROPOSED-INTEL-BULK-DISPATCHER-CAP-3)
+//   - 2s stagger between consecutive `starting` transitions
+//     (I-PROPOSED-INTEL-BULK-DISPATCHER-STAGGER-2S)
+//   - status enum: pending | starting | running | complete | failed |
+//     skipped_concurrent
+//   - 409 concurrent_run → skipped_concurrent + toast emitted
+//   - tick interval 500ms; reconciles `running` against list_active_runs
+//
+// node:test + source-string assertions (mingla-admin pattern). Behavioural
+// proof lives in the source-inspect; the runtime hook depends on
+// invokeWithRefresh which is not stubbable without RTL/vitest.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const HOOK = path.join(ADMIN_ROOT, "src", "hooks", "useBulkRunDispatcher.js");
+
+describe("ORCH-1013 Finding B — useBulkRunDispatcher invariants", () => {
+  const src = fs.readFileSync(HOOK, "utf8");
+
+  it("declares MAX_CONCURRENT = 3 (hard cap)", () => {
+    assert.ok(
+      /MAX_CONCURRENT\s*=\s*3\b/.test(src),
+      "MAX_CONCURRENT constant must be 3",
+    );
+  });
+
+  it("declares STAGGER_MS = 2000 (2s stagger between starts)", () => {
+    assert.ok(
+      /STAGGER_MS\s*=\s*2_?000\b/.test(src),
+      "STAGGER_MS constant must be 2000ms",
+    );
+  });
+
+  it("gates `pending → starting` on inFlight < MAX_CONCURRENT", () => {
+    assert.ok(
+      src.includes("inFlight >= MAX_CONCURRENT"),
+      "tick must short-circuit when inFlight >= MAX_CONCURRENT",
+    );
+  });
+
+  it("gates `pending → starting` on STAGGER_MS since lastStartedAt", () => {
+    assert.ok(
+      src.includes("now - lastStartedAt < STAGGER_MS"),
+      "tick must enforce >= STAGGER_MS between consecutive starts",
+    );
+  });
+
+  it("classifies 409 concurrent_run as skipped_concurrent", () => {
+    assert.ok(
+      src.includes('code === "concurrent_run"'),
+      "must distinguish concurrent_run from generic failures",
+    );
+    assert.ok(
+      src.includes('"skipped_concurrent"'),
+      "status string 'skipped_concurrent' must be the 409 verdict",
+    );
+  });
+
+  it("emits a toast on start failure", () => {
+    // The hook calls onToast({ variant: 'warning', title: 'Couldn\'t start ...', description: msg }).
+    assert.ok(
+      src.includes("Couldn't start"),
+      "toast title for start failure must include \"Couldn't start\"",
+    );
+    assert.ok(
+      src.includes('variant: "warning"'),
+      "toast must use warning variant for start failures",
+    );
+  });
+
+  it("reconciles running → complete via list_active_runs (auto-queue trigger)", () => {
+    assert.ok(
+      src.includes("list_active_runs"),
+      "must poll list_active_runs to detect server-side completion",
+    );
+    assert.ok(
+      src.includes('status: "complete"'),
+      "must flip running rows to complete when run_id drops out of list_active_runs",
+    );
+  });
+
+  it("dedupes enqueue (same city_id twice → one entry)", () => {
+    assert.ok(
+      src.includes("existingIds.has(c.city_id)"),
+      "enqueue must skip city_ids already in the queue",
+    );
+  });
+
+  it("cancelAll only affects pending entries (in-flight runs use per-card cancel)", () => {
+    assert.ok(
+      src.includes('c.status === "pending"') &&
+        src.includes("skipped_concurrent"),
+      "cancelAll must only flip status=pending → skipped_concurrent",
+    );
+  });
+
+  it("ports per-place cost ($0.0040) for confirm_high_cost gating", () => {
+    // Each city's start_run call must pass confirm_high_cost when its individual
+    // estimate exceeds $5 (per SPEC §3 B.5).
+    assert.ok(
+      /\*\s*0\.004\b/.test(src) || src.includes("PER_PLACE_COST_USD"),
+      "per-place cost ($0.0040) must be applied to compute confirm_high_cost",
+    );
+    assert.ok(
+      src.includes("confirm_high_cost"),
+      "per-city start_run call must include confirm_high_cost flag",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_overview_bulk_button.test.js
+++ b/mingla-admin/src/__tests__/orch1013_overview_bulk_button.test.js
@@ -1,0 +1,82 @@
+// ORCH-1013 Finding B regression — Overview tab gains a "Run remainder on
+// all" CTA + wires it to <RunRemainderOnAllConfirmModal /> + useBulkRunDispatcher.
+// candidateCities derives from rows.filter(r => r.remaining_count > 0).
+// On confirm, dispatcher.enqueue + toast + silent refresh fire.
+//
+// node:test + source-string assertions (mingla-admin pattern).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const TAB = path.join(
+  ADMIN_ROOT,
+  "src",
+  "components",
+  "placeIntelligenceTrial",
+  "IntelligenceOverviewTab.jsx",
+);
+
+describe("ORCH-1013 Finding B — Overview tab bulk launcher wiring", () => {
+  const src = fs.readFileSync(TAB, "utf8");
+
+  it("imports the bulk modal + useBulkRunDispatcher hook", () => {
+    assert.ok(
+      src.includes("RunRemainderOnAllConfirmModal"),
+      "must import the new bulk modal",
+    );
+    assert.ok(
+      src.includes("useBulkRunDispatcher"),
+      "must import the bulk dispatcher hook",
+    );
+  });
+
+  it("derives candidateCities = rows.filter(r => r.remaining_count > 0)", () => {
+    assert.ok(
+      src.includes("candidateCities"),
+      "must derive candidateCities",
+    );
+    assert.ok(
+      src.includes("r.remaining_count > 0"),
+      "candidateCities filter must require remaining_count > 0",
+    );
+  });
+
+  it("renders 'Run remainder on all' button with count in label", () => {
+    assert.ok(
+      src.includes("Run remainder on all"),
+      "must render the bulk CTA label",
+    );
+    assert.ok(
+      src.includes("candidateCities.length"),
+      "button must use candidateCities.length for the (N) suffix + disabled gating",
+    );
+  });
+
+  it("button disabled when zero candidates with a helpful tooltip", () => {
+    assert.ok(
+      src.includes("All cities are fully evaluated"),
+      "must surface the all-clear tooltip when nothing to evaluate",
+    );
+  });
+
+  it("on confirm, dispatcher.enqueue + toast + silent refresh", () => {
+    assert.ok(
+      src.includes("dispatcher.enqueue(cities)"),
+      "onConfirm must dispatch the cities",
+    );
+    assert.ok(
+      src.includes("Bulk remainder queued"),
+      "toast title must mention 'Bulk remainder queued'",
+    );
+    assert.ok(
+      src.includes("refresh({ silent: true })"),
+      "must silently refresh after enqueue so the coverage table reflects the launch",
+    );
+  });
+});

--- a/mingla-admin/src/__tests__/orch1013_run_remainder_on_all_modal.test.js
+++ b/mingla-admin/src/__tests__/orch1013_run_remainder_on_all_modal.test.js
@@ -1,0 +1,95 @@
+// ORCH-1013 Finding B regression — <RunRemainderOnAllConfirmModal /> contract:
+//   - <$10 totals: checkbox-only confirm
+//   - >$10 totals: requires typed "RUN ALL" phrase + checkbox
+//   - Body lists each candidate city with name + remaining_count + per-city cost
+//   - Footer disclosure: "Up to 3 cities will run at a time"
+//   - Cites Gemini pricing URL (COMMS-0003)
+//
+// node:test + source-string assertions (mingla-admin pattern).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ADMIN_ROOT = path.resolve(__dirname, "..", "..");
+const MODAL = path.join(
+  ADMIN_ROOT,
+  "src",
+  "components",
+  "placeIntelligenceTrial",
+  "RunRemainderOnAllConfirmModal.jsx",
+);
+
+describe("ORCH-1013 Finding B — RunRemainderOnAllConfirmModal contract", () => {
+  const src = fs.readFileSync(MODAL, "utf8");
+
+  it("declares the >$10 typed-confirm threshold + fixed phrase 'RUN ALL'", () => {
+    assert.ok(
+      /COST_REVIEW_THRESHOLD_USD\s*=\s*10\b/.test(src),
+      "high-cost threshold constant must be $10",
+    );
+    assert.ok(
+      /TYPED_CONFIRM_PHRASE\s*=\s*"RUN ALL"/.test(src),
+      "typed phrase must be literally 'RUN ALL' (SPEC §7-D6)",
+    );
+  });
+
+  it("renders the typed-input gate only when totalCost > threshold", () => {
+    assert.ok(
+      src.includes("requiresTypedConfirm = totalCost > COST_REVIEW_THRESHOLD_USD"),
+      "must derive requiresTypedConfirm from totalCost > $10",
+    );
+  });
+
+  it("canConfirm requires checkbox AND (no typed gate OR typed matches)", () => {
+    assert.ok(
+      src.includes("acknowledged") &&
+        src.includes("typedMatches") &&
+        src.includes("requiresTypedConfirm"),
+      "canConfirm must require acknowledged + (no typed gate OR typedMatches)",
+    );
+  });
+
+  it("checkbox label discloses the total Gemini charge", () => {
+    assert.ok(
+      src.includes("I understand this will charge"),
+      "checkbox label must disclose the dollar charge",
+    );
+  });
+
+  it("body lists candidate cities with name + remaining_count + per-city cost", () => {
+    assert.ok(
+      src.includes("safeCities.map"),
+      "body must render one row per candidate city",
+    );
+    assert.ok(
+      src.includes("remaining_count") && src.includes("perPlaceCostUsd"),
+      "each row must show remaining_count and per-city cost",
+    );
+  });
+
+  it("footer line discloses the 3-concurrent dispatcher behaviour", () => {
+    assert.ok(
+      src.includes("Up to 3 cities will run at a time"),
+      "footer disclosure must mention the 3-concurrent cap",
+    );
+  });
+
+  it("cites Gemini pricing URL (COMMS-0003)", () => {
+    assert.ok(
+      src.includes("ai.google.dev/pricing/gemini-2-5-flash"),
+      "Gemini pricing URL must be linked inline per COMMS-0003",
+    );
+  });
+
+  it("primary CTA disabled until canConfirm", () => {
+    assert.ok(
+      src.includes("disabled={!canConfirm}"),
+      "primary CTA must reflect canConfirm gate",
+    );
+  });
+});

--- a/mingla-admin/src/components/placeIntelligenceTrial/ActiveRunCard.jsx
+++ b/mingla-admin/src/components/placeIntelligenceTrial/ActiveRunCard.jsx
@@ -1,0 +1,277 @@
+/**
+ * ActiveRunCard — ORCH-1013 Finding B
+ *
+ * Per-run card rendered inside <ActiveRunsControlTower />. Displays:
+ *   - city + mode + status pill + processed/total + percent
+ *   - progress bar (matches existing token language at TrialResultsTab L718-L723)
+ *   - succeeded / failed / cost so far / live ETA
+ *   - Gemini cost cross-check (processed * $0.0040 vs cost_so_far) with a
+ *     ±$0.0010/place tolerance warning when drift > 25%
+ *   - soft-cancel button (lucide-react X) → CancelRunConfirmModal → POST
+ *     {action:'cancel_trial', run_id}
+ *   - terminal-state pills (Cancelled / Done / Failed) + View affordance
+ *
+ * Gemini pricing reference (COMMS-0003):
+ * https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30).
+ *
+ * SPEC §3 B.3 + §7-D5 (icon=X not Square).
+ */
+
+import { useMemo, useState } from "react";
+import {
+  Globe,
+  Clock,
+  ArrowRight,
+  RotateCcw,
+  X,
+  Loader2,
+  AlertTriangle,
+} from "lucide-react";
+import { Button } from "../ui/Button";
+import { CancelRunConfirmModal } from "./CancelRunConfirmModal";
+import { invokeWithRefresh } from "../../lib/supabase";
+import { extractFunctionError } from "../../lib/edgeFunctionError";
+import { useToast } from "../../context/ToastContext";
+
+const PER_PLACE_COST_USD = 0.004;
+const COST_DRIFT_TOLERANCE_USD_PER_PLACE = 0.001; // ±25% of $0.0040
+const COST_DRIFT_MIN_PROCESSED = 10;
+
+function modeIcon(mode) {
+  if (mode === "full_city") return Globe;
+  if (mode === "sample") return Clock;
+  if (mode === "remainder") return ArrowRight;
+  if (mode === "retry_failed") return RotateCcw;
+  return Clock;
+}
+
+function statusPillClasses(status) {
+  if (status === "complete") {
+    return "bg-[var(--color-success-50)] text-[var(--color-success-700)]";
+  }
+  if (status === "cancelled") {
+    return "bg-[var(--color-warning-50)] text-[var(--color-warning-700)]";
+  }
+  if (status === "failed") {
+    return "bg-[var(--color-error-50)] text-[var(--color-error-700)]";
+  }
+  if (status === "running") {
+    return "bg-[var(--color-info-50)] text-[var(--color-info-700)]";
+  }
+  if (status === "cancelling") {
+    return "bg-[var(--color-warning-50)] text-[var(--color-warning-700)]";
+  }
+  return "bg-[var(--gray-100)] text-[var(--color-text-tertiary)]";
+}
+
+function statusLabel(status) {
+  if (status === "complete") return "Done";
+  if (status === "cancelled") return "Cancelled";
+  if (status === "failed") return "Failed";
+  return status;
+}
+
+function formatEta(seconds) {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return "—";
+  if (seconds < 60) return `~${Math.round(seconds)}s`;
+  const min = Math.round(seconds / 60);
+  if (min < 90) return `~${min} min`;
+  const hrs = (min / 60).toFixed(1);
+  return `~${hrs} hrs`;
+}
+
+export function ActiveRunCard({ run, onCancelled, onViewRun }) {
+  const { addToast } = useToast();
+  const [cancelModalOpen, setCancelModalOpen] = useState(false);
+  const [cancelLoading, setCancelLoading] = useState(false);
+
+  const Icon = modeIcon(run.mode);
+  const total = Number(run.total_count || 0);
+  const processed = Number(run.processed_count || 0);
+  const succeeded = Number(run.succeeded_count || 0);
+  const failed = Number(run.failed_count || 0);
+  const costSoFar = Number(run.cost_so_far_usd || 0);
+  const estCost = Number(run.estimated_cost_usd || 0);
+  const pct = total > 0 ? (processed / total) * 100 : 0;
+  const pctLabel = total > 0 ? Math.round(pct) : 0;
+
+  const expectedCost = useMemo(
+    () => +(processed * PER_PLACE_COST_USD).toFixed(4),
+    [processed],
+  );
+  const costDriftWarn = useMemo(() => {
+    if (processed < COST_DRIFT_MIN_PROCESSED) return false;
+    const diff = Math.abs(costSoFar - expectedCost);
+    const tolerance = processed * COST_DRIFT_TOLERANCE_USD_PER_PLACE;
+    return diff > tolerance;
+  }, [processed, costSoFar, expectedCost]);
+
+  const isTerminal = ["complete", "cancelled", "failed"].includes(run.status);
+  const isRunning = run.status === "running";
+  const isCancelling = run.status === "cancelling";
+
+  async function handleCancelConfirmed() {
+    if (!run.id) return;
+    setCancelLoading(true);
+    try {
+      const { error } = await invokeWithRefresh("run-place-intelligence-trial", {
+        body: { action: "cancel_trial", run_id: run.id },
+      });
+      if (error) {
+        addToast({
+          variant: "error",
+          title: "Couldn't cancel",
+          description: await extractFunctionError(error, "cancel_trial failed"),
+        });
+        return;
+      }
+      addToast({
+        variant: "info",
+        title: "Cancelling…",
+        description: "Run will stop after current chunk (~30-90s).",
+      });
+      setCancelModalOpen(false);
+      onCancelled?.(run.id);
+    } catch (err) {
+      addToast({
+        variant: "error",
+        title: "Couldn't cancel",
+        description: err?.message || "Unknown error",
+      });
+    } finally {
+      setCancelLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <div
+        className="border border-[var(--color-brand-200)] rounded-lg p-4 bg-[var(--color-brand-50)] space-y-3"
+        data-testid="active-run-card"
+        data-run-id={run.id}
+        data-run-status={run.status}
+      >
+        {/* Top row: city + mode + status pill + counts */}
+        <div className="flex items-baseline justify-between gap-2">
+          <h4 className="text-sm font-semibold text-[var(--color-text-primary)] flex items-center gap-2">
+            <Icon className="w-4 h-4 inline" aria-hidden="true" />
+            <span>{run.city_name}</span>
+            <span className="text-xs font-normal text-[var(--color-text-tertiary)]">
+              · {run.mode}
+            </span>
+          </h4>
+          <div className="flex items-center gap-2 shrink-0">
+            <span
+              className={[
+                "text-[10px] uppercase tracking-wide font-mono px-1.5 py-0.5 rounded",
+                statusPillClasses(run.status),
+              ].join(" ")}
+            >
+              {statusLabel(run.status)}
+            </span>
+            <span className="text-xs font-mono tabular-nums text-[var(--color-text-secondary)]">
+              {processed.toLocaleString()} / {total.toLocaleString()} ({pctLabel}%)
+            </span>
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div
+          className="h-2 bg-[var(--color-brand-200)] rounded-full overflow-hidden"
+          role="progressbar"
+          aria-valuenow={pctLabel}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${run.city_name} progress ${pctLabel}%`}
+        >
+          <div
+            className="h-full bg-[var(--color-brand-500)] transition-all duration-200"
+            style={{ width: `${Math.max(0, Math.min(100, pct))}%` }}
+          />
+        </div>
+
+        {/* Metrics row */}
+        <div className="flex flex-wrap items-center gap-3 text-xs">
+          <span className="text-[var(--color-success-700)] font-mono tabular-nums">
+            ✓ {succeeded}
+          </span>
+          <span className="text-[var(--color-error-700)] font-mono tabular-nums">
+            ✗ {failed}
+          </span>
+          <span className="text-[var(--color-text-secondary)] font-mono tabular-nums">
+            cost: ${costSoFar.toFixed(4)} of ~${estCost.toFixed(2)}
+          </span>
+          <span
+            className="ml-auto text-[var(--color-text-secondary)] font-mono tabular-nums"
+            title={
+              run._liveRatePerMin
+                ? `~${run._liveRatePerMin.toFixed(1)} places/min`
+                : "Insufficient sample for ETA (< 30s)"
+            }
+          >
+            ETA: {isRunning ? formatEta(run._liveEtaSeconds) : "—"}
+          </span>
+        </div>
+
+        {/* Cost cross-check (italic, font-mono, optional warning) */}
+        <div className="text-[10px] text-[var(--color-text-tertiary)] italic font-mono flex items-center gap-1.5">
+          <span>
+            {processed.toLocaleString()} × $
+            {PER_PLACE_COST_USD.toFixed(4)} = $
+            {expectedCost.toFixed(4)} expected · $
+            {costSoFar.toFixed(4)} actual
+          </span>
+          {costDriftWarn && (
+            <AlertTriangle
+              className="w-3 h-3 text-[var(--color-warning-700)] shrink-0"
+              aria-label="Cost drift from $0.0040/place baseline > 25% — verify Gemini pricing"
+            />
+          )}
+        </div>
+
+        {/* Action row */}
+        <div className="flex items-center gap-2">
+          {isRunning && (
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={X}
+              onClick={() => setCancelModalOpen(true)}
+              aria-label="Cancel run"
+            >
+              Cancel
+            </Button>
+          )}
+          {isCancelling && (
+            <div className="flex items-center gap-2 text-xs text-[var(--color-warning-700)]">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />
+              <span>Cancelling… (~30-90s)</span>
+            </div>
+          )}
+          {isTerminal && (
+            <Button
+              variant="ghost"
+              size="sm"
+              iconRight={ArrowRight}
+              onClick={() => onViewRun?.(run.id)}
+            >
+              View
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <CancelRunConfirmModal
+        open={cancelModalOpen}
+        onClose={() => setCancelModalOpen(false)}
+        onConfirm={handleCancelConfirmed}
+        cityName={run.city_name}
+        processedCount={processed}
+        totalCount={total}
+        loading={cancelLoading}
+      />
+    </>
+  );
+}
+
+export default ActiveRunCard;

--- a/mingla-admin/src/components/placeIntelligenceTrial/ActiveRunsControlTower.jsx
+++ b/mingla-admin/src/components/placeIntelligenceTrial/ActiveRunsControlTower.jsx
@@ -1,0 +1,85 @@
+/**
+ * ActiveRunsControlTower — ORCH-1013 Finding B
+ *
+ * Pinned panel mounted ABOVE the Place Intelligence tabs (in
+ * PlaceIntelligenceTrialPage). Renders one <ActiveRunCard /> per in-flight
+ * run; auto-hides when there are no active or terminal runs to display.
+ *
+ * Polling is owned by useActiveRunsPoller (5s tick, visibility-aware,
+ * tab-close-durable: server retains place_intelligence_runs rows).
+ *
+ * Replaces the in-tab active-run banner formerly mounted at
+ * TrialResultsTab L702-L769 (deleted in this same PR).
+ *
+ * Invariant I-PROPOSED-INTEL-CONTROL-TOWER-VISIBILITY-GATE: returns null when
+ * BOTH activeRuns.length === 0 AND terminalRuns.length === 0. No empty card frame.
+ *
+ * Gemini pricing reference (COMMS-0003):
+ * https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30).
+ *
+ * SPEC §3 B.2.
+ */
+
+// `motion` is consumed via member access (`Motion.div`); the no-unused-vars
+// rule doesn't track that, so import under an uppercase alias to match the
+// rule's varsIgnorePattern `^[A-Z_]`.
+import { AnimatePresence, motion as Motion } from "framer-motion";
+import { SectionCard } from "../ui/Card";
+import { ActiveRunCard } from "./ActiveRunCard";
+import { useActiveRunsPoller } from "../../hooks/useActiveRunsPoller";
+
+const CARD_TRANSITION = {
+  initial: { opacity: 0, y: 4 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, x: 8 },
+  transition: { duration: 0.2, ease: "easeOut" },
+};
+
+export function ActiveRunsControlTower({ onViewRun }) {
+  const { activeRuns, terminalRuns, error } = useActiveRunsPoller();
+
+  const totalCount = activeRuns.length + terminalRuns.length;
+  if (totalCount === 0) return null;
+
+  // Render terminal runs first (they're transient), then active runs by
+  // started_at desc so the freshest run is at the bottom or top consistently.
+  // Per SPEC just stack vertically with gap-2; ordering preserves identity.
+  const allRuns = [
+    ...activeRuns,
+    ...terminalRuns.filter(
+      (t) => !activeRuns.some((a) => a.id === t.id),
+    ),
+  ];
+
+  return (
+    <SectionCard
+      title={`Active runs (${activeRuns.length})`}
+      role="region"
+      aria-label="Active intelligence runs"
+    >
+      <div className="flex flex-col gap-2" role="region" aria-label="Active intelligence runs">
+        {error && (
+          <p className="text-xs text-[var(--color-warning-700)] italic">
+            {error}
+          </p>
+        )}
+        <AnimatePresence initial={false}>
+          {allRuns.map((run) => (
+            <Motion.div
+              key={run.id}
+              layout
+              initial={CARD_TRANSITION.initial}
+              animate={CARD_TRANSITION.animate}
+              exit={CARD_TRANSITION.exit}
+              transition={CARD_TRANSITION.transition}
+            >
+              <ActiveRunCard run={run} onViewRun={onViewRun} />
+            </Motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+    </SectionCard>
+  );
+}
+
+export default ActiveRunsControlTower;

--- a/mingla-admin/src/components/placeIntelligenceTrial/IntelligenceOverviewTab.jsx
+++ b/mingla-admin/src/components/placeIntelligenceTrial/IntelligenceOverviewTab.jsx
@@ -27,6 +27,9 @@ import { extractFunctionError } from "../../lib/edgeFunctionError";
 import { fetchIntelligenceCoverage } from "../../services/intelligenceCoverageService";
 import { timeAgo } from "../../lib/formatters";
 import { RunRemainderConfirmModal } from "./RunRemainderConfirmModal";
+// ORCH-1013 Finding B — bulk launch ("Run remainder on all").
+import { RunRemainderOnAllConfirmModal } from "./RunRemainderOnAllConfirmModal";
+import { useBulkRunDispatcher } from "../../hooks/useBulkRunDispatcher";
 
 const PER_PLACE_COST_USD = 0.0040;
 
@@ -59,6 +62,9 @@ export function IntelligenceOverviewTab({ onSwitchToResults, onTabChange }) {
   const [error, setError] = useState(null);
   const [modalCity, setModalCity] = useState(null); // { id, name, remaining_count }
   const [checkingActiveRun, setCheckingActiveRun] = useState(false);
+  // ORCH-1013 Finding B — bulk-launch modal + 3-concurrent dispatcher.
+  const [bulkModalOpen, setBulkModalOpen] = useState(false);
+  const dispatcher = useBulkRunDispatcher({ onToast: addToast });
 
   const refresh = useCallback(async ({ silent = false } = {}) => {
     if (!silent) setLoading(true);
@@ -83,6 +89,20 @@ export function IntelligenceOverviewTab({ onSwitchToResults, onTabChange }) {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  // ORCH-1013 Finding B — list of cities with un-evaluated remainder; feeds the
+  // bulk modal + dispatcher.
+  const candidateCities = useMemo(
+    () =>
+      rows
+        .filter((r) => r.remaining_count > 0)
+        .map((r) => ({
+          city_id: r.city_id,
+          city_name: r.city_name,
+          remaining_count: r.remaining_count,
+        })),
+    [rows],
+  );
 
   const aggregate = useMemo(() => {
     const totals = rows.reduce(
@@ -209,15 +229,33 @@ export function IntelligenceOverviewTab({ onSwitchToResults, onTabChange }) {
         title="Per-city coverage"
         subtitle={`${rows.length} cit${rows.length === 1 ? "y" : "ies"} · ${aggregate.servable.toLocaleString()} servable · ${aggregate.evaluated.toLocaleString()} evaluated (${aggregate.coverage_pct.toFixed(1)}%)`}
         action={
-          <Button
-            size="sm"
-            variant="ghost"
-            icon={RefreshCw}
-            onClick={() => refresh()}
-            disabled={loading}
-          >
-            Refresh
-          </Button>
+          <div className="flex items-center gap-2">
+            {/* ORCH-1013 Finding B — bulk "Run remainder on all" trigger. */}
+            <Button
+              size="sm"
+              variant="secondary"
+              icon={Play}
+              onClick={() => setBulkModalOpen(true)}
+              disabled={loading || candidateCities.length === 0}
+              title={
+                candidateCities.length === 0
+                  ? "All cities are fully evaluated"
+                  : `Run remainder on ${candidateCities.length} un-evaluated cit${candidateCities.length === 1 ? "y" : "ies"}`
+              }
+            >
+              Run remainder on all
+              {candidateCities.length > 0 ? ` (${candidateCities.length})` : ""}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              icon={RefreshCw}
+              onClick={() => refresh()}
+              disabled={loading}
+            >
+              Refresh
+            </Button>
+          </div>
         }
       >
         <div className="flex flex-col gap-4">
@@ -388,6 +426,29 @@ export function IntelligenceOverviewTab({ onSwitchToResults, onTabChange }) {
           onSwitchToResults?.();
         }}
         onConcurrentRun={() => onSwitchToResults?.()}
+      />
+
+      {/* ORCH-1013 Finding B — bulk "Run remainder on all" modal + dispatcher. */}
+      <RunRemainderOnAllConfirmModal
+        open={bulkModalOpen}
+        onClose={() => setBulkModalOpen(false)}
+        candidateCities={candidateCities}
+        perPlaceCostUsd={PER_PLACE_COST_USD}
+        onConfirm={(cities) => {
+          dispatcher.enqueue(cities);
+          const totalCost = cities.reduce(
+            (sum, c) => sum + Number(c.remaining_count || 0) * PER_PLACE_COST_USD,
+            0,
+          );
+          addToast({
+            variant: "info",
+            title: "Bulk remainder queued",
+            description: `${cities.length} cit${cities.length === 1 ? "y" : "ies"}, ~$${totalCost.toFixed(2)} total. Up to 3 run at a time.`,
+          });
+          // Surface the in-flight runs ASAP — the control tower poll picks them
+          // up within 5s anyway.
+          refresh({ silent: true });
+        }}
       />
     </>
   );

--- a/mingla-admin/src/components/placeIntelligenceTrial/RunRemainderOnAllConfirmModal.jsx
+++ b/mingla-admin/src/components/placeIntelligenceTrial/RunRemainderOnAllConfirmModal.jsx
@@ -1,0 +1,214 @@
+/**
+ * RunRemainderOnAllConfirmModal — ORCH-1013 Finding B
+ *
+ * Bulk-launch confirmation modal for "Run remainder on all un-evaluated cities".
+ * Mirrors the cost-guard shape of RunRemainderConfirmModal (single city) but
+ * with a city-list body + a single typed-confirm phrase ("RUN ALL") for
+ * totals >$10 (typing every city name is hostile UX — SPEC §7-D6).
+ *
+ * Gemini 2.5 Flash pricing reference (COMMS-0003):
+ * https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30).
+ *
+ * SPEC §3 B.5.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowRight, ExternalLink } from "lucide-react";
+import { Modal, ModalBody, ModalFooter } from "../ui/Modal";
+import { Button } from "../ui/Button";
+
+const COST_REVIEW_THRESHOLD_USD = 10;
+const TYPED_CONFIRM_PHRASE = "RUN ALL";
+const DEFAULT_PER_PLACE_COST_USD = 0.004;
+
+export function RunRemainderOnAllConfirmModal({
+  open,
+  onClose,
+  candidateCities = [],
+  perPlaceCostUsd = DEFAULT_PER_PLACE_COST_USD,
+  onConfirm,
+}) {
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [typed, setTyped] = useState("");
+  const checkboxRef = useRef(null);
+  const typedInputRef = useRef(null);
+
+  const safeCities = useMemo(
+    () => candidateCities.filter((c) => c?.remaining_count > 0),
+    [candidateCities],
+  );
+
+  const sumRemaining = useMemo(
+    () => safeCities.reduce((sum, c) => sum + Number(c.remaining_count || 0), 0),
+    [safeCities],
+  );
+  const totalCost = useMemo(
+    () => +(sumRemaining * perPlaceCostUsd).toFixed(2),
+    [sumRemaining, perPlaceCostUsd],
+  );
+
+  const requiresTypedConfirm = totalCost > COST_REVIEW_THRESHOLD_USD;
+  const typedMatches = typed.trim() === TYPED_CONFIRM_PHRASE;
+  const canConfirm =
+    safeCities.length > 0 &&
+    acknowledged &&
+    (!requiresTypedConfirm || typedMatches);
+
+  // Reset state each time the modal opens (mirrors RunRemainderConfirmModal).
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!open) return;
+    setAcknowledged(false);
+    setTyped("");
+    requestAnimationFrame(() => {
+      if (requiresTypedConfirm) typedInputRef.current?.focus();
+      else checkboxRef.current?.focus();
+    });
+  }, [open, requiresTypedConfirm]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  if (!open) return null;
+
+  const costColor =
+    totalCost > 10
+      ? "text-[var(--color-error-700)]"
+      : totalCost > 5
+        ? "text-[var(--color-warning-700)]"
+        : "text-[var(--color-text-primary)]";
+
+  const cityWord = safeCities.length === 1 ? "city" : "cities";
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`Run remainder on ${safeCities.length} un-evaluated ${cityWord}`}
+      size="md"
+    >
+      <ModalBody>
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-[var(--color-text-primary)] leading-6">
+            This will queue a remainder run for every city with un-evaluated
+            servable places, using Gemini 2.5 Flash.
+          </p>
+
+          {/* Per-city list */}
+          <div className="rounded-lg bg-[var(--gray-50)] border border-[var(--gray-200)] divide-y divide-[var(--gray-200)] max-h-[220px] overflow-y-auto">
+            {safeCities.map((c) => (
+              <div
+                key={c.city_id}
+                className="flex items-baseline justify-between gap-3 px-3 py-2 text-sm"
+              >
+                <span className="text-[var(--color-text-primary)] font-medium truncate">
+                  {c.city_name}
+                </span>
+                <span className="text-xs font-mono tabular-nums text-[var(--color-text-secondary)] shrink-0">
+                  {Number(c.remaining_count || 0).toLocaleString()} places · ~$
+                  {(c.remaining_count * perPlaceCostUsd).toFixed(2)}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* Totals */}
+          <div className="rounded-lg bg-[var(--gray-50)] border border-[var(--gray-200)] p-4">
+            <div className="text-[10px] uppercase tracking-wide font-mono text-[var(--color-text-tertiary)] mb-1.5">
+              Totals
+            </div>
+            <div className="flex items-baseline justify-between font-mono tabular-nums text-sm">
+              <span className="text-[var(--color-text-secondary)]">
+                {sumRemaining.toLocaleString()} places × $
+                {perPlaceCostUsd.toFixed(4)}
+              </span>
+              <span className={["font-semibold", costColor].join(" ")}>
+                ~${totalCost.toFixed(2)}
+              </span>
+            </div>
+            <p className="text-xs text-[var(--color-text-tertiary)] mt-1">
+              Gemini 2.5 Flash, server-side. Pricing:{" "}
+              <a
+                href="https://ai.google.dev/pricing/gemini-2-5-flash"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-[var(--color-text-secondary)]"
+              >
+                ai.google.dev/pricing
+                <ExternalLink className="inline w-3 h-3 ml-0.5" aria-hidden="true" />
+              </a>
+              <span className="ml-1">(verified 2026-05-30)</span>
+            </p>
+          </div>
+
+          {/* High-cost gate: typed phrase */}
+          {requiresTypedConfirm && (
+            <div className="border-l-4 border-l-[var(--color-warning-500)] bg-[var(--color-warning-50)] p-4 rounded-r-lg">
+              <h4 className="text-sm font-semibold text-[var(--color-warning-700)] mb-1">
+                Cost exceeds ${COST_REVIEW_THRESHOLD_USD}
+              </h4>
+              <p className="text-xs text-[var(--color-warning-700)] mb-2">
+                Type <span className="font-mono">{TYPED_CONFIRM_PHRASE}</span>{" "}
+                below to confirm.
+              </p>
+              <input
+                ref={typedInputRef}
+                type="text"
+                value={typed}
+                onChange={(e) => setTyped(e.target.value)}
+                placeholder={TYPED_CONFIRM_PHRASE}
+                className={[
+                  "w-full h-10 text-sm bg-[var(--color-background-primary)] text-[var(--color-text-primary)]",
+                  "border border-[var(--gray-300)] rounded-lg outline-none transition-all duration-150 px-3",
+                  "focus:border-[var(--color-warning-500)] focus:ring-2 focus:ring-[var(--color-warning-100,var(--color-warning-50))]",
+                ].join(" ")}
+                aria-label={`Type "${TYPED_CONFIRM_PHRASE}" to confirm`}
+              />
+              {typedMatches && (
+                <p className="text-xs text-[var(--color-success-700)] mt-1.5">
+                  ✓ matches
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Acknowledgement checkbox */}
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              ref={checkboxRef}
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              className="mt-0.5 cursor-pointer"
+            />
+            <span className="text-sm text-[var(--color-text-primary)]">
+              I understand this will charge ~${totalCost.toFixed(2)} on the Gemini API.
+            </span>
+          </label>
+
+          <p className="text-xs text-[var(--color-text-tertiary)] italic">
+            Up to 3 cities will run at a time. Remaining cities queue
+            automatically and start as slots free up.
+          </p>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          iconRight={ArrowRight}
+          onClick={() => {
+            if (!canConfirm) return;
+            onConfirm?.(safeCities);
+            onClose?.();
+          }}
+          disabled={!canConfirm}
+        >
+          Queue all
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default RunRemainderOnAllConfirmModal;

--- a/mingla-admin/src/components/placeIntelligenceTrial/TrialResultsTab.jsx
+++ b/mingla-admin/src/components/placeIntelligenceTrial/TrialResultsTab.jsx
@@ -16,7 +16,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   Play, RefreshCw, Square,
-  Globe, Clock, RotateCcw, ArrowRight, Info,
+  RotateCcw, Info,
 } from "lucide-react";
 import { supabase, invokeWithRefresh } from "../../lib/supabase";
 import { extractFunctionError } from "../../lib/edgeFunctionError";
@@ -26,7 +26,9 @@ import { Button } from "../ui/Button";
 import { Spinner } from "../ui/Spinner";
 import { RunHistoryGroups } from "./RunHistoryGroups";
 import { SignalDistributionPanel } from "./SignalDistributionPanel";
-import { CancelRunConfirmModal } from "./CancelRunConfirmModal";
+// ORCH-1013 Finding B — the in-tab active-run banner is deleted in this PR;
+// CancelRunConfirmModal is now consumed exclusively by <ActiveRunCard /> inside
+// the page-level <ActiveRunsControlTower />.
 import { RunRemainderConfirmModal } from "./RunRemainderConfirmModal";
 
 function formatCost(n) {
@@ -86,21 +88,22 @@ export function TrialResultsTab() {
   // ORCH-1008 — extended with 'remainder' as a third option.
   const [mode, setMode] = useState("sample");
 
-  // ORCH-0737 — active full-city run state. activeRunId set after start_run
-  // OR via list_active_runs hydration on mount (cross-session resume).
-  // activeRun is the polled parent row; updated every 5s while running.
+  // ORCH-0737 — active full-city run state. activeRunId is set after a same-
+  // session start_run / retry_failed / remainder; the polling effect below
+  // watches it to refresh the history list on terminal status.
+  // ORCH-1013 Finding B — `activeRun` no longer has a UI reader (banner was
+  // deleted), but the setter still feeds the polling-effect terminal check;
+  // keep the reducer underscored so lint passes without a behavioural change.
   const [activeRunId, setActiveRunId] = useState(null);
-  const [activeRun, setActiveRun] = useState(null);
+  const [_activeRun, setActiveRun] = useState(null);
   const [cityCoverage, setCityCoverage] = useState(null);
   const [coverageLoading, setCoverageLoading] = useState(false);
   const [retryingFailed, setRetryingFailed] = useState(false);
-  // ORCH-1008 Phase 4 — modal state for cancel + remainder confirmation
-  const [cancelModalOpen, setCancelModalOpen] = useState(false);
-  const [cancelLoading, setCancelLoading] = useState(false);
+  // ORCH-1008 Phase 4 — modal state for remainder confirmation. ORCH-1013
+  // Finding B deleted the in-tab cancel modal state (cancelModalOpen /
+  // cancelLoading / bannerDismissed) — cancel UX now lives in the shared
+  // <ActiveRunsControlTower /> mounted at the page level.
   const [remainderModalOpen, setRemainderModalOpen] = useState(false);
-  // Dismissed-banner persistence for terminal active-run state (so we don't
-  // keep showing a cancelled/failed banner once operator acknowledges).
-  const [bannerDismissed, setBannerDismissed] = useState(false);
 
   const fetchCityCoverage = useCallback(async (targetCityId, { quiet = false } = {}) => {
     if (!targetCityId) {
@@ -213,38 +216,14 @@ export function TrialResultsTab() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allRows, cityId]);
 
-  // ORCH-0737 — cross-session resume on mount. If any full-city run is currently
-  // active (status pending/running/cancelling), hydrate UI immediately so the
-  // operator sees in-progress state on tab reopen.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const { data, error } = await invokeWithRefresh("run-place-intelligence-trial", {
-          body: { action: "list_active_runs" },
-        });
-        if (cancelled) return;
-        if (error) return; // silent: feature is non-critical for hydration
-        if (data?.runs?.length > 0) {
-          // Pick the most recent active run; if multiple, panel shows newest first
-          setActiveRunId(data.runs[0].id);
-          setActiveRun(data.runs[0]);
-        }
-      } catch {
-        // silent
-      }
-    })();
-    return () => { cancelled = true; };
-  }, []);
+  // ORCH-1013 Finding B — cross-session hydration effect deleted: the page-
+  // level <ActiveRunsControlTower /> owns active-run UI; in-tab hydration
+  // would orphan activeRun state with no visible consumer. Sample-mode
+  // browser-loop uses `progress` state below, not `activeRun`.
 
-  // ORCH-0737 — poll active run status every 5s while activeRunId is set.
-  // When run reaches terminal state (complete/cancelled/failed), stop polling
-  // and refresh the run-history list.
-  // ORCH-1008 Phase 4 — reset banner-dismissed when a new active run mounts
-  useEffect(() => {
-    if (activeRunId) setBannerDismissed(false);
-  }, [activeRunId]);
-
+  // ORCH-0737 — poll active run status every 5s while activeRunId is set
+  // (still used for SAME-SESSION full_city / remainder / retry_failed flows
+  // started from THIS tab, so the history list refreshes on completion).
   useEffect(() => {
     if (!activeRunId) return;
     let cancelled = false;
@@ -273,35 +252,9 @@ export function TrialResultsTab() {
     return () => { cancelled = true; };
   }, [activeRunId, cityId, fetchCityCoverage, refresh]);
 
-  // ORCH-0737 — cancel active full-city run (calls cancel_trial action).
-  // ORCH-1008 Phase 4 — replaced window.confirm with CancelRunConfirmModal.
-  async function handleCancelActiveRunConfirmed() {
-    if (!activeRunId) return;
-    setCancelLoading(true);
-    try {
-      const { error } = await invokeWithRefresh("run-place-intelligence-trial", {
-        body: { action: "cancel_trial", run_id: activeRunId },
-      });
-      if (error) {
-        addToast({
-          variant: "error",
-          title: "Couldn't cancel",
-          description: await extractFunctionError(error, "cancel_trial failed"),
-        });
-        return;
-      }
-      addToast({
-        variant: "info",
-        title: "Cancelling…",
-        description: "Run will stop after current chunk (~30-90s).",
-      });
-    } catch (err) {
-      addToast({ variant: "error", title: "Couldn't cancel", description: err.message });
-    } finally {
-      setCancelLoading(false);
-      setCancelModalOpen(false);
-    }
-  }
+  // ORCH-1013 Finding B — handleCancelActiveRunConfirmed deleted. Cancel UX
+  // now lives on each <ActiveRunCard /> inside the control tower; that card
+  // owns its own CancelRunConfirmModal mount.
 
   // ORCH-0737 — top-level dispatcher. Branches on mode.
   // ORCH-1008 — remainder mode uses the dedicated modal (same code path the
@@ -317,14 +270,9 @@ export function TrialResultsTab() {
     return handleRunFullCityTrial();
   }
 
-  function handleResumeFromN() {
-    if (!cityId || !activeRun) return;
-    setMode("remainder");
-    setBannerDismissed(true);
-    setActiveRunId(null);
-    setActiveRun(null);
-    setRemainderModalOpen(true);
-  }
+  // ORCH-1013 Finding B — handleResumeFromN deleted. Resume affordance is
+  // deferred; operator re-fires remainder from the Overview tab or via the
+  // bulk "Run remainder on all" button.
 
   // ORCH-0737 — full-city async mode. Submits start_run with mode=full_city,
   // optional confirm_high_cost flag (after double-confirm dialog), then sets
@@ -694,79 +642,9 @@ export function TrialResultsTab() {
       }
     >
       <div className="space-y-4">
-        {/* ORCH-0737 — active-run panel for full-city durable runs. Renders
-            above the form when a full-city run is in flight. Survives tab
-            close/refresh via list_active_runs hydration on mount.
-            ORCH-1008 Phase 4 — banner can be dismissed once terminal; Resume
-            button appears for cancelled runs (kicks remainder modal). */}
-        {activeRun && !bannerDismissed && (
-          <div className="border border-[var(--color-brand-200)] rounded-lg p-4 space-y-3 bg-[var(--color-brand-50)]">
-            <div className="flex items-baseline justify-between gap-2">
-              <h4 className="text-sm font-semibold text-[var(--color-text-primary)] flex items-center gap-2">
-                {activeRun.mode === "retry_failed"
-                  ? <><RotateCcw className="w-4 h-4 inline" /> Retry failed run</>
-                  : activeRun.mode === "full_city"
-                    ? <><Globe className="w-4 h-4 inline" /> Full-city run</>
-                    : <><Clock className="w-4 h-4 inline" /> Sample run</>}
-                {" — "}{activeRun.city_name}
-              </h4>
-              <span className="text-xs font-mono text-[var(--color-text-secondary)]">
-                {activeRun.processed_count} / {activeRun.total_count}
-                {" "}({Math.round((activeRun.processed_count / Math.max(1, activeRun.total_count)) * 100)}%)
-              </span>
-            </div>
-            <div className="h-2 bg-[var(--gray-200)] rounded-full overflow-hidden">
-              <div
-                className="h-full bg-[var(--color-brand-500)] transition-all duration-200"
-                style={{ width: `${(activeRun.processed_count / Math.max(1, activeRun.total_count)) * 100}%` }}
-              />
-            </div>
-            <div className="flex flex-wrap items-center gap-3 text-xs">
-              <span className="text-[var(--color-success-700)] font-mono">✓ {activeRun.succeeded_count}</span>
-              <span className="text-[var(--color-error-700)] font-mono">✗ {activeRun.failed_count}</span>
-              <span className="text-[var(--color-text-secondary)] font-mono">
-                cost: ${Number(activeRun.cost_so_far_usd || 0).toFixed(4)} of ~${Number(activeRun.estimated_cost_usd || 0).toFixed(2)}
-              </span>
-              <span className="ml-auto">
-                <span className={[
-                  "text-[10px] uppercase tracking-wide font-mono px-1.5 py-0.5 rounded",
-                  activeRun.status === "running" && "bg-[var(--color-info-50)] text-[var(--color-info-700)]",
-                  activeRun.status === "cancelling" && "bg-[var(--color-warning-50)] text-[var(--color-warning-700)]",
-                  activeRun.status === "pending" && "bg-[var(--gray-100)] text-[var(--color-text-tertiary)]",
-                ].filter(Boolean).join(" ")}>
-                  {activeRun.status}
-                </span>
-              </span>
-            </div>
-            {activeRun.status === "running" && (
-              <Button variant="danger" size="sm" icon={Square} onClick={() => setCancelModalOpen(true)}>
-                Cancel run
-              </Button>
-            )}
-            {activeRun.status === "cancelling" && (
-              <p className="text-xs text-[var(--color-warning-700)]">
-                Cancelling… will stop after current chunk (~30-90s).
-              </p>
-            )}
-            {activeRun.status === "cancelled" && cityId && (
-              <Button
-                variant="primary"
-                size="sm"
-                iconRight={ArrowRight}
-                onClick={handleResumeFromN}
-              >
-                Resume from place {Number(activeRun.processed_count || 0) + 1}
-              </Button>
-            )}
-            <p className="text-xs text-[var(--color-text-tertiary)] italic">
-              {activeRun.mode === "retry_failed"
-                ? "Retrying failed places on the server — safe to close this tab. Status updates every 5s while page is open."
-                : (activeRun.mode === "full_city" || activeRun.mode === "remainder")
-                ? "Running on the server — safe to close this tab. Status updates every 5s while page is open."
-                : "Sample run in progress."}
-            </p>
-          </div>
-        )}
+        {/* ORCH-1013 Finding B — in-tab active-run banner deleted. Live
+            progress now surfaces in the page-level <ActiveRunsControlTower />
+            pinned above the tabs (PlaceIntelligenceTrialPage). */}
 
         {/* ORCH-0734 — city picker + sample size. ORCH-0737 — added mode toggle.
             Sample mode: browser-loop, ~75 min/200 places.
@@ -966,11 +844,9 @@ export function TrialResultsTab() {
               </div>
             </div>
           )}
-          {!!activeRunId && (
-            <p className="text-xs text-[var(--color-warning-700)]">
-              Already a run in progress — wait or cancel above before starting another.
-            </p>
-          )}
+          {/* ORCH-1013 Finding B — "Already a run in progress" warning deleted;
+              the page-level <ActiveRunsControlTower /> now surfaces the running
+              run with its own soft-cancel affordance. */}
           <div className="flex flex-wrap items-center gap-3 pt-1 border-t border-[var(--gray-200)]">
             <span className="text-xs text-[var(--color-text-tertiary)] uppercase tracking-wide font-mono shrink-0">AI Provider</span>
             <span className="text-xs font-medium text-[var(--color-text-primary)]">Gemini 2.5 Flash</span>
@@ -1124,16 +1000,9 @@ export function TrialResultsTab() {
         )}
       </div>
 
-      {/* ORCH-1008 Phase 4 — confirmation modals */}
-      <CancelRunConfirmModal
-        open={cancelModalOpen}
-        onClose={() => setCancelModalOpen(false)}
-        onConfirm={handleCancelActiveRunConfirmed}
-        cityName={activeRun?.city_name}
-        processedCount={activeRun?.processed_count || 0}
-        totalCount={activeRun?.total_count || 0}
-        loading={cancelLoading}
-      />
+      {/* ORCH-1008 Phase 4 — confirmation modals.
+          ORCH-1013 Finding B — the CancelRunConfirmModal mount moved to
+          <ActiveRunCard /> inside the page-level control tower. */}
       <RunRemainderConfirmModal
         open={remainderModalOpen}
         onClose={() => setRemainderModalOpen(false)}

--- a/mingla-admin/src/hooks/useActiveRunsPoller.js
+++ b/mingla-admin/src/hooks/useActiveRunsPoller.js
@@ -1,0 +1,193 @@
+/**
+ * useActiveRunsPoller — ORCH-1013 Finding B
+ *
+ * Polls the run-place-intelligence-trial edge fn's `list_active_runs` action
+ * every 5s and surfaces every in-progress run (status pending|running|cancelling)
+ * to the <ActiveRunsControlTower /> panel. Maintains a per-run rolling buffer of
+ * (timestamp, processed_count) for client-side ETA computation. Tracks terminal
+ * runs for a 3s "show-then-fade" tail so cancelled / complete / failed runs
+ * surface their final pill before unmounting.
+ *
+ * Polling is suppressed when document.visibilityState === 'hidden' so background
+ * tabs don't eat edge-fn quota or distort the ETA buffer.
+ *
+ * Gemini pricing reference (COMMS-0003):
+ * https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30).
+ *
+ * Contract (SPEC §3 B.4):
+ *   activeRuns        — runs currently active (pending|running|cancelling)
+ *   terminalRuns      — runs that just terminated; auto-expire after 3s
+ *   loading           — true on the first tick only
+ *   error             — null until 3 consecutive poll failures
+ *   refresh()         — fire a poll immediately (used by the modal after enqueue)
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invokeWithRefresh } from "../lib/supabase";
+
+const POLL_INTERVAL_MS = 5_000;
+const TERMINAL_DISPLAY_MS = 3_000;
+const ETA_BUFFER_CAP = 12; // 12 * 5s = 60s window
+const ETA_MIN_WINDOW_MS = 30_000; // require 30s of samples before computing
+const ERROR_THRESHOLD = 3;
+
+export function useActiveRunsPoller() {
+  const [activeRuns, setActiveRuns] = useState([]);
+  const [terminalRuns, setTerminalRuns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Persistent across renders, not in state.
+  const consecutiveErrorsRef = useRef(0);
+  const etaBuffersRef = useRef(new Map()); // run_id -> [{ ts, processed }]
+  const terminalTimersRef = useRef(new Map()); // run_id -> timeout handle
+  const knownRunIdsRef = useRef(new Set()); // run_ids seen in previous tick
+  const isUnmountedRef = useRef(false);
+
+  // Stable refs to the latest tick + state so we don't restart intervals on
+  // every render.
+  const tickRef = useRef(null);
+
+  function stageTerminal(run) {
+    // Show the terminal card for 3s then drop it.
+    setTerminalRuns((prev) => {
+      // Replace any existing terminal entry for this run id.
+      const filtered = prev.filter((r) => r.id !== run.id);
+      return [...filtered, run];
+    });
+    const existing = terminalTimersRef.current.get(run.id);
+    if (existing) clearTimeout(existing);
+    const handle = setTimeout(() => {
+      terminalTimersRef.current.delete(run.id);
+      if (isUnmountedRef.current) return;
+      setTerminalRuns((prev) => prev.filter((r) => r.id !== run.id));
+    }, TERMINAL_DISPLAY_MS);
+    terminalTimersRef.current.set(run.id, handle);
+    // Drop the eta buffer for terminated runs.
+    etaBuffersRef.current.delete(run.id);
+  }
+
+  async function tick() {
+    if (document.visibilityState === "hidden") return;
+    try {
+      const { data, error: pollErr } = await invokeWithRefresh(
+        "run-place-intelligence-trial",
+        { body: { action: "list_active_runs" } },
+      );
+      if (pollErr) {
+        consecutiveErrorsRef.current += 1;
+        if (consecutiveErrorsRef.current >= ERROR_THRESHOLD) {
+          setError("Couldn't refresh active runs (retrying)");
+        }
+        return;
+      }
+      consecutiveErrorsRef.current = 0;
+      setError(null);
+      const rawRuns = Array.isArray(data?.runs) ? data.runs : [];
+      const now = Date.now();
+      const nowIds = new Set(rawRuns.map((r) => r.id));
+
+      // Update each active run's ETA buffer + compute liveEta.
+      const enriched = rawRuns.map((run) => {
+        const buf = etaBuffersRef.current.get(run.id) || [];
+        const next = [...buf, { ts: now, processed: Number(run.processed_count || 0) }];
+        // Cap buffer.
+        while (next.length > ETA_BUFFER_CAP) next.shift();
+        etaBuffersRef.current.set(run.id, next);
+
+        let liveEtaSeconds = null;
+        let liveRatePerMin = null;
+        if (next.length >= 2) {
+          const first = next[0];
+          const last = next[next.length - 1];
+          const dtMs = last.ts - first.ts;
+          if (dtMs >= ETA_MIN_WINDOW_MS) {
+            const dProcessed = last.processed - first.processed;
+            const ratePerSec = dProcessed / (dtMs / 1000);
+            if (ratePerSec > 0) {
+              const remaining = Math.max(
+                0,
+                Number(run.total_count || 0) - Number(run.processed_count || 0),
+              );
+              liveEtaSeconds = remaining / ratePerSec;
+              liveRatePerMin = ratePerSec * 60;
+            }
+          }
+        }
+        return { ...run, _liveEtaSeconds: liveEtaSeconds, _liveRatePerMin: liveRatePerMin };
+      });
+
+      // For every previously-known run id no longer present, fetch its terminal
+      // state once and stage it in `terminalRuns`.
+      const droppedIds = [...knownRunIdsRef.current].filter((id) => !nowIds.has(id));
+      for (const droppedId of droppedIds) {
+        try {
+          const { data: statusData } = await invokeWithRefresh(
+            "run-place-intelligence-trial",
+            { body: { action: "run_status", run_id: droppedId } },
+          );
+          const terminal = statusData?.parent;
+          if (terminal && ["complete", "cancelled", "failed"].includes(terminal.status)) {
+            stageTerminal({
+              ...terminal,
+              _liveEtaSeconds: null,
+              _liveRatePerMin: null,
+            });
+          }
+        } catch {
+          // silent — drop without terminal display
+        }
+      }
+
+      knownRunIdsRef.current = nowIds;
+      setActiveRuns(enriched);
+    } catch {
+      consecutiveErrorsRef.current += 1;
+      if (consecutiveErrorsRef.current >= ERROR_THRESHOLD) {
+        setError("Couldn't refresh active runs (retrying)");
+      }
+    } finally {
+      if (loading) setLoading(false);
+    }
+  }
+
+  // Keep latest tick function in a ref so the interval doesn't restart.
+  tickRef.current = tick;
+
+  const refresh = useCallback(async () => {
+    if (tickRef.current) await tickRef.current();
+  }, []);
+
+  useEffect(() => {
+    isUnmountedRef.current = false;
+    // Fire-and-forget first poll.
+    refresh();
+    const interval = setInterval(() => {
+      if (tickRef.current) tickRef.current();
+    }, POLL_INTERVAL_MS);
+
+    function onVisibility() {
+      if (document.visibilityState === "visible") {
+        // Resume with an immediate tick.
+        if (tickRef.current) tickRef.current();
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      isUnmountedRef.current = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+      // Clear all terminal-display timers.
+      for (const handle of terminalTimersRef.current.values()) clearTimeout(handle);
+      terminalTimersRef.current.clear();
+      etaBuffersRef.current.clear();
+    };
+    // refresh is stable (useCallback []), so interval mounts once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { activeRuns, terminalRuns, loading, error, refresh };
+}
+
+export default useActiveRunsPoller;

--- a/mingla-admin/src/hooks/useBulkRunDispatcher.js
+++ b/mingla-admin/src/hooks/useBulkRunDispatcher.js
@@ -1,0 +1,242 @@
+/**
+ * useBulkRunDispatcher — ORCH-1013 Finding B
+ *
+ * Client-side dispatcher for the "Run remainder on all un-evaluated cities"
+ * bulk action. Enforces:
+ *   - Hard cap: inFlight ≤ 3 at all times (I-PROPOSED-INTEL-BULK-DISPATCHER-CAP-3).
+ *   - 2s stagger between consecutive `starting` transitions
+ *     (I-PROPOSED-INTEL-BULK-DISPATCHER-STAGGER-2S).
+ *   - Auto-queue: when a running run completes (drops from list_active_runs),
+ *     the dispatcher picks up the next `pending` city.
+ *
+ * Per SPEC §3 B.6 + §7-D2: tab-close loses pending cities. Server has no
+ * intelligence_run_queue; that's a future ORCH if the operator demands it.
+ * In-flight runs are server-durable (place_intelligence_runs row); the control
+ * tower hydrates them on reopen.
+ *
+ * Gemini pricing reference (COMMS-0003):
+ * https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30).
+ *
+ * Contract (SPEC §3 B.6):
+ *   state.queue       — [{ city_id, city_name, remaining_count, status,
+ *                          run_id?, error?, started_at? }]
+ *   state.inFlight    — count of queue entries with status in {starting, running}
+ *   enqueue(cities)   — append cities to the queue and start the tick loop
+ *   cancelAll()       — flip every `pending` to `skipped_concurrent`; does NOT
+ *                       cancel in-flight runs (operator uses per-card cancel)
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invokeWithRefresh } from "../lib/supabase";
+import { extractFunctionError } from "../lib/edgeFunctionError";
+
+const MAX_CONCURRENT = 3;
+const STAGGER_MS = 2_000;
+const TICK_INTERVAL_MS = 500;
+
+function countInFlight(queue) {
+  return queue.filter((c) => c.status === "starting" || c.status === "running")
+    .length;
+}
+
+export function useBulkRunDispatcher({ onToast } = {}) {
+  const [state, setState] = useState({ queue: [], inFlight: 0 });
+  const queueRef = useRef([]);
+  const tickIntervalRef = useRef(null);
+  const startingInFlightRef = useRef(false); // guard re-entry during a `starting` POST
+
+  function syncState() {
+    setState({
+      queue: [...queueRef.current],
+      inFlight: countInFlight(queueRef.current),
+    });
+  }
+
+  function ensureTick() {
+    if (tickIntervalRef.current) return;
+    tickIntervalRef.current = setInterval(tick, TICK_INTERVAL_MS);
+  }
+
+  function stopTick() {
+    if (tickIntervalRef.current) {
+      clearInterval(tickIntervalRef.current);
+      tickIntervalRef.current = null;
+    }
+  }
+
+  async function startCity(city) {
+    // Mark `starting` synchronously so the next tick sees the inFlight bump.
+    const idx = queueRef.current.findIndex((c) => c.city_id === city.city_id);
+    if (idx < 0) return;
+    queueRef.current[idx] = {
+      ...queueRef.current[idx],
+      status: "starting",
+      started_at: Date.now(),
+    };
+    syncState();
+
+    try {
+      const estCost = Math.max(0, city.remaining_count) * 0.004;
+      const confirmHighCost = estCost > 5;
+      const { data, error: startErr } = await invokeWithRefresh(
+        "run-place-intelligence-trial",
+        {
+          body: {
+            action: "start_run",
+            city_id: city.city_id,
+            mode: "remainder",
+            confirm_high_cost: confirmHighCost,
+          },
+        },
+      );
+      if (startErr) {
+        // Pull the error code if present (e.g. concurrent_run = 409).
+        let code = null;
+        try {
+          if (startErr.context?.json) {
+            const j = await startErr.context.json();
+            code = j?.error ?? null;
+          }
+        } catch {
+          // ignore
+        }
+        const msg = await extractFunctionError(startErr, "start_run failed");
+        const newStatus = code === "concurrent_run" ? "skipped_concurrent" : "failed";
+        const i2 = queueRef.current.findIndex((c) => c.city_id === city.city_id);
+        if (i2 >= 0) {
+          queueRef.current[i2] = {
+            ...queueRef.current[i2],
+            status: newStatus,
+            error: msg,
+          };
+        }
+        if (onToast) {
+          onToast({
+            variant: "warning",
+            title: `Couldn't start ${city.city_name}`,
+            description: msg,
+          });
+        }
+        syncState();
+        return;
+      }
+      const runId = data?.runId ?? null;
+      const i2 = queueRef.current.findIndex((c) => c.city_id === city.city_id);
+      if (i2 >= 0) {
+        queueRef.current[i2] = {
+          ...queueRef.current[i2],
+          status: "running",
+          run_id: runId,
+        };
+      }
+      syncState();
+    } catch (err) {
+      const i2 = queueRef.current.findIndex((c) => c.city_id === city.city_id);
+      if (i2 >= 0) {
+        queueRef.current[i2] = {
+          ...queueRef.current[i2],
+          status: "failed",
+          error: err?.message || "Unknown error",
+        };
+      }
+      if (onToast) {
+        onToast({
+          variant: "warning",
+          title: `Couldn't start ${city.city_name}`,
+          description: err?.message || "Unknown error",
+        });
+      }
+      syncState();
+    }
+  }
+
+  async function reconcileRunningWithPoller() {
+    // Best-effort: poll list_active_runs and flip any `running` queue entries
+    // whose run_id no longer appears to `complete`. This unblocks the next
+    // `pending` city in the queue.
+    try {
+      const { data, error: pErr } = await invokeWithRefresh(
+        "run-place-intelligence-trial",
+        { body: { action: "list_active_runs" } },
+      );
+      if (pErr) return;
+      const liveRunIds = new Set((data?.runs || []).map((r) => r.id));
+      let changed = false;
+      for (let i = 0; i < queueRef.current.length; i++) {
+        const c = queueRef.current[i];
+        if (c.status === "running" && c.run_id && !liveRunIds.has(c.run_id)) {
+          queueRef.current[i] = { ...c, status: "complete" };
+          changed = true;
+        }
+      }
+      if (changed) syncState();
+    } catch {
+      // silent
+    }
+  }
+
+  async function tick() {
+    if (startingInFlightRef.current) return;
+
+    // First, reconcile any `running` rows that have finished server-side.
+    await reconcileRunningWithPoller();
+
+    const inFlight = countInFlight(queueRef.current);
+    if (inFlight >= MAX_CONCURRENT) return;
+
+    // Find last start timestamp (for stagger gating).
+    const lastStartedAt = queueRef.current.reduce((max, c) => {
+      const ts = Number(c.started_at || 0);
+      return ts > max ? ts : max;
+    }, 0);
+    const now = Date.now();
+    if (now - lastStartedAt < STAGGER_MS && lastStartedAt > 0) return;
+
+    const next = queueRef.current.find((c) => c.status === "pending");
+    if (!next) {
+      // Nothing pending. If nothing in flight either, stop the tick.
+      if (inFlight === 0) stopTick();
+      return;
+    }
+
+    startingInFlightRef.current = true;
+    try {
+      await startCity(next);
+    } finally {
+      startingInFlightRef.current = false;
+    }
+  }
+
+  const enqueue = useCallback((cities) => {
+    if (!Array.isArray(cities) || cities.length === 0) return;
+    const existingIds = new Set(queueRef.current.map((c) => c.city_id));
+    const incoming = cities
+      .filter((c) => c?.city_id && !existingIds.has(c.city_id))
+      .map((c) => ({
+        city_id: c.city_id,
+        city_name: c.city_name,
+        remaining_count: Number(c.remaining_count || 0),
+        status: "pending",
+      }));
+    queueRef.current = [...queueRef.current, ...incoming];
+    syncState();
+    ensureTick();
+  }, []);
+
+  const cancelAll = useCallback(() => {
+    queueRef.current = queueRef.current.map((c) =>
+      c.status === "pending" ? { ...c, status: "skipped_concurrent" } : c,
+    );
+    syncState();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      stopTick();
+    };
+  }, []);
+
+  return { state, enqueue, cancelAll };
+}
+
+export default useBulkRunDispatcher;

--- a/mingla-admin/src/pages/PlaceIntelligenceTrialPage.jsx
+++ b/mingla-admin/src/pages/PlaceIntelligenceTrialPage.jsx
@@ -28,6 +28,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Tabs } from "../components/ui/Tabs";
 import { TrialResultsTab } from "../components/placeIntelligenceTrial/TrialResultsTab";
 import { IntelligenceOverviewTab } from "../components/placeIntelligenceTrial/IntelligenceOverviewTab";
+// ORCH-1013 Finding B — shared control tower for parallel city backfills.
+import { ActiveRunsControlTower } from "../components/placeIntelligenceTrial/ActiveRunsControlTower";
 
 // ORCH-1008 — Overview is the operator's landing tab; Trial Results follows.
 const TABS = [
@@ -61,6 +63,11 @@ export function PlaceIntelligenceTrialPage({ onTabChange }) {
           </p>
         </div>
       </div>
+
+      {/* ORCH-1013 Finding B — pinned active-runs panel. Auto-hides when no
+          active or terminal runs are in the poller buffer. Cancelled-card
+          "View" deep-links to the Results tab. */}
+      <ActiveRunsControlTower onViewRun={() => setActiveTab("results")} />
 
       <div>
         <Tabs tabs={TABS} activeTab={activeTab} onChange={setActiveTab} />

--- a/supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts
@@ -1,0 +1,255 @@
+// ORCH-1013 ADVERSARIAL — Finding A: handleIntelligenceCoverage coverage math
+// edge cases that the implementor's coverage_servable_filter.test.ts misses.
+//
+// Implementor's tests fixture only Cary (760/761/1), Raleigh (1540/1540/0),
+// and one "empty" sentinel. This file probes the corner cases the SPEC §3
+// Finding A "edge-case audit" section enumerates:
+//
+//   - city with 0 servable + 0 evaluated → filtered out (servable_count > 0 filter)
+//   - city with N servable + 0 evaluated → 0 evaluated, N remaining, 0% coverage
+//   - city where ALL evaluated rows drifted out (post-fix returns 0 evaluated)
+//   - Place evaluated multiple times across mode changes → Set-dedupe to 1
+//   - The `Math.min(evaluated, servable)` clamp is still in place (defensive)
+//   - Race-window: evaluated > servable by 1 row → clamp prevents 100.x% display
+//   - coverage_pct toFixed(1) rounds correctly at boundaries
+//
+// Plus source-inspect for the .filter(r => r.servable_count > 0) drop-row
+// guard at L2312, which the implementor's test doesn't cover.
+
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// Pure mirror of the per-city aggregation at index.ts L2284-L2316 (post-Finding A).
+function aggregateCityCoverage(
+  cityId: string,
+  servableRows: { city_id: string }[],
+  completedRowsServableOnly: { city_id: string; place_pool_id: string }[],
+): {
+  servable_count: number;
+  evaluated_count: number;
+  remaining_count: number;
+  coverage_pct: number;
+} {
+  const servable = servableRows.filter((r) => r.city_id === cityId).length;
+  const evaluatedSet = new Set<string>();
+  for (const r of completedRowsServableOnly) {
+    if (r.city_id === cityId && r.place_pool_id) {
+      evaluatedSet.add(r.place_pool_id);
+    }
+  }
+  const evaluated = evaluatedSet.size;
+  return {
+    servable_count: servable,
+    evaluated_count: Math.min(evaluated, servable),
+    remaining_count: Math.max(0, servable - evaluated),
+    coverage_pct: servable === 0
+      ? 0
+      : Math.min(100, +((evaluated / servable) * 100).toFixed(1)),
+  };
+}
+
+// Mirror of the final rows.filter + sort.
+function buildRows(
+  cities: { id: string; name: string; country: string }[],
+  servableRows: { city_id: string }[],
+  completedRowsServableOnly: { city_id: string; place_pool_id: string }[],
+) {
+  return cities
+    .map((c) => {
+      const agg = aggregateCityCoverage(c.id, servableRows, completedRowsServableOnly);
+      return {
+        city_id: c.id,
+        city_name: c.name,
+        country: c.country,
+        ...agg,
+      };
+    })
+    .filter((r) => r.servable_count > 0)
+    .sort((a, b) => b.servable_count - a.servable_count);
+}
+
+Deno.test("ADV-A1 — city with 0 servable + 0 evaluated → dropped from response", () => {
+  const cities = [{ id: "empty", name: "Empty City", country: "US" }];
+  const rows = buildRows(cities, [], []);
+  assertEquals(rows.length, 0, "city with 0 servable must be filtered out");
+});
+
+Deno.test("ADV-A2 — city with N servable + 0 evaluated → 0%, N remaining", () => {
+  const cities = [{ id: "lagos", name: "Lagos", country: "NG" }];
+  const servable = Array.from({ length: 908 }, () => ({ city_id: "lagos" }));
+  const rows = buildRows(cities, servable, []);
+  assertEquals(rows.length, 1);
+  assertEquals(rows[0].servable_count, 908);
+  assertEquals(rows[0].evaluated_count, 0);
+  assertEquals(rows[0].remaining_count, 908);
+  assertEquals(rows[0].coverage_pct, 0);
+});
+
+Deno.test("ADV-A3 — extreme drift: ALL evaluated rows drifted (post-fix returns 0 evaluated)", () => {
+  // Simulating that the JOIN filtered out 100% of evaluated rows because
+  // every previously-evaluated place is now non-servable. Post-fix, the
+  // completedRowsServableOnly array is empty.
+  const cities = [{ id: "churn", name: "Churn City", country: "US" }];
+  const servable = Array.from({ length: 100 }, () => ({ city_id: "churn" }));
+  // 0 still-servable evaluated (extreme pool churn scenario)
+  const rows = buildRows(cities, servable, []);
+  assertEquals(rows[0].evaluated_count, 0);
+  assertEquals(rows[0].remaining_count, 100);
+  assertEquals(rows[0].coverage_pct, 0);
+  assert(rows[0].remaining_count >= 0, "remaining must never be negative");
+});
+
+Deno.test("ADV-A4 — same place evaluated multiple times → Set-dedupe to 1", () => {
+  // Place evaluated 3x (sample, then full_city, then retry_failed)
+  const cities = [{ id: "dup", name: "Dup City", country: "US" }];
+  const servable = Array.from({ length: 10 }, () => ({ city_id: "dup" }));
+  const completed = [
+    { city_id: "dup", place_pool_id: "p1" },
+    { city_id: "dup", place_pool_id: "p1" }, // same place, different run
+    { city_id: "dup", place_pool_id: "p1" }, // same place, again
+    { city_id: "dup", place_pool_id: "p2" },
+  ];
+  const rows = buildRows(cities, servable, completed);
+  assertEquals(rows[0].evaluated_count, 2, "Set must dedupe duplicate evaluation rows");
+  assertEquals(rows[0].remaining_count, 8);
+});
+
+Deno.test("ADV-A5 — race window: evaluated > servable by 1 → clamp prevents 100.x display", () => {
+  // The 4 parallel queries are NOT transactional. If a place's is_servable
+  // flips between the servableRes query and the completedRes query, evaluated
+  // could exceed servable by 1. The retained Math.min(evaluated, servable)
+  // clamp ensures coverage_pct ≤ 100 and remaining ≥ 0.
+  const cities = [{ id: "race", name: "Race City", country: "US" }];
+  const servable = Array.from({ length: 9 }, () => ({ city_id: "race" })); // 9 servable
+  // 10 evaluated (the 10th was servable at query-time-1, now isn't)
+  const completed = Array.from({ length: 10 }, (_v, i) => ({
+    city_id: "race",
+    place_pool_id: `r${i}`,
+  }));
+  const rows = buildRows(cities, servable, completed);
+  assertEquals(rows[0].servable_count, 9);
+  assertEquals(
+    rows[0].evaluated_count,
+    9,
+    "Math.min clamp must cap evaluated at servable",
+  );
+  assertEquals(
+    rows[0].remaining_count,
+    0,
+    "Math.max clamp must prevent negative remaining (9 - 10 = -1 → 0)",
+  );
+  // coverage_pct uses unclamped evaluated/servable but is itself clamped to 100
+  assertEquals(rows[0].coverage_pct, 100, "coverage_pct must be clamped to ≤ 100");
+});
+
+Deno.test("ADV-A6 — coverage_pct rounding at boundaries", () => {
+  // 99.87% should display as 99.9 (toFixed(1))
+  const cities = [{ id: "cary", name: "Cary", country: "US" }];
+  const servable = Array.from({ length: 761 }, () => ({ city_id: "cary" }));
+  const completed = Array.from({ length: 760 }, (_v, i) => ({
+    city_id: "cary",
+    place_pool_id: `c${i}`,
+  }));
+  const rows = buildRows(cities, servable, completed);
+  // 760/761 = 0.99868... × 100 = 99.868... → toFixed(1) = 99.9
+  assertEquals(rows[0].coverage_pct, 99.9);
+});
+
+Deno.test("ADV-A7 — coverage_pct exact 100% with 1540 places", () => {
+  const cities = [{ id: "raleigh", name: "Raleigh", country: "US" }];
+  const servable = Array.from({ length: 1540 }, () => ({ city_id: "raleigh" }));
+  const completed = Array.from({ length: 1540 }, (_v, i) => ({
+    city_id: "raleigh",
+    place_pool_id: `r${i}`,
+  }));
+  const rows = buildRows(cities, servable, completed);
+  assertStrictEquals(rows[0].coverage_pct, 100);
+});
+
+Deno.test("ADV-A8 — rows sorted by servable_count DESC", () => {
+  const cities = [
+    { id: "small", name: "Small", country: "US" },
+    { id: "big", name: "Big", country: "US" },
+    { id: "med", name: "Med", country: "US" },
+  ];
+  const servable = [
+    ...Array.from({ length: 100 }, () => ({ city_id: "small" })),
+    ...Array.from({ length: 1000 }, () => ({ city_id: "big" })),
+    ...Array.from({ length: 500 }, () => ({ city_id: "med" })),
+  ];
+  const rows = buildRows(cities, servable, []);
+  assertEquals(rows.map((r) => r.city_name), ["Big", "Med", "Small"]);
+});
+
+// ── Source-inspect: post-fix safety guards must still be present ──
+
+Deno.test("ADV-A9 — source still has .filter(r => r.servable_count > 0) drop guard", async () => {
+  const url = new URL("../index.ts", import.meta.url);
+  const src = await Deno.readTextFile(url);
+  assert(
+    src.includes(".filter((r) => r.servable_count > 0)"),
+    "drop-row guard at L2312 must remain after Finding A",
+  );
+});
+
+Deno.test("ADV-A10 — source retains Math.min/Math.max defensive clamp", async () => {
+  const url = new URL("../index.ts", import.meta.url);
+  const src = await Deno.readTextFile(url);
+  assert(
+    src.includes("Math.min(evaluated, servable)"),
+    "Math.min clamp must remain as defensive safety per SPEC §7-D9",
+  );
+  assert(
+    src.includes("Math.max(0, servable - evaluated)"),
+    "Math.max clamp must remain as defensive safety per SPEC §7-D9",
+  );
+});
+
+Deno.test("ADV-A11 — source retains coverage_pct toFixed(1) for display stability", async () => {
+  const url = new URL("../index.ts", import.meta.url);
+  const src = await Deno.readTextFile(url);
+  assert(
+    src.includes("Math.min(100, +((evaluated / servable) * 100).toFixed(1))"),
+    "coverage_pct must round to 1 decimal place and clamp to 100",
+  );
+});
+
+Deno.test("ADV-A12 — Finding A query still gates by .eq('status', 'completed')", async () => {
+  const url = new URL("../index.ts", import.meta.url);
+  const src = await Deno.readTextFile(url);
+  // Locate the Finding A query specifically (it's the one with the !inner join)
+  const findingAIdx = src.indexOf(
+    'select("city_id, place_pool_id, place_pool!inner(is_servable)")',
+  );
+  assert(findingAIdx > 0, "Finding A query must be present");
+  // The .eq("status", "completed") gate should be within the next ~300 chars
+  const slice = src.slice(findingAIdx, findingAIdx + 400);
+  assert(
+    slice.includes('.eq("status", "completed")'),
+    "Finding A fix must NOT drop the status='completed' filter from the evaluated query",
+  );
+});
+
+Deno.test("ADV-A13 — Brussels / Lagos / London (cities with servable but 0 evaluated) → 0% remaining=servable", () => {
+  // From the live-DB probe: Brussels=1858, Lagos=908, London=3495, all 0 evaluated.
+  const cities = [
+    { id: "bxl", name: "Brussels", country: "BE" },
+    { id: "los", name: "Lagos", country: "NG" },
+    { id: "lon", name: "London", country: "GB" },
+  ];
+  const servable = [
+    ...Array.from({ length: 1858 }, () => ({ city_id: "bxl" })),
+    ...Array.from({ length: 908 }, () => ({ city_id: "los" })),
+    ...Array.from({ length: 3495 }, () => ({ city_id: "lon" })),
+  ];
+  const rows = buildRows(cities, servable, []);
+  assertEquals(rows.length, 3);
+  for (const row of rows) {
+    assertEquals(row.evaluated_count, 0, `${row.city_name} must be 0 evaluated`);
+    assertEquals(row.remaining_count, row.servable_count, `${row.city_name} remaining must equal servable`);
+    assertEquals(row.coverage_pct, 0);
+  }
+});

--- a/supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
@@ -1,0 +1,149 @@
+// ORCH-1013 Finding A regression test — handleIntelligenceCoverage MUST only
+// count `(city_id, place_pool_id)` evaluation pairs where the joined
+// place_pool.is_servable = true at query time. The pre-fix bug counted every
+// completed trial-run row regardless of pool state, then masked the over-count
+// with Math.min(evaluated, servable); the resulting `remaining_count` lied.
+//
+// Verified live 2026-05-30 against Cary: 6 drifted (re-classified non-servable)
+// trial-run rows over-counted the evaluated set; the clamp produced
+// evaluated=761/servable=761/remaining=0, masking 1 truly-un-evaluated servable
+// place. The fix swaps the completedRes query to use a !inner join on
+// place_pool filtered by is_servable=true, restoring evaluated=760/remaining=1.
+//
+// This file pins both behaviors:
+//   1. Pure function reproduction of the JS-side aggregation given the corrected
+//      query result shape — asserts evaluated_count and remaining_count match
+//      live truth.
+//   2. Source-inspect — asserts the edge-fn source contains the !inner+is_servable
+//      filter so any future revert of the join (or the .eq filter) is caught.
+//
+// Together these form a two-key revert detector mirroring the runRemainder
+// test pattern in this same directory.
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// Pure mirror of the per-city aggregation at index.ts ~L2276-L2300.
+// Reads the CORRECTED completedRes shape (only currently-servable places).
+function aggregateCityCoverage(
+  cityId: string,
+  servableRows: { city_id: string }[],
+  completedRowsServableOnly: { city_id: string; place_pool_id: string }[],
+): {
+  servable_count: number;
+  evaluated_count: number;
+  remaining_count: number;
+  coverage_pct: number;
+} {
+  const servable = servableRows.filter((r) => r.city_id === cityId).length;
+  const evaluatedSet = new Set<string>();
+  for (const r of completedRowsServableOnly) {
+    if (r.city_id === cityId && r.place_pool_id) {
+      evaluatedSet.add(r.place_pool_id);
+    }
+  }
+  const evaluated = evaluatedSet.size;
+  return {
+    servable_count: servable,
+    evaluated_count: Math.min(evaluated, servable),
+    remaining_count: Math.max(0, servable - evaluated),
+    coverage_pct: servable === 0
+      ? 0
+      : Math.min(100, +((evaluated / servable) * 100).toFixed(1)),
+  };
+}
+
+Deno.test("Finding A — Cary drift fixture: 760/761 evaluated, 1 remaining", () => {
+  // Live Cary truth, 2026-05-30. servable=761, evaluated-and-still-servable=760
+  // (6 drift rows are excluded by the fixed query), un-evaluated=1.
+  const CITY = "cary";
+  const servable = Array.from({ length: 761 }, (_v, i) => ({
+    city_id: CITY,
+  }));
+  // Only the 760 still-servable evaluation rows surface from the fixed query.
+  const completedServableOnly = Array.from({ length: 760 }, (_v, i) => ({
+    city_id: CITY,
+    place_pool_id: `pool-${i}`,
+  }));
+
+  const agg = aggregateCityCoverage(CITY, servable, completedServableOnly);
+  assertEquals(agg.servable_count, 761);
+  assertEquals(agg.evaluated_count, 760);
+  assertEquals(agg.remaining_count, 1);
+  assertEquals(agg.coverage_pct, 99.9);
+});
+
+Deno.test("Finding A — pre-fix bug fixture (drifted rows counted): would FAIL the contract", () => {
+  // BEFORE-fix: completed-rows include 6 drifted (non-servable) ids. The pre-fix
+  // code dedup'd via Set, producing evaluatedSet.size = 766. Then clamp:
+  //   evaluated_count = min(766, 761) = 761
+  //   remaining_count = max(0, 761 - 766) = 0
+  // This test demonstrates that aggregation against the UNFILTERED completedRes
+  // shape returns the WRONG numbers — proving the bug lives in the query, not
+  // the aggregation. The fixed query strips the 6 drift rows, restoring truth.
+  const CITY = "cary";
+  const servable = Array.from({ length: 761 }, () => ({ city_id: CITY }));
+  const completedUnfiltered = [
+    ...Array.from({ length: 760 }, (_v, i) => ({
+      city_id: CITY,
+      place_pool_id: `pool-${i}`,
+    })),
+    // 6 drift rows that the broken query would also include
+    ...Array.from({ length: 6 }, (_v, i) => ({
+      city_id: CITY,
+      place_pool_id: `drift-${i}`,
+    })),
+  ];
+  const agg = aggregateCityCoverage(CITY, servable, completedUnfiltered);
+  // Aggregation behaviour is unchanged; the clamp produces the bug shape.
+  assertEquals(agg.servable_count, 761);
+  assertEquals(agg.evaluated_count, 761); // wrongly clamped from 766
+  assertEquals(agg.remaining_count, 0); // wrongly says fully covered
+  // Therefore: the fix MUST live in the query (filter drift rows out), not
+  // the aggregation. The next test asserts the query has the !inner filter.
+});
+
+Deno.test("Finding A — Raleigh genuinely-100% case: 1540/1540/0", () => {
+  const CITY = "raleigh";
+  const servable = Array.from({ length: 1540 }, () => ({ city_id: CITY }));
+  const completedServableOnly = Array.from({ length: 1540 }, (_v, i) => ({
+    city_id: CITY,
+    place_pool_id: `pool-${i}`,
+  }));
+  const agg = aggregateCityCoverage(CITY, servable, completedServableOnly);
+  assertEquals(agg.servable_count, 1540);
+  assertEquals(agg.evaluated_count, 1540);
+  assertEquals(agg.remaining_count, 0);
+  assertEquals(agg.coverage_pct, 100.0);
+});
+
+Deno.test("Finding A — empty city (0 servable, N evaluated) returns 0/0/0", () => {
+  const CITY = "empty";
+  const agg = aggregateCityCoverage(CITY, [], []);
+  assertEquals(agg.servable_count, 0);
+  assertEquals(agg.evaluated_count, 0);
+  assertEquals(agg.remaining_count, 0);
+  assertEquals(agg.coverage_pct, 0);
+});
+
+// ── Source-inspect: the JOIN filter MUST be present in the edge fn. ──
+Deno.test("Finding A — source contains place_pool!inner join + is_servable filter", async () => {
+  const url = new URL("../index.ts", import.meta.url);
+  const src = await Deno.readTextFile(url);
+  assert(
+    src.includes(
+      'select("city_id, place_pool_id, place_pool!inner(is_servable)")',
+    ),
+    "completedRes query must select place_pool!inner(is_servable) — ORCH-1013 Finding A regression",
+  );
+  assert(
+    src.includes('.eq("place_pool.is_servable", true)'),
+    "completedRes query must filter to place_pool.is_servable = true — ORCH-1013 Finding A regression",
+  );
+  assert(
+    src.includes("ORCH-1013 Finding A"),
+    "Finding A comment marker missing — comment provides traceability for the join hint",
+  );
+});

--- a/supabase/functions/run-place-intelligence-trial/index.ts
+++ b/supabase/functions/run-place-intelligence-trial/index.ts
@@ -2213,10 +2213,18 @@ async function handleIntelligenceCoverage(
       .select("city_id")
       .eq("is_servable", true)
       .not("city_id", "is", null),
+    // ORCH-1013 Finding A — restrict evaluated set to places STILL servable.
+    // Without the !inner+is_servable filter, places that drifted out of the
+    // pool (e.g. re-classified non-servable post-evaluation) are counted as
+    // evaluated, falsely inflating coverage to 100% and zeroing remaining.
+    // Verified live 2026-05-30 against Cary: 6 drifted rows masked 1 truly
+    // un-evaluated servable place. See SPEC §3 Finding A.
+    // Gemini pricing ref (COMMS-0003): https://ai.google.dev/pricing/gemini-2-5-flash
     db
       .from("place_intelligence_trial_runs")
-      .select("city_id, place_pool_id")
+      .select("city_id, place_pool_id, place_pool!inner(is_servable)")
       .eq("status", "completed")
+      .eq("place_pool.is_servable", true)
       .not("city_id", "is", null),
     db
       .from("place_intelligence_runs")
@@ -2286,6 +2294,11 @@ async function handleIntelligenceCoverage(
         city_name: c.name,
         country: c.country,
         servable_count: servable,
+        // ORCH-1013 Finding A — `evaluated` is now ≤ `servable` by construction
+        // (the JOIN at the completedRes query filters to currently-servable
+        // places only). Math.min/Math.max retained as defensive cosmetic safety
+        // for the 4 non-transactional parallel queries (race could theoretically
+        // see a 1-row skew). See SPEC §3 Finding A + §7 D9.
         evaluated_count: Math.min(evaluated, servable),
         remaining_count: Math.max(0, servable - evaluated),
         coverage_pct: coveragePct,


### PR DESCRIPTION
## Summary

Bundles 3 findings surfaced from ORCH-1008 close + META-ORCH-1009 backfill prep, single PR for a clean slate before the big pipeline work.

**Finding A — Coverage math (P1 bug fix).** Overview tab's per-city coverage was counting evaluations of places that have since drifted out of `is_servable` (closed venues, marked chains, etc.). Cary live shows 100% / 0 remaining but is actually 760 / 761 = 99.9% with 1 servable un-evaluated place hidden behind 6 drifted-out evaluated places. One-line edge-fn query change: add `place_pool!inner(is_servable)` filter to the `completedRes` subquery. Math.min clamp stays as defensive cosmetic safety. Live DB Cary truth confirmed at tester time: 761 servable / 760 evaluated-and-still-servable / 1 truly remaining. New invariant `I-PROPOSED-INTEL-COVERAGE-COUNTS-CURRENTLY-SERVABLE` DRAFT → ACTIVE on merge.

**Finding B — Multi-run control tower.** When operator backfills 5+ cities in parallel for META-ORCH-1009 Sub-C, today's status-grouped UI required clicking into each city's run to see progress. Added always-on "Active runs" panel at top of Place Intelligence (mounts only when ≥1 in_progress) with per-card city name + live progress bar + live ETA (rate over last 60s) + running spend + soft-cancel. Polls `list_active_runs` every 5s. Plus "Run remainder on all un-evaluated cities" button in Overview header with typed "RUN ALL" confirm at >\$10, 2s stagger between starts, client-side 3-concurrent cap with auto-queue. 5 new components/hooks + 3 edits to existing pages; dead in-tab banner removed.

**Finding C — Tailwind drift fix.** Pre-existing anchor `node_modules/tailwindcss` was half-extracted (19/27 files, 1/8 .mjs — `dist/lib.mjs` missing was what `@tailwindcss/node@4.2.1` imports), blocking `npm run build` / `npm run dev` / `npx eslint`. Forensics confirmed published tarball intact via `npm pack`. Fix: `rm -rf node_modules && npm ci`. NO package.json or lockfile changes. `npm run build` exits 0 in 11.58s post-fix; `npm run dev` ready in 851ms. Absorbs the earlier ORCH-1012.

## Step 0.5 evidence

- **Implementor:** 39 admin tests (node:test + source-inspect — mirrors codebase convention, no new vitest dep) + 5 Deno tests = 44 new, all pass. Fails-on-revert verified.
- **Tester:** 53 admin behavioral + 13 Deno coverage edge cases = 66 new adversarial tests, all pass. Fails-on-revert proven for both Finding A query revert and Finding B constant tampering.
- **Pre-existing:** 75 admin tests still pass, zero regressions.

Live DB Cary truth confirmed post-tester: 761/760/1.

## Test plan

- [ ] `cd mingla-admin && npm run build` exits 0 (Finding C)
- [ ] Open admin → Place Intelligence → Overview shows Cary as 99.9% / 1 remaining (NOT 100% / 0)
- [ ] Click "Run remainder on all" → confirm modal with total places + estimated cost; >\$10 requires typing "RUN ALL"
- [ ] On confirm, 3 cities start, 4th waits in queue; runs stagger 2s apart
- [ ] Active runs panel appears at top with progress bars + ETAs + spend
- [ ] Cancel one mid-run → confirm modal → in-flight place finishes, no new starts, card shows "Cancelled" pill, slides into Cancelled status group
- [ ] Edge fn redeployed by orchestrator post-merge (verify Finding A active in production)

## Pre-merge gate (will satisfy before merge)

- All required checks green
- Mergeable CLEAN, not BEHIND (rebased on `1af58e4ca` + my CLOSE banner commit pending push)
- Reviews APPROVED (operator gate)
- Operator-confirmed edge fn redeploy

## Notes

- 1 P1 QA-discovered + fixed in QA commit `333b03df2` (allowlist gap for the new QA test file — same COMMS-0002 gate trap as ORCH-1008, caught BEFORE CI this time)
- 3 P3 cosmetic items deferred for fix-forward (grep-only impl tests, pre-existing perf flake, retained `_activeRun` reducer documented as implementor Deviation #6)
- ORCH-1012 absorbed; will be marked RESOLVED in OPEN_INVESTIGATIONS post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)