### PR TITLE
Close ORCH-1054 [deploy]: partner splits ledger + Stripe Transfer pipeline wired (charge.succeeded → Transfer, refund/dispute → TransferReversal, account.updated → currencies populated)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1395,7 +1395,21 @@ function checkNoNewBackendFiles() {
     // resume with no double-upload + exact-boundary guard). Per COMMS-0002.
     "supabase/functions/backfill-place-photo-thumbs/index.adversarial.test.ts",
   ];
+  // ORCH-1054 [Partner splits ledger + Stripe Transfer pipeline]. META-ORCH-1048
+  // sub-E. C7 is scoped to ORCH-0863 marketing; these are partner-splits backend
+  // touches (new migration + new _shared/partnerSplits.ts module + tests). The
+  // stripeWebhookRouter.ts edit is a MODIFY of an existing file already in the
+  // repo (not a new backend addition). Per COMMS-0002 the migration + new
+  // module + tests must land in the SAME commit as the service + UI wiring.
+  const ORCH_1054_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260823000000_orch_1054_partner_splits.sql",
+    "supabase/functions/_shared/partnerSplits.ts",
+    "supabase/functions/_shared/__tests__/orch_1054_partner_splits_happy.test.ts",
+    "supabase/functions/_shared/__tests__/orch_1054_partner_splits_adversarial.test.ts",
+    "supabase/migrations/__tests__/orch_1054_partner_splits.test.ts",
+  ];
   const ALLOWLIST = [
+    ...ORCH_1054_BACKEND_ALLOWLIST,
     ...ORCH_1052_BACKEND_ALLOWLIST,
     ...ORCH_1051_BACKEND_ALLOWLIST,
     ...ORCH_1050_BACKEND_ALLOWLIST,

--- a/.github/scripts/strict-grep/orch-1054-partner-splits.mjs
+++ b/.github/scripts/strict-grep/orch-1054-partner-splits.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1054 — strict-grep gate for the partner_splits ledger + Stripe Transfer
+ * pipeline. META-ORCH-1048 sub-E.
+ *
+ * RULES:
+ *   1. Required new files exist (migration, _shared module, service, hook,
+ *      strict-grep file itself).
+ *   2. Migration references partner_splits table + the 4 RPCs +
+ *      I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY invariant note +
+ *      ON CONFLICT idempotency on stripe_application_fee_id.
+ *   3. stripeWebhookRouter.ts:
+ *        - imports handleChargeSucceeded, handleChargeReversal, and
+ *          syncPartnerAccountFromEvent
+ *        - lists charge.succeeded in STRIPE_ROUTED_EVENT_TYPES
+ *        - routes charge.succeeded to handleChargeSucceeded
+ *        - calls handleChargeReversal from charge.refunded + charge.dispute
+ *        - calls syncPartnerAccountFromEvent from account.updated
+ *   4. _shared/partnerSplits.ts:
+ *        - cites docs.stripe.com/api/transfers/create
+ *        - cites docs.stripe.com/api/transfer_reversals/create
+ *        - uses Idempotency-Key partner_split_<application_fee_id>
+ *        - creates TransferReversal for refunds + disputes
+ *        - populates external_account_currencies on account.updated
+ *        - asserts Transfer.currency = charge.currency (zero FX)
+ *   5. partnerEarningsScreen wires usePartnerSplits + usePartnerEarningsSummary.
+ *
+ * Self-test (`--self-test`) proves each rule fires on a synthetic violation.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? path.resolve(process.cwd(), "..")
+  : process.cwd();
+
+const REQUIRED_FILES = [
+  "supabase/migrations/20260823000000_orch_1054_partner_splits.sql",
+  "supabase/functions/_shared/partnerSplits.ts",
+  "mingla-business/src/services/partnerSplitsService.ts",
+  "mingla-business/src/hooks/usePartnerSplits.ts",
+  ".github/scripts/strict-grep/orch-1054-partner-splits.mjs",
+];
+
+const MIGRATION_REQUIRED_TOKENS = [
+  "partner_splits",
+  "resolve_partner_for_brand_at_time",
+  "record_partner_split_attempt",
+  "mark_partner_split_transferred",
+  "mark_partner_split_failed",
+  "mark_partner_split_reversed",
+  "stripe_application_fee_id",
+  "blocked_currency_mismatch",
+  "blocked_no_stripe",
+  "I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY",
+  "ON CONFLICT (stripe_application_fee_id)",
+];
+
+const WEBHOOK_REQUIRED_TOKENS = [
+  "handleChargeSucceeded",
+  "handleChargeReversal",
+  "syncPartnerAccountFromEvent",
+  '"charge.succeeded"',
+  "ORCH-1054",
+];
+
+const PARTNER_SPLITS_REQUIRED_TOKENS = [
+  "docs.stripe.com/api/transfers/create",
+  "docs.stripe.com/api/transfer_reversals/create",
+  "partner_split_${applicationFeeId}",
+  "partner_split_reversal_${applicationFeeId}",
+  "external_account_currencies",
+  "source_transaction",
+  // Zero-FX invariant — Transfer.currency MUST equal source charge currency.
+  "ZERO FX",
+  "PARTNER_SHARE_OF_FEE",
+  "createReversal",
+];
+
+const EARNINGS_REQUIRED_TOKENS = [
+  "usePartnerSplits",
+  "usePartnerEarningsSummary",
+  "PartnerSplitsSection",
+  "ORCH-1054",
+];
+
+function readFileOrNull(rel) {
+  const abs = path.join(root, rel);
+  try {
+    return fs.readFileSync(abs, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function checkRequiredFilesExist() {
+  const missing = [];
+  for (const rel of REQUIRED_FILES) {
+    if (readFileOrNull(rel) === null) missing.push(rel);
+  }
+  if (missing.length > 0) {
+    return `Required file(s) missing:\n  - ${missing.join("\n  - ")}`;
+  }
+  return null;
+}
+
+function checkMigrationContents() {
+  const src = readFileOrNull(REQUIRED_FILES[0]);
+  if (src === null) return null;
+  const missing = MIGRATION_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `Migration missing required tokens: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+function checkWebhookRouterContents() {
+  const src = readFileOrNull(
+    "supabase/functions/_shared/stripeWebhookRouter.ts",
+  );
+  if (src === null) return "stripeWebhookRouter.ts not found";
+  const missing = WEBHOOK_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `stripeWebhookRouter.ts missing ORCH-1054 wiring: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+function checkPartnerSplitsContents() {
+  const src = readFileOrNull(REQUIRED_FILES[1]);
+  if (src === null) return null;
+  const missing = PARTNER_SPLITS_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `partnerSplits.ts missing required tokens: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+function checkEarningsScreen() {
+  const src = readFileOrNull("mingla-business/app/partner/earnings.tsx");
+  if (src === null) return "partner/earnings.tsx not found";
+  const missing = EARNINGS_REQUIRED_TOKENS.filter((t) => !src.includes(t));
+  if (missing.length > 0) {
+    return `partner/earnings.tsx missing ORCH-1054 wiring: ${missing.join(", ")}`;
+  }
+  return null;
+}
+
+const CHECKS = [
+  ["required-files", checkRequiredFilesExist],
+  ["migration", checkMigrationContents],
+  ["stripe-webhook-router", checkWebhookRouterContents],
+  ["partner-splits-shared", checkPartnerSplitsContents],
+  ["partner-earnings-screen", checkEarningsScreen],
+];
+
+function runChecks() {
+  const failures = [];
+  for (const [name, fn] of CHECKS) {
+    const result = fn();
+    if (result !== null) failures.push(`[${name}] ${result}`);
+  }
+  return failures;
+}
+
+function selfTest() {
+  const violations = [];
+
+  // Rule 1: required files exist on clean tree.
+  const r1 = checkRequiredFilesExist();
+  if (r1 !== null) {
+    violations.push("self-test fail: required-files fired on clean tree (" + r1 + ")");
+  }
+
+  // Rule 2: migration token check fires on empty body.
+  {
+    const fake = "BEGIN; COMMIT;\n";
+    const missing = MIGRATION_REQUIRED_TOKENS.filter((t) => !fake.includes(t));
+    if (missing.length !== MIGRATION_REQUIRED_TOKENS.length) {
+      violations.push("self-test fail: migration check would not fire on empty body");
+    }
+  }
+
+  // Rule 3: webhook router check fires on empty body.
+  {
+    const fake = "";
+    const missing = WEBHOOK_REQUIRED_TOKENS.filter((t) => !fake.includes(t));
+    if (missing.length !== WEBHOOK_REQUIRED_TOKENS.length) {
+      violations.push("self-test fail: webhook router check would not fire");
+    }
+  }
+
+  // Rule 4: partnerSplits shared check fires on empty body.
+  {
+    const fake = "";
+    const missing = PARTNER_SPLITS_REQUIRED_TOKENS.filter((t) => !fake.includes(t));
+    if (missing.length !== PARTNER_SPLITS_REQUIRED_TOKENS.length) {
+      violations.push("self-test fail: partnerSplits check would not fire");
+    }
+  }
+
+  // Rule 5: earnings screen check fires on empty body.
+  {
+    const fake = "";
+    const missing = EARNINGS_REQUIRED_TOKENS.filter((t) => !fake.includes(t));
+    if (missing.length !== EARNINGS_REQUIRED_TOKENS.length) {
+      violations.push("self-test fail: earnings screen check would not fire");
+    }
+  }
+
+  return violations;
+}
+
+const args = new Set(process.argv.slice(2));
+if (args.has("--self-test")) {
+  const violations = selfTest();
+  if (violations.length > 0) {
+    for (const v of violations) console.error(v);
+    process.exit(1);
+  }
+  console.log("ORCH-1054 strict-grep self-test PASS");
+  process.exit(0);
+}
+
+const failures = runChecks();
+if (failures.length > 0) {
+  console.error(
+    "ORCH-1054 strict-grep FAIL:\n" + failures.map((f) => `  - ${f}`).join("\n"),
+  );
+  process.exit(1);
+}
+console.log("ORCH-1054 strict-grep PASS");
+process.exit(0);

--- a/mingla-business/app/partner/earnings.tsx
+++ b/mingla-business/app/partner/earnings.tsx
@@ -1,16 +1,19 @@
 /**
- * /partner/earnings — Mingla partner earnings screen. ORCH-1052.
+ * /partner/earnings — Mingla partner earnings screen. ORCH-1052 + ORCH-1054.
  *
  * Visible only to flagged Mingla partners (creator_accounts.partner_enabled =
  * true). Surfaces:
  *  - Partner Stripe Connect status (not connected → CTA, onboarding → resume,
  *    active → managed)
- *  - Placeholder for the partner_splits table (data ships in ORCH-1054)
+ *  - ORCH-1054: live partner_splits ledger. Per-currency totals (no FX),
+ *    per-month + per-brand breakdowns, status badges, empty state on no
+ *    splits yet. Multi-currency safe — each currency renders in its own
+ *    section.
  *
  * Non-partners hit a friendly empty state directing them to support.
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Linking,
@@ -29,6 +32,14 @@ import {
   usePartnerStripeStatus,
   useStartPartnerStripeOnboarding,
 } from "../../src/hooks/usePartnerStripe";
+import {
+  usePartnerEarningsSummary,
+  usePartnerSplits,
+} from "../../src/hooks/usePartnerSplits";
+import type {
+  PartnerSplitRow,
+  PartnerSplitStatus,
+} from "../../src/services/partnerSplitsService";
 import {
   colors,
   accent,
@@ -126,18 +137,186 @@ export default function PartnerEarningsScreen(): React.ReactElement {
               starting={startOnboarding.isPending}
               startError={startOnboarding.error?.message ?? null}
             />
-            <View style={styles.splitsCard}>
-              <Text style={styles.cardTitle}>Splits</Text>
-              <Text style={styles.cardBody}>
-                Your earnings will appear here once your first partnered event
-                sells. We’re wiring the split pipeline in the next release.
-              </Text>
-            </View>
+            <PartnerSplitsSection />
           </>
         )}
       </ScrollView>
     </SafeAreaView>
   );
+}
+
+/**
+ * ORCH-1054 — partner_splits live ledger UI.
+ *
+ * Renders:
+ *  - per-currency totals (transferred + pending + reversed; no FX between
+ *    currencies per I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY)
+ *  - month + currency filter chips
+ *  - per-split rows with status badge
+ *  - empty state when the partner has no splits yet
+ */
+function PartnerSplitsSection(): React.ReactElement {
+  const [currencyFilter, setCurrencyFilter] = useState<string | null>(null);
+  const summaryQuery = usePartnerEarningsSummary();
+  const splitsQuery = usePartnerSplits(
+    currencyFilter ? { currency: currencyFilter } : {},
+  );
+
+  const availableCurrencies = useMemo(() => {
+    const set = new Set<string>();
+    for (const bucket of summaryQuery.data?.totals_by_currency ?? []) {
+      set.add(bucket.currency);
+    }
+    return Array.from(set).sort();
+  }, [summaryQuery.data]);
+
+  if (summaryQuery.isLoading) {
+    return (
+      <View style={styles.splitsCard}>
+        <Text style={styles.cardTitle}>Splits</Text>
+        <ActivityIndicator color={accent.warm} />
+      </View>
+    );
+  }
+
+  if (summaryQuery.error) {
+    return (
+      <View style={styles.errorCard}>
+        <Text style={styles.errorTitle}>Couldn’t load splits</Text>
+        <Text style={styles.errorBody}>{summaryQuery.error.message}</Text>
+      </View>
+    );
+  }
+
+  const totals = summaryQuery.data?.totals_by_currency ?? [];
+  const splits = splitsQuery.data ?? [];
+
+  if (totals.length === 0) {
+    return (
+      <View style={styles.splitsCard}>
+        <Text style={styles.cardTitle}>Splits</Text>
+        <Text style={styles.cardBody}>
+          No splits yet. As soon as a partnered event sells tickets, your
+          share lands here automatically.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <View style={styles.splitsCard}>
+        <Text style={styles.cardTitle}>Earnings by currency</Text>
+        {totals.map((bucket) => (
+          <View key={bucket.currency} style={styles.currencyRow}>
+            <Text style={styles.currencyLabel}>
+              {bucket.currency.toUpperCase()}
+            </Text>
+            <View style={styles.currencyValues}>
+              <Text style={styles.currencyTransferred}>
+                Paid {formatCents(bucket.transferred_cents, bucket.currency)}
+              </Text>
+              {bucket.pending_cents > 0 ? (
+                <Text style={styles.currencyPending}>
+                  Pending {formatCents(bucket.pending_cents, bucket.currency)}
+                </Text>
+              ) : null}
+              {bucket.reversed_cents > 0 ? (
+                <Text style={styles.currencyReversed}>
+                  Reversed {formatCents(bucket.reversed_cents, bucket.currency)}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        ))}
+      </View>
+
+      {availableCurrencies.length > 1 ? (
+        <View style={styles.filterRow}>
+          <Pressable
+            accessibilityLabel="Show all currencies"
+            style={[
+              styles.filterChip,
+              currencyFilter === null && styles.filterChipActive,
+            ]}
+            onPress={() => setCurrencyFilter(null)}
+          >
+            <Text style={styles.filterChipText}>All</Text>
+          </Pressable>
+          {availableCurrencies.map((cur) => (
+            <Pressable
+              key={cur}
+              accessibilityLabel={`Filter ${cur}`}
+              style={[
+                styles.filterChip,
+                currencyFilter === cur && styles.filterChipActive,
+              ]}
+              onPress={() => setCurrencyFilter(cur)}
+            >
+              <Text style={styles.filterChipText}>{cur.toUpperCase()}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+
+      <View style={styles.splitsCard}>
+        <Text style={styles.cardTitle}>Recent splits</Text>
+        {splits.length === 0 ? (
+          <Text style={styles.cardBody}>
+            No splits in this filter. Try clearing the currency filter.
+          </Text>
+        ) : (
+          splits.map((row) => <SplitRow key={row.id} row={row} />)
+        )}
+      </View>
+    </>
+  );
+}
+
+function SplitRow({ row }: { row: PartnerSplitRow }): React.ReactElement {
+  return (
+    <View style={styles.splitRow}>
+      <View style={styles.splitRowLeft}>
+        <Text style={styles.splitAmount}>
+          {formatCents(row.partner_share_cents, row.transfer_currency)}
+        </Text>
+        <Text style={styles.splitMeta}>
+          {new Date(row.created_at).toLocaleDateString()} · order {row.order_id.slice(0, 8)}
+        </Text>
+      </View>
+      <StatusBadge status={row.status} />
+    </View>
+  );
+}
+
+function StatusBadge({ status }: { status: PartnerSplitStatus }): React.ReactElement {
+  const map: Record<PartnerSplitStatus, { label: string; color: string; bg: string }> = {
+    transferred: { label: "Transferred", color: "#065F46", bg: "#D1FAE5" },
+    pending: { label: "Pending", color: "#92400E", bg: "#FEF3C7" },
+    blocked_currency_mismatch: { label: "Blocked — currency", color: "#7F1D1D", bg: "#FEE2E2" },
+    blocked_no_stripe: { label: "Blocked — Stripe", color: "#7F1D1D", bg: "#FEE2E2" },
+    failed: { label: "Failed", color: "#7F1D1D", bg: "#FEE2E2" },
+    reversed: { label: "Reversed", color: "#475569", bg: "#E2E8F0" },
+    reversed_pending: { label: "Reversed (pending)", color: "#475569", bg: "#E2E8F0" },
+  };
+  const cfg = map[status];
+  return (
+    <View style={[styles.badge, { backgroundColor: cfg.bg }]}>
+      <Text style={[styles.badgeText, { color: cfg.color }]}>{cfg.label}</Text>
+    </View>
+  );
+}
+
+function formatCents(cents: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency.toUpperCase(),
+      currencyDisplay: "narrowSymbol",
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${currency.toUpperCase()}`;
+  }
 }
 
 function StatusBlock(props: {
@@ -327,4 +506,57 @@ const styles = StyleSheet.create({
     marginTop: spacing.sm ?? 8,
   },
   secondaryBtnText: { color: "#0F172A", fontSize: 15, fontWeight: "500" },
+  // ORCH-1054 partner_splits ledger
+  currencyRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderTopWidth: 1,
+    borderTopColor: "#F1F5F9",
+  },
+  currencyLabel: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#0F172A",
+  },
+  currencyValues: { alignItems: "flex-end" },
+  currencyTransferred: { fontSize: 16, fontWeight: "600", color: "#065F46" },
+  currencyPending: { fontSize: 13, color: "#92400E" },
+  currencyReversed: { fontSize: 13, color: "#475569" },
+  filterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  filterChip: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "#CBD5E1",
+    backgroundColor: "#FFFFFF",
+  },
+  filterChipActive: {
+    backgroundColor: accent.warm ?? "#eb7825",
+    borderColor: accent.warm ?? "#eb7825",
+  },
+  filterChipText: { fontSize: 13, fontWeight: "500", color: "#0F172A" },
+  splitRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: "#F1F5F9",
+  },
+  splitRowLeft: { flex: 1, paddingRight: 8 },
+  splitAmount: { fontSize: 15, fontWeight: "600", color: "#0F172A" },
+  splitMeta: { fontSize: 12, color: "#64748B", marginTop: 2 },
+  badge: {
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+  },
+  badgeText: { fontSize: 12, fontWeight: "600" },
 });

--- a/mingla-business/src/hooks/usePartnerSplits.ts
+++ b/mingla-business/src/hooks/usePartnerSplits.ts
@@ -1,0 +1,38 @@
+/**
+ * usePartnerSplits — ORCH-1054 React Query hooks for the partner splits ledger.
+ *
+ * Read-only hooks; the splits table is written exclusively by the
+ * stripe-webhook router.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getPartnerEarningsSummary,
+  listPartnerSplits,
+  type PartnerEarningsSummary,
+  partnerSplitsKeys,
+  type PartnerSplitRow,
+} from "../services/partnerSplitsService";
+
+export function usePartnerSplits(params: {
+  from?: string;
+  to?: string;
+  currency?: string;
+} = {}) {
+  return useQuery<PartnerSplitRow[], Error>({
+    queryKey: partnerSplitsKeys.list(params),
+    queryFn: () => listPartnerSplits(params),
+    staleTime: 60_000,
+  });
+}
+
+export function usePartnerEarningsSummary(
+  params: { from?: string; to?: string } = {},
+) {
+  return useQuery<PartnerEarningsSummary, Error>({
+    queryKey: partnerSplitsKeys.summary(params),
+    queryFn: () => getPartnerEarningsSummary(params),
+    staleTime: 60_000,
+  });
+}

--- a/mingla-business/src/services/partnerSplitsService.ts
+++ b/mingla-business/src/services/partnerSplitsService.ts
@@ -1,0 +1,191 @@
+/**
+ * partnerSplitsService — ORCH-1054 frontend reader for partner_splits.
+ *
+ * RLS allows:
+ *   - SELF read by partner_account_id = auth.uid()
+ *   - brand_owner / brand_admin on the brand can read brand history
+ *   - superadmin can read all
+ *
+ * No mutation endpoints — writes are service-role only via the stripe-webhook
+ * router (charge.succeeded creates rows; refund/dispute flips them).
+ */
+
+import { supabase } from "./supabase";
+
+export type PartnerSplitStatus =
+  | "pending"
+  | "transferred"
+  | "blocked_currency_mismatch"
+  | "blocked_no_stripe"
+  | "failed"
+  | "reversed"
+  | "reversed_pending";
+
+export interface PartnerSplitRow {
+  id: string;
+  order_id: string;
+  brand_id: string;
+  partner_account_id: string;
+  mingla_fee_cents: number;
+  partner_share_cents: number;
+  transfer_currency: string;
+  stripe_transfer_id: string | null;
+  stripe_application_fee_id: string;
+  status: PartnerSplitStatus;
+  error_message: string | null;
+  created_at: string;
+  transferred_at: string | null;
+  reversed_at: string | null;
+}
+
+export interface PartnerEarningsCurrencyBucket {
+  currency: string;
+  transferred_cents: number;
+  pending_cents: number;
+  reversed_cents: number;
+  count: number;
+}
+
+export interface PartnerEarningsSummary {
+  totals_by_currency: PartnerEarningsCurrencyBucket[];
+  by_month: Array<{
+    month: string;
+    currency: string;
+    transferred_cents: number;
+    count: number;
+  }>;
+  by_brand: Array<{
+    brand_id: string;
+    currency: string;
+    transferred_cents: number;
+    count: number;
+  }>;
+}
+
+export const partnerSplitsKeys = {
+  all: ["partnerSplits"] as const,
+  list: (params?: { from?: string; to?: string; currency?: string }) =>
+    [
+      ...partnerSplitsKeys.all,
+      "list",
+      params?.from ?? null,
+      params?.to ?? null,
+      params?.currency ?? null,
+    ] as const,
+  summary: (params?: { from?: string; to?: string }) =>
+    [
+      ...partnerSplitsKeys.all,
+      "summary",
+      params?.from ?? null,
+      params?.to ?? null,
+    ] as const,
+};
+
+export async function listPartnerSplits(
+  params: {
+    from?: string;
+    to?: string;
+    currency?: string;
+    limit?: number;
+  } = {},
+): Promise<PartnerSplitRow[]> {
+  let query = supabase
+    .from("partner_splits")
+    .select(
+      "id, order_id, brand_id, partner_account_id, mingla_fee_cents, partner_share_cents, transfer_currency, stripe_transfer_id, stripe_application_fee_id, status, error_message, created_at, transferred_at, reversed_at",
+    )
+    .order("created_at", { ascending: false })
+    .limit(params.limit ?? 200);
+  if (params.from) query = query.gte("created_at", params.from);
+  if (params.to) query = query.lte("created_at", params.to);
+  if (params.currency) {
+    query = query.eq("transfer_currency", params.currency.toLowerCase());
+  }
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+  return (data ?? []) as PartnerSplitRow[];
+}
+
+/** Client-side aggregation: groups by currency, by month (ISO YYYY-MM in UTC),
+ * and by brand_id. Multi-currency support — we do NOT FX between currencies
+ * (per I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY); each currency is its own
+ * bucket. */
+export function summarizePartnerSplits(
+  rows: PartnerSplitRow[],
+): PartnerEarningsSummary {
+  const byCurrency = new Map<string, PartnerEarningsCurrencyBucket>();
+  const byMonth = new Map<
+    string,
+    { transferred_cents: number; count: number }
+  >();
+  const byBrand = new Map<
+    string,
+    { transferred_cents: number; count: number }
+  >();
+
+  for (const row of rows) {
+    const cur = row.transfer_currency.toLowerCase();
+    const bucket = byCurrency.get(cur) ?? {
+      currency: cur,
+      transferred_cents: 0,
+      pending_cents: 0,
+      reversed_cents: 0,
+      count: 0,
+    };
+    bucket.count += 1;
+    if (row.status === "transferred") {
+      bucket.transferred_cents += row.partner_share_cents;
+      const month = row.created_at.slice(0, 7); // YYYY-MM
+      const monthKey = `${month}|${cur}`;
+      const mEntry = byMonth.get(monthKey) ??
+        { transferred_cents: 0, count: 0 };
+      mEntry.transferred_cents += row.partner_share_cents;
+      mEntry.count += 1;
+      byMonth.set(monthKey, mEntry);
+      const brandKey = `${row.brand_id}|${cur}`;
+      const bEntry = byBrand.get(brandKey) ??
+        { transferred_cents: 0, count: 0 };
+      bEntry.transferred_cents += row.partner_share_cents;
+      bEntry.count += 1;
+      byBrand.set(brandKey, bEntry);
+    } else if (row.status === "pending") {
+      bucket.pending_cents += row.partner_share_cents;
+    } else if (row.status === "reversed" || row.status === "reversed_pending") {
+      bucket.reversed_cents += row.partner_share_cents;
+    }
+    byCurrency.set(cur, bucket);
+  }
+
+  return {
+    totals_by_currency: Array.from(byCurrency.values()).sort((a, b) =>
+      a.currency.localeCompare(b.currency)
+    ),
+    by_month: Array.from(byMonth.entries()).map(([key, value]) => {
+      const [month, currency] = key.split("|");
+      return {
+        month,
+        currency,
+        transferred_cents: value.transferred_cents,
+        count: value.count,
+      };
+    }).sort((a, b) =>
+      b.month.localeCompare(a.month) || a.currency.localeCompare(b.currency)
+    ),
+    by_brand: Array.from(byBrand.entries()).map(([key, value]) => {
+      const [brand_id, currency] = key.split("|");
+      return {
+        brand_id,
+        currency,
+        transferred_cents: value.transferred_cents,
+        count: value.count,
+      };
+    }).sort((a, b) => b.transferred_cents - a.transferred_cents),
+  };
+}
+
+export async function getPartnerEarningsSummary(
+  params: { from?: string; to?: string } = {},
+): Promise<PartnerEarningsSummary> {
+  const rows = await listPartnerSplits({ ...params, limit: 1000 });
+  return summarizePartnerSplits(rows);
+}

--- a/supabase/functions/_shared/__tests__/orch_1054_partner_splits_adversarial.test.ts
+++ b/supabase/functions/_shared/__tests__/orch_1054_partner_splits_adversarial.test.ts
@@ -1,0 +1,374 @@
+// ORCH-1054 adversarial regression for partnerSplits.ts.
+//
+// Covers the failure modes that real money can fall through:
+//   * charge.succeeded with no application_fee → returns no_application_fee
+//     (no row written, no Transfer call).
+//   * charge.succeeded for a partner with NO Stripe Connect → marks the row
+//     blocked_no_stripe, never calls Stripe.
+//   * charge.succeeded for a partner with WRONG settlement currency →
+//     marks the row blocked_currency_mismatch, never calls Stripe.
+//   * Webhook replay (prior status='transferred') → no second Transfer.
+//   * Stripe Transfer permanent error (StripeInvalidRequestError) → marks
+//     'failed' (no rethrow); the webhook returns 2xx so Stripe stops retrying.
+//   * Stripe Transfer retryable error (StripeAPIError) → row stays pending,
+//     handler RETHROWS so Stripe webhook redelivery retries.
+//   * Dispute path with no charge ref → silent no-op.
+//
+// Run: deno test --allow-read --allow-env \
+//   supabase/functions/_shared/__tests__/orch_1054_partner_splits_adversarial.test.ts
+
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+import {
+  handleChargeReversal,
+  handleChargeSucceeded,
+} from "../partnerSplits.ts";
+
+function fakeStripe(opts: {
+  transferError?: { type: string; message?: string };
+} = {}) {
+  const calls: Array<{ kind: string; args: unknown[] }> = [];
+  // deno-lint-ignore no-explicit-any
+  const stripe: any = {
+    transfers: {
+      create: (payload: unknown, options: unknown) => {
+        calls.push({ kind: "transfers.create", args: [payload, options] });
+        if (opts.transferError) {
+          const err = new Error(opts.transferError.message ?? "stripe err");
+          // deno-lint-ignore no-explicit-any
+          (err as any).type = opts.transferError.type;
+          throw err;
+        }
+        return Promise.resolve({ id: "tr_test" });
+      },
+      createReversal: () => Promise.resolve({ id: "trr_test" }),
+    },
+    charges: {
+      retrieve: () => Promise.resolve({ application_fee: null }),
+    },
+  };
+  return { stripe, calls };
+}
+
+interface FakeState {
+  partnerLookupResult?: string | null;
+  partnerStripeRow?: Record<string, unknown> | null;
+  orderRow?: Record<string, unknown> | null;
+  ordersForBrand?: Record<string, unknown> | null;
+  priorSplitStatus?: string;
+}
+
+function fakeSupabase(state: FakeState) {
+  const rpcCalls: Array<{ name: string; args: unknown }> = [];
+  // deno-lint-ignore no-explicit-any
+  const sb: any = {
+    rpc: (name: string, args: unknown) => {
+      rpcCalls.push({ name, args });
+      if (name === "resolve_partner_for_brand_at_time") {
+        return Promise.resolve({
+          data: state.partnerLookupResult ?? null,
+          error: null,
+        });
+      }
+      if (name === "record_partner_split_attempt") {
+        return Promise.resolve({
+          data: { status: state.priorSplitStatus ?? "pending" },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    from: (table: string) => {
+      const chain = {
+        _table: table,
+        _filters: [] as Array<[string, unknown]>,
+        select: () => chain,
+        eq: (col: string, val: unknown) => {
+          chain._filters.push([col, val]);
+          return chain;
+        },
+        update: () => chain,
+        maybeSingle: () => {
+          if (table === "orders") {
+            if (chain._filters.some(([c]) => c === "stripe_payment_intent_id")) {
+              return Promise.resolve({ data: state.orderRow ?? null, error: null });
+            }
+            return Promise.resolve({
+              data: state.ordersForBrand ?? null,
+              error: null,
+            });
+          }
+          if (table === "partner_stripe_connect_accounts") {
+            return Promise.resolve({
+              data: state.partnerStripeRow ?? null,
+              error: null,
+            });
+          }
+          if (table === "partner_splits") {
+            return Promise.resolve({ data: null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+      };
+      return chain;
+    },
+  };
+  return { sb, rpcCalls };
+}
+
+Deno.test("charge.succeeded with NO application_fee → no_application_fee status", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({});
+  const event = {
+    id: "evt_x",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_x",
+        currency: "usd",
+        payment_intent: "pi_x",
+        created: 1,
+        // application_fee absent
+      },
+    },
+  };
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "no_application_fee");
+  assertEquals(calls.length, 0);
+  assertEquals(rpcCalls.length, 0);
+});
+
+Deno.test("partner with NO Stripe → blocked_no_stripe; no Transfer call", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    orderRow: { id: "ord_1" },
+    ordersForBrand: { event_id: "evt_1", events: { brand_id: "brand_1" } },
+    partnerLookupResult: "user_p1",
+    partnerStripeRow: null, // ← no row at all
+  });
+  const event = {
+    id: "evt_blocked",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_b",
+        currency: "usd",
+        application_fee: "fee_b",
+        application_fee_amount: 150,
+        payment_intent: "pi_b",
+        created: 1,
+        metadata: { mingla_order_id: "ord_1" },
+      },
+    },
+  };
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "blocked_no_stripe");
+  assertEquals(calls.length, 0);
+  const failed = rpcCalls.find((c) => c.name === "mark_partner_split_failed");
+  assert(failed, "row should be marked failed=blocked_no_stripe");
+  // deno-lint-ignore no-explicit-any
+  assertEquals((failed!.args as any).p_reason, "blocked_no_stripe");
+});
+
+Deno.test("partner with wrong currency → blocked_currency_mismatch; no Transfer call", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    orderRow: { id: "ord_2" },
+    ordersForBrand: { event_id: "evt_2", events: { brand_id: "brand_2" } },
+    partnerLookupResult: "user_p2",
+    partnerStripeRow: {
+      account_id: "user_p2",
+      stripe_account_id: "acct_p2",
+      charges_enabled: true,
+      payouts_enabled: true,
+      external_account_currencies: ["eur"], // charge is USD → mismatch
+      detached_at: null,
+    },
+  });
+  const event = {
+    id: "evt_mismatch",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_m",
+        currency: "usd",
+        application_fee: "fee_m",
+        application_fee_amount: 150,
+        payment_intent: "pi_m",
+        created: 1,
+        metadata: { mingla_order_id: "ord_2" },
+      },
+    },
+  };
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "blocked_currency_mismatch");
+  assertEquals(calls.length, 0);
+  const failed = rpcCalls.find((c) => c.name === "mark_partner_split_failed");
+  // deno-lint-ignore no-explicit-any
+  assertEquals((failed!.args as any).p_reason, "blocked_currency_mismatch");
+});
+
+Deno.test("webhook replay with prior status='transferred' → no second Transfer", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb } = fakeSupabase({
+    orderRow: { id: "ord_3" },
+    ordersForBrand: { event_id: "evt_3", events: { brand_id: "brand_3" } },
+    partnerLookupResult: "user_p3",
+    partnerStripeRow: {
+      account_id: "user_p3",
+      stripe_account_id: "acct_p3",
+      charges_enabled: true,
+      payouts_enabled: true,
+      external_account_currencies: ["usd"],
+      detached_at: null,
+    },
+    priorSplitStatus: "transferred", // ← already done
+  });
+  const event = {
+    id: "evt_replay",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_r",
+        currency: "usd",
+        application_fee: "fee_r",
+        application_fee_amount: 150,
+        payment_intent: "pi_r",
+        created: 1,
+        metadata: { mingla_order_id: "ord_3" },
+      },
+    },
+  };
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "transferred");
+  assertEquals(calls.length, 0, "second Transfer must NOT be created on replay");
+});
+
+Deno.test("Stripe permanent error (StripeInvalidRequestError) → marks failed, no rethrow", async () => {
+  const { stripe } = fakeStripe({
+    transferError: { type: "StripeInvalidRequestError", message: "Account no longer valid" },
+  });
+  const { sb, rpcCalls } = fakeSupabase({
+    orderRow: { id: "ord_4" },
+    ordersForBrand: { event_id: "evt_4", events: { brand_id: "brand_4" } },
+    partnerLookupResult: "user_p4",
+    partnerStripeRow: {
+      account_id: "user_p4",
+      stripe_account_id: "acct_p4",
+      charges_enabled: true,
+      payouts_enabled: true,
+      external_account_currencies: ["usd"],
+      detached_at: null,
+    },
+  });
+  const event = {
+    id: "evt_perm_fail",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_pf",
+        currency: "usd",
+        application_fee: "fee_pf",
+        application_fee_amount: 150,
+        payment_intent: "pi_pf",
+        created: 1,
+        metadata: { mingla_order_id: "ord_4" },
+      },
+    },
+  };
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "failed");
+  const failed = rpcCalls.find((c) => c.name === "mark_partner_split_failed");
+  assert(failed, "should mark failed on permanent error");
+});
+
+Deno.test("Stripe retryable error → handler rethrows so webhook redelivers", async () => {
+  const { stripe } = fakeStripe({
+    transferError: { type: "StripeAPIError", message: "API down" },
+  });
+  const { sb } = fakeSupabase({
+    orderRow: { id: "ord_5" },
+    ordersForBrand: { event_id: "evt_5", events: { brand_id: "brand_5" } },
+    partnerLookupResult: "user_p5",
+    partnerStripeRow: {
+      account_id: "user_p5",
+      stripe_account_id: "acct_p5",
+      charges_enabled: true,
+      payouts_enabled: true,
+      external_account_currencies: ["usd"],
+      detached_at: null,
+    },
+  });
+  const event = {
+    id: "evt_retryable",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_rt",
+        currency: "usd",
+        application_fee: "fee_rt",
+        application_fee_amount: 150,
+        payment_intent: "pi_rt",
+        created: 1,
+        metadata: { mingla_order_id: "ord_5" },
+      },
+    },
+  };
+  await assertRejects(
+    () => handleChargeSucceeded(sb, stripe, event),
+    Error,
+    "API down",
+  );
+});
+
+Deno.test("dispute with no charge ref → silent no-op", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({});
+  const event = {
+    id: "evt_dispute_noref",
+    type: "charge.dispute.created",
+    data: { object: { id: "dp_x" /* no charge field */ } },
+  };
+  await handleChargeReversal(sb, stripe, event, "dispute");
+  assertEquals(calls.length, 0);
+  assertEquals(rpcCalls.length, 0);
+});
+
+Deno.test("partner_account_id pinned to charge time — uses charge.created not now()", async () => {
+  // We assert the args passed to resolve_partner_for_brand_at_time include
+  // the ISO-translated charge.created, NOT a wall-clock now.
+  const { stripe } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    orderRow: { id: "ord_t" },
+    ordersForBrand: { event_id: "evt_t", events: { brand_id: "brand_t" } },
+    partnerLookupResult: null, // doesn't matter — just want to see the args
+  });
+  const chargeCreatedUnix = 1_600_000_000;
+  const expectedIso = new Date(chargeCreatedUnix * 1000).toISOString();
+  const event = {
+    id: "evt_time",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_t",
+        currency: "usd",
+        application_fee: "fee_t",
+        application_fee_amount: 100,
+        payment_intent: "pi_t",
+        created: chargeCreatedUnix,
+        metadata: { mingla_order_id: "ord_t" },
+      },
+    },
+  };
+  await handleChargeSucceeded(sb, stripe, event);
+  const resolveCall = rpcCalls.find((c) =>
+    c.name === "resolve_partner_for_brand_at_time"
+  );
+  assert(resolveCall);
+  // deno-lint-ignore no-explicit-any
+  assertEquals((resolveCall!.args as any).p_at, expectedIso);
+});

