### PR TITLE
Close ORCH-1052 [deploy]: partner identity + account-level Stripe Connect + currency-match invite gate wired

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1288,6 +1288,21 @@ function checkNoNewBackendFiles() {
     "supabase/functions/accept-scanner-invitation/__tests__/orch-1051-accept-happy.test.ts",
     "supabase/functions/accept-scanner-invitation/__tests__/orch-1051-accept-adversarial.test.ts",
   ];
+  // ORCH-1052 [Partner identity + account-level Stripe Connect + currency-
+  // match invite gate]. META-ORCH-1048 sub-D. C7 is scoped to ORCH-0863
+  // marketing; these are partner-Stripe + invite-gate backend touches
+  // (migration + 2 new edge fns + modified accept-brand-invitation + tests).
+  // Per COMMS-0002 must land in the SAME commit as the service + UI wiring.
+  const ORCH_1052_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260822000000_orch_1052_partner_identity_stripe.sql",
+    "supabase/functions/partner-stripe-onboard/index.ts",
+    "supabase/functions/partner-stripe-account-session/index.ts",
+    "supabase/functions/accept-brand-invitation/index.ts",
+    "supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-happy.test.ts",
+    "supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-adversarial.test.ts",
+    "supabase/functions/accept-brand-invitation/__tests__/orch-1052-currency-gate.test.ts",
+    "supabase/migrations/__tests__/orch_1052_partner_can_accept_brand.test.ts",
+  ];
   // ORCH-1056 [Lead welcome email]: modifies the beta-access edge fn (already
   // allowlisted above) to also send the lead a welcome email (web-app link +
   // Ari spotlight + mobile-in-the-works). Adds two new test files. C7 flags new
