### PR TITLE
ORCH-1046: Fix business home Upcoming list showing 0 sold / $0 for upcoming events

### DIFF
--- a/mingla-business/app/(tabs)/home.tsx
+++ b/mingla-business/app/(tabs)/home.tsx
@@ -293,17 +293,21 @@ export default function HomeTab(): React.ReactElement {
       ? (primaryLiveItem.source as LiveEvent)
       : null;
 
-  // Sales summary lookup only for event/experience live items — trips have
-  // their own ticketsSoldCount on the Trip row.
-  const summaryLiveEvents = useMemo<LiveEvent[]>(
+  // Sales summary lookup for ALL event/experience items — both live AND upcoming.
+  // Upcoming (scheduled, future-dated) events are still selling tickets, so their
+  // sold count + revenue must be fetched too. Previously this filtered to
+  // status === "live", so every upcoming row fell back to a false "0 sold" / "$0"
+  // (its orders were never fetched). Trips are excluded — they carry their own
+  // ticketsSoldCount on the Trip row; drafts have no orders.
+  const summaryEvents = useMemo<LiveEvent[]>(
     () =>
       upcoming.items
-        .filter((i) => i.status === "live" && (i.kind === "event" || i.kind === "experience"))
+        .filter((i) => i.kind === "event" || i.kind === "experience")
         .map((i) => i.source as LiveEvent),
     [upcoming.items],
   );
   const eventSalesSummaries = useEventSalesSummaries(
-    summaryLiveEvents,
+    summaryEvents,
     currentBrand?.defaultCurrency,
   );
 


### PR DESCRIPTION
## Problem
On the business app **home → Upcoming** list, every *upcoming* (scheduled, future-dated) event showed **0 sold / \$0** even while tickets were actively selling. Live events were fine.

## Root cause
[home.tsx](mingla-business/app/(tabs)/home.tsx) built the sales-summary fetch list with a `status === "live"` filter:

```js
upcoming.items.filter((i) => i.status === "live" && (i.kind === "event" || i.kind === "experience"))
```

But the FlatList renders **all** `upcoming.items` (live *and* upcoming), all reading the same `eventSalesSummaries` map. Upcoming events were never in that map, so `UpcomingListItem` hit its hardcoded fallbacks `?? "0 sold"` and `?? formatCurrencyRound(0, …)`.

Not RLS, auth, or currency — proven by impersonating the brand owner under RLS (the exact `events!inner` query returns all orders) and by the DB server-truth.

## Fix
Drop the `status === "live"` clause so every event/experience item fetches its orders. Trips/drafts remain excluded by the existing `kind` filter (trips carry their own count; drafts have no orders). Renamed `summaryLiveEvents → summaryEvents`.

## Verification
- **On device**: "Vibes and Stuff" now shows real **44 sold / \$2,860** (6 orders, 44 line-item tickets) instead of 0/\$0. Confirmed by operator.
- `home.orch_0974` + adversarial suites: **11/11 pass**.
- `tsc`: no new errors; no dangling `summaryLiveEvents` refs.
- Events-tab card (`EventListCard`) was already correct (fetches orders for all real events) — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)