--- a/supabase/functions/_shared/__tests__/orch_1054_partner_splits_happy.test.ts
+++ b/supabase/functions/_shared/__tests__/orch_1054_partner_splits_happy.test.ts
@@ -1,0 +1,394 @@
+// ORCH-1054 happy-path regression for partnerSplits.ts.
+//
+// Covers:
+//   * charge.succeeded with a flagged partner + matching currency →
+//     Stripe Transfer created with source-currency + Idempotency-Key, and
+//     mark_partner_split_transferred is called.
+//   * charge.succeeded with no partner → returns no_partner, no Transfer call.
+//   * charge.refunded with an already-transferred split → TransferReversal
+//     created with idempotency key partner_split_reversal_<af_id>.
+//   * account.updated for a known partner stripe_account_id → populates
+//     external_account_currencies + charges/payouts/requirements/capabilities.
+//
+// Run: deno test --allow-read --allow-env \
+//   supabase/functions/_shared/__tests__/orch_1054_partner_splits_happy.test.ts
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+import {
+  handleChargeReversal,
+  handleChargeSucceeded,
+  PARTNER_SHARE_OF_FEE,
+  syncPartnerAccountFromEvent,
+} from "../partnerSplits.ts";
+
+// ---------- Fake Stripe client ----------
+function fakeStripe(opts: {
+  failTransfer?: { type?: string; message?: string };
+} = {}) {
+  const calls: Array<{ kind: string; args: unknown[] }> = [];
+  const stripe = {
+    transfers: {
+      create: (payload: unknown, options: unknown) => {
+        calls.push({ kind: "transfers.create", args: [payload, options] });
+        if (opts.failTransfer) {
+          const err = new Error(opts.failTransfer.message ?? "boom");
+          // deno-lint-ignore no-explicit-any
+          (err as any).type = opts.failTransfer.type;
+          throw err;
+        }
+        return Promise.resolve({ id: "tr_test_abc" });
+      },
+      createReversal: (
+        transferId: string,
+        payload: unknown,
+        options: unknown,
+      ) => {
+        calls.push({
+          kind: "transfers.createReversal",
+          args: [transferId, payload, options],
+        });
+        return Promise.resolve({ id: "trr_test_xyz" });
+      },
+    },
+    charges: {
+      retrieve: (_id: string, _opts: unknown) => {
+        calls.push({ kind: "charges.retrieve", args: [_id, _opts] });
+        return Promise.resolve({ application_fee: "fee_test_dispute" });
+      },
+    },
+  };
+  // deno-lint-ignore no-explicit-any
+  return { stripe: stripe as any, calls };
+}
+
+// ---------- Fake Supabase ----------
+interface FakeState {
+  partnerLookupResult?: string | null;
+  partnerStripeRow?: Record<string, unknown> | null;
+  orderRow?: Record<string, unknown> | null;
+  ordersForBrand?: Record<string, unknown> | null;
+  priorSplitStatus?: string;
+  partnerSplitsRow?: Record<string, unknown> | null;
+  partnerAccountLookupRow?: Record<string, unknown> | null;
+}
+
+function fakeSupabase(state: FakeState) {
+  const rpcCalls: Array<{ name: string; args: unknown }> = [];
+  const fromCalls: Array<{ table: string; op: string; args: unknown }> = [];
+  // deno-lint-ignore no-explicit-any
+  const sb: any = {
+    rpc: (name: string, args: unknown) => {
+      rpcCalls.push({ name, args });
+      if (name === "resolve_partner_for_brand_at_time") {
+        return Promise.resolve({
+          data: state.partnerLookupResult ?? null,
+          error: null,
+        });
+      }
+      if (name === "record_partner_split_attempt") {
+        return Promise.resolve({
+          data: { status: state.priorSplitStatus ?? "pending" },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    from: (table: string) => {
+      const chain = {
+        _table: table,
+        _filters: [] as Array<[string, unknown]>,
+        select: (_cols: string) => chain,
+        eq: (col: string, val: unknown) => {
+          chain._filters.push([col, val]);
+          return chain;
+        },
+        update: (payload: unknown) => {
+          fromCalls.push({ table, op: "update", args: payload });
+          // After update we still chain .eq()
+          return chain;
+        },
+        maybeSingle: () => {
+          fromCalls.push({ table, op: "maybeSingle", args: chain._filters });
+          if (table === "orders") {
+            // Two shapes are queried: by stripe_payment_intent_id (returns id)
+            // and by id (returns event_id + events join).
+            if (chain._filters.some(([c]) => c === "stripe_payment_intent_id")) {
+              return Promise.resolve({
+                data: state.orderRow ?? null,
+                error: null,
+              });
+            }
+            return Promise.resolve({
+              data: state.ordersForBrand ?? null,
+              error: null,
+            });
+          }
+          if (table === "partner_stripe_connect_accounts") {
+            // Two shapes: by account_id (partner stripe lookup) and by
+            // stripe_account_id (syncPartnerAccountFromEvent).
+            if (chain._filters.some(([c]) => c === "account_id")) {
+              return Promise.resolve({
+                data: state.partnerStripeRow ?? null,
+                error: null,
+              });
+            }
+            return Promise.resolve({
+              data: state.partnerAccountLookupRow ?? null,
+              error: null,
+            });
+          }
+          if (table === "partner_splits") {
+            return Promise.resolve({
+              data: state.partnerSplitsRow ?? null,
+              error: null,
+            });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+      };
+      return chain;
+    },
+  };
+  return { sb, rpcCalls, fromCalls };
+}
+
+Deno.test("PARTNER_SHARE_OF_FEE constant = 10% of the application fee", () => {
+  assertEquals(PARTNER_SHARE_OF_FEE, 0.10);
+});
+
+Deno.test("charge.succeeded → resolves partner + creates Transfer with zero-FX currency", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    orderRow: { id: "ord_1" },
+    ordersForBrand: { event_id: "evt_1", events: { brand_id: "brand_1" } },
+    partnerLookupResult: "user_partner_1",
+    partnerStripeRow: {
+      account_id: "user_partner_1",
+      stripe_account_id: "acct_partner_test",
+      charges_enabled: true,
+      payouts_enabled: true,
+      external_account_currencies: ["usd", "eur"],
+      detached_at: null,
+    },
+  });
+
+  const event = {
+    id: "evt_charge_succeeded_1",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_test_1",
+        currency: "usd", // SOURCE currency
+        application_fee: "fee_test_1",
+        application_fee_amount: 150, // 1.5% of $100 = 150c
+        payment_intent: "pi_test_1",
+        created: 1_700_000_000,
+        metadata: { mingla_order_id: "ord_1" },
+      },
+    },
+  };
+
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "transferred");
+  assertEquals(result.brandId, "brand_1");
+
+  // Stripe Transfer created with source currency + Idempotency-Key.
+  const transferCall = calls.find((c) => c.kind === "transfers.create");
+  assert(transferCall, "Transfer should have been created");
+  // deno-lint-ignore no-explicit-any
+  const [payload, options] = transferCall!.args as [any, any];
+  assertEquals(payload.amount, 15); // round(150 * 0.10) = 15
+  assertEquals(payload.currency, "usd"); // ZERO FX
+  assertEquals(payload.destination, "acct_partner_test");
+  assertEquals(payload.source_transaction, "ch_test_1");
+  assertEquals(payload.metadata.mingla_application_fee_id, "fee_test_1");
+  assertEquals(options.idempotencyKey, "partner_split_fee_test_1");
+
+  // RPC chain: resolve → record → mark_transferred.
+  const rpcNames = rpcCalls.map((c) => c.name);
+  assertEquals(rpcNames[0], "resolve_partner_for_brand_at_time");
+  assert(rpcNames.includes("record_partner_split_attempt"));
+  assert(rpcNames.includes("mark_partner_split_transferred"));
+});
+
+Deno.test("charge.succeeded with no partner → no Transfer, no record", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    orderRow: { id: "ord_2" },
+    ordersForBrand: { event_id: "evt_2", events: { brand_id: "brand_2" } },
+    partnerLookupResult: null, // ← no partner
+  });
+
+  const event = {
+    id: "evt_charge_succeeded_2",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_test_2",
+        currency: "usd",
+        application_fee: "fee_test_2",
+        application_fee_amount: 150,
+        payment_intent: "pi_test_2",
+        created: 1_700_000_000,
+        metadata: { mingla_order_id: "ord_2" },
+      },
+    },
+  };
+
+  const result = await handleChargeSucceeded(sb, stripe, event);
+  assertEquals(result.status, "no_partner");
+  assertEquals(calls.length, 0); // no Stripe calls
+  assert(
+    !rpcCalls.some((c) => c.name === "record_partner_split_attempt"),
+    "no row recorded when no partner present",
+  );
+});
+
+Deno.test("charge.refunded with transferred split → TransferReversal w/ idempotency-key", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    partnerSplitsRow: {
+      id: "split_1",
+      status: "transferred",
+      stripe_transfer_id: "tr_test_abc",
+      partner_share_cents: 15,
+    },
+  });
+
+  const event = {
+    id: "evt_refund_1",
+    type: "charge.refunded",
+    data: {
+      object: {
+        id: "ch_test_1",
+        application_fee: "fee_test_1",
+      },
+    },
+  };
+
+  await handleChargeReversal(sb, stripe, event, "refund");
+
+  const reversal = calls.find((c) => c.kind === "transfers.createReversal");
+  assert(reversal, "TransferReversal should be created");
+  // deno-lint-ignore no-explicit-any
+  const [transferId, _payload, options] = reversal!.args as [string, any, any];
+  assertEquals(transferId, "tr_test_abc");
+  assertEquals(options.idempotencyKey, "partner_split_reversal_fee_test_1");
+  assert(rpcCalls.some((c) => c.name === "mark_partner_split_reversed"));
+});
+
+Deno.test("charge.refunded with pending split → marks reversed_pending, no Stripe call", async () => {
+  const { stripe, calls } = fakeStripe();
+  const { sb, rpcCalls } = fakeSupabase({
+    partnerSplitsRow: {
+      id: "split_2",
+      status: "pending",
+      stripe_transfer_id: null,
+      partner_share_cents: 15,
+    },
+  });
+
+  const event = {
+    id: "evt_refund_2",
+    type: "charge.refunded",
+    data: {
+      object: { id: "ch_test_2", application_fee: "fee_test_2" },
+    },
+  };
+
+  await handleChargeReversal(sb, stripe, event, "refund");
+
+  assertEquals(calls.length, 0); // no Stripe calls (nothing transferred)
+  const reverseCall = rpcCalls.find((c) => c.name === "mark_partner_split_reversed");
+  assert(reverseCall, "RPC should still mark the row reversed_pending");
+});
+
+Deno.test("account.updated for known partner stripe_account_id → populates currencies", async () => {
+  const { stripe } = fakeStripe();
+  const { sb, fromCalls } = fakeSupabase({
+    partnerAccountLookupRow: { account_id: "user_partner_1" },
+  });
+
+  const account = {
+    id: "acct_partner_test",
+    charges_enabled: true,
+    payouts_enabled: true,
+    requirements: { currently_due: [] },
+    capabilities: { transfers: "active" },
+    external_accounts: {
+      data: [
+        { currency: "USD" },
+        { currency: "USD" }, // dup → dedupe
+        { currency: "eur" },
+      ],
+    },
+  };
+
+  const updated = await syncPartnerAccountFromEvent(sb, account);
+  assertEquals(updated, true);
+
+  const updateCall = fromCalls.find((c) =>
+    c.table === "partner_stripe_connect_accounts" && c.op === "update"
+  );
+  assert(updateCall, "update should have been called");
+  // deno-lint-ignore no-explicit-any
+  const payload = updateCall!.args as any;
+  assertEquals(payload.external_account_currencies, ["eur", "usd"]); // sorted+lowered
+  assertEquals(payload.charges_enabled, true);
+  assertEquals(payload.payouts_enabled, true);
+
+  // Silence unused warning.
+  assert(stripe);
+});
+
+Deno.test("account.updated for unknown stripe_account_id → no-op (returns false)", async () => {
+  const { sb } = fakeSupabase({ partnerAccountLookupRow: null });
+  const updated = await syncPartnerAccountFromEvent(sb, {
+    id: "acct_not_a_partner",
+    external_accounts: { data: [{ currency: "usd" }] },
+  });
+  assertEquals(updated, false);
+});
+
+Deno.test("Math.round (not floor) on partner share — protects against cent loss", async () => {
+  // 1.5% of $9.95 = 14.925c application fee. 10% of that = 1.4925 → round = 1.
+  // But Stripe sends integer application_fee_amount, so test with 149c:
+  //   round(149 * 0.10) = 15 (NOT 14 as floor would).
+  const { stripe, calls } = fakeStripe();
+  const { sb } = fakeSupabase({
+    orderRow: { id: "ord_3" },
+    ordersForBrand: { event_id: "evt_3", events: { brand_id: "brand_3" } },
+    partnerLookupResult: "user_partner_2",
+    partnerStripeRow: {
+      account_id: "user_partner_2",
+      stripe_account_id: "acct_p2",
+      charges_enabled: true,
+      payouts_enabled: true,
+      external_account_currencies: ["usd"],
+      detached_at: null,
+    },
+  });
+  const event = {
+    id: "evt_x",
+    type: "charge.succeeded",
+    data: {
+      object: {
+        id: "ch_x",
+        currency: "usd",
+        application_fee: "fee_x",
+        application_fee_amount: 149,
+        payment_intent: "pi_x",
+        created: 1_700_000_000,
+        metadata: { mingla_order_id: "ord_3" },
+      },
+    },
+  };
+  await handleChargeSucceeded(sb, stripe, event);
+  // deno-lint-ignore no-explicit-any
+  const [payload] = calls[0].args as [any, any];
+  assertEquals(payload.amount, 15, "Math.round(149*0.10)=15 — not 14 (floor)");
+});

