### PR TITLE
pre-ORCH-1056 hotfix: gate pk_live/pk_test validator on MINGLA_STRIPE_MODE

### DIFF
--- a/mingla-business/app.config.ts
+++ b/mingla-business/app.config.ts
@@ -120,18 +120,39 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       // Cycle B2a Path C V3 — Stripe Connect publishable key. Used by the
       // Mingla-hosted connect-onboarding page (Path B host) when initialising
       // @stripe/connect-js. Publishable keys are public-by-design (ship in client
-      // bundle). ORCH-0954 amendment: Vercel production requires pk_live_;
-      // Vercel preview/development and local dev require pk_test_ so TEST-mode
-      // embedded Account Sessions can render on preview without weakening prod.
+      // bundle).
+      //
+      // ORCH-0954 amendment: Vercel production previously required pk_live_;
+      // Vercel preview/development and local dev required pk_test_.
+      //
+      // pre-ORCH-1056 hotfix (2026-06-02): the live-on-production rule assumed
+      // Supabase edge fns were also flipped to rk_live_*. They are NOT — Supabase
+      // is on rk_test_* across the board, which silently collapses the Stripe
+      // Connect embedded iframe (cross-account pk vs ak mismatch). Until the
+      // unified-mode system lands (ORCH-1056), production must MATCH the
+      // backend mode. MINGLA_STRIPE_MODE (defaults to "test") gates which pk
+      // prefix is required on production builds.
       EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY: (() => {
         const fromEnv = process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY;
         const vercelEnv = process.env.VERCEL_ENV;
         const sandboxFallback =
           "pk_test_51TTnt1PjlZyAYA40f3kjmxF6uXjfEJKfFR25LiJpVqd7qw6TYfDqqKLcNamL3JGlD2vxh94Bzn4ciaqsMNN1PJ0C00oZVosOxd";
+        // Default to "live" when unset preserves the pre-hotfix behavior so a
+        // mid-rollout deploy (validator landed, MINGLA_STRIPE_MODE not yet set)
+        // does not start rejecting the existing pk_live_ production env. Set
+        // MINGLA_STRIPE_MODE=test on Vercel + swap the pk to pk_test_* in the
+        // same change to align production with the test-mode backend.
+        const stripeMode = process.env.MINGLA_STRIPE_MODE ?? "live";
+        if (stripeMode !== "test" && stripeMode !== "live") {
+          throw new Error(
+            `Unsupported MINGLA_STRIPE_MODE "${stripeMode}". Expected "test" or "live".`,
+          );
+        }
+        const requiredPkPrefix = stripeMode === "live" ? "pk_live_" : "pk_test_";
         if (vercelEnv === "production") {
-          if (!fromEnv || !fromEnv.startsWith("pk_live_")) {
+          if (!fromEnv || !fromEnv.startsWith(requiredPkPrefix)) {
             throw new Error(
-              "EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a pk_live_ value for Vercel production builds.",
+              `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY must be a ${requiredPkPrefix} value for Vercel production builds when MINGLA_STRIPE_MODE=${stripeMode}.`,
             );
           }
           return fromEnv;


### PR DESCRIPTION
## Summary

- Adds `MINGLA_STRIPE_MODE` env var (`test` | `live`, defaults to `live`) to `mingla-business/app.config.ts:130` validator
- Production-build pk prefix is now gated on the mode: `live` → `pk_live_*` (preserves existing behavior); `test` → `pk_test_*` (new path)
- Vercel preview/development + local-dev rules unchanged

## Why

The Stripe Connect embedded iframe at `business.usemingla.com/connect-partner-onboarding` is silently collapsing to 1px. Root cause: web client ships with `pk_live_*` (live MINGLA LLC platform `acct_1TU23t`), but Supabase edge fns are still on `rk_test_*` (sandbox MINGLA LLC sandbox platform `acct_1TTnt1`). The Stripe SDK sees the cross-account mismatch and exits without rendering.

Until ORCH-1056 (unified mode system: single switch + helper + handshake + admin dashboard) ships, production needs to match the test-mode backend. This validator change unlocks the swap.

## Companion change (operator follow-up after merge)

```
vercel env rm  EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY production
vercel env add EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY production  # paste sandbox pk_test_51TTnt1...
vercel env add MINGLA_STRIPE_MODE production                  # value: test
vercel --prod
```

## Test plan

- [ ] Land this PR (no Vercel deploy triggered until env is also swapped)
- [ ] Swap Vercel envs per companion above
- [ ] `vercel --prod` redeploy
- [ ] Open partner Stripe onboarding from dev build → Stripe Connect iframe renders the form instead of collapsing to 1px
- [ ] Existing brand Stripe onboarding still works (same backend, same fix path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)