### PR TITLE
ORCH-1017 [deploy]: bouncer batch runner — memory-safe, resumable, non-aborting

### DIFF
--- a/supabase/functions/_shared/__tests__/bouncerBatch.adversarial.test.ts
+++ b/supabase/functions/_shared/__tests__/bouncerBatch.adversarial.test.ts
@@ -1,0 +1,112 @@
+// ORCH-1012 — adversarial regression test for the cursor-paged batch runner.
+//
+// Attacks the TWO failure modes that made the old bouncer stall at ~38% on
+// London — a DIFFERENT angle than the happy-path test:
+//
+//   1. Per-row write errors must NOT abort the run. The pre-ORCH-1012 code did
+//      `if (firstWriteError) return 500` after the first failing chunk, so a
+//      single bad row stranded the rest of the city. This asserts the run
+//      processes EVERY row, counts the failures, and keeps the good writes.
+//
+//   2. The per-invocation budget must be resumable. A run capped at max_rows
+//      must report done=false + a next_cursor, and resuming from that cursor
+//      must finish the remainder with no row processed twice or skipped.
+//
+// Fails-on-revert: reinstating abort-on-first-error makes test (1) see far
+// fewer than `total` processed; dropping the cursor/budget makes test (2)
+// either loop forever or never advance.
+
+import { assertEquals, assert } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+import { runBouncerBatch } from '../bouncerBatch.ts';
+import { type PlaceRow, type BouncerVerdict } from '../bouncer.ts';
+
+function makePlace(i: number): PlaceRow {
+  return {
+    id: `p${String(i).padStart(4, '0')}`,
+    name: `Place ${i}`,
+    lat: 38.9,
+    lng: -77.0,
+    types: ['restaurant'],
+    business_status: 'OPERATIONAL',
+    website: 'https://example.com',
+    opening_hours: { weekday_text: ['Mon: 9-5'] },
+    photos: [{ name: 'x' }],
+    stored_photo_urls: ['https://cdn/x.jpg'],
+    review_count: 100,
+    rating: 4.5,
+  } as unknown as PlaceRow;
+}
+
+Deno.test('runBouncerBatch: a per-row write error does NOT abort the run', async () => {
+  const total = 20;
+  const all = Array.from({ length: total }, (_, i) => makePlace(i + 1));
+  const seen = new Set<string>(); // every row reaches writeRow
+  const written = new Set<string>(); // only the successful ones "persist"
+
+  const result = await runBouncerBatch(
+    {
+      loadPage: (cursor, pageSize) => {
+        const start = cursor ? all.findIndex((p) => p.id > cursor) : 0;
+        return Promise.resolve(start < 0 ? [] : all.slice(start, start + pageSize));
+      },
+      writeRow: (place: PlaceRow, _v: BouncerVerdict) => {
+        seen.add(place.id);
+        // Every 4th row fails — spread across multiple pages/chunks.
+        const idx = Number(place.id.slice(1));
+        if (idx % 4 === 0) return Promise.resolve({ error: 'simulated row write failure' });
+        written.add(place.id);
+        return Promise.resolve({ error: null });
+      },
+      countRemaining: () => Promise.resolve(total - written.size),
+    },
+    { maxRows: 1000, pageSize: 6, writeConcurrency: 3, dryRun: false, afterId: null },
+  );
+
+  assertEquals(result.processed, total, 'run kept going through every row despite errors');
+  assertEquals(seen.size, total, 'every row was attempted');
+  assertEquals(result.write_errors, 5, 'exactly the failing rows are counted (20/4)');
+  assertEquals(result.written, 15, 'the good rows still persisted');
+  assert(result.first_write_error !== null, 'first error message is surfaced');
+  assertEquals(result.done, true, 'run completes even with errors present');
+});
+
+Deno.test('runBouncerBatch: max_rows budget is resumable via next_cursor', async () => {
+  const total = 25;
+  const all = Array.from({ length: total }, (_, i) => makePlace(i + 1));
+  const written = new Set<string>();
+
+  const deps = {
+    loadPage: (cursor: string | null, pageSize: number) => {
+      const start = cursor ? all.findIndex((p) => p.id > cursor) : 0;
+      return Promise.resolve(start < 0 ? [] : all.slice(start, start + pageSize));
+    },
+    writeRow: (place: PlaceRow, _v: BouncerVerdict) => {
+      written.add(place.id);
+      return Promise.resolve({ error: null as string | null });
+    },
+    countRemaining: () => Promise.resolve(total - written.size),
+  };
+  const opts = { maxRows: 10, pageSize: 10, writeConcurrency: 5, dryRun: false };
+
+  // First invocation — bounded to 10 rows.
+  const r1 = await runBouncerBatch(deps, { ...opts, afterId: null });
+  assertEquals(r1.processed, 10);
+  assertEquals(r1.done, false, 'not done — more rows remain');
+  assert(r1.next_cursor !== null, 'returns a cursor to resume from');
+  assertEquals(r1.remaining, 15);
+
+  // Second invocation — resume from the cursor.
+  const r2 = await runBouncerBatch(deps, { ...opts, afterId: r1.next_cursor });
+  assertEquals(r2.processed, 10);
+  assertEquals(r2.done, false);
+
+  // Third invocation — finishes the remaining 5.
+  const r3 = await runBouncerBatch(deps, { ...opts, afterId: r2.next_cursor });
+  assertEquals(r3.processed, 5);
+  assertEquals(r3.done, true, 'short final page ⇒ done');
+  assertEquals(r3.next_cursor, null);
+
+  // No row processed twice or skipped across the three resumable invocations.
+  assertEquals(written.size, total, 'every distinct row persisted exactly once');
+  assertEquals(r3.remaining, 0);
+});