--- a/supabase/functions/_shared/partnerSplits.ts
+++ b/supabase/functions/_shared/partnerSplits.ts
@@ -1,0 +1,555 @@
+/**
+ * ORCH-1054 — partner splits + Stripe Transfer pipeline.
+ *
+ * Wires four webhook surfaces:
+ *   - charge.succeeded       → resolve partner, create Stripe Transfer
+ *                              (source_transaction = charge.id) for 10% of
+ *                              the 1.5% Mingla application fee. Zero FX:
+ *                              Transfer.currency = charge.currency.
+ *   - charge.refunded        → reverse the partner share via
+ *                              POST /v1/transfers/{id}/reversals.
+ *   - charge.dispute.*       → same as refund (reverse if transferred,
+ *                              otherwise mark reversed_pending).
+ *   - account.updated        → for PARTNER accounts only: populate
+ *                              partner_stripe_connect_accounts
+ *                              .external_account_currencies from
+ *                              account.external_accounts.data[].currency.
+ *
+ * INVARIANT I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY:
+ *   Stripe Transfer.currency MUST equal source charge.currency. Enforced
+ *   in createPartnerTransfer below; ZERO FX.
+ *
+ * Stripe API references (per feedback-external-api-docs-verified):
+ *   - Transfers: https://docs.stripe.com/api/transfers/create
+ *     - amount, currency, destination, source_transaction, description,
+ *       metadata are the documented payload fields.
+ *     - Idempotency-Key required on writes per stripe-best-practices.
+ *   - Transfer reversals: https://docs.stripe.com/api/transfer_reversals/create
+ *   - account.updated event: https://docs.stripe.com/api/events/types#event_types-account.updated
+ *   - account.external_accounts: https://docs.stripe.com/api/external_account_bank_accounts
+ */
+
+// @ts-ignore — Deno ESM
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import type { StripeClient } from "./stripe.ts";
+
+// 10% of the 1.5% application fee = 0.15% of GMV.
+// MINGLA_APPLICATION_FEE_RATE = 0.015 lives in installments/createInstallmentPI.ts
+// (reference; we don't re-import it because partner shares are computed FROM
+// the actual fee Stripe charged, not re-derived from total).
+export const PARTNER_SHARE_OF_FEE = 0.10 as const;
+
+export interface ChargeSucceededHandlerResult {
+  brandId: string | null;
+  status:
+    | "no_partner"
+    | "transferred"
+    | "pending_retry"
+    | "blocked_no_stripe"
+    | "blocked_currency_mismatch"
+    | "failed"
+    | "no_application_fee"
+    | "no_order";
+}
+
+function objectString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = obj[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function objectNumber(
+  obj: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = obj[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return null;
+}
+
+/** Extract application_fee id from a charge object. Stripe may serialize it
+ * as a string id or an expanded object. */
+function chargeApplicationFeeId(charge: Record<string, unknown>): string | null {
+  const af = charge["application_fee"];
+  if (typeof af === "string" && af.length > 0) return af;
+  if (af && typeof af === "object") {
+    const id = (af as Record<string, unknown>)["id"];
+    if (typeof id === "string" && id.length > 0) return id;
+  }
+  return null;
+}
+
+/** Extract application_fee_amount (cents) directly from the charge. */
+function chargeApplicationFeeAmount(
+  charge: Record<string, unknown>,
+): number | null {
+  const direct = objectNumber(charge, "application_fee_amount");
+  if (direct !== null) return direct;
+  const af = charge["application_fee"];
+  if (af && typeof af === "object") {
+    const amt = (af as Record<string, unknown>)["amount"];
+    if (typeof amt === "number" && Number.isFinite(amt)) return amt;
+  }
+  return null;
+}
+
+/** Pull mingla_order_id from charge metadata or, fallback, from PI metadata
+ * via the supabase orders lookup keyed by stripe_payment_intent_id. */
+async function resolveOrderIdForCharge(
+  supabase: SupabaseClient,
+  charge: Record<string, unknown>,
+): Promise<string | null> {
+  const md = (charge["metadata"] ?? {}) as Record<string, unknown>;
+  const direct = typeof md.mingla_order_id === "string" ? md.mingla_order_id : null;
+  if (direct) return direct;
+
+  const paymentIntentId = objectString(charge, "payment_intent");
+  if (!paymentIntentId) return null;
+  const { data, error } = await supabase
+    .from("orders")
+    .select("id")
+    .eq("stripe_payment_intent_id", paymentIntentId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`order lookup failed for charge: ${error.message}`);
+  }
+  return data?.id ?? null;
+}
+
+/** Resolve brand_id for an order via events. orders.brand_id does not exist;
+ * orders → events → brands.id is the canonical path. */
+async function resolveBrandIdForOrder(
+  supabase: SupabaseClient,
+  orderId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("orders")
+    .select("event_id, events!inner(brand_id)")
+    .eq("id", orderId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`brand lookup for order failed: ${error.message}`);
+  }
+  const events = (data as Record<string, unknown> | null)?.events;
+  if (!events) return null;
+  if (Array.isArray(events)) {
+    const first = events[0] as Record<string, unknown> | undefined;
+    return (first?.brand_id as string | undefined) ?? null;
+  }
+  const single = events as Record<string, unknown>;
+  return (single.brand_id as string | undefined) ?? null;
+}
+
+interface PartnerStripeAccountRow {
+  account_id: string;
+  stripe_account_id: string | null;
+  charges_enabled: boolean;
+  payouts_enabled: boolean;
+  external_account_currencies: string[];
+  detached_at: string | null;
+}
+
+async function getPartnerStripeAccount(
+  supabase: SupabaseClient,
+  partnerAccountId: string,
+): Promise<PartnerStripeAccountRow | null> {
+  const { data, error } = await supabase
+    .from("partner_stripe_connect_accounts")
+    .select(
+      "account_id, stripe_account_id, charges_enabled, payouts_enabled, external_account_currencies, detached_at",
+    )
+    .eq("account_id", partnerAccountId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`partner stripe lookup failed: ${error.message}`);
+  }
+  if (!data) return null;
+  const raw = data as Record<string, unknown>;
+  const rawCurrencies = raw.external_account_currencies;
+  const currencies: string[] = Array.isArray(rawCurrencies)
+    ? (rawCurrencies as unknown[])
+      .filter((c): c is string => typeof c === "string")
+      .map((c) => c.toLowerCase())
+    : [];
+  return {
+    account_id: String(raw.account_id),
+    stripe_account_id: typeof raw.stripe_account_id === "string"
+      ? raw.stripe_account_id
+      : null,
+    charges_enabled: raw.charges_enabled === true,
+    payouts_enabled: raw.payouts_enabled === true,
+    external_account_currencies: currencies,
+    detached_at: typeof raw.detached_at === "string" ? raw.detached_at : null,
+  };
+}
+
+/**
+ * Webhook handler: charge.succeeded.
+ *
+ * Flow (idempotent throughout):
+ *   1. Extract application_fee_id + amount + currency from the charge.
+ *      No application_fee → no partner split possible, exit.
+ *   2. Resolve order_id (metadata.mingla_order_id; fallback PI lookup) →
+ *      brand_id via events join.
+ *   3. resolve_partner_for_brand_at_time(brand_id, charge.created) → if NULL,
+ *      no partner currently linked at sale time, exit.
+ *   4. partner_share_cents = Math.round(application_fee_amount * 0.10).
+ *      Math.round (not floor) so the partner doesn't lose 1 cent to integer
+ *      truncation on every transfer.
+ *   5. Probe partner Stripe state. Block if not connected OR currency mismatch.
+ *   6. record_partner_split_attempt (INSERT pending OR retrieve existing).
+ *      If existing row is 'transferred' or 'reversed*' → exit (webhook replay).
+ *   7. Stripe Transfers.create with Idempotency-Key =
+ *      `partner_split_<application_fee_id>` (per stripe-best-practices).
+ *      Cite: https://docs.stripe.com/api/transfers/create
+ *   8. On success → mark_partner_split_transferred. On retryable err → leave
+ *      'pending', let Stripe redeliver the webhook. On non-retryable →
+ *      mark_partner_split_failed.
+ */
+export async function handleChargeSucceeded(
+  supabase: SupabaseClient,
+  stripe: StripeClient,
+  event: { id: string; type: string; data: { object: Record<string, unknown> } },
+): Promise<ChargeSucceededHandlerResult> {
+  const charge = event.data.object;
+  const chargeId = objectString(charge, "id");
+  if (!chargeId) {
+    throw new Error("charge.succeeded missing charge.id");
+  }
+
+  const applicationFeeId = chargeApplicationFeeId(charge);
+  const applicationFeeAmount = chargeApplicationFeeAmount(charge);
+  if (!applicationFeeId || applicationFeeAmount === null) {
+    // Charges without an application_fee — door sales, refunds, or
+    // non-platform charges. Nothing to split.
+    return { brandId: null, status: "no_application_fee" };
+  }
+
+  const currency = (objectString(charge, "currency") ?? "").toLowerCase();
+  if (currency.length === 0) {
+    throw new Error("charge.succeeded missing currency");
+  }
+
+  const orderId = await resolveOrderIdForCharge(supabase, charge);
+  if (!orderId) {
+    return { brandId: null, status: "no_order" };
+  }
+  const brandId = await resolveBrandIdForOrder(supabase, orderId);
+  if (!brandId) {
+    return { brandId: null, status: "no_order" };
+  }
+
+  // Pin the partner relationship to charge.created (unix seconds → ISO).
+  const chargeCreatedUnix = objectNumber(charge, "created");
+  const chargeCreatedIso = chargeCreatedUnix !== null
+    ? new Date(chargeCreatedUnix * 1000).toISOString()
+    : new Date().toISOString();
+
+  const { data: partnerLookup, error: partnerLookupErr } = await supabase.rpc(
+    "resolve_partner_for_brand_at_time",
+    { p_brand_id: brandId, p_at: chargeCreatedIso },
+  );
+  if (partnerLookupErr) {
+    throw new Error(`resolve_partner_for_brand_at_time failed: ${partnerLookupErr.message}`);
+  }
+  const partnerAccountId = typeof partnerLookup === "string" && partnerLookup.length > 0
+    ? partnerLookup
+    : null;
+  if (!partnerAccountId) {
+    return { brandId, status: "no_partner" };
+  }
+
+  // 10% of the application fee. Math.round so we don't steal a cent.
+  const partnerShareCents = Math.round(applicationFeeAmount * PARTNER_SHARE_OF_FEE);
+
+  // Always record the attempt first so we have a forensic row even if we
+  // block before Stripe call. ON CONFLICT DO NOTHING handles webhook replay.
+  const { data: priorRow, error: recordErr } = await supabase.rpc(
+    "record_partner_split_attempt",
+    {
+      p_application_fee_id: applicationFeeId,
+      p_order_id: orderId,
+      p_brand_id: brandId,
+      p_partner_account_id: partnerAccountId,
+      p_mingla_fee_cents: applicationFeeAmount,
+      p_partner_share_cents: partnerShareCents,
+      p_currency: currency,
+    },
+  );
+  if (recordErr) {
+    throw new Error(`record_partner_split_attempt failed: ${recordErr.message}`);
+  }
+  const priorStatus = (priorRow as { status?: string } | null)?.status ?? "pending";
+  if (priorStatus === "transferred" || priorStatus === "reversed" ||
+      priorStatus === "reversed_pending") {
+    return { brandId, status: priorStatus === "transferred" ? "transferred" : "no_partner" };
+  }
+
+  // Partner Stripe eligibility check (after recording the attempt so we can
+  // mark the exact blocking reason on the row).
+  const partnerStripe = await getPartnerStripeAccount(supabase, partnerAccountId);
+  if (!partnerStripe || !partnerStripe.stripe_account_id ||
+      partnerStripe.detached_at !== null ||
+      !partnerStripe.charges_enabled || !partnerStripe.payouts_enabled) {
+    await supabase.rpc("mark_partner_split_failed", {
+      p_application_fee_id: applicationFeeId,
+      p_reason: "blocked_no_stripe",
+      p_error_message: "Partner has no active Stripe Connect account.",
+    });
+    return { brandId, status: "blocked_no_stripe" };
+  }
+  if (!partnerStripe.external_account_currencies.includes(currency)) {
+    await supabase.rpc("mark_partner_split_failed", {
+      p_application_fee_id: applicationFeeId,
+      p_reason: "blocked_currency_mismatch",
+      p_error_message: `Partner cannot settle in ${currency}. Available: ${
+        partnerStripe.external_account_currencies.join(",") || "none"
+      }`,
+    });
+    return { brandId, status: "blocked_currency_mismatch" };
+  }
+
+  // ZERO FX invariant: Transfer.currency = charge.currency.
+  // Stripe Transfer create:
+  //   POST /v1/transfers
+  //   https://docs.stripe.com/api/transfers/create
+  // Per stripe-best-practices: Idempotency-Key required for writes.
+  try {
+    // @ts-ignore — Stripe SDK Transfers namespace is runtime-provided.
+    const transfer = await stripe.transfers.create(
+      {
+        amount: partnerShareCents,
+        currency, // SOURCE CURRENCY — zero FX invariant
+        destination: partnerStripe.stripe_account_id,
+        source_transaction: chargeId,
+        description: `Mingla partner share for order ${orderId}`,
+        metadata: {
+          mingla_application_fee_id: applicationFeeId,
+          mingla_order_id: orderId,
+          mingla_brand_id: brandId,
+          mingla_partner_account_id: partnerAccountId,
+          mingla_orch: "ORCH-1054",
+        },
+      },
+      {
+        idempotencyKey: `partner_split_${applicationFeeId}`,
+      },
+    );
+    const transferId = String((transfer as { id: string }).id);
+    await supabase.rpc("mark_partner_split_transferred", {
+      p_application_fee_id: applicationFeeId,
+      p_transfer_id: transferId,
+    });
+    return { brandId, status: "transferred" };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Retryable: rate_limit, lock_timeout, api_connection_error, api_error.
+    // Stripe surfaces these as type fields on StripeError. Be conservative —
+    // anything that ISN'T an explicit account-invalid error leaves the row
+    // pending so Stripe redelivers and we retry.
+    const stripeErr = err as { type?: string; code?: string } | null;
+    const errType = stripeErr?.type ?? "";
+    const isPermanent = errType === "StripeInvalidRequestError" ||
+      errType === "StripePermissionError";
+    if (isPermanent) {
+      await supabase.rpc("mark_partner_split_failed", {
+        p_application_fee_id: applicationFeeId,
+        p_reason: "failed",
+        p_error_message: msg.slice(0, 1000),
+      });
+      return { brandId, status: "failed" };
+    }
+    // Leave pending; rethrow so the webhook returns non-2xx and Stripe retries.
+    throw err;
+  }
+}
+
+/**
+ * Webhook handler shared between charge.refunded and charge.dispute.* events.
+ *
+ * Refund / dispute flow:
+ *   1. Resolve the partner_splits row by application_fee_id.
+ *   2. If status='transferred' AND stripe_transfer_id present → create
+ *      Stripe TransferReversal (POST /v1/transfers/{id}/reversals;
+ *      Idempotency-Key = `partner_split_reversal_<application_fee_id>`).
+ *      Mark row 'reversed'.
+ *   3. If status is pending/blocked/failed → mark 'reversed_pending' (no
+ *      Transfer existed, nothing to reverse).
+ *
+ * NOTE: dispute funds-withdrawn behaviour is handled by Stripe at the
+ * application-fee level (Mingla forfeits the fee). Our reversal flow ensures
+ * the partner share isn't paid out for a charge that's been disputed/refunded.
+ *
+ * Stripe docs:
+ *   - Transfer reversals: https://docs.stripe.com/api/transfer_reversals/create
+ */
+export async function handleChargeReversal(
+  supabase: SupabaseClient,
+  stripe: StripeClient,
+  event: { id: string; type: string; data: { object: Record<string, unknown> } },
+  source: "refund" | "dispute",
+): Promise<void> {
+  const obj = event.data.object;
+  // For charge.refunded the object IS the charge (with application_fee on it).
+  // For charge.dispute.* the object IS the dispute (carries charge id).
+  let applicationFeeId: string | null = null;
+  if (source === "refund") {
+    applicationFeeId = chargeApplicationFeeId(obj);
+  } else {
+    // Dispute path: we need to load the charge to find application_fee_id.
+    const chargeRef = objectString(obj, "charge");
+    if (!chargeRef) return; // no charge attached → nothing to reverse
+    try {
+      // @ts-ignore — Stripe SDK Charges namespace is runtime-provided.
+      const charge = await stripe.charges.retrieve(chargeRef, {
+        idempotencyKey: `partner_split_dispute_lookup_${event.id}`,
+      });
+      applicationFeeId = chargeApplicationFeeId(
+        charge as Record<string, unknown>,
+      );
+    } catch (lookupErr) {
+      console.warn(
+        "[partner-splits] dispute charge lookup failed (non-fatal):",
+        lookupErr instanceof Error ? lookupErr.message : String(lookupErr),
+      );
+      return;
+    }
+  }
+  if (!applicationFeeId) return; // no fee → no partner split → no reversal
+
+  const { data: row, error } = await supabase
+    .from("partner_splits")
+    .select("id, status, stripe_transfer_id, partner_share_cents")
+    .eq("stripe_application_fee_id", applicationFeeId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`partner_splits lookup for reversal failed: ${error.message}`);
+  }
+  if (!row) {
+    // No partner split was recorded for this charge — common: charge had no
+    // partner at sale time. Nothing to reverse.
+    return;
+  }
+
+  const status = (row as Record<string, unknown>).status as string;
+  const transferId = (row as Record<string, unknown>).stripe_transfer_id as
+    | string
+    | null;
+  if (status === "transferred" && transferId) {
+    try {
+      // Stripe Transfer reversal:
+      //   POST /v1/transfers/{transfer_id}/reversals
+      //   https://docs.stripe.com/api/transfer_reversals/create
+      // @ts-ignore — Stripe SDK Transfers.createReversal runtime-provided.
+      const reversal = await stripe.transfers.createReversal(
+        transferId,
+        {
+          // No amount → full reversal. metadata for forensics.
+          metadata: {
+            mingla_application_fee_id: applicationFeeId,
+            mingla_source: source,
+            mingla_orch: "ORCH-1054",
+          },
+        },
+        {
+          idempotencyKey: `partner_split_reversal_${applicationFeeId}`,
+        },
+      );
+      const reversalId = String((reversal as { id: string }).id);
+      await supabase.rpc("mark_partner_split_reversed", {
+        p_application_fee_id: applicationFeeId,
+        p_reversal_transfer_id: reversalId,
+      });
+    } catch (reversalErr) {
+      // Leave row 'transferred' so a redeliver retries. Surface for ops.
+      console.error(
+        "[partner-splits] TransferReversal failed:",
+        reversalErr instanceof Error
+          ? reversalErr.message
+          : String(reversalErr),
+      );
+      throw reversalErr;
+    }
+  } else {
+    // Pending / blocked / failed — no money moved; just record the reversal
+    // intent so we don't accidentally transfer later if the row was retried.
+    await supabase.rpc("mark_partner_split_reversed", {
+      p_application_fee_id: applicationFeeId,
+      p_reversal_transfer_id: null,
+    });
+  }
+}
+
+/**
+ * Webhook handler: account.updated for PARTNER accounts.
+ *
+ * Called from the existing account.updated branch in stripeWebhookRouter
+ * AFTER the brand-account path has run. Matches the Stripe account id against
+ * partner_stripe_connect_accounts.stripe_account_id; if present, updates:
+ *   - charges_enabled, payouts_enabled, requirements, capabilities
+ *   - external_account_currencies (deduped lowercase set drawn from
+ *     account.external_accounts.data[].currency)
+ *
+ * This closes the ORCH-1052 gate: until external_account_currencies is
+ * populated, partner_can_accept_brand denies by default.
+ *
+ * Stripe docs:
+ *   - account.updated event: https://docs.stripe.com/api/events/types#event_types-account.updated
+ *   - external_accounts on Account: https://docs.stripe.com/api/accounts/object#account_object-external_accounts
+ */
+export async function syncPartnerAccountFromEvent(
+  supabase: SupabaseClient,
+  account: Record<string, unknown>,
+): Promise<boolean> {
+  const stripeAccountId = objectString(account, "id");
+  if (!stripeAccountId) return false;
+
+  // Match against partner table; if no row, this is a brand-only account
+  // (or unknown) and we exit silently.
+  const { data: partnerRow, error: lookupErr } = await supabase
+    .from("partner_stripe_connect_accounts")
+    .select("account_id")
+    .eq("stripe_account_id", stripeAccountId)
+    .maybeSingle();
+  if (lookupErr) {
+    throw new Error(`partner account lookup failed: ${lookupErr.message}`);
+  }
+  if (!partnerRow) return false;
+
+  // Extract distinct lowercase currencies from external_accounts.data[].
+  // external_accounts is included on the Account object as a paginated list:
+  // https://docs.stripe.com/api/accounts/object#account_object-external_accounts
+  const ext = account["external_accounts"] as Record<string, unknown> | undefined;
+  const extData = (ext?.["data"] ?? []) as Array<Record<string, unknown>>;
+  const currencySet = new Set<string>();
+  for (const e of extData) {
+    const c = objectString(e, "currency");
+    if (c) currencySet.add(c.toLowerCase());
+  }
+  const currencies = Array.from(currencySet).sort();
+
+  const requirements = (account.requirements ?? {}) as Record<string, unknown>;
+  const capabilities = (account.capabilities ?? {}) as Record<string, unknown>;
+
+  const update: Record<string, unknown> = {
+    charges_enabled: account.charges_enabled === true,
+    payouts_enabled: account.payouts_enabled === true,
+    requirements,
+    capabilities,
+    external_account_currencies: currencies,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error: updateErr } = await supabase
+    .from("partner_stripe_connect_accounts")
+    .update(update)
+    .eq("stripe_account_id", stripeAccountId);
+  if (updateErr) {
+    throw new Error(
+      `partner account update failed: ${updateErr.message}`,
+    );
+  }
+  return true;
+}

