### PR TITLE
ORCH-1056: lead welcome email (web-app link + Ari spotlight + mobile-in-works)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1264,6 +1264,15 @@ function checkNoNewBackendFiles() {
     // tester-authored adversarial regression (ORCH-1045 QA) — same backend dir.
     "supabase/functions/beta-access-lead-submit/__tests__/submit_handler_sideeffects.tester.test.ts",
   ];
+  // ORCH-1056 [Lead welcome email]: modifies the beta-access edge fn (already
+  // allowlisted above) to also send the lead a welcome email (web-app link +
+  // Ari spotlight + mobile-in-the-works). Adds two new test files. C7 flags new
+  // backend files; per COMMS-0002 they land in the same commit as the edge-fn
+  // change. No marketing scope.
+  const ORCH_1056_BACKEND_ALLOWLIST = [
+    "supabase/functions/beta-access-lead-submit/__tests__/welcome_email.test.ts",
+    "supabase/functions/beta-access-lead-submit/__tests__/welcome_email_adversarial.tester.test.ts",
+  ];
   // ORCH-1030 [Consumer app notification deep-linking]. C7 is scoped to
   // ORCH-0863 marketing; ORCH-1030's backend touches correct the notification
   // producers' deep links so they actually reach the device: birthday/holiday
@@ -1335,6 +1344,7 @@ function checkNoNewBackendFiles() {
   ];
   const ALLOWLIST = [
     ...ORCH_1045_BACKEND_ALLOWLIST,
+    ...ORCH_1056_BACKEND_ALLOWLIST,
     ...ORCH_1034_BACKEND_ALLOWLIST,
     ...ORCH_1043_BACKEND_ALLOWLIST,
     ...ORCH_1032_BACKEND_ALLOWLIST,

--- a/supabase/functions/beta-access-lead-submit/__tests__/submit_handler_sideeffects.tester.test.ts
+++ b/supabase/functions/beta-access-lead-submit/__tests__/submit_handler_sideeffects.tester.test.ts
@@ -155,9 +155,11 @@ function withEnv(fn: () => Promise<void>): () => Promise<void> {
   };
 }
 
