### PR TITLE
feat(marketing) [deploy]: Balanced content protection (SEO-safe)

### DIFF
--- a/mingla-marketing/app/globals.css
+++ b/mingla-marketing/app/globals.css
@@ -358,3 +358,42 @@ body {
     scroll-behavior: auto !important;
   }
 }
+
+/* ----------------------------------------------------------------------------
+   Content protection (Balanced). Interaction/visual rules ONLY — they apply to
+   human browsers, never to crawlers, so SEO is unaffected: the server-rendered
+   HTML + metadata Googlebot reads is unchanged. Determined copying can't be
+   fully stopped on the web (anything rendered is downloaded); this raises
+   friction against casual copying, dragging, and printing of our creative.
+---------------------------------------------------------------------------- */
+html {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+/* Keep real form fields fully usable (selection + copy inside inputs). */
+input,
+textarea,
+select,
+[contenteditable='true'] {
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+/* Make images/video hard to drag out or long-press-save. */
+img,
+video {
+  -webkit-user-drag: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+/* Blank the page for print / print-to-PDF. */
+@media print {
+  html,
+  body {
+    display: none !important;
+  }
+}

--- a/mingla-marketing/app/layout.tsx
+++ b/mingla-marketing/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Mochiy_Pop_One, Nunito_Sans, Inter } from 'next/font/google'
 import './globals.css'
+import { ContentProtection } from '@/components/marketing/content-protection'
 
 // Brand display — matches the live usemingla.com brand font.
 // Mochiy Pop One ships in a single weight (400) with no italic axis.
@@ -47,6 +48,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Skip to content
         </a>
         {children}
+        <ContentProtection />
       </body>
     </html>
   )

--- a/mingla-marketing/components/marketing/content-protection.tsx
+++ b/mingla-marketing/components/marketing/content-protection.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { useEffect } from 'react'
+
+// Content protection (Balanced). A client-only behavior layer that discourages
+// casual copying of the marketing creative WITHOUT touching the server-rendered
+// HTML/metadata — so search crawlers index the page exactly as before and SEO
+// is unaffected. Note: no web technique can truly prevent screenshots or a
+// determined developer; this raises friction, it is not DRM.
+//
+// What it blocks for human browsers:
+//   - right-click / context menu (save-image-as, view-source entry points)
+//   - copy / cut (except inside real form fields) + text selection start
+//   - image/element drag-out
+//   - devtools + save + print + view-source keyboard shortcuts
+export function ContentProtection() {
+  useEffect(() => {
+    const isFormField = (el: EventTarget | null): boolean =>
+      el instanceof HTMLElement &&
+      (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)
+
+    // Always-block (context menu, drag). Returns false for legacy handlers.
+    const hardBlock = (e: Event): void => {
+      e.preventDefault()
+    }
+
+    // Copy/cut/selection — allow inside form fields so users can still use forms.
+    const softBlock = (e: Event): void => {
+      if (!isFormField(e.target)) e.preventDefault()
+    }
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const key = e.key.toLowerCase()
+      const mod = e.ctrlKey || e.metaKey
+
+      // F12 — devtools
+      if (e.key === 'F12') {
+        e.preventDefault()
+        return
+      }
+      // Ctrl/Cmd+U (view-source), Ctrl/Cmd+S (save), Ctrl/Cmd+P (print)
+      if (mod && !e.shiftKey && !e.altKey && (key === 'u' || key === 's' || key === 'p')) {
+        e.preventDefault()
+        return
+      }
+      // Ctrl/Cmd+Shift+I / J / C  — devtools (inspect, console, element picker)
+      if (mod && e.shiftKey && (key === 'i' || key === 'j' || key === 'c')) {
+        e.preventDefault()
+        return
+      }
+      // macOS Cmd+Opt+I / J / C — devtools
+      if (e.metaKey && e.altKey && (key === 'i' || key === 'j' || key === 'c')) {
+        e.preventDefault()
+      }
+    }
+
+    document.addEventListener('contextmenu', hardBlock)
+    document.addEventListener('dragstart', hardBlock)
+    document.addEventListener('copy', softBlock)
+    document.addEventListener('cut', softBlock)
+    document.addEventListener('selectstart', softBlock)
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.removeEventListener('contextmenu', hardBlock)
+      document.removeEventListener('dragstart', hardBlock)
+      document.removeEventListener('copy', softBlock)
+      document.removeEventListener('cut', softBlock)
+      document.removeEventListener('selectstart', softBlock)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [])
+
+  return null
+}

--- a/mingla-marketing/next.config.ts
+++ b/mingla-marketing/next.config.ts
@@ -1,12 +1,26 @@
 import path from 'node:path'
 import type { NextConfig } from 'next'
 
+// Security + content-protection headers. SEO-safe: crawlers still receive the
+// full server-rendered HTML/metadata; these only stop the site (and its
+// creative) from being embedded/framed by other origins, block MIME sniffing,
+// and trim referrer leakage.
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'Content-Security-Policy', value: "frame-ancestors 'self'" },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+]
+
 const config: NextConfig = {
   reactStrictMode: true,
   devIndicators: false,
   // Pin trace root to this app so Next does not climb into the parent monorepo
   // and pick up the user-home lockfile.
   outputFileTracingRoot: path.join(__dirname),
+  // Never ship original-source browser source maps to production clients, so the
+  // un-minified TSX/JSX can't be reconstructed from the deployed bundle.
+  productionBrowserSourceMaps: false,
   images: {
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [
@@ -16,6 +30,9 @@ const config: NextConfig = {
   },
   experimental: {
     optimizePackageImports: ['lucide-react', 'framer-motion'],
+  },
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }]
   },
 }
 


### PR DESCRIPTION
Raises friction against casual copying of the marketing creative **without touching server-rendered HTML/metadata**, so SEO is unaffected (crawlers index the page exactly as before). Not DRM — no web technique can stop screenshots or a determined developer.

- **ContentProtection** client layer: blocks context-menu, copy/cut (form fields exempt), selection start, drag-out, and devtools/save/print/view-source keyboard shortcuts.
- **globals.css**: `user-select:none` (inputs exempt), no image/video drag, print-blanking.
- **next.config**: `frame-ancestors 'self'` + `X-Frame-Options` (no cross-origin embedding of our creative), `nosniff`, `Referrer-Policy`, and `productionBrowserSourceMaps:false` (original TSX can't be reconstructed from the bundle).

Verified: `tsc` clean, `next build` clean (all routes). `[deploy]` triggers the marketing Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)