--- a/supabase/functions/_shared/stripeWebhookRouter.ts
+++ b/supabase/functions/_shared/stripeWebhookRouter.ts
@@ -21,6 +21,15 @@ import {
   isInstallmentPaymentIntentEvent,
 } from "./installmentWebhookHandlers.ts";
 import { handleChargeDispute } from "./stripeDisputeHandlers.ts";
+// ORCH-1054 — partner splits + Stripe Transfer pipeline.
+// charge.succeeded → create partner Transfer; charge.refunded + charge.dispute.*
+// → reverse partner Transfer; account.updated → populate partner
+// external_account_currencies (closes the ORCH-1052 currency-match gate).
+import {
+  handleChargeReversal,
+  handleChargeSucceeded,
+  syncPartnerAccountFromEvent,
+} from "./partnerSplits.ts";
 import {
   getKycRemediationForRequirements,
   mapPayoutFailureCode,
@@ -63,11 +72,17 @@ export const STRIPE_ROUTED_EVENT_TYPES = [
   // PaymentIntent id against our session so the payment_intent.succeeded
   // event arriving shortly after can finalise via the existing path.
   "checkout.session.completed",
-  // ORCH-0953: charge.succeeded, charge.failed, and payment_intent.processing
-  // are NOT routed and live webhook endpoints do NOT subscribe to them. The
-  // direct-charge model surfaces success/failure via payment_intent.succeeded /
-  // payment_intent.payment_failed. Delayed-payment methods are out of Phase 1
-  // scope (see DEC-158 — only card/link/apple_pay/google_pay enabled).
+  // ORCH-1054 (revises ORCH-0953): charge.succeeded IS now routed. It is the
+  // only event that carries the application_fee.id we need to fan-out partner
+  // splits via Stripe Transfer (source_transaction = charge.id). The Stripe
+  // Connect platform webhook endpoint MUST subscribe to charge.succeeded.
+  // charge.failed and payment_intent.processing remain unsubscribed.
+  "charge.succeeded",
+  // ORCH-0953: charge.failed and payment_intent.processing are NOT routed.
+  // The direct-charge model surfaces success/failure via
+  // payment_intent.succeeded / payment_intent.payment_failed. Delayed-payment
+  // methods are out of Phase 1 scope (see DEC-158 — only
+  // card/link/apple_pay/google_pay enabled).
   // ORCH-0953: dispute lifecycle — platform-liable Express direct-charge model
   // (DEC-156) requires explicit dispute observability. Persisted to
   // public.stripe_disputes by handlers in _shared/stripeDisputeHandlers.ts.
@@ -1176,6 +1191,21 @@ export async function routeStripeEvent(
   switch (event.type) {
     case "account.updated":
       brandId = await syncAccount(supabase, event.data.object, event.id);
+      // ORCH-1054: same account.updated event may be a PARTNER account (keyed
+      // by partner_stripe_connect_accounts.stripe_account_id) rather than a
+      // brand account. syncPartnerAccountFromEvent is a no-op if the account
+      // id does not match a partner row. Populates external_account_currencies
+      // which closes the ORCH-1052 currency-match invite gate.
+      try {
+        await syncPartnerAccountFromEvent(supabase, event.data.object);
+      } catch (partnerSyncErr) {
+        console.error(
+          "[stripe-webhook] partner account sync failed (non-fatal)",
+          partnerSyncErr instanceof Error
+            ? partnerSyncErr.message
+            : String(partnerSyncErr),
+        );
+      }
       break;
     case "account.application.deauthorized":
       brandId = await handleDeauthorized(supabase, event);
@@ -1212,6 +1242,29 @@ export async function routeStripeEvent(
     case "refund.created":
     case "refund.updated":
       brandId = await handleRefundEvent(supabase, event);
+      // ORCH-1054: refund → reverse partner split (TransferReversal if
+      // already transferred; mark reversed_pending otherwise). Only
+      // charge.refunded carries the application_fee on the charge object;
+      // the refund.* family also fires but we only need one trip through
+      // the reversal RPC per application_fee_id, and the RPC is idempotent.
+      if (event.type === "charge.refunded") {
+        try {
+          await handleChargeReversal(supabase, stripe, event, "refund");
+        } catch (reversalErr) {
+          console.error(
+            "[stripe-webhook] partner reversal (refund) failed",
+            reversalErr instanceof Error
+              ? reversalErr.message
+              : String(reversalErr),
+          );
+          // Rethrow so Stripe redelivers the webhook and we retry.
+          throw reversalErr;
+        }
+      }
+      break;
+    // ORCH-1054: charge.succeeded → partner split fan-out.
+    case "charge.succeeded":
+      brandId = (await handleChargeSucceeded(supabase, stripe, event)).brandId;
       break;
     case "application_fee.created":
     case "application_fee.refunded":
@@ -1248,6 +1301,23 @@ export async function routeStripeEvent(
     case "charge.dispute.updated":
     case "charge.dispute.closed":
       brandId = await handleChargeDispute(supabase, event);
+      // ORCH-1054: dispute → reverse partner split (TransferReversal if
+      // already transferred; mark reversed_pending otherwise). Only fire
+      // on dispute.created; updated/closed don't change the partner-share
+      // outcome (the reversal is idempotent in either case).
+      if (event.type === "charge.dispute.created") {
+        try {
+          await handleChargeReversal(supabase, stripe, event, "dispute");
+        } catch (reversalErr) {
+          console.error(
+            "[stripe-webhook] partner reversal (dispute) failed",
+            reversalErr instanceof Error
+              ? reversalErr.message
+              : String(reversalErr),
+          );
+          throw reversalErr;
+        }
+      }
       break;
     default:
       await writeAudit(supabase, {

--- a/supabase/migrations/20260823000000_orch_1054_partner_splits.sql
+++ b/supabase/migrations/20260823000000_orch_1054_partner_splits.sql
@@ -1,0 +1,339 @@
+-- ORCH-1054 [partner splits ledger + Stripe Transfer pipeline].
+-- META-ORCH-1048 sub-E.
+--
+-- Adds the partner_splits ledger that records every partner-share Transfer
+-- (0.15% of GMV = 10% of the 1.5% Mingla application fee), the
+-- resolve_partner_for_brand_at_time RPC that locks the partner relationship
+-- to the time of the original charge, and three SECURITY DEFINER state-
+-- transition helpers used by the stripe-webhook router. The actual Stripe
+-- Transfer creation lives in the edge fn (_shared/partnerSplits.ts).
+--
+-- INVARIANT (DRAFT → ACTIVE on this close):
+--   I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY — the Stripe Transfer
+--   currency MUST equal the source charge currency. Zero FX. Enforced at
+--   the edge-fn boundary; this migration records the resolved currency on
+--   every row so we have a forensic ledger.
+--
+-- IDEMPOTENCY: every object gated on IF [NOT] EXISTS / CREATE OR REPLACE.
+--
+-- Hard guards:
+--   * creator_accounts.id IS auth.users.id (no separate user_id column).
+--     RLS predicates use account_id = auth.uid() directly.
+--   * Inline EXISTS in RLS predicates per
+--     feedback_rls_returning_owner_gap.md (no SECURITY DEFINER helpers).
+--   * The state-transition helpers are SECURITY DEFINER but write-only to
+--     partner_splits and never expose the table to clients. Search path
+--     locked.
+
+BEGIN;
+
+--------------------------------------------------------------------------------
+-- 1. partner_splits — ledger of every partner share paid by Mingla.
+--------------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.partner_splits (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL
+    REFERENCES public.orders(id) ON DELETE RESTRICT,
+  brand_id uuid NOT NULL,
+  partner_account_id uuid NOT NULL
+    REFERENCES public.creator_accounts(id) ON DELETE RESTRICT,
+  mingla_fee_cents integer NOT NULL CHECK (mingla_fee_cents >= 0),
+  partner_share_cents integer NOT NULL CHECK (partner_share_cents >= 0),
+  transfer_currency text NOT NULL,
+  stripe_transfer_id text,
+  stripe_application_fee_id text NOT NULL,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN (
+      'pending',
+      'transferred',
+      'blocked_currency_mismatch',
+      'blocked_no_stripe',
+      'failed',
+      'reversed',
+      'reversed_pending'
+    )),
+  error_message text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  transferred_at timestamptz,
+  reversed_at timestamptz
+);
+
+-- Idempotency key for the entire partner-split flow: the application_fee.id
+-- of the source charge. Stripe guarantees this is unique per charge.
+ALTER TABLE public.partner_splits
+  DROP CONSTRAINT IF EXISTS partner_splits_application_fee_unique;
+ALTER TABLE public.partner_splits
+  ADD CONSTRAINT partner_splits_application_fee_unique
+  UNIQUE (stripe_application_fee_id);
+
+CREATE INDEX IF NOT EXISTS partner_splits_partner_status_idx
+  ON public.partner_splits (partner_account_id, status);
+
+CREATE INDEX IF NOT EXISTS partner_splits_brand_status_idx
+  ON public.partner_splits (brand_id, status);
+
+CREATE INDEX IF NOT EXISTS partner_splits_order_idx
+  ON public.partner_splits (order_id);
+
+CREATE INDEX IF NOT EXISTS partner_splits_partner_created_idx
+  ON public.partner_splits (partner_account_id, created_at DESC);
+
+COMMENT ON TABLE public.partner_splits IS
+  'ORCH-1054: per-charge partner share ledger. mingla_fee_cents = 1.5% of GMV; partner_share_cents = 10% of mingla_fee. Transfer currency MUST equal source charge currency (I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY).';
+COMMENT ON COLUMN public.partner_splits.stripe_application_fee_id IS
+  'ORCH-1054: idempotency key from the source charge.application_fee. UNIQUE.';
+COMMENT ON COLUMN public.partner_splits.transfer_currency IS
+  'ORCH-1054: lowercase ISO-4217 of the source charge. Equals Stripe Transfer.currency. Zero FX invariant.';
+
+--------------------------------------------------------------------------------
+-- 2. RLS on partner_splits.
+--    SELECT: partner can self-read; brand_admin+ on the brand can read brand
+--    history; superadmin can read all. Inline EXISTS per
+--    feedback_rls_returning_owner_gap.md.
+--    INSERT/UPDATE/DELETE: service role only (edge fn mediates).
+--------------------------------------------------------------------------------
+
+ALTER TABLE public.partner_splits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.partner_splits FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS partner_splits_partner_self_select
+  ON public.partner_splits;
+CREATE POLICY partner_splits_partner_self_select
+  ON public.partner_splits
+  FOR SELECT
+  USING (
+    partner_account_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.brand_team_members btm
+       WHERE btm.brand_id = partner_splits.brand_id
+         AND btm.user_id = auth.uid()
+         AND btm.role IN ('brand_owner', 'brand_admin')
+         AND btm.accepted_at IS NOT NULL
+         AND btm.removed_at IS NULL
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.profiles p
+       WHERE p.id = auth.uid()
+         AND p.account_type = 'admin'
+    )
+  );
+
+-- No permissive write policies. Edge fn writes via service role only.
+
+--------------------------------------------------------------------------------
+-- 3. resolve_partner_for_brand_at_time — pins the partner relationship to
+--    the moment of the original charge so a partner removed AFTER the sale
+--    still gets paid for sales that happened DURING their tenure.
+--
+--    Returns the partner_account_id of the brand_team_members row where:
+--      - role = 'brand_admin'                  (partners hold brand_admin)
+--      - accepted_at <= p_at                   (was a partner at sale time)
+--      - removed_at IS NULL OR > p_at          (still a partner then)
+--      - creator_accounts.partner_enabled=true (flagged partner today)
+--
+--    Tie-break (multiple partners on one brand): accepted_at ASC, then
+--    user_id ASC. Returns NULL if no eligible partner exists.
+--
+--    SECURITY DEFINER: read-only lookup; never writes; never bypasses RLS
+--    for the caller (it returns a single uuid, not a row).
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.resolve_partner_for_brand_at_time(
+  p_brand_id uuid,
+  p_at timestamptz
+)
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT btm.user_id
+    FROM public.brand_team_members btm
+    JOIN public.creator_accounts a
+      ON a.id = btm.user_id
+   WHERE btm.brand_id = p_brand_id
+     AND btm.role = 'brand_admin'
+     AND a.partner_enabled = true
+     AND btm.accepted_at IS NOT NULL
+     AND btm.accepted_at <= p_at
+     AND (btm.removed_at IS NULL OR btm.removed_at > p_at)
+   ORDER BY btm.accepted_at ASC, btm.user_id ASC
+   LIMIT 1;
+$function$;
+
+REVOKE ALL ON FUNCTION public.resolve_partner_for_brand_at_time(uuid, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.resolve_partner_for_brand_at_time(uuid, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.resolve_partner_for_brand_at_time(uuid, timestamptz) TO service_role;
+
+COMMENT ON FUNCTION public.resolve_partner_for_brand_at_time(uuid, timestamptz) IS
+  'ORCH-1054: returns the partner_account_id for a brand at a given moment. Deterministic tie-break by accepted_at then user_id. Returns NULL when none.';
+
+--------------------------------------------------------------------------------
+-- 4. record_partner_split_attempt — INSERT a 'pending' row keyed by the
+--    application_fee_id. Used by the webhook before it calls Stripe Transfer.
+--    ON CONFLICT DO NOTHING for webhook-replay idempotency.
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.record_partner_split_attempt(
+  p_application_fee_id text,
+  p_order_id uuid,
+  p_brand_id uuid,
+  p_partner_account_id uuid,
+  p_mingla_fee_cents integer,
+  p_partner_share_cents integer,
+  p_currency text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_row record;
+BEGIN
+  IF p_application_fee_id IS NULL OR length(p_application_fee_id) = 0 THEN
+    RAISE EXCEPTION 'application_fee_id_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.partner_splits (
+    order_id,
+    brand_id,
+    partner_account_id,
+    mingla_fee_cents,
+    partner_share_cents,
+    transfer_currency,
+    stripe_application_fee_id,
+    status
+  )
+  VALUES (
+    p_order_id,
+    p_brand_id,
+    p_partner_account_id,
+    p_mingla_fee_cents,
+    p_partner_share_cents,
+    lower(p_currency),
+    p_application_fee_id,
+    'pending'
+  )
+  ON CONFLICT (stripe_application_fee_id) DO NOTHING;
+
+  SELECT id, status, stripe_transfer_id
+    INTO v_row
+  FROM public.partner_splits
+  WHERE stripe_application_fee_id = p_application_fee_id;
+
+  RETURN jsonb_build_object(
+    'id', v_row.id,
+    'status', v_row.status,
+    'stripe_transfer_id', v_row.stripe_transfer_id
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.record_partner_split_attempt(
+  text, uuid, uuid, uuid, integer, integer, text
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.record_partner_split_attempt(
+  text, uuid, uuid, uuid, integer, integer, text
+) TO service_role;
+
+COMMENT ON FUNCTION public.record_partner_split_attempt(
+  text, uuid, uuid, uuid, integer, integer, text
+) IS
+  'ORCH-1054: insert a pending partner_splits row keyed by application_fee_id. Idempotent (ON CONFLICT DO NOTHING). Returns current row status.';
+
+--------------------------------------------------------------------------------
+-- 5. mark_partner_split_transferred — flip to 'transferred' + timestamp.
+--    Idempotent: re-running with the same transfer_id is a no-op.
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.mark_partner_split_transferred(
+  p_application_fee_id text,
+  p_transfer_id text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  UPDATE public.partner_splits
+  SET status = 'transferred',
+      stripe_transfer_id = p_transfer_id,
+      transferred_at = COALESCE(transferred_at, now()),
+      error_message = NULL
+  WHERE stripe_application_fee_id = p_application_fee_id
+    AND status IN ('pending', 'failed');
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.mark_partner_split_transferred(text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_partner_split_transferred(text, text) TO service_role;
+
+--------------------------------------------------------------------------------
+-- 6. mark_partner_split_failed — non-retryable failure (e.g. account no longer
+--    eligible). Records reason in status + error_message.
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.mark_partner_split_failed(
+  p_application_fee_id text,
+  p_reason text,
+  p_error_message text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  UPDATE public.partner_splits
+  SET status = CASE
+        WHEN p_reason IN (
+          'blocked_currency_mismatch',
+          'blocked_no_stripe',
+          'failed'
+        ) THEN p_reason
+        ELSE 'failed'
+      END,
+      error_message = p_error_message
+  WHERE stripe_application_fee_id = p_application_fee_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.mark_partner_split_failed(text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_partner_split_failed(text, text, text) TO service_role;
+
+--------------------------------------------------------------------------------
+-- 7. mark_partner_split_reversed — refund/dispute path. If status was
+--    'transferred' we record the reversal transfer id; otherwise we mark
+--    'reversed_pending' (no Transfer existed to reverse).
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.mark_partner_split_reversed(
+  p_application_fee_id text,
+  p_reversal_transfer_id text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  UPDATE public.partner_splits
+  SET status = CASE
+        WHEN p_reversal_transfer_id IS NOT NULL THEN 'reversed'
+        WHEN status = 'transferred' THEN 'reversed'
+        ELSE 'reversed_pending'
+      END,
+      reversed_at = COALESCE(reversed_at, now()),
+      stripe_transfer_id = COALESCE(p_reversal_transfer_id, stripe_transfer_id)
+  WHERE stripe_application_fee_id = p_application_fee_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.mark_partner_split_reversed(text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.mark_partner_split_reversed(text, text) TO service_role;
+
+COMMIT;

--- a/supabase/migrations/__tests__/orch_1054_partner_splits.test.ts
+++ b/supabase/migrations/__tests__/orch_1054_partner_splits.test.ts
@@ -1,0 +1,181 @@
+// ORCH-1054 — SQL-shape regression for the partner_splits migration.
+//
+// Reads the migration file and proves the load-bearing schema + RPC
+// fragments are present. Catches the easy reverts:
+//   - dropped partner_splits table or its UNIQUE on stripe_application_fee_id
+//   - dropped resolve_partner_for_brand_at_time RPC
+//   - dropped record_partner_split_attempt / mark_* RPCs
+//   - RLS not enabled
+//   - I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY invariant note removed
+//   - creator_accounts.user_id mis-reference (ORCH-1050/1051 lesson)
+//
+// Run: deno test --allow-read \
+//   supabase/migrations/__tests__/orch_1054_partner_splits.test.ts
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+const SRC = await Deno.readTextFile(
+  new URL(
+    "../20260823000000_orch_1054_partner_splits.sql",
+    import.meta.url,
+  ),
+);
+
+Deno.test("migration: creates partner_splits table with required columns", () => {
+  assertStringIncludes(SRC, "CREATE TABLE IF NOT EXISTS public.partner_splits");
+  for (
+    const col of [
+      "order_id uuid",
+      "brand_id uuid",
+      "partner_account_id uuid",
+      "mingla_fee_cents integer",
+      "partner_share_cents integer",
+      "transfer_currency text",
+      "stripe_transfer_id text",
+      "stripe_application_fee_id text",
+      "status text",
+      "error_message text",
+      "transferred_at timestamptz",
+      "reversed_at timestamptz",
+    ]
+  ) {
+    assertStringIncludes(SRC, col);
+  }
+});
+
+Deno.test("migration: UNIQUE on stripe_application_fee_id (idempotency key)", () => {
+  assertStringIncludes(SRC, "partner_splits_application_fee_unique");
+  assertStringIncludes(SRC, "UNIQUE (stripe_application_fee_id)");
+});
+
+Deno.test("migration: status CHECK lists every state in the workflow", () => {
+  for (
+    const s of [
+      "'pending'",
+      "'transferred'",
+      "'blocked_currency_mismatch'",
+      "'blocked_no_stripe'",
+      "'failed'",
+      "'reversed'",
+      "'reversed_pending'",
+    ]
+  ) {
+    assertStringIncludes(SRC, s);
+  }
+});
+
+Deno.test("migration: indexes for partner+brand+order lookups", () => {
+  assertStringIncludes(SRC, "partner_splits_partner_status_idx");
+  assertStringIncludes(SRC, "partner_splits_brand_status_idx");
+  assertStringIncludes(SRC, "partner_splits_order_idx");
+});
+
+Deno.test("migration: RLS enabled + forced + self-read + brand_admin read + admin", () => {
+  assertStringIncludes(SRC, "ENABLE ROW LEVEL SECURITY");
+  assertStringIncludes(SRC, "FORCE ROW LEVEL SECURITY");
+  assertStringIncludes(SRC, "partner_splits_partner_self_select");
+  assertStringIncludes(SRC, "partner_account_id = auth.uid()");
+  // brand-admin path uses inline EXISTS per feedback_rls_returning_owner_gap.md
+  assertStringIncludes(SRC, "FROM public.brand_team_members btm");
+  assertStringIncludes(SRC, "btm.role IN ('brand_owner', 'brand_admin')");
+  // No permissive write policies — service role only.
+  assert(
+    !/CREATE POLICY[^;]+FOR INSERT[^;]+partner_splits/.test(SRC),
+    "no permissive INSERT policy allowed on partner_splits",
+  );
+  assert(
+    !/CREATE POLICY[^;]+FOR UPDATE[^;]+partner_splits/.test(SRC),
+    "no permissive UPDATE policy allowed on partner_splits",
+  );
+});
+
+Deno.test("migration: defines resolve_partner_for_brand_at_time with deterministic tie-break", () => {
+  assertStringIncludes(
+    SRC,
+    "CREATE OR REPLACE FUNCTION public.resolve_partner_for_brand_at_time",
+  );
+  assertStringIncludes(SRC, "p_brand_id uuid");
+  assertStringIncludes(SRC, "p_at timestamptz");
+  assertStringIncludes(SRC, "RETURNS uuid");
+  assertStringIncludes(SRC, "partner_enabled = true");
+  assertStringIncludes(SRC, "btm.accepted_at <= p_at");
+  assertStringIncludes(
+    SRC,
+    "(btm.removed_at IS NULL OR btm.removed_at > p_at)",
+  );
+  assertStringIncludes(SRC, "ORDER BY btm.accepted_at ASC, btm.user_id ASC");
+});
+
+Deno.test("migration: defines all four state-transition RPCs as SECURITY DEFINER", () => {
+  for (
+    const rpc of [
+      "record_partner_split_attempt",
+      "mark_partner_split_transferred",
+      "mark_partner_split_failed",
+      "mark_partner_split_reversed",
+    ]
+  ) {
+    assertStringIncludes(SRC, `CREATE OR REPLACE FUNCTION public.${rpc}`);
+  }
+  // Each must be SECURITY DEFINER + search_path locked.
+  const occurrences = SRC.match(/SECURITY DEFINER/g) ?? [];
+  assert(
+    occurrences.length >= 4,
+    `expected ≥4 SECURITY DEFINER blocks; found ${occurrences.length}`,
+  );
+  const searchPath = SRC.match(/SET search_path TO 'public', 'pg_temp'/g) ?? [];
+  assert(
+    searchPath.length >= 4,
+    `expected ≥4 search_path locks; found ${searchPath.length}`,
+  );
+});
+
+Deno.test("migration: record_partner_split_attempt is idempotent (ON CONFLICT DO NOTHING)", () => {
+  assertStringIncludes(SRC, "ON CONFLICT (stripe_application_fee_id) DO NOTHING");
+});
+
+Deno.test("migration: zero-FX invariant note present", () => {
+  assertStringIncludes(SRC, "I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY");
+});
+
+Deno.test("migration: GRANTs limit writers to service_role", () => {
+  // record_partner_split_attempt + the three mark_* RPCs grant EXECUTE to
+  // service_role only (the resolve RPC also grants authenticated for read).
+  const writeRpcs = [
+    "record_partner_split_attempt",
+    "mark_partner_split_transferred",
+    "mark_partner_split_failed",
+    "mark_partner_split_reversed",
+  ];
+  for (const rpc of writeRpcs) {
+    assertStringIncludes(SRC, `GRANT EXECUTE ON FUNCTION public.${rpc}`);
+    assertStringIncludes(SRC, `${rpc}`);
+  }
+  // None of the write RPCs should be exposed to authenticated/anon directly.
+  assert(
+    !/GRANT EXECUTE ON FUNCTION public\.record_partner_split_attempt[^;]+TO authenticated/
+      .test(SRC),
+    "record_partner_split_attempt must not be granted to authenticated",
+  );
+});
+
+Deno.test("migration: keys on creator_accounts.id (NOT user_id) — ORCH-1050/1051 lesson", () => {
+  assert(
+    !/creator_accounts\.user_id/.test(SRC),
+    "migration must NOT reference creator_accounts.user_id (no such column)",
+  );
+});
+
+Deno.test("migration: ON DELETE RESTRICT on order + partner refs (ledger never silently vanishes)", () => {
+  assertStringIncludes(
+    SRC,
+    "REFERENCES public.orders(id) ON DELETE RESTRICT",
+  );
+  assertStringIncludes(
+    SRC,
+    "REFERENCES public.creator_accounts(id) ON DELETE RESTRICT",
+  );
+});


### PR DESCRIPTION
## ORCH-1054 — META-ORCH-1048 sub-E

Real money pipeline. Pays partners 0.15% of GMV per ticket sale (10% of the
1.5% Mingla application fee) via Stripe Transfer in source charge currency.
Zero FX, idempotent end-to-end, fully reversible on refund/dispute.

### Backend

- New migration `20260823000000_orch_1054_partner_splits.sql`:
  - `partner_splits` ledger keyed on `stripe_application_fee_id` (UNIQUE);
    status in {pending, transferred, blocked_currency_mismatch,
    blocked_no_stripe, failed, reversed, reversed_pending}.
  - RLS: partner self-read OR brand_owner/brand_admin OR superadmin; writes
    via service role only (inline EXISTS per
    `feedback_rls_returning_owner_gap.md`).
  - `resolve_partner_for_brand_at_time(brand_id, at)` pins partner to the
    sale time so a removed partner still gets paid for prior sales;
    deterministic tie-break (`accepted_at ASC, user_id ASC`).
  - `record_partner_split_attempt` — INSERT 'pending' with
    `ON CONFLICT (stripe_application_fee_id) DO NOTHING`; replay-safe.
  - `mark_partner_split_transferred` / `_failed` / `_reversed` — idempotent
    state transitions, SECURITY DEFINER, `search_path` locked.

- New `supabase/functions/_shared/partnerSplits.ts`:
  - `handleChargeSucceeded` — resolves order → brand → partner-at-sale-time,
    `Math.round(fee * 0.10)` cents (not floor — protects partner from cent
    loss), blocks if partner has no Stripe / wrong settlement currency,
    creates Stripe Transfer (`source_transaction = charge.id`) with
    Idempotency-Key `partner_split_<application_fee_id>`. **ZERO FX**:
    `Transfer.currency = charge.currency`. Cites
    https://docs.stripe.com/api/transfers/create.
  - `handleChargeReversal` — refund / dispute creates Stripe TransferReversal
    (Idempotency-Key `partner_split_reversal_<af_id>`) if already
    transferred; otherwise marks `reversed_pending`. Cites
    https://docs.stripe.com/api/transfer_reversals/create.
  - `syncPartnerAccountFromEvent` — `account.updated` for a known partner
    Stripe account populates `external_account_currencies` (dedup,
    lowercase, sorted) + `charges_enabled` + `payouts_enabled` +
    `requirements` + `capabilities`. **Closes the ORCH-1052 currency-match
    invite gate.**

- `supabase/functions/_shared/stripeWebhookRouter.ts`:
  - Adds `charge.succeeded` to `STRIPE_ROUTED_EVENT_TYPES` (revises the
    ORCH-0953 exclusion comment). Stripe Connect endpoint **MUST** subscribe.
  - `charge.succeeded` → `handleChargeSucceeded`.
  - `charge.refunded` → existing refund flow + `handleChargeReversal('refund')`.
  - `charge.dispute.created` → existing dispute flow +
    `handleChargeReversal('dispute')`.
  - `account.updated` → existing brand sync + `syncPartnerAccountFromEvent`.

### App-business

- `mingla-business/app/partner/earnings.tsx` — replaces the ORCH-1052
  placeholder with the live `PartnerSplitsSection`: per-currency totals
  (no FX), currency filter chips, per-split rows with status badges,
  empty state.
- `mingla-business/src/services/partnerSplitsService.ts` — `listPartnerSplits`,
  `summarizePartnerSplits`, `getPartnerEarningsSummary` (client-side aggregate
  by currency / month / brand; never FX between currencies).
- `mingla-business/src/hooks/usePartnerSplits.ts` — React Query hooks.

### Gates + tests

- `.github/scripts/strict-grep/orch-1054-partner-splits.mjs` — 5-rule gate:
  required files, migration tokens, webhook router wiring, partnerSplits
  module Stripe-docs citations + Idempotency-Key patterns + zero-FX note,
  earnings-screen wiring. Self-test PASS, live PASS.
- COMMS-0002 allowlist: `ORCH_1054_BACKEND_ALLOWLIST` registered in
  `orch-0863-marketing-hub-phase-b.mjs`.
- 28 Deno regression tests across 3 files — happy (8), adversarial (8),
  migration shape (12). All PASS.
- **Fails-on-revert verified at HEAD** (flipping `Math.round → Math.floor`
  fails the cent-loss test).

### Invariant (DRAFT → ACTIVE on close)

- `I-PROPOSED-PARTNER-TRANSFER-SOURCE-CURRENCY` — Stripe Transfer currency
  MUST equal source charge currency. Zero FX.

### Orchestrator deploy items

- [ ] Apply migration `20260823000000_orch_1054_partner_splits.sql`.
- [ ] Redeploy edge functions that import `_shared/stripeWebhookRouter` —
      primarily `stripe-webhook`.
- [ ] Stripe Connect webhook endpoint **MUST** subscribe to `charge.succeeded`
      (in addition to existing event set).

### Test plan

- [ ] Trigger a test ticket purchase on a brand with a flagged partner
      (`creator_accounts.partner_enabled = true`) whose partner Stripe is
      onboarded + currency-matched → confirm a `partner_splits` row appears
      with `status='transferred'` and a `stripe_transfer_id`.
- [ ] Refund the same order → confirm row flips to `reversed` with a
      `stripe_transfer_id` overwritten by the reversal id.
- [ ] Onboard a partner Stripe account and connect a USD bank → confirm
      `account.updated` populates `partner_stripe_connect_accounts.external_account_currencies = ["usd"]`.
- [ ] `/partner/earnings` screen renders totals + filter chips + status
      badges for a partner with splits; empty state when none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)