### PR TITLE
Close ORCH-1047 [deploy]: rename account_owner → brand_owner across SQL + TS + UI

### DIFF
--- a/.github/scripts/strict-grep/orch-1047-brand-owner-renamed.mjs
+++ b/.github/scripts/strict-grep/orch-1047-brand-owner-renamed.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1047 — strict-grep gate enforcing the brand role rename
+ * `account_owner` → `brand_owner`.
+ *
+ * WHY: forensics + product established that "account" is the auth identity
+ * (`creator_accounts`) and "brand" is the managed entity. The role on
+ * `brand_team_members.role` is per-brand, so the top-of-hierarchy literal
+ * MUST be `brand_owner` everywhere — SQL CHECK, RLS, RPCs, TS, UI copy.
+ *
+ * RULE: zero matches for the literal `account_owner` (case-sensitive) in
+ * active source code. Allowlisted surfaces:
+ *   - `supabase/migrations/2026050*` baseline squash (audit trail)
+ *   - `supabase/migrations/2026051*` + `2026052*` + `2026053*` + `2026060*`
+ *     + `2026072*` historical migrations (audit trail; the new
+ *     20260819 migration rewrites them at runtime)
+ *   - the rename migration itself
+ *   - `Mingla_Artifacts/` historical reports + dispatches
+ *   - any file with an inline `// orch-strict-grep-allow account_owner`
+ *     annotation (explicit opt-out for callers that genuinely need to
+ *     reference the dead label for documentation purposes)
+ *
+ * Self-test (`--self-test`) proves the gate fires on a synthetic file and
+ * stays silent on a clean file.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? path.resolve(process.cwd(), "..")
+  : process.cwd();
+
+const NEEDLE = "account_owner";
+
+// Roots to walk. Migrations are walked but most files are filtered via
+// allowlistMatch below.
+const SCAN_ROOTS = [
+  "supabase/migrations",
+  "supabase/functions",
+  "mingla-business/src",
+  "mingla-admin/src",
+  "app-mobile/src",
+  "packages",
+];
+
+const EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".sql",
+  ".md",
+  ".json",
+]);
+
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+  ".turbo",
+  ".vercel",
+  "__tests__",
+]);
+
+const HISTORICAL_MIGRATION_PREFIXES = [
+  "20260505",
+  "20260507",
+  "20260511",
+  "20260513",
+  "20260514",
+  "20260526",
+  "20260529",
+  "20260531",
+  "20260602",
+  "20260726",
+];
+
+const RENAME_MIGRATION_BASENAME =
+  "20260819000000_orch_1047_account_owner_to_brand_owner_rename.sql";
+
+const SELF_FILE_BASENAME = "orch-1047-brand-owner-renamed.mjs";
+
+function isAllowlisted(relPath) {
+  const base = path.basename(relPath);
+  // The rename migration itself documents both labels.
+  if (base === RENAME_MIGRATION_BASENAME) return true;
+  // This gate script's own name (self-reference safe).
+  if (base === SELF_FILE_BASENAME) return true;
+  // Historical reports & dispatches — never affect runtime.
+  if (relPath.startsWith("Mingla_Artifacts/")) return true;
+  // Allow historical migration files that pre-date the rename. Their
+  // 'account_owner' literals are audit trail; the new migration rewrites
+  // them at runtime. New SQL is required to use brand_owner.
+  if (relPath.startsWith("supabase/migrations/")) {
+    const migBase = path.basename(relPath);
+    if (HISTORICAL_MIGRATION_PREFIXES.some((p) => migBase.startsWith(p))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    if (IGNORE_DIRS.has(ent.name)) continue;
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      yield* walk(full);
+    } else if (ent.isFile()) {
+      const ext = path.extname(ent.name);
+      if (EXTENSIONS.has(ext)) yield full;
+    }
+  }
+}
+
+function scanFile(absPath, relPath, failures) {
+  if (isAllowlisted(relPath)) return;
+  let text;
+  try {
+    text = fs.readFileSync(absPath, "utf8");
+  } catch {
+    return;
+  }
+  if (!text.includes(NEEDLE)) return;
+  // Line-level scan so we can honor inline allow annotations.
+  const lines = text.split("\n");
+  lines.forEach((line, idx) => {
+    if (!line.includes(NEEDLE)) return;
+    if (line.includes("orch-strict-grep-allow account_owner")) return;
+    failures.push(`${relPath}:${idx + 1}: ${line.trim()}`);
+  });
+}
+
+function runGate(rootDir) {
+  const failures = [];
+  for (const rel of SCAN_ROOTS) {
+    const abs = path.join(rootDir, rel);
+    if (!fs.existsSync(abs)) continue;
+    for (const file of walk(abs)) {
+      const relPath = path.relative(rootDir, file);
+      scanFile(file, relPath, failures);
+    }
+  }
+  return failures;
+}
+
+// ---- Self-test
+if (process.argv.includes("--self-test")) {
+  const tmp = path.join("/tmp", "orch1047-selftest");
+  fs.rmSync(tmp, { recursive: true, force: true });
+  fs.mkdirSync(path.join(tmp, "mingla-business/src/utils"), { recursive: true });
+  fs.mkdirSync(path.join(tmp, "supabase/functions/foo"), { recursive: true });
+  fs.mkdirSync(path.join(tmp, "supabase/migrations"), { recursive: true });
+
+  // Synthetic clean file — should pass.
+  fs.writeFileSync(
+    path.join(tmp, "mingla-business/src/utils/brandRole.ts"),
+    `export const BRAND_ROLE_RANK = { brand_owner: 60 };\n`,
+  );
+
+  // Allowlisted historical migration — should pass even with the needle.
+  fs.writeFileSync(
+    path.join(tmp, "supabase/migrations/20260505000000_baseline.sql"),
+    `-- historical: 'account_owner' was the old label\n`,
+  );
+
+  let failures = runGate(tmp);
+  if (failures.length !== 0) {
+    console.error(
+      "ORCH-1047 self-test FAIL: clean tree reported failures:\n" +
+        failures.join("\n"),
+    );
+    process.exit(1);
+  }
+
+  // Inject a violating file — should fail.
+  fs.writeFileSync(
+    path.join(tmp, "supabase/functions/foo/index.ts"),
+    `const role = "account_owner";\n`,
+  );
+
+  failures = runGate(tmp);
+  if (failures.length === 0) {
+    console.error(
+      "ORCH-1047 self-test FAIL: violating file did NOT trigger the gate",
+    );
+    process.exit(1);
+  }
+
+  // Honor inline opt-out annotation.
+  fs.writeFileSync(
+    path.join(tmp, "supabase/functions/foo/index.ts"),
+    `// the old role was account_owner // orch-strict-grep-allow account_owner\n`,
+  );
+  failures = runGate(tmp);
+  if (failures.length !== 0) {
+    console.error(
+      "ORCH-1047 self-test FAIL: inline allow annotation did not suppress:\n" +
+        failures.join("\n"),
+    );
+    process.exit(1);
+  }
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+  console.log("ORCH-1047 gate self-test PASS (3/3 cases).");
+  process.exit(0);
+}
+
+// ---- Live mode
+const failures = runGate(root);
+if (failures.length > 0) {
+  console.error(
+    `ORCH-1047 gate FAIL — ${failures.length} match(es) for the dead label "account_owner" in active source code.\n` +
+      `The role was renamed to "brand_owner" by migration ${RENAME_MIGRATION_BASENAME}.\n` +
+      `Update each call site to use "brand_owner", or add an inline\n` +
+      `\`// orch-strict-grep-allow account_owner\` annotation if the reference\n` +
+      `is genuinely documentation-only.\n\nMatches:\n${failures.join("\n")}`,
+  );
+  process.exit(1);
+}
+
+console.log("ORCH-1047 gate PASS — no stale account_owner references found.");

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -764,6 +764,19 @@ jobs:
       - name: Run ORCH-1004 gate
         run: node .github/scripts/strict-grep/orch-1004-auth-scoped-query-readiness.mjs
 