-// ── SC-4: new lead → created + exactly ONE notify email to seth@usemingla.com ──
+// ── SC-4: new lead → created + notify to seth@ AND welcome to the lead ──
+// ORCH-1056 [TEST-MOD-APPROVED ORCH-1056]: a new lead now sends TWO emails —
+// the internal notify to seth@ AND the lead-facing welcome (web-app link + Ari).
 Deno.test(
-  "ADV new lead inserts → 200 created AND exactly one Resend email to seth@",
+  "ADV new lead inserts → 200 created AND two Resend emails (notify + welcome)",
   withEnv(async () => {
     const { restore, log } = installFakeBackend({
       // Successful insert → supabase-js returns 201 with empty body (no error).
@@ -168,10 +170,14 @@ Deno.test(
       assertEquals(res.status, 200);
       assertEquals(await res.json(), { ok: true, status: "created" });
       assertEquals(log.insertCalls, 1, "exactly one insert");
-      assertEquals(log.resendCalls, 1, "exactly one notify email on a new lead");
+      assertEquals(log.resendCalls, 2, "notify to Seth + welcome to the lead");
       assert(
         log.resendBodies[0].includes("seth@usemingla.com"),
-        "notify must be addressed to seth@usemingla.com",
+        "first email (notify) must be addressed to seth@usemingla.com",
+      );
+      assert(
+        log.resendBodies[1].includes("business.usemingla.com"),
+        "second email (welcome) must link the lead to the web app",
       );
     } finally {
       restore();
@@ -227,7 +233,8 @@ Deno.test(
       assertEquals(res.status, 200, "email failure must NOT fail the request");
       assertEquals(await res.json(), { ok: true, status: "created" });
       assertEquals(log.insertCalls, 1);
-      assertEquals(log.resendCalls, 1, "notify was attempted");
+      // ORCH-1056 [TEST-MOD-APPROVED ORCH-1056]: notify + welcome both attempted.
+      assertEquals(log.resendCalls, 2, "notify + welcome both attempted");
     } finally {
       restore();
     }

--- a/supabase/functions/beta-access-lead-submit/__tests__/welcome_email.test.ts
+++ b/supabase/functions/beta-access-lead-submit/__tests__/welcome_email.test.ts
@@ -1,0 +1,71 @@
+// ORCH-1056 — happy-path regression for the lead-facing welcome email.
+//
+// Exercises buildWelcomeEmail (the pure builder the handler ships). This is the
+// CLOSE Step 0.5 implementor regression: it PASSES on the fixed code and MUST
+// FAIL on revert (e.g. if buildWelcomeEmail is removed, or the business.usemingla.com
+// link / Ari spotlight / mobile-in-the-works line is dropped).
+//
+// Run: /Users/sethogieva/.deno/bin/deno test --allow-env --allow-net \
+//   supabase/functions/beta-access-lead-submit/__tests__/welcome_email.test.ts
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import { buildWelcomeEmail, validateLead } from "../index.ts";
+
+const FROM = "Mingla Beta <beta@usemingla.com>";
+
+function lead() {
+  const v = validateLead({
+    brandType: "restaurant",
+    brandName: "The Corner Table",
+    contactName: "Ada",
+    city: "Lagos",
+    email: "owner@thecornertable.com",
+    consent: true,
+    source: "organiser_marketing_nav",
+  });
+  if (!v.ok) throw new Error("fixture lead failed validation");
+  return v.lead;
+}
+
+Deno.test("welcome email is addressed to the lead", () => {
+  const email = buildWelcomeEmail(lead(), FROM);
+  assertEquals(email.to, ["owner@thecornertable.com"]);
+  assertEquals(email.from, FROM);
+});
+
+Deno.test("welcome subject confirms the beta list", () => {
+  const email = buildWelcomeEmail(lead(), FROM);
+  assert(
+    email.subject.toLowerCase().includes("on the list"),
+    `subject missing confirmation: ${email.subject}`,
+  );
+});
+
+Deno.test("welcome body links to the web app (business.usemingla.com)", () => {
+  const email = buildWelcomeEmail(lead(), FROM);
+  assert(
+    email.html.includes("https://business.usemingla.com"),
+    "html missing business.usemingla.com link",
+  );
+  assert(
+    email.text.includes("https://business.usemingla.com"),
+    "text missing business.usemingla.com link",
+  );
+});
+
+Deno.test("welcome body spotlights Ari + flags mobile as in-the-works", () => {
+  const email = buildWelcomeEmail(lead(), FROM);
+  assert(email.html.includes("Ari"), "html missing Ari spotlight");
+  assert(email.text.includes("Ari"), "text missing Ari spotlight");
+  assert(
+    email.html.toLowerCase().includes("mobile app is in the works"),
+    "html missing mobile-app-in-the-works line",
+  );
+  assert(
+    email.text.toLowerCase().includes("mobile app is in the works"),
+    "text missing mobile-app-in-the-works line",
+  );
+});

--- a/supabase/functions/beta-access-lead-submit/__tests__/welcome_email_adversarial.tester.test.ts
+++ b/supabase/functions/beta-access-lead-submit/__tests__/welcome_email_adversarial.tester.test.ts
@@ -1,0 +1,75 @@
+// ORCH-1056 — TESTER adversarial regression for the lead-facing welcome email.
+//
+// Attacks a DIFFERENT angle than welcome_email.test.ts (which asserts the happy
+// content). Here we guard the two ways this email can go wrong in production:
+//   1. Recipient confusion — the welcome must reach the LEAD, never the Mingla
+//      inbox (seth@usemingla.com is the NOTIFY recipient, not this one).
+//   2. Channel parity — both html AND text must carry the link + Ari + mobile
+//      message, so a plain-text client isn't left with a dead email.
+//   3. No injection / no fabricated data — a hostile brand_name/contact_name
+//      must NOT appear in the rendered welcome (it is static marketing copy).
+//
+// Run: /Users/sethogieva/.deno/bin/deno test --allow-env --allow-net \
+//   supabase/functions/beta-access-lead-submit/__tests__/welcome_email_adversarial.tester.test.ts
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import { buildWelcomeEmail, validateLead } from "../index.ts";
+
+const FROM = "Mingla Beta <beta@usemingla.com>";
+
+function hostileLead() {
+  const v = validateLead({
+    brandType: "club_nightlife",
+    brandName: "<script>alert(1)</script> Bar",
+    contactName: "<img src=x onerror=alert(2)>",
+    city: "Berlin",
+    email: "attacker@evil.test",
+    consent: true,
+    source: "organiser_marketing_hero",
+  });
+  if (!v.ok) throw new Error("fixture lead failed validation");
+  return v.lead;
+}
+
+Deno.test("[adversarial] welcome never goes to the Mingla inbox", () => {
+  const email = buildWelcomeEmail(hostileLead(), FROM);
+  assertEquals(email.to, ["attacker@evil.test"]);
+  assert(
+    !email.to.some((addr) => addr.includes("seth@usemingla.com")),
+    "welcome must NOT be sent to the internal notify inbox",
+  );
+});
+
+Deno.test("[adversarial] link + Ari + mobile message present in BOTH channels", () => {
+  const email = buildWelcomeEmail(hostileLead(), FROM);
+  for (const [name, body] of [["html", email.html], ["text", email.text]]) {
+    assert(
+      body.includes("business.usemingla.com"),
+      `${name} channel missing web-app link`,
+    );
+    assert(body.includes("Ari"), `${name} channel missing Ari`);
+    assert(
+      body.toLowerCase().includes("mobile app is in the works"),
+      `${name} channel missing mobile-in-the-works`,
+    );
+  }
+});
+
+Deno.test("[adversarial] hostile lead fields never render into the welcome", () => {
+  const email = buildWelcomeEmail(hostileLead(), FROM);
+  assert(
+    !email.html.includes("<script>alert(1)"),
+    "raw script payload leaked into welcome html",
+  );
+  assert(
+    !email.html.includes("onerror=alert(2)"),
+    "raw event-handler payload leaked into welcome html",
+  );
+  assert(
+    !email.text.includes("alert(1)") && !email.text.includes("alert(2)"),
+    "lead payload leaked into welcome text",
+  );
+});

--- a/supabase/functions/beta-access-lead-submit/index.ts
+++ b/supabase/functions/beta-access-lead-submit/index.ts
@@ -200,8 +200,78 @@ export function buildNotifyEmail(
   };
 }
 
+// ORCH-1056 — lead-facing welcome email. Pure → testable. Static marketing copy
+// only (no user-controlled field is interpolated into the HTML/text → no
+// injection surface, Constitution #9 — no fabricated data). Confirms the lead is
+// on the beta list, points them at the LIVE web app (business.usemingla.com),
+// flags the mobile app as in-the-works, and previews capabilities incl. Ari.
+export function buildWelcomeEmail(
+  lead: ValidatedLead,
+  from: string,
+): { from: string; to: string[]; subject: string; html: string; text: string } {
+  const BUSINESS_URL = "https://business.usemingla.com";
+
+  const html =
+    `<div style="font-family:system-ui,-apple-system,sans-serif;font-size:15px;line-height:1.55;color:#0e0e10;max-width:560px;">
+  <h1 style="margin:0 0 12px;font-size:22px;">You're on the list.</h1>
+  <p style="margin:0 0 16px;">Thanks for joining the Mingla Business beta. Your place deserves to be found — and you don't have to wait.</p>
+  <p style="margin:0 0 8px;font-weight:600;">Start now, on the web:</p>
+  <p style="margin:0 0 16px;"><a href="${BUSINESS_URL}" style="display:inline-block;background:#eb7825;color:#ffffff;text-decoration:none;font-weight:700;padding:12px 22px;border-radius:14px;">Open Mingla Business →</a></p>
+  <p style="margin:0 0 20px;color:#6b7280;font-size:13px;">That link (business.usemingla.com) is our web app. The mobile app is in the works — we'll email you the moment it lands.</p>
+  <h2 style="margin:0 0 8px;font-size:16px;">What you can do today</h2>
+  <ul style="margin:0 0 20px;padding-left:20px;">
+    <li>Create and publish events, trips, and experiences</li>
+    <li>Sell tickets and take bookings — one all-in price up front, paid out to you, no checkout surprises for your guests</li>
+    <li>Get discovered by people nearby looking for exactly your vibe</li>
+    <li>Build your audience and send email campaigns</li>
+    <li>Open a waitlist, set your hours and schedule, manage it all in one place</li>
+  </ul>
+  <h2 style="margin:0 0 8px;font-size:16px;">Coming very soon</h2>
+  <ul style="margin:0 0 20px;padding-left:20px;">
+    <li><strong>Ari — your AI co-pilot.</strong> We're building it right now. Very soon you'll run the whole business just by asking Ari: "create tonight's event," "launch a campaign," "who's coming Friday?" — done.</li>
+    <li>The mobile app</li>
+    <li>More ways to reach your people (SMS, and more)</li>
+  </ul>
+  <p style="margin:0;">We'll keep you posted as your spot opens.<br/>— The Mingla team</p>
+</div>`;
+
+  const text = [
+    "You're on the list.",
+    "",
+    "Thanks for joining the Mingla Business beta. Your place deserves to be found — and you don't have to wait.",
+    "",
+    `Start now, on the web: ${BUSINESS_URL}`,
+    "That link is our web app. The mobile app is in the works — we'll email you the moment it lands.",
+    "",
+    "What you can do today",
+    "- Create and publish events, trips, and experiences",
+    "- Sell tickets and take bookings — one all-in price up front, paid out to you, no checkout surprises for your guests",
+    "- Get discovered by people nearby looking for exactly your vibe",
+    "- Build your audience and send email campaigns",
+    "- Open a waitlist, set your hours and schedule, manage it all in one place",
+    "",
+    "Coming very soon",
+    "- Ari, your AI co-pilot. We're building it right now. Very soon you'll run the whole business just by asking Ari: create tonight's event, launch a campaign, who's coming Friday — done.",
+    "- The mobile app",
+    "- More ways to reach your people (SMS, and more)",
+    "",
+    "We'll keep you posted as your spot opens.",
+    "— The Mingla team",
+  ].join("\n");
+
+  return {
+    from,
+    to: [lead.email],
+    subject: "You're on the list — start with Mingla Business on the web",
+    html,
+    text,
+  };
+}
+
 // Best-effort Resend send. Returns ok/err; the CALLER decides it is non-fatal.
-async function sendNotify(
+// Generalized (ORCH-1056) to send any built email payload — the single Resend
+// fetch site keeps the ORCH-0785-A no-attachment opt-out below authoritative.
+async function sendEmail(
   apiKey: string,
   payload: ReturnType<typeof buildNotifyEmail>,
 ): Promise<{ ok: boolean; error?: string }> {
@@ -325,17 +395,28 @@ export async function handler(req: Request): Promise<Response> {
       Deno.env.get("RESEND_MARKETING_FROM") ??
       "Mingla Beta <beta@usemingla.com>";
     if (resendKey) {
-      const payload = buildNotifyEmail(lead, from, new Date().toISOString());
-      const sent = await sendNotify(resendKey, payload);
-      if (!sent.ok) {
+      // (1) Internal notify → Mingla inbox.
+      const notify = await sendEmail(
+        resendKey,
+        buildNotifyEmail(lead, from, new Date().toISOString()),
+      );
+      if (!notify.ok) {
         console.error(
           "[beta-access-lead-submit] notify email failed (non-fatal):",
-          sent.error,
+          notify.error,
+        );
+      }
+      // (2) ORCH-1056 — lead-facing welcome email (NEW lead only; non-fatal).
+      const welcome = await sendEmail(resendKey, buildWelcomeEmail(lead, from));
+      if (!welcome.ok) {
+        console.error(
+          "[beta-access-lead-submit] welcome email failed (non-fatal):",
+          welcome.error,
         );
       }
     } else {
       console.error(
-        "[beta-access-lead-submit] RESEND_API_KEY missing — skipped notify (non-fatal)",
+        "[beta-access-lead-submit] RESEND_API_KEY missing — skipped notify + welcome (non-fatal)",
       );
     }
 


### PR DESCRIPTION
On a NEW beta signup, the lead now receives a welcome email (in addition to the existing seth@ notification).

The lead email: confirms they're on the list, links to **business.usemingla.com** (the web app), notes the **mobile app is in the works**, lists what they can do today, and spotlights **Ari** (in progress — soon you'll run the whole business by asking Ari).

- `buildWelcomeEmail()` added (static copy, no user-field interpolation → no injection); sent to the lead, non-fatal, NEW-lead-only (duplicates still get nothing).
- `sendNotify` → `sendEmail` (single Resend fetch site; ORCH-0785-A opt-out intact).
- New regression tests: `welcome_email.test.ts` (happy) + `welcome_email_adversarial.tester.test.ts` (recipient-safety / channel-parity / no-injection); fails-on-revert proven.
- ORCH-1045 side-effects test updated to expect TWO emails on a new lead — `[TEST-MOD-APPROVED ORCH-1056]`.
- Strict-grep allowlist (COMMS-0002) updated in-commit; sender `Mingla Beta <beta@usemingla.com>`.

Verification: 35 Deno tests pass, `deno check` clean, ORCH-0785-A pass, C7 "All checks PASS". Backend-only — no Vercel/[deploy]. Edge fn redeployed from main post-merge + e2e verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)