### PR TITLE
ORCH-1006 cleanup: remove 3 stray node_modules symlinks from #269

### DIFF
--- a/app-mobile/node_modules
+++ b/app-mobile/node_modules
@@ -1,1 +1,0 @@
-/Users/sethogieva/Desktop/mingla-main/app-mobile/node_modules

--- a/mingla-admin/node_modules
+++ b/mingla-admin/node_modules
@@ -1,1 +1,0 @@
-/Users/sethogieva/Desktop/mingla-main/mingla-admin/node_modules

--- a/mingla-business/node_modules
+++ b/mingla-business/node_modules
@@ -1,1 +1,0 @@
-/Users/sethogieva/Desktop/mingla-main/mingla-business/node_modules


### PR DESCRIPTION
PR #269's conflict-resolution `git add -A` accidentally committed the worktree's symlinked `node_modules` directories (mode 120000 gitlinks) for `app-mobile`, `mingla-admin`, `mingla-business`. `node_modules/` is gitignored; these symlinks point at a per-worktree absolute path and would resolve to broken/incorrect targets on any fresh clone.

This removes them from the index only (3 deletions, nothing else). Working-tree node_modules untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)