+  orch-1047-brand-owner-renamed:
+    name: "ORCH-1047: brand role literal is brand_owner, not account_owner"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1047 gate self-test
+        run: node .github/scripts/strict-grep/orch-1047-brand-owner-renamed.mjs --self-test
+      - name: Run ORCH-1047 gate
+        run: node .github/scripts/strict-grep/orch-1047-brand-owner-renamed.mjs
+
   meta-orch-0827-package-isolation:
     name: "META-ORCH-0827: packages/ pure-presentational isolation"
     runs-on: ubuntu-latest

--- a/app-mobile/scripts/ci/orch-1047-rename-adversarial-check.mjs
+++ b/app-mobile/scripts/ci/orch-1047-rename-adversarial-check.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1047 — adversarial regression check (tester).
+ *
+ * Independent of the happy-path script: attacks different angles.
+ *   A-1: strict-grep gate self-check (subprocess) + fails-on-synthetic.
+ *   A-2: SQL migration file exists with the new CHECK constraint literal.
+ *   A-3: migration body integrity — DROP + UPDATE + new CHECK in same file.
+ *   A-4: trigger function body inserts `'brand_owner'`, not the old label.
+ *
+ * Append-only per ORCH-0840.
+ *
+ * Run: `node app-mobile/scripts/ci/orch-1047-rename-adversarial-check.mjs`
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../../");
+
+const failures = [];
+const passes = [];
+function check(label, cond, detail = "") {
+  if (cond) passes.push(label);
+  else failures.push(`${label}${detail ? ` — ${detail}` : ""}`);
+}
+
+// ── A-1: invoke the new strict-grep gate as a subprocess.
+const gatePath = path.join(
+  repoRoot,
+  ".github/scripts/strict-grep/orch-1047-brand-owner-renamed.mjs",
+);
+check("A-1a (strict-grep gate file exists)", fs.existsSync(gatePath));
+
+let gateLivePass = false;
+try {
+  execFileSync("node", [gatePath], { cwd: repoRoot, stdio: "pipe" });
+  gateLivePass = true;
+} catch (err) {
+  gateLivePass = false;
+}
+check("A-1b (strict-grep gate PASSES on current tree)", gateLivePass);
+
+let gateSelfTestPass = false;
+try {
+  execFileSync("node", [gatePath, "--self-test"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  gateSelfTestPass = true;
+} catch {
+  gateSelfTestPass = false;
+}
+check("A-1c (strict-grep gate self-test passes)", gateSelfTestPass);
+
+// ── A-2: migration file exists + contains the new CHECK constraint.
+const migrationsDir = path.join(repoRoot, "supabase/migrations");
+const migrationName = fs
+  .readdirSync(migrationsDir)
+  .find(
+    (n) =>
+      n.startsWith("20260819000000_orch_1047_") ||
+      /20260\d{6}_orch_1047_.*brand_owner.*rename\.sql/.test(n),
+  );
+check(
+  "A-2a (rename migration file present)",
+  !!migrationName,
+  migrationName ? "" : "no 20260819…orch_1047…rename.sql found",
+);
+
+let migrationSrc = "";
+if (migrationName) {
+  migrationSrc = fs.readFileSync(
+    path.join(migrationsDir, migrationName),
+    "utf8",
+  );
+}
+check(
+  "A-2b (migration contains new CHECK with brand_owner literal)",
+  migrationSrc.includes("CHECK (role = ANY (ARRAY[\n    'brand_owner'") ||
+    /CHECK \(role = ANY \(ARRAY\[\s*'brand_owner'/.test(migrationSrc),
+);
+
+// ── A-3: migration body integrity — DROP CONSTRAINT + UPDATE + new CHECK,
+// all in the same transaction.
+check(
+  "A-3a (migration drops the old role CHECK constraint)",
+  /DROP CONSTRAINT IF EXISTS brand_team_members_role_check/.test(migrationSrc),
+);
+check(
+  "A-3b (migration UPDATEs brand_team_members rows to brand_owner)",
+  /UPDATE public\.brand_team_members[\s\S]+?SET role = 'brand_owner'[\s\S]+?WHERE role = 'account_owner'/.test(
+    migrationSrc,
+  ),
+);
+check(
+  "A-3c (migration is wrapped in a single BEGIN/COMMIT transaction)",
+  /\bBEGIN;[\s\S]+COMMIT;\s*$/.test(migrationSrc),
+);
+
+// ── A-4: trigger function redefined with brand_owner literal in INSERT VALUES.
+check(
+  "A-4a (migration redefines biz_create_brand_owner_team_member)",
+  /CREATE OR REPLACE FUNCTION public\.biz_create_brand_owner_team_member/.test(
+    migrationSrc,
+  ),
+);
+check(
+  "A-4b (trigger function INSERTs the new 'brand_owner' literal)",
+  /VALUES\s*\([\s\S]+?'brand_owner'/.test(migrationSrc),
+);
+check(
+  "A-4c (biz_role_rank redefined with brand_owner = 60)",
+  /WHEN 'brand_owner' THEN 60/.test(migrationSrc),
+);
+
+// ── Report
+console.log("ORCH-1047 adversarial check");
+console.log(`  PASS: ${passes.length}`);
+console.log(`  FAIL: ${failures.length}`);
+if (failures.length > 0) {
+  console.error("Failures:");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("All ORCH-1047 adversarial tests PASS.");

--- a/app-mobile/scripts/ci/orch-1047-rename-regression-check.mjs
+++ b/app-mobile/scripts/ci/orch-1047-rename-regression-check.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1047 — implementor happy-path regression check.
+ *
+ * Verifies the TS authority (`mingla-business/src/utils/brandRole.ts`) reflects
+ * the rename to `brand_owner` and that no active source file still ships the
+ * old `account_owner` literal. Append-only per ORCH-0840.
+ *
+ * Run: `node app-mobile/scripts/ci/orch-1047-rename-regression-check.mjs`
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../../");
+
+const failures = [];
+const passes = [];
+function check(label, cond, detail = "") {
+  if (cond) {
+    passes.push(label);
+  } else {
+    failures.push(`${label}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+// ── Test 1: TS authority — BRAND_ROLE_RANK.brand_owner === 60
+// Read source rather than import (the file uses TS type assertions). A simple
+// regex-extract is sufficient because the constant block is fixed-format.
+const brandRolePath = path.join(
+  repoRoot,
+  "mingla-business/src/utils/brandRole.ts",
+);
+const brandRoleSrc = fs.readFileSync(brandRolePath, "utf8");
+const rankMatch = brandRoleSrc.match(
+  /export const BRAND_ROLE_RANK\s*=\s*\{([\s\S]*?)\}\s*as const/,
+);
+check("Test 1 (TS authority readable)", !!rankMatch);
+const rankBody = rankMatch ? rankMatch[1] : "";
+check(
+  "Test 1a (BRAND_ROLE_RANK.brand_owner === 60)",
+  /brand_owner\s*:\s*60/.test(rankBody),
+);
+
+// ── Test 2: BRAND_ROLE_RANK.account_owner removed (old key gone)
+check(
+  "Test 2 (BRAND_ROLE_RANK.account_owner removed)",
+  !/account_owner\s*:/.test(rankBody),
+  "old key still present in constant",
+);
+
+// ── Test 3: roleDisplayName('brand_owner') === 'Brand owner'
+const displayMatch = brandRoleSrc.match(
+  /case\s+"brand_owner":[\s\n]*return\s+"([^"]+)";/,
+);
+check(
+  "Test 3 (roleDisplayName('brand_owner') === 'Brand owner')",
+  !!displayMatch && displayMatch[1] === "Brand owner",
+  displayMatch ? `got: ${displayMatch[1]}` : "case not found",
+);
+
+// ── Test 4: static grep — zero matches for the dead literal in active source.
+const SCAN_DIRS = [
+  "mingla-business/src",
+  "mingla-admin/src",
+  "app-mobile/src",
+  "supabase/functions",
+];
+const EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+  "__tests__",
+]);
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    if (SKIP_DIRS.has(ent.name)) continue;
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) yield* walk(full);
+    else if (ent.isFile() && EXTS.has(path.extname(ent.name))) yield full;
+  }
+}
+
+const stragglers = [];
+for (const rel of SCAN_DIRS) {
+  const abs = path.join(repoRoot, rel);
+  if (!fs.existsSync(abs)) continue;
+  for (const file of walk(abs)) {
+    const text = fs.readFileSync(file, "utf8");
+    if (!text.includes("account_owner")) continue;
+    // honor the inline allow annotation the strict-grep gate also respects
+    const lines = text.split("\n");
+    lines.forEach((line, idx) => {
+      if (!line.includes("account_owner")) return;
+      if (line.includes("orch-strict-grep-allow account_owner")) return;
+      stragglers.push(`${path.relative(repoRoot, file)}:${idx + 1}`);
+    });
+  }
+}
+check(
+  "Test 4 (no account_owner literal in active TS / edge-fn source)",
+  stragglers.length === 0,
+  stragglers.length > 0 ? stragglers.slice(0, 5).join(", ") : "",
+);
+
+// ── Report
+console.log("ORCH-1047 regression check");
+console.log(`  PASS: ${passes.length}`);
+console.log(`  FAIL: ${failures.length}`);
+if (failures.length > 0) {
+  console.error("Failures:");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log("All ORCH-1047 happy-path tests PASS.");

--- a/mingla-business/src/components/team/RolePickerSheet.tsx
+++ b/mingla-business/src/components/team/RolePickerSheet.tsx
@@ -29,7 +29,7 @@ import { Sheet } from "../ui/Sheet";
 
 /** Render order mirrors operator UX convention: highest privilege first. */
 const ROLE_ORDER: ReadonlyArray<BrandRole> = [
-  "account_owner",
+  "brand_owner",
   "brand_admin",
   "event_manager",
   "finance_manager",

--- a/mingla-business/src/hooks/useCurrentBrandRole.ts
+++ b/mingla-business/src/hooks/useCurrentBrandRole.ts
@@ -2,13 +2,13 @@
  * useCurrentBrandRole — React Query hook for the current user's role within a brand (Cycle 13a).
  *
  * SPEC §4.6. Reads `brand_team_members` for the authenticated user; on null,
- * falls back to account_owner SYNTHESIS for solo operators (brand creator's
+ * falls back to brand_owner SYNTHESIS for solo operators (brand creator's
  * auth.uid() === creator_accounts.user_id of brands.account_id).
  *
  * The synthesis fallback is CRITICAL — without it, every existing solo
  * operator on a deploy of Cycle 13a loses access (no brand_team_members row
  * yet). The synthesis matches the SQL-side authority: RLS treats the brand
- * creator as account_owner via the same join chain (see biz_rank_for_caller
+ * creator as brand_owner via the same join chain (see biz_rank_for_caller
  * function in the b1 migration: brands.account_id → creator_accounts.user_id).
  *
  * [TRANSITIONAL] Stub-mode synthesis fallback (Cycle 13a rework v2 / DEC-092):
@@ -26,7 +26,7 @@
  * only fires for un-persisted local brands).
  *
  * Stale-store risk: if B-cycle later demotes the operator's role on a brand
- * (e.g. account_owner → event_manager) but the local `Brand.role` is still
+ * (e.g. brand_owner → event_manager) but the local `Brand.role` is still
  * "owner", the DB query returns the demoted role → `data.role` wins → stub
  * fallback does NOT override. Safe.
  *
@@ -131,7 +131,7 @@ export const useCurrentBrandRole = (
             {},
         };
       }
-      // Step 2: account_owner synthesis fallback for solo operators.
+      // Step 2: brand_owner synthesis fallback for solo operators.
       // Without this, every existing solo operator loses access on deploy.
       // Cycle 17e-A: filter deleted_at IS NULL per I-PROPOSED-A — soft-deleted
       // brands MUST NOT grant role synthesis to anyone (closed brand = no access).
@@ -152,7 +152,7 @@ export const useCurrentBrandRole = (
         .maybeSingle();
       if (accountErr) throw accountErr;
       if (accountRow !== null && accountRow.user_id === userId) {
-        return { role: "account_owner", permissionsOverride: {} };
+        return { role: "brand_owner", permissionsOverride: {} };
       }
       return { role: null, permissionsOverride: {} };
     },
@@ -164,14 +164,14 @@ export const useCurrentBrandRole = (
   // returns no role (typically because the brand is a local-only stub from
   // `brandList.STUB_BRANDS` and isn't persisted to the production DB yet).
   // Maps the existing local-only `Brand.role` enum to the 6-role enum:
-  //   "owner" → "account_owner" (rank 60 — top of hierarchy)
+  //   "owner" → "brand_owner" (rank 60 — top of hierarchy)
   //   "admin" → "brand_admin"   (rank 50)
   // Once B-cycle persists brands + brand_team_members, the queryFn returns
   // a non-null role on Step 1 or Step 2, `data.role` wins above, and this
   // branch becomes dead code. EXIT condition documented in file header.
   if (role === null && stubBrandRole !== null) {
     if (stubBrandRole === "owner") {
-      role = "account_owner";
+      role = "brand_owner";
     } else if (stubBrandRole === "admin") {
       role = "brand_admin";
     }

--- a/mingla-business/src/services/brandMapping.ts
+++ b/mingla-business/src/services/brandMapping.ts
@@ -145,7 +145,7 @@ export function membershipRoleToUiBrandRole(
   memberRole: string | null | undefined
 ): BrandRole {
   const r = memberRole?.toLowerCase() ?? "";
-  if (r === "account_owner") return "owner";
+  if (r === "brand_owner") return "owner";
   if (r === "brand_admin") return "admin";
   return "admin";
 }

--- a/mingla-business/src/store/brandList.ts
+++ b/mingla-business/src/store/brandList.ts
@@ -31,7 +31,7 @@
  * REMOVED. Brand-team state authority is now `src/store/brandTeamStore.ts`
  * which starts EMPTY (per Const #9 — no fabricated data) and accumulates real
  * invitations via the operator's invite-flow UI. Solo-operator default is
- * synthesized at read sites by `useCurrentBrandRole` (account_owner fallback).
+ * synthesized at read sites by `useCurrentBrandRole` (brand_owner fallback).
  *
  * Cycle 2 J-A10/J-A11 (schema v8): each brand carries stripeStatus + payouts
  * + refunds + balances + lastPayoutAt to drive the payments dashboard's 4

--- a/mingla-business/src/utils/brandRole.ts
+++ b/mingla-business/src/utils/brandRole.ts
@@ -12,7 +12,7 @@
  */
 
 export type BrandRole =
-  | "account_owner"
+  | "brand_owner"
   | "brand_admin"
   | "event_manager"
   | "finance_manager"
@@ -21,7 +21,8 @@ export type BrandRole =
 
 /**
  * Rank values mirror SQL biz_role_rank() at
- * supabase/migrations/20260502100000_b1_business_schema_rls.sql:11-30.
+ * supabase/migrations/20260502100000_b1_business_schema_rls.sql:11-30
+ * (ORCH-1047 renamed the top role literal from the old label → brand_owner).
  * Higher = more privilege. 0 = no membership.
  */
 export const BRAND_ROLE_RANK = {
@@ -30,15 +31,15 @@ export const BRAND_ROLE_RANK = {
   finance_manager: 30,
   event_manager: 40,
   brand_admin: 50,
-  account_owner: 60,
+  brand_owner: 60,
 } as const satisfies Record<BrandRole, number>;
 
 export const NO_MEMBERSHIP_RANK = 0;
 
 export const roleDisplayName = (role: BrandRole): string => {
   switch (role) {
-    case "account_owner":
-      return "Account owner";
+    case "brand_owner":
+      return "Brand owner";
     case "brand_admin":
       return "Brand admin";
     case "event_manager":
@@ -58,7 +59,7 @@ export const roleDisplayName = (role: BrandRole): string => {
 
 export const roleDescription = (role: BrandRole): string => {
   switch (role) {
-    case "account_owner":
+    case "brand_owner":
       return "Full control of the account, brands, and billing.";
     case "brand_admin":
       return "Manage brand settings, team, events, and finances.";

--- a/mingla-business/src/utils/permissionGates.ts
+++ b/mingla-business/src/utils/permissionGates.ts
@@ -50,7 +50,7 @@ export const canPerformAction = (
 export const gateCaptionFor = (action: GatedAction): string => {
   const requiredRank = MIN_RANK[action];
   const requiredRoleName = ((): string => {
-    if (requiredRank >= BRAND_ROLE_RANK.account_owner) return "account owner";
+    if (requiredRank >= BRAND_ROLE_RANK.brand_owner) return "brand owner";
     if (requiredRank >= BRAND_ROLE_RANK.brand_admin)
       return "brand admin or above";
     if (requiredRank >= BRAND_ROLE_RANK.event_manager)

--- a/supabase/functions/_shared/stripeEdgeAuth.ts
+++ b/supabase/functions/_shared/stripeEdgeAuth.ts
@@ -82,7 +82,7 @@ export async function getBrandPaymentManagerUserIds(
     .eq("brand_id", brandId)
     .is("removed_at", null)
     .not("accepted_at", "is", null)
-    .in("role", ["account_owner", "brand_admin", "finance_manager"]);
+    .in("role", ["brand_owner", "brand_admin", "finance_manager"]);
   if (error) {
     console.error("[stripeEdgeAuth] brand manager lookup failed:", error);
     return [];

--- a/supabase/migrations/20260819000000_orch_1047_account_owner_to_brand_owner_rename.sql
+++ b/supabase/migrations/20260819000000_orch_1047_account_owner_to_brand_owner_rename.sql
@@ -1,0 +1,269 @@
+-- ORCH-1047 — rename the brand role `account_owner` → `brand_owner` across
+-- SQL ground truth in a single transaction. Mechanical rename only — zero
+-- behavior change, zero permission change, zero new tables/columns/RPCs.
+--
+-- Why: Mingla "account" (`creator_accounts`) is the auth-side identity;
+-- `brands` are the managed entities; the role lives on
+-- `brand_team_members.role` and is per-brand, not per-account. Calling it
+-- `account_owner` confused every downstream spec. Unblocks META-ORCH-1048.
+--
+-- Pre-rename ground-truth touchpoints (each one updated below):
+--   - `biz_role_rank('account_owner') = 60` baseline 20260505:3315-3328
+--   - `biz_brand_effective_rank` calls `biz_role_rank('account_owner')`
+--     baseline 20260505:2987-3017
+--   - `brand_team_members_role_check` baseline 20260505:7750
+--   - `brand_invitations_role_check` baseline 20260505:7728
+--   - `biz_create_brand_owner_team_member` trigger function body inserts
+--     `'account_owner'` literal at 20260514:107 + 161
+--   - `brand_payment_managers_select_stripe_disputes` RLS policy IN-list
+--     20260726:46
+--
+-- Hard guards:
+--   - Single transaction (BEGIN/COMMIT). All DDL + DML atomic.
+--   - Data-preserving: existing rows UPDATE'd in same tx; CHECK constraints
+--     re-added with the new literal so no orphaned data.
+--   - Idempotent re-run: every CREATE OR REPLACE / DROP IF EXISTS guard.
+--   - No new permission surface — RLS policies are dropped and re-created
+--     with IDENTICAL predicate logic, only the role string flips.
+--
+-- Cross-refs:
+--   - SPEC dispatch: Mingla_Artifacts/prompts/SPEC_ORCH-1047_BRAND_OWNER_ROLE_RENAME.md
+--   - Memory: feedback-rls-returning-owner-gap, migration-history-drift-db-push-unsafe
+
+BEGIN;
+
+-- =============================================================
+-- 1. Drop the existing CHECK constraints that gate the OLD literal
+-- =============================================================
+-- These must come off before the UPDATE so the row-rewrite below isn't
+-- blocked by its own constraint. (UPDATE pre-check vs post-check race is
+-- not a problem because UPDATE is permissive while the constraint is gone.)
+
+ALTER TABLE public.brand_team_members
+  DROP CONSTRAINT IF EXISTS brand_team_members_role_check;
+
+ALTER TABLE public.brand_invitations
+  DROP CONSTRAINT IF EXISTS brand_invitations_role_check;
+
+-- =============================================================
+-- 2. Data rewrite: every row.role = 'account_owner' → 'brand_owner'
+-- =============================================================
+-- Audit the rewrite so the operator can confirm row count matches the
+-- pre-flight probe (forensics estimated based on production data; if the
+-- count differs significantly investigate before re-running).
+
+DO $$
+DECLARE
+  v_team_rows int;
+  v_invite_rows int;
+BEGIN
+  UPDATE public.brand_team_members
+    SET role = 'brand_owner'
+    WHERE role = 'account_owner';
+  GET DIAGNOSTICS v_team_rows = ROW_COUNT;
+  RAISE NOTICE 'ORCH-1047: renamed % brand_team_members rows from account_owner to brand_owner', v_team_rows;
+
+  UPDATE public.brand_invitations
+    SET role = 'brand_owner'
+    WHERE role = 'account_owner';
+  GET DIAGNOSTICS v_invite_rows = ROW_COUNT;
+  RAISE NOTICE 'ORCH-1047: renamed % brand_invitations rows from account_owner to brand_owner', v_invite_rows;
+END$$;
+
+-- =============================================================
+-- 3. Re-add CHECK constraints with the new literal
+-- =============================================================
+
+ALTER TABLE public.brand_team_members
+  ADD CONSTRAINT brand_team_members_role_check
+  CHECK (role = ANY (ARRAY[
+    'brand_owner'::text,
+    'brand_admin'::text,
+    'event_manager'::text,
+    'finance_manager'::text,
+    'marketing_manager'::text,
+    'scanner'::text
+  ]));
+
+ALTER TABLE public.brand_invitations
+  ADD CONSTRAINT brand_invitations_role_check
+  CHECK (role = ANY (ARRAY[
+    'brand_owner'::text,
+    'brand_admin'::text,
+    'event_manager'::text,
+    'finance_manager'::text,
+    'marketing_manager'::text,
+    'scanner'::text
+  ]));
+
+-- =============================================================
+-- 4. Re-define biz_role_rank() — flip the WHEN literal
+-- =============================================================
+-- Pattern preserved verbatim from baseline 20260505:3315-3328 — only the
+-- WHEN string changes. 'account_owner' falls through to ELSE 0 so any stale
+-- caller fails closed (NO_MEMBERSHIP_RANK semantics).
+
+CREATE OR REPLACE FUNCTION public.biz_role_rank(p_role text) RETURNS integer
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT CASE trim(lower(coalesce(p_role, '')))
+    WHEN 'scanner' THEN 10
+    WHEN 'marketing_manager' THEN 20
+    WHEN 'finance_manager' THEN 30
+    WHEN 'event_manager' THEN 40
+    WHEN 'brand_admin' THEN 50
+    WHEN 'brand_owner' THEN 60
+    ELSE 0
+  END;
+$$;
+
+ALTER FUNCTION public.biz_role_rank(text) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.biz_role_rank(text) IS
+  'Cycle B1 (ORCH-1047 rename): numeric rank for brand_team_members.role comparisons (higher = more privilege). brand_owner=60.';
+
+-- =============================================================
+-- 5. Re-define biz_brand_effective_rank() — synthesized-owner uses new label
+-- =============================================================
+-- The synthesized-owner branch passes `biz_role_rank('account_owner')` which
+-- now returns 0 — that would silently demote solo brand creators to
+-- no-membership rank. Flip the literal to `'brand_owner'` so it returns 60
+-- as before. Logic otherwise verbatim from baseline 20260505:2987-3017.
+
+CREATE OR REPLACE FUNCTION public.biz_brand_effective_rank(p_brand_id uuid, p_user_id uuid) RETURNS integer
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+  SELECT GREATEST(
+    CASE
+      WHEN EXISTS (
+        SELECT 1
+        FROM public.brands b
+        WHERE b.id = p_brand_id
+          AND b.account_id = p_user_id
+          AND b.deleted_at IS NULL
+      )
+      THEN public.biz_role_rank('brand_owner'::text)
+      ELSE 0
+    END,
+    COALESCE(
+      (
+        SELECT max(public.biz_role_rank(m.role))
+        FROM public.brand_team_members m
+        INNER JOIN public.brands b ON b.id = m.brand_id
+        WHERE m.brand_id = p_brand_id
+          AND m.user_id = p_user_id
+          AND m.removed_at IS NULL
+          AND m.accepted_at IS NOT NULL
+          AND b.deleted_at IS NULL
+      ),
+      0
+    )
+  );
+$$;
+
+ALTER FUNCTION public.biz_brand_effective_rank(uuid, uuid) OWNER TO postgres;
+
+-- =============================================================
+-- 6. Re-define biz_create_brand_owner_team_member() trigger fn
+-- =============================================================
+-- Function NAME was always brand_owner-themed; only the INSERTed role
+-- literal changes. Body otherwise verbatim from 20260514:67-118 with the
+-- single string flip. Idempotency guard + SECURITY DEFINER preserved.
+
+CREATE OR REPLACE FUNCTION public.biz_create_brand_owner_team_member()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public', 'pg_temp'
+  AS $$
+BEGIN
+  IF NEW.account_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.brand_team_members
+    WHERE brand_id = NEW.id
+      AND user_id  = NEW.account_id
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.brand_team_members (
+    brand_id,
+    user_id,
+    role,
+    invited_at,
+    accepted_at,
+    removed_at,
+    mingla_tos_accepted_at,
+    mingla_tos_version_accepted
+  )
+  VALUES (
+    NEW.id,
+    NEW.account_id,
+    'brand_owner',
+    NEW.created_at,
+    NEW.created_at,
+    NULL,
+    NULL,
+    NULL
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.biz_create_brand_owner_team_member() OWNER TO postgres;
+
+COMMENT ON FUNCTION public.biz_create_brand_owner_team_member() IS
+  'B2a Path C V3 RC-3 (ORCH-1047 rename): AFTER INSERT ON brands trigger fn that auto-creates the brand_owner brand_team_members row so V3 ToS gate (brand-mingla-tos-accept) UPDATE always matches a row. Idempotent.';
+
+COMMENT ON TRIGGER biz_brand_owner_team_member_after_insert ON public.brands IS
+  'B2a Path C V3 RC-3 (ORCH-1047 rename): ensures every new brand has a brand_team_members(role=brand_owner) row for its owner so V3 ToS gate UPDATE always matches.';
+
+-- =============================================================
+-- 7. RLS policy: brand_payment_managers_select_stripe_disputes
+-- =============================================================
+-- ORCH-0953 policy IN-list (`role IN ('account_owner', 'brand_admin',
+-- 'finance_manager')`). DROP + re-CREATE with identical predicate logic but
+-- the new role string. No new policy, no new permission.
+
+DROP POLICY IF EXISTS "brand_payment_managers_select_stripe_disputes"
+  ON public.stripe_disputes;
+
+CREATE POLICY "brand_payment_managers_select_stripe_disputes"
+  ON public.stripe_disputes FOR SELECT TO authenticated
+  USING (
+    brand_id IN (
+      SELECT brand_id
+      FROM public.brand_team_members
+      WHERE user_id = auth.uid()
+        AND removed_at IS NULL
+        AND accepted_at IS NOT NULL
+        AND role IN ('brand_owner', 'brand_admin', 'finance_manager')
+    )
+  );
+
+-- =============================================================
+-- 8. Verification probes
+-- =============================================================
+-- Belt-and-suspenders per ORCH-0734 / B2a V3 RC-3 pattern: assert end state
+-- so a misconfigured migration fails loudly at apply time.
+
+DO $$
+BEGIN
+  ASSERT (SELECT COUNT(*) FROM public.brand_team_members WHERE role = 'account_owner') = 0,
+    'ORCH-1047 verification failed: brand_team_members still has account_owner rows';
+  ASSERT (SELECT COUNT(*) FROM public.brand_invitations WHERE role = 'account_owner') = 0,
+    'ORCH-1047 verification failed: brand_invitations still has account_owner rows';
+  ASSERT (SELECT public.biz_role_rank('brand_owner')) = 60,
+    'ORCH-1047 verification failed: biz_role_rank(brand_owner) is not 60';
+  ASSERT (SELECT public.biz_role_rank('account_owner')) = 0,
+    'ORCH-1047 verification failed: biz_role_rank(account_owner) did not drop to 0';
+END$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Mechanical rename of the brand role label `account_owner` → `brand_owner` everywhere. Mingla "account" (`creator_accounts`) is the auth identity; brands are the managed entities. The old label confused every downstream spec. **Zero behavior change. Zero permission change. No new tables/columns/RPCs.**

Unblocks META-ORCH-1048 sub-B through sub-F by giving downstream specs the correct role naming.

## What changed
- **SQL migration** `supabase/migrations/20260819000000_orch_1047_account_owner_to_brand_owner_rename.sql` — single transaction:
  - DROP + UPDATE rows + ADD CHECK on both `brand_team_members` and `brand_invitations` (data-preserving)
  - `biz_role_rank()` flipped (`brand_owner=60`, `account_owner→0`)
  - `biz_brand_effective_rank()` synthesized-owner branch flipped (otherwise solo creators silently demote to rank 0)
  - `biz_create_brand_owner_team_member()` trigger body inserts `'brand_owner'`
  - `brand_payment_managers_select_stripe_disputes` RLS policy DROP+CREATE with identical predicate, new literal
  - End-state ASSERT block (rows = 0 in old label, rank = 60 for new, rank = 0 for old)
- **Edge fn** `supabase/functions/_shared/stripeEdgeAuth.ts:85` — manager-role IN-list
- **Business TS** — `brandRole.ts` (`BrandRole`, `BRAND_ROLE_RANK`, `roleDisplayName`, `roleDescription`), `permissionGates.ts:53` caption, `RolePickerSheet.tsx:32` order, `brandMapping.ts:148` server→UI mapping, `useCurrentBrandRole.ts` synthesis branches + docstrings, `brandList.ts:34` comment
- **Strict-grep gate** `.github/scripts/strict-grep/orch-1047-brand-owner-renamed.mjs` (+ workflow registration). Allowlists historical migrations + `Mingla_Artifacts/` + the rename migration itself + inline `// orch-strict-grep-allow account_owner` annotation
- Historical migration files (`20260505`, `20260514`, `20260513`, `20260726`, etc.) preserved verbatim as audit trail; the new migration rewrites their effects at apply time

## Step 0.5 regression evidence
- `app-mobile/scripts/ci/orch-1047-rename-regression-check.mjs` — 5/5 PASS on live tree, **3/5 FAIL** when `BRAND_ROLE_RANK.brand_owner` is reverted to `account_owner` (fails-on-revert verified)
- `app-mobile/scripts/ci/orch-1047-rename-adversarial-check.mjs` — 11/11 PASS on live tree, **7/11 FAIL** when migration body is stubbed (fails-on-revert verified)
- Strict-grep `--self-test` 3/3 PASS; live mode reports 0 stragglers
- Head commit: `188b1ee74`

## Migration apply note
**Orchestrator/operator applies via Supabase Management API after merge** per [migration-history-drift-db-push-unsafe](https://...). Do NOT `supabase db push` — apply with curl POST to `/v1/projects/.../database/query`, then INSERT version `20260819000000` into `schema_migrations`.

## Affected Surfaces
Business iOS + Business Android + Business Web preview + Backend (SQL CHECK + RPCs + RLS + trigger) + Admin Web (role-name display strings). Consumer / buyer-anon-web unaffected (no role concept exposed).

## Test plan
- [ ] CI green (strict-grep, web-build-check, supabase-migrations-and-stripe-deno, append-only tests)
- [ ] Migration applies cleanly via Management API (orchestrator after merge)
- [ ] Post-apply ASSERT block in migration confirms 0 stale rows + `biz_role_rank('brand_owner')=60`
- [ ] Smoke: create new brand → `brand_team_members.role='brand_owner'` row auto-inserted by trigger
- [ ] Smoke: Business app UI displays "Brand owner" not "Account owner" on team list

🤖 Generated with [Claude Code](https://claude.com/claude-code)