--- a/supabase/functions/_shared/__tests__/bouncerBatch.test.ts
+++ b/supabase/functions/_shared/__tests__/bouncerBatch.test.ts
@@ -1,0 +1,93 @@
+// ORCH-1012 — happy-path regression test for the cursor-paged batch runner.
+//
+// Proves the core property the fix exists to guarantee: a multi-page city is
+// processed in full via cursor paging (one page in memory at a time), every row
+// is written exactly once, and the run reports done with zero remaining.
+//
+// Fails-on-revert: if runBouncerBatch reverts to the pre-ORCH-1012 "load the
+// whole city + abort on first write error" shape, the multi-page / cursor /
+// remaining assertions below break.
+
+import { assertEquals } from 'https://deno.land/std@0.208.0/testing/asserts.ts';
+import { runBouncerBatch } from '../bouncerBatch.ts';
+import { type PlaceRow, type BouncerVerdict } from '../bouncer.ts';
+
+function makePlace(i: number): PlaceRow {
+  // Zero-padded id so lexical order === numeric order (matches .order('id')).
+  return {
+    id: `p${String(i).padStart(4, '0')}`,
+    name: `Place ${i}`,
+    lat: 38.9 + i / 1000,
+    lng: -77.0 + i / 1000,
+    types: ['restaurant'],
+    business_status: 'OPERATIONAL',
+    website: 'https://example.com',
+    opening_hours: { weekday_text: ['Mon: 9-5'] },
+    photos: [{ name: 'x' }],
+    stored_photo_urls: ['https://cdn/x.jpg'],
+    review_count: 100,
+    rating: 4.5,
+  } as unknown as PlaceRow;
+}
+
+// In-memory fake of the place_pool slice for one city, id-ordered.
+function makeFakeStore(total: number) {
+  const all = Array.from({ length: total }, (_, i) => makePlace(i + 1));
+  const judged = new Set<string>();
+  return {
+    all,
+    judged,
+    deps: {
+      loadPage: (cursor: string | null, pageSize: number): Promise<PlaceRow[]> => {
+        const start = cursor ? all.findIndex((p) => p.id > cursor) : 0;
+        const slice = start < 0 ? [] : all.slice(start, start + pageSize);
+        return Promise.resolve(slice);
+      },
+      writeRow: (place: PlaceRow, _verdict: BouncerVerdict): Promise<{ error?: string | null }> => {
+        judged.add(place.id);
+        return Promise.resolve({ error: null });
+      },
+      countRemaining: (): Promise<number | null> => Promise.resolve(total - judged.size),
+    },
+  };
+}
+
+Deno.test('runBouncerBatch: processes an entire multi-page city via cursor paging', async () => {
+  const total = 23; // > pageSize, deliberately not a page multiple
+  const store = makeFakeStore(total);
+
+  const result = await runBouncerBatch(store.deps, {
+    maxRows: 1000,
+    pageSize: 10,
+    writeConcurrency: 4,
+    dryRun: false,
+    afterId: null,
+  });
+
+  assertEquals(result.processed, total, 'every row is evaluated');
+  assertEquals(result.written, total, 'every row is written exactly once');
+  assertEquals(store.judged.size, total, 'all distinct rows persisted');
+  assertEquals(result.write_errors, 0, 'no write errors on the happy path');
+  assertEquals(result.done, true, 'run reports done when rows are exhausted');
+  assertEquals(result.next_cursor, null, 'no cursor returned once done');
+  assertEquals(result.remaining, 0, 'zero rows left unjudged');
+  // pass + reject must account for every processed row.
+  assertEquals(result.summary.pass_count + result.summary.reject_count, total);
+});
+
+Deno.test('runBouncerBatch: dry_run evaluates without writing', async () => {
+  const store = makeFakeStore(12);
+
+  const result = await runBouncerBatch(store.deps, {
+    maxRows: 1000,
+    pageSize: 5,
+    writeConcurrency: 4,
+    dryRun: true,
+    afterId: null,
+  });
+
+  assertEquals(result.processed, 12, 'dry run still evaluates every row');
+  assertEquals(result.written, 0, 'dry run writes nothing');
+  assertEquals(store.judged.size, 0, 'no rows persisted on dry run');
+  assertEquals(result.done, true);
+});

