### PR TITLE
ORCH-1024 [deploy]: photo backfill originals-only + separate thumbnail tab

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1172,7 +1172,22 @@ function checkNoNewBackendFiles() {
     "supabase/functions/generate-curated-experiences/index.ts",
     "supabase/functions/generate-curated-experiences/__tests__/utc_offset_passthrough.test.ts",
   ];
+  // ORCH-1024 [Photo backfill originals-only + separate thumbnail tab].
+  // C7 is scoped to ORCH-0863 marketing; ORCH-1024 makes the main photo
+  // backfill download+store ORIGINALS ONLY (the inline imagescript thumbnail
+  // generation that crashed `backfill-place-photos` with "not enough compute
+  // resources" is removed; thumbnails move to the separate
+  // `backfill-place-photo-thumbs` function driven from a new admin tab). It also
+  // carries the ORCH-1023 expired-name REFRESH fix + its process-path test.
+  // No marketing scope. Per COMMS-0002.
+  const ORCH_1024_BACKEND_ALLOWLIST = [
+    "supabase/functions/_shared/photoStorageService.ts",
+    "supabase/functions/_shared/photoStorageService.test.ts",
+    "supabase/functions/backfill-place-photos/index.ts",
+    "supabase/functions/backfill-place-photos/index.test.ts",
+  ];
   const ALLOWLIST = [
+    ...ORCH_1024_BACKEND_ALLOWLIST,
     ...ORCH_1021_BACKEND_ALLOWLIST,
     ...ORCH_1018_BACKEND_ALLOWLIST,
     ...ORCH_1017_BACKEND_ALLOWLIST,

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1024_PHOTO_ORIGINALS_ONLY_THUMBNAIL_TAB.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1024_PHOTO_ORIGINALS_ONLY_THUMBNAIL_TAB.md
@@ -1,0 +1,273 @@
+# IMPLEMENTATION — ORCH-1024 [Photo backfill originals-only + separate thumbnail tab]
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1024-[photo-originals-thumbnail-tab]/`
+**Branch:** `ORCH-1024-photo-originals-thumbnail-tab`
+**Status:** implemented and verified (no deploy)
+**Date:** 2026-05-31
+
+---
+
+## 1. Plain-English summary
+
+The admin "Download Photos" backfill was crashing Supabase with "not enough compute
+resources." Cause: ORCH-0957 had bolted inline thumbnail generation (decode → resize →
+re-encode every downloaded image, up to 50 per invocation) onto the photo-download hot
+path. This ORCH restores the pre-ORCH-0957 behavior: the main backfill now **downloads and
+stores ORIGINALS ONLY** — no decode, no resize, no thumbnail upload — which is light enough
+to run without exhausting compute.
+
+Thumbnail generation isn't lost; it moves to the already-existing, separate
+`backfill-place-photo-thumbs` edge function, now driven from a **new admin "Thumbnails"
+tab**. That tab runs a single GLOBAL job over every place that has stored originals but no
+thumbnail yet, with the same batch/pause/cancel/retry controls the Photos tab already has.
+
+The ORCH-1023 expired-photo-name REFRESH fix that was staged in this worktree is fully
+preserved.
+
+---
+
+## 2. Files changed
+
+| File | Surface | Change |
+|---|---|---|
+| `supabase/functions/_shared/photoStorageService.ts` | Backend (Edge) | Removed inline thumbnail generation; download/store ORIGINALS ONLY; decoupled `thumbs_backfilled_at` (no longer written) |
+| `supabase/functions/_shared/photoStorageService.test.ts` | Backend (Deno test) | Updated thumbnail assertions → originals-only; repurposed the thumb-fail test; `[TEST-MOD-APPROVED ORCH-1024]` |
+| `mingla-admin/src/pages/PlacePoolManagementPage.jsx` | Admin Web | New "Thumbnails" tab + `ThumbnailTab` component invoking `backfill-place-photo-thumbs`; Photos `active_runs` scoped to exclude the thumbs city marker |
+| `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` | CI gate | Added `ORCH_1024_BACKEND_ALLOWLIST` (4 backend files) spread into `ALLOWLIST` |
+
+**Kept untouched (staged ORCH-1023 work preserved):**
+`supabase/functions/backfill-place-photos/index.ts` and
+`supabase/functions/backfill-place-photos/index.test.ts` — the `fetchFreshPlacePhotos`
+refresh path + the `processBatch` process-path test still pass unchanged.
+
+---
+
+## 3. Thumbnail-removal + decoupling (exact)
+
+### `photoStorageService.ts`
+
+**Before:** In `attemptStorePhotos`, after uploading the original image, the function
+decoded the bytes with imagescript (`decode(new Uint8Array(imageData))`), and if the result
+was an `Image`, called `decoded.resize(THUMB_SIZE, THUMB_SIZE)` +
+`decoded.encodeJPEG(THUMB_JPEG_QUALITY)` and uploaded `${safePlaceId}/${i}_thumb.jpg`. It
+tracked `allUploadedThumbsSucceeded` and pushed `stage:'thumb'` failures on
+decode/upload/non-image. `updateStoredPhotoUrls` accepted an
+`allUploadedThumbsSucceeded` argument and wrote `thumbs_backfilled_at = now()` when all
+thumbs succeeded, alongside `stored_photo_urls`.
+
+**After:**
+- The entire thumbnail block (the `const thumbPath = …` through its full `try/catch` with
+  `decode`, `resize`, `encodeJPEG`, `_thumb.jpg` upload) is **deleted**. The original-image
+  download → `upload(${i}.${ext})` → `getPublicUrl` → `storedUrls.push(...)` is unchanged.
+- `allUploadedThumbsSucceeded` is removed entirely: the local var in `attemptStorePhotos`,
+  the `AttemptResult` interface field, and both return sites.
+- `updateStoredPhotoUrls` drops the `allUploadedThumbsSucceeded` parameter and now writes
+  **only** `{ stored_photo_urls: storedUrls }` — it never writes `thumbs_backfilled_at`.
+  Both call sites in `downloadAndStorePhotosWithDiagnostics` (cached path + refresh path)
+  drop the removed argument.
+- Removed imports/constants: `import { Image, decode } from ".../imagescript@1.2.17/mod.ts"`,
+  `THUMB_SIZE`, `THUMB_JPEG_QUALITY`. Verified no remaining references (grep clean).
+- `MAX_PHOTOS = 5` unchanged. The full refresh path (`fetchFreshPlacePhotos` +
+  `shouldRefreshPhotoNames` routing) unchanged.
+
+The `PhotoBackfillFailureStage` union still lists `'thumb'` as a harmless, now-unproduced
+member; no code path emits it. Left in place to avoid an unrelated type churn; the
+diagnostics shape is otherwise untouched.
+
+### The critical decoupling
+
+Leaving `thumbs_backfilled_at` **NULL** on every freshly-downloaded place is exactly what
+lets the separate thumbs pass pick those places up. The `backfill-place-photo-thumbs`
+function's pending-place query selects places with originals but no
+`thumbs_backfilled_at`; because the originals path no longer stamps that column, the global
+thumbs run will always see newly-downloaded places as pending.
+
+---
+
+## 4. New admin "Thumbnails" tab + run-attribution
+
+`ThumbnailTab` is a clone of `PhotoTab`'s job runner with these differences:
+
+- **Invokes `backfill-place-photo-thumbs`** (not `backfill-place-photos`). Same action
+  surface: `preview_run`, `create_run`, `run_next_batch`, `run_status`, `active_runs`,
+  `pause_run`, `resume_run`, `cancel_run`, `retry_batch`, `skip_batch`. Same admin auth.
+- **GLOBAL run — no city.** No `scope`/`registeredCity` props. `create_run` and
+  `preview_run` send no `cityId`/`city`/`country`. `preview_run` returns `totalPlaces`
+  (pending count); `create_run` returns `totalPlaces`/`totalBatches`.
+- **estimatedCost always $0** — surfaced as a static "$0.00" StatCard; no Google calls
+  (thumbnails are generated from already-stored originals).
+- **Surfaces** pending count, Run All / Run Next / Pause / Cancel, batch progress bar,
+  per-batch succeeded/failed/skipped, and `thumbsWritten` / `thumbsAlreadyPresent`
+  accumulated from `run_next_batch` responses (shown as StatCards + in the active-run
+  stats row when present).
+- Reuses existing `Tabs`, `StatCard`, `SectionCard`, `Button`, `useToast`, `formatCount`,
+  and the `stopAutoRef` auto-run loop pattern. No new dependencies. `Image as ImageIcon`
+  added to the existing lucide import.
+
+### Run-attribution handling (shared `photo_backfill_runs` table)
+
+Both functions write to `photo_backfill_runs`. Thumbnail runs are tagged
+`city = 'ORCH-0957 place-photo thumbs'` (`RUN_CITY`) / `country = 'GLOBAL'`.
+
+- **Thumbnails panel binds only to thumbnail runs:** the
+  `backfill-place-photo-thumbs` function's own `handleActiveRuns` already filters
+  `.eq('city', RUN_CITY).eq('country', RUN_COUNTRY)`, so `ThumbnailTab` only ever sees the
+  single global thumbs run.
+- **Photos panel is NOT disrupted by thumbnail runs:** the `backfill-place-photos`
+  function's `handleActiveRuns` returns ALL `ready/running/paused` runs with no city
+  filter, so a thumbs run WOULD otherwise leak into the Photos status bar. Fixed at the
+  admin layer (no edge-function edit, no deploy risk): a `THUMBS_RUN_CITY` constant guards
+  three feed points that drive the Photos status bar —
+  (1) the page-level mount hydration that sets `activePhotoRuns`,
+  (2) `PhotoTab.refreshActiveRuns`,
+  (3) `PhotoTab`'s mount-effect `onActiveRunsChange` + the `match` finder —
+  each now `.filter((r) => r?.run?.city !== THUMBS_RUN_CITY)`. The existing per-city
+  `match` already keyed on real city/country, so binding was already safe; the filter
+  hardens the visible status bar against ever rendering a thumbs run.
+
+The Photos tab otherwise renders identically (verified by `vite build` compile + unchanged
+Photos code paths).
+
+---
+
+## 5. Strict-grep allowlist (Task 4)
+
+Added `ORCH_1024_BACKEND_ALLOWLIST` to
+`.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` listing every
+`supabase/functions/**` file this ORCH touches:
+
+- `supabase/functions/_shared/photoStorageService.ts`
+- `supabase/functions/_shared/photoStorageService.test.ts`
+- `supabase/functions/backfill-place-photos/index.ts`
+- `supabase/functions/backfill-place-photos/index.test.ts`
+
+Spread into the `ALLOWLIST` array (first entry). The admin `.jsx` is correctly NOT added
+(not under C7's `supabase/**` scope). Verified all four covered + spread present.
+(`photoStorageService.ts`/`.test.ts` were already in `ORCH_0957_BACKEND_ALLOWLIST`; the
+two `backfill-place-photos` files were not in any list — the new allowlist clears them.)
+
+---
+
+## 6. Spec traceability
+
+| Task | Requirement | Status |
+|---|---|---|
+| 1 | Delete inline thumbnail block in `attemptStorePhotos` | ✅ deleted |
+| 1 | Remove `allUploadedThumbsSucceeded` (var + interface field + returns) | ✅ removed |
+| 1 | `updateStoredPhotoUrls` drops param + stops writing `thumbs_backfilled_at` (writes only `stored_photo_urls`) | ✅ |
+| 1 | Update caller to drop removed arg (both call sites) | ✅ |
+| 1 | Remove imagescript import + `THUMB_SIZE`/`THUMB_JPEG_QUALITY`; verify no refs | ✅ grep clean |
+| 1 | Keep `MAX_PHOTOS = 5` + entire refresh path | ✅ unchanged |
+| 2 | "writes original, thumb, thumbs_backfilled_at" → originals-only assertions | ✅ |
+| 2 | refresh test uploads → originals-only | ✅ |
+| 2 | repurpose/remove "leaves thumbs_backfilled_at unset" test | ✅ repurposed (non-decodable bytes still store original, no decode path) |
+| 2 | keep refresh/diagnostic tests intact | ✅ |
+| 2 | `[TEST-MOD-APPROVED ORCH-1024]` in commit body | ⏳ to be added at commit time |
+| 3 | New `thumbnails` tab invoking `backfill-place-photo-thumbs` | ✅ |
+| 3 | No `cityId`; `create_run` no city args; estimatedCost $0 | ✅ |
+| 3 | pending count, Run All/pause/cancel, batch progress, per-batch counts, thumbsWritten/thumbsAlreadyPresent | ✅ |
+| 3 | Thumbnails panel binds only to thumbnail runs; Photos panel not disrupted | ✅ |
+| 3 | Match existing styling/components; reuse helpers; no new deps | ✅ |
+| 4 | `ORCH_1024_BACKEND_ALLOWLIST` with 4 backend files, spread into ALLOWLIST; admin .jsx NOT added | ✅ |
+
+---
+
+## 7. Regression test
+
+- **Path:** `supabase/functions/_shared/photoStorageService.test.ts`
+- **Passing run:** `9 passed | 0 failed` (7 shared-service + 2 backfill process-path) via
+  `deno test --allow-all supabase/functions/_shared/photoStorageService.test.ts supabase/functions/backfill-place-photos/index.test.ts`.
+- **Fails-on-revert verified:** ran the NEW ORCH-1024 tests against the pre-edit
+  (thumb-generating) staged source — `FAILED | 5 passed | 2 failed`. The two failures are
+  exactly the originals-only assertions: expected uploads `["ChIJfresh/0.jpg"]` but the old
+  source uploaded `["ChIJfresh/0.jpg", "ChIJfresh/0_thumb.jpg"]`. This proves the tests
+  genuinely exercise the behavior change. Source then restored; gates green again.
+
+---
+
+## 8. Gate outputs
+
+### `deno check` (4 files)
+```
+$ deno check supabase/functions/_shared/photoStorageService.ts \
+    supabase/functions/backfill-place-photos/index.ts \
+    supabase/functions/backfill-place-photos/index.test.ts \
+    supabase/functions/_shared/photoStorageService.test.ts
+(no output — exit 0)
+```
+
+### `deno test` (2 files)
+```
+$ deno test --allow-all supabase/functions/_shared/photoStorageService.test.ts \
+    supabase/functions/backfill-place-photos/index.test.ts
+running 2 tests from ./supabase/functions/backfill-place-photos/index.test.ts
+processBatch: retryable provider pressure ... ok
+processBatch: non-retryable exhaustion ... ok
+running 7 tests from ./supabase/functions/_shared/photoStorageService.test.ts
+downloadAndStorePhotos writes ONLY the original (no thumb, no thumbs_backfilled_at) ... ok
+downloadAndStorePhotosWithDiagnostics refreshes expired cached names ... ok
+downloadAndStorePhotosWithDiagnostics does not refresh on retryable provider pressure ... ok
+downloadAndStorePhotosWithDiagnostics returns structured details refresh failure ... ok
+fetchFreshPlacePhotos normalizes places/ IDs ... ok
+photoBackfillFailureSummary treats post-refresh provider pressure as retryable ... ok
+downloadAndStorePhotos stores the original even for non-decodable bytes ... ok
+ok | 9 passed | 0 failed (568ms)
+```
+
+### strict-grep gate
+```
+$ node .github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+OK [C1..C6] ...
+OK [C7: no-new-backend-files] zero touches under supabase/migrations/ or supabase/functions/
+# All checks PASS  (exit 0)
+```
+(Self-test mode `--self-test` also passes.)
+
+### Admin build
+```
+$ npm run build   (mingla-admin/, vite v7.3.1)
+✓ 2940 modules transformed.
+✓ built in 5.56s   (exit 0)
+```
+Page compiles. ESLint on the page reports 18 problems vs 17 on the main baseline — the +1
+`set-state-in-effect` and +1 `exhaustive-deps` are faithful clones of the existing
+`PhotoTab` mount-effect convention already present (and already flagged) throughout this
+file; not new error patterns. `vite build` is the real compile gate and is clean.
+
+---
+
+## 9. Cross-surface note
+
+| Surface | Affected? | Why |
+|---|---|---|
+| Admin Web (`mingla-admin/`) | YES | New "Thumbnails" tab; Photos status-bar scoping |
+| Backend edge (`supabase/functions/_shared/photoStorageService.ts`) | YES | originals-only download path |
+| Consumer iOS / Android | No | consumes stored photo URLs; rendering unchanged (originals still stored at `${i}.${ext}`) |
+| Buyer/anon Web | No | no equivalent flow |
+| Business iOS / Android | No | no equivalent flow |
+| Business Web preview | No | no equivalent flow |
+
+Admin Web is the only touched UI surface. The thumbnail-consuming reader path
+(`imageCollage.ts` thumb fallback) is unaffected: originals are still stored at the same
+paths; thumbnails are now produced by the separate function on the new tab's run instead of
+inline, so thumbnail availability lags the originals download by one (admin-triggered)
+thumbs pass — which is the intended decoupling.
+
+---
+
+## 10. Discoveries for orchestrator
+
+- **`PhotoBackfillFailureStage` still lists `'thumb'`** as an unproduced union member. Left
+  intentionally to avoid type churn; a future cleanup could drop it once nothing references
+  the diagnostics `'thumb'` stage.
+- **The dispatch referenced an existing `ORCH_1023_BACKEND_ALLOWLIST`** in the strict-grep
+  file. It is NOT present in this worktree's copy of
+  `orch-0863-marketing-hub-phase-b.mjs` (the staged ORCH-1023 restore did not include a
+  strict-grep allowlist entry). This did not block ORCH-1024: the new
+  `ORCH_1024_BACKEND_ALLOWLIST` explicitly lists all four backend files (including the two
+  `backfill-place-photos` files the ORCH-1023 work touches), so the C7 gate is satisfied
+  for this branch regardless. Flagging in case ORCH-1023 was expected to carry its own
+  allowlist that got dropped.
+- **No deploy performed** (per dispatch). When this lands, the operator/orchestrator should
+  redeploy `backfill-place-photos` (originals-only) and confirm `backfill-place-photo-thumbs`
+  is deployed for the new tab to drive.

--- a/mingla-admin/src/pages/PlacePoolManagementPage.jsx
+++ b/mingla-admin/src/pages/PlacePoolManagementPage.jsx
@@ -18,6 +18,7 @@ import {
   ChevronDown, ChevronRight, AlertTriangle, CheckCircle,
   Download, ImageOff, Eye, Edit3, DollarSign, Layers,
   Square, SkipForward, XCircle, Loader, RotateCcw, Zap, MinusCircle,
+  Image as ImageIcon,
 } from "lucide-react";
 import { supabase } from "../lib/supabase";
 import { extractFunctionError } from "../lib/edgeFunctionError";
@@ -48,6 +49,14 @@ import { HARD_CAP_USD, formatCost, TILE_RADIUS_OPTIONS } from "../lib/seedingFor
 // HARD_CAP_USD + formatCost moved to lib/seedingFormat.js (shared with RefreshTab).
 
 const PRICE_TIERS = ["chill", "comfy", "bougie", "lavish"];
+
+// ORCH-1024 — thumbnail backfill runs share the `photo_backfill_runs` table with
+// the originals-download runs but are tagged with this synthetic city marker
+// (the `backfill-place-photo-thumbs` function's RUN_CITY). The Photos panel must
+// EXCLUDE these so a global thumbs run never appears as a city download run; the
+// Thumbnails panel binds to `backfill-place-photo-thumbs` whose own active_runs
+// already filters to exactly this marker.
+const THUMBS_RUN_CITY = "ORCH-0957 place-photo thumbs";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -1474,7 +1483,10 @@ function PhotoTab({ scope, registeredCity: regCity, onActiveRunsChange }) {
   const refreshActiveRuns = async () => {
     try {
       const data = await invoke({ action: "active_runs" });
-      if (onActiveRunsChange) onActiveRunsChange(data.runs || []);
+      // ORCH-1024: never surface thumbnail runs in the originals (Photos) status bar.
+      if (onActiveRunsChange) {
+        onActiveRunsChange((data.runs || []).filter((r) => r?.run?.city !== THUMBS_RUN_CITY));
+      }
     } catch { /* ignore */ }
   };
 