@@ -1381,6 +1396,7 @@ function checkNoNewBackendFiles() {
     "supabase/functions/backfill-place-photo-thumbs/index.adversarial.test.ts",
   ];
   const ALLOWLIST = [
+    ...ORCH_1052_BACKEND_ALLOWLIST,
     ...ORCH_1051_BACKEND_ALLOWLIST,
     ...ORCH_1050_BACKEND_ALLOWLIST,
     ...ORCH_1044_BACKEND_ALLOWLIST,

--- a/.github/scripts/strict-grep/orch-1052-partner-identity.mjs
+++ b/.github/scripts/strict-grep/orch-1052-partner-identity.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1052 — strict-grep gate for the partner-identity + account-level
+ * Stripe Connect + currency-match invite gate. META-ORCH-1048 sub-D.
+ *
+ * RULES:
+ *   1. Required new files exist:
+ *        - supabase/migrations/20260822000000_orch_1052_partner_identity_stripe.sql
+ *        - supabase/functions/partner-stripe-onboard/index.ts
+ *        - supabase/functions/partner-stripe-account-session/index.ts
+ *        - mingla-business/app/connect-partner-onboarding.web.tsx
+ *        - mingla-business/app/partner/earnings.tsx
+ *        - mingla-business/src/services/partnerStripeService.ts
+ *        - mingla-business/src/hooks/usePartnerStripe.ts
+ *   2. The migration file references partner_can_accept_brand, partner_enabled,
+ *      partner_stripe_connect_accounts, external_account_currencies, and the
+ *      RAISE EXCEPTION 'invite_currency_mismatch' (P0006).
+ *   3. The partner-stripe-onboard edge fn references creator_accounts
+ *      partner_enabled gate AND createRecipientAccount AND
+ *      createAccountSession.
+ *   4. The accept-brand-invitation edge fn now maps the new P0006 code AND
+ *      handles 'invite_currency_mismatch' error.
+ *   5. supabase/config.toml declares verify_jwt = true for both new fns.
+ *
+ * Self-test (`--self-test`) proves each rule fires on a synthetic violation
+ * and stays silent on a clean tree.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? path.resolve(process.cwd(), "..")
+  : process.cwd();
+
+const REQUIRED_FILES = [
+  "supabase/migrations/20260822000000_orch_1052_partner_identity_stripe.sql",
+  "supabase/functions/partner-stripe-onboard/index.ts",
+  "supabase/functions/partner-stripe-account-session/index.ts",
+  "mingla-business/app/connect-partner-onboarding.web.tsx",
+  "mingla-business/app/partner/earnings.tsx",
+  "mingla-business/src/services/partnerStripeService.ts",
+  "mingla-business/src/hooks/usePartnerStripe.ts",
+];
+
+const MIGRATION_REQUIRED_TOKENS = [
+  "partner_can_accept_brand",
+  "partner_enabled",
+  "partner_stripe_connect_accounts",
+  "external_account_currencies",
+  "invite_currency_mismatch",
+  "P0006",
+  "admin_toggle_partner",
+];
+
+const ONBOARD_REQUIRED_TOKENS = [
+  "creator_accounts",
+  "partner_enabled",
+  "createRecipientAccount",
+  "createAccountSession",
+  "partner_stripe_connect_accounts",
+];
+
+const ACCEPT_REQUIRED_TOKENS = [
+  "P0006",
+  "invite_currency_mismatch",
+  "parsePartnerGateDetail",
+];
+
+const CONFIG_REQUIRED_TOKENS = [
+  "[functions.partner-stripe-onboard]",
+  "[functions.partner-stripe-account-session]",
+];
+
+function readFileOrNull(rel) {
+  const abs = path.join(root, rel);
+  try {
+    return fs.readFileSync(abs, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function checkRequiredFilesExist() {
+  const missing = [];
+  for (const rel of REQUIRED_FILES) {
+    if (readFileOrNull(rel) === null) missing.push(rel);
+  }
+  if (missing.length > 0) {
+    return `Required file(s) missing:\n  - ${missing.join("\n  - ")}`;
+  }
+  return null;
+}
+
+function checkMigrationContents() {
+  const src = readFileOrNull(REQUIRED_FILES[0]);
+  if (src === null) return null; // covered by checkRequiredFilesExist
+  const missing = MIGRATION_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `Migration missing required tokens: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+function checkOnboardContents() {
+  const src = readFileOrNull(REQUIRED_FILES[1]);
+  if (src === null) return null;
+  const missing = ONBOARD_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `partner-stripe-onboard missing required tokens: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+function checkAcceptContents() {
+  const src = readFileOrNull("supabase/functions/accept-brand-invitation/index.ts");
+  if (src === null) return "accept-brand-invitation/index.ts not found";
+  const missing = ACCEPT_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `accept-brand-invitation missing ORCH-1052 P0006 handling: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+function checkConfigToml() {
+  const src = readFileOrNull("supabase/config.toml");
+  if (src === null) return "supabase/config.toml not found";
+  const missing = CONFIG_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `supabase/config.toml missing entries: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+const CHECKS = [
+  ["required-files", checkRequiredFilesExist],
+  ["migration", checkMigrationContents],
+  ["partner-stripe-onboard", checkOnboardContents],
+  ["accept-brand-invitation", checkAcceptContents],
+  ["config-toml", checkConfigToml],
+];
+
+function runChecks() {
+  const failures = [];
+  for (const [name, fn] of CHECKS) {
+    const result = fn();
+    if (result !== null) {
+      failures.push(`[${name}] ${result}`);
+    }
+  }
+  return failures;
+}
+
+function selfTest() {
+  // Each rule must fire on a synthetic violation.
+  const violations = [];
+
+  // Rule 1: required files exist.
+  const r1 = checkRequiredFilesExist();
+  if (r1 !== null) {
+    violations.push(
+      "self-test fail: required-files check fired on a clean tree (" + r1 + ")",
+    );
+  }
+
+  // Rule 2: simulate migration violation by parsing a stripped string.
+  {
+    const fakeMigration = "BEGIN; -- empty migration\nCOMMIT;\n";
+    const missing = MIGRATION_REQUIRED_TOKENS.filter(
+      (t) => !fakeMigration.includes(t),
+    );
+    if (missing.length !== MIGRATION_REQUIRED_TOKENS.length) {
+      violations.push(
+        "self-test fail: migration check would not fire on empty migration",
+      );
+    }
+  }
+
+  // Rule 3: empty onboard contents.
+  {
+    const fakeOnboard = "";
+    const missing = ONBOARD_REQUIRED_TOKENS.filter(
+      (t) => !fakeOnboard.includes(t),
+    );
+    if (missing.length !== ONBOARD_REQUIRED_TOKENS.length) {
+      violations.push("self-test fail: onboard check would not fire on empty fn");
+    }
+  }
+
+  // Rule 4: accept missing all required tokens.
+  {
+    const fakeAccept = "// stripped accept fn";
+    const missing = ACCEPT_REQUIRED_TOKENS.filter(
+      (t) => !fakeAccept.includes(t),
+    );
+    if (missing.length !== ACCEPT_REQUIRED_TOKENS.length) {
+      violations.push(
+        "self-test fail: accept-brand-invitation check would not fire when P0006 absent",
+      );
+    }
+  }
+
+  // Rule 5: config toml without entries.
+  {
+    const fakeConfig = "project_id = \"test\"\n";
+    const missing = CONFIG_REQUIRED_TOKENS.filter(
+      (t) => !fakeConfig.includes(t),
+    );
+    if (missing.length !== CONFIG_REQUIRED_TOKENS.length) {
+      violations.push("self-test fail: config check would not fire");
+    }
+  }
+
+  return violations;
+}
+
+const args = new Set(process.argv.slice(2));
+if (args.has("--self-test")) {
+  const violations = selfTest();
+  if (violations.length > 0) {
+    for (const v of violations) console.error(v);
+    process.exit(1);
+  }
+  console.log("ORCH-1052 strict-grep self-test PASS");
+  process.exit(0);
+}
+
+const failures = runChecks();
+if (failures.length > 0) {
+  console.error("ORCH-1052 strict-grep FAIL:\n" + failures.map((f) => `  - ${f}`).join("\n"));
+  process.exit(1);
+}
+console.log("ORCH-1052 strict-grep PASS");
+process.exit(0);

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -803,6 +803,19 @@ jobs:
       - name: Run ORCH-1051 gate
         run: node .github/scripts/strict-grep/orch-1051-scanner-invite-functional.mjs
 
+  orch-1052-partner-identity:
+    name: "ORCH-1052: partner identity + account-level Stripe + currency-match invite gate"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1052 gate self-test
+        run: node .github/scripts/strict-grep/orch-1052-partner-identity.mjs --self-test
+      - name: Run ORCH-1052 gate
+        run: node .github/scripts/strict-grep/orch-1052-partner-identity.mjs
+
   meta-orch-0827-package-isolation:
     name: "META-ORCH-0827: packages/ pure-presentational isolation"
     runs-on: ubuntu-latest

--- a/mingla-admin/src/pages/UserManagementPage.jsx
+++ b/mingla-admin/src/pages/UserManagementPage.jsx
@@ -245,13 +245,16 @@ export function UserManagementPage() {
   const fetchUserDetail = useCallback(async (userId) => {
     setDetailLoading(true);
     try {
-      const [profileRes, prefsRes, friendsRes, activityRes, sessionsRes, participationsRes] = await Promise.all([
+      const [profileRes, prefsRes, friendsRes, activityRes, sessionsRes, participationsRes, creatorAccountRes] = await Promise.all([
         supabase.from("profiles").select("*").eq("id", userId).single(),
         supabase.from("preferences").select("*").eq("profile_id", userId).maybeSingle(),
         supabase.from("friends").select("*, friend:profiles!friends_friend_user_id_fkey(display_name, email, avatar_url)").eq("user_id", userId).eq("status", "accepted"),
         supabase.from("user_activity").select("*").eq("user_id", userId).order("created_at", { ascending: false }).limit(20),
         supabase.from("user_sessions").select("*").eq("user_id", userId).order("started_at", { ascending: false }).limit(10),
         supabase.from("session_participants").select("*, session:collaboration_sessions(name, status, session_type, board_id)").eq("user_id", userId).limit(20),
+        // ORCH-1052: read partner_enabled / partner_country so the Toggle
+        // Mingla partner button can render the correct label + state.
+        supabase.from("creator_accounts").select("id, partner_enabled, partner_country").eq("id", userId).maybeSingle(),
       ]);
 
       if (profileRes.error) throw profileRes.error;
@@ -263,7 +266,14 @@ export function UserManagementPage() {
         : { data: [] };
 
       if (!mountedRef.current) return;
-      setUserDetail(profileRes.data);
+      // ORCH-1052: merge creator_accounts.partner_enabled / partner_country
+      // onto the profile detail so the partner toggle reads consistently.
+      const ca = creatorAccountRes?.data ?? null;
+      setUserDetail({
+        ...profileRes.data,
+        partner_enabled: ca?.partner_enabled === true,
+        partner_country: ca?.partner_country ?? null,
+      });
       setUserPrefs(prefsRes.data);
       setUserFriends(friendsRes.data || []);
       setUserBoards(boardsRes.data || []);
@@ -624,6 +634,42 @@ export function UserManagementPage() {
       if (mountedRef.current) setBulkActioning(false);
     }
   }, [selectedIds, addToast, fetchUsers, fetchStats]);
+
+  // ORCH-1052: admin-only toggle for creator_accounts.partner_enabled. Calls
+  // the SECURITY DEFINER admin_toggle_partner RPC which self-checks the
+  // profiles.account_type='admin' gate against auth.uid() and writes an
+  // audit_log row. Re-reads userDetail on success so the UI reflects the new
+  // partner_enabled state.
+  const [partnerTogglingIds, setPartnerTogglingIds] = useState(new Set());
+  const handlePartnerToggle = useCallback(async (userId, currentValue) => {
+    const newValue = !currentValue;
+    setPartnerTogglingIds(prev => { const next = new Set(prev); next.add(userId); return next; });
+    try {
+      const { error } = await supabase.rpc("admin_toggle_partner", {
+        p_account_id: userId,
+        p_enabled: newValue,
+      });
+      if (error) throw error;
+      logAdminAction("user.partner_toggle", "user", userId, { partner_enabled: newValue });
+      if (userDetail?.id === userId) {
+        // Re-read so the detail card reflects the new state.
+        fetchUserDetail(userId);
+      }
+      addToast({
+        variant: "success",
+        title: newValue ? "Marked as Mingla partner" : "Unmarked Mingla partner",
+        description: newValue
+          ? "User can now connect partner Stripe to receive partner earnings."
+          : "User is no longer a partner.",
+      });
+    } catch (err) {
+      addToast({ variant: "error", title: "Partner toggle failed", description: err.message });
+    } finally {
+      if (mountedRef.current) {
+        setPartnerTogglingIds(prev => { const next = new Set(prev); next.delete(userId); return next; });
+      }
+    }
+  }, [addToast, fetchUserDetail, userDetail]);
 
   const handleBetaToggle = useCallback(async (userId, currentValue) => {
     const newValue = !currentValue;
@@ -1123,6 +1169,18 @@ export function UserManagementPage() {
                 Edit
               </Button>
             )}
+            {/* ORCH-1052: Toggle Mingla partner. Reads creator_accounts.partner_enabled,
+                falls back to false when the user has no creator_accounts row. */}
+            <Button
+              variant="secondary"
+              size="sm"
+              loading={partnerTogglingIds.has(userDetail.id)}
+              onClick={() => handlePartnerToggle(userDetail.id, userDetail.partner_enabled === true)}
+            >
+              {userDetail.partner_enabled === true
+                ? "Unmark Mingla partner"
+                : "Toggle Mingla partner"}
+            </Button>
             {isBanned ? (
               <Button variant="secondary" size="sm" icon={UserCheck} loading={banningId === userDetail.id} onClick={() => handleUnban(userDetail.id)}>
                 Unban

--- a/mingla-business/app/connect-partner-onboarding.web.tsx
+++ b/mingla-business/app/connect-partner-onboarding.web.tsx
@@ -1,0 +1,292 @@
+/**
+ * /connect-partner-onboarding — Mingla-hosted Stripe Connect Embedded
+ * Components page for PARTNER (account-level) Stripe onboarding. ORCH-1052.
+ *
+ * Mirrors /connect-onboarding (the brand-level page) verbatim, but for
+ * partner identity: query param `account_id` (the partner's
+ * creator_accounts.id / auth.uid()) instead of `brand_id`. On exit, deep-
+ * links back to the native partner-onboarding-complete handler or routes to
+ * the partner earnings screen.
+ *
+ * ROUTE: business.usemingla.com/connect-partner-onboarding?session=...&account_id=...&return_to=...
+ *
+ * Uses Stripe's web Connect SDK (@stripe/react-connect-js + @stripe/connect-js).
+ * Cites https://docs.stripe.com/connect/embedded-components/account-onboarding.md.
+ */
+
+// orch-strict-grep-allow safearea-on-fullscreen-routes — web-only Stripe Connect Embedded Components page; renders DOM elements (<div>) via @stripe/react-connect-js, NOT React Native primitives. Mirrors connect-onboarding.web.tsx per I-PROPOSED-O.
+
+import React, { useEffect, useMemo, useState } from "react";
+import Constants from "expo-constants";
+import {
+  ConnectAccountOnboarding,
+  ConnectComponentsProvider,
+  ConnectNotificationBanner,
+} from "@stripe/react-connect-js";
+import { loadConnectAndInitialize } from "@stripe/connect-js";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+const MINGLA_BRAND_COLOR = "#eb7825" as const;
+
+export default function ConnectPartnerOnboardingPage(): React.ReactElement {
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    session: string | string[];
+    account_id: string | string[];
+    return_to: string | string[];
+  }>();
+
+  const sessionClientSecret = Array.isArray(params.session)
+    ? params.session[0]
+    : params.session;
+  const accountId = Array.isArray(params.account_id)
+    ? params.account_id[0]
+    : params.account_id;
+  const returnTo = Array.isArray(params.return_to)
+    ? params.return_to[0]
+    : params.return_to;
+
+  const [hasExited, setHasExited] = useState<boolean>(false);
+  const [initError, setInitError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const stripeConnectInstance = useMemo(() => {
+    if (typeof sessionClientSecret !== "string") return null;
+    const fromExtra = (Constants.expoConfig?.extra as
+      | Record<string, string>
+      | undefined)?.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+    const fromProcessEnv = process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+    const publishableKey = fromExtra ?? fromProcessEnv;
+    if (publishableKey === undefined || publishableKey.length === 0) {
+      setInitError(
+        "Stripe publishable key is not configured. Contact support@usemingla.com.",
+      );
+      return null;
+    }
+    try {
+      return loadConnectAndInitialize({
+        publishableKey,
+        fetchClientSecret: async () => sessionClientSecret,
+        appearance: { variables: { colorPrimary: MINGLA_BRAND_COLOR } },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setInitError(`Couldn't initialize Stripe: ${message}`);
+      return null;
+    }
+  }, [sessionClientSecret]);
+
+  const handleExit = (): void => {
+    setHasExited(true);
+    if (
+      typeof returnTo === "string" &&
+      returnTo.startsWith("mingla-business://")
+    ) {
+      if (typeof window !== "undefined") {
+        window.location.href = returnTo;
+      }
+    } else {
+      router.replace("/partner/earnings" as never);
+    }
+  };
+
+  const handleStepChange = (event: unknown): void => {
+    const step = typeof event === "object" && event !== null && "step" in event
+      ? String((event as { step?: unknown }).step ?? "unknown")
+      : "unknown";
+    console.info("[connect-partner-onboarding] step changed", {
+      accountId,
+      step,
+    });
+    try {
+      window.localStorage.setItem(
+        "mingla:partner-stripe-connect:last-onboarding-step",
+        JSON.stringify({ accountId, step, at: new Date().toISOString() }),
+      );
+    } catch {
+      // LocalStorage may be hardened-off.
+    }
+  };
+
+  const handleLoadError = (event: unknown): void => {
+    const message =
+      typeof event === "object" && event !== null && "error" in event
+        ? String(
+          (event as { error?: { message?: unknown } }).error?.message ?? "",
+        )
+        : "";
+    setLoadError(
+      message.length > 0 ? message : "Stripe couldn't load onboarding.",
+    );
+  };
+
+  if (typeof sessionClientSecret !== "string") {
+    return (
+      <div style={pageWrapperStyle}>
+        <div style={errorCardStyle}>
+          <h2 style={errorTitleStyle}>Invalid onboarding link</h2>
+          <p style={errorBodyStyle}>
+            This partner-onboarding link is missing a required parameter.
+            Return to Mingla Business and tap &ldquo;Set up partner
+            payouts&rdquo; again to start fresh.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (initError !== null) {
+    return (
+      <div style={pageWrapperStyle}>
+        <div style={errorCardStyle}>
+          <h2 style={errorTitleStyle}>Couldn&rsquo;t start onboarding</h2>
+          <p style={errorBodyStyle}>{initError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadError !== null) {
+    return (
+      <div style={pageWrapperStyle}>
+        <div style={errorCardStyle}>
+          <h2 style={errorTitleStyle}>Couldn&rsquo;t load onboarding</h2>
+          <p style={errorBodyStyle}>{loadError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (stripeConnectInstance === null) {
+    return (
+      <div style={pageWrapperStyle}>
+        <div style={loadingCardStyle}>
+          <p>Initializing onboarding…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (hasExited) {
+    return (
+      <div style={pageWrapperStyle}>
+        <div style={loadingCardStyle}>
+          <p>Onboarding session ended. Redirecting…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={pageWrapperStyle}>
+      <header style={headerStyle}>
+        <h1 style={headerTitleStyle}>Mingla — Partner payouts</h1>
+      </header>
+      <main style={mainStyle}>
+        <ConnectComponentsProvider connectInstance={stripeConnectInstance}>
+          <ConnectNotificationBanner
+            collectionOptions={{
+              fields: "eventually_due",
+              futureRequirements: "include",
+            }}
+          />
+          <ConnectAccountOnboarding
+            onExit={handleExit}
+            onStepChange={handleStepChange}
+            onLoadError={handleLoadError}
+            fullTermsOfServiceUrl="https://www.usemingla.com/terms-of-service/"
+            recipientTermsOfServiceUrl="https://www.usemingla.com/terms-of-service/"
+            privacyPolicyUrl="https://www.usemingla.com/privacy-policy/"
+            collectionOptions={{
+              fields: "eventually_due",
+              futureRequirements: "include",
+            }}
+          />
+        </ConnectComponentsProvider>
+      </main>
+      <footer style={footerStyle}>
+        <p style={footerTextStyle}>
+          Powered by Stripe. Your bank details go directly to Stripe — Mingla
+          never sees them.
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+const pageWrapperStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  backgroundColor: "#FAFAFA",
+  display: "flex",
+  flexDirection: "column",
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+};
+
+const headerStyle: React.CSSProperties = {
+  padding: "24px 24px 16px",
+  textAlign: "center",
+  borderBottom: "1px solid #E5E7EB",
+  backgroundColor: "#FFFFFF",
+};
+
+const headerTitleStyle: React.CSSProperties = {
+  fontSize: "20px",
+  fontWeight: 600,
+  margin: 0,
+  color: "#0F172A",
+};
+
+const mainStyle: React.CSSProperties = {
+  flex: 1,
+  padding: "24px",
+  maxWidth: "780px",
+  width: "100%",
+  margin: "0 auto",
+  boxSizing: "border-box",
+};
+
+const footerStyle: React.CSSProperties = {
+  padding: "16px 24px",
+  borderTop: "1px solid #E5E7EB",
+  backgroundColor: "#FFFFFF",
+  textAlign: "center",
+};
+
+const footerTextStyle: React.CSSProperties = {
+  fontSize: "13px",
+  color: "#475569",
+  margin: 0,
+};
+
+const errorCardStyle: React.CSSProperties = {
+  maxWidth: "480px",
+  margin: "80px auto",
+  padding: "32px",
+  backgroundColor: "#FFFFFF",
+  border: "1px solid #FCA5A5",
+  borderRadius: "12px",
+  boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
+};
+
+const errorTitleStyle: React.CSSProperties = {
+  fontSize: "20px",
+  fontWeight: 600,
+  margin: "0 0 12px",
+  color: "#0F172A",
+};
+
+const errorBodyStyle: React.CSSProperties = {
+  fontSize: "15px",
+  lineHeight: 1.5,
+  margin: 0,
+  color: "#475569",
+};
+
+const loadingCardStyle: React.CSSProperties = {
+  maxWidth: "480px",
+  margin: "80px auto",
+  padding: "32px",
+  textAlign: "center",
+  color: "#475569",
+};

--- a/mingla-business/app/partner/earnings.tsx
+++ b/mingla-business/app/partner/earnings.tsx
@@ -1,0 +1,330 @@
+/**
+ * /partner/earnings — Mingla partner earnings screen. ORCH-1052.
+ *
+ * Visible only to flagged Mingla partners (creator_accounts.partner_enabled =
+ * true). Surfaces:
+ *  - Partner Stripe Connect status (not connected → CTA, onboarding → resume,
+ *    active → managed)
+ *  - Placeholder for the partner_splits table (data ships in ORCH-1054)
+ *
+ * Non-partners hit a friendly empty state directing them to support.
+ */
+
+import React, { useCallback } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+
+import {
+  usePartnerStripeStatus,
+  useStartPartnerStripeOnboarding,
+} from "../../src/hooks/usePartnerStripe";
+import {
+  colors,
+  accent,
+  spacing,
+  radius,
+  typography,
+} from "../../src/constants/designSystem";
+
+const RETURN_DEEP_LINK = "mingla-business://partner-onboarding-complete";
+
+export default function PartnerEarningsScreen(): React.ReactElement {
+  const router = useRouter();
+  const statusQuery = usePartnerStripeStatus();
+  const startOnboarding = useStartPartnerStripeOnboarding();
+
+  const handleStartOnboarding = useCallback(async () => {
+    if (!statusQuery.data) return;
+    const country = statusQuery.data.partner_country ?? "GB";
+    try {
+      const result = await startOnboarding.mutateAsync({
+        country,
+        returnUrl: RETURN_DEEP_LINK,
+      });
+      if (Platform.OS === "web") {
+        // Web: navigate inline.
+        if (typeof window !== "undefined") {
+          window.location.href = result.onboarding_url;
+        }
+      } else {
+        // Native: open via expo-web-browser auth session.
+        await WebBrowser.openAuthSessionAsync(
+          result.onboarding_url,
+          RETURN_DEEP_LINK,
+        );
+        // On return, refresh status.
+        statusQuery.refetch();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("[partner/earnings] onboarding launch failed:", message);
+    }
+  }, [statusQuery, startOnboarding]);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={["top", "bottom"]}>
+      <Stack.Screen
+        options={{
+          title: "Partner earnings",
+          headerBackTitleVisible: false,
+        }}
+      />
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <Text style={styles.h1}>Partner earnings</Text>
+
+        {statusQuery.isLoading ? (
+          <View style={styles.center}>
+            <ActivityIndicator color={accent.warm} />
+          </View>
+        ) : statusQuery.error ? (
+          <View style={styles.errorCard}>
+            <Text style={styles.errorTitle}>Couldn’t load partner status</Text>
+            <Text style={styles.errorBody}>{statusQuery.error.message}</Text>
+            <Pressable
+              accessibilityLabel="Retry"
+              style={styles.secondaryBtn}
+              onPress={() => statusQuery.refetch()}
+            >
+              <Text style={styles.secondaryBtnText}>Retry</Text>
+            </Pressable>
+          </View>
+        ) : statusQuery.data?.partner_enabled === false ? (
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyTitle}>Not a Mingla partner yet</Text>
+            <Text style={styles.emptyBody}>
+              Mingla partners earn a share of every paid event they help bring
+              in. Want in? Email{" "}
+              <Text
+                style={styles.link}
+                onPress={() => Linking.openURL("mailto:partners@usemingla.com")}
+              >
+                partners@usemingla.com
+              </Text>
+              .
+            </Text>
+          </View>
+        ) : (
+          <>
+            <StatusBlock
+              status={statusQuery.data?.status ?? "not_connected"}
+              country={statusQuery.data?.country ?? null}
+              externalCurrencies={
+                statusQuery.data?.external_account_currencies ?? []
+              }
+              onStart={handleStartOnboarding}
+              starting={startOnboarding.isPending}
+              startError={startOnboarding.error?.message ?? null}
+            />
+            <View style={styles.splitsCard}>
+              <Text style={styles.cardTitle}>Splits</Text>
+              <Text style={styles.cardBody}>
+                Your earnings will appear here once your first partnered event
+                sells. We’re wiring the split pipeline in the next release.
+              </Text>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function StatusBlock(props: {
+  status: string;
+  country: string | null;
+  externalCurrencies: string[];
+  onStart: () => void;
+  starting: boolean;
+  startError: string | null;
+}): React.ReactElement {
+  const { status, country, externalCurrencies, onStart, starting, startError } =
+    props;
+
+  if (status === "active") {
+    return (
+      <View style={styles.statusCardActive}>
+        <Text style={styles.cardTitle}>Payouts ready</Text>
+        <Text style={styles.cardBody}>
+          Your partner Stripe account is active
+          {country ? ` (${country})` : ""}.
+          {externalCurrencies.length > 0
+            ? ` We can settle in ${externalCurrencies.join(", ").toUpperCase()}.`
+            : ""}
+        </Text>
+      </View>
+    );
+  }
+
+  if (status === "restricted") {
+    return (
+      <View style={styles.statusCard}>
+        <Text style={styles.cardTitle}>Stripe needs more info</Text>
+        <Text style={styles.cardBody}>
+          Open your partner Stripe to finish the requirements Stripe is
+          waiting on.
+        </Text>
+        <Pressable
+          accessibilityLabel="Resume Stripe onboarding"
+          style={styles.primaryBtn}
+          onPress={onStart}
+          disabled={starting}
+        >
+          <Text style={styles.primaryBtnText}>
+            {starting ? "Opening…" : "Resume onboarding"}
+          </Text>
+        </Pressable>
+        {startError ? <Text style={styles.errorBody}>{startError}</Text> : null}
+      </View>
+    );
+  }
+
+  if (status === "onboarding") {
+    return (
+      <View style={styles.statusCard}>
+        <Text style={styles.cardTitle}>Finish setting up payouts</Text>
+        <Text style={styles.cardBody}>
+          You started Stripe onboarding. Pick up where you left off.
+        </Text>
+        <Pressable
+          accessibilityLabel="Resume Stripe onboarding"
+          style={styles.primaryBtn}
+          onPress={onStart}
+          disabled={starting}
+        >
+          <Text style={styles.primaryBtnText}>
+            {starting ? "Opening…" : "Resume onboarding"}
+          </Text>
+        </Pressable>
+        {startError ? <Text style={styles.errorBody}>{startError}</Text> : null}
+      </View>
+    );
+  }
+
+  // not_connected
+  return (
+    <View style={styles.statusCard}>
+      <Text style={styles.cardTitle}>Connect partner Stripe</Text>
+      <Text style={styles.cardBody}>
+        Mingla pays partners through Stripe Connect. Set up your payout
+        account once — your bank details go directly to Stripe, never to
+        Mingla.
+      </Text>
+      <Pressable
+        accessibilityLabel="Connect Stripe"
+        style={styles.primaryBtn}
+        onPress={onStart}
+        disabled={starting}
+      >
+        <Text style={styles.primaryBtnText}>
+          {starting ? "Opening…" : "Connect Stripe"}
+        </Text>
+      </Pressable>
+      {startError ? <Text style={styles.errorBody}>{startError}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.background ?? "#FAFAFA" },
+  scroll: { padding: spacing.lg ?? 16, gap: spacing.md ?? 12 },
+  center: { paddingVertical: 48, alignItems: "center" },
+  h1: {
+    fontSize: 26,
+    fontWeight: "700",
+    color: colors.text ?? "#0F172A",
+    marginBottom: spacing.md ?? 12,
+  },
+  statusCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: radius.lg ?? 12,
+    padding: spacing.lg ?? 16,
+    gap: spacing.sm ?? 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  statusCardActive: {
+    backgroundColor: "#F0FDF4",
+    borderRadius: radius.lg ?? 12,
+    padding: spacing.lg ?? 16,
+    gap: spacing.sm ?? 8,
+    borderWidth: 1,
+    borderColor: "#86EFAC",
+  },
+  splitsCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: radius.lg ?? 12,
+    padding: spacing.lg ?? 16,
+    gap: spacing.sm ?? 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  emptyCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: radius.lg ?? 12,
+    padding: spacing.lg ?? 16,
+    gap: spacing.sm ?? 8,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+  },
+  errorCard: {
+    backgroundColor: "#FEF2F2",
+    borderRadius: radius.lg ?? 12,
+    padding: spacing.lg ?? 16,
+    gap: spacing.sm ?? 8,
+    borderWidth: 1,
+    borderColor: "#FCA5A5",
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: colors.text ?? "#0F172A",
+  },
+  cardBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: "#475569",
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: colors.text ?? "#0F172A",
+  },
+  emptyBody: { fontSize: 15, lineHeight: 22, color: "#475569" },
+  errorTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#7F1D1D",
+  },
+  errorBody: { fontSize: 14, color: "#7F1D1D" },
+  link: { color: accent.warm ?? "#eb7825", textDecorationLine: "underline" },
+  primaryBtn: {
+    backgroundColor: accent.warm ?? "#eb7825",
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: radius.md ?? 8,
+    alignItems: "center",
+    marginTop: spacing.sm ?? 8,
+  },
+  primaryBtnText: { color: "#FFFFFF", fontSize: 16, fontWeight: "600" },
+  secondaryBtn: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: radius.md ?? 8,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#CBD5E1",
+    marginTop: spacing.sm ?? 8,
+  },
+  secondaryBtnText: { color: "#0F172A", fontSize: 15, fontWeight: "500" },
+});

--- a/mingla-business/src/hooks/usePartnerStripe.ts
+++ b/mingla-business/src/hooks/usePartnerStripe.ts
@@ -1,0 +1,80 @@
+/**
+ * usePartnerStripe — React Query hooks for the partner identity Stripe
+ * surface. ORCH-1052.
+ *
+ * - usePartnerStripeStatus()        → status row (incl. partner_enabled)
+ * - useStartPartnerStripeOnboarding → mutation → AccountSession + onboarding_url
+ * - useRefreshPartnerAccountSession → mutation → fresh AccountSession
+ */
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import {
+  getPartnerStripeStatus,
+  partnerStripeKeys,
+  refreshPartnerAccountSession,
+  startPartnerOnboarding,
+  type PartnerAccountSessionResult,
+  type PartnerStripeStatusRow,
+  type StartPartnerOnboardingInput,
+  type StartPartnerOnboardingResult,
+} from "../services/partnerStripeService";
+
+export function usePartnerStripeStatus(): UseQueryResult<
+  PartnerStripeStatusRow,
+  Error
+> {
+  return useQuery<PartnerStripeStatusRow, Error>({
+    queryKey: partnerStripeKeys.status(),
+    queryFn: getPartnerStripeStatus,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useStartPartnerStripeOnboarding(): UseMutationResult<
+  StartPartnerOnboardingResult,
+  Error,
+  StartPartnerOnboardingInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation<
+    StartPartnerOnboardingResult,
+    Error,
+    StartPartnerOnboardingInput
+  >({
+    mutationFn: startPartnerOnboarding,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: partnerStripeKeys.status() });
+    },
+    onError: (error) => {
+      console.error("[useStartPartnerStripeOnboarding] failed", {
+        message: error.message,
+      });
+    },
+  });
+}
+
+export function useRefreshPartnerAccountSession(): UseMutationResult<
+  PartnerAccountSessionResult,
+  Error,
+  "onboarding" | "account_management"
+> {
+  return useMutation<
+    PartnerAccountSessionResult,
+    Error,
+    "onboarding" | "account_management"
+  >({
+    mutationFn: (surface) => refreshPartnerAccountSession(surface),
+    onError: (error) => {
+      console.error("[useRefreshPartnerAccountSession] failed", {
+        message: error.message,
+      });
+    },
+  });
+}

--- a/mingla-business/src/services/partnerStripeService.ts
+++ b/mingla-business/src/services/partnerStripeService.ts
@@ -1,0 +1,200 @@
+/**
+ * partnerStripeService — frontend wrapper for ORCH-1052 partner-Stripe edge
+ * functions. Mirrors brandStripeService for the partner identity (account-
+ * level Stripe Connect).
+ *
+ * Calls:
+ *  - partner-stripe-onboard          (initiates onboarding session)
+ *  - partner-stripe-account-session  (mints fresh AccountSession)
+ *
+ * React Query keys live in partnerStripeKeys. Hook layer lives in
+ * useStartPartnerStripeOnboarding / usePartnerStripeStatus.
+ */
+
+import { supabase } from "./supabase";
+import { businessWebOriginOverrideBody } from "./businessWebOriginOverride";
+
+export type PartnerStripeStatus =
+  | "not_a_partner"
+  | "not_connected"
+  | "onboarding"
+  | "active"
+  | "restricted";
+
+export interface PartnerStripeStatusRow {
+  status: PartnerStripeStatus;
+  account_id: string | null;
+  country: string | null;
+  charges_enabled: boolean;
+  payouts_enabled: boolean;
+  external_account_currencies: string[];
+  detached_at: string | null;
+  partner_enabled: boolean;
+  partner_country: string | null;
+}
+
+export interface StartPartnerOnboardingInput {
+  country: string;
+  returnUrl: string;
+}
+
+export interface StartPartnerOnboardingResult {
+  client_secret: string;
+  account_id: string;
+  onboarding_url: string;
+}
+
+export interface PartnerAccountSessionResult {
+  client_secret: string;
+  account_id: string;
+  target_url: string;
+}
+
+export const partnerStripeKeys = {
+  all: ["partnerStripe"] as const,
+  status: () => [...partnerStripeKeys.all, "status"] as const,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Reads partner-enabled flag + Stripe mirror row direct from Supabase. The
+ * partner_stripe_connect_accounts table is self-readable per ORCH-1052 RLS
+ * (account_id = auth.uid()). creator_accounts.partner_enabled is readable
+ * by the owning account under existing RLS. */
+export async function getPartnerStripeStatus(): Promise<PartnerStripeStatusRow> {
+  const { data: userResult, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResult.user) {
+    throw new Error("not_authenticated");
+  }
+  const userId = userResult.user.id;
+
+  const { data: account, error: accountErr } = await supabase
+    .from("creator_accounts")
+    .select("id, partner_enabled, partner_country")
+    .eq("id", userId)
+    .maybeSingle<{
+      id: string;
+      partner_enabled: boolean | null;
+      partner_country: string | null;
+    }>();
+  if (accountErr) throw new Error(accountErr.message);
+
+  const partnerEnabled = account?.partner_enabled === true;
+  const partnerCountry = account?.partner_country ?? null;
+
+  if (!partnerEnabled) {
+    return {
+      status: "not_a_partner",
+      account_id: null,
+      country: null,
+      charges_enabled: false,
+      payouts_enabled: false,
+      external_account_currencies: [],
+      detached_at: null,
+      partner_enabled: false,
+      partner_country: partnerCountry,
+    };
+  }
+
+  const { data: sca, error: scaErr } = await supabase
+    .from("partner_stripe_connect_accounts")
+    .select(
+      "stripe_account_id, country, charges_enabled, payouts_enabled, external_account_currencies, detached_at",
+    )
+    .eq("account_id", userId)
+    .maybeSingle<{
+      stripe_account_id: string | null;
+      country: string | null;
+      charges_enabled: boolean | null;
+      payouts_enabled: boolean | null;
+      external_account_currencies: unknown;
+      detached_at: string | null;
+    }>();
+  if (scaErr) throw new Error(scaErr.message);
+
+  if (!sca?.stripe_account_id) {
+    return {
+      status: "not_connected",
+      account_id: null,
+      country: null,
+      charges_enabled: false,
+      payouts_enabled: false,
+      external_account_currencies: [],
+      detached_at: null,
+      partner_enabled: true,
+      partner_country: partnerCountry,
+    };
+  }
+
+  const currencies = Array.isArray(sca.external_account_currencies)
+    ? sca.external_account_currencies
+      .filter((c): c is string => typeof c === "string")
+      .map((c) => c.toLowerCase())
+    : [];
+
+  let status: PartnerStripeStatus;
+  if (sca.detached_at !== null) {
+    status = "not_connected";
+  } else if (sca.charges_enabled === true && sca.payouts_enabled === true) {
+    status = "active";
+  } else if (sca.charges_enabled === true || sca.payouts_enabled === true) {
+    status = "restricted";
+  } else {
+    status = "onboarding";
+  }
+
+  return {
+    status,
+    account_id: sca.stripe_account_id,
+    country: sca.country,
+    charges_enabled: sca.charges_enabled ?? false,
+    payouts_enabled: sca.payouts_enabled ?? false,
+    external_account_currencies: currencies,
+    detached_at: sca.detached_at,
+    partner_enabled: true,
+    partner_country: partnerCountry,
+  };
+}
+
+export async function startPartnerOnboarding(
+  input: StartPartnerOnboardingInput,
+): Promise<StartPartnerOnboardingResult> {
+  const { data, error } = await supabase.functions.invoke<
+    StartPartnerOnboardingResult
+  >("partner-stripe-onboard", {
+    body: {
+      country: input.country,
+      return_url: input.returnUrl,
+      ...businessWebOriginOverrideBody(),
+    },
+  });
+  if (error) {
+    throw new Error(error.message ?? "partner_stripe_onboard_failed");
+  }
+  if (!data || !isRecord(data) || typeof data.client_secret !== "string") {
+    throw new Error("partner_stripe_onboard_invalid_response");
+  }
+  return data;
+}
+
+export async function refreshPartnerAccountSession(
+  surface: "onboarding" | "account_management",
+): Promise<PartnerAccountSessionResult> {
+  const { data, error } = await supabase.functions.invoke<
+    PartnerAccountSessionResult
+  >("partner-stripe-account-session", {
+    body: {
+      surface,
+      ...businessWebOriginOverrideBody(),
+    },
+  });
+  if (error) {
+    throw new Error(error.message ?? "partner_stripe_account_session_failed");
+  }
+  if (!data || !isRecord(data) || typeof data.client_secret !== "string") {
+    throw new Error("partner_stripe_account_session_invalid_response");
+  }
+  return data;
+}

--- a/mingla-business/src/utils/draftEventValidation.ts
+++ b/mingla-business/src/utils/draftEventValidation.ts
@@ -61,6 +61,16 @@ export const validateStep = (
 export const validatePublish = (
   draft: DraftEvent,
   brandStripeStatus: BrandStripeStatus,
+  /**
+   * ORCH-1052: when the caller is a flagged Mingla partner who hasn't yet
+   * connected their PARTNER Stripe identity, the publish gate also surfaces
+   * "Connect partner Stripe to receive partner earnings". One screen, one
+   * ask — partner gate bundles next to the brand gate (step 4).
+   */
+  partnerStripeGate?: {
+    partnerEnabled: boolean;
+    partnerStripeConnected: boolean;
+  },
 ): ValidationError[] => {
   const errors: ValidationError[] = [];
   for (let step = 0; step < 7; step++) {
@@ -76,6 +86,18 @@ export const validatePublish = (
       fieldKey: "stripeNotConnected",
       step: 4,
       message: "Connect Stripe to publish paid tickets.",
+    });
+  }
+  // ORCH-1052 partner money-gate bundle: same screen, additive ask.
+  if (
+    hasPaidTicket &&
+    partnerStripeGate?.partnerEnabled === true &&
+    partnerStripeGate.partnerStripeConnected !== true
+  ) {
+    errors.push({
+      fieldKey: "partnerStripeNotConnected",
+      step: 4,
+      message: "Connect partner Stripe to receive partner earnings.",
     });
   }
   return errors;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,3 +149,12 @@ verify_jwt = true
 
 [functions.accept-scanner-invitation]
 verify_jwt = true
+
+# ORCH-1052 [Partner identity + account-level Stripe Connect + currency-match
+# invite gate]. META-ORCH-1048 sub-D. Partner-Stripe onboarding + account-
+# session minter require an authenticated caller (auth.uid() → partner gate).
+[functions.partner-stripe-onboard]
+verify_jwt = true
+
+[functions.partner-stripe-account-session]
+verify_jwt = true

--- a/supabase/functions/accept-brand-invitation/__tests__/orch-1052-currency-gate.test.ts
+++ b/supabase/functions/accept-brand-invitation/__tests__/orch-1052-currency-gate.test.ts
@@ -1,0 +1,67 @@
+// ORCH-1052 — accept-brand-invitation currency-mismatch gate regression.
+//
+// Verifies P0006 code → 409 invite_currency_mismatch envelope including the
+// partner_gate payload parsed from the RPC EXCEPTION DETAIL. Pure-logic
+// (no network) so it runs in CI.
+//
+// Run: deno test --allow-read \
+//   supabase/functions/accept-brand-invitation/__tests__/orch-1052-currency-gate.test.ts
+
+import {
+  assertEquals,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import { mapRpcError, parsePartnerGateDetail } from "../index.ts";
+
+Deno.test("mapRpcError: P0006 → 409 invite_currency_mismatch", () => {
+  assertEquals(mapRpcError("P0006"), {
+    status: 409,
+    error: "invite_currency_mismatch",
+  });
+});
+
+Deno.test("mapRpcError: legacy ERRCODEs unchanged", () => {
+  assertEquals(mapRpcError("P0001"), { status: 404, error: "invite_not_found" });
+  assertEquals(mapRpcError("P0002"), { status: 410, error: "invite_already_used" });
+  assertEquals(mapRpcError("P0003"), { status: 410, error: "invite_expired" });
+  assertEquals(mapRpcError("P0004"), { status: 403, error: "invite_email_mismatch" });
+  assertEquals(mapRpcError("P0005"), { status: 410, error: "invite_revoked" });
+  assertEquals(mapRpcError("23505"), null);
+});
+
+Deno.test("parsePartnerGateDetail: parses currency_mismatch payload", () => {
+  const detail = JSON.stringify({
+    ok: false,
+    reason: "currency_mismatch",
+    brand_currency: "usd",
+    partner_currencies: ["gbp"],
+  });
+  const parsed = parsePartnerGateDetail(detail);
+  assertEquals(parsed, {
+    ok: false,
+    reason: "currency_mismatch",
+    brand_currency: "usd",
+    partner_currencies: ["gbp"],
+  });
+});
+
+Deno.test("parsePartnerGateDetail: parses partner_stripe_not_connected payload", () => {
+  const detail = JSON.stringify({
+    ok: false,
+    reason: "partner_stripe_not_connected",
+    required_currency: "eur",
+  });
+  const parsed = parsePartnerGateDetail(detail);
+  assertEquals(parsed, {
+    ok: false,
+    reason: "partner_stripe_not_connected",
+    required_currency: "eur",
+  });
+});
+
+Deno.test("parsePartnerGateDetail: returns null on missing / non-JSON / non-object", () => {
+  assertEquals(parsePartnerGateDetail(undefined), null);
+  assertEquals(parsePartnerGateDetail(""), null);
+  assertEquals(parsePartnerGateDetail("not-json"), null);
+  assertEquals(parsePartnerGateDetail("42"), null);
+  assertEquals(parsePartnerGateDetail("null"), null);
+});

--- a/supabase/functions/accept-brand-invitation/index.ts
+++ b/supabase/functions/accept-brand-invitation/index.ts
@@ -19,8 +19,15 @@
 //   → 401 { error:'unauthenticated' }
 //   → 403 { error:'invite_email_mismatch' }
 //   → 404 { error:'invite_not_found' }
+//   → 409 { error:'invite_currency_mismatch', reason, brand_currency, partner_currencies }
 //   → 410 { error:'invite_already_used' | 'invite_expired' | 'invite_revoked' }
 //   → 500 { error:'server' }
+//
+// ORCH-1052: P0006 invite_currency_mismatch surfaces when the accepting
+// account is a flagged Mingla partner whose partner Stripe Connect account
+// either isn't connected or can't settle in the brand's default_currency. The
+// RPC carries the partner-gate payload in the exception DETAIL (JSON); we
+// parse it and surface to the client.
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
@@ -62,9 +69,29 @@ export function mapRpcError(code: string | undefined): {
       return { status: 403, error: "invite_email_mismatch" };
     case "P0005":
       return { status: 410, error: "invite_revoked" };
+    case "P0006":
+      return { status: 409, error: "invite_currency_mismatch" };
     default:
       return null;
   }
+}
+
+// ORCH-1052: parse the partner-gate payload that the RPC packs into the
+// EXCEPTION DETAIL. Falls back to a minimal object when DETAIL is missing /
+// not JSON so the client always gets a stable envelope.
+export function parsePartnerGateDetail(
+  detail: string | undefined,
+): Record<string, unknown> | null {
+  if (typeof detail !== "string" || detail.length === 0) return null;
+  try {
+    const parsed = JSON.parse(detail);
+    if (parsed && typeof parsed === "object") {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // not JSON — fall through.
+  }
+  return null;
 }
 
 export async function handler(req: Request): Promise<Response> {
@@ -144,10 +171,33 @@ export async function handler(req: Request): Promise<Response> {
     if (rpcErr) {
       const mapped = mapRpcError(rpcErr.code);
       if (mapped) {
+        if (mapped.error === "invite_currency_mismatch") {
+          // ORCH-1052: surface the partner-gate payload (brand_currency,
+          // partner_currencies, reason) so the client can render a useful
+          // money-gate message and link out to partner-Stripe onboarding.
+          const partnerGate = parsePartnerGateDetail(
+            (rpcErr as { details?: string }).details ??
+              (rpcErr as { detail?: string }).detail,
+          );
+          return json(
+            { error: mapped.error, partner_gate: partnerGate },
+            mapped.status,
+          );
+        }
         return json({ error: mapped.error }, mapped.status);
       }
       // Sometimes pgrest surfaces the message instead of the code.
       const msg = rpcErr.message ?? "";
+      if (msg.includes("invite_currency_mismatch")) {
+        const partnerGate = parsePartnerGateDetail(
+          (rpcErr as { details?: string }).details ??
+            (rpcErr as { detail?: string }).detail,
+        );
+        return json(
+          { error: "invite_currency_mismatch", partner_gate: partnerGate },
+          409,
+        );
+      }
       if (msg.includes("invite_not_found")) {
         return json({ error: "invite_not_found" }, 404);
       }

--- a/supabase/functions/partner-stripe-account-session/index.ts
+++ b/supabase/functions/partner-stripe-account-session/index.ts
@@ -1,0 +1,205 @@
+/**
+ * partner-stripe-account-session — mints a fresh embedded Account Session
+ * for an already-onboarding partner. ORCH-1052.
+ *
+ * Mirrors brand-stripe-account-session but keyed on
+ * creator_accounts.id / partner_stripe_connect_accounts (no brand_id).
+ *
+ * POST body:
+ *   { surface: "account_management" | "onboarding",
+ *     business_web_origin_override?: string }
+ *
+ * Response (200):
+ *   { client_secret, account_id, target_url }
+ *
+ * Stripe API: POST /v1/account_sessions. Cites
+ * https://docs.stripe.com/api/account_sessions/create.md.
+ */
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { generateIdempotencyKey } from "../_shared/idempotency.ts";
+import { writeAudit } from "../_shared/audit.ts";
+import {
+  type AccountSessionComponents,
+  createAccountSession,
+} from "../_shared/stripeBlueprintClient.ts";
+import { resolveBusinessWebOrigin } from "../_shared/businessWebOrigin.ts";
+import {
+  corsHeaders,
+  jsonResponse,
+  requireUserId,
+  serviceRoleClient,
+} from "../_shared/stripeEdgeAuth.ts";
+
+const BUSINESS_WEB_ORIGIN = Deno.env.get("BUSINESS_WEB_ORIGIN");
+if (!BUSINESS_WEB_ORIGIN) {
+  throw new Error(
+    "BUSINESS_WEB_ORIGIN env var is not set. Configure in Supabase secrets.",
+  );
+}
+
+type AccountSessionSurface = "account_management" | "onboarding";
+
+interface RequestBody {
+  surface?: AccountSessionSurface;
+  business_web_origin_override?: string;
+}
+
+interface PartnerScaRow {
+  id: string;
+  stripe_account_id: string | null;
+  detached_at: string | null;
+  country: string | null;
+}
+
+function isSurface(value: unknown): value is AccountSessionSurface {
+  return value === "account_management" || value === "onboarding";
+}
+
+function targetPathForSurface(surface: AccountSessionSurface): string {
+  return surface === "account_management"
+    ? "/connect-partner-account-management"
+    : "/connect-partner-onboarding";
+}
+
+function componentsForSurface(
+  surface: AccountSessionSurface,
+): AccountSessionComponents {
+  if (surface === "account_management") {
+    return {
+      account_management: {
+        enabled: true,
+        features: {
+          external_account_collection: true,
+          disable_stripe_user_authentication: false,
+        },
+      },
+      notification_banner: {
+        enabled: true,
+        features: { external_account_collection: true },
+      },
+    };
+  }
+  return {
+    account_onboarding: {
+      enabled: true,
+      features: { external_account_collection: true },
+    },
+  };
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method_not_allowed" }, 405);
+  }
+
+  const userIdOrResponse = await requireUserId(req);
+  if (userIdOrResponse instanceof Response) return userIdOrResponse;
+  const userId = userIdOrResponse;
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse(
+      { error: "validation_error", detail: "invalid_json" },
+      400,
+    );
+  }
+
+  const businessWebOriginResult = resolveBusinessWebOrigin({
+    configuredOrigin: BUSINESS_WEB_ORIGIN,
+    override: body.business_web_origin_override,
+  });
+  if (!businessWebOriginResult.ok) {
+    return jsonResponse(
+      { error: "validation_error", detail: businessWebOriginResult.detail },
+      400,
+    );
+  }
+  const businessWebOrigin = businessWebOriginResult.origin;
+
+  if (!isSurface(body.surface)) {
+    return jsonResponse(
+      { error: "validation_error", detail: "surface_invalid" },
+      400,
+    );
+  }
+
+  const supabase = serviceRoleClient();
+
+  // Gate: partner_enabled true.
+  const { data: account, error: accountErr } = await supabase
+    .from("creator_accounts")
+    .select("id, partner_enabled")
+    .eq("id", userId)
+    .maybeSingle();
+  if (accountErr) {
+    console.error("[partner-stripe-account-session] account read failed:", accountErr);
+    return jsonResponse({ error: "internal_error" }, 500);
+  }
+  if (!account || account.partner_enabled !== true) {
+    return jsonResponse(
+      { error: "forbidden", detail: "not_a_partner" },
+      403,
+    );
+  }
+
+  const { data: scaRow, error: scaErr } = await supabase
+    .from("partner_stripe_connect_accounts")
+    .select("id, stripe_account_id, detached_at, country")
+    .eq("account_id", userId)
+    .maybeSingle<PartnerScaRow>();
+  if (scaErr) {
+    console.error("[partner-stripe-account-session] sca read failed:", scaErr);
+    return jsonResponse({ error: "internal_error" }, 500);
+  }
+  if (!scaRow?.stripe_account_id || scaRow.detached_at !== null) {
+    return jsonResponse({ error: "partner_not_onboarded" }, 404);
+  }
+
+  let accountSession: { client_secret: string };
+  try {
+    accountSession = await createAccountSession({
+      accountId: scaRow.stripe_account_id,
+      components: componentsForSurface(body.surface),
+      idempotencyKey: generateIdempotencyKey(
+        userId,
+        `partner_${body.surface}:${scaRow.stripe_account_id}`,
+      ),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      "[partner-stripe-account-session] account_session create failed:",
+      message,
+    );
+    return jsonResponse({ error: "stripe_api_error", detail: message }, 502);
+  }
+
+  const url = new URL(targetPathForSurface(body.surface), `${businessWebOrigin}/`);
+  url.searchParams.set("session", accountSession.client_secret);
+  url.searchParams.set("account_id", userId);
+  url.searchParams.set("return_to", "mingla-business://partner-onboarding-complete");
+
+  await writeAudit(supabase as never, {
+    user_id: userId,
+    brand_id: null,
+    action: "partner_stripe_connect.account_session_created",
+    target_type: "partner_stripe_connect_account",
+    target_id: scaRow.id,
+    after: {
+      stripe_account_id: scaRow.stripe_account_id,
+      surface: body.surface,
+    },
+  });
+
+  return jsonResponse({
+    client_secret: accountSession.client_secret,
+    account_id: scaRow.stripe_account_id,
+    target_url: url.toString(),
+  });
+});

--- a/supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-adversarial.test.ts
+++ b/supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-adversarial.test.ts
@@ -1,0 +1,57 @@
+// ORCH-1052 — adversarial regression for partner-stripe-onboard.
+//
+// Tester-style checks that catch easy regressions in the gate paths:
+//   - return_url scheme allowlist enforced
+//   - country normalisation guarded
+//   - auth required
+//
+// Run: deno test --allow-read \
+//   supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-adversarial.test.ts
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+const SRC = await Deno.readTextFile(
+  new URL("../index.ts", import.meta.url),
+);
+
+Deno.test("partner-stripe-onboard: return_url scheme allowlist (deep-link OR business origin)", () => {
+  assertStringIncludes(SRC, "mingla-business://");
+  assertStringIncludes(SRC, "return_url_invalid_scheme");
+});
+
+Deno.test("partner-stripe-onboard: country normalised through stripeSupportedCountries", () => {
+  assertStringIncludes(SRC, "normalizeStripeCountry");
+  assertStringIncludes(SRC, "country_unsupported");
+});
+
+Deno.test("partner-stripe-onboard: 401 unauthenticated when missing Bearer", () => {
+  assertStringIncludes(SRC, '"unauthenticated"');
+  assertStringIncludes(SRC, "Bearer");
+});
+
+Deno.test("partner-stripe-onboard: 403 forbidden when creator_account missing OR not a partner", () => {
+  assertStringIncludes(SRC, '"creator_account_missing"');
+  assertStringIncludes(SRC, '"not_a_partner"');
+});
+
+Deno.test("partner-stripe-onboard: validates JSON body before any DB read", () => {
+  assertStringIncludes(SRC, '"invalid_json"');
+});
+
+Deno.test("partner-stripe-onboard: Stripe failures bubble as 502 stripe_api_error", () => {
+  // 502 + stripe_api_error string ≥ 2 occurrences (account create + session).
+  const stripeErrCount = (SRC.match(/"stripe_api_error"/g) ?? []).length;
+  assert(
+    stripeErrCount >= 2,
+    `expected ≥2 stripe_api_error sites, found ${stripeErrCount}`,
+  );
+  assertStringIncludes(SRC, "502");
+});
+
+Deno.test("partner-stripe-onboard: writes audit log on success", () => {
+  assertStringIncludes(SRC, "writeAudit");
+  assertStringIncludes(SRC, "partner_stripe_connect.onboard_initiated");
+});

--- a/supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-happy.test.ts
+++ b/supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-happy.test.ts
@@ -1,0 +1,79 @@
+// ORCH-1052 — happy-path regression for partner-stripe-onboard.
+//
+// Pure-shape contract checks (no network). The handler's full behavior is
+// covered by adversarial tests + tester live-fire against the deployed fn.
+//
+// CLOSE Step 0.5: this test PASSES at the shipped contract head and MUST FAIL
+// on revert (e.g. if the onboard fn drops the partner_enabled gate, drops
+// the createRecipientAccount call, or stops minting an Account Session).
+//
+// Run: deno test --allow-read \
+//   supabase/functions/partner-stripe-onboard/__tests__/orch-1052-onboard-happy.test.ts
+
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+const SRC = await Deno.readTextFile(
+  new URL("../index.ts", import.meta.url),
+);
+
+Deno.test("partner-stripe-onboard: gates on creator_accounts.partner_enabled", () => {
+  // The handler MUST query creator_accounts for partner_enabled BEFORE any
+  // Stripe call. Source-level proof: the table + column tokens are present
+  // AND the 403 'not_a_partner' return path exists.
+  assertStringIncludes(SRC, 'from("creator_accounts")');
+  assertStringIncludes(SRC, "partner_enabled");
+  assertStringIncludes(SRC, '"not_a_partner"');
+});
+
+Deno.test("partner-stripe-onboard: uses Accounts v2 recipient blueprint", () => {
+  // Mirrors brand-stripe-onboard's blueprint client — must NOT inline a raw
+  // /v1/accounts call. Source-level proof: createRecipientAccount import.
+  assertStringIncludes(SRC, "createRecipientAccount");
+  assertStringIncludes(SRC, "createAccountSession");
+});
+
+Deno.test("partner-stripe-onboard: persists into partner_stripe_connect_accounts (NOT stripe_connect_accounts)", () => {
+  // Account-level partner identity table — must not collide with the brand-
+  // scoped stripe_connect_accounts mirror.
+  assertStringIncludes(SRC, 'from("partner_stripe_connect_accounts")');
+  assert(
+    !/from\("stripe_connect_accounts"\)/.test(SRC),
+    "partner-stripe-onboard must NOT touch brand-scoped stripe_connect_accounts",
+  );
+});
+
+Deno.test("partner-stripe-onboard: keys on creator_accounts.id (auth.uid()) NOT user_id", () => {
+  // ORCH-1050/1051 lesson: creator_accounts.id IS the auth.users.id; there
+  // is no separate user_id column. The onboard fn must filter by id, never
+  // user_id.
+  assertStringIncludes(SRC, '.eq("id", userId)');
+  assert(
+    !/\.eq\("user_id",\s*userId\)/.test(SRC),
+    "partner-stripe-onboard must NOT query creator_accounts by user_id",
+  );
+});
+
+Deno.test("partner-stripe-onboard: returns onboarding_url pointing at /connect-partner-onboarding", () => {
+  assertStringIncludes(SRC, "/connect-partner-onboarding");
+  assertStringIncludes(SRC, "client_secret");
+});
+
+Deno.test("partner-stripe-onboard: cites Stripe docs URLs inline (COMMS-0003)", () => {
+  assertStringIncludes(SRC, "docs.stripe.com/api/v2/accounts/create");
+  assertStringIncludes(SRC, "docs.stripe.com/api/account_sessions/create");
+});
+
+// Sanity: this test file's path is allowlisted via ORCH_1052_BACKEND_ALLOWLIST.
+Deno.test("partner-stripe-onboard: idempotency-key generation on Stripe calls", () => {
+  assertStringIncludes(SRC, "generateIdempotencyKey");
+  // Two Stripe calls: account create + account session.
+  const matches = SRC.match(/generateIdempotencyKey\(/g) ?? [];
+  assert(
+    matches.length >= 2,
+    `expected ≥2 idempotency-key sites, found ${matches.length}`,
+  );
+});

--- a/supabase/functions/partner-stripe-onboard/index.ts
+++ b/supabase/functions/partner-stripe-onboard/index.ts
@@ -1,0 +1,355 @@
+/**
+ * partner-stripe-onboard — initiates embedded Stripe Connect onboarding for a
+ * Mingla partner (account-level, NOT brand-level). ORCH-1052.
+ *
+ * Why account-level?
+ *   Partners share revenue with brand owners across many brands; the Stripe
+ *   payout identity belongs to the partner (creator_accounts.id), not to any
+ *   one brand. Brand-level Stripe Connect (brand-stripe-onboard) continues to
+ *   exist independently — partners get a SEPARATE Stripe account they own,
+ *   which we transfer to via ORCH-1054's split pipeline.
+ *
+ * POST body:
+ *   { country: string, return_url: string,
+ *     business_web_origin_override?: string }
+ *
+ * Response (200):
+ *   { client_secret, account_id, onboarding_url }
+ *
+ * Auth: Bearer JWT (verify_jwt=true). Caller's auth.uid() must satisfy
+ * creator_accounts.partner_enabled = true (403 'not_a_partner' otherwise).
+ *
+ * Stripe API:
+ *   - POST /v2/core/accounts — Accounts v2 with the Mingla recipient
+ *     blueprint (controller dashboard:'none', losses/fees collector:'stripe',
+ *     requirement_collection:'application' via the shared
+ *     STRIPE_MANAGED_RISK_CONTROLLER). Cites
+ *     https://docs.stripe.com/api/v2/accounts/create.md.
+ *   - POST /v1/account_sessions — short-lived embedded session for the
+ *     hosted /connect-partner-onboarding page. Cites
+ *     https://docs.stripe.com/api/account_sessions/create.md.
+ *
+ * Mirrors brand-stripe-onboard's controller/account-session shape; the
+ * country-replacement / money-movement preflight machinery from the brand
+ * function isn't needed here because partner accounts are new-only for
+ * ORCH-1052 (re-onboarding after detach is deferred to ORCH-1054).
+ */
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+// @ts-ignore — Deno ESM import
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { generateIdempotencyKey } from "../_shared/idempotency.ts";
+import { writeAudit } from "../_shared/audit.ts";
+import {
+  defaultCurrencyForCountry,
+  normalizeStripeCountry,
+} from "../_shared/stripeSupportedCountries.ts";
+import {
+  createAccountSession,
+  createRecipientAccount,
+} from "../_shared/stripeBlueprintClient.ts";
+import { resolveBusinessWebOrigin } from "../_shared/businessWebOrigin.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const BUSINESS_WEB_ORIGIN = Deno.env.get("BUSINESS_WEB_ORIGIN");
+if (!BUSINESS_WEB_ORIGIN) {
+  throw new Error(
+    "BUSINESS_WEB_ORIGIN env var is not set. Configure in Supabase secrets.",
+  );
+}
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+interface OnboardRequestBody {
+  country: string;
+  return_url: string;
+  business_web_origin_override?: string;
+}
+
+function isValidReturnUrl(s: unknown, businessWebOrigin: string): s is string {
+  if (typeof s !== "string") return false;
+  if (s.startsWith("mingla-business://")) return true;
+  if (s.startsWith(`${businessWebOrigin}/`)) return true;
+  return false;
+}
+
+interface JwtClaims {
+  sub: string;
+  email: string | null;
+}
+
+async function decodeAndVerifyJwt(token: string): Promise<JwtClaims | null> {
+  const userClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+  const { data, error } = await userClient.auth.getUser(token);
+  if (error || !data.user) return null;
+  return { sub: data.user.id, email: data.user.email ?? null };
+}
+
+interface CreatorAccountRow {
+  id: string;
+  partner_enabled: boolean;
+  partner_country: string | null;
+  display_name: unknown;
+}
+
+interface ExistingPartnerScaRow {
+  id: string;
+  stripe_account_id: string;
+  detached_at: string | null;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method_not_allowed" }, 405);
+  }
+
+  try {
+    let body: OnboardRequestBody;
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse(
+        { error: "validation_error", detail: "invalid_json" },
+        400,
+      );
+    }
+
+    const businessWebOriginResult = resolveBusinessWebOrigin({
+      configuredOrigin: BUSINESS_WEB_ORIGIN,
+      override: body?.business_web_origin_override,
+    });
+    if (!businessWebOriginResult.ok) {
+      return jsonResponse(
+        { error: "validation_error", detail: businessWebOriginResult.detail },
+        400,
+      );
+    }
+    const businessWebOrigin = businessWebOriginResult.origin;
+
+    if (!isValidReturnUrl(body?.return_url, businessWebOrigin)) {
+      return jsonResponse(
+        { error: "validation_error", detail: "return_url_invalid_scheme" },
+        400,
+      );
+    }
+    const country = normalizeStripeCountry(body?.country);
+    if (!country) {
+      return jsonResponse(
+        { error: "validation_error", detail: "country_unsupported" },
+        400,
+      );
+    }
+
+    // Auth.
+    const authHeader = req.headers.get("authorization") ?? "";
+    const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (!tokenMatch) return jsonResponse({ error: "unauthenticated" }, 401);
+    const claims = await decodeAndVerifyJwt(tokenMatch[1]);
+    if (!claims) return jsonResponse({ error: "unauthenticated" }, 401);
+    const userId = claims.sub;
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+    // Gate: caller must be a flagged partner. NOTE: creator_accounts.id IS
+    // auth.users.id — no separate user_id column. Per ORCH-1050/1051 lesson.
+    const { data: account, error: accountErr } = await supabase
+      .from("creator_accounts")
+      .select("id, partner_enabled, partner_country, display_name")
+      .eq("id", userId)
+      .maybeSingle<CreatorAccountRow>();
+    if (accountErr) {
+      console.error("[partner-stripe-onboard] account lookup failed:", accountErr);
+      return jsonResponse({ error: "internal_error" }, 500);
+    }
+    if (!account) {
+      return jsonResponse(
+        { error: "forbidden", detail: "creator_account_missing" },
+        403,
+      );
+    }
+    if (account.partner_enabled !== true) {
+      return jsonResponse(
+        { error: "forbidden", detail: "not_a_partner" },
+        403,
+      );
+    }
+
+    // Existing partner row? If active, reuse + mint a fresh AccountSession.
+    const { data: existingSca, error: existingErr } = await supabase
+      .from("partner_stripe_connect_accounts")
+      .select("id, stripe_account_id, detached_at")
+      .eq("account_id", userId)
+      .maybeSingle<ExistingPartnerScaRow>();
+    if (existingErr) {
+      console.error("[partner-stripe-onboard] sca read failed:", existingErr);
+      return jsonResponse({ error: "internal_error" }, 500);
+    }
+
+    let stripeAccountId: string;
+    let scaRowId: string | null = null;
+
+    if (existingSca?.stripe_account_id && existingSca.detached_at === null) {
+      // Active partner Stripe account — reuse.
+      stripeAccountId = existingSca.stripe_account_id;
+      scaRowId = existingSca.id;
+    } else {
+      // Fresh create — Accounts v2 with the Mingla recipient blueprint.
+      // Cites https://docs.stripe.com/api/v2/accounts/create.md.
+      const safeDisplay =
+        typeof account.display_name === "string" &&
+        account.display_name.trim().length > 0
+          ? account.display_name.trim()
+          : "Mingla partner";
+      const contactEmail = (claims.email && claims.email.trim().length > 0)
+        ? claims.email.trim()
+        : "support@usemingla.com";
+
+      let stripeAccount: { id: string };
+      try {
+        stripeAccount = await createRecipientAccount({
+          displayName: safeDisplay,
+          contactEmail,
+          country,
+          idempotencyKey: generateIdempotencyKey(
+            userId,
+            `partner_onboard_create:${country}`,
+          ),
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error("[partner-stripe-onboard] v2 account create failed:", message);
+        return jsonResponse(
+          { error: "stripe_api_error", detail: message },
+          502,
+        );
+      }
+      stripeAccountId = stripeAccount.id;
+
+      // Persist mirror row.
+      const { data: upserted, error: upsertErr } = await supabase
+        .from("partner_stripe_connect_accounts")
+        .upsert(
+          {
+            account_id: userId,
+            stripe_account_id: stripeAccountId,
+            controller_dashboard_type: "none",
+            charges_enabled: false,
+            payouts_enabled: false,
+            requirements: {},
+            country,
+            // external_account_currencies left at default '[]'::jsonb;
+            // ORCH-1054 wires the account.updated webhook to populate.
+            detached_at: null,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: "account_id" },
+        )
+        .select("id")
+        .single();
+      if (upsertErr || !upserted) {
+        console.error("[partner-stripe-onboard] sca upsert failed:", upsertErr);
+        return jsonResponse(
+          { error: "internal_error", detail: "sca_upsert_failed" },
+          500,
+        );
+      }
+      scaRowId = upserted.id;
+
+      // Also persist partner_country on creator_accounts so the SPEC's
+      // "country chosen at partner-Stripe onboarding" column stays in sync.
+      const { error: caUpdateErr } = await supabase
+        .from("creator_accounts")
+        .update({ partner_country: country })
+        .eq("id", userId);
+      if (caUpdateErr) {
+        // Non-fatal: the source of truth is partner_stripe_connect_accounts.country.
+        console.error(
+          "[partner-stripe-onboard] partner_country update failed:",
+          caUpdateErr,
+        );
+      }
+    }
+
+    // Mint embedded Account Session.
+    // Cites https://docs.stripe.com/api/account_sessions/create.md.
+    let accountSession: { client_secret: string };
+    try {
+      accountSession = await createAccountSession({
+        accountId: stripeAccountId,
+        components: {
+          account_onboarding: {
+            enabled: true,
+            features: {
+              external_account_collection: true,
+            },
+          },
+        },
+        idempotencyKey: generateIdempotencyKey(
+          userId,
+          `partner_onboard_session:${stripeAccountId}`,
+        ),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        "[partner-stripe-onboard] account_session create failed:",
+        message,
+      );
+      return jsonResponse(
+        { error: "stripe_api_error", detail: message },
+        502,
+      );
+    }
+
+    const onboardingUrl = `${businessWebOrigin}/connect-partner-onboarding` +
+      `?session=${encodeURIComponent(accountSession.client_secret)}` +
+      `&account_id=${encodeURIComponent(userId)}` +
+      `&return_to=${encodeURIComponent(body.return_url)}`;
+
+    try {
+      await writeAudit(supabase, {
+        user_id: userId,
+        brand_id: null,
+        action: "partner_stripe_connect.onboard_initiated",
+        target_type: "partner_stripe_connect_account",
+        target_id: scaRowId ?? stripeAccountId,
+        after: {
+          stripe_account_id: stripeAccountId,
+          controller_dashboard_type: "none",
+          country,
+          default_currency: defaultCurrencyForCountry(country),
+          onboarding_surface: "mingla_hosted_embedded_components",
+        },
+      });
+    } catch (auditErr) {
+      console.error("[partner-stripe-onboard] audit write failed:", auditErr);
+    }
+
+    return jsonResponse({
+      client_secret: accountSession.client_secret,
+      account_id: stripeAccountId,
+      onboarding_url: onboardingUrl,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[partner-stripe-onboard] unhandled error:", message);
+    return jsonResponse({ error: "internal_error" }, 500);
+  }
+});

--- a/supabase/migrations/20260822000000_orch_1052_partner_identity_stripe.sql
+++ b/supabase/migrations/20260822000000_orch_1052_partner_identity_stripe.sql
@@ -1,0 +1,484 @@
+-- ORCH-1052 [partner identity + account-level Stripe Connect + currency-match
+-- invite gate]. META-ORCH-1048 sub-D.
+--
+-- Adds account-level partner identity (creator_accounts.partner_enabled +
+-- partner_country), a partner-scoped Stripe Connect mirror table
+-- (partner_stripe_connect_accounts), and the currency-match invite gate RPC
+-- (partner_can_accept_brand) called by accept_invite_and_transfer_brand_ownership.
+--
+-- IDEMPOTENCY: every object is gated on IF [NOT] EXISTS / OR REPLACE; the
+-- migration is safe to re-apply.
+--
+-- Hard guards:
+--   * creator_accounts.id IS auth.users.id (no separate user_id column) — RLS
+--     policies use account_id = auth.uid() directly.
+--   * Inline EXISTS in RLS predicates per
+--     feedback_rls_returning_owner_gap.md (no SECURITY DEFINER helpers).
+--   * partner_can_accept_brand is SECURITY DEFINER (read-only, lookups only);
+--     it never writes and never bypasses RLS for the caller.
+--   * accept_invite_and_transfer_brand_ownership is CREATE OR REPLACE'd
+--     end-to-end (the prior body is preserved verbatim; we only PREPEND the
+--     partner currency-match preflight). See `prior_def_capture` comment.
+
+BEGIN;
+
+--------------------------------------------------------------------------------
+-- 1. creator_accounts: add partner_enabled + partner_country.
+--------------------------------------------------------------------------------
+
+ALTER TABLE public.creator_accounts
+  ADD COLUMN IF NOT EXISTS partner_enabled boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.creator_accounts
+  ADD COLUMN IF NOT EXISTS partner_country text;
+
+COMMENT ON COLUMN public.creator_accounts.partner_enabled IS
+  'ORCH-1052: account is a flagged Mingla partner (admin-toggled). Gates partner Stripe onboarding + revenue-split eligibility.';
+COMMENT ON COLUMN public.creator_accounts.partner_country IS
+  'ORCH-1052: ISO-3166-1 alpha-2 country chosen at partner-Stripe onboarding. Mirrors partner_stripe_connect_accounts.country.';
+
+-- Partial index for fast "is this account a partner?" lookups.
+CREATE INDEX IF NOT EXISTS creator_accounts_partner_enabled_idx
+  ON public.creator_accounts (id)
+  WHERE partner_enabled = true;
+
+--------------------------------------------------------------------------------
+-- 2. partner_stripe_connect_accounts — mirrors stripe_connect_accounts shape
+--    but keyed on creator_accounts.id (the partner identity) instead of brand_id.
+--------------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.partner_stripe_connect_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id uuid NOT NULL
+    REFERENCES public.creator_accounts(id) ON DELETE CASCADE,
+  stripe_account_id text NOT NULL,
+  country text NOT NULL,
+  charges_enabled boolean NOT NULL DEFAULT false,
+  payouts_enabled boolean NOT NULL DEFAULT false,
+  requirements jsonb NOT NULL DEFAULT '{}'::jsonb,
+  controller_dashboard_type text,
+  capabilities jsonb,
+  -- external_account_currencies: lowercase 3-letter ISO codes the partner's
+  -- connected Stripe account can SETTLE in. Populated by ORCH-1054 via the
+  -- account.updated webhook. For ORCH-1052 it starts as an empty array, which
+  -- means the currency-match gate denies by default — intentional; ORCH-1054
+  -- ships the data hookup.
+  external_account_currencies jsonb NOT NULL DEFAULT '[]'::jsonb,
+  detached_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- account_id is UNIQUE: one partner Stripe account per creator account.
+ALTER TABLE public.partner_stripe_connect_accounts
+  DROP CONSTRAINT IF EXISTS partner_stripe_connect_accounts_account_id_key;
+ALTER TABLE public.partner_stripe_connect_accounts
+  ADD CONSTRAINT partner_stripe_connect_accounts_account_id_key
+  UNIQUE (account_id);
+
+-- stripe_account_id is UNIQUE: Stripe ids never collide.
+ALTER TABLE public.partner_stripe_connect_accounts
+  DROP CONSTRAINT IF EXISTS partner_stripe_connect_accounts_stripe_account_id_key;
+ALTER TABLE public.partner_stripe_connect_accounts
+  ADD CONSTRAINT partner_stripe_connect_accounts_stripe_account_id_key
+  UNIQUE (stripe_account_id);
+
+CREATE INDEX IF NOT EXISTS partner_stripe_connect_accounts_account_id_idx
+  ON public.partner_stripe_connect_accounts (account_id);
+
+COMMENT ON TABLE public.partner_stripe_connect_accounts IS
+  'ORCH-1052: per-partner Stripe Connect mirror. Mirrors the brand-scoped stripe_connect_accounts shape but keyed on creator_accounts.id. external_account_currencies populated by ORCH-1054 via the account.updated webhook.';
+
+--------------------------------------------------------------------------------
+-- 3. RLS on partner_stripe_connect_accounts.
+--    SELECT: self-read only (account_id = auth.uid()) OR superadmin.
+--    INSERT/UPDATE/DELETE: service role only (edge fns mediate).
+--    Inline EXISTS predicates per feedback_rls_returning_owner_gap.md.
+--------------------------------------------------------------------------------
+
+ALTER TABLE public.partner_stripe_connect_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.partner_stripe_connect_accounts FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS partner_stripe_self_select
+  ON public.partner_stripe_connect_accounts;
+CREATE POLICY partner_stripe_self_select
+  ON public.partner_stripe_connect_accounts
+  FOR SELECT
+  USING (
+    account_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+       WHERE p.id = auth.uid()
+         AND p.account_type = 'admin'
+    )
+  );
+
+-- INSERT / UPDATE / DELETE intentionally have NO permissive policies. Edge fns
+-- write via the service role (which bypasses RLS); no client surface can mutate
+-- this table directly.
+
+--------------------------------------------------------------------------------
+-- 4. partner_can_accept_brand — currency-match invite gate RPC.
+--
+--    Called from accept_invite_and_transfer_brand_ownership BEFORE the standard
+--    accept logic. Returns jsonb:
+--      { ok: true, reason: 'not_a_partner' }          when the accepting
+--        account is not a flagged partner (gate skipped).
+--      { ok: false, reason: 'partner_stripe_not_connected',
+--        required_currency: <brand-currency> }        when partner has no row
+--        in partner_stripe_connect_accounts.
+--      { ok: false, reason: 'currency_mismatch',
+--        brand_currency, partner_currencies }          when the partner is
+--        connected but their external_account_currencies array doesn't include
+--        the brand's default_currency. For ORCH-1052 the array starts empty —
+--        ORCH-1054 wires the account.updated webhook to populate it; until then
+--        flagged partners will always hit this branch (intentional).
+--      { ok: true }                                    otherwise.
+--
+--    SECURITY DEFINER: read-only against creator_accounts /
+--    partner_stripe_connect_accounts / brands. Search path locked.
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.partner_can_accept_brand(
+  p_brand_id uuid,
+  p_partner_account_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_partner_enabled boolean;
+  v_brand_currency text;
+  v_stripe_row record;
+  v_partner_currencies jsonb;
+BEGIN
+  -- Gate 1: is the accepting account a Mingla partner?
+  SELECT a.partner_enabled INTO v_partner_enabled
+  FROM public.creator_accounts a
+  WHERE a.id = p_partner_account_id;
+
+  IF v_partner_enabled IS NULL OR v_partner_enabled = false THEN
+    RETURN jsonb_build_object('ok', true, 'reason', 'not_a_partner');
+  END IF;
+
+  -- Resolve brand currency (lowercased per Stripe convention).
+  SELECT lower(b.default_currency) INTO v_brand_currency
+  FROM public.brands b
+  WHERE b.id = p_brand_id;
+
+  IF v_brand_currency IS NULL OR length(v_brand_currency) = 0 THEN
+    -- Defensive: brand without default_currency cannot money-flow; let the
+    -- standard accept flow surface this via its own validation.
+    RETURN jsonb_build_object('ok', true, 'reason', 'brand_has_no_currency');
+  END IF;
+
+  -- Gate 2: partner Stripe connected?
+  SELECT psca.stripe_account_id, psca.external_account_currencies, psca.detached_at
+    INTO v_stripe_row
+  FROM public.partner_stripe_connect_accounts psca
+  WHERE psca.account_id = p_partner_account_id;
+
+  IF v_stripe_row.stripe_account_id IS NULL OR v_stripe_row.detached_at IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'reason', 'partner_stripe_not_connected',
+      'required_currency', v_brand_currency
+    );
+  END IF;
+
+  -- Gate 3: currency match against external_account_currencies (lowercase).
+  v_partner_currencies := COALESCE(v_stripe_row.external_account_currencies, '[]'::jsonb);
+
+  IF jsonb_typeof(v_partner_currencies) <> 'array'
+     OR jsonb_array_length(v_partner_currencies) = 0
+     OR NOT EXISTS (
+       SELECT 1 FROM jsonb_array_elements_text(v_partner_currencies) AS c
+        WHERE lower(c) = v_brand_currency
+     ) THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'reason', 'currency_mismatch',
+      'brand_currency', v_brand_currency,
+      'partner_currencies', v_partner_currencies
+    );
+  END IF;
+
+  RETURN jsonb_build_object('ok', true);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.partner_can_accept_brand(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.partner_can_accept_brand(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.partner_can_accept_brand(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION public.partner_can_accept_brand(uuid, uuid) IS
+  'ORCH-1052: currency-match invite gate. Returns ok=true when the accepting account is not a flagged partner OR the partner Stripe settlement currency includes the brand default_currency. Otherwise returns ok=false with reason in {partner_stripe_not_connected, currency_mismatch}.';
+
+--------------------------------------------------------------------------------
+-- 5. accept_invite_and_transfer_brand_ownership — prepend the partner gate.
+--
+--    The body below is the ORCH-1050 definition (captured via pg_get_functiondef
+--    at ORCH-1052 SPEC time) verbatim, with a single block inserted at the top:
+--    after the invitation lock & email check, BEFORE the role branch, we call
+--    partner_can_accept_brand. If the gate denies (ok=false AND reason !=
+--    'not_a_partner'), we RAISE with ERRCODE P0006 'invite_currency_mismatch'
+--    so the edge function can map it to a clean HTTP response.
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.accept_invite_and_transfer_brand_ownership(
+  p_token_hash text,
+  p_accepting_account_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_invitation record;
+  v_acceptor_email text;
+  v_acceptor_user_id uuid;
+  v_prior_owner_account_id uuid;
+  v_brand_record record;
+  v_transferred boolean := false;
+  v_partner_gate jsonb;
+  v_partner_gate_reason text;
+BEGIN
+  -- Resolve the accepting user's auth user_id from creator_accounts.
+  -- NOTE: creator_accounts.id IS the auth.users.id (no separate user_id col).
+  SELECT a.id INTO v_acceptor_user_id
+  FROM public.creator_accounts a
+  WHERE a.id = p_accepting_account_id;
+
+  IF v_acceptor_user_id IS NULL THEN
+    RAISE EXCEPTION 'invite_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT u.email INTO v_acceptor_email
+  FROM auth.users u
+  WHERE u.id = v_acceptor_user_id;
+
+  -- Lock the invitation row. FOR UPDATE so concurrent accepts serialize.
+  SELECT * INTO v_invitation
+  FROM public.brand_invitations
+  WHERE token_hash = p_token_hash
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'invite_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_invitation.status = 'accepted' THEN
+    RAISE EXCEPTION 'invite_already_used' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_invitation.status = 'revoked' THEN
+    RAISE EXCEPTION 'invite_revoked' USING ERRCODE = 'P0005';
+  END IF;
+
+  IF v_invitation.expires_at <= now() THEN
+    RAISE EXCEPTION 'invite_expired' USING ERRCODE = 'P0003';
+  END IF;
+
+  IF v_acceptor_email IS NULL
+     OR lower(v_acceptor_email) <> lower(v_invitation.email) THEN
+    RAISE EXCEPTION 'invite_email_mismatch' USING ERRCODE = 'P0004';
+  END IF;
+
+  -- ORCH-1052 partner currency-match gate. Runs AFTER email match (so
+  -- non-invitees never learn whether the accept would have been currency-
+  -- blocked) and BEFORE the role branch (so an ownership-transfer accept that
+  -- would land the partner on a wrong-currency brand is blocked before
+  -- repointing brands.account_id).
+  v_partner_gate := public.partner_can_accept_brand(
+    v_invitation.brand_id,
+    p_accepting_account_id
+  );
+  v_partner_gate_reason := v_partner_gate->>'reason';
+
+  IF (v_partner_gate->>'ok')::boolean = false
+     AND COALESCE(v_partner_gate_reason, '') <> 'not_a_partner' THEN
+    RAISE EXCEPTION 'invite_currency_mismatch' USING
+      ERRCODE = 'P0006',
+      DETAIL = v_partner_gate::text;
+  END IF;
+
+  -- Branch on role: ownership transfer vs standard membership.
+  IF v_invitation.role = 'brand_owner' THEN
+    SELECT * INTO v_brand_record
+    FROM public.brands
+    WHERE id = v_invitation.brand_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'invite_not_found' USING ERRCODE = 'P0001';
+    END IF;
+
+    v_prior_owner_account_id := v_brand_record.account_id;
+
+    UPDATE public.brand_team_members
+    SET role = 'brand_admin'
+    WHERE brand_id = v_invitation.brand_id
+      AND role = 'brand_owner'
+      AND removed_at IS NULL;
+
+    UPDATE public.brands
+    SET account_id = p_accepting_account_id
+    WHERE id = v_invitation.brand_id;
+
+    INSERT INTO public.brand_team_members
+      (brand_id, user_id, role, invited_at, accepted_at, removed_at)
+    VALUES
+      (v_invitation.brand_id, v_acceptor_user_id, 'brand_owner',
+       v_invitation.expires_at - interval '7 days', now(), NULL)
+    ON CONFLICT DO NOTHING;
+
+    UPDATE public.brand_team_members
+    SET role = 'brand_owner',
+        accepted_at = now(),
+        removed_at = NULL
+    WHERE brand_id = v_invitation.brand_id
+      AND user_id = v_acceptor_user_id
+      AND role <> 'brand_owner';
+
+    v_transferred := true;
+  ELSE
+    IF EXISTS (
+      SELECT 1 FROM public.brand_team_members
+      WHERE brand_id = v_invitation.brand_id
+        AND user_id = v_acceptor_user_id
+    ) THEN
+      UPDATE public.brand_team_members
+      SET role = v_invitation.role,
+          accepted_at = now(),
+          removed_at = NULL
+      WHERE brand_id = v_invitation.brand_id
+        AND user_id = v_acceptor_user_id;
+    ELSE
+      INSERT INTO public.brand_team_members
+        (brand_id, user_id, role, invited_at, accepted_at, removed_at)
+      VALUES
+        (v_invitation.brand_id, v_acceptor_user_id, v_invitation.role,
+         v_invitation.expires_at - interval '7 days', now(), NULL);
+    END IF;
+  END IF;
+
+  UPDATE public.brand_invitations
+  SET status = 'accepted',
+      accepted_at = now(),
+      accepted_by_account_id = p_accepting_account_id
+  WHERE id = v_invitation.id;
+
+  BEGIN
+    INSERT INTO public.audit_log
+      (user_id, brand_id, action, target_type, target_id, after)
+    VALUES (
+      v_acceptor_user_id,
+      v_invitation.brand_id,
+      CASE WHEN v_transferred
+        THEN 'brand_ownership_transferred'
+        ELSE 'brand_team_invitation_accepted'
+      END,
+      'brand_invitation',
+      v_invitation.id::text,
+      jsonb_build_object(
+        'role', v_invitation.role,
+        'transferred', v_transferred,
+        'previous_owner_account_id', v_prior_owner_account_id,
+        'new_owner_account_id', p_accepting_account_id,
+        'invitation_email', v_invitation.email,
+        'partner_gate', v_partner_gate
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    NULL;
+  END;
+
+  RETURN jsonb_build_object(
+    'brand_id', v_invitation.brand_id,
+    'role', v_invitation.role,
+    'transferred', v_transferred,
+    'previous_owner_account_id', v_prior_owner_account_id,
+    'new_owner_account_id',
+      CASE WHEN v_transferred THEN p_accepting_account_id ELSE NULL END,
+    'partner_gate', v_partner_gate
+  );
+END;
+$function$;
+
+--------------------------------------------------------------------------------
+-- 6. admin_toggle_partner — admin-only RPC to flip
+--    creator_accounts.partner_enabled. Mirrors the admin pattern: check the
+--    profiles.account_type='admin' gate inside the function (SECURITY DEFINER)
+--    and write an audit_log row.
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_toggle_partner(
+  p_account_id uuid,
+  p_enabled boolean
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_prior boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles p
+     WHERE p.id = auth.uid()
+       AND p.account_type = 'admin'
+  ) INTO v_is_admin;
+
+  IF NOT v_is_admin THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT partner_enabled INTO v_prior
+  FROM public.creator_accounts
+  WHERE id = p_account_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'account_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.creator_accounts
+  SET partner_enabled = p_enabled
+  WHERE id = p_account_id;
+
+  BEGIN
+    INSERT INTO public.audit_log
+      (user_id, brand_id, action, target_type, target_id, before, after)
+    VALUES (
+      auth.uid(),
+      NULL,
+      'admin.partner_enabled_toggle',
+      'creator_account',
+      p_account_id::text,
+      jsonb_build_object('partner_enabled', v_prior),
+      jsonb_build_object('partner_enabled', p_enabled)
+    );
+  EXCEPTION WHEN OTHERS THEN
+    NULL;
+  END;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'account_id', p_account_id,
+    'partner_enabled', p_enabled
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.admin_toggle_partner(uuid, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_toggle_partner(uuid, boolean) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_toggle_partner(uuid, boolean) TO service_role;
+
+COMMENT ON FUNCTION public.admin_toggle_partner(uuid, boolean) IS
+  'ORCH-1052: admin-only toggle for creator_accounts.partner_enabled. Self-checks profiles.account_type=admin via auth.uid().';
+
+COMMIT;

--- a/supabase/migrations/__tests__/orch_1052_partner_can_accept_brand.test.ts
+++ b/supabase/migrations/__tests__/orch_1052_partner_can_accept_brand.test.ts
@@ -1,0 +1,101 @@
+// ORCH-1052 — SQL-shape regression for the partner-identity migration.
+//
+// Reads the migration file and proves the load-bearing schema + RPC
+// fragments are present. Catches the easy reverts:
+//   - dropped partner_enabled column
+//   - dropped partner_stripe_connect_accounts table
+//   - dropped partner_can_accept_brand RPC
+//   - dropped P0006 invite_currency_mismatch raise
+//   - dropped admin_toggle_partner RPC
+//   - RLS not enabled on partner_stripe_connect_accounts
+//
+// Run: deno test --allow-read \
+//   supabase/migrations/__tests__/orch_1052_partner_can_accept_brand.test.ts
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+const SRC = await Deno.readTextFile(
+  new URL(
+    "../20260822000000_orch_1052_partner_identity_stripe.sql",
+    import.meta.url,
+  ),
+);
+
+Deno.test("migration: adds partner_enabled + partner_country to creator_accounts (idempotent)", () => {
+  assertStringIncludes(SRC, "ADD COLUMN IF NOT EXISTS partner_enabled boolean NOT NULL DEFAULT false");
+  assertStringIncludes(SRC, "ADD COLUMN IF NOT EXISTS partner_country text");
+  assertStringIncludes(SRC, "creator_accounts_partner_enabled_idx");
+});
+
+Deno.test("migration: creates partner_stripe_connect_accounts with required columns", () => {
+  assertStringIncludes(SRC, "CREATE TABLE IF NOT EXISTS public.partner_stripe_connect_accounts");
+  for (
+    const col of [
+      "account_id uuid",
+      "stripe_account_id text",
+      "country text",
+      "charges_enabled boolean",
+      "payouts_enabled boolean",
+      "requirements jsonb",
+      "external_account_currencies jsonb",
+      "detached_at timestamptz",
+    ]
+  ) {
+    assertStringIncludes(SRC, col);
+  }
+  // UNIQUE on account_id and stripe_account_id.
+  assertStringIncludes(SRC, "partner_stripe_connect_accounts_account_id_key");
+  assertStringIncludes(SRC, "partner_stripe_connect_accounts_stripe_account_id_key");
+});
+
+Deno.test("migration: enables RLS + self-read policy + service-role-only writes", () => {
+  assertStringIncludes(SRC, "ENABLE ROW LEVEL SECURITY");
+  assertStringIncludes(SRC, "FORCE ROW LEVEL SECURITY");
+  assertStringIncludes(SRC, "partner_stripe_self_select");
+  assertStringIncludes(SRC, "account_id = auth.uid()");
+  // No permissive INSERT/UPDATE/DELETE policies (writes via service role only).
+  assert(
+    !/CREATE POLICY[^;]+FOR INSERT[^;]+partner_stripe_connect_accounts/.test(SRC),
+    "no permissive INSERT policy allowed",
+  );
+  assert(
+    !/CREATE POLICY[^;]+FOR UPDATE[^;]+partner_stripe_connect_accounts/.test(SRC),
+    "no permissive UPDATE policy allowed",
+  );
+});
+
+Deno.test("migration: defines partner_can_accept_brand with all four return branches", () => {
+  assertStringIncludes(SRC, "CREATE OR REPLACE FUNCTION public.partner_can_accept_brand");
+  assertStringIncludes(SRC, "'not_a_partner'");
+  assertStringIncludes(SRC, "'partner_stripe_not_connected'");
+  assertStringIncludes(SRC, "'currency_mismatch'");
+  assertStringIncludes(SRC, "SECURITY DEFINER");
+  assertStringIncludes(SRC, "SET search_path TO 'public', 'pg_temp'");
+});
+
+Deno.test("migration: prepends partner gate inside accept_invite_and_transfer_brand_ownership", () => {
+  assertStringIncludes(SRC, "CREATE OR REPLACE FUNCTION public.accept_invite_and_transfer_brand_ownership");
+  assertStringIncludes(SRC, "public.partner_can_accept_brand");
+  assertStringIncludes(SRC, "invite_currency_mismatch");
+  assertStringIncludes(SRC, "P0006");
+});
+
+Deno.test("migration: defines admin_toggle_partner with admin self-check", () => {
+  assertStringIncludes(SRC, "CREATE OR REPLACE FUNCTION public.admin_toggle_partner");
+  assertStringIncludes(SRC, "account_type = 'admin'");
+  assertStringIncludes(SRC, "audit_log");
+});
+
+Deno.test("migration: ON DELETE CASCADE so partner row vanishes with creator_account", () => {
+  assertStringIncludes(SRC, "REFERENCES public.creator_accounts(id) ON DELETE CASCADE");
+});
+
+Deno.test("migration: keys on creator_accounts.id (NOT user_id) — ORCH-1050/1051 lesson", () => {
+  assert(
+    !/creator_accounts\.user_id/.test(SRC),
+    "migration must NOT reference creator_accounts.user_id (no such column)",
+  );
+});


### PR DESCRIPTION
## Summary

META-ORCH-1048 sub-D — the partner-program identity + money layer.

- Adds **account-level partner identity** (`creator_accounts.partner_enabled` + `partner_country`) flippable from the admin user-detail page via the new SECURITY DEFINER `admin_toggle_partner` RPC.
- Adds **`partner_stripe_connect_accounts`** — mirror of `stripe_connect_accounts` keyed on `creator_accounts.id`, with `external_account_currencies jsonb` carrying the partner's Stripe settlement currencies (default `[]`; ORCH-1054 populates via `account.updated` webhook). RLS: self-read only, service-role writes.
- Adds **`partner_can_accept_brand(brand_id, partner_account_id)`** currency-match gate RPC returning one of `not_a_partner` / `partner_stripe_not_connected` / `currency_mismatch` / ok. ORCH-1050's `accept_invite_and_transfer_brand_ownership` is `CREATE OR REPLACE`-d with the gate **prepended** verbatim around the existing body; gate denial raises ERRCODE `P0006 invite_currency_mismatch` with the gate payload in DETAIL. `accept-brand-invitation` edge fn maps `P0006 → 409 invite_currency_mismatch` with `partner_gate` payload.
- Adds **`partner-stripe-onboard`** + **`partner-stripe-account-session`** edge fns mirroring `brand-stripe-onboard` / `brand-stripe-account-session` for the partner identity. Uses the existing Mingla recipient blueprint (`STRIPE_MANAGED_RISK_CONTROLLER` via `stripeBlueprintClient`) — Stripe Accounts v2 (`POST /v2/core/accounts`) + embedded `AccountSession` (`POST /v1/account_sessions`), docs URLs cited inline per COMMS-0003.
- Adds **`/connect-partner-onboarding`** Mingla-hosted web page mounting Stripe Connect Embedded Components (`<ConnectAccountOnboarding>` via `@stripe/react-connect-js`) — mirrors `/connect-onboarding` verbatim with `account_id` instead of `brand_id`.
- Adds **`/partner/earnings`** screen gated on `partner_enabled` showing partner-Stripe status + `Connect Stripe`/`Resume onboarding` CTAs + a "splits ship in next release" placeholder (ORCH-1054 builds `partner_splits`).
- Extends `draftEventValidation.validatePublish` with an optional `partnerStripeGate` arg that bundles the partner money-gate next to the brand gate ("Connect partner Stripe to receive partner earnings"). Backward-compatible — existing 2-arg callers untouched.
- Wires the **ORCH-1052 strict-grep gate** into `strict-grep-mingla-business.yml` (5 rules: required files, migration tokens, onboard tokens, accept-brand P0006 handling, config.toml entries). `--self-test` passes.
- Adds **`ORCH_1052_BACKEND_ALLOWLIST`** stanza on the ORCH-0863 marketing-hub C7 gate per COMMS-0002.

**Deferred to ORCH-1054 (intentional, documented in the migration):** `partner_splits` table, `charge.succeeded` Transfer hook, `account.updated` webhook → `external_account_currencies` population, refund/dispute reversal. For ORCH-1052 the currency-match gate denies by default for flagged partners (empty array). Gate logic is built; data hookup waits.

**Hard guards:**
- `creator_accounts.id` IS `auth.users.id` — every lookup keys on `id`, never `user_id`
- Migration idempotent: `ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS` / `DROP CONSTRAINT IF EXISTS` / `CREATE OR REPLACE FUNCTION`
- RLS uses inline `EXISTS` per `feedback_rls_returning_owner_gap.md`; no SECURITY DEFINER helpers in USING/WITH CHECK
- All Stripe calls carry an `Idempotency-Key` (≥2 sites in onboard) + cite docs URLs inline
- ORCH-1050 RPC body preserved verbatim; only partner-gate preflight prepended

## Test plan

- [x] 27 Deno regression tests pass (`deno test --allow-read`): 8 migration SQL-shape + 7 onboard happy + 7 onboard adversarial + 5 accept-brand currency-gate
- [x] Existing ORCH-1050 accept-brand suite (14 tests) untouched
- [x] ORCH-1052 strict-grep `--self-test` PASS + live PASS against the head
- [x] ORCH-0863 marketing-hub C7 gate PASS with ORCH_1052_BACKEND_ALLOWLIST
- [ ] Orchestrator applies migration via Mgmt API (`20260822000000_orch_1052_partner_identity_stripe.sql` — idempotent re-apply safe)
- [ ] Orchestrator deploys: `partner-stripe-onboard`, `partner-stripe-account-session`, redeploy `accept-brand-invitation` (new P0006 mapping)
- [ ] Tester: admin toggles partner on Seth's account, partner-stripe-onboard returns onboarding URL, fake invite to a flagged-partner email surfaces 409 `invite_currency_mismatch` with payload
- [ ] Tester: non-partner invite flow regression (ORCH-1050) still PASSES end-to-end

Fails-on-revert hash: `c5dbb4b86`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)