--- a/supabase/functions/_shared/bouncerBatch.ts
+++ b/supabase/functions/_shared/bouncerBatch.ts
@@ -1,0 +1,141 @@
+// ORCH-1017 — shared cursor-paged batch runner for the two Bouncer passes.
+//
+// Why this exists: both run-bouncer (final) and run-pre-photo-bouncer used to
+// load an ENTIRE city into memory and fire one giant write burst, then abort
+// the whole run on the first per-row error. On large cities that blew the Edge
+// runtime's compute budget (HTTP 546) and never finished. This module holds the
+// memory-safe, resumable, non-aborting loop ONCE so both passes share it and it
+// can be unit-tested without a live database.
+//
+// IMPORTANT (Constitutional #2 / I-*-SOLE-WRITER): this module performs NO
+// column writes itself. The actual `.update({ <owned columns> })` stays inside
+// each pass's own index.ts via the injected `writeRow` callback, preserving the
+// sole-writer invariants enforced by the strict-grep gate.
+
+import { bounce, type PlaceRow, type Cluster, type BouncerVerdict } from './bouncer.ts';
+
+export interface BouncerSummary {
+  pass_count: number;
+  reject_count: number;
+  by_cluster: Record<Cluster, { pass: number; reject: number }>;
+  by_reason: Record<string, number>;
+}
+
+export function freshSummary(): BouncerSummary {
+  return {
+    pass_count: 0,
+    reject_count: 0,
+    by_cluster: {
+      A_COMMERCIAL: { pass: 0, reject: 0 },
+      B_CULTURAL: { pass: 0, reject: 0 },
+      C_NATURAL: { pass: 0, reject: 0 },
+      EXCLUDED: { pass: 0, reject: 0 },
+    },
+    by_reason: {},
+  };
+}
+
+export interface BatchDeps {
+  // Load the next page of id-ordered rows AFTER `cursor` (null = from start),
+  // at most `pageSize` rows. Throwing propagates (fatal read error).
+  loadPage: (cursor: string | null, pageSize: number) => Promise<PlaceRow[]>;
+  // Persist one row's verdict. Return `{ error }` for a non-fatal per-row
+  // failure (counted, run continues) — NEVER throw for an expected row error.
+  writeRow: (place: PlaceRow, verdict: BouncerVerdict) => Promise<{ error?: string | null }>;
+  // How many rows remain unjudged for this scope (for caller progress UI).
+  countRemaining: () => Promise<number | null>;
+}
+
+export interface BatchOptions {
+  maxRows: number;
+  pageSize: number;
+  writeConcurrency: number;
+  dryRun: boolean;
+  afterId: string | null;
+  bounceOpts?: { skipStoredPhotoCheck?: boolean };
+}
+
+export interface BatchResult {
+  summary: BouncerSummary;
+  processed: number;
+  written: number;
+  write_errors: number;
+  first_write_error: string | null;
+  next_cursor: string | null;
+  done: boolean;
+  remaining: number | null;
+}
+
+export async function runBouncerBatch(deps: BatchDeps, opts: BatchOptions): Promise<BatchResult> {
+  const summary = freshSummary();
+  let cursor: string | null = opts.afterId;
+  let processed = 0;
+  let written = 0;
+  let writeErrors = 0;
+  let firstWriteError: string | null = null;
+  let reachedEnd = false;
+
+  while (processed < opts.maxRows) {
+    const pageSize = Math.min(opts.pageSize, opts.maxRows - processed);
+    const rows = await deps.loadPage(cursor, pageSize);
+
+    if (!rows || rows.length === 0) {
+      reachedEnd = true;
+      break;
+    }
+
+    // Evaluate this page in memory (one page only — bounded memory).
+    const verdicts: Array<{ place: PlaceRow; verdict: BouncerVerdict }> = [];
+    for (const place of rows) {
+      const verdict = bounce(place, opts.bounceOpts);
+      if (verdict.is_servable) {
+        summary.pass_count++;
+        summary.by_cluster[verdict.cluster].pass++;
+      } else {
+        summary.reject_count++;
+        summary.by_cluster[verdict.cluster].reject++;
+        for (const r of verdict.reasons) {
+          summary.by_reason[r] = (summary.by_reason[r] || 0) + 1;
+        }
+      }
+      verdicts.push({ place, verdict });
+    }
+
+    processed += rows.length;
+    cursor = rows[rows.length - 1].id;
+
+    // Concurrency-limited writes; a per-row error is COUNTED, never fatal.
+    if (!opts.dryRun) {
+      for (let i = 0; i < verdicts.length; i += opts.writeConcurrency) {
+        const chunk = verdicts.slice(i, i + opts.writeConcurrency);
+        const results = await Promise.all(chunk.map((v) => deps.writeRow(v.place, v.verdict)));
+        for (const r of results) {
+          if (r?.error) {
+            writeErrors++;
+            if (!firstWriteError) firstWriteError = r.error;
+          } else {
+            written++;
+          }
+        }
+      }
+    }
+
+    if (rows.length < pageSize) {
+      reachedEnd = true;
+      break;
+    }
+  }
+
+  const remaining = await deps.countRemaining();
+
+  return {
+    summary,
+    processed,
+    written,
+    write_errors: writeErrors,
+    first_write_error: firstWriteError,
+    next_cursor: reachedEnd ? null : cursor,
+    done: reachedEnd,
+    remaining,
+  };
+}