@@ -1544,8 +1556,10 @@ function PhotoTab({ scope, registeredCity: regCity, onActiveRunsChange }) {
       try {
         const data = await invoke({ action: "active_runs" });
         if (cancelled) return;
-        if (onActiveRunsChange) onActiveRunsChange(data.runs || []);
-        const match = (data.runs || []).find(
+        // ORCH-1024: thumbnail runs share the table; keep them out of the Photos status bar.
+        const cityRuns = (data.runs || []).filter((r) => r?.run?.city !== THUMBS_RUN_CITY);
+        if (onActiveRunsChange) onActiveRunsChange(cityRuns);
+        const match = cityRuns.find(
           (r) => r.run.city === cityTextName && r.run.country === countryTextName
         );
         if (match) {
@@ -2029,6 +2043,430 @@ function PhotoTab({ scope, registeredCity: regCity, onActiveRunsChange }) {
 }
 
 
+// ── Thumbnails Tab (ORCH-1024) ───────────────────────────────────────────────
+// Clones the PhotoTab job runner but drives the SEPARATE
+// `backfill-place-photo-thumbs` edge function. This is a GLOBAL run over every
+// place that has stored originals but no thumbnails (no city scoping). Moving
+// thumbnail generation off the originals-download hot path is what keeps the main
+// `backfill-place-photos` function from crashing with "not enough compute
+// resources" (ORCH-0957 had inlined imagescript decode/resize/encode). Same
+// admin auth + same action surface (preview_run / create_run / run_next_batch /
+// run_status / active_runs / pause_run / resume_run / cancel_run / retry_batch /
+// skip_batch). estimatedCost is always $0; create_run takes no city/country args.
+
+function ThumbnailTab() {
+  const { addToast } = useToast();
+  const mountedRef = useRef(true);
+  useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false; }; }, []);
+
+  const [loading, setLoading] = useState(false);
+  const [pendingCount, setPendingCount] = useState(null);
+
+  const [activeRun, setActiveRun] = useState(null);
+  const [batches, setBatches] = useState([]);
+  const [runningBatch, setRunningBatch] = useState(false);
+  const [autoRunning, setAutoRunning] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [expandedBatch, setExpandedBatch] = useState(null);
+  // Aggregate thumbnail counters surfaced by run_next_batch responses.
+  const [thumbsWritten, setThumbsWritten] = useState(0);
+  const [thumbsAlreadyPresent, setThumbsAlreadyPresent] = useState(0);
+  const stopAutoRef = useRef(false);
+
+  const invoke = async (body) => {
+    const { data, error } = await supabase.functions.invoke("backfill-place-photo-thumbs", { body });
+    if (error) {
+      const msg = await extractFunctionError(error, "Edge function error");
+      throw new Error(msg);
+    }
+    if (data?.error) throw new Error(data.error);
+    return data;
+  };
+
+  // Accumulate per-batch thumb counters when the function reports them.
+  const accumulateThumbCounters = (data) => {
+    if (data && typeof data.thumbsWritten === "number") {
+      setThumbsWritten((prev) => prev + data.thumbsWritten);
+    }
+    if (data && typeof data.thumbsAlreadyPresent === "number") {
+      setThumbsAlreadyPresent((prev) => prev + data.thumbsAlreadyPresent);
+    }
+  };
+
+  // ── Pending preview (totalPlaces = places with originals but no thumbs) ─────
+
+  const fetchPreview = async () => {
+    try {
+      const data = await invoke({ action: "preview_run" });
+      if (mountedRef.current) setPendingCount(Number(data.totalPlaces) || 0);
+    } catch {
+      if (mountedRef.current) setPendingCount(null);
+    }
+  };
+
+  // ── Hydrate the (single, global) active thumbnail run on mount ─────────────
+
+  useEffect(() => {
+    setLoading(true);
+    let cancelled = false;
+    (async () => {
+      await fetchPreview();
+      try {
+        const data = await invoke({ action: "active_runs" });
+        if (cancelled) return;
+        const match = (data.runs || [])[0];
+        if (match) {
+          const status = await invoke({ action: "run_status", runId: match.id });
+          if (!cancelled) { setActiveRun(status.run); setBatches(status.batches || []); }
+        } else if (!cancelled) {
+          setActiveRun(null); setBatches([]);
+        }
+      } catch { /* ignore */ }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // ── Create run (global — no city/country args) ─────────────────────────────
+
+  const handleCreateRun = async () => {
+    setCreating(true);
+    try {
+      const data = await invoke({ action: "create_run" });
+      if (data.status === "nothing_to_do") {
+        addToast({ variant: "info", title: "No thumbnails to generate", description: "Every place with originals already has thumbnails." });
+        await fetchPreview();
+        setCreating(false);
+        return;
+      }
+      if (data.status === "already_active") {
+        const status = await invoke({ action: "run_status", runId: data.runId });
+        setActiveRun(status.run); setBatches(status.batches || []);
+        setCreating(false);
+        return;
+      }
+      const status = await invoke({ action: "run_status", runId: data.runId });
+      setActiveRun(status.run); setBatches(status.batches || []);
+      addToast({
+        variant: "success",
+        title: "Thumbnail run created",
+        description: `${formatCount(data.totalPlaces)} places, ${formatCount(data.totalBatches)} batches`,
+      });
+      await fetchPreview();
+    } catch (err) {
+      console.error("[ThumbnailBackfill] create run error:", err);
+      addToast({ variant: "error", title: "Failed to create run", description: err.message });
+    }
+    setCreating(false);
+  };
+
+  // ── Run Next Batch ─────────────────────────────────────────────────────────
+
+  const handleRunNext = async () => {
+    if (!activeRun || runningBatch) return;
+    setRunningBatch(true);
+    try {
+      const data = await invoke({ action: "run_next_batch", runId: activeRun.id });
+      accumulateThumbCounters(data);
+      if (data.done) addToast({ variant: "success", title: "All batches complete!" });
+      const status = await invoke({ action: "run_status", runId: activeRun.id });
+      setActiveRun(status.run); setBatches(status.batches || []);
+    } catch (err) {
+      addToast({ variant: "error", title: "Batch failed", description: err.message });
+    }
+    setRunningBatch(false);
+    await fetchPreview();
+  };
+
+  // ── Run All (auto-advance) ─────────────────────────────────────────────────
+
+  const handleRunAll = async () => {
+    if (!activeRun) return;
+    setAutoRunning(true);
+    stopAutoRef.current = false;
+
+    try {
+      if (activeRun.status === "paused") {
+        await invoke({ action: "resume_run", runId: activeRun.id });
+      }
+    } catch { /* ignore */ }
+
+    while (!stopAutoRef.current && mountedRef.current) {
+      try {
+        setRunningBatch(true);
+        const data = await invoke({ action: "run_next_batch", runId: activeRun.id });
+        accumulateThumbCounters(data);
+        setRunningBatch(false);
+
+        const status = await invoke({ action: "run_status", runId: activeRun.id });
+        if (mountedRef.current) { setActiveRun(status.run); setBatches(status.batches || []); }
+
+        if (data.done) {
+          addToast({ variant: "success", title: "All batches complete!" });
+          break;
+        }
+        if (stopAutoRef.current) {
+          addToast({ variant: "info", title: "Auto-run paused" });
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      } catch (err) {
+        setRunningBatch(false);
+        try { await invoke({ action: "pause_run", runId: activeRun.id }); } catch { /* ignore */ }
+        addToast({ variant: "error", title: "Batch failed — auto-run paused", description: err.message });
+        try {
+          const status = await invoke({ action: "run_status", runId: activeRun.id });
+          if (mountedRef.current) { setActiveRun(status.run); setBatches(status.batches || []); }
+        } catch { /* ignore */ }
+        break;
+      }
+    }
+
+    setAutoRunning(false);
+    setRunningBatch(false);
+    await fetchPreview();
+  };
+
+  // ── Pause / Cancel / Retry / Skip / Dismiss ────────────────────────────────
+
+  const handlePause = async () => {
+    stopAutoRef.current = true;
+    try {
+      await invoke({ action: "pause_run", runId: activeRun.id });
+      const status = await invoke({ action: "run_status", runId: activeRun.id });
+      setActiveRun(status.run); setBatches(status.batches || []);
+    } catch (err) {
+      addToast({ variant: "error", title: "Pause failed", description: err.message });
+    }
+  };
+
+  const handleCancel = async () => {
+    stopAutoRef.current = true;
+    try {
+      await invoke({ action: "cancel_run", runId: activeRun.id });
+      const status = await invoke({ action: "run_status", runId: activeRun.id });
+      setActiveRun(status.run); setBatches(status.batches || []);
+      addToast({ variant: "info", title: "Run cancelled" });
+    } catch (err) {
+      addToast({ variant: "error", title: "Cancel failed", description: err.message });
+    }
+  };
+
+  const handleRetryBatch = async (batchId) => {
+    setRunningBatch(true);
+    try {
+      await invoke({ action: "retry_batch", runId: activeRun.id, batchId });
+      const status = await invoke({ action: "run_status", runId: activeRun.id });
+      setActiveRun(status.run); setBatches(status.batches || []);
+      addToast({ variant: "success", title: "Batch retried" });
+    } catch (err) {
+      addToast({ variant: "error", title: "Retry failed", description: err.message });
+    }
+    setRunningBatch(false);
+    await fetchPreview();
+  };
+
+  const handleSkipBatch = async (batchId) => {
+    try {
+      await invoke({ action: "skip_batch", runId: activeRun.id, batchId });
+      const status = await invoke({ action: "run_status", runId: activeRun.id });
+      setActiveRun(status.run); setBatches(status.batches || []);
+    } catch (err) {
+      addToast({ variant: "error", title: "Skip failed", description: err.message });
+    }
+  };
+
+  const handleDismiss = () => {
+    setActiveRun(null);
+    setBatches([]);
+    fetchPreview();
+  };
+
+  // ── Derived values ─────────────────────────────────────────────────────────
+
+  const runProgressPct = activeRun && activeRun.total_batches > 0
+    ? Math.round(((activeRun.completed_batches + activeRun.failed_batches + activeRun.skipped_batches) / activeRun.total_batches) * 100)
+    : 0;
+  const isTerminal = activeRun && ["completed", "cancelled", "failed"].includes(activeRun.status);
+  const canRunNext = activeRun && !isTerminal && !runningBatch && !autoRunning;
+  const canRunAll = activeRun && !isTerminal && !autoRunning;
+  const canCancel = activeRun && !isTerminal;
+
+  const statusColors = {
+    ready: "bg-blue-100 text-blue-800",
+    running: "bg-green-100 text-green-800",
+    paused: "bg-yellow-100 text-yellow-800",
+    completed: "bg-green-100 text-green-800",
+    cancelled: "bg-gray-100 text-gray-600",
+    failed: "bg-red-100 text-red-800",
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Stats */}
+      <div className="grid grid-cols-4 gap-4">
+        <StatCard icon={ImageIcon} label="Pending Thumbnails" value={pendingCount ?? "—"} />
+        <StatCard icon={CheckCircle} label="Thumbs Written" value={formatCount(thumbsWritten)} />
+        <StatCard icon={Layers} label="Already Present" value={formatCount(thumbsAlreadyPresent)} />
+        <StatCard icon={DollarSign} label="Est. Cost" value="$0.00" />
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 py-4 text-sm text-[var(--color-text-secondary)]">
+          <Loader className="w-4 h-4 animate-spin" /> Loading thumbnail status...
+        </div>
+      ) : !activeRun ? (
+        /* ── Phase 1: No active run ──────────────────────────────────── */
+        <SectionCard title="Generate Thumbnails"
+          subtitle="Creates 384×384 thumbnails for every place that has stored originals but no thumbnail yet. Global run — no city selection needed.">
+          {pendingCount === 0 ? (
+            <div className="py-4">
+              <div className="flex items-center gap-2 text-sm text-[var(--color-success-700)]">
+                <CheckCircle className="w-4 h-4" /> Every place with originals already has thumbnails.
+              </div>
+              <Button size="sm" variant="secondary" icon={RefreshCw} className="mt-3" onClick={fetchPreview}>
+                Re-check
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="rounded-lg p-4 bg-[var(--gray-50)]">
+                <div className="text-sm space-y-2">
+                  <div>
+                    <strong>{pendingCount === null ? "—" : formatCount(pendingCount)}</strong> places have originals but no thumbnails.
+                  </div>
+                  <div className="text-[var(--color-text-secondary)]">
+                    Thumbnails are generated from already-stored originals (no Google calls). Estimated cost: <strong>$0.00</strong>.
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button variant="primary" icon={ImageIcon} onClick={handleCreateRun} disabled={creating}>
+                  {creating
+                    ? "Creating..."
+                    : `Run All (${pendingCount === null ? "—" : formatCount(pendingCount)} places)`}
+                </Button>
+                <Button variant="secondary" icon={RefreshCw} onClick={fetchPreview} size="sm">
+                  Re-check
+                </Button>
+              </div>
+            </div>
+          )}
+        </SectionCard>
+      ) : (
+        /* ── Phase 2: Active run ─────────────────────────────────────── */
+        <div className="space-y-4">
+          <SectionCard title="Thumbnail Generation"
+            badge={<span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusColors[activeRun.status] || ""}`}>{activeRun.status}</span>}>
+            <div className="space-y-4">
+              <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+                <span>{activeRun.completed_batches + activeRun.failed_batches + activeRun.skipped_batches}/{activeRun.total_batches} batches</span>
+                <span className="text-[var(--color-success-700)]">{activeRun.total_succeeded} succeeded</span>
+                {activeRun.total_failed > 0 && <span className="text-[var(--color-error-700)]">{activeRun.total_failed} failed</span>}
+                {activeRun.total_skipped > 0 && <span className="text-[var(--color-text-secondary)]">{activeRun.total_skipped} skipped</span>}
+                {thumbsWritten > 0 && <span>{formatCount(thumbsWritten)} thumbs written</span>}
+                {thumbsAlreadyPresent > 0 && <span className="text-[var(--color-text-secondary)]">{formatCount(thumbsAlreadyPresent)} already present</span>}
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="flex-1 bg-[var(--gray-100)] rounded-full h-3 overflow-hidden">
+                  <div className="h-full rounded-full bg-[var(--color-brand-500)] transition-all duration-500"
+                    style={{ width: `${runProgressPct}%` }} />
+                </div>
+                <span className="text-sm font-medium w-12 text-right">{runProgressPct}%</span>
+              </div>
+
+              <div className="flex gap-2">
+                {isTerminal ? (
+                  <Button variant="secondary" onClick={handleDismiss}>Dismiss</Button>
+                ) : autoRunning ? (
+                  <>
+                    <Button variant="secondary" icon={Pause} onClick={handlePause}>Pause</Button>
+                    <Button variant="secondary" icon={XCircle} onClick={handleCancel}>Cancel</Button>
+                  </>
+                ) : (
+                  <>
+                    <Button variant="primary" icon={Play} onClick={handleRunNext} disabled={!canRunNext}>
+                      {runningBatch ? "Running..." : "Run Next"}
+                    </Button>
+                    <Button variant="secondary" icon={Zap} onClick={handleRunAll} disabled={!canRunAll}>
+                      Run All
+                    </Button>
+                    <Button variant="secondary" icon={XCircle} onClick={handleCancel} disabled={!canCancel}>
+                      Cancel
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          </SectionCard>
+
+          <SectionCard title="Batches" subtitle={`${batches.length} total`}>
+            <div className="divide-y divide-[var(--color-border)]">
+              {batches.map((b) => {
+                const isExpanded = expandedBatch === b.id;
+                const hasFailed = b.failed_places && b.failed_places.length > 0;
+                return (
+                  <div key={b.id} className="py-2">
+                    <div className="flex items-center gap-3 text-sm">
+                      {b.status === "pending" && <span className="w-4 h-4 rounded-full bg-gray-300 inline-block" />}
+                      {b.status === "running" && <Loader className="w-4 h-4 animate-spin text-[var(--color-brand-600)]" />}
+                      {b.status === "completed" && <CheckCircle className="w-4 h-4 text-[var(--color-success-700)]" />}
+                      {b.status === "failed" && <XCircle className="w-4 h-4 text-[var(--color-error-700)]" />}
+                      {b.status === "skipped" && <MinusCircle className="w-4 h-4 text-gray-400" />}
+
+                      <span className="font-medium">Batch {b.batch_index + 1}</span>
+
+                      {b.status === "pending" && <span className="text-[var(--color-text-secondary)]">{b.place_count} places</span>}
+                      {b.status === "running" && <span className="text-[var(--color-brand-600)]">processing...</span>}
+                      {b.status === "completed" && (
+                        <span className="text-[var(--color-text-secondary)]">
+                          {b.succeeded} succeeded{b.failed > 0 ? `, ${b.failed} failed` : ""}{b.skipped > 0 ? `, ${b.skipped} skipped` : ""}
+                        </span>
+                      )}
+                      {b.status === "failed" && <span className="text-[var(--color-error-700)]">all {b.place_count} failed</span>}
+                      {b.status === "skipped" && <span className="text-gray-400">skipped</span>}
+
+                      {b.status === "failed" && !isTerminal && (
+                        <div className="ml-auto flex gap-1">
+                          <Button size="xs" variant="secondary" icon={RotateCcw} onClick={() => handleRetryBatch(b.id)} disabled={runningBatch}>
+                            Retry
+                          </Button>
+                          <Button size="xs" variant="secondary" icon={SkipForward} onClick={() => handleSkipBatch(b.id)}>
+                            Skip
+                          </Button>
+                        </div>
+                      )}
+
+                      {hasFailed && b.status !== "pending" && (
+                        <button className="ml-auto p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+                          onClick={() => setExpandedBatch(isExpanded ? null : b.id)}>
+                          {isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                        </button>
+                      )}
+                    </div>
+
+                    {isExpanded && hasFailed && (
+                      <div className="mt-2 ml-7 space-y-1">
+                        {b.failed_places.map((fp, i) => (
+                          <div key={i} className="text-xs text-[var(--color-error-700)] bg-red-50 rounded px-2 py-1">
+                            <span className="font-mono">{fp.googlePlaceId || fp.placePoolId}</span>
+                            {fp.error && <span className="ml-2 text-[var(--color-text-secondary)]">— {fp.error}</span>}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </SectionCard>
+        </div>
+      )}
+    </div>
+  );
+}
+
 
 // ── Tab 6: Stats & Analytics ─────────────────────────────────────────────────
 
@@ -2472,7 +2910,13 @@ export function PlacePoolManagementPage({ onTabChange }) {
   // Hydrate photo backfill active runs on mount
   useEffect(() => {
     supabase.functions.invoke("backfill-place-photos", { body: { action: "active_runs" } })
-      .then(({ data }) => { if (mountedRef.current && data?.runs) setActivePhotoRuns(data.runs); })
+      .then(({ data }) => {
+        if (mountedRef.current && data?.runs) {
+          // ORCH-1024: exclude thumbnail runs (shared table, synthetic city marker)
+          // so the Photos status bar only ever shows real city download runs.
+          setActivePhotoRuns(data.runs.filter((r) => r?.run?.city !== THUMBS_RUN_CITY));
+        }
+      })
       .catch(() => {});
   }, []);
 
@@ -2517,6 +2961,7 @@ export function PlacePoolManagementPage({ onTabChange }) {
     { id: "seeding", label: "Seeding" },
     { id: "refresh", label: "Refresh" },
     { id: "photos", label: "Photos" },
+    { id: "thumbnails", label: "Thumbnails" },
     { id: "excluded", label: "Bouncer-Excluded" },
   ];
 
@@ -2630,6 +3075,10 @@ export function PlacePoolManagementPage({ onTabChange }) {
           ) : (
             <div className="text-center py-12 text-[var(--color-text-secondary)]">Select a city to manage photos.</div>
           )
+        )}
+        {activeTab === "thumbnails" && (
+          /* ORCH-1024: global thumbnail backfill — no city scope required. */
+          <ThumbnailTab />
         )}
         {activeTab === "excluded" && (
           <ExcludedTab scope={scope} onRefresh={refresh} />

--- a/supabase/functions/_shared/photoStorageService.test.ts
+++ b/supabase/functions/_shared/photoStorageService.test.ts
@@ -1,14 +1,23 @@
 import { Image } from "https://deno.land/x/imagescript@1.2.17/mod.ts";
 import { assertEquals, assertExists } from "https://deno.land/std@0.168.0/testing/asserts.ts";
-import { downloadAndStorePhotos } from "./photoStorageService.ts";
+import {
+  downloadAndStorePhotos,
+  downloadAndStorePhotosWithDiagnostics,
+  fetchFreshPlacePhotos,
+  formatPhotoBackfillFailedPlace,
+  photoBackfillFailureSummary,
+  type PhotoBackfillDiagnosticResult,
+} from "./photoStorageService.ts";
 
 function createSupabaseMock() {
   const uploads: Array<{ path: string; body: unknown; options: Record<string, unknown> }> = [];
   const updates: Array<Record<string, unknown>> = [];
+  const updateFilters: Array<{ column: string; value: string }> = [];
 
   return {
     uploads,
     updates,
+    updateFilters,
     client: {
       storage: {
         from(bucket: string) {
@@ -36,7 +45,7 @@ function createSupabaseMock() {
             return {
               eq(column: string, value: string) {
                 assertEquals(column, "google_place_id");
-                assertEquals(value, "place:abc");
+                updateFilters.push({ column, value });
                 return Promise.resolve({ error: null });
               },
             };
@@ -57,7 +66,14 @@ function bodyFrom(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
-Deno.test("downloadAndStorePhotos writes original, thumb, and thumbs_backfilled_at on successful thumb generation", async () => {
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+Deno.test("downloadAndStorePhotos writes ONLY the original (no thumb, no thumbs_backfilled_at)", async () => {
   const priorFetch = globalThis.fetch;
   const jpeg = await makeJpegBytes();
   globalThis.fetch = () => Promise.resolve(new Response(bodyFrom(jpeg), {
@@ -75,16 +91,212 @@ Deno.test("downloadAndStorePhotos writes original, thumb, and thumbs_backfilled_
     );
 
     assertEquals(urls, ["https://x.supabase.co/storage/v1/object/public/place-photos/place_abc/0.jpg"]);
-    assertEquals(mock.uploads.map((u) => u.path), ["place_abc/0.jpg", "place_abc/0_thumb.jpg"]);
-    assertEquals(mock.uploads[1].options.contentType, "image/jpeg");
-    assertEquals(mock.uploads[1].options.upsert, true);
-    assertExists(mock.updates[0].thumbs_backfilled_at);
+    // ORCH-1024: originals-only — exactly one upload (the original), no _thumb.jpg.
+    assertEquals(mock.uploads.map((u) => u.path), ["place_abc/0.jpg"]);
+    assertEquals(mock.uploads.length, 1);
+    assertEquals(mock.uploads[0].options.upsert, true);
+    // ORCH-1024: decoupling — update writes ONLY stored_photo_urls, never thumbs_backfilled_at.
+    assertEquals(mock.updates[0].stored_photo_urls, urls);
+    assertEquals("thumbs_backfilled_at" in mock.updates[0], false);
   } finally {
     globalThis.fetch = priorFetch;
   }
 });
 
-Deno.test("downloadAndStorePhotos leaves thumbs_backfilled_at unset when thumb generation fails after original upload", async () => {
+Deno.test("downloadAndStorePhotosWithDiagnostics refreshes expired cached names through Place Details and stores fresh media", async () => {
+  const priorFetch = globalThis.fetch;
+  const calls: Array<{ url: string; headers?: HeadersInit }> = [];
+  const jpeg = await makeJpegBytes();
+  globalThis.fetch = (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, headers: init?.headers });
+    if (url.includes("/photos/old/media")) {
+      return Promise.resolve(jsonResponse({
+        error: { status: "INVALID_ARGUMENT", message: "Photo name has expired" },
+      }, 400));
+    }
+    if (url === "https://places.googleapis.com/v1/places/ChIJfresh") {
+      const headers = new Headers(init?.headers);
+      assertEquals(headers.get("X-Goog-Api-Key"), "api-key");
+      assertEquals(headers.get("X-Goog-FieldMask"), "id,photos");
+      return Promise.resolve(jsonResponse({
+        id: "ChIJfresh",
+        photos: [{ name: "places/ChIJfresh/photos/fresh", widthPx: 800, heightPx: 600 }],
+      }));
+    }
+    if (url.includes("/photos/fresh/media")) {
+      return Promise.resolve(new Response(bodyFrom(jpeg), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }));
+    }
+    return Promise.resolve(jsonResponse({ error: "unexpected URL" }, 500));
+  };
+
+  try {
+    const mock = createSupabaseMock();
+    const result = await downloadAndStorePhotosWithDiagnostics(
+      mock.client as any,
+      "ChIJfresh",
+      [{ name: "places/ChIJfresh/photos/old" }],
+      "api-key",
+      { delayBetweenPhotosMs: 0, rateLimitDelayMs: 0 },
+    );
+
+    assertEquals(result.storedUrls, ["https://x.supabase.co/storage/v1/object/public/place-photos/ChIJfresh/0.jpg"]);
+    assertEquals(result.refreshed, true);
+    assertEquals(result.freshPhotoCount, 1);
+    assertEquals(calls.map((c) => c.url), [
+      "https://places.googleapis.com/v1/places/ChIJfresh/photos/old/media?maxWidthPx=800&key=api-key",
+      "https://places.googleapis.com/v1/places/ChIJfresh",
+      "https://places.googleapis.com/v1/places/ChIJfresh/photos/fresh/media?maxWidthPx=800&key=api-key",
+    ]);
+    // ORCH-1024: originals-only — refreshed media uploads the original only, no _thumb.jpg.
+    assertEquals(mock.uploads.map((u) => u.path), ["ChIJfresh/0.jpg"]);
+    assertEquals(mock.updates[0].photos, [{ name: "places/ChIJfresh/photos/fresh", widthPx: 800, heightPx: 600 }]);
+    assertEquals(mock.updates[1].stored_photo_urls, result.storedUrls);
+    // ORCH-1024: decoupling — even on the refresh path, no thumbs_backfilled_at is written.
+    assertEquals("thumbs_backfilled_at" in mock.updates[1], false);
+    assertEquals(result.failures[0].code, "PHOTO_MEDIA_NAME_INVALID");
+  } finally {
+    globalThis.fetch = priorFetch;
+  }
+});
+
+Deno.test("downloadAndStorePhotosWithDiagnostics does not refresh on retryable provider pressure", async () => {
+  const priorFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = (input: URL | RequestInfo) => {
+    const url = String(input);
+    calls.push(url);
+    return Promise.resolve(jsonResponse({
+      error: { status: "RESOURCE_EXHAUSTED", message: "Rate limited" },
+    }, 429));
+  };
+
+  try {
+    const mock = createSupabaseMock();
+    const result = await downloadAndStorePhotosWithDiagnostics(
+      mock.client as any,
+      "place:abc",
+      [{ name: "places/abc/photos/1" }],
+      "api-key",
+      { delayBetweenPhotosMs: 0, rateLimitDelayMs: 0 },
+    );
+
+    assertEquals(result.storedUrls, []);
+    assertEquals(result.refreshed, false);
+    assertEquals(result.failures.length, 1);
+    assertEquals(result.failures[0].code, "PHOTO_MEDIA_RATE_LIMIT");
+    assertEquals(result.failures[0].retryable, true);
+    assertEquals(mock.updates.length, 0);
+    assertEquals(calls, ["https://places.googleapis.com/v1/places/abc/photos/1/media?maxWidthPx=800&key=api-key"]);
+  } finally {
+    globalThis.fetch = priorFetch;
+  }
+});
+
+Deno.test("downloadAndStorePhotosWithDiagnostics returns structured details refresh failure", async () => {
+  const priorFetch = globalThis.fetch;
+  globalThis.fetch = (input: URL | RequestInfo) => {
+    const url = String(input);
+    if (url.includes("/media")) {
+      return Promise.resolve(jsonResponse({
+        error: { status: "INVALID_ARGUMENT", message: "Photo name has expired" },
+      }, 400));
+    }
+    return Promise.resolve(jsonResponse({
+      error: { status: "PERMISSION_DENIED", message: "API key denied" },
+    }, 403));
+  };
+
+  try {
+    const mock = createSupabaseMock();
+    const result = await downloadAndStorePhotosWithDiagnostics(
+      mock.client as any,
+      "places/ChIJfresh",
+      [{ name: "places/ChIJfresh/photos/old" }],
+      "api-key",
+      { delayBetweenPhotosMs: 0, rateLimitDelayMs: 0 },
+    );
+
+    assertEquals(result.storedUrls, []);
+    assertEquals(result.refreshed, true);
+    assertEquals(result.freshPhotoCount, 0);
+    const detailsFailure = result.failures.find((failure) => failure.stage === "details_refresh");
+    assertExists(detailsFailure);
+    assertEquals(detailsFailure.status, 403);
+    assertEquals(detailsFailure.code, "PHOTO_DETAILS_REFRESH_FAILED");
+    assertEquals(detailsFailure.retryable, false);
+    assertEquals(mock.uploads.length, 0);
+  } finally {
+    globalThis.fetch = priorFetch;
+  }
+});
+
+Deno.test("fetchFreshPlacePhotos normalizes places/ IDs for Place Details URL", async () => {
+  const calls: string[] = [];
+  const fetchImpl = (input: URL | RequestInfo) => {
+    calls.push(String(input));
+    return Promise.resolve(jsonResponse({
+      id: "ChIJfresh",
+      photos: [{ name: "places/ChIJfresh/photos/fresh" }],
+    }));
+  };
+
+  const result = await fetchFreshPlacePhotos("places/ChIJfresh", "api-key", fetchImpl as typeof fetch);
+
+  assertEquals(result.failure, undefined);
+  assertEquals(result.photos, [{ name: "places/ChIJfresh/photos/fresh" }]);
+  assertEquals(calls, ["https://places.googleapis.com/v1/places/ChIJfresh"]);
+});
+
+Deno.test("photoBackfillFailureSummary treats post-refresh provider pressure as retryable", () => {
+  const result: PhotoBackfillDiagnosticResult = {
+    storedUrls: [],
+    refreshed: true,
+    freshPhotoCount: 1,
+    failures: [
+      {
+        stage: "media_cached",
+        status: 400,
+        code: "PHOTO_MEDIA_NAME_INVALID",
+        message: "Cached name expired",
+        retryable: false,
+        refreshable: true,
+      },
+      {
+        stage: "media_refreshed",
+        status: 429,
+        code: "PHOTO_MEDIA_RATE_LIMIT",
+        message: "Google Places media request was rate limited",
+        retryable: true,
+      },
+    ],
+  };
+  const summary = photoBackfillFailureSummary(result);
+
+  assertEquals(summary, {
+    error: "Google Places media request was rate limited",
+    code: "PHOTO_MEDIA_RATE_LIMIT",
+    retryable: true,
+  });
+  assertEquals(formatPhotoBackfillFailedPlace("pp-1", "ChIJfresh", result), {
+    placePoolId: "pp-1",
+    googlePlaceId: "ChIJfresh",
+    error: "Google Places media request was rate limited",
+    code: "PHOTO_MEDIA_RATE_LIMIT",
+    retryable: true,
+    refreshed: true,
+    failures: result.failures,
+  });
+});
+
+Deno.test("downloadAndStorePhotos stores the original even for non-decodable bytes (no thumbnail decode path)", async () => {
+  // ORCH-1024: thumbnail generation (imagescript decode/resize/encode) was removed from this
+  // function entirely. Previously, non-decodable bytes broke the thumb decode and left
+  // thumbs_backfilled_at unset. Now there is no decode path at all: arbitrary bytes still
+  // upload the original successfully and never write thumbs_backfilled_at.
   const priorFetch = globalThis.fetch;
   globalThis.fetch = () => Promise.resolve(new Response(new Uint8Array([1, 2, 3, 4]), {
     status: 200,
@@ -102,6 +314,7 @@ Deno.test("downloadAndStorePhotos leaves thumbs_backfilled_at unset when thumb g
 
     assertEquals(urls, ["https://x.supabase.co/storage/v1/object/public/place-photos/place_abc/0.jpg"]);
     assertEquals(mock.uploads.map((u) => u.path), ["place_abc/0.jpg"]);
+    assertEquals(mock.uploads.length, 1);
     assertEquals(mock.updates[0].stored_photo_urls, urls);
     assertEquals("thumbs_backfilled_at" in mock.updates[0], false);
   } finally {

--- a/supabase/functions/_shared/photoStorageService.ts
+++ b/supabase/functions/_shared/photoStorageService.ts
@@ -7,11 +7,8 @@
  */
 
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { Image, decode } from "https://deno.land/x/imagescript@1.2.17/mod.ts";
 
 const BUCKET = 'place-photos';
-const THUMB_SIZE = 384;
-const THUMB_JPEG_QUALITY = 80;
 
 const DEFAULT_PLACEHOLDER = 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=800&q=80';
 
@@ -39,6 +36,485 @@ export function getPlaceholderForCategory(category?: string | null): string {
 const MAX_PHOTOS = 5;
 const DOWNLOAD_TIMEOUT_MS = 12000;
 const DELAY_BETWEEN_PHOTOS_MS = 200;
+const RATE_LIMIT_DELAY_MS = 2000;
+
+export type PlacePhotoMetadata = {
+  name: string;
+  widthPx?: number;
+  heightPx?: number;
+  authorAttributions?: unknown[];
+};
+
+export type PhotoBackfillFailureStage =
+  | 'media_cached'
+  | 'details_refresh'
+  | 'media_refreshed'
+  | 'storage'
+  | 'thumb';
+
+export interface PhotoBackfillFailure {
+  stage: PhotoBackfillFailureStage;
+  status?: number;
+  code: string;
+  message: string;
+  retryable: boolean;
+  refreshable?: boolean;
+  photoName?: string;
+}
+
+export interface PhotoBackfillDiagnosticResult {
+  storedUrls: string[];
+  refreshed: boolean;
+  freshPhotoCount: number;
+  failures: PhotoBackfillFailure[];
+}
+
+export interface PhotoBackfillFailedPlace {
+  placePoolId: string;
+  googlePlaceId: string;
+  error: string;
+  code: string;
+  retryable: boolean;
+  refreshed: boolean;
+  failures: PhotoBackfillFailure[];
+}
+
+interface PhotoDownloadOptions {
+  fetchImpl?: typeof fetch;
+  delayBetweenPhotosMs?: number;
+  rateLimitDelayMs?: number;
+}
+
+interface AttemptResult {
+  storedUrls: string[];
+  failures: PhotoBackfillFailure[];
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function safeGooglePlaceId(googlePlaceId: string): string {
+  return googlePlaceId.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+function normalizeBarePlaceId(googlePlaceId: string): string {
+  return googlePlaceId.startsWith('places/')
+    ? googlePlaceId.slice('places/'.length)
+    : googlePlaceId;
+}
+
+function summarizeBody(body: string): string {
+  return body.replace(/\s+/g, ' ').trim().substring(0, 200);
+}
+
+function classifyMediaHttpFailure(
+  stage: 'media_cached' | 'media_refreshed',
+  status: number,
+  body: string,
+  photoName: string,
+): PhotoBackfillFailure {
+  const normalizedBody = body.toLowerCase();
+  if (status === 429) {
+    return {
+      stage,
+      status,
+      code: 'PHOTO_MEDIA_RATE_LIMIT',
+      message: 'Google Places media request was rate limited',
+      retryable: true,
+      refreshable: false,
+      photoName,
+    };
+  }
+  if (status >= 500) {
+    return {
+      stage,
+      status,
+      code: 'PHOTO_MEDIA_PROVIDER_5XX',
+      message: 'Google Places media request failed with a provider error',
+      retryable: true,
+      refreshable: false,
+      photoName,
+    };
+  }
+  if (status === 401 || status === 403) {
+    return {
+      stage,
+      status,
+      code: 'PHOTO_MEDIA_AUTH_OR_QUOTA',
+      message: `Google Places media request was denied${body ? `: ${summarizeBody(body)}` : ''}`,
+      retryable: false,
+      refreshable: false,
+      photoName,
+    };
+  }
+  if (
+    status === 400 ||
+    status === 404 ||
+    normalizedBody.includes('invalid_argument') ||
+    (normalizedBody.includes('invalid') && normalizedBody.includes('photo'))
+  ) {
+    return {
+      stage,
+      status,
+      code: 'PHOTO_MEDIA_NAME_INVALID',
+      message: `Google Places photo media name was invalid or expired${body ? `: ${summarizeBody(body)}` : ''}`,
+      retryable: false,
+      refreshable: true,
+      photoName,
+    };
+  }
+  return {
+    stage,
+    status,
+    code: 'PHOTO_MEDIA_HTTP_ERROR',
+    message: `Google Places media request failed with HTTP ${status}${body ? `: ${summarizeBody(body)}` : ''}`,
+    retryable: false,
+    refreshable: false,
+    photoName,
+  };
+}
+
+function shouldRefreshPhotoNames(failures: PhotoBackfillFailure[]): boolean {
+  return failures.length > 0 && failures.every((failure) => failure.refreshable === true);
+}
+
+function isRetryableProviderPressure(failures: PhotoBackfillFailure[]): boolean {
+  return failures.length > 0 && failures.every((failure) => failure.retryable === true);
+}
+
+export function photoBackfillFailureSummary(result: PhotoBackfillDiagnosticResult): {
+  error: string;
+  code: string;
+  retryable: boolean;
+} {
+  if (result.failures.some((failure) => failure.stage === 'details_refresh')) {
+    const detailsFailure = result.failures.find((failure) => failure.stage === 'details_refresh');
+    return {
+      error: detailsFailure?.message ?? 'Google Place Details photo refresh failed',
+      code: detailsFailure?.code ?? 'PHOTO_DETAILS_REFRESH_FAILED',
+      retryable: detailsFailure?.retryable ?? false,
+    };
+  }
+
+  const decisiveFailures = result.refreshed
+    ? result.failures.filter((failure) => !(failure.stage === 'media_cached' && failure.refreshable === true))
+    : result.failures;
+
+  if (result.refreshed) {
+    const retryable = isRetryableProviderPressure(decisiveFailures);
+    if (retryable && decisiveFailures[0]) {
+      return {
+        error: decisiveFailures[0].message,
+        code: decisiveFailures[0].code,
+        retryable: true,
+      };
+    }
+    return {
+      error: 'Photo media names expired; Place Details refresh returned no usable media',
+      code: 'PHOTO_NAME_REFRESH_EXHAUSTED',
+      retryable,
+    };
+  }
+
+  const firstFailure = decisiveFailures[0];
+  if (firstFailure) {
+    return {
+      error: firstFailure.message,
+      code: firstFailure.code,
+      retryable: isRetryableProviderPressure(decisiveFailures),
+    };
+  }
+
+  return {
+    error: 'All photo downloads failed',
+    code: 'PHOTO_DOWNLOAD_FAILED',
+    retryable: false,
+  };
+}
+
+export function formatPhotoBackfillFailedPlace(
+  placePoolId: string,
+  googlePlaceId: string,
+  result: PhotoBackfillDiagnosticResult,
+): PhotoBackfillFailedPlace {
+  const summary = photoBackfillFailureSummary(result);
+  return {
+    placePoolId,
+    googlePlaceId,
+    error: summary.error,
+    code: summary.code,
+    retryable: summary.retryable,
+    refreshed: result.refreshed,
+    failures: result.failures,
+  };
+}
+
+export async function fetchFreshPlacePhotos(
+  googlePlaceId: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ photos: PlacePhotoMetadata[]; failure?: PhotoBackfillFailure }> {
+  if (!googlePlaceId || !apiKey) {
+    return {
+      photos: [],
+      failure: {
+        stage: 'details_refresh',
+        code: 'PHOTO_DETAILS_REFRESH_CONFIG_MISSING',
+        message: 'Missing Google place ID or API key for Place Details photo refresh',
+        retryable: false,
+      },
+    };
+  }
+
+  const barePlaceId = normalizeBarePlaceId(googlePlaceId);
+  const url = `https://places.googleapis.com/v1/places/${encodeURIComponent(barePlaceId)}`;
+
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask': 'id,photos',
+      },
+    });
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => '');
+      return {
+        photos: [],
+        failure: {
+          stage: 'details_refresh',
+          status: response.status,
+          code: 'PHOTO_DETAILS_REFRESH_FAILED',
+          message: `Google Place Details photo refresh failed with HTTP ${response.status}${errBody ? `: ${summarizeBody(errBody)}` : ''}`,
+          retryable: response.status === 429 || response.status >= 500,
+        },
+      };
+    }
+
+    const body = await response.json().catch(() => null) as { photos?: unknown } | null;
+    const photos = Array.isArray(body?.photos)
+      ? body.photos.filter((photo): photo is PlacePhotoMetadata =>
+        !!photo &&
+        typeof photo === 'object' &&
+        typeof (photo as { name?: unknown }).name === 'string' &&
+        (photo as { name: string }).name.trim().length > 0
+      )
+      : [];
+
+    if (photos.length === 0) {
+      return {
+        photos: [],
+        failure: {
+          stage: 'details_refresh',
+          code: 'PHOTO_DETAILS_REFRESH_NO_PHOTOS',
+          message: 'Google Place Details photo refresh returned no usable photos',
+          retryable: false,
+        },
+      };
+    }
+
+    return { photos };
+  } catch (err) {
+    return {
+      photos: [],
+      failure: {
+        stage: 'details_refresh',
+        code: (err as any)?.name === 'AbortError'
+          ? 'PHOTO_DETAILS_REFRESH_TIMEOUT'
+          : 'PHOTO_DETAILS_REFRESH_NETWORK_ERROR',
+        message: err instanceof Error ? err.message : String(err),
+        retryable: true,
+      },
+    };
+  }
+}
+
+async function attemptStorePhotos(
+  supabaseAdmin: SupabaseClient,
+  googlePlaceId: string,
+  photos: PlacePhotoMetadata[],
+  apiKey: string,
+  stage: 'media_cached' | 'media_refreshed',
+  options: Required<Pick<PhotoDownloadOptions, 'fetchImpl' | 'delayBetweenPhotosMs' | 'rateLimitDelayMs'>>,
+): Promise<AttemptResult> {
+  const storedUrls: string[] = [];
+  const failures: PhotoBackfillFailure[] = [];
+  const photosToProcess = photos.slice(0, MAX_PHOTOS);
+  const safePlaceId = safeGooglePlaceId(googlePlaceId);
+
+  for (let i = 0; i < photosToProcess.length; i++) {
+    const photo = photosToProcess[i];
+    if (!photo.name) {
+      failures.push({
+        stage,
+        code: 'PHOTO_NAME_MISSING',
+        message: 'Google photo metadata is missing a photo name',
+        retryable: false,
+        refreshable: true,
+      });
+      continue;
+    }
+
+    try {
+      const googleUrl = `https://places.googleapis.com/v1/${photo.name}/media?maxWidthPx=800&key=${apiKey}`;
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+
+      const response = await options.fetchImpl(googleUrl, {
+        signal: controller.signal,
+        headers: { 'Accept': 'image/jpeg, image/png, image/webp, */*' },
+      });
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errBody = await response.text().catch(() => '');
+        const failure = classifyMediaHttpFailure(stage, response.status, errBody, photo.name);
+        failures.push(failure);
+        console.warn(`[photo-storage] Download failed for ${safePlaceId}/${i}: HTTP ${response.status} - ${summarizeBody(errBody)}`);
+        if (response.status === 429) {
+          await delay(options.rateLimitDelayMs);
+        }
+        continue;
+      }
+
+      const imageData = await response.arrayBuffer();
+      if (imageData.byteLength === 0) {
+        failures.push({
+          stage,
+          code: 'PHOTO_MEDIA_EMPTY_BODY',
+          message: 'Google Places media response body was empty',
+          retryable: false,
+          refreshable: false,
+          photoName: photo.name,
+        });
+        continue;
+      }
+
+      const contentType = response.headers.get('content-type') || 'image/jpeg';
+      const ext = contentType.includes('png') ? 'png' : contentType.includes('webp') ? 'webp' : 'jpg';
+      const storagePath = `${safePlaceId}/${i}.${ext}`;
+
+      const { error: uploadError } = await supabaseAdmin.storage
+        .from(BUCKET)
+        .upload(storagePath, imageData, {
+          contentType,
+          upsert: true,
+          cacheControl: '31536000',
+        });
+
+      if (uploadError) {
+        failures.push({
+          stage: 'storage',
+          code: 'PHOTO_STORAGE_UPLOAD_FAILED',
+          message: uploadError.message,
+          retryable: false,
+          photoName: photo.name,
+        });
+        console.warn(`[photo-storage] Upload failed for ${storagePath}:`, uploadError.message);
+        continue;
+      }
+
+      const { data: urlData } = supabaseAdmin.storage
+        .from(BUCKET)
+        .getPublicUrl(storagePath);
+
+      if (urlData?.publicUrl) {
+        storedUrls.push(urlData.publicUrl);
+      }
+
+      if (i < photosToProcess.length - 1) {
+        await delay(options.delayBetweenPhotosMs);
+      }
+    } catch (err) {
+      const isTimeout = (err as any)?.name === 'AbortError';
+      failures.push({
+        stage,
+        code: isTimeout ? 'PHOTO_MEDIA_TIMEOUT' : 'PHOTO_MEDIA_NETWORK_ERROR',
+        message: err instanceof Error ? err.message : String(err),
+        retryable: true,
+        refreshable: false,
+        photoName: photo.name,
+      });
+      if (isTimeout) {
+        console.warn(`[photo-storage] Download timeout for ${safePlaceId}/${i}`);
+      } else {
+        console.error(`[photo-storage] Download error for ${safePlaceId}/${i}:`,
+          err instanceof Error ? err.message : String(err));
+      }
+    }
+  }
+
+  return { storedUrls, failures };
+}
+
+async function updateStoredPhotoUrls(
+  supabaseAdmin: SupabaseClient,
+  googlePlaceId: string,
+  storedUrls: string[],
+): Promise<PhotoBackfillFailure | null> {
+  if (storedUrls.length === 0) return null;
+
+  try {
+    const updatePayload: Record<string, unknown> = { stored_photo_urls: storedUrls };
+    const { error: updateErr } = await supabaseAdmin
+      .from('place_pool')
+      .update(updatePayload)
+      .eq('google_place_id', googlePlaceId);
+
+    if (updateErr) {
+      console.error(`[photo-storage] DB update failed for ${googlePlaceId}:`, updateErr.message);
+      return {
+        stage: 'storage',
+        code: 'PHOTO_DB_STORED_URL_UPDATE_FAILED',
+        message: updateErr.message,
+        retryable: false,
+      };
+    }
+  } catch (err) {
+    console.error(`[photo-storage] DB update error for ${googlePlaceId}:`,
+      err instanceof Error ? err.message : String(err));
+    return {
+      stage: 'storage',
+      code: 'PHOTO_DB_STORED_URL_UPDATE_ERROR',
+      message: err instanceof Error ? err.message : String(err),
+      retryable: false,
+    };
+  }
+
+  return null;
+}
+
+async function updateFreshPhotoMetadata(
+  supabaseAdmin: SupabaseClient,
+  googlePlaceId: string,
+  freshPhotos: PlacePhotoMetadata[],
+): Promise<PhotoBackfillFailure | null> {
+  try {
+    const { error } = await supabaseAdmin
+      .from('place_pool')
+      .update({ photos: freshPhotos })
+      .eq('google_place_id', googlePlaceId);
+    if (error) {
+      return {
+        stage: 'details_refresh',
+        code: 'PHOTO_DETAILS_METADATA_UPDATE_FAILED',
+        message: error.message,
+        retryable: false,
+      };
+    }
+  } catch (err) {
+    return {
+      stage: 'details_refresh',
+      code: 'PHOTO_DETAILS_METADATA_UPDATE_ERROR',
+      message: err instanceof Error ? err.message : String(err),
+      retryable: false,
+    };
+  }
+  return null;
+}
 
 /**
  * Download photos from Google Places API and store them in Supabase Storage.
@@ -50,143 +526,112 @@ const DELAY_BETWEEN_PHOTOS_MS = 200;
 export async function downloadAndStorePhotos(
   supabaseAdmin: SupabaseClient,
   googlePlaceId: string,
-  photos: Array<{ name: string; widthPx?: number; heightPx?: number }>,
+  photos: PlacePhotoMetadata[],
   apiKey: string,
 ): Promise<string[]> {
-  if (!photos || photos.length === 0 || !apiKey || !googlePlaceId) return [];
+  const result = await downloadAndStorePhotosWithDiagnostics(
+    supabaseAdmin,
+    googlePlaceId,
+    photos,
+    apiKey,
+  );
+  return result.storedUrls;
+}
 
-  const storedUrls: string[] = [];
-  const photosToProcess = photos.slice(0, MAX_PHOTOS);
-  let allUploadedThumbsSucceeded = true;
-
-  // Sanitize googlePlaceId for use as a storage path (remove special chars)
-  const safePlaceId = googlePlaceId.replace(/[^a-zA-Z0-9_-]/g, '_');
-
-  for (let i = 0; i < photosToProcess.length; i++) {
-    const photo = photosToProcess[i];
-    if (!photo.name) continue;
-
-    try {
-      // Download from Google Places Media API
-      const googleUrl = `https://places.googleapis.com/v1/${photo.name}/media?maxWidthPx=800&key=${apiKey}`;
-
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
-
-      const response = await fetch(googleUrl, {
-        signal: controller.signal,
-        headers: { 'Accept': 'image/jpeg, image/png, image/webp, */*' },
-      });
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        const errBody = await response.text().catch(() => '');
-        console.warn(`[photo-storage] Download failed for ${safePlaceId}/${i}: HTTP ${response.status} — ${errBody.substring(0, 200)}`);
-        // On 429 (rate limit), wait longer before next attempt
-        if (response.status === 429) {
-          await new Promise(r => setTimeout(r, 2000));
-        }
-        continue;
-      }
-
-      // Read as array buffer
-      const imageData = await response.arrayBuffer();
-      if (imageData.byteLength === 0) continue;
-
-      // Determine content type from response
-      const contentType = response.headers.get('content-type') || 'image/jpeg';
-      const ext = contentType.includes('png') ? 'png' : contentType.includes('webp') ? 'webp' : 'jpg';
-      const storagePath = `${safePlaceId}/${i}.${ext}`;
-
-      // Upload to Supabase Storage (upsert — overwrites if exists)
-      const { error: uploadError } = await supabaseAdmin.storage
-        .from(BUCKET)
-        .upload(storagePath, imageData, {
-          contentType,
-          upsert: true,
-          cacheControl: '31536000', // 1 year cache (photos don't change)
-        });
-
-      if (uploadError) {
-        console.warn(`[photo-storage] Upload failed for ${storagePath}:`, uploadError.message);
-        continue;
-      }
-
-      // ORCH-0957: generate a pre-sized JPEG variant next to the original so
-      // collage composition can read through the non-metered object endpoint.
-      const thumbPath = `${safePlaceId}/${i}_thumb.jpg`;
-      try {
-        const decoded = await decode(new Uint8Array(imageData));
-        if (decoded instanceof Image) {
-          decoded.resize(THUMB_SIZE, THUMB_SIZE);
-          const thumbBytes = await decoded.encodeJPEG(THUMB_JPEG_QUALITY);
-          const { error: thumbUploadError } = await supabaseAdmin.storage
-            .from(BUCKET)
-            .upload(thumbPath, thumbBytes, {
-              contentType: 'image/jpeg',
-              upsert: true,
-              cacheControl: '31536000',
-            });
-          if (thumbUploadError) {
-            allUploadedThumbsSucceeded = false;
-            console.warn(`[photo-storage] Thumb upload failed for ${thumbPath}:`, thumbUploadError.message);
-          }
-        } else {
-          allUploadedThumbsSucceeded = false;
-          console.warn(`[photo-storage] Decoded as non-Image for ${storagePath}; thumb skipped`);
-        }
-      } catch (thumbErr) {
-        allUploadedThumbsSucceeded = false;
-        console.warn(`[photo-storage] Thumb generation failed for ${storagePath}:`,
-          thumbErr instanceof Error ? thumbErr.message : String(thumbErr));
-      }
-
-      // Get public URL
-      const { data: urlData } = supabaseAdmin.storage
-        .from(BUCKET)
-        .getPublicUrl(storagePath);
-
-      if (urlData?.publicUrl) {
-        storedUrls.push(urlData.publicUrl);
-      }
-
-      // Delay between photos to avoid rate limiting
-      if (i < photosToProcess.length - 1) {
-        await new Promise(r => setTimeout(r, DELAY_BETWEEN_PHOTOS_MS));
-      }
-    } catch (err) {
-      // Individual photo failure is non-fatal — skip and continue
-      if ((err as any)?.name === 'AbortError') {
-        console.warn(`[photo-storage] Download timeout for ${safePlaceId}/${i}`);
-      } else {
-        console.error(`[photo-storage] Download error for ${safePlaceId}/${i}:`,
-          err instanceof Error ? err.message : String(err));
-      }
-    }
+export async function downloadAndStorePhotosWithDiagnostics(
+  supabaseAdmin: SupabaseClient,
+  googlePlaceId: string,
+  photos: PlacePhotoMetadata[],
+  apiKey: string,
+  options: PhotoDownloadOptions = {},
+): Promise<PhotoBackfillDiagnosticResult> {
+  if (!photos || photos.length === 0 || !apiKey || !googlePlaceId) {
+    return { storedUrls: [], refreshed: false, freshPhotoCount: 0, failures: [] };
   }
 
-  // Update place_pool with stored URLs
-  if (storedUrls.length > 0) {
-    try {
-      const updatePayload: Record<string, unknown> = { stored_photo_urls: storedUrls };
-      if (allUploadedThumbsSucceeded) {
-        updatePayload.thumbs_backfilled_at = new Date().toISOString();
-      }
-      const { error: updateErr } = await supabaseAdmin
-        .from('place_pool')
-        .update(updatePayload)
-        .eq('google_place_id', googlePlaceId);
+  const resolvedOptions = {
+    fetchImpl: options.fetchImpl ?? fetch,
+    delayBetweenPhotosMs: options.delayBetweenPhotosMs ?? DELAY_BETWEEN_PHOTOS_MS,
+    rateLimitDelayMs: options.rateLimitDelayMs ?? RATE_LIMIT_DELAY_MS,
+  };
 
-      if (updateErr) {
-        console.error(`[photo-storage] DB update failed for ${googlePlaceId}:`, updateErr.message);
-      }
-    } catch (err) {
-      console.error(`[photo-storage] DB update error for ${googlePlaceId}:`,
-        err instanceof Error ? err.message : String(err));
-    }
+  const cachedAttempt = await attemptStorePhotos(
+    supabaseAdmin,
+    googlePlaceId,
+    photos,
+    apiKey,
+    'media_cached',
+    resolvedOptions,
+  );
+  const failures = [...cachedAttempt.failures];
+
+  if (cachedAttempt.storedUrls.length > 0) {
+    const updateFailure = await updateStoredPhotoUrls(
+      supabaseAdmin,
+      googlePlaceId,
+      cachedAttempt.storedUrls,
+    );
+    if (updateFailure) failures.push(updateFailure);
+    return {
+      storedUrls: cachedAttempt.storedUrls,
+      refreshed: false,
+      freshPhotoCount: 0,
+      failures,
+    };
   }
 
-  return storedUrls;
+  if (!shouldRefreshPhotoNames(cachedAttempt.failures)) {
+    return {
+      storedUrls: [],
+      refreshed: false,
+      freshPhotoCount: 0,
+      failures,
+    };
+  }
+
+  const refresh = await fetchFreshPlacePhotos(googlePlaceId, apiKey, resolvedOptions.fetchImpl);
+  if (refresh.failure) {
+    failures.push(refresh.failure);
+    return {
+      storedUrls: [],
+      refreshed: true,
+      freshPhotoCount: 0,
+      failures,
+    };
+  }
+
+  const metadataUpdateFailure = await updateFreshPhotoMetadata(
+    supabaseAdmin,
+    googlePlaceId,
+    refresh.photos,
+  );
+  if (metadataUpdateFailure) failures.push(metadataUpdateFailure);
+
+  const refreshedAttempt = await attemptStorePhotos(
+    supabaseAdmin,
+    googlePlaceId,
+    refresh.photos,
+    apiKey,
+    'media_refreshed',
+    resolvedOptions,
+  );
+  failures.push(...refreshedAttempt.failures);
+
+  if (refreshedAttempt.storedUrls.length > 0) {
+    const updateFailure = await updateStoredPhotoUrls(
+      supabaseAdmin,
+      googlePlaceId,
+      refreshedAttempt.storedUrls,
+    );
+    if (updateFailure) failures.push(updateFailure);
+  }
+
+  return {
+    storedUrls: refreshedAttempt.storedUrls,
+    refreshed: true,
+    freshPhotoCount: refresh.photos.length,
+    failures,
+  };
 }
 
 /**

--- a/supabase/functions/backfill-place-photos/index.test.ts
+++ b/supabase/functions/backfill-place-photos/index.test.ts
@@ -1,0 +1,205 @@
+// ORCH-1023 rework regression harness — backfill-place-photos PROCESS PATH.
+//
+// QA (CONDITIONAL PASS) required a repo-running test for the `backfill-place-photos`
+// process path proving (a) structured `failed_places` are returned/persisted, and
+// (b) retryable provider pressure updates `place_pool.stored_photo_urls` to `null`
+// instead of the terminal sentinel `['__backfill_failed__']`. The shared
+// photoStorageService tests stop at the diagnostic result; they never exercise the
+// branch in processBatch that routes retryable→null vs non-retryable→sentinel and
+// writes the structured failed-place object. These tests attack exactly that branch.
+//
+// Google Places calls are mocked via globalThis.fetch (no live API). The handler's
+// serve() bootstrap is guarded by import.meta.main, so importing processBatch here
+// does not bind the HTTP server.
+
+import { assertEquals, assertExists } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { processBatch } from "./index.ts";
+
+interface RecordedUpdate {
+  payload: Record<string, unknown>;
+  eqColumn: string;
+  eqValue: string;
+}
+
+interface PlaceRow {
+  id: string;
+  google_place_id: string | null;
+  photos: unknown;
+  stored_photo_urls: string[] | null;
+}
+
+// Mock Supabase client covering the two surfaces processBatch touches:
+//   1. place_pool eligibility re-check  -> select(...).eq(...).eq(...).eq(...).maybeSingle()
+//   2. failure write-back               -> update({...}).eq('id', placeId)
+// plus the storage surface the shared service would use on a success (unused here).
+function createDbMock(place: PlaceRow) {
+  const updates: RecordedUpdate[] = [];
+
+  const selectChain = {
+    eq() {
+      return selectChain;
+    },
+    maybeSingle() {
+      return Promise.resolve({ data: place, error: null });
+    },
+  };
+
+  return {
+    updates,
+    client: {
+      storage: {
+        from(bucket: string) {
+          assertEquals(bucket, "place-photos");
+          return {
+            upload() {
+              return Promise.resolve({ error: null });
+            },
+            getPublicUrl(path: string) {
+              return {
+                data: {
+                  publicUrl: `https://x.supabase.co/storage/v1/object/public/place-photos/${path}`,
+                },
+              };
+            },
+          };
+        },
+      },
+      from(table: string) {
+        assertEquals(table, "place_pool");
+        return {
+          select() {
+            return selectChain;
+          },
+          update(payload: Record<string, unknown>) {
+            return {
+              eq(eqColumn: string, eqValue: string) {
+                updates.push({ payload, eqColumn, eqValue });
+                return Promise.resolve({ error: null });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+Deno.test("processBatch: retryable provider pressure writes stored_photo_urls=null (not the sentinel) and returns a structured failed place", async () => {
+  const priorFetch = globalThis.fetch;
+  // 5xx is retryable + non-refreshable -> no Place Details refresh, no rate-limit sleep.
+  globalThis.fetch = () =>
+    Promise.resolve(jsonResponse({
+      error: { status: "UNAVAILABLE", message: "Backend temporarily unavailable" },
+    }, 503));
+
+  try {
+    const place: PlaceRow = {
+      id: "pp-retryable",
+      google_place_id: "ChIJtest",
+      photos: [{ name: "places/ChIJtest/photos/old" }],
+      stored_photo_urls: null,
+    };
+    const db = createDbMock(place);
+
+    const result = await processBatch(
+      db.client as any,
+      { place_pool_ids: ["pp-retryable"] },
+      "api-key",
+      "pre_photo_passed",
+    );
+
+    assertEquals(result.succeeded, 0);
+    assertEquals(result.failed, 1);
+    assertEquals(result.skipped, 0);
+
+    // Structured failed place returned (the batch no longer collapses to a generic string).
+    assertEquals(result.failedPlaces.length, 1);
+    const fp = result.failedPlaces[0];
+    assertEquals(fp.placePoolId, "pp-retryable");
+    assertEquals(fp.googlePlaceId, "ChIJtest");
+    assertEquals(fp.retryable, true);
+    assertEquals(fp.refreshed, false);
+    assertExists(fp.code);
+    assertEquals(Array.isArray(fp.failures), true);
+
+    // Exactly one write-back, scoped by id, setting stored_photo_urls to null.
+    assertEquals(db.updates.length, 1);
+    assertEquals(db.updates[0].eqColumn, "id");
+    assertEquals(db.updates[0].eqValue, "pp-retryable");
+    assertEquals(db.updates[0].payload, { stored_photo_urls: null });
+
+    // The terminal sentinel must NEVER be written on retryable pressure.
+    const wroteSentinel = db.updates.some((u) => {
+      const v = u.payload.stored_photo_urls;
+      return Array.isArray(v) && v.length === 1 && v[0] === "__backfill_failed__";
+    });
+    assertEquals(wroteSentinel, false);
+  } finally {
+    globalThis.fetch = priorFetch;
+  }
+});
+
+Deno.test("processBatch: non-retryable exhaustion writes the terminal sentinel and returns a structured failed place", async () => {
+  const priorFetch = globalThis.fetch;
+  // Cached media name expired (400, refreshable) -> one Place Details refresh ->
+  // 403 PERMISSION_DENIED (non-retryable) -> terminal failure.
+  globalThis.fetch = (input: URL | RequestInfo) => {
+    const url = String(input);
+    if (url.includes("/media")) {
+      return Promise.resolve(jsonResponse({
+        error: { status: "INVALID_ARGUMENT", message: "Photo name has expired" },
+      }, 400));
+    }
+    // Place Details refresh call.
+    return Promise.resolve(jsonResponse({
+      error: { status: "PERMISSION_DENIED", message: "API key denied" },
+    }, 403));
+  };
+
+  try {
+    const place: PlaceRow = {
+      id: "pp-terminal",
+      google_place_id: "ChIJtest",
+      photos: [{ name: "places/ChIJtest/photos/old" }],
+      stored_photo_urls: null,
+    };
+    const db = createDbMock(place);
+
+    const result = await processBatch(
+      db.client as any,
+      { place_pool_ids: ["pp-terminal"] },
+      "api-key",
+      "pre_photo_passed",
+    );
+
+    assertEquals(result.succeeded, 0);
+    assertEquals(result.failed, 1);
+
+    assertEquals(result.failedPlaces.length, 1);
+    const fp = result.failedPlaces[0];
+    assertEquals(fp.placePoolId, "pp-terminal");
+    assertEquals(fp.retryable, false);
+    assertEquals(fp.refreshed, true);
+    assertExists(fp.code);
+
+    // Exactly one write-back, scoped by id, setting the terminal sentinel.
+    assertEquals(db.updates.length, 1);
+    assertEquals(db.updates[0].eqColumn, "id");
+    assertEquals(db.updates[0].eqValue, "pp-terminal");
+    assertEquals(db.updates[0].payload, { stored_photo_urls: ["__backfill_failed__"] });
+
+    // On non-retryable exhaustion we must NOT clear to null (that would re-queue a
+    // place that genuinely cannot be backfilled).
+    const clearedToNull = db.updates.some((u) => u.payload.stored_photo_urls === null);
+    assertEquals(clearedToNull, false);
+  } finally {
+    globalThis.fetch = priorFetch;
+  }
+});

--- a/supabase/functions/backfill-place-photos/index.ts
+++ b/supabase/functions/backfill-place-photos/index.ts
@@ -1,6 +1,11 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { downloadAndStorePhotos } from '../_shared/photoStorageService.ts';
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import {
+  downloadAndStorePhotosWithDiagnostics,
+  formatPhotoBackfillFailedPlace,
+  photoBackfillFailureSummary,
+  type PhotoBackfillFailedPlace,
+} from '../_shared/photoStorageService.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -16,7 +21,13 @@ function json(data: unknown, status = 200): Response {
 
 const COST_PER_PLACE = 0.035; // 5 photos × $0.007
 
-serve(async (req: Request) => {
+// ORCH-1023 rework: the request handler is exported and the serve() bootstrap is
+// guarded by import.meta.main (proven repo pattern — mirrors
+// backfill-place-photo-thumbs/index.ts) so the batch process path can be imported
+// and exercised by a Deno regression test without binding the HTTP server. The
+// Supabase edge runtime runs this file as the entry module (import.meta.main=true),
+// so production behavior is unchanged.
+export async function handler(req: Request): Promise<Response> {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
 
   try {
@@ -92,7 +103,11 @@ serve(async (req: Request) => {
     console.error('[backfill-place-photos] Error:', err);
     return json({ error: err instanceof Error ? err.message : 'Internal error' }, 500);
   }
-});
+}
+
+if (import.meta.main) {
+  serve(handler);
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Action handlers
@@ -116,7 +131,8 @@ serve(async (req: Request) => {
 //   'refresh_servable'  — admin maintenance for already-final-bouncer-approved places.
 //                         Gate: is_servable=true (regardless of photo state).
 //                         Use case: forcing photo re-download for a healthy city.
-type BackfillMode = 'pre_photo_passed' | 'refresh_servable';
+export type BackfillMode = 'pre_photo_passed' | 'refresh_servable';
+type SupabaseDb = SupabaseClient<any, any, any, any, any>;
 
 function parseBackfillMode(raw: unknown): BackfillMode {
   // ORCH-0678: 'pre_photo_passed' is the default — it's the first-pass mode used
@@ -241,7 +257,7 @@ function buildRunPreview(places: CityPlaceRow[], mode: BackfillMode) {
 }
 
 async function loadCityPlacesForRun(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   cityId: string,
   mode: BackfillMode,
 ): Promise<{ places: CityPlaceRow[]; analysis: RunPreviewAnalysis; eligiblePlaces: CityPlaceRow[] }> {
@@ -278,7 +294,7 @@ async function loadCityPlacesForRun(
 }
 
 async function handlePreviewRun(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
 ): Promise<Response> {
   const cityId = body.cityId as string;
@@ -307,7 +323,7 @@ async function handlePreviewRun(
 }
 
 async function handleCreateRun(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
   userId: string,
 ): Promise<Response> {
@@ -428,7 +444,7 @@ async function handleCreateRun(
 // ── run_next_batch ────────────────────────────────────────────────────────
 
 async function handleRunNextBatch(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
   apiKey: string,
 ): Promise<Response> {
@@ -590,15 +606,15 @@ async function handleRunNextBatch(
 
 // ── Shared batch processing logic ─────────────────────────────────────────
 
-interface BatchResult {
+export interface BatchResult {
   succeeded: number;
   failed: number;
   skipped: number;
-  failedPlaces: Array<{ placePoolId: string; googlePlaceId: string; error: string }>;
+  failedPlaces: Array<PhotoBackfillFailedPlace>;
 }
 
-async function processBatch(
-  db: ReturnType<typeof createClient>,
+export async function processBatch(
+  db: SupabaseDb,
   batch: { place_pool_ids: string[] },
   apiKey: string,
   mode: BackfillMode,
@@ -652,25 +668,34 @@ async function processBatch(
       }
 
       // Download and store
-      const storedUrls = await downloadAndStorePhotos(
+      const photoResult = await downloadAndStorePhotosWithDiagnostics(
         db, place.google_place_id, photoMeta, apiKey
       );
 
-      if (storedUrls && storedUrls.length > 0) {
+      if (photoResult.storedUrls.length > 0) {
         // ORCH-0640: card_pool update block REMOVED. place_pool.stored_photo_urls
         // is the sole photo authority (I-POOL-ONLY-SERVING); card_pool is dropped.
         succeeded++;
       } else {
-        // All photos failed
-        await db
-          .from('place_pool')
-          .update({ stored_photo_urls: ['__backfill_failed__'] })
-          .eq('id', place.id);
-        failedPlaces.push({
-          placePoolId: place.id,
-          googlePlaceId: place.google_place_id,
-          error: 'All photo downloads failed',
-        });
+        const summary = photoBackfillFailureSummary(photoResult);
+        if (summary.retryable) {
+          // Retryable provider pressure should not poison rows with the terminal
+          // sentinel. Clear any existing sentinel so a later retry can re-attempt.
+          await db
+            .from('place_pool')
+            .update({ stored_photo_urls: null })
+            .eq('id', place.id);
+        } else {
+          await db
+            .from('place_pool')
+            .update({ stored_photo_urls: ['__backfill_failed__'] })
+            .eq('id', place.id);
+        }
+        failedPlaces.push(formatPhotoBackfillFailedPlace(
+          place.id,
+          place.google_place_id,
+          photoResult,
+        ));
         failed++;
       }
     } catch (err) {
@@ -686,6 +711,15 @@ async function processBatch(
         placePoolId: placeId,
         googlePlaceId: 'unknown',
         error: errMsg,
+        code: 'PHOTO_BACKFILL_UNEXPECTED_EXCEPTION',
+        retryable: false,
+        refreshed: false,
+        failures: [{
+          stage: 'storage',
+          code: 'PHOTO_BACKFILL_UNEXPECTED_EXCEPTION',
+          message: errMsg,
+          retryable: false,
+        }],
       });
       failed++;
     }
@@ -702,7 +736,7 @@ async function processBatch(
 // ── run_status ────────────────────────────────────────────────────────────
 
 async function handleRunStatus(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
 ): Promise<Response> {
   const runId = body.runId as string;
@@ -728,7 +762,7 @@ async function handleRunStatus(
 // ── active_runs ───────────────────────────────────────────────────────────
 
 async function handleActiveRuns(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
 ): Promise<Response> {
   const { data: runs } = await db
     .from('photo_backfill_runs')
@@ -760,7 +794,7 @@ async function handleActiveRuns(
 // ── cancel_run ────────────────────────────────────────────────────────────
 
 async function handleCancelRun(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
 ): Promise<Response> {
   const runId = body.runId as string;
@@ -806,7 +840,7 @@ async function handleCancelRun(
 // ── pause_run ─────────────────────────────────────────────────────────────
 
 async function handlePauseRun(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
 ): Promise<Response> {
   const runId = body.runId as string;
@@ -834,7 +868,7 @@ async function handlePauseRun(
 // ── resume_run ────────────────────────────────────────────────────────────
 
 async function handleResumeRun(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
 ): Promise<Response> {
   const runId = body.runId as string;
@@ -862,7 +896,7 @@ async function handleResumeRun(
 // ── retry_batch ───────────────────────────────────────────────────────────
 
 async function handleRetryBatch(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
   apiKey: string,
 ): Promise<Response> {
@@ -993,7 +1027,7 @@ async function handleRetryBatch(
 // ── skip_batch ────────────────────────────────────────────────────────────
 
 async function handleSkipBatch(
-  db: ReturnType<typeof createClient>,
+  db: SupabaseDb,
   body: Record<string, unknown>,
 ): Promise<Response> {
   const runId = body.runId as string;


### PR DESCRIPTION
## What & why
`backfill-place-photos` was crashing Supabase with "not enough compute resources" because ORCH-0957 bolted inline imagescript thumbnail generation onto the photo-download hot path (decode/resize/encode up to 50 images per invocation). This restores the pre-ORCH-0957 behavior: **main backfill stores originals only**, and thumbnails run in the existing separate `backfill-place-photo-thumbs` function, now driven from a **new admin "Thumbnails" tab**.

The ORCH-1023 expired-name **refresh fix** (self-heals stale Google photo names) and its process-path test are preserved.

## Changes
- `photoStorageService.ts` — remove inline thumbnail block + imagescript import + THUMB constants + `allUploadedThumbsSucceeded`; `updateStoredPhotoUrls` writes only `stored_photo_urls` (no `thumbs_backfilled_at`, the decoupling that hands new downloads to the thumbs pass). `MAX_PHOTOS=5` unchanged.
- `photoStorageService.test.ts` — originals-only assertions `[TEST-MOD-APPROVED ORCH-1024]`.
- `PlacePoolManagementPage.jsx` — new Thumbnails tab (global $0 run); Photos panel filters out the shared-table thumbs run marker.
- strict-grep `ORCH_1024_BACKEND_ALLOWLIST`.

## Gates
- `deno check` clean (4 files)
- `deno test` 9/9, fails-on-revert verified
- strict-grep PASS (C7 via allowlist)
- admin `vite build` OK (2940 modules)

Edge `backfill-place-photos` to be deployed from main after merge. Admin web deploys via `[deploy]` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)