### PR TITLE
fix(marketing) [deploy]: business nav uses official logo PNG (not SVG tracing)

### DIFF
--- a/mingla-marketing/components/marketing/glass-nav.tsx
+++ b/mingla-marketing/components/marketing/glass-nav.tsx
@@ -60,7 +60,7 @@ export function GlassNav() {
           >
             {surface === 'organiser' ? (
               <img
-                src="/brand/mingla-business-logo.svg"
+                src="/brand/mingla-business-logo.png"
                 alt="Mingla Business"
                 className="h-20 w-20 select-none"
                 draggable={false}


### PR DESCRIPTION
The `/organisers` nav rendered `/brand/mingla-business-logo.svg` — a vector tracing of the logo that shows a cut-out artifact (looks "not really a PNG"). The official 2000×2000 transparent PNG is already committed in `public/brand`; this just points the nav `<img>` at it.

One-line change. `[deploy]` triggers the marketing Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)