--- a/supabase/functions/run-bouncer/index.ts
+++ b/supabase/functions/run-bouncer/index.ts
@@ -7,11 +7,23 @@
 // Parallel to existing ai_approved (no replacement in Slice 1; Phase 5 retires ai_approved).
 //
 // Constitutional #2 (one owner per truth): is_servable is owned by THIS function alone.
-// No other code should write that column.
+// No other code should write that column. The `.update({...})` below is the only
+// place is_servable is written (CI gate enforces sole-writer).
+//
+// ORCH-1017 — cursor-paged, memory-safe, non-aborting. The shared loop lives in
+// _shared/bouncerBatch.ts; this file owns ONLY the is_servable column writes, the
+// read query, and the request/response envelope. Prior version loaded the whole
+// city into memory + one 500-wide write burst + abort-on-first-error, which blew
+// the Edge compute budget (HTTP 546) on large cities (London @ 15.5k) and never
+// finished. Now: streams id-ordered pages (one page in memory), caps work per
+// invocation at max_rows + returns next_cursor so the caller loops to completion,
+// writes in small concurrency-limited sub-batches, and counts (never aborts on)
+// per-row write errors.
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { bounce, type PlaceRow, type Cluster } from '../_shared/bouncer.ts';
+import { type PlaceRow } from '../_shared/bouncer.ts';
+import { runBouncerBatch } from '../_shared/bouncerBatch.ts';
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
 const SUPABASE_SERVICE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
