### PR TITLE
Close ORCH-1036: launch-city gate override no longer clobbered by final onboarding save

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md
@@ -1,0 +1,153 @@
+# IMPLEMENTATION — ORCH-1036 [Launch-city gate override clobbered by final onboarding save]
+
+- **Mode:** IMPLEMENT
+- **Date:** 2026-06-01
+- **Author:** mingla-implementor (Claude)
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1036-[gate-override-clobber]/` on branch `ORCH-1036-gate-override-clobber`
+- **Status:** implemented and verified (tsc clean on touched files, regression test green + fails-on-revert proven)
+- **Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md` (ROOT CAUSE PROVEN)
+
+---
+
+## 1. Comms ledger (read on entry)
+
+Scanned the Active table. No `BLOCK`+`OPEN` row addressed to `mingla-implementor`, `ORCH-1036`, or `ALL`. Relevant `ALL`/WARN rows factored:
+- COMMS-0003 (external-API docs verified) — **N/A**, no external API touched.
+- COMMS-0004 (INTAKE ID-collision scan) — **N/A**, not an INTAKE turn.
+- COMMS-0002 (ORCH-0863 strict-grep backend gate) — **N/A**, no `supabase/functions/` or migration touch (app-mobile only).
+- COMMS-0012/0011/0013/0015 (WARN) — read; none bear on this app-mobile-only onboarding fix.
+
+No new cross-ORCH discovery requiring a ledger write. (The ORCH-1028 gate being uncommitted WIP is noted in §10 Discoveries, but it does not clobber another in-flight ORCH.)
+
+---
+
+## 2. What changed (plain English)
+
+The last step of onboarding was erasing the city a new user picked at the launch-city gate. The gate correctly saved the city + coordinates + "not using GPS"; then the final preferences save re-wrote the row and set the city label back to empty (it copied an always-empty field over it). The coordinates survived, so the deck still showed the right city — but the Preferences sheet showed a blank city. The fix makes the final save preserve the picked city instead of nulling it, while still keeping a true GPS user's custom city empty.
+
+---
+
+## 3. Old → New Receipts
+
+### `app-mobile/src/utils/onboardingLocationOverride.ts` (NEW)
+**What it did before:** did not exist.
+**What it does now:** exports a pure `resolveOnboardingLocationOverride(state)` that derives the four location-override columns (`custom_location`, `custom_lat`, `custom_lng`, implied `use_gps_location` is passed through separately) from onboarding state, keyed off `use_gps_location`:
+- GPS user (`true`) → `custom_location/lat/lng = null` (no stale override).
+- non-GPS (`false`) → `custom_location = cityName (gate) ?? manualLocation (legacy)`, coords from `coordinates`.
+**Why:** isolates the derivation so the FINAL save can preserve the gate/manual override instead of clobbering it, and so a unit-/integration-level regression test can exercise the exact shipped logic (fails-on-revert).
+**Lines changed:** +77 (new file).
+
+### `app-mobile/src/components/OnboardingFlow.tsx`
+**What it did before:** `handleSavePreferences` (Step-4→5 transition) upserted `preferences` with `custom_location: data.manualLocation` and a trailing `as any` cast; it OMITTED `custom_lat/lng` from the DB upsert (they survived only by luck of column-scoped upsert). The gate (`handleLaunchGateConfirmCity`) sets `data.cityName`/`data.coordinates`/`useGpsLocation=false` but NEVER `data.manualLocation`, so for a gate user `data.manualLocation` was `null` → the save clobbered the gate's `custom_location` to `null`.
+**What it does now:** derives the override via `resolveOnboardingLocationOverride({ useGpsLocation, cityName, manualLocation, coordinates })` and writes `custom_location` / `custom_lat` / `custom_lng` from that result in BOTH the persisted `updateUserPreferences` upsert AND the in-handler `queryClient.setQueryData(['userPreferences', user.id], …)` cache pre-seed. The `as any` cast is removed (payload is now a valid `Partial<UserPreferences>` — tsc clean).
+**Why:** preserves the gate's (and legacy manual-location's) `custom_location` through end-of-onboarding while keeping a true GPS user's custom location null. Aligns persisted DB row and React Query cache so cold-relaunch and in-session agree.
+**Lines changed:** ~30 (import +1; derivation block; upsert location fields; cache block location fields; cast removed).
+
+---
+
+## 4. Approach decision (keeps BOTH gate user AND GPS user correct)
+
+Chose the investigation's preferred Option 2 (source from gate state), generalized to also cover the legacy manual-location flow:
+
+| User | `use_gps_location` | `cityName` | `manualLocation` | Resolved `custom_location` | Correct? |
+|---|---|---|---|---|---|
+| Launch-city gate (DC) | false | `"Washington"` | null | `"Washington"` | ✅ persists |
+| Legacy manual-location | false | null | `"Brooklyn, NY, USA"` | `"Brooklyn, NY, USA"` | ✅ persists |
+| True GPS | true | `"San Francisco"` (reverse-geocoded) | null | `null` | ✅ clean (no stale override) |
+
+Why not "omit the fields entirely" (the acceptable alternative): omitting would leave a true GPS user's `custom_location` at whatever was previously in the row (stale) on re-onboard, and would not let the save correct a GPS user back to null. Explicitly writing the resolved values makes the final save authoritative for both cases without guesswork.
+
+---
+
+## 5. Invariant verification
+
+| Invariant | Preserved? | Evidence |
+|---|---|---|
+| **I-1028-ONE-LOCATION-OWNER** | YES (improved) | The save no longer introduces an *independent* third value for the location fields — it DERIVES them from the same onboarding `data` state the location step / gate populated. The gate remains the semantic owner; the save echoes the gate's choice rather than overwriting it with an unrelated (null) source. Previously the save was a divergent second writer that won with a null; now it agrees with the gate. |
+| **I-LOCATION-INVALIDATE-ON-LOCATION-ONLY** | YES (untouched) | No change to any React Query *key* shape. `useUserLocation.ts` query key untouched. The save's `setQueryData(['userPreferences', user.id], …)` writes data (an existing call), it does not add a refresh signal to the location key. No new `invalidateQueries` introduced in this handler. |
+
+No third writer of `custom_location`/`use_gps_location` was introduced. Writers remain: the gate (`handleLaunchGateConfirmCity`), the final save (`handleSavePreferences`, now consistent with the gate), and the Preferences sheet (existing).
+
+---
+
+## 6. Cross-surface impact (Step 3.5)
+
+- **Consumer iOS** — AFFECTED. `OnboardingFlow.tsx` is the consumer onboarding. Picked launch city now persists through onboarding. Parity: automatic (shared file).
+- **Consumer Android** — AFFECTED, identical shared code path. Parity automatic.
+- **Buyer/anonymous Web** — NOT affected (no onboarding flow).
+- **Business iOS / Android** — NOT affected (separate app, no consumer onboarding).
+- **Admin Web** — NOT affected (does not render this flow).
+- **Business Web preview** — NOT affected.
+
+Single feature, shared file across the only two affected surfaces (iOS + Android) → parity automatic.
+
+---
+
+## 7. Regression Test
+
+- **Path:** `app-mobile/src/utils/__tests__/onboardingLocationOverride.test.ts` (Deno test — the app-mobile `__tests__` convention here is Deno, confirmed by sibling `openingHoursUtils.test.ts` et al.).
+- **What it proves:** replays the FULL post-gate sequence (gate-confirm → `handleSavePreferences`) through a PostgREST-faithful column-scoped upsert simulator, feeding the save's location fields from the REAL shipped `resolveOnboardingLocationOverride`. Asserts:
+  1. **Gate survival (the point):** after gate-confirm THEN save, `custom_location === "Washington"`, `use_gps_location === false`, coords intact — i.e. the override SURVIVES to end-of-onboarding, not just at pick time.
+  2. Legacy manual-location (no gate) also survives the save.
+  3. True GPS user stays clean: `custom_location === null`, coords null, `use_gps_location === true`.
+  4. Resolver unit: non-GPS prefers gate `cityName` over a stale `manualLocation`.
+
+**Passing run (fix in place):**
+```
+running 4 tests from ./src/utils/__tests__/onboardingLocationOverride.test.ts
+ORCH-1036: gate-confirmed launch city SURVIVES handleSavePreferences ... ok
+ORCH-1036: legacy manual-location (typed city, no gate) also survives the save ... ok
+ORCH-1036: true GPS user stays clean — custom_location null, use_gps_location true ... ok
+ORCH-1036: resolver unit — non-GPS prefers gate cityName over manualLocation ... ok
+ok | 4 passed | 0 failed (7ms)
+```
+
+**Fails-on-revert verified at `e944b0b202e08145bac81ca125b60d45ad8cf915`** (worktree HEAD before the fix commit). Reverting the resolver to the pre-fix behavior (`custom_location: state.manualLocation`) produced:
+```
+FAILED | 1 passed | 3 failed (26ms)
+```
+The critical gate-survival test failed with `custom_location` Actual=`null`/`Some Stale Typed City` vs Expected=`Washington`, plus the GPS-clean test failed — proving the test exercises the bug. Fix restored → 4 passed.
+
+Command (run from `app-mobile/`):
+```
+/Users/sethogieva/.deno/bin/deno test --no-check src/utils/__tests__/onboardingLocationOverride.test.ts
+```
+
+---
+
+## 8. Verification matrix
+
+| Criterion | How verified | Result |
+|---|---|---|
+| `handleSavePreferences` no longer nulls the gate's `custom_location` | Code read + regression test #1 (gate survival) | PASS |
+| Gate user's picked city persists through full onboarding | Regression test #1 asserts non-null after the full sequence | PASS |
+| GPS user stays clean (`custom_location=null`, `use_gps_location=true`) | Regression test #3 | PASS |
+| Cache (`setQueryData`) matches persisted values | Code read — both blocks use the same resolved vars | PASS |
+| `as any` cast removed without type errors | `npx tsc --noEmit` → no errors in `OnboardingFlow.tsx`/`onboardingLocationOverride.ts`/`preferencesService.ts` | PASS |
+| Regression test fails on revert | Reverted resolver → 3 failed; restored → 4 passed | PASS |
+| No third location writer / invariants held | §5 | PASS |
+
+`tsc --noEmit` on the whole app-mobile reports only PRE-EXISTING, unrelated errors (BoardDiscussion, TripCard, payments tests, brand-rendering package, Deno-style test files) — none in the three touched files. No new errors introduced.
+
+---
+
+## 9. Cache safety
+
+- No query KEY changed. `['userPreferences', user.id]` key unchanged; `setQueryData` now writes the same resolved location values as the DB upsert → in-session cache and cold-relaunch DB fetch agree (both non-null for a gate user, both null for a GPS user). Fixes the §6 "cache vs DB divergence" hidden flaw from the investigation (cache used to write `data.manualLocation` = null too, so it was consistently-wrong; now consistently-correct).
+
+---
+
+## 10. Discoveries for Orchestrator
+
+- **ORCH-1028 launch-city gate is uncommitted WIP on the anchor checkout only.** The gate handler (`handleLaunchGateConfirmCity`, `launchGate` state, `check-launch-city`) lives as uncommitted changes on `~/Desktop/mingla-main` `OnboardingFlow.tsx` (the file Metro :8109 serves), NOT on any branch — this ORCH-1036 worktree branch is based on `e944b0b20` which predates the gate. **This ORCH-1036 fix was applied to `handleSavePreferences`, which is byte-identical in both the pre-gate and gate versions and touches a different function than the gate handler**, so it will merge cleanly with ORCH-1028 whenever ORCH-1028 is committed. Recommend the orchestrator ensure ORCH-1028's gate work gets committed/PR'd so this fix and the gate land on `main` together; until then the bug only reproduces against the anchor WIP (as the investigation noted).
+- **Pre-existing: `handleManualLocation` (legacy typed-city flow) never sets `data.useGpsLocation = false`.** It sets `manualLocation` + `coordinates` but leaves `useGpsLocation` at its prior value. With this fix, the save's GPS branch keys off `use_gps_location`; if a legacy manual-location user still has `useGpsLocation=true`, their typed city would resolve to null. This is OUT OF SCOPE for ORCH-1036 (the gate path correctly sets `useGpsLocation=false`), but is a latent correctness gap in the legacy manual path worth a follow-up ORCH if that path is still reachable. Not fixed here to honor scope discipline.
+
+---
+
+## 11. Files changed
+
+- `app-mobile/src/utils/onboardingLocationOverride.ts` (NEW, +77)
+- `app-mobile/src/utils/__tests__/onboardingLocationOverride.test.ts` (NEW regression test, +~165)
+- `app-mobile/src/components/OnboardingFlow.tsx` (import +1; derivation + upsert + cache fields; `as any` removed)
+
+No migrations, no edge functions, no deploy. app-mobile only.

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md
@@ -1,0 +1,120 @@
+# INVESTIGATION — ORCH-1036 [Launch-city gate override clobbered by final onboarding save]
+
+- **Mode:** INVESTIGATE (investigation only — no fix)
+- **Date:** 2026-06-01
+- **Author:** mingla-forensics (Claude)
+- **Confidence:** ROOT CAUSE PROVEN (six-field evidence + deterministic DB replay + matching production rows + live deck render)
+- **Anchor:** `/Users/sethogieva/Desktop/mingla-main` (running Metro :8109, iPhone 17 Pro sim `17091E60…`)
+- **Comms ledger:** read on entry. No `BLOCK`/`OPEN` row addressed to `mingla-forensics` or `ORCH-1036`/`ALL` requiring action this turn (COMMS-0003 external-API and COMMS-0017 device-reservation are FYI/WARN, not applicable — no external API touched, physical Samsung not used). No new cross-ORCH discovery requiring a ledger write.
+
+---
+
+## 1. Symptom Summary
+
+| | |
+|---|---|
+| **Expected** | A new user outside a live city picks a live city (DC) at the ORCH-1028 launch-city gate. That choice persists as their custom location: the preferences sheet shows "Washington" and the deck uses DC. |
+| **Actual** | After completing the rest of onboarding, the picked city's **label disappears**: `preferences.custom_location` is `NULL`. The preferences sheet shows a blank city (looks like GPS / no custom location). The coordinates DO survive, so the deck still pulls DC cards — but the user-visible custom-location state is half-erased. |
+| **Repro** | Operator reproduced twice today (incl. after delete+recreate). Confirmed by 2 production `preferences` rows written 2026-06-01 07:04 and 07:26 UTC. |
+| **When it started** | ORCH-1028 launch-city gate (just shipped; gate code is the uncommitted WIP on the anchor `OnboardingFlow.tsx`, which is exactly what Metro :8109 is serving). |
+
+---
+
+## 2. Root Cause (🔴 — six fields)
+
+| Field | Evidence |
+|---|---|
+| **File + line** | `app-mobile/src/components/OnboardingFlow.tsx:1722` (the `handleSavePreferences` upsert), specifically the `custom_location: data.manualLocation` key at **line 1732**. |
+| **Exact code** | `await withTimeout(PreferencesService.updateUserPreferences(user.id, { intents…, categories…, travel_mode…, …, use_gps_location: data.useGpsLocation, custom_location: data.manualLocation, intent_toggle: true, category_toggle: true } as any), 8000, 'saveOnboardingPreferences')` |
+| **What it does** | Fires at the Step-4 `travel_time → Step-5` transition (AFTER the Step-3 `location` gate). It upserts the `preferences` row including `custom_location: data.manualLocation`. The launch-city gate (`handleLaunchGateConfirmCity`, line 1536) set `data.cityName` and `data.coordinates`, but **never set `data.manualLocation`** — so for a gate user `data.manualLocation` is `null`. The upsert therefore overwrites the gate's `custom_location: 'Washington'` with `null`. (It OMITS `custom_lat`/`custom_lng`, so those survive — see below.) |
+| **What it should do** | The final save must preserve the gate's override: either carry `custom_location` = the gate's `data.cityName` (and `custom_lat/custom_lng` = the gate's coords) when `use_gps_location === false`, or omit `custom_location` from this payload entirely when the gate already wrote it (so the upsert leaves it untouched, exactly as it already does for `custom_lat/custom_lng`). |
+| **Causal chain** | (1) Step-3 gate: user picks DC → `handleLaunchGateConfirmCity` upserts `{custom_lat:38.907, custom_lng:-77.037, custom_location:'Washington', use_gps_location:false}` ✅. It sets local `data.useGpsLocation=false`, `data.coordinates`, `data.cityName='Washington'` — **but not `data.manualLocation`** (line 1559-1564). (2) User continues to Step-4 (categories→transport→travel_time). (3) `handleSavePreferences` upserts a fresh preferences object with `custom_location: data.manualLocation` (= `null`) and OMITS `custom_lat/custom_lng`. (4) supabase-js `.upsert()` → PostgREST `INSERT … ON CONFLICT (profile_id) DO UPDATE SET <only provided columns>`: `custom_location` is provided as `null` → **clobbered to null**; `custom_lat/custom_lng` are NOT provided → **preserved**. (5) Net DB state: `use_gps_location=false, custom_location=null, custom_lat=38.907, custom_lng=-77.037`. (6) Preferences sheet load (`PreferencesSheet.tsx:433`) gates the city-label on `!isGps && prefs.custom_location` — false because `custom_location` is null → search box renders blank, looks like "no custom location". |
+| **Verification step** | (a) Deterministic replay of the two upserts in onboarding order against a temp mirror of `preferences` → `custom_location` goes `'Washington'`→`null`, `custom_lat/lng` preserved (see §4). (b) Two production rows from today match this exact signature byte-for-byte. (c) Live deck on the sim renders a DC restaurant card (coords survived). |
+
+**Service mechanism:** `PreferencesService.updateUserPreferences` (`app-mobile/src/services/preferencesService.ts:65-81`) does `supabase.from("preferences").upsert({profile_id:userId, ...preferences, updated_at})` with **no `onConflict`**. PK is `preferences_pkey PRIMARY KEY (profile_id)`, so the conflict target is `profile_id`. PostgREST builds the `DO UPDATE SET` column list from the payload keys only — **omitted columns are preserved, provided columns (including explicit `null`) are written.** This is why `custom_lat/lng` survive but `custom_location` is nulled. supabase-js `2.74.0`.
+
+---
+
+## 3. Candidate causes considered & disproven (Prime Directive 1)
+
+1. **🔴 CONFIRMED — `handleSavePreferences` clobbers `custom_location` with `data.manualLocation` (null).** Proven (§2/§4).
+2. **DISPROVEN — supabase-js upsert nulls ALL omitted columns ("replace" semantics), clobbering `custom_lat/lng` too.** Replay (§4) and production rows show `custom_lat/lng` SURVIVE. PostgREST upsert is column-scoped, not row-replace. So the deck (coords-first) still works.
+3. **DISPROVEN — a locale / GPS side-effect re-runs after the gate and resets `use_gps_location` to true.** `captureLocation` sets `useGpsLocation=true` (line 1402) but runs BEFORE the gate; the locale writes at lines 1442/1466 (and the `handleManualLocation` writes at 1655/1690) touch only `profiles.currency`/`measurement_system`, never `preferences` and never location. `handleSavePreferences` writes `use_gps_location: data.useGpsLocation` which the gate set to `false` — and the production rows confirm `use_gps_location` stayed `false`. No GPS reset occurs.
+4. **DISPROVEN — the upsert inserts a NEW row (missing PK) instead of updating.** PK is `profile_id`, which the payload always includes; the two writes target the same row (confirmed by single-row result in replay and single row per profile in prod).
+5. **DISPROVEN — pure display bug with intact data.** `custom_location` is genuinely `null` in the DB (data integrity loss), not merely mis-rendered. The display blank is a *downstream consequence* of the data clobber.
+
+---
+
+## 4. Live-fire repro & deterministic proof
+
+### 4a. Production rows (operator's two live full-onboarding repros today)
+
+`SELECT profile_id, use_gps_location, custom_location, custom_lat, custom_lng, updated_at FROM preferences ORDER BY updated_at DESC` (Management API, project `gqnoajqerqhnvulmnyvv`):
+
+```
+4c500601-…  use_gps_location=false  custom_location=NULL  custom_lat=38.9072873  custom_lng=-77.0369274  2026-06-01 07:26:05Z
+78d9913f-…  use_gps_location=false  custom_location=NULL  custom_lat=38.9072873  custom_lng=-77.0369274  2026-06-01 07:04:53Z
+```
+
+`38.9072873, -77.0369274` is the exact `seeding_cities` center for **Washington** (the only `is_live_for_consumers=true` city). Contrast with older manual-location rows (e.g. `ac7f00ee-…`) which carry BOTH a full `custom_location` string AND coords. The two fresh rows have coords with a **null label** — the precise set-then-clear signature.
+
+### 4b. Deterministic two-write replay (isolates the clobber mechanism)
+
+Replayed the exact onboarding write order against a temp table mirroring `preferences` (PK `profile_id`), inside a transaction, rolled back:
+
+- **After STEP A (gate write — `handleLaunchGateConfirmCity`):**
+  `use_gps_location=false, custom_location='Washington', custom_lat=38.9072873, custom_lng=-77.0369274` ✅ override correct.
+- **After STEP B (`handleSavePreferences` — `custom_location:null`, omits `custom_lat/lng`):**
+  `use_gps_location=false, custom_location=NULL, custom_lat=38.9072873, custom_lng=-77.0369274, categories=[…]` ← **`custom_location` clobbered to null; coords preserved.**
+
+This matches the production rows exactly and proves the column-scoped upsert behavior.
+
+### 4c. Live deck render (coords survive → deck DOES use the override)
+
+Sim screenshot `Mingla_Artifacts/reports/orch-1036-evidence/sim_current_state.png` (iPhone 17 Pro, Metro :8109): post-onboarding deck rendering **"Pisco y Nazca Ceviche Gastrobar"** — a Washington DC venue. The deck is pulling DC cards because `useUserLocation` Priority-1 reads `custom_lat/custom_lng` (which survived). Confirms the deck side is NOT broken by the clobber.
+
+---
+
+## 5. Outcome & journey step-back (isolation)
+
+**User goal:** "I'm outside a live city; let me browse DC instead, and have the app remember that."
+
+| Journey node | Reality |
+|---|---|
+| Pick DC at gate | ✅ gate writes coords + label + `use_gps_location:false` |
+| Finish onboarding | ❌ `handleSavePreferences` nulls the **label** (`custom_location`); coords kept |
+| Deck loads | ✅ uses DC (coords-first in `useUserLocation.ts:55`) |
+| Open Preferences sheet | ❌ `PreferencesSheet.tsx:433` needs `custom_location` to show the city → blank; user perceives "my city didn't save" |
+| Apply prefs without retyping | ⚠️ recoverable — sheet restored `selectedCoords` from `custom_lat/lng` (line 447) and re-saves them (line 938), but label stays null unless re-typed |
+
+**Conclusion:** this is a **persistence clobber** (real `custom_location` data loss in the DB), whose most visible symptom is the **preferences-sheet blank-city display**. The deck continues to work because coords survive. Fixing the single write at line 1732 (and ideally carrying coords from the gate too, for robustness) restores the full outcome. No upstream/downstream node other than this write needs to change to deliver the outcome — but see §6 hidden flaws.
+
+---
+
+## 6. Blast radius & hidden flaws
+
+- **🟠 Contributing — `handleSavePreferences` builds a fresh "save-all" preferences object that does not carry the gate's override fields.** Any field the gate owns but this save also writes will be clobbered. Today only `custom_location` collides (gate writes it, save writes it as `data.manualLocation`). `custom_lat/lng` escape only by luck (omitted). If a future edit adds `custom_lat/lng` to this save payload sourced from `data.coordinates`, note `data.coordinates` IS set by the gate (line 1562) so that would actually be fine — but `data.manualLocation` is the mismatch.
+- **🟡 Hidden flaw — cache vs DB divergence.** The same handler's `queryClient.setQueryData(['userPreferences'], …)` at line 1749 writes the FULL correct object (including `custom_lat/lng` from `data.coordinates` and `custom_location: data.manualLocation` = null). So in-session cache has correct coords but null label; on cold relaunch the DB row (null label, intact coords) is fetched. Both paths agree on "null label, valid coords" — consistent, but consistently wrong on the label.
+- **🟡 Hidden flaw — `as any` on the save payload (line 1735)** suppresses type-checking that could have caught the `custom_location` field-shape mismatch.
+- **🔵 Observation — `I-1028-ONE-LOCATION-OWNER`** (cited at gate line 1542) is violated in spirit: the gate claims to be the one owner of the four `custom_*`/`use_gps_location` fields, but `handleSavePreferences` is a second writer of `custom_location` + `use_gps_location` that runs later and wins.
+- **Cross-surface:** consumer iOS + Android share `OnboardingFlow.tsx` → both affected. No business/admin/web analog (onboarding is consumer-app only).
+
+---
+
+## 7. Fix strategy (direction only — NOT a spec)
+
+Make `handleSavePreferences` preserve the gate's override. Minimal options:
+1. **Omit `custom_location` (and `use_gps_location`) from the `handleSavePreferences` upsert** so the gate's values are left untouched (mirrors how `custom_lat/lng` already survive), OR
+2. **Source them from the same state the gate set:** when `data.useGpsLocation === false`, write `custom_location: data.cityName ?? data.manualLocation` and `custom_lat/custom_lng: data.coordinates?.lat/lng`. Keep `custom_location: null` only when `data.useGpsLocation === true`.
+
+Either restores `custom_location='Washington'` end-to-end. Confirm the in-handler `setQueryData` (line 1749) writes the same non-null label.
+
+## 8. Regression prevention (direction)
+- A test that runs gate-confirm → save-preferences and asserts the persisted `preferences` row keeps `custom_location` non-null when `use_gps_location=false`.
+- Consider giving `updateUserPreferences` an explicit single owner for the four location fields, or drop the `as any` so the payload is type-checked.
+
+---
+
+## 9. Confidence
+
+**ROOT CAUSE PROVEN.** Six-field evidence complete; clobber mechanism deterministically replayed; matches two production full-onboarding repros from today; live deck confirms coords survive (display-side isolation). The only un-exercised path is a Maestro-driven fresh-account onboarding from scratch — not required, because the operator's own two completed onboardings today produced the exact DB signature and the mechanism is proven at the SQL layer.

--- a/Mingla_Artifacts/reports/QA_ORCH-1036_GATE_OVERRIDE_CLOBBER.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1036_GATE_OVERRIDE_CLOBBER.md
@@ -1,0 +1,149 @@
+# QA — ORCH-1036 [Launch-city gate override clobbered by final onboarding save]
+
+- **Mode:** TARGETED (orchestrator-dispatched)
+- **Date:** 2026-06-01
+- **Tester:** mingla-tester (Claude)
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1036-[gate-override-clobber]/` on branch `ORCH-1036-gate-override-clobber`
+- **Commit under test:** `caeb5f261` (fix) + `935bf1558` (this QA's adversarial test)
+- **Inputs:** `IMPLEMENTATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md`, `INVESTIGATION_ORCH-1036_GATE_OVERRIDE_CLOBBER.md`
+- **Comms ledger:** read on entry. No `BLOCK`/`OPEN` row addressed to `mingla-tester`, `ORCH-1036`, or `ALL` requires action for this app-mobile-only frontend QA. COMMS-0002/0003/0004 are backend/external-API/intake concerns (N/A — no `supabase/functions`, no migration, no external API, not an INTAKE turn). COMMS-0017 (physical Samsung reservation) is RESOLVED. No new cross-ORCH discovery requiring a ledger write.
+
+---
+
+## VERDICT: CONDITIONAL PASS
+
+The fix is **correct and complete at the code + unit/integration + DB-evidence layers**, and **BOTH clobber sites are fixed**. The single reason this is CONDITIONAL rather than full PASS is the live full-onboarding sim repro: it is **not cleanly feasible from this worktree without violating two hard constraints** (see §6). The unit/integration floor is fully met and the production DB evidence independently corroborates both the bug and the post-fix outcome. Orchestrator may accept the deferral, or run the optional live leg per §6 before CLOSE.
+
+| Severity | Count |
+|---|---|
+| P0 | 0 |
+| P1 | 0 |
+| P2 | 0 |
+| P3 | 1 (empty/whitespace label not trimmed — not reachable via real onboarding state; pinned by test) |
+| P4 | 2 (clean resolver isolation; DB↔cache now provably agree) |
+
+---
+
+## 1. BOTH clobber sites confirmed fixed (the dispatch's central question)
+
+The dispatch flagged TWO clobber sites in `handleSavePreferences`. Mapping the anchor-WIP line numbers (1732 + 1758) to the actual code:
+
+| Site | Anchor line (gate WIP) | What it is | Pre-fix | Post-fix (worktree) | Fixed? |
+|---|---|---|---|---|---|
+| **Site 1** | `OnboardingFlow.tsx:1732` | Persisted `PreferencesService.updateUserPreferences` upsert | `custom_location: data.manualLocation` (+ `as any`, OMITS coords) | `custom_location: resolvedCustomLocation` + explicit `custom_lat/lng` from resolver; `as any` removed | ✅ worktree line 1595 |
+| **Site 2** | `OnboardingFlow.tsx:1758` | In-handler `queryClient.setQueryData(['userPreferences', user.id], …)` cache pre-seed | `custom_location: data.manualLocation`, coords from `data.coordinates` | `custom_location: resolvedCustomLocation`, coords from resolver | ✅ worktree line 1623 |
+
+**The dispatch's "solo vs collab" guess was incorrect** — the two sites are **DB-write vs React-Query-cache-write**, both inside the single `handleSavePreferences`. Both nulled `custom_location` for a gate user because `data.manualLocation` is always null on the gate path. The implementor's investigation only named Site 1 explicitly (line 1732) but DID fix both; this QA independently confirms Site 2 (the cache write) was also clobbering and is now fixed.
+
+**Crucially, both sites consume the SAME resolver result.** The fix destructures `resolveOnboardingLocationOverride(...)` ONCE into `resolvedCustomLocation`/`resolvedCustomLat`/`resolvedCustomLng` (worktree lines 1573-1582) and reuses those three vars in both the DB upsert (1595-1597) and the cache write (1623-1625). Therefore the persisted row and the in-session cache are guaranteed byte-identical on the location fields — this also closes the investigation's §6 "cache vs DB divergence" hidden flaw. Verified by reading the diff and by my adversarial two-writer-parity test.
+
+Evidence — actual diff (worktree `caeb5f261` vs base `e944b0b20`):
+```
+- custom_location: data.manualLocation,                  →  custom_location: resolvedCustomLocation,   (DB)
++ custom_lat: resolvedCustomLat, custom_lng: resolvedCustomLng,  (now explicit at DB site)
+- } as any),                                              →  }),                                        (cast removed)
+- custom_location: data.manualLocation,                  →  custom_location: resolvedCustomLocation,   (cache)
+- custom_lat: data.coordinates?.lat ?? null,             →  custom_lat: resolvedCustomLat,
+- custom_lng: data.coordinates?.lng ?? null,             →  custom_lng: resolvedCustomLng,
+```
+
+If only one site had been fixed, this would be a FAIL. **Both are fixed.** PASS on the central question.
+
+---
+
+## 2. Implementor regression test — green + fails-on-revert (independently re-verified)
+
+- **Path:** `app-mobile/src/utils/__tests__/onboardingLocationOverride.test.ts` (4 tests, Deno).
+- **Run (fix in place):** `4 passed | 0 failed`.
+- **Fails-on-revert (this QA re-ran it, not trusting the implementor's claim):** I reverted the resolver body to the pre-fix behavior (`custom_location: state.manualLocation` unconditionally) and re-ran → `1 passed | 3 failed`. The critical gate-survival test failed `custom_location` Actual=`null` vs Expected=`"Washington"`; the GPS-clean test and the resolver-unit test also failed. Restored the resolver → `4 passed`. Tree clean afterward (only a `deno.lock` cache touch, reverted).
+
+Command (from `app-mobile/`): `/Users/sethogieva/.deno/bin/deno test --no-check src/utils/__tests__/onboardingLocationOverride.test.ts`
+
+The test correctly models the PostgREST column-scoped upsert (provided keys incl. explicit null overwrite; omitted keys preserved), matching the investigation's proven mechanism and `preferencesService.ts:75` (`upsert(payload)` with no `onConflict`).
+
+---
+
+## 3. Tester adversarial regression test — distinct angle, green + fails-on-revert
+
+- **Path:** `app-mobile/src/utils/__tests__/onboardingLocationOverride.adversarial.test.ts` (5 tests, Deno). Committed to the ORCH-1036 branch as `935bf1558` so it ships in the closing PR.
+- **Distinct angles (NOT a renamed copy of the happy-path test):**
+  1. **Two-writer DB↔cache parity** — asserts the persisted DB write AND the in-handler `setQueryData` cache write carry the IDENTICAL resolved override. The implementor's test only exercises a single upsert simulator; this attacks the cold-relaunch-vs-in-session divergence (investigation §6 hidden flaw) that the bug spanned across BOTH sites.
+  2. **GPS → custom → GPS toggle** in one session — a user who picked a city then re-ran GPS; the resolver must NULL the stale override (the inverse failure mode). Models an existing override row being cleared.
+  3. **Idempotency** — running the final save twice converges to the same row, no drift.
+  4. **Non-GPS with no label at all** — resolver does not invent a label.
+  5. **Empty/whitespace label boundary** — pins current behavior (P3, see §5).
+- **Run (fix in place):** `5 passed | 0 failed`. Combined with the implementor's: `9 passed | 0 failed`.
+- **Fails-on-revert:** against the pre-fix resolver → `1 passed | 4 failed` (parity, GPS-toggle, idempotency, and empty-label tests all break; only the all-null defensive case survives). Restored → green.
+
+---
+
+## 4. Both-path trace (Step 3 of dispatch)
+
+- **Site 1 (DB) + Site 2 (cache) both apply the resolver** — confirmed §1.
+- **Cache update matches persisted values** — both sites read the same three destructured vars; a true GPS user ends with `custom_location=null`/`custom_lat=null`/`custom_lng=null`/`use_gps_location=true` at BOTH sites (resolver GPS branch returns all-null; `use_gps_location: data.useGpsLocation` is `true`). Verified by code read + adversarial parity test + resolver probe (`useGpsLocation:true` → `{custom_location:null,custom_lat:null,custom_lng:null}` even with stale cityName/coords present).
+- **Downstream consumers (cross-domain):**
+  - `PreferencesSheet.tsx:433` — `if (!isGps && prefs.custom_location) setSearchLocation(prefs.custom_location)`. Pre-fix null → blank city box (the user-visible symptom). Post-fix "Washington" → label renders. **Symptom fixed.**
+  - `PreferencesSheet.tsx:447` — coords from `custom_lat/lng` (survived even pre-fix; unchanged).
+  - `useUserLocation.ts:140-143` — reads `custom_lat/lng/location` + `use_gps_location` from cached prefs; cache + DB now agree, so deck and label are consistent on cold relaunch.
+- **No third location writer introduced.** Writers remain: gate (`handleLaunchGateConfirmCity`, anchor only), final save (now derives from the same state), Preferences sheet. The resolver is a pure derivation of existing onboarding state.
+
+---
+
+## 5. Findings
+
+- **P3 — empty/whitespace `cityName` is not trimmed/empty-checked.** The resolver uses `??`, which only catches `null`/`undefined`. Probe: `cityName:""` → `custom_location:""` (not null); `"   "` → `"   "`. **Not a live bug:** the gate sources `cityName` from `seeding_cities.name` (always a real non-empty string, e.g. "Washington" — confirmed in DB) and the legacy path sources `manualLocation` from a geocoded address; neither can be empty via real onboarding. Even if `""` slipped through, `PreferencesSheet.tsx:433` gates on truthiness so `""` reads as "no custom location" (same as null) — no visible corruption. Pinned by an adversarial test so a future `trim()`/empty-check is deliberate, not a silent change. Optional hardening for a follow-up; not a blocker.
+- **P4 — clean resolver isolation.** Extracting `resolveOnboardingLocationOverride` as a pure function is the right call: it makes the exact shipped logic unit-testable with fails-on-revert and keeps the gate as semantic owner (I-1028 honored).
+- **P4 — DB↔cache now provably agree.** Single resolver call feeding both sites eliminates the divergence class entirely.
+- **Out-of-scope note (already flagged by implementor §10):** the legacy `handleManualLocation` flow never sets `useGpsLocation=false`; if a legacy typed-city user retained `useGpsLocation=true`, the resolver's GPS branch would null their typed city. The gate path correctly sets `useGpsLocation=false`, so ORCH-1036's scope is unaffected. Latent legacy gap worth a follow-up ORCH if that path is still reachable — NOT a regression introduced by this fix.
+
+---
+
+## 6. Live full-onboarding repro — attempted, blocked, with strong DB-evidence substitute
+
+**Result: live end-to-end sim repro NOT cleanly feasible from this worktree.** Stated explicitly per the dispatch.
+
+**Why (two hard blockers, both honored rather than overridden):**
+1. **The gate code and the fix live in different places.** The ORCH-1028 launch-city gate (`handleLaunchGateConfirmCity`/`launchGate`/`check-launch-city`) that *triggers* the bug exists ONLY as **uncommitted WIP on the anchor `~/Desktop/mingla-main` `OnboardingFlow.tsx`** (confirmed: anchor on `main`, file shows `M`, gate handler present at anchor lines ~1536-1548). This ORCH-1036 worktree branch is based on `e944b0b20`, which **predates the gate** — `grep` for the gate handler in the worktree returns nothing. So no single checkout currently has BOTH the gate AND the fix in one runnable bundle. (This is exactly the implementor's §10 discovery.)
+2. **Metro :8109 is the operator's live test session and must not be disturbed.** `lsof` confirms node PID 43534 listening on :8109; the dispatch and the running-Metro state indicate Seth is actively testing the anchor WIP. Producing a clean repro would require either applying the fix onto the anchor's gate WIP and reloading (forbidden — `feedback_shared_anchor_checkout_staging_hazard.md`: never edit the shared anchor working tree where another session's uncommitted gate work lives; it would also mutate what Seth is testing mid-session) or killing/replacing Metro :8109 (explicitly forbidden by the dispatch).
+
+**What was verified instead (the unit test is the floor; this is the ceiling available without the blockers):**
+- **Production DB evidence — bug present (independent of the implementor's claims):** `SELECT … FROM preferences ORDER BY updated_at DESC` returns two rows written today (`4c500601` 07:26 UTC, `78d9913f` 07:04 UTC) with the exact clobber fingerprint — `use_gps_location=false`, `custom_location=NULL`, `custom_lat=38.9072873`, `custom_lng=-77.0369274` (the precise `seeding_cities` Washington center, the only `is_live_for_consumers=true` city). Coords survived, label nulled — the column-scoped-upsert signature.
+- **Production DB evidence — the fix's target outcome is reachable:** legacy non-GPS rows (`ac7f00ee`, `84f1980e`) show `use_gps_location=false` WITH a non-null `custom_location` string AND coords — proving a non-GPS row CAN and SHOULD carry a label. A true GPS row (`c727d491`) shows `use_gps_location=true` + all custom_* null — the clean state the resolver preserves. The resolver, fed the gate user's state (`useGpsLocation=false, cityName="Washington", coords={38.907,-77.037}`), yields `custom_location="Washington"` + those coords at both sites — converting the `4c500601`/`78d9913f` NULL signature into a non-null "Washington" row. This is exactly what regression test #1 asserts.
+- **No production data mutated.** Read-only queries only; the two repro rows left intact (no test-data cleanup needed since nothing was written).
+
+**Confidence ladder:** the *runtime mechanism* is `proven` at the SQL/DB layer (matching production rows from today + deterministic resolver behavior), and the code-level fix is `proven` by diff + 9 passing tests with fails-on-revert. The *full Maestro-driven fresh-account onboarding* leg is `probable`-blocked (blocker named, not hand-wavable). Per the tester verdict gate, a UI/runtime change without a `proven` full-platform sim leg caps at CONDITIONAL PASS with explicit operator deferral — which is what this is.
+
+**To convert to full PASS (optional, orchestrator's call), the cleanest path is at CLOSE time:** once ORCH-1028's gate is committed and ORCH-1036 is rebased/merged so a single bundle has BOTH, run one Maestro flow: fresh account → set sim GPS outside DC → pick Washington at the gate → complete onboarding → assert the new `preferences` row has `custom_location="Washington"`, `use_gps_location=false`, coords intact. The fix's old-strings are byte-identical to the anchor WIP's `handleSavePreferences` (verified: anchor 1722-1764 matches the worktree pre-fix body), so the merge is clean and the post-merge behavior is the tested behavior.
+
+---
+
+## 7. Platform parity
+
+`OnboardingFlow.tsx` is shared consumer code → iOS + Android inherit the identical fix automatically (single file, no platform branches in the changed code). Web: no consumer onboarding flow (N/A). Business/Admin: separate apps, no consumer onboarding (N/A). The fix is pure TS state-derivation with no platform-specific API — parity is automatic by construction.
+
+---
+
+## 8. Constitution + invariants
+
+- **Rule 2 (one owner per truth):** IMPROVED. The final save no longer introduces an independent null-valued writer of `custom_location`; it derives from the same onboarding state the gate populated. Gate remains semantic owner. **I-1028-ONE-LOCATION-OWNER honored.**
+- **I-LOCATION-INVALIDATE-ON-LOCATION-ONLY:** PASS. No query-key shape changed; `useUserLocation` key untouched; no new `invalidateQueries`. The `setQueryData(['userPreferences', user.id], …)` write is an existing call, only its location field VALUES changed.
+- **Rule 3 (no silent failures):** unchanged (existing try/catch + `setPrefsSaveError`).
+- Rules 1, 4-14: N/A or unchanged — no taps, keys, auth, currency, datetime, or hydration logic touched.
+
+---
+
+## 9. Completion-condition checklist (`/goal`)
+
+1. Independent tests green — ✅ `9 passed | 0 failed` (4 implementor + 5 adversarial), output captured §2-§3.
+2. `tsc --noEmit` on app-mobile — ✅ no errors in the three touched files (`OnboardingFlow.tsx`, `onboardingLocationOverride.ts`, `preferencesService.ts`); pre-existing unrelated errors elsewhere only.
+3. Both regression tests in `git diff origin/main --name-only` — ✅ all four files present (fix ×2 + both tests); adversarial attacks a different angle (DB↔cache parity / GPS-toggle / idempotency); implementor's fails-on-revert re-verified this turn at the pre-fix resolver state.
+4. UI/runtime full-platform `proven` sim leg — ⚠️ NOT met for the full-onboarding Maestro leg (blocked per §6, blocker named and genuinely unresolvable without violating the anchor-edit / don't-kill-Metro constraints). DB-layer runtime mechanism IS `proven`. This is the one clause forcing CONDITIONAL rather than full PASS.
+5. Zero open P0/P1 — ✅ (only 1×P3 + 2×P4).
+
+Clauses 1-3 and 5 fully met; clause 4 is the explicit deferral.
+
+---
+
+## 10. Recommendation to orchestrator
+
+**CONDITIONAL PASS — safe to CLOSE with the live-onboarding leg deferred to merge time.** Both clobber sites are fixed, both tests pass with fails-on-revert and ship in the PR, the DB evidence proves both the bug and the fix's target outcome, and all invariants hold. The only gap is the full Maestro onboarding repro, which is structurally blocked until ORCH-1028's gate and this fix coexist in one bundle (i.e. at merge). Recommended close path: ensure ORCH-1028 gate is committed, rebase/merge ORCH-1036 on top, then run the one-flow Maestro repro in §6 as the final pre-CLOSE confirmation (byte-identical old-strings guarantee a clean merge).

--- a/app-mobile/src/components/OnboardingFlow.tsx
+++ b/app-mobile/src/components/OnboardingFlow.tsx
@@ -33,6 +33,7 @@ import { geocodingService } from '../services/geocodingService'
 import { sendOtp, verifyOtp, OtpChannel } from '../services/otpService'
 import { logger } from '../utils/logger'
 import { saveOnboardingData, clearOnboardingData } from '../utils/onboardingPersistence'
+import { resolveOnboardingLocationOverride } from '../utils/onboardingLocationOverride'
 import { detectLocaleFromCoordinates, detectLocaleFromCountryName } from '../utils/localeDetection'
 
 // Legacy saved_people + audio services removed — pairing uses real behavior data.
@@ -1557,6 +1558,29 @@ const OnboardingFlow = ({
     setSavingPrefs(true)
     setPrefsSaveError(false)
     try {
+      // ORCH-1036 [gate-override clobber]: this final save must NOT null out the
+      // launch-city override the location step already wrote (I-1028-ONE-LOCATION-OWNER).
+      // The launch-city gate sets data.cityName + data.coordinates + useGpsLocation=false
+      // but NOT data.manualLocation; the legacy manual-location flow sets data.manualLocation.
+      // Sourcing custom_location from the always-null data.manualLocation clobbered the
+      // gate's custom_location to null while the coords survived (column-scoped upsert),
+      // leaving a deck-works-but-blank-city state. Derive the four location fields from
+      // the SAME onboarding state the location step populated, keyed off use_gps_location:
+      //  - GPS user  → custom_location/lat/lng = null (no stale override)
+      //  - non-GPS   → custom_location = data.cityName (gate) ?? data.manualLocation (legacy),
+      //                coords from data.coordinates
+      // This derives from existing state — it is NOT a third independent writer.
+      const {
+        custom_location: resolvedCustomLocation,
+        custom_lat: resolvedCustomLat,
+        custom_lng: resolvedCustomLng,
+      } = resolveOnboardingLocationOverride({
+        useGpsLocation: data.useGpsLocation,
+        cityName: data.cityName,
+        manualLocation: data.manualLocation,
+        coordinates: data.coordinates,
+      })
+
       await withTimeout(
         PreferencesService.updateUserPreferences(user.id, {
           intents: data.selectedIntents,
@@ -1568,10 +1592,12 @@ const OnboardingFlow = ({
           date_option: 'this_weekend',
           selected_dates: data.selectedDates?.length > 0 ? data.selectedDates : null,
           use_gps_location: data.useGpsLocation,
-          custom_location: data.manualLocation,
+          custom_location: resolvedCustomLocation,
+          custom_lat: resolvedCustomLat,
+          custom_lng: resolvedCustomLng,
           intent_toggle: true,
           category_toggle: true,
-        } as any),
+        }),
         8000,
         'saveOnboardingPreferences'
       )
@@ -1594,9 +1620,9 @@ const OnboardingFlow = ({
         datetime_pref: datetimePref,
         date_option: 'this_weekend',
         use_gps_location: data.useGpsLocation,
-        custom_location: data.manualLocation,
-        custom_lat: data.coordinates?.lat ?? null,
-        custom_lng: data.coordinates?.lng ?? null,
+        custom_location: resolvedCustomLocation,
+        custom_lat: resolvedCustomLat,
+        custom_lng: resolvedCustomLng,
         intent_toggle: true,
         category_toggle: true,
         selected_dates: data.selectedDates?.length > 0 ? data.selectedDates : null,

--- a/app-mobile/src/utils/__tests__/onboardingLocationOverride.adversarial.test.ts
+++ b/app-mobile/src/utils/__tests__/onboardingLocationOverride.adversarial.test.ts
@@ -1,0 +1,193 @@
+// @ts-nocheck
+/**
+ * ORCH-1036 [launch-city gate override clobber] — ADVERSARIAL regression test
+ * (tester-authored, distinct angle from the implementor's happy-path test).
+ *
+ * The implementor's test (onboardingLocationOverride.test.ts) replays gate-confirm
+ * THEN handleSavePreferences through a single column-scoped upsert simulator and
+ * asserts the DB row keeps custom_location.
+ *
+ * This test attacks DIFFERENT angles the happy-path test does not cover:
+ *
+ *   ANGLE 1 — TWO-WRITER PARITY: the real bug clobbered custom_location at BOTH
+ *     sites inside handleSavePreferences — the persisted updateUserPreferences
+ *     upsert (anchor line 1732) AND the in-handler queryClient.setQueryData cache
+ *     pre-seed (anchor line 1758). Both must receive the IDENTICAL resolved value,
+ *     or the cold-relaunch DB row and the in-session cache diverge. We model BOTH
+ *     writers from one resolver call and assert byte-equality of the location fields.
+ *
+ *   ANGLE 2 — GPS → custom → GPS toggle within one onboarding session: a user who
+ *     picked a launch city (or typed one), then went BACK and re-ran GPS capture.
+ *     useGpsLocation flips back to true while cityName/manualLocation/coordinates
+ *     still hold the stale picked-city values. The resolver MUST null all three
+ *     custom_* fields so no stale override is persisted (the inverse of the bug).
+ *
+ *   ANGLE 3 — empty / whitespace-only label boundary (documents current behavior).
+ *
+ *   ANGLE 4 — IDEMPOTENCY: running the final save twice (re-onboard / retry tap)
+ *     must converge to the same row, not accumulate or drift.
+ */
+import {
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  resolveOnboardingLocationOverride,
+  type OnboardingLocationState,
+} from "../onboardingLocationOverride.ts";
+
+const WASHINGTON = { name: "Washington", lat: 38.9072873, lng: -77.0369274 };
+
+// PostgREST column-scoped upsert simulator (same mechanism as the prod row).
+type Row = Record<string, unknown>;
+function makeUpsertStore() {
+  let row: Row | null = null;
+  return {
+    upsert(payload: Row) {
+      row = row === null ? { ...payload } : { ...row, ...payload };
+    },
+    get(): Row | null {
+      return row === null ? null : { ...row };
+    },
+  };
+}
+
+// The DB-persisted location payload (handleSavePreferences updateUserPreferences).
+function dbWritePayload(resolved: { custom_location: string | null; custom_lat: number | null; custom_lng: number | null }, useGps: boolean) {
+  return {
+    profile_id: "user-1",
+    use_gps_location: useGps,
+    custom_location: resolved.custom_location,
+    custom_lat: resolved.custom_lat,
+    custom_lng: resolved.custom_lng,
+  };
+}
+
+// The in-handler React Query cache pre-seed (handleSavePreferences setQueryData).
+// In the SHIPPED code both blocks destructure the SAME resolver result, so this
+// mirrors the cache object's location fields.
+function cacheWriteLocationFields(resolved: { custom_location: string | null; custom_lat: number | null; custom_lng: number | null }, useGps: boolean) {
+  return {
+    use_gps_location: useGps,
+    custom_location: resolved.custom_location,
+    custom_lat: resolved.custom_lat,
+    custom_lng: resolved.custom_lng,
+  };
+}
+
+Deno.test("ORCH-1036 adversarial: persisted DB write and in-session cache write carry the IDENTICAL gate override (no DB↔cache divergence)", () => {
+  // Gate user finishing onboarding (the exact bug condition: manualLocation null).
+  const state: OnboardingLocationState = {
+    useGpsLocation: false,
+    cityName: "Washington",
+    manualLocation: null,
+    coordinates: { lat: WASHINGTON.lat, lng: WASHINGTON.lng },
+  };
+  // The SHIPPED code resolves ONCE and feeds both sites — model that.
+  const resolved = resolveOnboardingLocationOverride(state);
+
+  const db = dbWritePayload(resolved, state.useGpsLocation);
+  const cache = cacheWriteLocationFields(resolved, state.useGpsLocation);
+
+  // Both sites must persist the override, not null it.
+  assertEquals(db.custom_location, "Washington");
+  assertEquals(cache.custom_location, "Washington");
+
+  // CRITICAL: DB and cache must AGREE on every location field, or cold relaunch
+  // (DB) disagrees with in-session (cache) — the §9 cache-vs-DB divergence flaw.
+  assertEquals(db.custom_location, cache.custom_location);
+  assertEquals(db.custom_lat, cache.custom_lat);
+  assertEquals(db.custom_lng, cache.custom_lng);
+  assertEquals(db.use_gps_location, cache.use_gps_location);
+  assertEquals(cache.custom_lat, WASHINGTON.lat);
+  assertEquals(cache.custom_lng, WASHINGTON.lng);
+});
+
+Deno.test("ORCH-1036 adversarial: GPS → custom → GPS toggle in one session clears the stale override (inverse of the bug)", () => {
+  // User picked Washington, then went back and re-enabled GPS capture.
+  // useGpsLocation flips to true but the stale picked-city fields linger in `data`.
+  const state: OnboardingLocationState = {
+    useGpsLocation: true, // toggled back to GPS
+    cityName: "Washington", // stale from the earlier gate pick
+    manualLocation: "Brooklyn, NY, USA", // stale from an even-earlier typed attempt
+    coordinates: { lat: WASHINGTON.lat, lng: WASHINGTON.lng }, // stale coords
+  };
+  const resolved = resolveOnboardingLocationOverride(state);
+
+  const store = makeUpsertStore();
+  // Simulate an earlier gate write that DID set an override on the row...
+  store.upsert({
+    profile_id: "user-1",
+    custom_location: "Washington",
+    custom_lat: WASHINGTON.lat,
+    custom_lng: WASHINGTON.lng,
+    use_gps_location: false,
+  });
+  // ...then the final save fires with useGpsLocation back to true.
+  store.upsert(dbWritePayload(resolved, state.useGpsLocation));
+
+  const row = store.get()!;
+  // The override must be cleared — a true GPS user must NOT keep a stale custom location,
+  // even though the row previously held one. This is I-1028-ONE-LOCATION-OWNER's other edge.
+  assertEquals(row.custom_location, null);
+  assertEquals(row.custom_lat, null);
+  assertEquals(row.custom_lng, null);
+  assertEquals(row.use_gps_location, true);
+});
+
+Deno.test("ORCH-1036 adversarial: idempotency — running the final save twice converges to the same gate override", () => {
+  const state: OnboardingLocationState = {
+    useGpsLocation: false,
+    cityName: "Washington",
+    manualLocation: null,
+    coordinates: { lat: WASHINGTON.lat, lng: WASHINGTON.lng },
+  };
+  const store = makeUpsertStore();
+  store.upsert(dbWritePayload(resolveOnboardingLocationOverride(state), state.useGpsLocation));
+  const afterFirst = store.get()!;
+  store.upsert(dbWritePayload(resolveOnboardingLocationOverride(state), state.useGpsLocation));
+  const afterSecond = store.get()!;
+
+  assertEquals(afterSecond.custom_location, "Washington");
+  assertEquals(afterFirst.custom_location, afterSecond.custom_location);
+  assertEquals(afterFirst.custom_lat, afterSecond.custom_lat);
+  assertEquals(afterFirst.custom_lng, afterSecond.custom_lng);
+  assertEquals(afterFirst.use_gps_location, afterSecond.use_gps_location);
+});
+
+Deno.test("ORCH-1036 adversarial: non-GPS with NO label at all does not persist a coords-only ghost override mismatch", () => {
+  // Defensive: non-GPS but neither cityName nor manualLocation present (should never
+  // happen via the gate, but proves the resolver does not invent a label).
+  const resolved = resolveOnboardingLocationOverride({
+    useGpsLocation: false,
+    cityName: null,
+    manualLocation: null,
+    coordinates: null,
+  });
+  assertEquals(resolved.custom_location, null);
+  assertEquals(resolved.custom_lat, null);
+  assertEquals(resolved.custom_lng, null);
+});
+
+Deno.test("ORCH-1036 adversarial: empty-string label boundary (documents current behavior; downstream truthiness-gates it)", () => {
+  // The resolver uses `??`, which only catches null/undefined — an empty/whitespace
+  // string passes through. In practice neither the gate (real seeding_cities.name) nor
+  // the legacy geocoded manualLocation can be empty, and PreferencesSheet gates the city
+  // label on truthiness so "" reads as "no custom location" (same as null) — no visible
+  // corruption. This test pins the CURRENT behavior so a future trim()/empty-check is a
+  // deliberate, test-visible change, not a silent regression.
+  const empty = resolveOnboardingLocationOverride({
+    useGpsLocation: false,
+    cityName: "",
+    manualLocation: null,
+    coordinates: { lat: 1, lng: 2 },
+  });
+  assertEquals(empty.custom_location, ""); // current behavior — falsy, gated downstream
+  // and the manualLocation fallback only fires when cityName is null/undefined, NOT "":
+  const emptyWithFallback = resolveOnboardingLocationOverride({
+    useGpsLocation: false,
+    cityName: "",
+    manualLocation: "Brooklyn",
+    coordinates: { lat: 1, lng: 2 },
+  });
+  assertEquals(emptyWithFallback.custom_location, ""); // "" is non-null → wins over fallback
+});

--- a/app-mobile/src/utils/__tests__/onboardingLocationOverride.test.ts
+++ b/app-mobile/src/utils/__tests__/onboardingLocationOverride.test.ts
@@ -1,0 +1,162 @@
+// @ts-nocheck
+/**
+ * ORCH-1036 [launch-city gate override clobber] — regression test
+ *
+ * Proves the launch-city gate's custom_location override SURVIVES the full
+ * post-gate onboarding sequence (gate-confirm THEN handleSavePreferences), not
+ * just at pick time. This is the exact gap that let the bug ship in ORCH-1028:
+ * the gate wrote custom_location='Washington', then the final preferences save
+ * re-upserted custom_location=null (sourced from the always-null data.manualLocation),
+ * clobbering it while the coords survived (column-scoped upsert).
+ *
+ * The test exercises the REAL shipped derivation (resolveOnboardingLocationOverride,
+ * used by OnboardingFlow.tsx handleSavePreferences) feeding a PostgREST-faithful
+ * column-scoped upsert simulator that replays BOTH writers against one row.
+ *
+ * Mechanism faithfulness:
+ *   PreferencesService.updateUserPreferences upserts on PK profile_id with NO
+ *   onConflict and NO column list, so PostgREST builds DO UPDATE SET from the
+ *   payload keys only: keys present (incl. explicit null) overwrite the column;
+ *   omitted keys are preserved. The simulator below replicates exactly that.
+ */
+import {
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  resolveOnboardingLocationOverride,
+  type OnboardingLocationState,
+} from "../onboardingLocationOverride.ts";
+
+const WASHINGTON = { name: "Washington", lat: 38.9072873, lng: -77.0369274 };
+
+// ── PostgREST column-scoped upsert simulator ──────────────────────────────
+// One conflict target (profile_id). Provided keys (incl. explicit null) win;
+// omitted keys are preserved. Mirrors supabase.from('preferences').upsert(payload)
+// with no onConflict + no defaultToNull control.
+type Row = Record<string, unknown>;
+function makeUpsertStore() {
+  let row: Row | null = null;
+  return {
+    upsert(payload: Row) {
+      if (row === null) {
+        row = { ...payload };
+      } else {
+        // DO UPDATE SET <only provided columns> — explicit null overwrites,
+        // omitted columns are left untouched.
+        row = { ...row, ...payload };
+      }
+    },
+    get(): Row | null {
+      return row === null ? null : { ...row };
+    },
+  };
+}
+
+// ── The exact write the launch-city gate (ORCH-1028 handleLaunchGateConfirmCity)
+// performs: the four custom_*/use_gps_location override fields, nothing else. ──
+function gateConfirmPayload(city: { name: string; lat: number; lng: number }) {
+  return {
+    profile_id: "user-1",
+    custom_lat: city.lat,
+    custom_lng: city.lng,
+    custom_location: city.name,
+    use_gps_location: false,
+  };
+}
+
+// ── The exact location-bearing portion of the FINAL save (handleSavePreferences),
+// built from the SHIPPED derivation under test. ──
+function savePreferencesLocationPayload(state: OnboardingLocationState) {
+  const resolved = resolveOnboardingLocationOverride(state);
+  return {
+    profile_id: "user-1",
+    // non-location prefs the real save also writes (present so the row is realistic)
+    categories: ["nature"],
+    travel_mode: "walking",
+    use_gps_location: state.useGpsLocation,
+    custom_location: resolved.custom_location,
+    custom_lat: resolved.custom_lat,
+    custom_lng: resolved.custom_lng,
+  };
+}
+
+Deno.test("ORCH-1036: gate-confirmed launch city SURVIVES handleSavePreferences (custom_location stays non-null)", () => {
+  const store = makeUpsertStore();
+
+  // STEP A — user picks Washington at the launch-city gate (out-of-live-city user).
+  store.upsert(gateConfirmPayload(WASHINGTON));
+
+  // Snapshot at pick time — override correct (this is where the OLD code also looked fine).
+  const afterGate = store.get()!;
+  assertEquals(afterGate.custom_location, "Washington");
+  assertEquals(afterGate.use_gps_location, false);
+
+  // STEP B — user finishes onboarding; the FINAL preferences save fires.
+  // The gate set cityName + coordinates + useGpsLocation=false but NOT manualLocation.
+  const onboardingStateAtSave: OnboardingLocationState = {
+    useGpsLocation: false,
+    cityName: "Washington",
+    manualLocation: null, // gate never sets this — the exact bug condition
+    coordinates: { lat: WASHINGTON.lat, lng: WASHINGTON.lng },
+  };
+  store.upsert(savePreferencesLocationPayload(onboardingStateAtSave));
+
+  // ASSERT — after the FULL gate→save sequence, the override survives end-to-end.
+  const afterSave = store.get()!;
+  assertEquals(afterSave.custom_location, "Washington"); // <-- was null pre-fix (clobbered)
+  assertEquals(afterSave.use_gps_location, false);
+  assertEquals(afterSave.custom_lat, WASHINGTON.lat);
+  assertEquals(afterSave.custom_lng, WASHINGTON.lng);
+});
+
+Deno.test("ORCH-1036: legacy manual-location (typed city, no gate) also survives the save", () => {
+  const store = makeUpsertStore();
+
+  // Legacy flow: user typed a city; manualLocation set, cityName not set by gate.
+  const onboardingState: OnboardingLocationState = {
+    useGpsLocation: false,
+    cityName: null,
+    manualLocation: "Brooklyn, NY, USA",
+    coordinates: { lat: 40.6782, lng: -73.9442 },
+  };
+  store.upsert(savePreferencesLocationPayload(onboardingState));
+
+  const row = store.get()!;
+  assertEquals(row.custom_location, "Brooklyn, NY, USA");
+  assertEquals(row.use_gps_location, false);
+  assertEquals(row.custom_lat, 40.6782);
+  assertEquals(row.custom_lng, -73.9442);
+});
+
+Deno.test("ORCH-1036: true GPS user stays clean — custom_location null, use_gps_location true", () => {
+  const store = makeUpsertStore();
+
+  // GPS user: captureLocation set useGpsLocation=true + a cityName from reverse-geocode,
+  // but they did NOT pick a launch city. The save must NOT persist a stale custom_location.
+  const onboardingState: OnboardingLocationState = {
+    useGpsLocation: true,
+    cityName: "San Francisco", // reverse-geocoded label — must NOT become a custom override
+    manualLocation: null,
+    coordinates: { lat: 37.7749, lng: -122.4194 },
+  };
+  store.upsert(savePreferencesLocationPayload(onboardingState));
+
+  const row = store.get()!;
+  assertEquals(row.custom_location, null);
+  assertEquals(row.custom_lat, null);
+  assertEquals(row.custom_lng, null);
+  assertEquals(row.use_gps_location, true);
+});
+
+Deno.test("ORCH-1036: resolver unit — non-GPS prefers gate cityName over manualLocation", () => {
+  // When both are present (defensive), the gate's city wins (it is the live-city choice).
+  const resolved = resolveOnboardingLocationOverride({
+    useGpsLocation: false,
+    cityName: "Washington",
+    manualLocation: "Some Stale Typed City",
+    coordinates: { lat: WASHINGTON.lat, lng: WASHINGTON.lng },
+  });
+  assertEquals(resolved.custom_location, "Washington");
+  assertEquals(resolved.custom_lat, WASHINGTON.lat);
+  assertEquals(resolved.custom_lng, WASHINGTON.lng);
+});

--- a/app-mobile/src/utils/onboardingLocationOverride.ts
+++ b/app-mobile/src/utils/onboardingLocationOverride.ts
@@ -1,0 +1,63 @@
+/**
+ * ORCH-1036 [launch-city gate override clobber]
+ *
+ * Pure derivation of the four location-override fields that the FINAL onboarding
+ * preferences save (`handleSavePreferences` in OnboardingFlow.tsx) must persist.
+ *
+ * Why this exists as its own pure function:
+ * The launch-city gate (ORCH-1028 `handleLaunchGateConfirmCity`) writes
+ * `custom_location` + `custom_lat/lng` + `use_gps_location=false` to the
+ * `preferences` row at the location step. A LATER onboarding step
+ * (`handleSavePreferences`) re-upserts the same row. PostgREST upsert is
+ * column-scoped: any key present in the payload (including an explicit `null`)
+ * overwrites that column; omitted keys are preserved. The bug (ORCH-1036) was
+ * that `handleSavePreferences` sourced `custom_location` from the always-null
+ * `data.manualLocation` (the gate never sets `manualLocation`), nulling the
+ * gate's `custom_location` while the coords survived — a deck-works-but-
+ * blank-city state.
+ *
+ * The fix: derive all four fields from the SAME onboarding state the location
+ * step populated, keyed off `use_gps_location`. This is a derivation of existing
+ * state, NOT a third independent writer of the location fields
+ * (I-1028-ONE-LOCATION-OWNER honored).
+ *
+ *  - GPS user (use_gps_location=true)  → custom_location/lat/lng = null
+ *  - non-GPS user (false)              → custom_location = gate's cityName,
+ *                                        falling back to the legacy manual-location
+ *                                        string; coords from data.coordinates.
+ */
+export interface OnboardingLocationState {
+  useGpsLocation: boolean
+  /** Set by the launch-city gate (ORCH-1028) AND by GPS capture. */
+  cityName: string | null
+  /** Set by the legacy manual-location flow (typed city). Gate never sets this. */
+  manualLocation: string | null
+  coordinates: { lat: number; lng: number } | null
+}
+
+export interface ResolvedLocationOverride {
+  custom_location: string | null
+  custom_lat: number | null
+  custom_lng: number | null
+}
+
+/**
+ * Resolve the location-override columns for the final onboarding preferences save
+ * so that a launch-city / manual-location override SURVIVES the save, while a true
+ * GPS user ends up with a clean (null) custom location.
+ */
+export function resolveOnboardingLocationOverride(
+  state: OnboardingLocationState
+): ResolvedLocationOverride {
+  if (state.useGpsLocation) {
+    // True GPS user: no custom override. Never leave a stale custom_location.
+    return { custom_location: null, custom_lat: null, custom_lng: null }
+  }
+  // Non-GPS: preserve whatever the location step wrote. The launch-city gate sets
+  // `cityName`; the legacy manual-location flow sets `manualLocation`.
+  return {
+    custom_location: state.cityName ?? state.manualLocation ?? null,
+    custom_lat: state.coordinates?.lat ?? null,
+    custom_lng: state.coordinates?.lng ?? null,
+  }
+}


### PR DESCRIPTION
## ORCH-1036 — launch-city gate override clobber (fixes a bug shipped in ORCH-1028)

**Bug:** a new user picks a live city at the onboarding launch-city gate; the gate correctly writes `custom_location` + coords + `use_gps_location=false`, but the later `handleSavePreferences` step upserted `custom_location: data.manualLocation` (always null for a gate user), **nulling the picked city**. Coords survived (column-scoped upsert) so the deck still showed the city, but the Preferences sheet showed a blank location. Proven via 2 real production rows + transaction replay.

**Fix:** a shared `onboardingLocationOverride.ts` resolver feeds BOTH save sites (the DB upsert + the `setQueryData` cache write) so they agree — preserving the gate/typed city when not on GPS, and keeping a true-GPS user's custom location null. Removes the `as any` cast that hid the type mismatch.

**Evidence:**
- QA: CONDITIONAL PASS, zero P0/P1 (one harmless P3: empty-label not trimmed). `Mingla_Artifacts/reports/QA_ORCH-1036_GATE_OVERRIDE_CLOBBER.md`.
- Both clobber sites confirmed fixed + DB↔cache parity restored.
- Step 0.5: implementor test (4, **proves override survives the full gate→save sequence** — the exact gap that let this ship in 1028) + tester adversarial (5: parity, GPS-toggle, idempotency, boundary). Both green, fails-on-revert proven.
- tsc clean; invariants I-1028-ONE-LOCATION-OWNER + I-LOCATION-INVALIDATE-ON-LOCATION-ONLY held.
- Deferred: the live Maestro full-onboarding leg → operator will confirm on the dev build post-merge.

app-mobile only — no migration, no deploy; rides next native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)