### PR TITLE
Close ORCH-1017: fix Intelligence Trial "Couldn't load coverage" (Edge HTTP 546)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1062,7 +1062,27 @@ function checkNoNewBackendFiles() {
     "supabase/functions/run-place-intelligence-trial/__tests__/ai_signal_scores_adversarial.test.ts",
     "supabase/migrations/__tests__/meta_orch_1009_sub_a_ai_signal_scores_backfill.test.sql",
   ];
+  // ORCH-1017 [Intelligence Trial "Couldn't load coverage" — Edge HTTP 546]:
+  // moves the intelligence_coverage per-city aggregation out of JS (which pulled
+  // ~79k place_pool rows into the edge fn and intermittently blew the Edge
+  // WORKER_LIMIT) into the SECURITY DEFINER RPC pg_intelligence_coverage().
+  // New migration + 2 new Deno tests; the 2 ORCH-1013 coverage tests have their
+  // source-inspect halves repointed at the RPC/migration ([TEST-MOD-APPROVED
+  // ORCH-1017]). The edge-fn source path is already covered by ORCH_1015 /
+  // META_ORCH_1009_SUB_A above — listed here for explicit ORCH-1017 ownership;
+  // the ALLOWLIST spread is a union so dups are harmless. C7 is scoped to
+  // ORCH-0863 marketing; this entry covers the ORCH-1017 backend touches.
+  const ORCH_1017_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql",
+    "supabase/functions/run-place-intelligence-trial/index.ts",
+    "supabase/functions/run-place-intelligence-trial/__tests__/orch1017_coverage_rpc.test.ts",
+    "supabase/functions/run-place-intelligence-trial/__tests__/orch1017_coverage_rpc_adversarial.test.ts",
+    "supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts",
+    "supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts",
+    "supabase/functions/run-place-intelligence-trial/__tests__/intelligence_coverage_seed_refresh.test.ts",
+  ];
   const ALLOWLIST = [
+    ...ORCH_1017_BACKEND_ALLOWLIST,
     ...ORCH_1006_BACKEND_ALLOWLIST,
     ...ORCH_0989_BACKEND_ALLOWLIST,
     ...ORCH_0990_BACKEND_ALLOWLIST,

--- a/supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/coverage_adversarial.test.ts
@@ -184,52 +184,58 @@ Deno.test("ADV-A8 — rows sorted by servable_count DESC", () => {
   assertEquals(rows.map((r) => r.city_name), ["Big", "Med", "Small"]);
 });
 
-// ── Source-inspect: post-fix safety guards must still be present ──
+// ── Source-inspect (ORCH-1017): the aggregation moved into the
+//    pg_intelligence_coverage() migration. The same defensive guards the JS
+//    handler carried (drop-empty, clamp, coverage rounding, completed gate)
+//    must now exist in SQL form. Each test asserts BOTH that index.ts calls the
+//    RPC (so a JS-revert is caught) AND that the migration retains the guard.
 
-Deno.test("ADV-A9 — source still has .filter(r => r.servable_count > 0) drop guard", async () => {
-  const url = new URL("../index.ts", import.meta.url);
-  const src = await Deno.readTextFile(url);
+const MIGRATION_SQL = await Deno.readTextFile(
+  new URL(
+    "../../../migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql",
+    import.meta.url,
+  ),
+);
+const INDEX_SRC = await Deno.readTextFile(new URL("../index.ts", import.meta.url));
+
+Deno.test("ADV-A9 — RPC call present + migration drops servable_count=0 cities", () => {
   assert(
-    src.includes(".filter((r) => r.servable_count > 0)"),
-    "drop-row guard at L2312 must remain after Finding A",
+    INDEX_SRC.includes('db.rpc("pg_intelligence_coverage")'),
+    "handler must call the RPC — ORCH-1017",
+  );
+  assert(
+    /WHERE\s+s\.servable_count\s*>\s*0/i.test(MIGRATION_SQL),
+    "migration must retain the servable_count > 0 drop guard",
   );
 });
 
-Deno.test("ADV-A10 — source retains Math.min/Math.max defensive clamp", async () => {
-  const url = new URL("../index.ts", import.meta.url);
-  const src = await Deno.readTextFile(url);
+Deno.test("ADV-A10 — migration retains LEAST/GREATEST defensive clamp", () => {
   assert(
-    src.includes("Math.min(evaluated, servable)"),
-    "Math.min clamp must remain as defensive safety per SPEC §7-D9",
+    /LEAST\s*\(\s*COALESCE\(\s*e\.evaluated_count/i.test(MIGRATION_SQL),
+    "evaluated_count must be LEAST(evaluated, servable) — defensive clamp per SPEC §7-D9",
   );
   assert(
-    src.includes("Math.max(0, servable - evaluated)"),
-    "Math.max clamp must remain as defensive safety per SPEC §7-D9",
-  );
-});
-
-Deno.test("ADV-A11 — source retains coverage_pct toFixed(1) for display stability", async () => {
-  const url = new URL("../index.ts", import.meta.url);
-  const src = await Deno.readTextFile(url);
-  assert(
-    src.includes("Math.min(100, +((evaluated / servable) * 100).toFixed(1))"),
-    "coverage_pct must round to 1 decimal place and clamp to 100",
+    /GREATEST\s*\(\s*0\s*,\s*s\.servable_count\s*-\s*COALESCE\(\s*e\.evaluated_count/i
+      .test(MIGRATION_SQL),
+    "remaining_count must be GREATEST(0, servable - evaluated) — defensive clamp per SPEC §7-D9",
   );
 });
 
-Deno.test("ADV-A12 — Finding A query still gates by .eq('status', 'completed')", async () => {
-  const url = new URL("../index.ts", import.meta.url);
-  const src = await Deno.readTextFile(url);
-  // Locate the Finding A query specifically (it's the one with the !inner join)
-  const findingAIdx = src.indexOf(
-    'select("city_id, place_pool_id, place_pool!inner(is_servable)")',
-  );
-  assert(findingAIdx > 0, "Finding A query must be present");
-  // The .eq("status", "completed") gate should be within the next ~300 chars
-  const slice = src.slice(findingAIdx, findingAIdx + 400);
+Deno.test("ADV-A11 — migration clamps + rounds coverage_pct (LEAST(100, ROUND(...,1)))", () => {
   assert(
-    slice.includes('.eq("status", "completed")'),
-    "Finding A fix must NOT drop the status='completed' filter from the evaluated query",
+    /LEAST\s*\(\s*100\s*,\s*ROUND\(/i.test(MIGRATION_SQL),
+    "coverage_pct must clamp to 100 and round to 1dp in SQL",
+  );
+  assert(
+    /ROUND\([\s\S]*?\*\s*100\s*,\s*1\s*\)/i.test(MIGRATION_SQL),
+    "coverage_pct must round (evaluated/servable)*100 to 1 decimal place",
+  );
+});
+
+Deno.test("ADV-A12 — migration evaluated CTE still gates by status = 'completed'", () => {
+  assert(
+    /tr\.status\s*=\s*'completed'/i.test(MIGRATION_SQL),
+    "evaluated CTE must NOT drop the status='completed' filter",
   );
 });
 

--- a/supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/coverage_servable_filter.test.ts
@@ -128,22 +128,37 @@ Deno.test("Finding A — empty city (0 servable, N evaluated) returns 0/0/0", ()
   assertEquals(agg.coverage_pct, 0);
 });
 
-// ── Source-inspect: the JOIN filter MUST be present in the edge fn. ──
-Deno.test("Finding A — source contains place_pool!inner join + is_servable filter", async () => {
-  const url = new URL("../index.ts", import.meta.url);
-  const src = await Deno.readTextFile(url);
+// ── Source-inspect (ORCH-1017): the aggregation moved from JS into the
+//    pg_intelligence_coverage() RPC to fix the Edge WORKER_LIMIT / HTTP 546.
+//    The two-key revert detector is repointed at the new architecture:
+//      key 1 — index.ts calls the RPC (and no longer hand-rolls the JS query);
+//      key 2 — the migration's `evaluated` CTE preserves the is_servable join
+//              (ORCH-1013 Finding A) so coverage can't re-inflate from drifted
+//              rows. A revert to the JS 6-query path fails key 1; dropping the
+//              is_servable join in SQL fails key 2.
+Deno.test("Finding A — RPC + migration preserve the is_servable evaluated filter", async () => {
+  const src = await Deno.readTextFile(new URL("../index.ts", import.meta.url));
   assert(
-    src.includes(
-      'select("city_id, place_pool_id, place_pool!inner(is_servable)")',
+    src.includes('db.rpc("pg_intelligence_coverage")'),
+    "handleIntelligenceCoverage must call the pg_intelligence_coverage RPC — ORCH-1017",
+  );
+
+  const sql = await Deno.readTextFile(
+    new URL(
+      "../../../migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql",
+      import.meta.url,
     ),
-    "completedRes query must select place_pool!inner(is_servable) — ORCH-1013 Finding A regression",
   );
   assert(
-    src.includes('.eq("place_pool.is_servable", true)'),
-    "completedRes query must filter to place_pool.is_servable = true — ORCH-1013 Finding A regression",
+    /JOIN\s+place_pool\s+pp\s+ON\s+pp\.id\s*=\s*tr\.place_pool_id/i.test(sql),
+    "evaluated CTE must JOIN place_pool to gate on servability — ORCH-1013 Finding A regression",
   );
   assert(
-    src.includes("ORCH-1013 Finding A"),
-    "Finding A comment marker missing — comment provides traceability for the join hint",
+    /pp\.is_servable\s*=\s*true/i.test(sql),
+    "evaluated CTE must filter pp.is_servable = true — ORCH-1013 Finding A regression",
+  );
+  assert(
+    /COUNT\s*\(\s*DISTINCT\s+tr\.place_pool_id\s*\)/i.test(sql),
+    "evaluated CTE must COUNT DISTINCT place_pool_id (dedupe across mode changes) — ORCH-1013 Finding A",
   );
 });

--- a/supabase/functions/run-place-intelligence-trial/__tests__/intelligence_coverage_seed_refresh.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/intelligence_coverage_seed_refresh.test.ts
@@ -181,26 +181,47 @@ Deno.test(
 const INDEX_TS_PATH = new URL("../index.ts", import.meta.url);
 const INDEX_TS = await Deno.readTextFile(INDEX_TS_PATH);
 
-Deno.test("ORCH-1014 — edge fn source declares STALE_THRESHOLD_MS = 90 days", () => {
+// ORCH-1017 — the per-city aggregation moved from JS into the
+// pg_intelligence_coverage() RPC (fixing Edge WORKER_LIMIT / HTTP 546). The
+// source-inspect assertions below are repointed at the migration SQL; the
+// pure-math mirrors above are unchanged and remain the behavioral spec.
+const MIGRATION_SQL = await Deno.readTextFile(
+  new URL(
+    "../../../migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql",
+    import.meta.url,
+  ),
+);
+
+Deno.test("ORCH-1014 — RPC migration encodes the 90-day stale threshold", () => {
   assert(
-    /ORCH_1014_STALE_THRESHOLD_MS\s*=\s*90\s*\*\s*24\s*\*\s*60\s*\*\s*60\s*\*\s*1000/.test(INDEX_TS),
-    "must declare 90-day stale threshold constant",
+    INDEX_TS.includes('db.rpc("pg_intelligence_coverage")'),
+    "handler must call the RPC — ORCH-1017",
+  );
+  assert(
+    /interval\s+'90 days'/i.test(MIGRATION_SQL),
+    "stale_refresh_count must use a 90-day interval in SQL",
   );
 });
 
-Deno.test("ORCH-1014 — edge fn source fetches servable details (last_detail_refresh, generative_summary, editorial_summary, reviews)", () => {
-  assert(
-    INDEX_TS.includes(
-      '"city_id, last_detail_refresh, generative_summary, editorial_summary, reviews"',
-    ),
-    "must select the 4 detail-readiness columns from place_pool",
-  );
+Deno.test("ORCH-1014 — migration servable CTE reads the 4 detail-readiness columns", () => {
+  for (const col of [
+    "last_detail_refresh",
+    "generative_summary",
+    "editorial_summary",
+    "reviews",
+  ]) {
+    assert(
+      MIGRATION_SQL.includes(col),
+      `servable/missing-fields aggregate must reference ${col}`,
+    );
+  }
 });
 
-Deno.test("ORCH-1014 — edge fn source fetches seed window (city_id, created_at) across all place_pool", () => {
+Deno.test("ORCH-1014 — migration seed_window CTE aggregates created_at across all place_pool", () => {
   assert(
-    INDEX_TS.includes('"city_id, created_at"'),
-    "must select city_id + created_at for the seed window",
+    /MIN\s*\(\s*pp\.created_at\s*\)/i.test(MIGRATION_SQL) &&
+      /MAX\s*\(\s*pp\.created_at\s*\)/i.test(MIGRATION_SQL),
+    "seed_window must MIN/MAX(created_at) for first/last_seeded_at",
   );
 });
 
@@ -317,21 +338,19 @@ Deno.test(
 );
 
 Deno.test(
-  "ORCH-1015 — edge fn source declares ORCH_1015_REFRESH_CUTOVER_DATE_MS = 2026-03-19",
+  "ORCH-1015 — migration encodes the 2026-03-19 details-refresh cutover",
   () => {
     assert(
-      /const\s+ORCH_1015_REFRESH_CUTOVER_DATE_MS\s*=\s*Date\.parse\(\s*"2026-03-19T00:00:00Z"\s*\)/.test(
-        INDEX_TS,
-      ),
-      "edge fn must declare ORCH_1015_REFRESH_CUTOVER_DATE_MS = Date.parse('2026-03-19T00:00:00Z')",
+      /2026-03-19/.test(MIGRATION_SQL),
+      "needs_refresh_count must compare last_detail_refresh against the 2026-03-19 cutover in SQL",
     );
   },
 );
 
-Deno.test("ORCH-1015 — edge fn source fetches seeding_cities.coverage_radius_km", () => {
+Deno.test("ORCH-1015 — migration computes regeocoded from coverage_radius_km", () => {
   assert(
-    INDEX_TS.includes('"id, name, country, coverage_radius_km"'),
-    "seeding_cities .select must include coverage_radius_km for the regeocoded flag",
+    /coverage_radius_km\s*=\s*0/i.test(MIGRATION_SQL),
+    "regeocoded must be derived from seeding_cities.coverage_radius_km = 0",
   );
 });
 

--- a/supabase/functions/run-place-intelligence-trial/__tests__/orch1017_coverage_rpc.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/orch1017_coverage_rpc.test.ts
@@ -1,0 +1,187 @@
+// ORCH-1017 happy-path regression — Intelligence Coverage moved from a JS-side
+// 6-query Promise.all aggregation (which pulled ~79k place_pool rows into the
+// edge fn and intermittently blew the Edge WORKER_LIMIT → HTTP 546) into a
+// single Postgres SECURITY DEFINER RPC, pg_intelligence_coverage().
+//
+// Two-key revert detector for the FIX itself:
+//   key 1 — handleIntelligenceCoverage calls db.rpc("pg_intelligence_coverage")
+//           and NO LONGER hand-rolls the 6-query Promise.all over place_pool.
+//   key 2 — the migration defines the RPC with the full aggregation contract.
+//
+// fails-on-revert: reverting to the JS aggregation removes the db.rpc(...) call
+// (key 1 FAILS) and/or removes the migration (key 2 FAILS). A handler that
+// re-adds a raw place_pool scan re-introduces the 546 and FAILS the "no full
+// scan in handler" guard below.
+
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const INDEX_TS = await Deno.readTextFile(new URL("../index.ts", import.meta.url));
+const MIGRATION_SQL = await Deno.readTextFile(
+  new URL(
+    "../../../migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql",
+    import.meta.url,
+  ),
+);
+
+// ── key 1: handler calls the RPC, not the JS 6-query path ──────────────────
+Deno.test("ORCH-1017 — handler calls pg_intelligence_coverage RPC", () => {
+  assert(
+    INDEX_TS.includes('db.rpc("pg_intelligence_coverage")'),
+    "handleIntelligenceCoverage must delegate to the RPC",
+  );
+});
+
+Deno.test("ORCH-1017 — handler no longer hand-rolls the place_pool scan that caused HTTP 546", () => {
+  // Isolate the handler body and assert it contains no raw place_pool fetch nor
+  // the old 6-query Promise.all — those are exactly what exceeded the worker limit.
+  const start = INDEX_TS.indexOf("async function handleIntelligenceCoverage(");
+  assert(start > 0, "handler must exist");
+  const next = INDEX_TS.indexOf("\nasync function ", start + 1);
+  const body = INDEX_TS.slice(start, next === -1 ? undefined : next);
+  assert(
+    !body.includes('.from("place_pool")'),
+    "handler must NOT scan place_pool directly — that is the 546 root cause (ORCH-1017)",
+  );
+  assert(
+    !/servableDetailsRes|seedWindowRes/.test(body),
+    "handler must NOT re-introduce the old per-row servable/seed fetches",
+  );
+});
+
+// ── key 2: migration defines the RPC with the security + aggregation contract ─
+Deno.test("ORCH-1017 — migration creates a SECURITY DEFINER RPC granted to service_role only", () => {
+  assert(
+    /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.pg_intelligence_coverage\(\)/i.test(
+      MIGRATION_SQL,
+    ),
+    "migration must create pg_intelligence_coverage()",
+  );
+  assert(/SECURITY\s+DEFINER/i.test(MIGRATION_SQL), "RPC must be SECURITY DEFINER");
+  assert(
+    /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+public\.pg_intelligence_coverage\(\)\s+TO\s+service_role/i
+      .test(MIGRATION_SQL),
+    "EXECUTE must be granted to service_role",
+  );
+  assert(
+    /REVOKE\s+ALL[\s\S]*?anon/i.test(MIGRATION_SQL) &&
+      /REVOKE\s+ALL[\s\S]*?authenticated/i.test(MIGRATION_SQL),
+    "EXECUTE must be revoked from anon + authenticated (admin-gated in the edge fn)",
+  );
+});
+
+Deno.test("ORCH-1017 — migration aggregates per city (GROUP BY city_id, ORDER BY servable_count DESC)", () => {
+  assert(/GROUP\s+BY\s+pp\.city_id/i.test(MIGRATION_SQL), "must GROUP BY city_id");
+  assert(
+    /ORDER\s+BY\s+s\.servable_count\s+DESC/i.test(MIGRATION_SQL),
+    "rows must be ordered by servable_count DESC (contract preserved)",
+  );
+});
+
+// ── Behavioral spec: a SQL-faithful mirror reproduces the row contract ──────
+// This mirrors what pg_intelligence_coverage() computes per city so the math
+// contract is pinned independently of the SQL text. Numbers below match the
+// live-DB truth captured 2026-05-30 (Raleigh 100%, Durham 6.0%, London 0%).
+type Pool = {
+  city_id: string;
+  is_servable: boolean;
+  last_detail_refresh: string | null;
+  reviews: unknown[] | null;
+  generative_summary: string | null;
+  editorial_summary: string | null;
+};
+type Trial = { city_id: string; place_pool_id: string; status: string; servable: boolean };
+
+const CUTOVER = Date.parse("2026-03-19T00:00:00Z");
+
+function coverageRow(
+  cityId: string,
+  pool: Pool[],
+  trials: Trial[],
+) {
+  const servableRows = pool.filter((p) => p.city_id === cityId && p.is_servable);
+  const servable = servableRows.length;
+  const evaluatedSet = new Set<string>();
+  for (const t of trials) {
+    if (t.city_id === cityId && t.status === "completed" && t.servable) {
+      evaluatedSet.add(t.place_pool_id);
+    }
+  }
+  const evaluatedRaw = evaluatedSet.size;
+  const evaluated = Math.min(evaluatedRaw, servable);
+  const remaining = Math.max(0, servable - evaluatedRaw);
+  const coverage = servable === 0
+    ? 0
+    : Math.min(100, +((evaluatedRaw / servable) * 100).toFixed(1));
+  const needs = servableRows.filter(
+    (p) => p.last_detail_refresh === null || Date.parse(p.last_detail_refresh) < CUTOVER,
+  ).length;
+  return {
+    servable_count: servable,
+    evaluated_count: evaluated,
+    remaining_count: remaining,
+    coverage_pct: coverage,
+    needs_refresh_count: needs,
+    refreshed_new_fields: servable > 0 && needs === 0,
+  };
+}
+
+Deno.test("ORCH-1017 — math mirror: Raleigh-style fully-evaluated city → 100% / 0 remaining", () => {
+  const pool: Pool[] = Array.from({ length: 3 }, (_, i) => ({
+    city_id: "ral",
+    is_servable: true,
+    last_detail_refresh: "2026-04-01T00:00:00Z",
+    reviews: [1],
+    generative_summary: "x",
+    editorial_summary: "y",
+  }));
+  const trials: Trial[] = pool.map((_, i) => ({
+    city_id: "ral",
+    place_pool_id: `p${i}`,
+    status: "completed",
+    servable: true,
+  }));
+  const r = coverageRow("ral", pool, trials);
+  assertEquals(r.servable_count, 3);
+  assertEquals(r.evaluated_count, 3);
+  assertEquals(r.remaining_count, 0);
+  assertEquals(r.coverage_pct, 100);
+  assertEquals(r.refreshed_new_fields, true);
+});
+
+Deno.test("ORCH-1017 — math mirror: Durham-style partial → 6.0% (rounded 1dp)", () => {
+  // 39 of 648 evaluated → 6.0%
+  const pool: Pool[] = Array.from({ length: 648 }, () => ({
+    city_id: "dur",
+    is_servable: true,
+    last_detail_refresh: "2026-05-01T00:00:00Z",
+    reviews: [1],
+    generative_summary: "x",
+    editorial_summary: "y",
+  }));
+  const trials: Trial[] = Array.from({ length: 39 }, (_, i) => ({
+    city_id: "dur",
+    place_pool_id: `p${i}`,
+    status: "completed",
+    servable: true,
+  }));
+  const r = coverageRow("dur", pool, trials);
+  assertEquals(r.coverage_pct, 6.0);
+  assertEquals(r.remaining_count, 609);
+});
+
+Deno.test("ORCH-1017 — math mirror: London-style 0 evaluated → 0% remaining=servable", () => {
+  const pool: Pool[] = Array.from({ length: 10 }, (_, i) => ({
+    city_id: "lon",
+    is_servable: true,
+    // 7 below cutover (need refresh), 3 above
+    last_detail_refresh: i < 7 ? "2026-01-01T00:00:00Z" : "2026-04-01T00:00:00Z",
+    reviews: null, // missing fields
+    generative_summary: null,
+    editorial_summary: null,
+  }));
+  const r = coverageRow("lon", pool, []);
+  assertEquals(r.coverage_pct, 0);
+  assertEquals(r.remaining_count, 10);
+  assertEquals(r.needs_refresh_count, 7);
+  assertEquals(r.refreshed_new_fields, false);
+});

--- a/supabase/functions/run-place-intelligence-trial/__tests__/orch1017_coverage_rpc_adversarial.test.ts
+++ b/supabase/functions/run-place-intelligence-trial/__tests__/orch1017_coverage_rpc_adversarial.test.ts
@@ -1,0 +1,143 @@
+// ORCH-1017 ADVERSARIAL — attacks angles the happy-path test does not:
+//   1. PostgREST numeric serialization: coverage_pct / cost may arrive as STRINGS
+//      ("0.0", "100") — the handler's toNum() must coerce to JS numbers so the
+//      admin UI's numeric math (badges, cost preview) doesn't break.
+//   2. Empty / null RPC payload → empty rows array, never a throw.
+//   3. SQL clamp boundaries: a race where evaluated > servable must NOT yield a
+//      negative remaining nor a >100% coverage (LEAST/GREATEST in the migration).
+//   4. Security: the RPC must REVOKE from PUBLIC and only GRANT service_role —
+//      a SECURITY DEFINER fn exposed to anon would leak the whole place corpus.
+//   5. The handler must preserve the full 21-field wire contract (no field
+//      silently dropped in the JS→SQL move).
+//
+// The happy-path file pins the math + RPC wiring; this file pins serialization
+// robustness, the error/empty path, the security grant, and contract width.
+
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const INDEX_TS = await Deno.readTextFile(new URL("../index.ts", import.meta.url));
+const MIGRATION_SQL = await Deno.readTextFile(
+  new URL(
+    "../../../migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql",
+    import.meta.url,
+  ),
+);
+
+// Mirror of the handler's toNum() coercion (index.ts).
+const toNum = (v: unknown): number | null =>
+  v === null || v === undefined ? null : typeof v === "number" ? v : Number(v);
+
+Deno.test("ADV-1017-1 — numeric coverage_pct arrives as string → coerced to number", () => {
+  assertEquals(toNum("0.0"), 0);
+  assertEquals(toNum("100"), 100);
+  assertEquals(toNum("6.0"), 6);
+  assertEquals(toNum(42.5), 42.5);
+});
+
+Deno.test("ADV-1017-2 — null/undefined numeric → null (not NaN, not 0)", () => {
+  assertEquals(toNum(null), null);
+  assertEquals(toNum(undefined), null);
+  // NaN would silently corrupt the UI; assert we never emit it for nullish input
+  assert(!Number.isNaN(toNum(null) as unknown as number) || toNum(null) === null);
+});
+
+Deno.test("ADV-1017-3 — handler maps empty/null RPC data to [] without throwing", () => {
+  // Mirror the exact guard: ((data as ...[] | null) ?? []).map(...)
+  const mapEmpty = (data: unknown[] | null) => (data ?? []).map((r) => r);
+  assertEquals(mapEmpty(null), []);
+  assertEquals(mapEmpty([]), []);
+  // and the source actually contains the ?? [] guard
+  assert(
+    /\?\?\s*\[\]\)\s*\.map\(/.test(INDEX_TS),
+    "handler must default null RPC data to [] before mapping",
+  );
+});
+
+Deno.test("ADV-1017-4 — migration REVOKEs from PUBLIC (no anon leak of the place corpus)", () => {
+  assert(
+    /REVOKE\s+ALL\s+ON\s+FUNCTION\s+public\.pg_intelligence_coverage\(\)\s+FROM\s+PUBLIC/i
+      .test(MIGRATION_SQL),
+    "SECURITY DEFINER fn must REVOKE ALL FROM PUBLIC",
+  );
+  // And must NOT grant to anon or authenticated anywhere.
+  assert(
+    !/GRANT\s+EXECUTE[\s\S]*?\bTO\s+anon/i.test(MIGRATION_SQL),
+    "must never GRANT EXECUTE to anon",
+  );
+  assert(
+    !/GRANT\s+EXECUTE[\s\S]*?\bTO\s+authenticated/i.test(MIGRATION_SQL),
+    "must never GRANT EXECUTE to authenticated",
+  );
+});
+
+Deno.test("ADV-1017-5 — migration pins search_path (SECURITY DEFINER hardening)", () => {
+  assert(
+    /SET\s+search_path\s*=\s*public/i.test(MIGRATION_SQL),
+    "SECURITY DEFINER fn must pin search_path to avoid hijack",
+  );
+});
+
+Deno.test("ADV-1017-6 — clamp prevents negative remaining + >100% coverage under race skew", () => {
+  // SQL: LEAST(evaluated, servable) + GREATEST(0, servable-evaluated) +
+  // LEAST(100, ROUND(...)). Reproduce the worst case: evaluated = servable + 5.
+  const servable = 100;
+  const evaluatedRaw = 105;
+  const evaluated = Math.min(evaluatedRaw, servable);
+  const remaining = Math.max(0, servable - evaluatedRaw);
+  const coverage = Math.min(100, +((evaluatedRaw / servable) * 100).toFixed(1));
+  assertEquals(evaluated, 100, "evaluated clamped to servable");
+  assertEquals(remaining, 0, "remaining never negative");
+  assertEquals(coverage, 100, "coverage never exceeds 100");
+});
+
+Deno.test("ADV-1017-7 — full 21-field wire contract preserved in handler output", () => {
+  const start = INDEX_TS.indexOf("async function handleIntelligenceCoverage(");
+  const next = INDEX_TS.indexOf("\nasync function ", start + 1);
+  const body = INDEX_TS.slice(start, next === -1 ? undefined : next);
+  for (
+    const field of [
+      "city_id:",
+      "city_name:",
+      "country:",
+      "servable_count:",
+      "evaluated_count:",
+      "remaining_count:",
+      "coverage_pct:",
+      "last_run_id:",
+      "last_run_at:",
+      "last_run_status:",
+      "last_run_cost_usd:",
+      "last_run_mode:",
+      "first_seeded_at:",
+      "last_seeded_at:",
+      "refresh_oldest_at:",
+      "refresh_newest_at:",
+      "stale_refresh_count:",
+      "missing_fields_count:",
+      "regeocoded:",
+      "refreshed_new_fields:",
+      "needs_refresh_count:",
+    ]
+  ) {
+    assert(body.includes(field), `wire contract must still emit ${field}`);
+  }
+});
+
+Deno.test("ADV-1017-8 — migration latest_run picks most-recent terminal run (DISTINCT ON + nulls last)", () => {
+  assert(
+    /DISTINCT\s+ON\s*\(\s*r\.city_id\s*\)/i.test(MIGRATION_SQL),
+    "latest_run must DISTINCT ON (city_id)",
+  );
+  assert(
+    /ORDER\s+BY\s+r\.city_id\s*,\s*r\.completed_at\s+DESC\s+NULLS\s+LAST/i.test(
+      MIGRATION_SQL,
+    ),
+    "latest_run ordering must be completed_at DESC NULLS LAST (matches prior JS sort)",
+  );
+  assert(
+    /status\s+IN\s*\(\s*'complete'\s*,\s*'failed'\s*,\s*'cancelled'\s*\)/i.test(
+      MIGRATION_SQL,
+    ),
+    "latest_run must consider exactly the 3 terminal statuses",
+  );
+});

--- a/supabase/functions/run-place-intelligence-trial/index.ts
+++ b/supabase/functions/run-place-intelligence-trial/index.ts
@@ -2385,251 +2385,64 @@ async function insertRetryChildrenInChunks(
 //   https://ai.google.dev/pricing/gemini-2-5-flash (verified 2026-05-30).
 // ═══════════════════════════════════════════════════════════════════════════
 
-// ORCH-1014 — operator-chosen stale threshold (90 days). Internal operational
-// constant, not an external API parameter. last_detail_refresh older than
-// this counts as "stale" in the Refresh status badge.
-const ORCH_1014_STALE_THRESHOLD_MS = 90 * 24 * 60 * 60 * 1000;
-
-// ORCH-1015 — operator-chosen cutover date for the 48-field DETAIL_FIELD_MASK.
-// Set 2026-03-19 (commit 596b3c05c "feat: admin stale-place lifecycle UI +
-// manual refresh edge function"). Anchored to the introduction of the full
-// field set the Gemini intelligence trial reads (editorialSummary,
-// generativeSummary, priceRange + 23 facet booleans). Hardcoded; if the field
-// mask ever expands again, operator opens a new ORCH to bump this value —
-// NOT runtime-tunable. See supabase/functions/admin-refresh-places/index.ts
-// L31-L143 (DETAIL_FIELD_MASK array).
-const ORCH_1015_REFRESH_CUTOVER_DATE_MS = Date.parse("2026-03-19T00:00:00Z");
+// ORCH-1017 — the Intelligence Coverage operational constants (90-day stale
+// threshold from ORCH-1014; 2026-03-19 details-refresh cutover from ORCH-1015,
+// commit 596b3c05c's 48-field DETAIL_FIELD_MASK) now live INSIDE the
+// pg_intelligence_coverage() RPC (migration
+// 20260807000000_orch_1017_pg_intelligence_coverage.sql), since the per-city
+// aggregation moved from JS into Postgres to fix the Edge WORKER_LIMIT / HTTP
+// 546 failure. If the field mask ever expands again, bump the cutover in that
+// migration via a new ORCH — NOT runtime-tunable. See
+// supabase/functions/admin-refresh-places/index.ts L31-L143 (DETAIL_FIELD_MASK).
 
 async function handleIntelligenceCoverage(
   db: SupabaseClient,
 ): Promise<Response> {
-  // 6 parallel queries → client-side join (Supabase MCP-friendly; avoids
-  // a new SECURITY DEFINER RPC for what is admin-only read state).
-  // ORCH-1014 added (5) servableDetailsRes + (6) seedWindowRes for the new
-  // Seed + Refresh status badges. The pre-existing (2) servableRes count
-  // remains as the canonical servable_count source; (5) only feeds the new
-  // refresh/missing aggregates so the count contract stays identical.
-  const [
-    citiesRes,
-    servableRes,
-    completedRes,
-    runsRes,
-    servableDetailsRes,
-    seedWindowRes,
-  ] = await Promise.all([
-    db
-      .from("seeding_cities")
-      // ORCH-1015 — coverage_radius_km drives the `regeocoded` flag (= 0 ⇔ city
-      // re-seeded under the 2026-04 bbox model; deprecated otherwise). See
-      // supabase/functions/admin-seed-places/index.ts L166-L168 BBOX MODEL note.
-      .select("id, name, country, coverage_radius_km")
-      .order("name"),
-    db
-      .from("place_pool")
-      .select("city_id")
-      .eq("is_servable", true)
-      .not("city_id", "is", null),
-    // ORCH-1013 Finding A — restrict evaluated set to places STILL servable.
-    // Without the !inner+is_servable filter, places that drifted out of the
-    // pool (e.g. re-classified non-servable post-evaluation) are counted as
-    // evaluated, falsely inflating coverage to 100% and zeroing remaining.
-    // Verified live 2026-05-30 against Cary: 6 drifted rows masked 1 truly
-    // un-evaluated servable place. See SPEC §3 Finding A.
-    // Gemini pricing ref (COMMS-0003): https://ai.google.dev/pricing/gemini-2-5-flash
-    db
-      .from("place_intelligence_trial_runs")
-      .select("city_id, place_pool_id, place_pool!inner(is_servable)")
-      .eq("status", "completed")
-      .eq("place_pool.is_servable", true)
-      .not("city_id", "is", null),
-    db
-      .from("place_intelligence_runs")
-      .select(
-        "city_id, id, completed_at, status, cost_so_far_usd, mode, started_at",
-      )
-      .in("status", ["complete", "failed", "cancelled"])
-      .order("completed_at", { ascending: false, nullsFirst: false }),
-    // ORCH-1014 NEW — servable details for the Refresh status badge
-    db
-      .from("place_pool")
-      .select("city_id, last_detail_refresh, generative_summary, editorial_summary, reviews")
-      .eq("is_servable", true)
-      .not("city_id", "is", null),
-    // ORCH-1014 NEW — seed window across ALL place_pool rows (servable + non)
-    db
-      .from("place_pool")
-      .select("city_id, created_at")
-      .not("city_id", "is", null),
-  ]);
+  // ORCH-1017 — aggregation pushed entirely into Postgres via the
+  // `pg_intelligence_coverage()` SECURITY DEFINER RPC (migration
+  // 20260807000000_orch_1017_pg_intelligence_coverage.sql). This REPLACES the
+  // prior 6-query Promise.all + JS-side per-city aggregation, which pulled the
+  // ENTIRE place_pool (~79k rows) for the seed window, the servable set (~13.6k)
+  // TWICE — one copy carrying generative_summary + editorial_summary + the full
+  // reviews jsonb array per row — plus ~2.6k run rows into the edge function's
+  // memory on every call. That intermittently exceeded the Edge WORKER_LIMIT and
+  // returned HTTP 546 ("not enough compute resources"). The RPC does one GROUP BY
+  // and returns ~17 city rows; payload + compute drop by ~3 orders of magnitude.
+  //
+  // Output shape is byte-for-byte identical to the prior JS row builder (same
+  // field names, same filters, same constants: 90-day stale threshold +
+  // 2026-03-19 refresh cutover). numeric columns are coerced to JS numbers so the
+  // contract (coverage_pct/last_run_cost_usd as numbers) is preserved regardless
+  // of PostgREST numeric serialization.
+  const { data, error } = await db.rpc("pg_intelligence_coverage");
+  if (error) return json({ error: error.message }, 500);
 
-  if (citiesRes.error) return json({ error: citiesRes.error.message }, 500);
-  if (servableRes.error) return json({ error: servableRes.error.message }, 500);
-  if (completedRes.error) return json({ error: completedRes.error.message }, 500);
-  if (runsRes.error) return json({ error: runsRes.error.message }, 500);
-  if (servableDetailsRes.error) return json({ error: servableDetailsRes.error.message }, 500);
-  if (seedWindowRes.error) return json({ error: seedWindowRes.error.message }, 500);
+  const toNum = (v: unknown): number | null =>
+    v === null || v === undefined ? null : typeof v === "number" ? v : Number(v);
 
-  const servableByCity = new Map<string, number>();
-  for (const row of servableRes.data || []) {
-    if (!row.city_id) continue;
-    servableByCity.set(row.city_id, (servableByCity.get(row.city_id) || 0) + 1);
-  }
-
-  // ORCH-1014 — refresh + missing-fields aggregates, all scoped to is_servable=true
-  const refreshOldestByCity = new Map<string, string>(); // ISO
-  const refreshNewestByCity = new Map<string, string>(); // ISO
-  const staleRefreshByCity = new Map<string, number>();
-  const missingFieldsByCity = new Map<string, number>();
-  // ORCH-1015 — per-city count of servable places with last_detail_refresh
-  // strictly before the 2026-03-19 cutover (NULL counts as needing refresh,
-  // mirroring the existing ORCH-1014 stale-NULL treatment).
-  const needsRefreshByCity = new Map<string, number>();
-  const nowMs = Date.now();
-  for (const row of servableDetailsRes.data || []) {
-    if (!row.city_id) continue;
-    const cityId = row.city_id as string;
-
-    // refresh window
-    const lastRefresh = (row.last_detail_refresh ?? null) as string | null;
-    if (lastRefresh) {
-      const cur = refreshOldestByCity.get(cityId);
-      if (!cur || lastRefresh < cur) refreshOldestByCity.set(cityId, lastRefresh);
-      const curN = refreshNewestByCity.get(cityId);
-      if (!curN || lastRefresh > curN) refreshNewestByCity.set(cityId, lastRefresh);
-      if (nowMs - Date.parse(lastRefresh) > ORCH_1014_STALE_THRESHOLD_MS) {
-        staleRefreshByCity.set(cityId, (staleRefreshByCity.get(cityId) || 0) + 1);
-      }
-      // ORCH-1015 — below-cutover places need refresh under the 48-field mask
-      if (Date.parse(lastRefresh) < ORCH_1015_REFRESH_CUTOVER_DATE_MS) {
-        needsRefreshByCity.set(cityId, (needsRefreshByCity.get(cityId) || 0) + 1);
-      }
-    } else {
-      // Treat NULL last_detail_refresh as stale (never refreshed)
-      staleRefreshByCity.set(cityId, (staleRefreshByCity.get(cityId) || 0) + 1);
-      // ORCH-1015 — NULL also counts as needing refresh (never refreshed at all)
-      needsRefreshByCity.set(cityId, (needsRefreshByCity.get(cityId) || 0) + 1);
-    }
-
-    // missing fields
-    const reviewsLen = Array.isArray(row.reviews) ? row.reviews.length : 0;
-    const missingAny =
-      row.generative_summary == null ||
-      row.editorial_summary == null ||
-      row.reviews == null ||
-      reviewsLen === 0;
-    if (missingAny) {
-      missingFieldsByCity.set(cityId, (missingFieldsByCity.get(cityId) || 0) + 1);
-    }
-  }
-
-  // ORCH-1014 — seed window across ALL place_pool rows (servable + non-servable)
-  const firstSeededByCity = new Map<string, string>();
-  const lastSeededByCity = new Map<string, string>();
-  for (const row of seedWindowRes.data || []) {
-    if (!row.city_id || !row.created_at) continue;
-    const cityId = row.city_id as string;
-    const createdAt = row.created_at as string;
-    const f = firstSeededByCity.get(cityId);
-    if (!f || createdAt < f) firstSeededByCity.set(cityId, createdAt);
-    const l = lastSeededByCity.get(cityId);
-    if (!l || createdAt > l) lastSeededByCity.set(cityId, createdAt);
-  }
-
-  // distinct (city_id, place_pool_id) pairs across all completed runs
-  const evaluatedByCity = new Map<string, Set<string>>();
-  for (const row of completedRes.data || []) {
-    if (!row.city_id || !row.place_pool_id) continue;
-    let set = evaluatedByCity.get(row.city_id);
-    if (!set) {
-      set = new Set<string>();
-      evaluatedByCity.set(row.city_id, set);
-    }
-    set.add(row.place_pool_id as string);
-  }
-
-  // First terminal run per city (already sorted desc by completed_at)
-  const latestRunByCity = new Map<
-    string,
-    {
-      id: string;
-      completed_at: string | null;
-      status: string;
-      cost_so_far_usd: number | null;
-      mode: string;
-    }
-  >();
-  for (const row of runsRes.data || []) {
-    if (!row.city_id) continue;
-    if (latestRunByCity.has(row.city_id)) continue;
-    latestRunByCity.set(row.city_id, {
-      id: row.id as string,
-      completed_at: (row.completed_at ?? row.started_at ?? null) as string | null,
-      status: row.status as string,
-      cost_so_far_usd: (row.cost_so_far_usd ?? null) as number | null,
-      mode: row.mode as string,
-    });
-  }
-
-  const rows = (citiesRes.data || [])
-    .map((c) => {
-      const servable = servableByCity.get(c.id) || 0;
-      const evaluated = (evaluatedByCity.get(c.id) || new Set()).size;
-      const lastRun = latestRunByCity.get(c.id) || null;
-      const coveragePct = servable === 0
-        ? 0
-        : Math.min(100, +((evaluated / servable) * 100).toFixed(1));
-      return {
-        city_id: c.id,
-        city_name: c.name,
-        country: c.country,
-        servable_count: servable,
-        // ORCH-1013 Finding A — `evaluated` is now ≤ `servable` by construction
-        // (the JOIN at the completedRes query filters to currently-servable
-        // places only). Math.min/Math.max retained as defensive cosmetic safety
-        // for the 4 non-transactional parallel queries (race could theoretically
-        // see a 1-row skew). See SPEC §3 Finding A + §7 D9.
-        evaluated_count: Math.min(evaluated, servable),
-        remaining_count: Math.max(0, servable - evaluated),
-        coverage_pct: coveragePct,
-        last_run_id: lastRun?.id ?? null,
-        last_run_at: lastRun?.completed_at ?? null,
-        last_run_status: lastRun?.status ?? null,
-        last_run_cost_usd: lastRun?.cost_so_far_usd ?? null,
-        last_run_mode: lastRun?.mode ?? null,
-        // ORCH-1014 — Seed status badge inputs (all place_pool rows for this city)
-        // PRESERVED post-ORCH-1015 for operator diagnostic use.
-        first_seeded_at: firstSeededByCity.get(c.id) ?? null,
-        last_seeded_at: lastSeededByCity.get(c.id) ?? null,
-        // ORCH-1014 — Refresh status badge inputs (is_servable=true only)
-        // PRESERVED post-ORCH-1015 for operator diagnostic use.
-        refresh_oldest_at: refreshOldestByCity.get(c.id) ?? null,
-        refresh_newest_at: refreshNewestByCity.get(c.id) ?? null,
-        stale_refresh_count: staleRefreshByCity.get(c.id) ?? 0,
-        missing_fields_count: missingFieldsByCity.get(c.id) ?? 0,
-        // ORCH-1015 — Boundary + Details binary readiness flags driving the
-        // 3-band ladder + smart-skip bulk launcher.
-        // regeocoded: city has been re-seeded under the bbox model (the
-        //   coverage_radius_km column is zeroed when operator re-seeds; see
-        //   supabase/functions/admin-seed-places/index.ts L166-L168
-        //   "BBOX MODEL (2026-04): … coverage_radius_km is deprecated").
-        regeocoded: (c.coverage_radius_km ?? null) === 0,
-        // refreshed_new_fields: TRUE iff every servable place has been refreshed
-        //   under the 48-field DETAIL_FIELD_MASK (commit 596b3c05c, 2026-03-19).
-        //   Equivalent to needs_refresh_count === 0 with at least one servable
-        //   place — NULL last_detail_refresh counts as not-refreshed (mirrors
-        //   the stale-NULL treatment above + the operator's mental model of
-        //   "have ALL my places been refreshed under the new mask?"). When
-        //   servable_count is 0 the city is filtered out below entirely.
-        refreshed_new_fields:
-          servable > 0 && (needsRefreshByCity.get(c.id) ?? 0) === 0,
-        // needs_refresh_count: number of servable places with last_detail_refresh
-        //   strictly before the cutover (or NULL). Used by DetailsReadinessBadge
-        //   to size the warning ("⚠ 41 places need refresh").
-        needs_refresh_count: needsRefreshByCity.get(c.id) ?? 0,
-      };
-    })
-    .filter((r) => r.servable_count > 0)
-    .sort((a, b) => b.servable_count - a.servable_count);
+  const rows = ((data as Record<string, unknown>[] | null) ?? []).map((r) => ({
+    city_id: r.city_id,
+    city_name: r.city_name,
+    country: r.country,
+    servable_count: r.servable_count,
+    evaluated_count: r.evaluated_count,
+    remaining_count: r.remaining_count,
+    coverage_pct: toNum(r.coverage_pct),
+    last_run_id: r.last_run_id ?? null,
+    last_run_at: r.last_run_at ?? null,
+    last_run_status: r.last_run_status ?? null,
+    last_run_cost_usd: toNum(r.last_run_cost_usd),
+    last_run_mode: r.last_run_mode ?? null,
+    first_seeded_at: r.first_seeded_at ?? null,
+    last_seeded_at: r.last_seeded_at ?? null,
+    refresh_oldest_at: r.refresh_oldest_at ?? null,
+    refresh_newest_at: r.refresh_newest_at ?? null,
+    stale_refresh_count: r.stale_refresh_count ?? 0,
+    missing_fields_count: r.missing_fields_count ?? 0,
+    regeocoded: r.regeocoded === true,
+    refreshed_new_fields: r.refreshed_new_fields === true,
+    needs_refresh_count: r.needs_refresh_count ?? 0,
+  }));
 
   return json({ rows });
 }

--- a/supabase/migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql
+++ b/supabase/migrations/20260807000000_orch_1017_pg_intelligence_coverage.sql
@@ -1,0 +1,164 @@
+-- ORCH-1017 — Intelligence Trial "Couldn't load coverage" / HTTP 546 compute-limit fix.
+--
+-- ROOT CAUSE: the `intelligence_coverage` action in the edge fn
+-- `run-place-intelligence-trial` (handleIntelligenceCoverage, index.ts) ran 6
+-- unaggregated SELECTs via Promise.all and aggregated per-city IN JAVASCRIPT.
+-- It pulled the ENTIRE place_pool (~79k rows) for the seed-window, the servable
+-- set (~13.6k) TWICE — one copy dragging generative_summary + editorial_summary
+-- + the full reviews jsonb array per row — plus ~2.6k completed-run rows, into
+-- the edge function's memory on every request. That intermittently exceeded the
+-- Supabase Edge Function WORKER_LIMIT (CPU/wall-clock/memory), returning HTTP 546
+-- ("Function failed due to not having enough compute resources"). Warm/cold +
+-- GC timing decided whether a given request squeaked under the limit, so it
+-- failed intermittently and worsened as place_pool grew.
+--
+-- FIX: push the entire aggregation into Postgres as ONE GROUP BY query exposed as
+-- a SECURITY DEFINER RPC. The edge fn now calls this and returns the ~17 city
+-- rows verbatim — payload + compute drop by ~3 orders of magnitude. Output shape
+-- is byte-for-byte identical to the prior JS handler (verified field-by-field
+-- against handleIntelligenceCoverage's row builder).
+--
+-- The two operator-chosen constants are inlined exactly as in the edge fn:
+--   * stale-refresh threshold = 90 days   (ORCH_1014_STALE_THRESHOLD_MS)
+--   * details-refresh cutover = 2026-03-19 (ORCH_1015_REFRESH_CUTOVER_DATE_MS)
+--
+-- Gemini pricing / external-API references unchanged (COMMS-0003 — none touched).
+--
+-- SECURITY: SECURITY DEFINER, EXECUTE granted to service_role ONLY. The edge fn
+-- gates admin (admin_users.status='active') BEFORE calling this and invokes it
+-- with the service-role client, so this RPC is never reachable by anon/auth users.
+
+CREATE OR REPLACE FUNCTION public.pg_intelligence_coverage()
+RETURNS TABLE (
+  city_id               uuid,
+  city_name             text,
+  country               text,
+  servable_count        integer,
+  evaluated_count       integer,
+  remaining_count       integer,
+  coverage_pct          numeric,
+  last_run_id           uuid,
+  last_run_at           timestamptz,
+  last_run_status       text,
+  last_run_cost_usd     numeric,
+  last_run_mode         text,
+  first_seeded_at       timestamptz,
+  last_seeded_at        timestamptz,
+  refresh_oldest_at     timestamptz,
+  refresh_newest_at     timestamptz,
+  stale_refresh_count   integer,
+  missing_fields_count  integer,
+  regeocoded            boolean,
+  refreshed_new_fields  boolean,
+  needs_refresh_count   integer
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+STABLE
+AS $$
+  WITH
+  -- (1) ALL place_pool rows per city → seed window (servable + non-servable).
+  seed_window AS (
+    SELECT pp.city_id,
+           MIN(pp.created_at) AS first_seeded_at,
+           MAX(pp.created_at) AS last_seeded_at
+    FROM place_pool pp
+    WHERE pp.city_id IS NOT NULL
+    GROUP BY pp.city_id
+  ),
+  -- (2) Servable rows per city → count + refresh window + stale + missing-fields
+  --     + needs-refresh-since-cutover. Scoped to is_servable=true (mirrors the
+  --     edge fn's servableRes + servableDetailsRes, collapsed into one scan).
+  servable AS (
+    SELECT pp.city_id,
+           COUNT(*)::int AS servable_count,
+           MIN(pp.last_detail_refresh) FILTER (WHERE pp.last_detail_refresh IS NOT NULL) AS refresh_oldest_at,
+           MAX(pp.last_detail_refresh) FILTER (WHERE pp.last_detail_refresh IS NOT NULL) AS refresh_newest_at,
+           COUNT(*) FILTER (
+             WHERE pp.last_detail_refresh IS NULL
+                OR pp.last_detail_refresh < (now() - interval '90 days')
+           )::int AS stale_refresh_count,
+           COUNT(*) FILTER (
+             WHERE pp.generative_summary IS NULL
+                OR pp.editorial_summary IS NULL
+                OR pp.reviews IS NULL
+                OR jsonb_typeof(pp.reviews) <> 'array'
+                OR jsonb_array_length(pp.reviews) = 0
+           )::int AS missing_fields_count,
+           COUNT(*) FILTER (
+             WHERE pp.last_detail_refresh IS NULL
+                OR pp.last_detail_refresh < timestamptz '2026-03-19 00:00:00+00'
+           )::int AS needs_refresh_count
+    FROM place_pool pp
+    WHERE pp.is_servable = true
+      AND pp.city_id IS NOT NULL
+    GROUP BY pp.city_id
+  ),
+  -- (3) Distinct currently-servable evaluated places per city (ORCH-1013 Finding A:
+  --     the is_servable join prevents drifted rows inflating coverage).
+  evaluated AS (
+    SELECT tr.city_id,
+           COUNT(DISTINCT tr.place_pool_id)::int AS evaluated_count
+    FROM place_intelligence_trial_runs tr
+    JOIN place_pool pp ON pp.id = tr.place_pool_id
+    WHERE tr.status = 'completed'
+      AND pp.is_servable = true
+      AND tr.city_id IS NOT NULL
+    GROUP BY tr.city_id
+  ),
+  -- (4) Most-recent terminal parent run per city (completed_at desc, nulls last).
+  latest_run AS (
+    SELECT DISTINCT ON (r.city_id)
+           r.city_id,
+           r.id   AS last_run_id,
+           COALESCE(r.completed_at, r.started_at) AS last_run_at,
+           r.status AS last_run_status,
+           r.cost_so_far_usd AS last_run_cost_usd,
+           r.mode AS last_run_mode
+    FROM place_intelligence_runs r
+    WHERE r.status IN ('complete', 'failed', 'cancelled')
+      AND r.city_id IS NOT NULL
+    ORDER BY r.city_id, r.completed_at DESC NULLS LAST
+  )
+  SELECT
+    c.id AS city_id,
+    c.name AS city_name,
+    c.country,
+    s.servable_count,
+    LEAST(COALESCE(e.evaluated_count, 0), s.servable_count) AS evaluated_count,
+    GREATEST(0, s.servable_count - COALESCE(e.evaluated_count, 0)) AS remaining_count,
+    CASE
+      WHEN s.servable_count = 0 THEN 0
+      ELSE LEAST(100, ROUND((COALESCE(e.evaluated_count, 0)::numeric / s.servable_count) * 100, 1))
+    END AS coverage_pct,
+    lr.last_run_id,
+    lr.last_run_at,
+    lr.last_run_status,
+    lr.last_run_cost_usd,
+    lr.last_run_mode,
+    sw.first_seeded_at,
+    sw.last_seeded_at,
+    s.refresh_oldest_at,
+    s.refresh_newest_at,
+    s.stale_refresh_count,
+    s.missing_fields_count,
+    COALESCE(c.coverage_radius_km = 0, false) AS regeocoded,
+    (s.servable_count > 0 AND s.needs_refresh_count = 0) AS refreshed_new_fields,
+    s.needs_refresh_count
+  FROM seeding_cities c
+  JOIN servable s   ON s.city_id = c.id          -- INNER JOIN drops servable_count=0 cities
+  LEFT JOIN seed_window sw ON sw.city_id = c.id
+  LEFT JOIN evaluated e    ON e.city_id = c.id
+  LEFT JOIN latest_run lr  ON lr.city_id = c.id
+  WHERE s.servable_count > 0
+  ORDER BY s.servable_count DESC;
+$$;
+
+REVOKE ALL ON FUNCTION public.pg_intelligence_coverage() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.pg_intelligence_coverage() FROM anon;
+REVOKE ALL ON FUNCTION public.pg_intelligence_coverage() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.pg_intelligence_coverage() TO service_role;
+
+COMMENT ON FUNCTION public.pg_intelligence_coverage() IS
+  'ORCH-1017 — per-city Intelligence Trial coverage aggregated in Postgres (replaces the JS-side 6-query aggregation in run-place-intelligence-trial that hit Edge WORKER_LIMIT / HTTP 546). service_role only; edge fn admin-gates before calling.';


### PR DESCRIPTION
## What & why

Admin → Intelligence Trial → Overview → "Per-city coverage" intermittently showed **"Couldn't load coverage — Function failed due to not having enough compute resources"**.

**Root cause (proven):** the `intelligence_coverage` action in `run-place-intelligence-trial` aggregated per-city coverage **in JavaScript** — 6 unaggregated `Promise.all` queries pulling the entire `place_pool` (~79k rows) for the seed window, the servable set (~13.6k) **twice** (one copy carrying `generative_summary` + `editorial_summary` + full `reviews` jsonb), plus ~2.6k run rows into the edge function's memory on every call. Edge-fn logs showed **HTTP 546** (Supabase WORKER_LIMIT) interleaved with 200s, pre-kill execution times 3.8s / 10.7s. Warm/cold + GC timing decided whether a request squeaked under the limit → intermittent failure, worsening as `place_pool` grows.

**Fix:** push the whole aggregation into Postgres as one `GROUP BY` exposed via the SECURITY DEFINER RPC `pg_intelligence_coverage()` (service_role-only; edge fn admin-gates before calling). The handler returns the ~17 city rows verbatim — payload + compute drop ~3 orders of magnitude. Output is byte-for-byte identical to the prior JS row builder (same fields, filters, and the 90-day stale + 2026-03-19 refresh-cutover constants, now in SQL).

## Evidence
- Migration `20260807000000` applied to remote; function present, `security_definer=true`, EXECUTE → `service_role`/`postgres` only (not anon/authenticated/public).
- RPC body validated live: returns the correct 9 cities matching the ORCH-1015 close truth (7 band-1, London `needs_refresh=7`, Baltimore `regeocoded=false`).
- Edge fn redeployed (`verify_jwt:true` preserved); liveness probe HTTP 401 in 0.66s (boots fast, no 546).
- Tests: 52 passed / 0 failed; `deno check` clean. Fails-on-revert verified — reverting the RPC call to a `place_pool` scan FAILS the ORCH-1017 happy-path tests.

## Step 0.5 regression gate
- Implementor happy-path: `__tests__/orch1017_coverage_rpc.test.ts` (RPC+migration contract + SQL-faithful math mirror). Fails-on-revert verified at `01f86b333`.
- Adversarial (different angle): `__tests__/orch1017_coverage_rpc_adversarial.test.ts` (numeric coercion, empty payload, REVOKE-from-PUBLIC security, clamp boundaries, 21-field wire contract).
- 3 existing ORCH-1013/1014 coverage tests: source-inspect halves repointed JS→RPC/migration under `[TEST-MOD-APPROVED ORCH-1017]`; pure-math mirrors unchanged.

## Notes
- Backend-only — no Vercel build inputs touched, so **no `[deploy]` tag** needed.
- C7 (ORCH-0863 no-new-backend-files) allowlist extended with `ORCH_1017_BACKEND_ALLOWLIST`.
- Migration reconciled around ORCH-1006's remote-only `20260805000000` without importing it (COMMS-0013/0014 context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)