### PR TITLE
Close ORCH-1044: Swipe History category slug leak (resolver hardening)

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1044_CATEGORY_LABEL_RESOLVER.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1044_CATEGORY_LABEL_RESOLVER.md
@@ -1,0 +1,151 @@
+# IMPLEMENTATION — ORCH-1044 [Category label resolver: missing-key guard hardening]
+
+- **ORCH:** ORCH-1044
+- **Branch / worktree:** `ORCH-1044-swipe-history-category-slug-leak` @ `~/Desktop/mingla-orchs/ORCH-1044-[swipe-history-category-slug-leak]/`
+- **Mode:** IMPLEMENT
+- **Date:** 2026-06-02
+- **Implementor:** mingla-implementor (Claude)
+- **Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1044_CATEGORY_LABEL_RESOLVER.md` (committed `609cd9658`) — APPROVED.
+- **Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1044_SWIPE_HISTORY_CATEGORY_SLUG.md` (committed `c1ac0367a`) — PROVEN.
+- **Comms ledger:** read on entry. No BLOCK entry targets `mingla-implementor`, `ORCH-1044`, or `ALL`. The open `ALL`-WARN entries (COMMS-0002 strict-grep backend gate, COMMS-0003 external-API-docs, COMMS-0004 intake numbering, COMMS-0015 deploy hygiene) are all N/A to this scope: pure `app-mobile/` frontend util + Deno tests, no backend file, no external network API (i18next is a bundled library), no new ORCH-ID claimed, no edge deploy. Noted, not acked.
+- **Status:** implemented and verified.
+
+---
+
+## 1. Layman Summary
+
+The "cards you viewed this session" list was showing an internal code like `category_romantic` instead of the friendly "Romantic". The fix is one logic change inside the single shared helper that ~14 screens use: it now asks i18next directly "does this label have a translation?" instead of comparing two strings that never matched on a miss — so on a miss it cleanly falls back to a title-cased word. Every screen that uses the helper is hardened at once. The helper can never again emit a `category_*` or `intent_*`-shaped token, and two unit tests lock that in (with a proof that they go red if the fix is reverted).
+
+---
+
+## 2. What Changed (Old → New Receipts)
+
+### `app-mobile/src/utils/categoryUtils.ts`
+**What it did before:** `getReadableCategoryName` statically imported the RN i18n singleton (`import i18n from '../i18n'`) at module top, and detected a missing translation with `if (translated === key)`. Because i18next strips the namespace on a miss (`appendNamespaceToMissingKey:false`), the miss-return `"category_romantic"` was never equal to the prefixed `key` `"common:category_romantic"`, so the title-case fallback was dead code and the bare token leaked to the UI.
+**What it does now:**
+- Extracted the pure resolution into an exported internal function `resolveReadableCategoryName(categoryKey: string, i18nLike: CategoryI18nLike): string` that takes an injected i18n-like object (`{ exists, t }`). This is the §6.1(a) test seam — unit-testable in Deno without booting RN.
+- `getReadableCategoryName(categoryKey: string): string` is now a thin wrapper that delegates to the pure resolver with the real i18n singleton. **Public signature unchanged.**
+- The miss-detection is now Decision D-1: `if (!i18nLike.exists(key)) return <title-case fallback>; return i18nLike.t(key);`. This asks i18next its own resource-lookup question, immune to namespace-stripping and to the NG-1 init options.
+- The real `../i18n` singleton is now loaded **lazily** via `require('../i18n')` inside `getI18n()`, only on first runtime call. This makes module-load RN-free so a Deno test can statically import the file. (The lazy load defers, not removes, the RN dependency — runtime behavior of `getReadableCategoryName` is identical for app users.)
+- Added the protective comment (top-of-file seam note + the D-1 guard comment citing ORCH-1044 and "i18next strips the namespace on a miss, so equality against the prefixed key is never true").
+**Why:** SC-1…SC-5, Decisions D-1/D-2/D-3, S-1/S-2/S-3, NG-1/NG-2/NG-3.
+**Lines changed:** ~+45 / -8 (one function split into pure + wrapper; top-level import → lazy accessor; comments).
+
+### `app-mobile/src/utils/__tests__/categoryLabelResolver.test.ts` (NEW)
+**What it does:** §7.1 happy-path T-01…T-08 via the pure resolver + a minimal i18n stub registering ONLY the real `category_*` keys from `en/common.json` (no `category_romantic`/`intent_*`), reproducing the production resource state. Asserts curated labels resolve to friendly labels and the localized hit path + empty guard are preserved.
+**Why:** Step 0.5 gate, SC-1/SC-2/SC-3/SC-6.
+**Lines:** ~88.
+
+### `app-mobile/src/utils/__tests__/categoryLabelResolver.adversarial.test.ts` (NEW)
+**What it does:** §7.2 adversarial T-A1…T-A5 — token-shape invariant `/^(common:)?(category|intent)_/`, namespace-strip simulation (stub `t()` returns the stripped key on a miss), `intent_`-shaped input defense, legacy-slug normalization + hit-path coexistence, hyphen/case normalization.
+**Why:** Step 0.5 gate, SC-1/SC-4/SC-6, DRAFT invariants I-CATEGORY-LABEL-NO-TOKEN-LEAK + I-CATEGORY-MISS-DETECTED-BY-EXISTENCE.
+**Lines:** ~98.
+
+---
+
+## 3. Spec Traceability (Success Criteria)
+
+| SC | Statement | How verified | Verdict |
+|---|---|---|---|
+| SC-1 | Curated labels return the friendly label, never a `category_/intent_` token | T-01…T-06 + T-A1 green; T-A1 fails-on-revert | PASS |
+| SC-2 | Valid slug (`casual_food`) still returns localized `i18n.t` ("Casual") | T-07 green | PASS |
+| SC-3 | Empty input → `'Experience'` | T-08 green | PASS |
+| SC-4 | Miss detected by existence check decoupled from namespace-strip | T-A2 green (stub `t()` returns stripped key on miss; resolver still yields "Romantic") | PASS |
+| SC-5 | Public signature + 14 call sites + i18n init unchanged | `getReadableCategoryName(categoryKey: string): string` unchanged; 26 call invocations across consumers untouched (`git diff` shows only `categoryUtils.ts` + 2 new tests); `i18n/index.ts` untouched | PASS |
+| SC-6 | Both test files run green in the Deno util runner | 13 passed / 0 failed | PASS |
+
+### Deviation from spec (flagged, not silently fixed) — T-06 expected string
+SPEC §7.1 T-06 expects `getReadableCategoryName('Take a Stroll') === 'Take a Stroll'`. The LOCKED, unchanged title-case fallback formula `slug.replace(/_/g,' ').replace(/\b\w/g, upper)` uppercases EVERY word boundary, so the actual output is **`'Take A Stroll'`**. The spec's expected string contradicts its own locked formula (D-1 step 2 keeps the formula verbatim; NG-3 forbids refactoring the resolver). Per Prime Directive 2 I did NOT alter the formula (that would change behavior for all consumers and exceed scope). The test asserts the resolver's true output (`'Take A Stroll'`) with an inline note. SC-1 (no token leak) still holds for this input. Registered below for the orchestrator.
+
+---
+
+## 4. Regression Test (Step 0.5 gate)
+
+- **Files:** `app-mobile/src/utils/__tests__/categoryLabelResolver.test.ts` (happy-path, implementor-owned) + `categoryLabelResolver.adversarial.test.ts` (adversarial).
+- **Runner:** same as sibling util Deno tests — `deno test --no-check <files>` (`deno.land/std@0.168.0/testing/asserts.ts`, `// @ts-nocheck` header), matching `curatedStopsAvailability.test.ts` / `openingHoursUtils.test.ts`. There is no dedicated GitHub workflow job for `app-mobile/src/utils/__tests__` Deno tests (the sibling ORCH-1019/1021 tests are Step-0.5 local-gate tests, not CI-jobbed); these two register into that same local Deno runner, per SPEC §7 "do not invent a new workflow."
+- **Passing run (fix in place):** `ok | 13 passed | 0 failed`.
+- **Fails-on-revert verified at commit `609cd9658`** (the pre-fix HEAD = spec commit; the fix is the working-tree change on top of it): temporarily restoring the old `if (translated === key)` equality guard (with the production-faithful stub whose `t()` returns the namespace-stripped key on a miss) turns **10 of 13 tests RED** — including the core T-A1 token-shape anchor and T-A2 namespace-strip simulation (`Actual: category_romantic / Expected: Romantic`). Restoring the `exists()` guard returns to `13 passed | 0 failed`. The tests genuinely exercise the bug.
+- **Shipped in the same branch as the fix** (not a side branch): yes.
+
+---
+
+## 5. Verification Matrix
+
+| Check | Method | Result |
+|---|---|---|
+| Tests green (fix) | `deno test --no-check` | 13/13 PASS |
+| Fails-on-revert | revert D-1 guard → rerun | 10/13 FAIL → restore → 13/13 PASS |
+| Typecheck (touched files) | `npx tsc --noEmit`, grep for `categoryUtils`/`categoryLabelResolver` | zero errors in touched files |
+| Typecheck (no new errors) | baseline error count stash-vs-fix | 260 baseline == 260 with fix (no new errors; baseline is pre-existing repo-wide noise in unrelated files) |
+| Lint (`categoryUtils.ts`) | `npx eslint` | clean (the intentional lazy `require` suppressed with the correct `@typescript-eslint/no-require-imports` directive) |
+| Lint (test files) | `npx eslint` | only `import/no-unresolved` on the Deno URL — identical to every sibling Deno test (baseline behavior, not a regression; these are Deno-run, not ESLint-gated) |
+| `i18n.exists()` real at runtime | i18next `index.d.ts:288 exists: ExistsFunction` | confirmed available on the singleton (i18next ^26) |
+
+---
+
+## 6. Cross-Surface Impact (Step 3.5)
+
+| Surface | Affected? | Why |
+|---|---|---|
+| Consumer iOS | YES | shared `categoryUtils.ts`; Swipe History + 13 other consumers now show friendly labels. |
+| Consumer Android | YES — **automatic parity** | same RN util, no platform branch. The Deno unit test is platform-agnostic and governs both. |
+| Buyer/anonymous Web | NO | does not consume `getReadableCategoryName`. |
+| Business iOS / Android | NO | no curated Swipe History / category render via this util. |
+| Admin Web | NO | does not render curated category labels. |
+| Business Web preview | NO | same as Business apps. |
+
+One success criterion (SC-1) governs both covered surfaces because parity is automatic via shared code. Affected-surface count for the binding gate is 1 shared code path → no manual parity drift risk.
+
+---
+
+## 7. Invariant Verification
+
+| Invariant | Preserved? |
+|---|---|
+| I-CATEGORY-SLUG-CANONICAL (legacy→canonical via `legacyToSlug`) | Y — T-A4 (`fine_dining`→"Fine Dining") green; `legacyToSlug` untouched |
+| I-CURATED-LABEL-SOURCE (`categoryLabel` stays identity source) | Y — D-2 fallback returns the same word family as `categoryLabel`; no `intent_*` override |
+| Constitution #10 (locale-aware display) | Preserved on the HIT path (real slugs localize); degrades to English title-case on the curated MISS path — the bounded accepted trade-off (NG-3 follow-up F/U-2) |
+| Constitution #3 (no silent failures) | Y — the miss is now a deliberate, tested fallback, not a swallowed token leak |
+| I-CATEGORY-LABEL-NO-TOKEN-LEAK (DRAFT) | Established + enforced by T-A1 — flips ACTIVE on CLOSE |
+| I-CATEGORY-MISS-DETECTED-BY-EXISTENCE (DRAFT) | Established + enforced by T-A2 — flips ACTIVE on CLOSE |
+
+---
+
+## 8. Constitutional Compliance (diff scan)
+
+All 14 rules PASS or N/A on the diff. Touched: #3 (no silent failures — improved), #10 (locale-aware — preserved on hit, bounded degrade on miss per spec). No `any`/`@ts-ignore`/silent catch introduced. Explicit return types present on both new functions. The one `require` is an intentional, documented test seam, not an escape hatch.
+
+---
+
+## 9. Cache Safety / Parity
+
+- **Cache:** none — pure synchronous render-time string resolution. No query keys, no AsyncStorage shape change.
+- **Solo/collab parity:** both Swipe History mount sites (`DismissedCardsSheet.tsx:179` solo, `:257` collab) call the same resolver and are hardened identically. No mode-specific code.
+
+---
+
+## 10. Regression Surface (for the tester)
+
+1. Swipe History (`DismissedCardsSheet`) solo + collab rows — curated cards show friendly labels, never `category_*`.
+2. `ExpandedCardModal` / board cards / friend-page holiday cards / Saved + Calendar tabs — the F-3 blast-radius consumers; confirm single place cards still localize correctly.
+3. The localized HIT path for real slugs (single place cards) — must not regress (T-07 covers `casual_food`).
+4. Non-English locale on the HIT path (real category slugs should still localize via the singleton's `t`).
+
+---
+
+## 11. Discoveries for Orchestrator
+
+- **Spec T-06 expected-value error (cosmetic, non-blocking):** SPEC §7.1 T-06 expects `'Take a Stroll'` but the locked title-case formula yields `'Take A Stroll'` (every-word-boundary uppercase). The test asserts the true output. No code defect; the spec table cell was inconsistent with its own locked formula. The only inputs where title-case diverges from the deck's `intent_*` label are multi-word lowercase-particle labels like "Take a Stroll" → "Take A Stroll" — which is exactly the deferred F/U-2 localization parity gap, not a new bug.
+- **F/U-1 (register):** the mixed-input contract of `getReadableCategoryName` (real slug vs. human label vs. experienceType) — Investigation §10. A future ORCH should type or split the input so a non-`category_*` string can't reach the `category_*` namespace.
+- **F/U-2 (register):** full localization of curated category labels in Swipe History (the deferred `intent_*`/experienceType-aware parity route from D-2). Only worth doing alongside F/U-1.
+- **Repo-wide tsc baseline is dirty (260 errors)** in unrelated files (BoardDiscussion, TripCard, packages/brand-rendering, jest/Deno test globals, etc.). My change adds zero new errors, but the project does not currently typecheck clean overall — flag for a separate hygiene ORCH if a green `tsc` gate is ever desired.
+
+---
+
+## 12. Deploy / Migration
+
+None. NG-5 (no backend/migration/RLS/edge). OTA deferred per `project_ota_deferred_until_new_build.md` — the merged change rides the next native build. No `supabase db push`, no edge deploy, no `eas update`.
+
+---
+
+*Implemented strictly in scope: `categoryUtils.ts` + the two test files only. No call-site edits, no i18n init changes, no new translation keys, no drive-by refactors.*

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1044_SWIPE_HISTORY_CATEGORY_SLUG.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1044_SWIPE_HISTORY_CATEGORY_SLUG.md
@@ -1,0 +1,208 @@
+# INVESTIGATION — ORCH-1044 [Swipe History curated category slug leak]
+
+- **ORCH:** ORCH-1044
+- **Branch / worktree:** `ORCH-1044-swipe-history-category-slug-leak` @ `~/Desktop/mingla-orchs/ORCH-1044-[swipe-history-category-slug-leak]/`
+- **Mode:** INVESTIGATE (root-cause only — NO fix proposed)
+- **Date:** 2026-06-02
+- **Investigator:** mingla-forensics (Claude)
+- **Confidence:** **PROVEN** (root cause reproduced with the real `i18next` library; pure source/i18n-logic bug, no gesture/animation/runtime element requiring sim repro)
+
+---
+
+## 1. Symptom Summary
+
+| | |
+|---|---|
+| **Surface** | Consumer app → Swipe History sheet (`DismissedCardsSheet.tsx`), the "N cards viewed this session" list opened from the deck. |
+| **Expected** | Each row's category meta shows a friendly label, e.g. **"Romantic"**, **"Adventurous"**, **"First Dates"**. |
+| **Actual** | For **curated** cards the row shows the raw i18n-key string **`category_romantic`** (and `category_adventurous`, `category_group_fun`, `category_picnic_dates`, `category_take_a_stroll`, and `category_first date` for "First Date"). |
+| **Scope** | Curated experience cards only. Single place cards render correctly. |
+| **Platform** | iOS **and** Android — `DismissedCardsSheet.tsx` is a shared React Native component; no platform branch. |
+
+---
+
+## 2. Investigation Manifest (files read, in trace order)
+
+| # | File | Why |
+|---|---|---|
+| 1 | `app-mobile/src/components/DismissedCardsSheet.tsx` | The reported render surface. |
+| 2 | `app-mobile/src/utils/categoryUtils.ts` | `getReadableCategoryName` — the label resolver the sheet calls. |
+| 3 | `app-mobile/src/utils/cardConverters.ts` | `curatedToRecommendation` — sets `Recommendation.category` for curated cards. |
+| 4 | `app-mobile/src/types/curatedExperience.ts` | Curated card data shape (`categoryLabel`, `experienceType`). |
+| 5 | `supabase/functions/generate-curated-experiences/index.ts` | Origin of `categoryLabel` (`CURATED_TYPE_LABELS` ← `EXPERIENCE_TYPES[].label`). |
+| 6 | `app-mobile/src/components/CuratedExperienceSwipeCard.tsx` | The **correct** live-deck render path (for comparison). |
+| 7 | `app-mobile/src/components/SwipeableCards.tsx` | Mount sites of the sheet + the curated-vs-single render branch (line 2497). |
+| 8 | `app-mobile/src/i18n/index.ts` | i18next `init()` options (no `nsSeparator`/`appendNamespaceToMissingKey` override). |
+| 9 | `app-mobile/src/i18n/locales/en/common.json` | Proves `category_*` keys exist only for real slugs; `intent_*` keys exist for experience types. |
+| 10 | (web) i18next configuration docs | Default `appendNamespaceToMissingKey: false` behavior. |
+
+---
+
+## 3. Findings
+
+### 🔴 F-1 — ROOT CAUSE: the namespace-stripped missing-key return defeats the equality guard in `getReadableCategoryName`, so the raw i18n key leaks to the UI
+
+**File + line:** `app-mobile/src/utils/categoryUtils.ts:110-116`
+
+**Exact code:**
+```ts
+// Try i18n translation
+const key = `common:category_${normalizedSlug}`;   // line 110 — namespaced key
+const translated = i18n.t(key);                     // line 111
+// If i18n returns the key itself (no translation found), fall back to formatting
+if (translated === key) {                           // line 113 — BROKEN GUARD
+  return slug.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+return translated;                                  // line 116 — leaks "category_romantic"
+```
+
+**What it does (current behavior):** `key` is built **with** the `common:` namespace prefix. On a missing key, i18next (default config — `appendNamespaceToMissingKey: false`) returns the key **without** the namespace prefix, i.e. `"category_romantic"`. The guard compares `translated` (`"category_romantic"`) against `key` (`"common:category_romantic"`) — these are **never equal on a miss**, so the human-readable title-case fallback at line 114 is dead code for namespaced keys. The function returns the bare key `category_romantic`, which the sheet renders verbatim.
+
+**What it should do (correct behavior):** When the translation is missing it must fall back to the title-cased slug (`"Romantic"`), exactly as the comment at line 112 intends. The guard must detect the miss correctly — the miss-return is the namespace-stripped form `category_${normalizedSlug}`, not the full `common:category_${normalizedSlug}`. (Direction only; no fix specced here.)
+
+**Causal chain:**
+1. Server `generate-curated-experiences/index.ts:638` sets `categoryLabel: CURATED_TYPE_LABELS[experienceType]` where `CURATED_TYPE_LABELS` ← `EXPERIENCE_TYPES[].label` (e.g. `'romantic'` → `'Romantic'`). See edge fn lines 364-368, 270-271.
+2. Client `cardConverters.ts:71` maps the curated card to a `Recommendation` with `category: card.categoryLabel || 'Experience'` → `category === 'Romantic'`.
+3. `DismissedCardsSheet.tsx:179` calls `getReadableCategoryName(card.category)` → `getReadableCategoryName('Romantic')`.
+4. In `categoryUtils.ts`: `stripped = 'Romantic'` (the `/^category\./` regex needs a literal **dot**, so `category_*` is never stripped — but that's not the issue here since the input is `'Romantic'`); `slug = 'Romantic'`; `normalizedSlug = 'romantic'`; `key = 'common:category_romantic'`.
+5. `'romantic'` has **no** `category_romantic` entry in `common.json` (the `category_*` namespace only covers real category slugs — nature, brunch, etc.; verified §5 Data layer). i18next returns the namespace-stripped miss value `'category_romantic'`.
+6. Guard `'category_romantic' === 'common:category_romantic'` → **false** → fallback skipped → returns `'category_romantic'`.
+7. Sheet renders `category_romantic` in the row meta. ✗
+
+**Verification step (PROVEN — executed):** Ran the real `i18next` (`app-mobile` has `i18next ^26.0.4`) in Node with only `category_nature` registered:
+```
+miss namespaced key returns: "category_romantic"
+hit returns: "Nature & Views"
+equality guard (translated === "common:category_romantic"): false
+```
+This confirms (a) the miss strips the namespace and (b) the guard is false on a miss, so line 116 returns the bare key. External confirmation: i18next docs — `appendNamespaceToMissingKey` defaults to `false`, so the namespace is not appended to a missing key (https://www.i18next.com/overview/configuration-options).
+
+---
+
+### 🟠 F-2 — CONTRIBUTING: Swipe History does not use the curated `intent_*` render path that the live deck uses
+
+**File + line:** broken path `DismissedCardsSheet.tsx:179` and `:257`; correct path `CuratedExperienceSwipeCard.tsx:73-74`.
+
+The **live deck** renders curated cards through `<CuratedExperienceSwipeCard>` (selected at `SwipeableCards.tsx:2497` when `cardType === 'curated'`), which derives the label as:
+```ts
+const rawIntentKey = (card.experienceType || 'adventurous').replace(/-/g, '_'); // 'romantic'
+const categoryLabel = t(`common:intent_${rawIntentKey}`);                        // 'common:intent_romantic' → "Romantic"
+```
+The `intent_*` keys **do** exist in `common.json` (lines 104-109: `intent_romantic`, `intent_adventurous`, `intent_first_date`, `intent_group_fun`, `intent_picnic_dates`, `intent_take_a_stroll`), so the live deck label resolves correctly and **never touches the broken `getReadableCategoryName` path**.
+
+Swipe History instead funnels **every** card — curated and single — through `getReadableCategoryName(card.category)`, where for curated cards `card.category` is the human label `'Romantic'` (not the `experienceType` and not a real category slug). The resolver then hits F-1. This is why the bug is **curated-only** and **Swipe-History-only**: single place cards carry a real slug (e.g. `casual_food`) that resolves cleanly, and the deck/expanded curated render uses `intent_*`.
+
+This is classified Contributing (not a second root cause): even if the sheet kept calling `getReadableCategoryName`, fixing F-1's guard would make it return `"Romantic"` (title-cased fallback) and the symptom would disappear. F-2 explains the path divergence and is the natural place a parity-consistent fix would live.
+
+---
+
+### 🟡 F-3 — HIDDEN FLAW: the same broken guard silently degrades EVERY missing-category render across the app, not just Swipe History
+
+**File + line:** `categoryUtils.ts:113` (single shared resolver) consumed by 14 call sites.
+
+`getReadableCategoryName` is called from (verified by grep):
+- `DismissedCardsSheet.tsx:179, :257` (Swipe History — reported)
+- `SwipeableBoardCards.tsx:245, :383` (collab board cards + expanded)
+- `board/SwipeableSessionCards.tsx:253` (guarded: `isCurated ? "" : ...` — curated suppressed, so safe today)
+- `SwipeableCards.tsx:2418, :2560` (single-card preview/front — fed real slugs, safe today)
+- `ExpandedCardModal.tsx:2058, :2178, :2192`
+- `expandedCard/CardInfoSection.tsx:120`
+- `PersonGridCard.tsx:81`, `PersonHolidayView.tsx:271` (friend-page holiday cards)
+- `activity/SavedTab.tsx:1795`, `activity/CalendarTab.tsx:1636`
+
+Any of these that receives a curated `categoryLabel` (e.g. `'Romantic'`) or any string lacking a `category_<slug>` key will leak the bare `category_<x>` key for the same reason. The blast radius is the whole resolver, not one screen. Swipe History is simply where the operator first saw it because it unconditionally routes curated cards through this resolver. (Surfaces that route curated cards through `intent_*` or suppress the label — `CuratedExperienceSwipeCard`, `SwipeableSessionCards` — are not affected today.)
+
+---
+
+### 🔵 F-4 — OBSERVATION: the leak does not produce "Category Romantic" because the namespace is stripped, not preserved
+
+A naïve reading of the guard suggests the worst case is the title-cased `"Romantic"` fallback or `"Category Romantic"`. Neither happens. Because i18next strips the namespace on a miss, the returned value is `category_romantic` (underscore preserved, prefix intact, no title-casing) — matching the operator's verbatim report exactly. This is the tell that distinguishes "missing translation key with broken guard" from "slug passed straight to UI."
+
+---
+
+## 4. Data Origin of the slug (chain of custody)
+
+`category_romantic` is **not** a literal anywhere in the repo (grep across `*.ts/tsx/json/sql` returns zero). It is constructed at runtime inside `getReadableCategoryName`:
+
+```
+EXPERIENCE_TYPES[].label = "Romantic"                         (edge fn: generate-curated-experiences/index.ts:270-271)
+  → CURATED_TYPE_LABELS["romantic"] = "Romantic"              (edge fn:364-368)
+  → card.categoryLabel = "Romantic"                            (edge fn:638)
+  → Recommendation.category = "Romantic"                       (client: cardConverters.ts:71)
+  → getReadableCategoryName("Romantic")                        (client: DismissedCardsSheet.tsx:179)
+  → normalizedSlug = "romantic" → key = "common:category_romantic"  (categoryUtils.ts:107-110)
+  → i18next miss returns "category_romantic" (namespace stripped)    (categoryUtils.ts:111)
+  → guard false → returns "category_romantic"                  (categoryUtils.ts:113-116)
+```
+
+So the slug-looking string is a **synthesized missing i18n key**, not data that exists in the dismissed-card record, the recommendation payload, or the DB. The curated record's real fields are `experienceType: 'romantic'` and `categoryLabel: 'Romantic'`.
+
+---
+
+## 5. Five-Layer Cross-Check
+
+| Layer | Finding |
+|---|---|
+| **Docs** | Comment at `categoryUtils.ts:112` states intent: "If i18n returns the key itself (no translation found), fall back to formatting." The code does **not** match this intent — the guard never recognizes the miss for namespaced keys. **Docs ↔ Code contradict → bug confirmed here.** |
+| **Schema/Types** | `curatedExperience.ts`: `categoryLabel?: string` (human label) and `experienceType: string` (slug-ish, e.g. `romantic`). `Recommendation.category` is fed the *label*, not the *experienceType* nor a real category slug. No type prevents a non-`category_*` string from reaching the resolver. |
+| **Code** | `cardConverters.ts:71` `category = categoryLabel`; `DismissedCardsSheet.tsx:179` calls `getReadableCategoryName`; `categoryUtils.ts:110-116` mis-guards the miss. Live deck uses `intent_*` instead (`CuratedExperienceSwipeCard.tsx:74`) — divergent paths. |
+| **Runtime** | Reproduced with real i18next: `t('common:category_romantic')` → `"category_romantic"`; guard `=== 'common:category_romantic'` → false; resolver returns `"category_romantic"`. |
+| **Data (i18n resources)** | `en/common.json` `category_*` keys (lines 62-84) cover ONLY real category slugs (nature, icebreakers, drinks_and_music, brunch, casual, casual_food, upscale_fine_dining, movies, theatre, creative_arts, play, flowers, plus legacy). There is **no** `category_romantic / _adventurous / _group_fun / _picnic_dates / _take_a_stroll / _first_date`. The matching keys live under `intent_*` (lines 104-109). |
+
+All five layers agree on the mechanism; the Docs↔Code contradiction at `categoryUtils.ts:112-116` is the locus.
+
+---
+
+## 6. Blast Radius Map
+
+- **Reported surface:** Swipe History `DismissedCardsSheet.tsx:179` (own swiped cards) and `:257` (collab "Also passed by your group" rows) — both curated cards leak.
+- **Solo AND collab:** Both. The sheet is mounted twice in `SwipeableCards.tsx` (lines 2074, 2698) with identical props; collab rows hit the same resolver at `:257`.
+- **iOS AND Android:** Shared RN component, no platform branch → identical defect on both.
+- **Other resolver consumers (F-3):** any of the 14 call sites that pass a curated `categoryLabel` or any string lacking a `category_<slug>` key (ExpandedCardModal, board cards, friend-page holiday cards, Saved/Calendar tabs). Single place cards and the curated deck/`intent_*` path are unaffected today.
+- **NOT affected:** live deck curated card (`CuratedExperienceSwipeCard` → `intent_*`), `SwipeableSessionCards` (curated label suppressed to `""`), Admin/Business (no curated category render).
+- **Cache/query keys:** none involved — pure synchronous render-time string resolution.
+- **Invariants:** brushes Constitution #10 (locale-aware display) — the label is meant to be locale-aware but degrades to a raw English key on the missing-key path; not currency, but the same "user sees an internal token" class.
+
+---
+
+## 7. Candidate Causes Considered & Disproven
+
+| Candidate | Verdict | Evidence |
+|---|---|---|
+| Slug `category_romantic` stored in the dismissed-card record / recommendation payload and rendered raw | **DISPROVEN** | Literal absent from repo (grep). `Recommendation.category` is set to `categoryLabel` (`"Romantic"`) at `cardConverters.ts:71`, not to any `category_*` string. The slug is synthesized at render time. |
+| `card.category` holds the `experienceType` (`romantic`) and is rendered without the resolver | **DISPROVEN** | `DismissedCardsSheet.tsx:179` DOES call `getReadableCategoryName`; and `category` is the label, not the experienceType (cardConverters.ts:71). |
+| Missing locale file / non-en language | **DISPROVEN** | Reproduces on `en`. The `category_romantic` key is absent in en too (and everywhere); it's the wrong key namespace, not a missing translation file. |
+| `getReadableCategoryName` not called at all (raw value) | **DISPROVEN** | It is called; the bug is INSIDE it (line 113 guard). |
+| **Equality guard fails because i18next strips the namespace on a miss** | **CONFIRMED (root cause)** | Node repro + i18next docs (§3 F-1 verification). |
+
+---
+
+## 8. Outcome & Journey Step-Back
+
+- **User's goal:** review what they swiped this session and recognize each card at a glance ("Was that the romantic wine-bar plan?").
+- **Journey:** open deck → swipe a few curated cards → tap "Review all cards" / "Review dismissed" → Swipe History sheet lists rows with thumbnail + title + category meta + status.
+- **Divergence point:** the category meta line shows `category_romantic` — an internal token — breaking recognition and trust (looks like a bug/untranslated string to the user). The title and thumbnail still read, so the card is identifiable, but the screen looks broken.
+- **Does fixing F-1 deliver the outcome?** Yes for the reported screen: fixing the guard makes the resolver return the title-cased fallback (`"Romantic"`). For full parity with the live deck (which shows the localized `intent_*` label), the SPEC should decide whether Swipe History should also route curated cards through the `intent_*` label (F-2) so the label matches the deck exactly and is locale-aware, rather than only the English title-case fallback. Both options remove the raw token; the parity option is the higher-quality outcome. **No fix is prescribed here — flagged for SPEC.**
+
+---
+
+## 9. Fix Strategy (DIRECTION ONLY — not a spec, not code)
+
+Two independent levers; SPEC chooses scope:
+1. **Correct the miss-detection in `getReadableCategoryName` (F-1)** — the guard must compare against the namespace-stripped miss form (or use i18next's `exists()` / a `defaultValue` / `appendNamespaceToMissingKey`) so the title-case fallback actually fires. This single change fixes Swipe History and hardens all 14 consumers (F-3).
+2. **(Optional, parity) Route curated cards in Swipe History through the `intent_*` label (F-2)** so the meta line matches the live deck's localized label exactly instead of an English title-case fallback.
+
+Regression-prevention direction: a unit test on `getReadableCategoryName('Romantic')` (and the other curated labels) asserting it returns a human label and never a `category_*`/`intent_*`-shaped token; optionally a strict-grep/test guard that the curated `categoryLabel` set has matching i18n keys in whatever namespace the resolver targets.
+
+---
+
+## 10. Discoveries for Orchestrator
+
+- **F-3 blast radius** is app-wide (the shared resolver), not Swipe-History-local. Whoever specs the fix should fix the resolver guard (not just the one call site) and add the resolver-level regression test, so the latent leak across ExpandedCardModal / board / friend-page / Saved / Calendar is closed in the same pass.
+- **Naming smell (non-blocking):** `getReadableCategoryName` is fed three different kinds of input across the codebase — real category slugs (`casual_food`), human display labels (`Romantic`), and (potentially) experience types. The mixed contract is what lets a non-`category_*` string reach the `category_*` namespace. Worth a SPEC note even though it's not the proximate bug.
+
+---
+
+## 11. Confidence
+
+**PROVEN.** Root cause has all six fields, the exact failing line is identified (`categoryUtils.ts:113-116`), the miss-return behavior is reproduced with the real `i18next ^26.0.4` library, the correct vs broken render paths are both read and compared, the data origin is traced end-to-end through the edge function and client converter, and ≥2 alternative causes were disproven with evidence. This is a deterministic source/i18n-logic defect with no gesture/animation/timing element, so a simulator launch is not required to elevate beyond `probable` — the Node reproduction against the production i18next is the live-fire equivalent for this bug class. No fix proposed (per dispatch).

--- a/Mingla_Artifacts/reports/QA_ORCH-1044.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1044.md
@@ -1,0 +1,168 @@
+# QA — ORCH-1044 [Swipe-History category slug leak: category-label resolver hardening]
+
+- **ORCH:** ORCH-1044
+- **Mode:** TARGETED (offline unit + invariant; live render deferred to batched signed-in session per dispatch)
+- **Date:** 2026-06-02
+- **Tester:** mingla-tester (Claude)
+- **Branch / worktree:** `ORCH-1044-swipe-history-category-slug-leak` @ `~/Desktop/mingla-orchs/ORCH-1044-[swipe-history-category-slug-leak]/`
+- **Code under test:** commit `2ff371116` — `app-mobile/src/utils/categoryUtils.ts` + 2 implementor Deno tests.
+- **Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1044_CATEGORY_LABEL_RESOLVER.md` (APPROVED, `609cd9658`).
+- **Implementation report:** `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1044_CATEGORY_LABEL_RESOLVER.md`.
+- **Comms ledger:** read on entry. No `BLOCK`+`OPEN` row targets `mingla-tester`, `ORCH-1044`, or `ALL`. The open `ALL`-WARN rows are all N/A to this scope: COMMS-0002 (strict-grep `no-new-backend-files`) — no `supabase/functions/` file touched; COMMS-0003 (external-API docs at SPEC) — i18next is a bundled library, no network API/enum/payload introduced; COMMS-0004 (ORCH-ID intake collision) — no new ID claimed; COMMS-0012/0015 (deploy/migration hygiene) — no deploy, no migration, no edge fn. Noted, not acked (FYI-grade for this scope).
+
+---
+
+## VERDICT: PASS
+
+- **P0:** 0 | **P1:** 0 | **P2:** 0 | **P3:** 0 | **P4:** 2
+- **Report:** `Mingla_Artifacts/reports/QA_ORCH-1044.md`
+- **Unit evidence:** `/Users/sethogieva/.deno/bin/deno test --no-check --allow-read` over all 3 suites → **21 passed | 0 failed**.
+- **Regression tests:** implementor = `categoryLabelResolver.test.ts` (8, happy-path) + `categoryLabelResolver.adversarial.test.ts` (5, adversarial) — ✅ independently re-confirmed fails-on-revert (10/13 RED when the old equality guard is restored). tester = `categoryLabelResolver.fullcorpus.test.ts` (8, distinct full-corpus + inverse-config angle) — ✅ green, ✅ fails-on-revert (T-T2 + T-T6 RED under old guard).
+- **Sim evidence:** DEFERRED corroboration, not a blocker. This is a deterministic, pure synchronous string-resolution fix in a shared RN util with no platform branch; the binding gate is the platform-agnostic Deno unit suite (per SPEC §5/§7). Live Swipe-History on-screen render (`DismissedCardsSheet` solo `:179` + collab `:257`) is explicitly deferred to the batched orchestrator-run signed-in session per dispatch. Confidence ladder: `proven` at the unit + invariant layer; live render = corroboration item carried to the batch.
+
+### Verdict-gate justification (the offline-PASS carve-out)
+The standing tester gate normally requires `proven`-level live-fire sim repro for any UI/runtime finding. The dispatch explicitly authorizes an offline PASS here on the basis that the fix is (a) a pure deterministic resolver, (b) unit-proven across 21 assertions, (c) fails-on-revert at the exact pre-fix guard, and (d) governed by a token-shape invariant that is machine-checkable without a device. The render is corroboration, not the gate. This is consistent with the source-only exemption band for "pure logic, no platform branch" — the unit suite IS the parity gate because parity is automatic via shared code (one resolver, no `Platform.select`). The live render is queued, not skipped.
+
+---
+
+## 1. Layman Summary
+
+The "cards you viewed this session" list was showing an internal code (`category_romantic`) instead of a friendly label ("Romantic"). The fix swaps a broken string-equality check for i18next's own `exists()` lookup inside the single shared helper that ~14 screens use, so the friendly title-case fallback now fires on a missing translation. I re-ran the implementor's 13 tests (all green), independently confirmed they go red if the fix is reverted, wrote a distinct 8-test adversarial suite (full real-locale-corpus sweep + the inverse i18next miss-config the existing tests never touch), confirmed it also goes red on revert, and statically verified the public signature, all 14 call sites, the i18n init, and `common.json` are untouched. The cosmetic "Take A Stroll" vs "Take a Stroll" spec deviation is adjudicated non-blocking. Verdict: PASS on unit + invariant evidence; the on-screen Swipe-History render is carried to the batched signed-in session as corroboration.
+
+---
+
+## 2. Independent Test Execution (captured)
+
+### 2.1 Both existing suites — 13/13 (Do-now step 1)
+`cd app-mobile/src/utils/__tests__ && deno test --no-check categoryLabelResolver.test.ts categoryLabelResolver.adversarial.test.ts`
+```
+running 8 tests from ./categoryLabelResolver.test.ts   → T-01…T-08 ok
+running 5 tests from ./categoryLabelResolver.adversarial.test.ts → T-A1…T-A5 ok
+ok | 13 passed | 0 failed (32ms)
+```
+Existing tests were NOT modified (append-only honored — the diff adds only the new file).
+
+### 2.2 Tester adversarial suite — 8/8 (Do-now step 2)
+New file: `app-mobile/src/utils/__tests__/categoryLabelResolver.fullcorpus.test.ts` (T-T0…T-T7).
+`deno test --no-check --allow-read categoryLabelResolver.fullcorpus.test.ts` → `ok | 8 passed | 0 failed`.
+
+**Distinct angle vs. the two existing suites (not a renamed copy):**
+| Surface | Existing suites | This suite |
+|---|---|---|
+| Stub seed | 3–11 hand-picked keys | **FULL real en/common.json corpus** (23 `category_*` keys) read **live** from the locale file at test time — tracks the real resource state, catches a future label edit that introduces a token-shaped value |
+| Miss config | strip only (`appendNamespaceToMissingKey:false`) | **BOTH** strip AND the **inverse prefixed-key config** (`:true`) — proves the fix is immune to the config flip NG-1 forbids, a surface the old equality guard happened to survive under one config but not the other |
+| Curated coverage | 6 hand-listed labels | **every real `intent_*` deck label** (the 6 from corpus) swept as human-label input |
+| HIT path | `casual_food` only | `casual_food` + `upscale_fine_dining` + `nature` under both configs + legacy-alias `fine_dining`→`Fine Dining` |
+| Empty guard | one config | both configs |
+
+T-T2 confirms the localized HIT path still works for real slugs and every curated label resolves token-free; T-T4/T-T5 assert real slugs return their real labels ("Casual", "Fine Dining", "Nature & Views") — Do-now step 2's "localized HIT path still works" requirement is satisfied at full corpus fidelity.
+
+**Real finding surfaced by my own test (resolved correctly, not a defect):** my first T-T1 draft asserted every `category_*` key's slug returns its own verbatim label. It failed on `brunch_lunch_casual` — because `legacyToSlug` intentionally canonicalizes `brunch_lunch_casual` → `brunch` (ORCH-0597), so the resolver returns "Brunch", not the corpus's own `category_brunch_lunch_casual` value. This is the documented canonicalization contract (I-CATEGORY-SLUG-CANONICAL), not a bug. I corrected the test to assert the **binding no-token-leak invariant for ALL real slugs** and exact-label identity only for non-legacy-remapped slugs. This is a P4 note that the resolver's legacy-remap and the locale corpus both legitimately carry overlapping keys.
+
+### 2.3 All three suites together, fix in place
+`deno test --no-check --allow-read categoryLabelResolver.test.ts categoryLabelResolver.adversarial.test.ts categoryLabelResolver.fullcorpus.test.ts` → **`ok | 21 passed | 0 failed (61ms)`**.
+
+`deno check` (type) on all three test files → clean (`Check ...` ×3; `// @ts-nocheck` headers match the sibling Deno-util convention).
+
+---
+
+## 3. Fails-on-Revert — Independently Re-verified (Do-now step 3)
+
+I did NOT trust the implementor's claim. Method: backed up the working `categoryUtils.ts`, restored the OLD guard verbatim inside the pure resolver — `const translated = i18nLike.t(key); if (translated === key) { …title-case… } return translated;` — re-ran, then restored the fix.
+
+| Suite | Fix in place | Old equality guard restored |
+|---|---|---|
+| `categoryLabelResolver.test.ts` (8) | 8 ok | **6 FAIL** (T-01…T-06 leak `category_romantic` / `category_take a stroll`); T-07/T-08 still pass (hit + empty don't depend on miss-detection) |
+| `categoryLabelResolver.adversarial.test.ts` (5) | 5 ok | **4 FAIL** (T-A1/T-A2/T-A3/T-A5); T-A4 passes (hit path) |
+| **`categoryLabelResolver.fullcorpus.test.ts` (8, tester)** | 8 ok | **2 FAIL** (T-T2 curated labels leak tokens; T-T6 raw input echoes `category_category_romantic`) |
+
+Combined: restoring the broken guard turns **12 of 21** tests RED across the three suites; restoring the `exists()` guard returns all to green. The tests genuinely exercise the reported leak — confirmed independently, not by reading the implementor's claim.
+
+**Sharp observation (strengthens, not weakens, the verdict):** my T-T3 (inverse prefixed-key config) does NOT fail on revert — and that is correct and meaningful. Under `appendNamespaceToMissingKey:true`, `t()` returns the prefixed `common:category_romantic`, which the old `translated === key` guard WOULD have caught (equality holds), so the fallback would fire under that config. The bug only manifests under the prod-default strip config. T-T3 documents that the `exists()` fix is robust to BOTH configs whereas the old guard was accidentally correct under one — exactly the fragility Decision D-1 was chosen to eliminate (decoupled from the NG-1 init options). The adversarial value of T-T3 is forward-regression protection against an NG-1 config flip, not the original repro.
+
+---
+
+## 4. Spec Compliance Matrix (Do-now step 4)
+
+| SC | Statement | Verification (captured) | Verdict |
+|---|---|---|---|
+| SC-1 | Curated labels return friendly label, never `/^(common:)?(category\|intent)_/` | T-01…T-06 + T-A1 + T-T2 green; all fail-on-revert | PASS |
+| SC-2 | Valid slug (`casual_food`) still returns localized `i18n.t` ("Casual") | T-07 + T-T4 green | PASS |
+| SC-3 | Empty input → `'Experience'` | T-08 + T-T7 green (both configs) | PASS |
+| SC-4 | Miss detected by existence check decoupled from namespace-strip | T-A2 (strip) + T-T3 (prefixed/inverse config) green — fix survives BOTH miss shapes | PASS — **strengthened** beyond spec (spec only required strip-immunity; tester proved config-flip immunity too) |
+| SC-5 | Public signature + 14 call sites + i18n init unchanged | `getReadableCategoryName(categoryKey: string): string` unchanged (line 162); `git diff origin/main...HEAD --name-only` shows **0** files under `src/components`, `src/services`, `src/i18n`, `src/i18n/locales` — only `categoryUtils.ts` + 2 tests + 3 docs. 26 call invocations across 11 consumer files untouched. | PASS |
+| SC-6 | Both test files run green in the Deno util runner | 13/13 (existing) + 8/8 (tester) = 21/21 | PASS |
+
+NG verification: NG-1 (i18n init untouched — 0 diff in `src/i18n`), NG-2 (no new/renamed keys — 0 diff in `src/i18n/locales`), NG-3 (mixed-input contract not refactored — title-case formula verbatim), NG-4 (`CuratedExperienceSwipeCard.tsx` untouched — not in diff), NG-5 (no backend/migration/RLS/edge — 0 `supabase/` diff). All HELD.
+
+---
+
+## 5. T-06 "Take A Stroll" vs "Take a Stroll" Adjudication (Do-now step 5)
+
+**Finding (P4 — cosmetic, NON-BLOCKING).** SPEC §7.1 T-06 expects `getReadableCategoryName('Take a Stroll') === 'Take a Stroll'`, but the LOCKED, unchanged title-case fallback formula `slug.replace(/_/g,' ').replace(/\b\w/g, c => c.toUpperCase())` uppercases every word boundary → actual output `'Take A Stroll'`. The implementor correctly asserted the resolver's true output and flagged the spec-table inconsistency rather than silently altering the formula (which would change behavior for all consumers and violate NG-3).
+
+**Adjudication: does NOT block.**
+1. The spec's own LOCKED formula (D-1 step 2) produces `'Take A Stroll'`; the §7.1 expected-string cell contradicts the formula it locks. The implementor obeyed the formula (Prime Directive: code is right, don't weaken the contract to match a typo in the expected column).
+2. SC-1 — the binding success criterion — holds: `'Take A Stroll'` does NOT match `/^(common:)?(category|intent)_/`. The token leak (the actual bug) is gone. T-A1 + T-T2 prove it.
+3. The only inputs where title-case diverges from the deck's `intent_*` label are multi-word lowercase-particle labels ("Take a Stroll" → "Take A Stroll"). The deck's localized `intent_take_a_stroll` = "Take a Stroll" is the correct product copy, reachable only via the deferred F/U-2 localization route (D-2). Swipe History intentionally falls back to title-case of the card's own `categoryLabel` — internally consistent with the card's identity field, just with naive particle-casing.
+4. User impact: a curated Swipe-History row may read "Take A Stroll" instead of "Take a Stroll". Cosmetic title-casing of one particle; not a token, not a wrong word, not misleading. Maps cleanly to the already-registered F/U-2 (full curated-label localization). 
+
+**Routing:** record T-06 as resolved-by-adjudication; it is the deferred-localization follow-up (F/U-2), not a new defect or a rework trigger.
+
+---
+
+## 6. Constitution (diff scan)
+
+| # | Rule | Verdict |
+|---|---|---|
+| 3 | No silent failures | PASS — the miss is now a deliberate, tested fallback; the swallowed token leak is gone |
+| 10 | Currency/locale-aware | PASS on HIT path (real slugs localize); bounded English title-case degrade on the curated MISS path per spec-accepted trade-off (F/U-2 registered) |
+| 1,2,4,5,6,7,8,9,11,12,13,14 | — | N/A — pure synchronous string util; no state ownership, no async, no auth, no cache, no datetime, no persisted-state, no currency |
+
+No `any`, no `@ts-ignore`, no silent catch introduced. The one `require('../i18n')` is the documented lazy test-seam (S-3), suppressed with the correct ESLint directive — an intentional, commented seam, not an escape hatch (P4 praise: clean, well-justified, with a protective anti-regression comment block).
+
+---
+
+## 7. Cross-Domain / Parity
+
+- **Solo + collab parity:** both Swipe-History mount sites call the same resolver — `DismissedCardsSheet.tsx:179` (solo, `card.category`) + `:257` (collab, `cd.category ?? ''`). Hardened identically; no mode-specific branch. Verified by grep.
+- **iOS + Android parity:** shared RN util, no `Platform.select`. The Deno unit suite is the platform-agnostic binding gate for both (SPEC §5). No per-platform divergence possible.
+- **Other surfaces:** Business apps / Admin / buyer-anon web do NOT consume `getReadableCategoryName` — not affected (SPEC §5 #3–#7).
+- **Blast radius (11 consumer files / 26 invocations):** all inherit the fix without edits; the resolver is the single owner of the label string. No competing owner.
+
+---
+
+## 8. Deferred Corroboration (for the batched signed-in session)
+
+Carry to the orchestrator-run signed-in batch (NOT a blocker for this PASS):
+1. **Swipe History `DismissedCardsSheet` — solo (`:179`):** open a solo deck, left-swipe a curated experience card, open Swipe History → the row reads the friendly label (e.g. "Romantic"), never `category_romantic`.
+2. **Swipe History `DismissedCardsSheet` — collab (`:257`):** in a group/collab deck, confirm dismissed curated cards in the shared sheet also show friendly labels.
+3. **Single place card (HIT path regression):** confirm a real category slug card still shows its localized label (e.g. "Casual") — T-07/T-T4 cover this offline; eyeball confirms no single-card regression.
+4. **Non-English locale on HIT path:** real `category_*` slugs still localize via the singleton's `t` (the fallback only triggers on a miss).
+
+---
+
+## 9. Discoveries for Orchestrator
+
+- **P4 — Spec T-06 expected-value typo (cosmetic):** §7.1 expects "Take a Stroll" but the locked formula yields "Take A Stroll". Resolved by adjudication (§5); maps to existing F/U-2. No code change.
+- **P4 — Locale corpus + legacy-remap overlap (note, not a defect):** `en/common.json` carries `category_*` keys for legacy slugs (`brunch_lunch_casual`, `fine_dining`, `casual_eats`, `watch`, `live_performance`, …) that `legacyToSlug` canonicalizes to a DIFFERENT slug, so resolving the legacy slug returns the canonical label, not the legacy key's own value. Surfaced by my T-T1 first draft; corrected by asserting the no-token-leak invariant for all + exact identity only for non-remapped slugs. Consistent with I-CATEGORY-SLUG-CANONICAL. Worth a future hygiene pass to prune dead legacy `category_*` keys from `common.json` alongside F/U-1, but harmless today.
+- **DRAFT invariants ready to flip ACTIVE on CLOSE:** I-CATEGORY-LABEL-NO-TOKEN-LEAK (enforced by T-A1 + T-T1/T-T2/T-T6) and I-CATEGORY-MISS-DETECTED-BY-EXISTENCE (enforced by T-A2 + T-T3). The tester suite adds independent enforcement of both.
+- **F/U-1 / F/U-2** remain registered (mixed-input typing; full curated-label localization). Not in scope.
+- **No CI workflow job** runs `app-mobile/src/utils/__tests__` Deno tests today (these are Step-0.5 local-gate tests, matching the ORCH-1019/1021 sibling pattern). The three files register into that same local Deno runner; no new workflow invented (per SPEC §7). Flag for the orchestrator if a CI-jobbed gate for these is ever desired.
+
+---
+
+## 10. Completion Condition Audit (/goal)
+
+| Clause | Status |
+|---|---|
+| Both existing Deno tests re-run 13/13 | ✅ captured §2.1 |
+| Committed passing SECOND adversarial test, distinct angle | ✅ `categoryLabelResolver.fullcorpus.test.ts`, 8/8, full-corpus + inverse-config angle (§2.2) — committed this turn |
+| Fails-on-revert re-confirmed (independent) | ✅ 12/21 RED under restored old guard; restored fix → 21/21 (§3) |
+| SC-1…SC-6 + no-token invariant verified | ✅ §4 matrix, all PASS; SC-4 strengthened |
+| T-06 adjudicated | ✅ §5 — cosmetic, non-blocking, maps to F/U-2 |
+| Verdict report routed to orchestrator | ✅ this file + Section B handoff |
+| Live-fire sim | DEFERRED per dispatch — corroboration, not gate (offline-PASS carve-out justified §VERDICT) |
+| Zero open P0/P1 | ✅ 0 P0, 0 P1 |
+
+PASS holds on every required clause; the only deferral is the dispatch-authorized live render.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1044_CATEGORY_LABEL_RESOLVER.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1044_CATEGORY_LABEL_RESOLVER.md
@@ -1,0 +1,222 @@
+# SPEC — ORCH-1044 [Category label resolver: missing-key guard hardening]
+
+- **ORCH:** ORCH-1044
+- **Branch / worktree:** `ORCH-1044-swipe-history-category-slug-leak` @ `~/Desktop/mingla-orchs/ORCH-1044-[swipe-history-category-slug-leak]/`
+- **Mode:** SPEC (fix design only — NO implementation code in this file)
+- **Date:** 2026-06-02
+- **Author:** mingla-forensics (Claude)
+- **Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1044_SWIPE_HISTORY_CATEGORY_SLUG.md` (committed `c1ac0367a`) — **PROVEN**, APPROVED.
+- **Comms ledger:** read on entry. No BLOCK/WARN entry targets `mingla-forensics`, `ORCH-1044`, or `ALL` that requires action this turn. COMMS-0003 (external-API-docs-at-SPEC) is N/A: i18next is a bundled library, not a network API; no provider enum/payload/endpoint is introduced. Noted, not acked (FYI-grade for this scope).
+
+---
+
+## 1. Layman Summary
+
+In the "cards you viewed this session" list, curated experience cards were showing an internal code like `category_romantic` instead of a friendly label like "Romantic". The investigation proved this is a one-line logic bug in a single shared helper (`getReadableCategoryName`) that ~14 screens use: its "did the translation exist?" check is written wrong, so whenever a label has no translation entry it leaks the raw code instead of falling back to a clean title-cased word. This spec fixes the helper at its core so every screen is hardened at once, and locks it with a unit test that asserts the helper can never again emit a `category_*` or `intent_*`-shaped token. No data is bad — the bad string is built fresh at render time — so there is nothing to clean up; the fix is purely the resolver.
+
+---
+
+## 2. Scope, Non-Goals, Assumptions
+
+### 2.1 Scope (LOCKED)
+- **S-1** Fix the missing-key detection inside `getReadableCategoryName` (`app-mobile/src/utils/categoryUtils.ts:110-116`) so that an i18next miss is detected correctly **regardless of namespace stripping**, and the human-readable title-case fallback fires. The resolver must NEVER return a string of shape `category_*`, `intent_*`, or `common:category_*` / `common:intent_*`.
+- **S-2** The fix lives at the **resolver level** (the single shared function), so all ~14 consumers (F-3 blast radius) are hardened in one change — not patched per-call-site.
+- **S-3** Make the resolver **unit-testable in isolation** of the React-Native i18n module (see §6 — `categoryUtils.ts` imports `../i18n`, which pulls AsyncStorage + RN; a Deno/node unit test cannot load that). The fix must allow the i18next lookup to be exercised/stubbed without booting the full RN i18n stack. This is a structural requirement of the test contract, not a gold-plate.
+- **S-4** Ship the regression unit test specified in §7 (happy-path + adversarial), runnable in the existing `app-mobile/src/utils/__tests__` Deno harness.
+
+### 2.2 Non-Goals (LOCKED)
+- **NG-1** Do NOT change i18next global init options (`appendNamespaceToMissingKey`, `nsSeparator`, `returnNull`, `parseMissingKeyHandler`) in `app-mobile/src/i18n/index.ts`. Those are app-wide and altering them risks the 23-namespace / 29-language config and the ORCH-0675 lazy-load contract. The fix is local to the resolver. (Rationale: a global `appendNamespaceToMissingKey:true` would "fix" the equality guard but silently change miss-return shape for every other `t()` call in the app — out of scope and risky.)
+- **NG-2** Do NOT add new i18n keys, rename `intent_*`/`category_*` keys, or touch `common.json`. The fix is detection logic, not new translations.
+- **NG-3** Do NOT refactor the mixed-input contract of `getReadableCategoryName` (slug vs. label vs. experienceType — Investigation §10 naming smell). Register it as a follow-up; this ORCH only stops the token leak.
+- **NG-4** Do NOT modify the live-deck path (`CuratedExperienceSwipeCard.tsx`) — it already resolves correctly via `intent_*` and is unaffected.
+- **NG-5** No backend / migration / RLS / edge-function changes. The slug is synthesized client-side at render; no DB data is wrong.
+
+### 2.3 Assumptions
+- **A-1** i18next runtime config is unchanged from investigation time: default `nsSeparator: ':'`, `appendNamespaceToMissingKey: false`, `defaultNS: 'common'`, `fallbackLng: 'en'`. Verified in `app-mobile/src/i18n/index.ts:805-829` (no override of those three). i18next `^26.0.4`.
+- **A-2** On a miss, `i18n.t('common:category_romantic')` returns the **namespace-stripped** key `'category_romantic'` (PROVEN in investigation §3 F-1 via Node repro + docs https://www.i18next.com/overview/configuration-options).
+- **A-3** `i18n.exists(key, options?)` is available in i18next ^26 and returns `boolean` for whether a key resolves (docs: https://www.i18next.com/overview/api#exists). This is the robust primitive the recommended fix uses.
+
+---
+
+## 3. Root-Cause Recap (from PROVEN investigation)
+
+`categoryUtils.ts:110-116`:
+```ts
+const key = `common:category_${normalizedSlug}`;   // built WITH the common: prefix
+const translated = i18n.t(key);                     // on a MISS, returns "category_romantic" (prefix STRIPPED)
+if (translated === key) {                           // "category_romantic" === "common:category_romantic" → FALSE on every miss
+  return slug.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()); // DEAD on namespaced keys
+}
+return translated;                                  // leaks "category_romantic" to the UI
+```
+The equality guard compares the stripped miss-return against the prefixed key, so it is never true on a miss → the title-case fallback is dead code → the bare key leaks. (Investigation F-1, PROVEN.)
+
+---
+
+## 4. Decisions (made + justified)
+
+### Decision D-1 — The robust guard: use `i18n.exists()`, not string-equality. **(RECOMMENDED + LOCKED)**
+
+**Options considered:**
+
+| Option | Mechanism | Verdict |
+|---|---|---|
+| **(a) `i18n.exists(key)` gate** | Call `i18n.exists('common:category_${normalizedSlug}')`; if false → title-case fallback; if true → return `i18n.t(key)`. | **RECOMMENDED.** Detects the miss at the source of truth (i18next's own resource lookup), immune to namespace-stripping, immune to `appendNamespaceToMissingKey`, immune to `nsSeparator` config. No string-shape heuristics. Documented stable API. |
+| (b) Compare against BOTH forms | `translated === key \|\| translated === 'category_${normalizedSlug}'` (prefixed AND stripped). | Works today, but couples the guard to the current `appendNamespaceToMissingKey:false` behavior — flips silently if that option ever changes. Fragile. Rejected as primary. |
+| (c) `t(key, { defaultValue })` sentinel | Pass a unique sentinel `defaultValue`; if returned value === sentinel → miss. | Robust, but requires inventing/maintaining a sentinel and reads less clearly than `exists()`. Acceptable fallback if `exists()` is somehow unavailable, but `exists()` is available in ^26 (A-3). |
+
+**Chosen: (a) `i18n.exists()`.** Justification: it asks i18next the exact question we mean ("is there a translation for this key?") instead of inferring it from the shape of a returned string. It cannot be defeated by namespace stripping (the precise mechanism that caused this bug), and it is decoupled from the three init options in NG-1 — so a future i18n config change cannot silently reintroduce the leak. As defense-in-depth, the implementor SHOULD also keep an output guard (Decision D-3) so that even an unexpected `exists()`/`t()` interaction can never emit a token-shaped string.
+
+**Contract the implementor must satisfy (LOCKED, behavior — not code):**
+1. Build the lookup key exactly as today: `common:category_${normalizedSlug}`.
+2. If the key does NOT exist (`i18n.exists(...) === false`): return the title-cased fallback of `slug` — `slug.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())`. This already produces "Romantic", "Group Fun", etc.
+3. If the key exists: return `i18n.t(key)` (the localized label).
+4. The empty-input guard (`if (!categoryKey) return 'Experience'`) and the legacy-slug normalization (`legacyToSlug`, `stripped`, `normalizedSlug`) are unchanged.
+
+### Decision D-2 — Parity question: title-case fallback, NOT `intent_*` routing. **(RECOMMENDED + LOCKED)**
+
+**Question (from dispatch):** should Swipe History additionally route curated cards through the `intent_*` label for EXACT parity with the live deck (`CuratedExperienceSwipeCard.tsx:73-74`), or is the title-case friendly fallback sufficient?
+
+**Recommendation: title-case fallback is sufficient. Do NOT route Swipe History through `intent_*`.**
+
+**Justification (evidence-backed):**
+1. **The resolver doesn't receive the experienceType.** The deck derives its label from `card.experienceType` (the slug `'romantic'`) → `t('common:intent_romantic')`. Swipe History calls `getReadableCategoryName(card.category)`, and `card.category` is the **human label** `'Romantic'` (set at `cardConverters.ts:71` from `categoryLabel`), not the experienceType. Routing through `intent_*` from inside the resolver would require the resolver to reverse-map a display label back to an experience-type slug — a new, fragile, lossy mapping. Lowest-risk path is to fix the existing fallback the resolver already owns.
+2. **`intent_*` and title-case actually DIVERGE for two labels — and title-case is the correct, consistent product copy here.** Verified in `en/common.json`:
+   - `intent_first_date` → "First Dates" (plural) vs. source label "First Date" (singular, per `CuratedExperienceSwipeCard.CURATED_ICON_MAP`).
+   - `intent_take_a_stroll` → "Take a Stroll" (matches title-case of `'Take a Stroll'`).
+   - `intent_romantic`/`_adventurous`/`_group_fun`/`_picnic_dates` → "Romantic"/"Adventurous"/"Group Fun"/"Picnic Dates" (all identical to title-case of the source label).
+   Forcing `intent_*` would make Swipe History say "First Dates" while the card's own `categoryLabel` says "First Date" — a NEW inconsistency. The title-case fallback returns the same word family the curated record actually carries (`categoryLabel`), so the Swipe History row matches the card's own identity field. This is the cleaner, more consistent label per the dispatch's "least risk, clean, consistent" lean.
+3. **The friendly fallback is locale-degraded only on the miss path, which is exactly the curated case.** For real category slugs (single place cards), the `category_*` key exists and `i18n.t()` returns the localized string — locale-aware as before. For curated labels there is no localized key in EITHER namespace that `getReadableCategoryName` can reach with the input it has, so English title-case is the honest best the resolver can do without the larger refactor in NG-3. Brushing Constitution #10 here is accepted as the bounded trade-off (Investigation §6); full localization of curated labels in Swipe History is registered as the NG-3 follow-up.
+
+**Net:** Decision D-1 alone fully removes the reported token leak AND yields a label consistent with the curated card's own `categoryLabel`. The `intent_*` parity route is explicitly **deferred** (see §10 Follow-ups), not adopted.
+
+### Decision D-3 — Output safety net (defense-in-depth). **(LOCKED)**
+The resolver's returned value must NEVER match `/^(common:)?(category|intent)_/`. The implementor must guarantee this by construction (D-1 ensures the only two return paths are a localized human string or a title-cased fallback). No separate runtime regex strip is required in product code IF D-1 is implemented as specified; the **test** in §7 enforces this invariant. (Do not add a regex scrubber that masks a future logic regression — fix detection at the source per D-1.)
+
+---
+
+## 5. Cross-Surface Impact (Phase 2.5 — MANDATORY)
+
+The fix is a single shared pure-ish util in `app-mobile/`. Parity is **automatic** across iOS/Android because there is no platform branch.
+
+| # | Surface | Covered? | User-visible behavior demanded | Files | Parity |
+|---|---|---|---|---|---|
+| 1 | **Consumer iOS** (`app-mobile/` iOS) | YES | Swipe History (and all 14 resolver consumers) show "Romantic"/"Group Fun"/… never `category_romantic`. | `app-mobile/src/utils/categoryUtils.ts` | shared |
+| 2 | **Consumer Android** (`app-mobile/` Android) | YES | Identical to iOS. | same | **automatic** (shared RN util, no platform branch) — SC covers both via one criterion (SC-1). |
+| 3 | **Buyer/anonymous Web** (`mingla-business/` buyer routes) | NO | Buyer-anon routes do not render curated category labels via this resolver. | — | n/a — surface does not consume `getReadableCategoryName`. |
+| 4 | **Business iOS** (`mingla-business/`) | NO | No curated category render via this util. | — | n/a — business app has no curated Swipe History. |
+| 5 | **Business Android** (`mingla-business/`) | NO | Same as #4. | — | n/a. |
+| 6 | **Admin Web** (`mingla-admin/`) — adjacent | NO | Admin does not render curated category labels. | — | n/a (Investigation §6 "NOT affected"). |
+| 7 | **Business Web preview** — adjacent | NO | Same as #4/#5. | — | n/a. |
+
+Because parity across the only two covered surfaces (consumer iOS + Android) is automatic via shared code, **one success criterion (SC-1) governs both**; no separate SC-1-iOS / SC-1-Android split is required (the unit test is platform-agnostic and is the binding gate).
+
+---
+
+## 6. Layer Specification
+
+Only the **utility layer** is touched. No DB / edge / service / hook / realtime / new-component layers.
+
+### 6.1 Utility layer — `app-mobile/src/utils/categoryUtils.ts`
+- **Function:** `getReadableCategoryName(categoryKey: string): string` — signature UNCHANGED (LOCKED). No new params, no async, no behavioral change for valid `category_*` slugs.
+- **Change:** replace the broken `if (translated === key)` miss-detection (lines 111-116) with the Decision D-1 contract (`i18n.exists()` gate → fallback-or-localized). The comment at line 112 stays accurate ("If i18n returns no translation, fall back to formatting") — update it to describe the `exists()` mechanism so the next reader doesn't reintroduce the equality guard.
+- **Testability requirement (S-3, LOCKED):** the resolver currently hard-imports `import i18n from '../i18n'` (module-load pulls AsyncStorage + RN, which a Deno/node unit test cannot evaluate). The implementor MUST make the i18next dependency exercisable in a unit test without booting the RN i18n module. Acceptable approaches (implementor's choice — 🎨 OPEN within this band):
+  - (a) Extract the pure resolution into an internal function that takes an injected `{ exists, t }` i18n-like object, with the exported `getReadableCategoryName` delegating to it using the real `i18n` singleton; the test calls the internal function with a stub. **(Preferred — keeps the public API identical and adds zero call-site churn.)**
+  - (b) Provide a documented test seam (e.g., a module-level setter / dependency-injection hook) the test uses to substitute a minimal i18n stub.
+  - The chosen seam MUST NOT change `getReadableCategoryName`'s public signature or any of the 14 call sites.
+- **Static-analysis floor (LOCKED):** explicit return type present (it is); no `any`; no `@ts-ignore`; no silent catch. The function stays synchronous.
+
+### 6.2 Consumers — NO edits (LOCKED)
+All 14 call sites (`DismissedCardsSheet.tsx:179,:257`; `SwipeableBoardCards.tsx`; `ExpandedCardModal.tsx:2058,:2178,:2192`; `expandedCard/CardInfoSection.tsx`; `PersonGridCard.tsx`; `PersonHolidayView.tsx`; `activity/SavedTab.tsx`; `activity/CalendarTab.tsx`; `SwipeableCards.tsx`; `board/SwipeableSessionCards.tsx`) keep calling `getReadableCategoryName(card.category)` unchanged. The resolver fix hardens them all (S-2). Editing call sites is OUT of scope (NG).
+
+---
+
+## 7. Test Contract (REQUIRED)
+
+**Harness:** Deno test under `app-mobile/src/utils/__tests__/` matching the sibling pattern (`openingHoursUtils.test.ts`, `curatedStopsAvailability.test.ts`: `Deno.test(...)` + `assertEquals`/`assertMatch`/`assert` from `deno.land/std@0.168.0/testing/asserts.ts`, `// @ts-nocheck` header). Two files mirroring the established naming:
+- `categoryLabelResolver.test.ts` — happy-path regression.
+- `categoryLabelResolver.adversarial.test.ts` — adversarial.
+
+The resolver is exercised through the §6.1 test seam with a **minimal i18n stub** that registers ONLY the real-category keys present in `common.json` (e.g. `category_nature`, `category_casual_food`) and NO `category_romantic`/`intent_*` keys — reproducing the exact production resource state that triggered the bug.
+
+### 7.1 Happy-path test (`categoryLabelResolver.test.ts`)
+
+| Test | Input (`categoryKey`) | i18n stub state | Expected return | Asserts |
+|---|---|---|---|---|
+| T-01 | `'Romantic'` | no `category_romantic` key | `'Romantic'` | exact equality |
+| T-02 | `'Adventurous'` | no key | `'Adventurous'` | exact equality |
+| T-03 | `'First Date'` | no key | `'First Date'` | exact equality (singular, matches `categoryLabel` source — confirms D-2: NOT "First Dates") |
+| T-04 | `'Group Fun'` | no key | `'Group Fun'` | exact equality |
+| T-05 | `'Picnic Dates'` | no key | `'Picnic Dates'` | exact equality |
+| T-06 | `'Take a Stroll'` | no key | `'Take a Stroll'` | exact equality |
+| T-07 | `'casual_food'` (real slug) | `category_casual_food` → "Casual" present | `'Casual'` | exact equality — proves the localized HIT path still works (no regression for single place cards) |
+| T-08 | `''` (empty) | — | `'Experience'` | exact equality — empty guard intact |
+
+### 7.2 Adversarial test (`categoryLabelResolver.adversarial.test.ts`)
+
+| Test | Scenario | Input | Expected | Asserts |
+|---|---|---|---|---|
+| T-A1 | **Token-shape invariant (the core regression anchor)** | each of `'Romantic'`, `'Adventurous'`, `'First Date'`, `'Group Fun'`, `'Picnic Dates'`, `'Take a Stroll'` | return value does NOT match `/^(common:)?(category\|intent)_/` AND does NOT contain a `:` namespace separator | `assert(!/^(common:)?(category\|intent)_/.test(out))` for every curated label — fails on revert of D-1 |
+| T-A2 | **Namespace-strip simulation** | stub `t()` to return the namespace-stripped key on a miss (i.e. `'category_romantic'` for input `'Romantic'`), exactly as production i18next does | resolver still returns `'Romantic'`, NOT `'category_romantic'` | proves the fix relies on `exists()` (or equivalent), not on string equality that the strip defeats |
+| T-A3 | **`intent_`-shaped input never leaks** | `'intent_romantic'` (defensive: a caller mistakenly passes an intent key) | does NOT return `'intent_romantic'` or `'common:intent_romantic'`; returns a title-cased string | guards the F-3 blast-radius class |
+| T-A4 | **Legacy slug still normalizes** | `'fine_dining'` with `category_upscale_fine_dining` → "Fine Dining" present | `'Fine Dining'` | proves legacy `legacyToSlug` path + HIT path coexist with the new guard |
+| T-A5 | **Hyphen + case normalization** | `'first-date'` (hyphen, lower) | a clean human label, not a token; not `category_first_date` | confirms `normalizedSlug` + guard interplay on a miss |
+
+**iOS/Android parity:** the unit is a shared RN util with no platform branch; the Deno unit test is platform-agnostic and is the binding gate for BOTH consumer iOS and Android (per §5). No separate per-platform test required; the tester's runtime parity check (if dispatched) confirms the rendered Swipe History row on each platform shows the friendly label.
+
+**CI wiring:** register the two test files so they run in the same Deno job that already runs the sibling `app-mobile/src/utils/__tests__` files (the implementor adds them to the existing util-test invocation; do not invent a new workflow). If they must be added to `package.json` scripts following the `test:orch-XXXX` convention, name them `test:orch-1044` / `test:orch-1044-adv`.
+
+---
+
+## 8. Success Criteria (observable, testable, unambiguous)
+
+- **SC-1 (LOCKED)** For every curated label — `'Romantic'`, `'Adventurous'`, `'First Date'`, `'Group Fun'`, `'Picnic Dates'`, `'Take a Stroll'` — `getReadableCategoryName` returns the exact friendly label in §7.1 (T-01…T-06) and NEVER a string matching `/^(common:)?(category|intent)_/`. (Covers consumer iOS + Android via shared code.)
+- **SC-2 (LOCKED)** For a valid category slug whose `category_*` key exists (e.g. `'casual_food'`), the resolver still returns the localized label `i18n.t('common:category_casual_food')` ("Casual") — no regression to single place cards (T-07).
+- **SC-3 (LOCKED)** Empty / falsy input returns `'Experience'` (T-08) — empty guard preserved.
+- **SC-4 (LOCKED)** The miss is detected by an existence check decoupled from namespace-stripping; simulating the production strip (T-A2) still yields the friendly label.
+- **SC-5 (LOCKED)** `getReadableCategoryName`'s public signature, the 14 call sites, and i18n global init options are unchanged (NG-1, NG-3, §6.2).
+- **SC-6 (LOCKED)** Both test files run green in the existing Deno util-test job.
+
+---
+
+## 9. Invariants
+
+### Preserve (existing)
+- **I-CATEGORY-SLUG-CANONICAL** — legacy→canonical slug normalization (`legacyToSlug`) unchanged; verified by T-A4.
+- **I-CURATED-LABEL-SOURCE** — curated `categoryLabel` remains the identity source; D-2 keeps Swipe History consistent with it (does not override with a diverging `intent_*` string).
+- **Constitution #10 (locale-aware display)** — preserved on the HIT path (real slugs localize); on the curated MISS path it degrades to English title-case as the bounded, accepted trade-off (NG-3 registers full localization as follow-up).
+- **Constitution #3 (no silent failures)** — the miss is now a deliberate, tested fallback, not a swallowed error leaking a token.
+
+### Establish (new) — propose to orchestrator for INVARIANT_REGISTRY
+- **I-CATEGORY-LABEL-NO-TOKEN-LEAK (DRAFT)** — `getReadableCategoryName` MUST NEVER return a value matching `/^(common:)?(category|intent)_/`. Enforced by §7 T-A1. Flips ACTIVE on ORCH-1044 CLOSE.
+- **I-CATEGORY-MISS-DETECTED-BY-EXISTENCE (DRAFT)** — missing-key detection MUST use i18next existence semantics (`exists()` / sentinel `defaultValue`), NOT equality against the prefixed key string. Enforced by T-A2. Flips ACTIVE on CLOSE.
+
+---
+
+## 10. Regression Prevention & Follow-ups
+
+- **Structural safeguard:** T-A1 (token-shape invariant) + T-A2 (namespace-strip simulation) are fails-on-revert anchors — reintroducing the `translated === key` equality guard, or removing the existence check, turns both red.
+- **Protective comment:** the resolver MUST carry a one-line comment explaining WHY the guard uses existence-not-equality (cite ORCH-1044 + "i18next strips the namespace on a miss, so equality against the prefixed key is never true"). This is the institutional memory that stops the next editor from "simplifying" it back.
+- **Follow-up F/U-1 (register, do NOT do here):** the mixed-input contract of `getReadableCategoryName` (slug vs. label vs. experienceType — Investigation §10). A future ORCH should split label-resolution from slug-resolution or type the input so a non-`category_*` string can't reach the `category_*` namespace.
+- **Follow-up F/U-2 (register):** full localization of curated category labels in Swipe History (the deferred `intent_*` / experienceType-aware parity route from D-2) — only worth doing alongside F/U-1, and only if non-English curated labels become a product priority.
+
+---
+
+## 11. Implementation Order
+
+1. `app-mobile/src/utils/categoryUtils.ts` — apply Decision D-1 guard fix + the §6.1 test seam + protective comment (single file, one function).
+2. `app-mobile/src/utils/__tests__/categoryLabelResolver.test.ts` — §7.1 happy-path.
+3. `app-mobile/src/utils/__tests__/categoryLabelResolver.adversarial.test.ts` — §7.2 adversarial.
+4. CI: ensure both files are picked up by the existing Deno util-test invocation (and `package.json` `test:orch-1044*` scripts if the convention requires).
+5. Run the two Deno tests locally → green (SC-6). No deploy / migration / OTA step (NG-5; OTA deferred per memory `project_ota_deferred_until_new_build.md`).
+
+---
+
+## 12. LOCKED vs OPEN summary
+
+- **🔒 LOCKED:** root-cause fix at the resolver (D-1 `exists()` guard); title-case parity decision (D-2, no `intent_*` routing); unchanged public signature + 14 call sites + i18n init (NG-1/NG-3); the §7 test tables (T-01…T-08, T-A1…T-A5) and their exact expected strings; SC-1…SC-6; the two DRAFT invariants; the no-token-leak regex `/^(common:)?(category|intent)_/`.
+- **🎨 OPEN (implementor's craft):** the exact test-seam mechanism (injected i18n-like object vs. documented setter — §6.1 a/b); internal naming of the extracted helper; whether to also keep option-(b)/(c) belt-and-suspenders inside the guard as defense-in-depth so long as the public behavior matches the locked test tables; wording of the protective comment.
+
+---
+
+*No implementation code is included per the dispatch. This SPEC defines the contract; the implementor executes.*

--- a/app-mobile/src/utils/__tests__/categoryLabelResolver.adversarial.test.ts
+++ b/app-mobile/src/utils/__tests__/categoryLabelResolver.adversarial.test.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+// ORCH-1044 T-A1…T-A5 (adversarial) regression test.
+//
+// Hardens the I-CATEGORY-LABEL-NO-TOKEN-LEAK invariant: the resolver MUST NEVER
+// return a value matching /^(common:)?(category|intent)_/ and must survive the
+// exact namespace-strip behavior that defeated the old equality guard.
+//
+// Deno-runnable via the §6.1(a) seam (pure resolver + injected stub) — no RN.
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { resolveReadableCategoryName } from "../categoryUtils.ts";
+
+// The no-token-leak invariant regex (SPEC §10, LOCKED).
+const TOKEN_SHAPE = /^(common:)?(category|intent)_/;
+
+// Real category_* keys (same production subset as the happy-path stub).
+const REAL_CATEGORY_KEYS: Record<string, string> = {
+  "common:category_nature": "Nature & Views",
+  "common:category_casual_food": "Casual",
+  "common:category_upscale_fine_dining": "Fine Dining",
+};
+
+// PRODUCTION-FAITHFUL stub: on a miss, t() returns the namespace-STRIPPED key
+// ("category_romantic"), exactly as real i18next does with
+// appendNamespaceToMissingKey:false. This is the behavior that defeated the old
+// `translated === key` guard. The fix must rely on exists(), not on t()'s shape.
+const stubI18n = {
+  exists: (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(REAL_CATEGORY_KEYS, key),
+  t: (key: string): string =>
+    REAL_CATEGORY_KEYS[key] ?? key.replace(/^common:/, ""), // strips namespace on miss
+};
+
+const resolve = (input: string): string =>
+  resolveReadableCategoryName(input, stubI18n);
+
+const CURATED_LABELS = [
+  "Romantic",
+  "Adventurous",
+  "First Date",
+  "Group Fun",
+  "Picnic Dates",
+  "Take a Stroll",
+];
+
+// T-A1 — Token-shape invariant: the core regression anchor.
+// Fails on revert of D-1 (the equality guard would leak "category_romantic").
+Deno.test("ORCH-1044 T-A1: curated labels never return a category_/intent_ token or a namespace separator", () => {
+  for (const label of CURATED_LABELS) {
+    const out = resolve(label);
+    assert(
+      !TOKEN_SHAPE.test(out),
+      `'${label}' leaked a token-shaped string: '${out}'`,
+    );
+    assert(
+      !out.includes(":"),
+      `'${label}' leaked a namespace separator: '${out}'`,
+    );
+  }
+});
+
+// T-A2 — Namespace-strip simulation: even though t() returns the stripped key
+// on a miss, exists() reports false, so the resolver must NOT echo it.
+Deno.test("ORCH-1044 T-A2: namespace-stripped miss-return does not leak ('Romantic', not 'category_romantic')", () => {
+  // Sanity: the stub's t() would itself leak the token on a miss…
+  assertEquals(stubI18n.t("common:category_romantic"), "category_romantic");
+  // …but the resolver relies on exists(), so it returns the friendly label.
+  assertEquals(resolve("Romantic"), "Romantic");
+});
+
+// T-A3 — intent_-shaped input never leaks (defensive: a caller misroutes an
+// intent key into the category resolver). Guards the F-3 blast-radius class.
+Deno.test("ORCH-1044 T-A3: 'intent_romantic' input never returns an intent_/category_ token", () => {
+  const out = resolve("intent_romantic");
+  assert(
+    !TOKEN_SHAPE.test(out),
+    `intent-shaped input leaked a token: '${out}'`,
+  );
+  // Title-cased human label of the normalized slug.
+  assertEquals(out, "Intent Romantic");
+});
+
+// T-A4 — Legacy slug still normalizes AND the localized HIT path coexists with
+// the new guard: 'fine_dining' → legacyToSlug → upscale_fine_dining → hit.
+Deno.test("ORCH-1044 T-A4: 'fine_dining' → 'Fine Dining' (legacy normalize + hit path)", () => {
+  assertEquals(resolve("fine_dining"), "Fine Dining");
+});
+
+// T-A5 — Hyphen + case normalization on a miss yields a clean human label,
+// never a token.
+Deno.test("ORCH-1044 T-A5: 'first-date' → clean label, not 'category_first_date'", () => {
+  const out = resolve("first-date");
+  assert(!TOKEN_SHAPE.test(out), `leaked a token: '${out}'`);
+  assertEquals(out, "First-Date");
+});

--- a/app-mobile/src/utils/__tests__/categoryLabelResolver.fullcorpus.test.ts
+++ b/app-mobile/src/utils/__tests__/categoryLabelResolver.fullcorpus.test.ts
@@ -1,0 +1,171 @@
+// @ts-nocheck
+// ORCH-1044 T-T1…T-T7 (TESTER-authored adversarial regression test).
+//
+// DISTINCT ANGLE from the implementor's two suites:
+//   - categoryLabelResolver.test.ts        → 8 hand-picked happy-path strings.
+//   - categoryLabelResolver.adversarial.test.ts → 5 cases, stub seeded with a
+//     3-11 key SUBSET, namespace-strip (appendNamespaceToMissingKey:false) only.
+//
+// This suite attacks three new surfaces the existing two never touch:
+//   (1) FULL-CORPUS sweep: the stub is seeded with the ENTIRE real en/common.json
+//       category_* resource set (all 23 keys, read live from the locale file at
+//       test time — not a hand-maintained subset). Every real localized label is
+//       asserted against the no-token-leak invariant, so a future label edit that
+//       accidentally introduces a token-shaped value is caught.
+//   (2) INVERSE namespace config: i18next can be configured with
+//       appendNamespaceToMissingKey:true, in which case t() on a miss returns the
+//       PREFIXED key "common:category_romantic" (the opposite of the strip the
+//       existing T-A2 simulates). A resolver that relied on ANY t()-shape heuristic
+//       would break under one config or the other; only an exists()-gated resolver
+//       survives BOTH. This proves SC-4 against the config flip NG-1 forbids.
+//   (3) EVERY curated intent_* deck label (the real 6 from en/common.json) driven
+//       through the resolver as a human label, against the full real corpus, must
+//       yield a clean non-token string — the production miss path at full fidelity.
+//
+// Deno-runnable via the §6.1(a) seam (pure resolver + injected stub) — no RN.
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { resolveReadableCategoryName } from "../categoryUtils.ts";
+
+// The no-token-leak invariant regex (SPEC §10, LOCKED — I-CATEGORY-LABEL-NO-TOKEN-LEAK).
+const TOKEN_SHAPE = /^(common:)?(category|intent)_/;
+
+// Read the LIVE locale corpus so this test tracks the real resource state, not a
+// frozen hand-copy. URL is relative to this test file.
+const commonJsonUrl = new URL(
+  "../../i18n/locales/en/common.json",
+  import.meta.url,
+);
+const common: Record<string, string> = JSON.parse(
+  await Deno.readTextFile(commonJsonUrl),
+);
+
+// The full real category_* key set, namespaced exactly as the resolver queries it.
+const REAL_CATEGORY_KEYS: Record<string, string> = {};
+for (const [k, v] of Object.entries(common)) {
+  if (k.startsWith("category_")) REAL_CATEGORY_KEYS[`common:${k}`] = v;
+}
+
+// The real curated intent_* deck labels (the human strings card.category carries).
+const CURATED_INTENT_LABELS = Object.entries(common)
+  .filter(([k]) => k.startsWith("intent_"))
+  .map(([, v]) => v);
+
+// ── Stub A: namespace-STRIP on miss (appendNamespaceToMissingKey:false — prod default).
+const stubStrip = {
+  exists: (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(REAL_CATEGORY_KEYS, key),
+  t: (key: string): string =>
+    REAL_CATEGORY_KEYS[key] ?? key.replace(/^common:/, ""),
+};
+
+// ── Stub B: namespace-KEEP on miss (appendNamespaceToMissingKey:true — the flip
+//    NG-1 forbids; tested here only to prove the resolver is immune to it).
+const stubKeep = {
+  exists: (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(REAL_CATEGORY_KEYS, key),
+  t: (key: string): string => REAL_CATEGORY_KEYS[key] ?? key, // returns "common:category_romantic"
+};
+
+// Sanity: the live corpus actually has the keys we expect (guards against an empty
+// read silently making the sweep vacuous).
+Deno.test("ORCH-1044 T-T0: live en/common.json corpus loaded (>=20 category_*, ==6 intent_*)", () => {
+  assert(
+    Object.keys(REAL_CATEGORY_KEYS).length >= 20,
+    `expected >=20 real category_* keys, got ${Object.keys(REAL_CATEGORY_KEYS).length}`,
+  );
+  assertEquals(CURATED_INTENT_LABELS.length, 6);
+});
+
+// Legacy-alias slugs that legacyToSlug intentionally REMAPS to a different
+// canonical slug (so resolving them returns the CANONICAL key's label, not the
+// alias key's own corpus value). These are not bugs — the remap is the ORCH-0434
+// /0597/0598 canonicalization contract. The full-corpus sweep asserts only the
+// no-token-leak invariant for these; the non-remapped slugs additionally assert
+// exact-label identity. Derived from the resolver's own legacyToSlug table.
+const LEGACY_REMAPPED_SLUGS = new Set([
+  "first_meet", "picnic_park", "picnic", "drink", "casual_eats", "fine_dining",
+  "watch", "live_performance", "wellness", "brunch_lunch_casual", "movies_theatre",
+  "nature_views", // category_nature_views slug "nature_views" → not in legacyToSlug,
+  // but its own key exists so it self-resolves; kept here only if it diverges.
+]);
+
+// T-T1 — FULL-CORPUS sweep: every real category_* slug resolves TOKEN-FREE (the
+// binding ORCH-1044 invariant). For slugs that are NOT legacy-remapped, the output
+// must additionally equal the slug's own localized label verbatim. A future
+// common.json edit introducing a category_-shaped VALUE is caught by the regex arm.
+Deno.test("ORCH-1044 T-T1: every real category_* slug resolves token-free; non-remapped slugs return their verbatim label", () => {
+  for (const [nsKey, label] of Object.entries(REAL_CATEGORY_KEYS)) {
+    const slug = nsKey.replace(/^common:category_/, "");
+    const out = resolveReadableCategoryName(slug, stubStrip);
+    // Binding invariant — applies to EVERY real slug (remapped or not).
+    assert(!TOKEN_SHAPE.test(out), `real label for '${slug}' is token-shaped: '${out}'`);
+    assert(!out.includes(":"), `real label for '${slug}' leaked a namespace sep: '${out}'`);
+    // Identity arm — only for slugs the resolver does not canonicalize away.
+    if (!LEGACY_REMAPPED_SLUGS.has(slug)) {
+      assertEquals(out, label, `non-remapped slug '${slug}' did not return its real label`);
+    }
+  }
+});
+
+// T-T2 — EVERY curated intent_* deck label, driven as a human label through the
+// resolver against the FULL real corpus, yields a clean non-token string.
+// (These labels have NO category_* key, so they take the title-case miss path.)
+Deno.test("ORCH-1044 T-T2: every curated intent_* deck label resolves token-free against full corpus", () => {
+  assert(CURATED_INTENT_LABELS.length > 0, "no intent_* labels found in corpus");
+  for (const label of CURATED_INTENT_LABELS) {
+    const out = resolveReadableCategoryName(label, stubStrip);
+    assert(!TOKEN_SHAPE.test(out), `curated label '${label}' leaked a token: '${out}'`);
+    assert(!out.includes(":"), `curated label '${label}' leaked a namespace sep: '${out}'`);
+    assert(out.length > 0, `curated label '${label}' resolved empty`);
+  }
+});
+
+// T-T3 — INVERSE namespace config (appendNamespaceToMissingKey:true): t() returns
+// the PREFIXED key on a miss. A resolver gating on t()-shape would echo
+// "common:category_romantic"; the exists()-gated resolver still yields "Romantic".
+Deno.test("ORCH-1044 T-T3: prefixed-key miss config does NOT leak (immune to appendNamespaceToMissingKey flip)", () => {
+  // Sanity: the keep-stub's t() WOULD leak the prefixed token on a miss…
+  assertEquals(stubKeep.t("common:category_romantic"), "common:category_romantic");
+  // …but the resolver relies on exists(), so the flip cannot reach the UI.
+  for (const label of ["Romantic", "Adventurous", "Group Fun"]) {
+    const out = resolveReadableCategoryName(label, stubKeep);
+    assert(!TOKEN_SHAPE.test(out), `'${label}' leaked under prefixed-key config: '${out}'`);
+    assert(!out.includes(":"), `'${label}' leaked a namespace sep under prefix config: '${out}'`);
+  }
+  assertEquals(resolveReadableCategoryName("Romantic", stubKeep), "Romantic");
+});
+
+// T-T4 — Localized HIT path returns the REAL labels for representative slugs under
+// BOTH stub configs (the hit path must be config-independent).
+Deno.test("ORCH-1044 T-T4: localized HIT returns real labels (casual_food→Casual, upscale_fine_dining→Fine Dining, nature→Nature & Views)", () => {
+  for (const stub of [stubStrip, stubKeep]) {
+    assertEquals(resolveReadableCategoryName("casual_food", stub), "Casual");
+    assertEquals(resolveReadableCategoryName("upscale_fine_dining", stub), "Fine Dining");
+    assertEquals(resolveReadableCategoryName("nature", stub), "Nature & Views");
+  }
+});
+
+// T-T5 — Legacy alias → canonical HIT under full corpus: 'fine_dining' maps via
+// legacyToSlug to 'upscale_fine_dining', whose key exists → localized "Fine Dining".
+Deno.test("ORCH-1044 T-T5: legacy alias 'fine_dining' resolves to localized 'Fine Dining' under full corpus", () => {
+  assertEquals(resolveReadableCategoryName("fine_dining", stubStrip), "Fine Dining");
+});
+
+// T-T6 — Defensive: a category_-prefixed RAW token passed as input must not be
+// echoed back as a token (the leak class this ORCH exists to kill), regardless of
+// which miss config is active.
+Deno.test("ORCH-1044 T-T6: raw 'category_romantic' input never echoes the token (either config)", () => {
+  for (const stub of [stubStrip, stubKeep]) {
+    const out = resolveReadableCategoryName("category_romantic", stub);
+    assert(!TOKEN_SHAPE.test(out), `raw token input echoed under config: '${out}'`);
+  }
+});
+
+// T-T7 — Empty/whitespace guard holds under both configs.
+Deno.test("ORCH-1044 T-T7: empty input → 'Experience' under both miss configs", () => {
+  assertEquals(resolveReadableCategoryName("", stubStrip), "Experience");
+  assertEquals(resolveReadableCategoryName("", stubKeep), "Experience");
+});

--- a/app-mobile/src/utils/__tests__/categoryLabelResolver.test.ts
+++ b/app-mobile/src/utils/__tests__/categoryLabelResolver.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+// ORCH-1044 T-01…T-08 (implementor-owned, happy-path) regression test.
+//
+// Deno-runnable: it imports the PURE resolver `resolveReadableCategoryName`
+// from categoryUtils.ts and injects a minimal i18n stub, so it never boots the
+// RN i18n module (AsyncStorage + react-i18next). This is the §6.1(a) test seam.
+//
+// Fails-on-revert anchor for the D-1 fix: the stub registers ONLY the real
+// `category_*` keys that exist in en/common.json and NO `category_romantic` /
+// `intent_*` keys — reproducing the exact production resource state that
+// triggered the leak. With the OLD `translated === key` guard, the namespace-
+// stripped miss-return ("category_romantic") never equals the prefixed key
+// ("common:category_romantic"), so the resolver leaked "category_romantic"
+// and T-01…T-06 FAIL. With the `exists()` guard they return the friendly label.
+import {
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { resolveReadableCategoryName } from "../categoryUtils.ts";
+
+// Minimal i18n stub mirroring the production resource state at bug time:
+// only the REAL category_* keys present in en/common.json are registered.
+// NO category_romantic / category_adventurous / intent_* keys exist — exactly
+// why curated labels missed and leaked their bare key.
+const REAL_CATEGORY_KEYS: Record<string, string> = {
+  "common:category_nature": "Nature & Views",
+  "common:category_casual_food": "Casual",
+  "common:category_casual": "Casual",
+  "common:category_upscale_fine_dining": "Fine Dining",
+  "common:category_brunch": "Brunch",
+  "common:category_movies": "Movies",
+  "common:category_theatre": "Theatre",
+  "common:category_creative_arts": "Creative & Arts",
+  "common:category_play": "Play",
+  "common:category_icebreakers": "Icebreakers",
+  "common:category_drinks_and_music": "Drinks & Music",
+};
+
+// Faithful to real i18next default behavior:
+//  - exists(key) → true only if the key is a registered resource.
+//  - t(key) on a MISS → the namespace-STRIPPED key ("category_romantic"),
+//    matching appendNamespaceToMissingKey:false (PROVEN in investigation §3).
+const stubI18n = {
+  exists: (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(REAL_CATEGORY_KEYS, key),
+  t: (key: string): string =>
+    REAL_CATEGORY_KEYS[key] ?? key.replace(/^common:/, ""),
+};
+
+const resolve = (input: string): string =>
+  resolveReadableCategoryName(input, stubI18n);
+
+// ── Curated labels (the reported bug): no category_* key → title-case fallback.
+Deno.test("ORCH-1044 T-01: 'Romantic' → 'Romantic' (no token leak)", () => {
+  assertEquals(resolve("Romantic"), "Romantic");
+});
+
+Deno.test("ORCH-1044 T-02: 'Adventurous' → 'Adventurous'", () => {
+  assertEquals(resolve("Adventurous"), "Adventurous");
+});
+
+Deno.test("ORCH-1044 T-03: 'First Date' → 'First Date' (singular, D-2: NOT 'First Dates')", () => {
+  assertEquals(resolve("First Date"), "First Date");
+});
+
+Deno.test("ORCH-1044 T-04: 'Group Fun' → 'Group Fun'", () => {
+  assertEquals(resolve("Group Fun"), "Group Fun");
+});
+
+Deno.test("ORCH-1044 T-05: 'Picnic Dates' → 'Picnic Dates'", () => {
+  assertEquals(resolve("Picnic Dates"), "Picnic Dates");
+});
+
+// T-06 NOTE (implementor): SPEC §7.1 expected 'Take a Stroll', but the LOCKED,
+// unchanged title-case fallback formula — slug.replace(/_/g,' ').replace(/\b\w/g,
+// upper) — uppercases EVERY word boundary, so 'Take a Stroll' resolves to
+// 'Take A Stroll'. The spec's expected string contradicts its own locked formula
+// (D-1 step 2 / NG-3 keeps the formula untouched). Asserting the resolver's true
+// output here; the SC-1 invariant (never a category_/intent_ token) still holds.
+// Logged as a discovery for the orchestrator. The deck's intent_take_a_stroll
+// localized label ("Take a Stroll") is the deferred F/U-2 parity route, not this.
+Deno.test("ORCH-1044 T-06: 'Take a Stroll' → 'Take A Stroll' (locked title-case formula)", () => {
+  assertEquals(resolve("Take a Stroll"), "Take A Stroll");
+});
+
+// ── Real category slug: localized HIT path still works (no single-card regression).
+Deno.test("ORCH-1044 T-07: 'casual_food' → 'Casual' (localized hit preserved)", () => {
+  assertEquals(resolve("casual_food"), "Casual");
+});
+
+// ── Empty guard intact.
+Deno.test("ORCH-1044 T-08: '' → 'Experience' (empty guard)", () => {
+  assertEquals(resolve(""), "Experience");
+});

--- a/app-mobile/src/utils/categoryUtils.ts
+++ b/app-mobile/src/utils/categoryUtils.ts
@@ -3,7 +3,32 @@
  * Provides functions to convert category translation keys to readable names.
  * 10 categories: 8 visible + 2 hidden (Groceries, Flowers). ORCH-0434.
  */
-import i18n from '../i18n';
+
+// ORCH-1044 (test seam, S-3): the i18n singleton (`../i18n`) hard-imports
+// react-i18next + AsyncStorage at module load, so a Deno/node unit test cannot
+// statically import this module without booting the full RN stack. We therefore
+// (1) expose the pure resolution in `resolveReadableCategoryName`, which takes an
+// injected i18n-like object, and (2) load the real `../i18n` singleton LAZILY
+// only when the exported `getReadableCategoryName` is called at runtime. This
+// keeps module load RN-free for unit tests while leaving the public API and all
+// ~14 call sites unchanged. Do NOT reintroduce a top-level `import i18n` — it
+// re-breaks the §6.1 seam (SPEC_ORCH-1044).
+
+/** Minimal i18next surface the resolver actually uses. */
+export interface CategoryI18nLike {
+  exists: (key: string) => boolean;
+  t: (key: string) => string;
+}
+
+let i18nSingleton: CategoryI18nLike | null = null;
+const getI18n = (): CategoryI18nLike => {
+  if (!i18nSingleton) {
+    // Lazy load: defers the RN/AsyncStorage import to first runtime call.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    i18nSingleton = require('../i18n').default as CategoryI18nLike;
+  }
+  return i18nSingleton;
+};
 
 // ORCH-0424: Selection limits removed. intents[] and categories[] are unbounded.
 // Do NOT reintroduce caps without a product decision.
@@ -44,10 +69,17 @@ export const VISIBLE_CATEGORY_SLUGS = [...VALID_SLUGS].filter(
 );
 
 /**
- * Convert translation key to readable category name.
- * Uses i18n for locale-aware display names, with legacy slug normalization.
+ * Pure category-label resolver (ORCH-1044, S-3 test seam).
+ *
+ * Takes an injected i18n-like object so it can be unit-tested in Deno/node
+ * WITHOUT booting the RN i18n module. `getReadableCategoryName` delegates here
+ * with the real `../i18n` singleton. Public behavior is identical to the prior
+ * `getReadableCategoryName`; the only change is Decision D-1 (existence guard).
  */
-export const getReadableCategoryName = (categoryKey: string): string => {
+export const resolveReadableCategoryName = (
+  categoryKey: string,
+  i18nLike: CategoryI18nLike,
+): string => {
   if (!categoryKey) return 'Experience';
 
   // ORCH-0434: Legacy slugs now resolve to new canonical slugs.
@@ -106,15 +138,29 @@ export const getReadableCategoryName = (categoryKey: string): string => {
   const slug = legacyToSlug[stripped] ?? legacyToSlug[categoryKey] ?? stripped;
   const normalizedSlug = slug.replace(/-/g, '_').toLowerCase();
 
-  // Try i18n translation
+  // Try i18n translation.
   const key = `common:category_${normalizedSlug}`;
-  const translated = i18n.t(key);
-  // If i18n returns the key itself (no translation found), fall back to formatting
-  if (translated === key) {
+  // ORCH-1044 (D-1): detect a missing key with i18next's own existence check,
+  // NOT string-equality against `key`. On a MISS, i18next STRIPS the namespace
+  // and returns "category_<slug>" (default appendNamespaceToMissingKey:false),
+  // so `translated === key` is NEVER true on a miss → the old guard was dead
+  // code and the bare "category_romantic" token leaked to the UI. `exists()`
+  // asks i18next directly and is immune to namespace-stripping + the init
+  // options in NG-1. Do NOT "simplify" this back to an equality check.
+  if (!i18nLike.exists(key)) {
     return slug.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
   }
-  return translated;
+  return i18nLike.t(key);
 };
+
+/**
+ * Convert translation key to readable category name.
+ * Uses i18n for locale-aware display names, with legacy slug normalization.
+ * Delegates to the pure `resolveReadableCategoryName` with the real i18n
+ * singleton (loaded lazily — see the test-seam note at the top of this file).
+ */
+export const getReadableCategoryName = (categoryKey: string): string =>
+  resolveReadableCategoryName(categoryKey, getI18n());
 
 /**
  * Get category slug from translation key or category name.


### PR DESCRIPTION
## What
Swipe History showed raw codes like `category_romantic` instead of friendly labels on curated cards. Root cause: `getReadableCategoryName` used a `translated === key` miss-guard that never matched (i18next strips the namespace on a miss), so the friendly fallback never ran and the raw slug leaked.

## Fix
Use i18next's `i18n.exists()` to detect the miss + title-case fallback, at the shared resolver — hardens all ~14 call sites. Resolver can never again emit a `category_*`/`intent_*` token. Public signature + all call sites untouched; no i18n-init/new-keys/backend changes.

## Tests (Step 0.5 satisfied)
- Implementor happy-path `categoryLabelResolver.test.ts` + adversarial `.adversarial.test.ts` (13/13).
- Tester full-corpus adversarial `categoryLabelResolver.fullcorpus.test.ts` (8/8) — sweeps all 23 real category keys + inverse miss-config.
- Fails-on-revert independently reconfirmed (12/21 red on revert).

## QA
PASS (0 P0/P1). Live Swipe-History render deferred to batched signed-in session as corroboration (deterministic resolver fix; platform-agnostic unit suite is the parity gate).

## Deploy
app-mobile only — no `[deploy]`, no migration, no edge deploy, no OTA (rides next native build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)