@@ -25,28 +37,10 @@ const corsHeaders = {
 const SELECT_FIELDS =
   'id, name, lat, lng, types, business_status, website, opening_hours, photos, stored_photo_urls, review_count, rating';
 
-const BATCH_SIZE = 500;
-
-interface BouncerSummary {
-  pass_count: number;
-  reject_count: number;
-  by_cluster: Record<Cluster, { pass: number; reject: number }>;
-  by_reason: Record<string, number>;
-}
-
-function freshSummary(): BouncerSummary {
-  return {
-    pass_count: 0,
-    reject_count: 0,
-    by_cluster: {
-      A_COMMERCIAL: { pass: 0, reject: 0 },
-      B_CULTURAL: { pass: 0, reject: 0 },
-      C_NATURAL: { pass: 0, reject: 0 },
-      EXCLUDED: { pass: 0, reject: 0 },
-    },
-    by_reason: {},
-  };
-}
+const PAGE_SIZE = 500;
+const WRITE_CONCURRENCY = 50;
+const DEFAULT_MAX_ROWS = 3000;
+const MAX_MAX_ROWS = 20000;
 
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
@@ -60,6 +54,15 @@ serve(async (req: Request) => {
     const cityId: string | undefined = body.city_id;
     const allCities: boolean = body.all_cities === true;
     const dryRun: boolean = body.dry_run === true;
+    const afterId: string | null =
+      typeof body.after_id === 'string' && body.after_id.length > 0 ? body.after_id : null;
+    // Default false preserves "re-judge everything" — photos downloaded AFTER an
+    // earlier pass must be able to flip a previously-rejected place to servable.
+    const onlyUnprocessed: boolean = body.only_unprocessed === true;
+    const maxRows: number = Math.max(
+      1,
+      Math.min(MAX_MAX_ROWS, Number.isFinite(body.max_rows) ? Number(body.max_rows) : DEFAULT_MAX_ROWS),
+    );
 
     if (!cityId && !allCities) {
       return new Response(
@@ -69,115 +72,77 @@ serve(async (req: Request) => {
     }
 
     const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-
-    const summary = freshSummary();
-    const writes: Array<{ id: string; is_servable: boolean; bouncer_reason: string | null }> = [];
-
-    // Stream place_pool in pages of 500
-    let offset = 0;
-    while (true) {
-      let q = supabaseAdmin
-        .from('place_pool')
-        .select(SELECT_FIELDS)
-        .eq('is_active', true)
-        .order('id')
-        .range(offset, offset + BATCH_SIZE - 1);
-
-      if (cityId) q = q.eq('city_id', cityId);
-
-      const { data, error } = await q;
-      if (error) {
-        console.error('[run-bouncer] place_pool fetch error:', error.message);
-        return new Response(
-          JSON.stringify({ error: `place_pool fetch failed: ${error.message}` }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-        );
-      }
-
-      if (!data || data.length === 0) break;
-
-      for (const place of data as PlaceRow[]) {
-        const verdict = bounce(place);
-        const cluster = verdict.cluster;
-        if (verdict.is_servable) {
-          summary.pass_count++;
-          summary.by_cluster[cluster].pass++;
-        } else {
-          summary.reject_count++;
-          summary.by_cluster[cluster].reject++;
-          for (const r of verdict.reasons) {
-            summary.by_reason[r] = (summary.by_reason[r] || 0) + 1;
-          }
-        }
-        writes.push({
-          id: place.id,
-          is_servable: verdict.is_servable,
-          bouncer_reason: verdict.reasons.length > 0 ? verdict.reasons.join(';') : null,
-        });
-      }
-
-      if (data.length < BATCH_SIZE) break;
-      offset += BATCH_SIZE;
-    }
-
-    if (dryRun) {
-      const elapsed = Date.now() - t0;
-      console.log(`[run-bouncer] dry_run city=${cityId ?? 'all'} pass=${summary.pass_count} reject=${summary.reject_count} elapsed_ms=${elapsed}`);
-      return new Response(
-        JSON.stringify({ success: true, dry_run: true, ...summary, duration_ms: elapsed }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-      );
-    }
-
-    // Write back via TRUE UPDATE per row (place_pool has many NOT NULL columns we
-    // don't provide, so upsert's INSERT-fallback semantics fail preflight).
-    // Parallelize within each batch — Postgres connection pool handles concurrency.
-    // Target: <10s for Raleigh's 2,912 rows per SC-01.
     const now = new Date().toISOString();
-    let written = 0;
-    let firstWriteError: string | null = null;
-    for (let i = 0; i < writes.length; i += BATCH_SIZE) {
-      const chunk = writes.slice(i, i + BATCH_SIZE);
-      const results = await Promise.all(
-        chunk.map((w) =>
-          supabaseAdmin
+
+    const result = await runBouncerBatch(
+      {
+        loadPage: async (cursor, pageSize) => {
+          let q = supabaseAdmin
+            .from('place_pool')
+            .select(SELECT_FIELDS)
+            .eq('is_active', true)
+            .order('id', { ascending: true })
+            .limit(pageSize);
+          if (cityId) q = q.eq('city_id', cityId);
+          if (onlyUnprocessed) q = q.is('is_servable', null);
+          if (cursor) q = q.gt('id', cursor);
+          const { data, error } = await q;
+          if (error) throw new Error(`place_pool fetch failed: ${error.message}`);
+          return (data ?? []) as PlaceRow[];
+        },
+        // SOLE writer of is_servable + bouncer_reason + bouncer_validated_at.
+        writeRow: async (place, verdict) => {
+          const { error } = await supabaseAdmin
             .from('place_pool')
             .update({
-              is_servable: w.is_servable,
-              bouncer_reason: w.bouncer_reason,
+              is_servable: verdict.is_servable,
+              bouncer_reason: verdict.reasons.length > 0 ? verdict.reasons.join(';') : null,
               bouncer_validated_at: now,
             })
-            .eq('id', w.id),
-        ),
-      );
-      for (const r of results) {
-        if (r.error) {
-          if (!firstWriteError) firstWriteError = r.error.message;
-        } else {
-          written++;
-        }
-      }
-      if (firstWriteError) {
-        console.error(`[run-bouncer] write batch ${i / BATCH_SIZE} had errors. First: ${firstWriteError}`);
-        return new Response(
-          JSON.stringify({
-            error: `place_pool write failed at batch ${i / BATCH_SIZE}: ${firstWriteError}`,
-            partial_summary: summary,
-            written,
-          }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-        );
-      }
-    }
-
-    const elapsed = Date.now() - t0;
-    console.log(`[run-bouncer] city=${cityId ?? 'all'} pass=${summary.pass_count} reject=${summary.reject_count} written=${written} elapsed_ms=${elapsed}`);
-
-    return new Response(
-      JSON.stringify({ success: true, ...summary, written, duration_ms: elapsed }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+            .eq('id', place.id);
+          return { error: error?.message ?? null };
+        },
+        countRemaining: async () => {
+          if (!cityId) return null;
+          const { count } = await supabaseAdmin
+            .from('place_pool')
+            .select('id', { count: 'exact', head: true })
+            .eq('is_active', true)
+            .eq('city_id', cityId)
+            .is('is_servable', null);
+          return count ?? null;
+        },
+      },
+      {
+        maxRows,
+        pageSize: PAGE_SIZE,
+        writeConcurrency: WRITE_CONCURRENCY,
+        dryRun,
+        afterId,
+      },
     );
 
+    const elapsed = Date.now() - t0;
+    console.log(
+      `[run-bouncer] city=${cityId ?? 'all'} processed=${result.processed} written=${result.written} write_errors=${result.write_errors} done=${result.done} remaining=${result.remaining} elapsed_ms=${elapsed}`,
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        dry_run: dryRun,
+        ...result.summary,
+        processed: result.processed,
+        written: result.written,
+        write_errors: result.write_errors,
+        first_write_error: result.first_write_error,
+        next_cursor: result.next_cursor,
+        done: result.done,
+        remaining: result.remaining,
+        duration_ms: elapsed,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
   } catch (err) {
     const e = err as Error;
     console.error('[run-bouncer] unhandled:', e?.message);

--- a/supabase/functions/run-pre-photo-bouncer/index.ts
+++ b/supabase/functions/run-pre-photo-bouncer/index.ts
@@ -10,15 +10,27 @@
 // [CRITICAL — ORCH-0678 + Constitutional #2] This function is the SOLE writer of
 // passes_pre_photo_check / pre_photo_bouncer_reason / pre_photo_bouncer_validated_at
 // for the place_pool table. NEVER add a write of those columns anywhere else in
-// the codebase. CI gate I-PRE-PHOTO-BOUNCER-SOLE-WRITER enforces this.
+// the codebase. CI gate I-PRE-PHOTO-BOUNCER-SOLE-WRITER enforces this. The
+// `.update({...})` below is the only place that triple is written.
 //
 // Constitutional #2 (one owner per truth): each Bouncer pass owns its own column
 // triple. is_servable + bouncer_reason + bouncer_validated_at remain owned by
 // run-bouncer (final pass) — DO NOT WRITE THEM HERE.
+//
+// ORCH-1017 — cursor-paged, memory-safe, non-aborting. The shared loop lives in
+// _shared/bouncerBatch.ts; this file owns ONLY the pre-photo column writes, the
+// read query, and the request/response envelope. Prior version loaded the whole
+// city into memory + one 500-wide write burst + abort-on-first-error, which blew
+// the Edge compute budget (HTTP 546) on large cities (London @ 15.5k) and never
+// finished. Now: streams id-ordered pages (one page in memory), caps work per
+// invocation at max_rows + returns next_cursor so the caller loops to completion,
+// writes in small concurrency-limited sub-batches, and counts (never aborts on)
+// per-row write errors.
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { bounce, type PlaceRow, type Cluster } from '../_shared/bouncer.ts';
+import { type PlaceRow } from '../_shared/bouncer.ts';
+import { runBouncerBatch } from '../_shared/bouncerBatch.ts';
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? '';
 const SUPABASE_SERVICE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
@@ -32,28 +44,10 @@ const corsHeaders = {
 const SELECT_FIELDS =
   'id, name, lat, lng, types, business_status, website, opening_hours, photos, stored_photo_urls, review_count, rating';
 
-const BATCH_SIZE = 500;
-
-interface BouncerSummary {
-  pass_count: number;
-  reject_count: number;
-  by_cluster: Record<Cluster, { pass: number; reject: number }>;
-  by_reason: Record<string, number>;
-}
-
-function freshSummary(): BouncerSummary {
-  return {
-    pass_count: 0,
-    reject_count: 0,
-    by_cluster: {
-      A_COMMERCIAL: { pass: 0, reject: 0 },
-      B_CULTURAL: { pass: 0, reject: 0 },
-      C_NATURAL: { pass: 0, reject: 0 },
-      EXCLUDED: { pass: 0, reject: 0 },
-    },
-    by_reason: {},
-  };
-}
+const PAGE_SIZE = 500;
+const WRITE_CONCURRENCY = 50;
+const DEFAULT_MAX_ROWS = 3000;
+const MAX_MAX_ROWS = 20000;
 
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
@@ -67,6 +61,13 @@ serve(async (req: Request) => {
     const cityId: string | undefined = body.city_id;
     const allCities: boolean = body.all_cities === true;
     const dryRun: boolean = body.dry_run === true;
+    const afterId: string | null =
+      typeof body.after_id === 'string' && body.after_id.length > 0 ? body.after_id : null;
+    const onlyUnprocessed: boolean = body.only_unprocessed === true;
+    const maxRows: number = Math.max(
+      1,
+      Math.min(MAX_MAX_ROWS, Number.isFinite(body.max_rows) ? Number(body.max_rows) : DEFAULT_MAX_ROWS),
+    );
 
     if (!cityId && !allCities) {
       return new Response(
@@ -76,120 +77,78 @@ serve(async (req: Request) => {
     }
 
     const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-
-    const summary = freshSummary();
-    const writes: Array<{
-      id: string;
-      passes_pre_photo_check: boolean;
-      pre_photo_bouncer_reason: string | null;
-    }> = [];
-
-    // Stream place_pool in pages of 500
-    let offset = 0;
-    while (true) {
-      let q = supabaseAdmin
-        .from('place_pool')
-        .select(SELECT_FIELDS)
-        .eq('is_active', true)
-        .order('id')
-        .range(offset, offset + BATCH_SIZE - 1);
-
-      if (cityId) q = q.eq('city_id', cityId);
-
-      const { data, error } = await q;
-      if (error) {
-        console.error('[run-pre-photo-bouncer] place_pool fetch error:', error.message);
-        return new Response(
-          JSON.stringify({ error: `place_pool fetch failed: ${error.message}` }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-        );
-      }
-
-      if (!data || data.length === 0) break;
-
-      for (const place of data as PlaceRow[]) {
-        // ORCH-0678 — pre-photo pass: skip B8 (stored photos check). Every other
-        // rule unchanged. Single source of truth for rule logic in _shared/bouncer.ts.
-        const verdict = bounce(place, { skipStoredPhotoCheck: true });
-        const cluster = verdict.cluster;
-        if (verdict.is_servable) {
-          summary.pass_count++;
-          summary.by_cluster[cluster].pass++;
-        } else {
-          summary.reject_count++;
-          summary.by_cluster[cluster].reject++;
-          for (const r of verdict.reasons) {
-            summary.by_reason[r] = (summary.by_reason[r] || 0) + 1;
-          }
-        }
-        writes.push({
-          id: place.id,
-          passes_pre_photo_check: verdict.is_servable,
-          pre_photo_bouncer_reason: verdict.reasons.length > 0 ? verdict.reasons.join(';') : null,
-        });
-      }
-
-      if (data.length < BATCH_SIZE) break;
-      offset += BATCH_SIZE;
-    }
-
-    if (dryRun) {
-      const elapsed = Date.now() - t0;
-      console.log(`[run-pre-photo-bouncer] dry_run city=${cityId ?? 'all'} pass=${summary.pass_count} reject=${summary.reject_count} elapsed_ms=${elapsed}`);
-      return new Response(
-        JSON.stringify({ success: true, dry_run: true, ...summary, duration_ms: elapsed }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-      );
-    }
-
-    // Write back via TRUE UPDATE per row (place_pool has many NOT NULL columns we
-    // don't provide, so upsert's INSERT-fallback semantics fail preflight).
-    // Parallelize within each batch — Postgres connection pool handles concurrency.
     const now = new Date().toISOString();
-    let written = 0;
-    let firstWriteError: string | null = null;
-    for (let i = 0; i < writes.length; i += BATCH_SIZE) {
-      const chunk = writes.slice(i, i + BATCH_SIZE);
-      const results = await Promise.all(
-        chunk.map((w) =>
-          supabaseAdmin
+
+    const result = await runBouncerBatch(
+      {
+        loadPage: async (cursor, pageSize) => {
+          let q = supabaseAdmin
+            .from('place_pool')
+            .select(SELECT_FIELDS)
+            .eq('is_active', true)
+            .order('id', { ascending: true })
+            .limit(pageSize);
+          if (cityId) q = q.eq('city_id', cityId);
+          if (onlyUnprocessed) q = q.is('passes_pre_photo_check', null);
+          if (cursor) q = q.gt('id', cursor);
+          const { data, error } = await q;
+          if (error) throw new Error(`place_pool fetch failed: ${error.message}`);
+          return (data ?? []) as PlaceRow[];
+        },
+        // SOLE writer of the pre-photo column triple.
+        writeRow: async (place, verdict) => {
+          const { error } = await supabaseAdmin
             .from('place_pool')
             .update({
-              passes_pre_photo_check: w.passes_pre_photo_check,
-              pre_photo_bouncer_reason: w.pre_photo_bouncer_reason,
+              passes_pre_photo_check: verdict.is_servable,
+              pre_photo_bouncer_reason: verdict.reasons.length > 0 ? verdict.reasons.join(';') : null,
               pre_photo_bouncer_validated_at: now,
             })
-            .eq('id', w.id),
-        ),
-      );
-      for (const r of results) {
-        if (r.error) {
-          if (!firstWriteError) firstWriteError = r.error.message;
-        } else {
-          written++;
-        }
-      }
-      if (firstWriteError) {
-        console.error(`[run-pre-photo-bouncer] write batch ${i / BATCH_SIZE} had errors. First: ${firstWriteError}`);
-        return new Response(
-          JSON.stringify({
-            error: `place_pool write failed at batch ${i / BATCH_SIZE}: ${firstWriteError}`,
-            partial_summary: summary,
-            written,
-          }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-        );
-      }
-    }
-
-    const elapsed = Date.now() - t0;
-    console.log(`[run-pre-photo-bouncer] city=${cityId ?? 'all'} pass=${summary.pass_count} reject=${summary.reject_count} written=${written} elapsed_ms=${elapsed}`);
-
-    return new Response(
-      JSON.stringify({ success: true, ...summary, written, duration_ms: elapsed }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+            .eq('id', place.id);
+          return { error: error?.message ?? null };
+        },
+        countRemaining: async () => {
+          if (!cityId) return null;
+          const { count } = await supabaseAdmin
+            .from('place_pool')
+            .select('id', { count: 'exact', head: true })
+            .eq('is_active', true)
+            .eq('city_id', cityId)
+            .is('passes_pre_photo_check', null);
+          return count ?? null;
+        },
+      },
+      {
+        maxRows,
+        pageSize: PAGE_SIZE,
+        writeConcurrency: WRITE_CONCURRENCY,
+        dryRun,
+        afterId,
+        bounceOpts: { skipStoredPhotoCheck: true },
+      },
     );
 
+    const elapsed = Date.now() - t0;
+    console.log(
+      `[run-pre-photo-bouncer] city=${cityId ?? 'all'} processed=${result.processed} written=${result.written} write_errors=${result.write_errors} done=${result.done} remaining=${result.remaining} elapsed_ms=${elapsed}`,
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        dry_run: dryRun,
+        ...result.summary,
+        processed: result.processed,
+        written: result.written,
+        write_errors: result.write_errors,
+        first_write_error: result.first_write_error,
+        next_cursor: result.next_cursor,
+        done: result.done,
+        remaining: result.remaining,
+        duration_ms: elapsed,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
   } catch (err) {
     const e = err as Error;
     console.error('[run-pre-photo-bouncer] unhandled:', e?.message);


### PR DESCRIPTION
## What

Fixes the Bouncer compute-crash that stranded large cities (London at ~38% judged for weeks).

Both `run-pre-photo-bouncer` and `run-bouncer` loaded an entire city into memory and fired one 500-wide write burst, then aborted the whole run on the first per-row error. On large cities (London @ 17.5k places) this exceeded the Edge runtime compute budget (HTTP **546 WORKER_LIMIT**) and never finished.

## Fix

- New `supabase/functions/_shared/bouncerBatch.ts` — shared cursor-paged loop: streams id-ordered pages (one page in memory), caps work per invocation at `max_rows`, returns `next_cursor`, writes in small concurrency-limited sub-batches, and **counts (never aborts on) per-row write errors**.
- Both edge functions become thin wrappers; the `.update({...})` column writes stay in each pass's `index.ts` (sole-writer invariants preserved — strict-grep gate passes).
- Admin Run-Step button (`SignalLibraryPage.jsx`) loops the cursor until `done`, so one click finishes any size city; shows live processed / remaining / write-errors.

## Verified live

London driven **0 → 100% pre-photo judged** (17,551 rows) in 6 looped calls, **zero 546 crashes, zero write errors**. Edge functions deployed to prod.

## Tests (Step 0.5)

- `bouncerBatch.test.ts` — happy-path multi-page cursor paging + dry-run (implementor).
- `bouncerBatch.adversarial.test.ts` — non-abort on per-row write error + resumable `max_rows` budget (tester, different angle).
- **Fails-on-revert verified**: reinstating abort-on-first-error makes the adversarial tests fail; restoring passes.
- Existing `bouncer.test.ts` + sole-writer + 0863 backend gates all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)