### PR TITLE
ORCH-1060 [deploy]: green up main CI (7 pre-existing strict-grep failures)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1408,7 +1408,16 @@ function checkNoNewBackendFiles() {
     "supabase/functions/_shared/__tests__/orch_1054_partner_splits_adversarial.test.ts",
     "supabase/migrations/__tests__/orch_1054_partner_splits.test.ts",
   ];
+  // ORCH-1060 [main CI green-up] — comment-only touches to two existing edge
+  // functions (audit-exemption note on stripe-mode + no-attachment opt-out on
+  // invite-scanner) to satisfy I-PROPOSED-S / ORCH-0785-A. No new backend files,
+  // no runtime change, no edge deploy. Per COMMS-0002.
+  const ORCH_1060_BACKEND_ALLOWLIST = [
+    "supabase/functions/stripe-mode/index.ts",
+    "supabase/functions/invite-scanner/index.ts",
+  ];
   const ALLOWLIST = [
+    ...ORCH_1060_BACKEND_ALLOWLIST,
     ...ORCH_1054_BACKEND_ALLOWLIST,
     ...ORCH_1052_BACKEND_ALLOWLIST,
     ...ORCH_1051_BACKEND_ALLOWLIST,

--- a/.github/scripts/strict-grep/orch-0885-a-no-bottomnav-on-wide-desktop.mjs
+++ b/.github/scripts/strict-grep/orch-0885-a-no-bottomnav-on-wide-desktop.mjs
@@ -58,6 +58,11 @@ const ALLOWLIST = new Set([
   // INTAKE time as a known prior consumer; if this file ever ships in
   // production navigation, file a new ORCH amending the allow-list.
   "mingla-business/app/__styleguide.tsx",
+  // Type-only consumers — import the `BottomNavTab` TYPE (not the BottomNav
+  // component) for the desktop tab-visibility gate. No runtime chrome mount.
+  // (ORCH-1060 CI green-up; type imports are erased at build, never render.)
+  "mingla-business/src/utils/navTabGate.ts",
+  "mingla-business/src/utils/__tests__/navTabGate.test.ts",
 ]);
 
 const failures = [];

--- a/mingla-business/.metro-cycle-baseline.txt
+++ b/mingla-business/.metro-cycle-baseline.txt
@@ -36,3 +36,16 @@ src/store/liveEventStore.ts | src/utils/publishedEventEditGuards.ts
 src/context/AuthContext.tsx | src/hooks/useBrandListShim.ts | src/hooks/useBrands.ts | src/store/currentBrandStore.ts | src/utils/clearAllStores.ts
 src/context/AuthContext.tsx | src/hooks/useBrands.ts | src/store/draftEventStore.ts | src/store/liveEventStore.ts | src/utils/clearAllStores.ts
 src/context/AuthContext.tsx | src/hooks/useBrands.ts | src/store/draftEventStore.ts | src/utils/clearAllStores.ts | src/utils/liveEventConverter.ts
+# ORCH-1050/1052/1055 introduced new lazy hook-runtime cycles through the brand
+# graph (useBrands now pulls useEventOrders + usePublicEvents/services, and the
+# currentBrandId reliability fix wired useBrandListShim/currentBrandStore deeper).
+# All are runtime-lazy (hooks called at render, never at module top level), so
+# they resolve fine — same benign pattern as the ORCH-1004 block above. The
+# introducing PRs merged without baselining; ORCH-1060 (main CI green-up)
+# baselines them with this rationale. Cycle-breaking refactor tracked separately.
+src/context/AuthContext.tsx | src/hooks/useBrandListShim.ts | src/hooks/useBrands.ts | src/hooks/useEventOrders.ts | src/store/currentBrandStore.ts | src/utils/clearAllStores.ts
+src/hooks/useBrands.ts | src/hooks/useEventOrders.ts | src/store/draftEventStore.ts | src/store/liveEventStore.ts
+src/hooks/useBrands.ts | src/hooks/useEventOrders.ts | src/store/draftEventStore.ts | src/utils/liveEventConverter.ts
+src/hooks/useBrandListShim.ts | src/hooks/useBrands.ts | src/hooks/usePublicEvents.ts | src/services/brandMapping.ts | src/services/publicEventsService.ts | src/store/currentBrandStore.ts | src/utils/deriveBrandStripeStatus.ts
+src/hooks/useBrandListShim.ts | src/hooks/useBrands.ts | src/hooks/usePublicEvents.ts | src/services/publicEventsService.ts | src/services/tripsService.ts | src/store/currentBrandStore.ts
+src/hooks/useBrandListShim.ts | src/hooks/useBrands.ts | src/store/currentBrandStore.ts

--- a/mingla-business/src/components/scanners/InviteScannerSheet.tsx
+++ b/mingla-business/src/components/scanners/InviteScannerSheet.tsx
@@ -3,7 +3,7 @@
  *
  * Sends invites through the `invite-scanner` edge function. The function
  * writes to `public.scanner_invitations` and ships a Resend invite email.
- * The legacy [TRANSITIONAL] zustand-only path is gone — invitations are
+ * The legacy [TRANSITIONAL] zustand-only path is gone (exit condition: ORCH-1051) — invitations are
  * real canonical rows from the moment "Send invitation" returns success.
  *
  * Scope picker: operator chooses "This event only" (default, preserves

--- a/mingla-business/src/hooks/useBrandInvitations.ts
+++ b/mingla-business/src/hooks/useBrandInvitations.ts
@@ -2,7 +2,7 @@
  * useBrandInvitations / useBrandTeamMembers / mutations (ORCH-1050).
  *
  * React Query layer for the brand-team invite flow. Replaces the
- * [TRANSITIONAL] zustand-only reads in /brand/[id]/team. Const #5: server
+ * [TRANSITIONAL] zustand-only reads in /brand/[id]/team (exit condition: ORCH-1050 — now React Query). Const #5: server
  * state lives in React Query, never Zustand.
  *
  * Cache invalidation rules:

--- a/mingla-business/src/hooks/useScannerInvitations.ts
+++ b/mingla-business/src/hooks/useScannerInvitations.ts
@@ -2,7 +2,7 @@
  * useScannerInvitations / mutations (ORCH-1051).
  *
  * React Query layer for the scanner-team invite flow. Replaces the
- * [TRANSITIONAL] zustand-only reads. Const #5: server state lives in
+ * [TRANSITIONAL] zustand-only reads (exit condition: ORCH-1051 — now React Query). Const #5: server state lives in
  * React Query, never Zustand.
  *
  * Cache invalidation rules:

--- a/mingla-business/src/services/brandInvitationsService.ts
+++ b/mingla-business/src/services/brandInvitationsService.ts
@@ -2,7 +2,7 @@
  * brandInvitationsService — backend contract for the brand-team invite flow
  * (ORCH-1050).
  *
- * Replaces the [TRANSITIONAL] local-Zustand-only flow with real Supabase
+ * Replaces the [TRANSITIONAL] local-Zustand-only flow (exit condition: ORCH-1050) with real Supabase
  * persistence + Resend email + ownership-transfer RPC. The store now lives
  * only as an optimistic-UI cache between "Invite tapped" and "edge fn
  * returned"; canonical state is read from public.brand_invitations and

--- a/mingla-business/src/services/scannerInvitationsService.ts
+++ b/mingla-business/src/services/scannerInvitationsService.ts
@@ -2,7 +2,7 @@
  * scannerInvitationsService — backend contract for the scanner-team invite
  * flow (ORCH-1051).
  *
- * Replaces the [TRANSITIONAL] local-Zustand-only flow with real Supabase
+ * Replaces the [TRANSITIONAL] local-Zustand-only flow (exit condition: ORCH-1051) with real Supabase
  * persistence + Resend email + branch-on-scope accept RPC. The
  * `scannerInvitationsStore` now lives only as an optimistic-UI cache between
  * "Invite tapped" and "edge fn returned"; canonical state is read from

--- a/mingla-business/src/utils/auditActionLabels.ts
+++ b/mingla-business/src/utils/auditActionLabels.ts
@@ -73,6 +73,11 @@ export const KNOWN_STATIC_SLUGS: readonly string[] = [
   // emitted by brand-stripe-account-session after a successful Account
   // Session mint for the embedded onboarding or account-management surface.
   "stripe_connect.account_session_created",
+  // ORCH-1052 [Partner onboarding] — partner-side Stripe Connect audit slugs
+  // emitted by partner-stripe-onboard (onboard_initiated) +
+  // partner-stripe-account-session (account_session_created).
+  "partner_stripe_connect.onboard_initiated",
+  "partner_stripe_connect.account_session_created",
   "order_cancelled",
   "order_refund_issued",
   "mingla_tos_accept",
@@ -141,6 +146,19 @@ export const resolveAuditActionLabel = (action: string): AuditActionLabel => {
       return {
         title: "Opened Stripe account management",
         detail: "An embedded Account Session was minted for onboarding or account management.",
+        category: "stripe_connect",
+        iconHint: "bank",
+      };
+    case "partner_stripe_connect.onboard_initiated":
+      return {
+        title: "Started partner Stripe onboarding",
+        category: "stripe_connect",
+        iconHint: "bank",
+      };
+    case "partner_stripe_connect.account_session_created":
+      return {
+        title: "Opened partner Stripe account management",
+        detail: "An embedded Account Session was minted for partner onboarding or account management.",
         category: "stripe_connect",
         iconHint: "bank",
       };

--- a/mingla-business/src/utils/reapOrphanStorageKeys.ts
+++ b/mingla-business/src/utils/reapOrphanStorageKeys.ts
@@ -29,13 +29,15 @@ const KNOWN_MINGLA_KEYS = new Set<string>([
   "mingla-business.guestStore.v1",
   "mingla-business.eventEditLog.v1",
   "mingla-business.notificationPrefsStore.v1",
-  "mingla-business.scannerInvitationsStore.v2",
   "mingla-business.doorSalesStore.v1",
   "mingla-business.scanStore.v1",
   // ORCH-1050: brandTeamStore.v1 was removed from the persist allowlist.
   // The store is now in-memory optimistic only (canonical state lives in
   // public.brand_invitations via React Query). The reaper now sweeps any
   // residual `mingla-business.brandTeamStore.v1` key from prior installs.
+  // ORCH-1051/1060: scannerInvitationsStore.v2 likewise removed — scanner
+  // invitations are now React-Query server state (public.scanner_invitations),
+  // not a persisted store. The reaper sweeps any residual key from prior installs.
 ]);
 
 const SUPABASE_AUTH_KEY_PATTERN = /^sb-.+-auth-token$/;

--- a/supabase/functions/invite-scanner/index.ts
+++ b/supabase/functions/invite-scanner/index.ts
@@ -193,6 +193,8 @@ async function sendInviteEmail(
   payload: ReturnType<typeof buildInviteEmail>,
 ): Promise<{ ok: boolean; error?: string }> {
   try {
+    // no-attachment: scanner invite is a transactional HTML email (accept link
+    // only) — no PDF/ticket/file attachment by design.
     const response = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {

--- a/supabase/functions/stripe-mode/index.ts
+++ b/supabase/functions/stripe-mode/index.ts
@@ -17,6 +17,12 @@
  *   - https://docs.stripe.com/keys (publishable key prefixes)
  */
 
+// orch-strict-grep-allow stripe-fn-no-audit — public, anonymous, read-only mode
+// reporter. No Stripe API call, no state mutation, no user/brand context to
+// audit (the answer is already public via the bundled pk_ prefix). I-PROPOSED-S
+// audit logging targets authenticated Stripe-mutating ops; nothing to log here.
+// Validated against stripe-best-practices security reference (ORCH-1060).
+
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import {
   resolvePublishablePrefix,


### PR DESCRIPTION
## ORCH-1060 — main CI green-up

Resolves 7 pre-existing strict-grep gate failures that were merged to `main` red (the branch is unprotected, so ORCH-1050/1052/1055/1056 landed despite them). None were introduced by this PR — each is a missing registration/baseline/allowlist the introducing ORCH skipped.

| Gate | Fix |
|---|---|
| I-PROPOSED-M | Drop stale `scannerInvitationsStore.v2` persist-key whitelist entry (store removed, now React Query) |
| I-PROPOSED-N | Add exit-condition keyword to 5 historical `[TRANSITIONAL]` references (completed migrations) |
| I-PROPOSED-K | Baseline 6 new lazy hook-runtime require-cycles in the brand graph + rationale (same benign pattern as ORCH-1004) |
| I-PROPOSED-S | File-level audit exemption for `stripe-mode` — public, anonymous, read-only mode reporter (no Stripe API call, no mutation, no user ctx). Validated against the stripe-best-practices security reference. |
| ORCH-0785-A | Declare `no-attachment` opt-out on the `invite-scanner` Resend POST (transactional HTML, no file) |
| ORCH-0806 | Register `partner_stripe_connect.*` audit slugs + labels (ORCH-1052 partner flow) |
| ORCH-0885-A | Allowlist `navTabGate` type-only `BottomNavTab` imports (type erased at build, no component mount) |

All 6 non-cycle gates verified PASS locally; require-cycles baselined from CI's own normalized output (deterministic; this PR changes no import edges). Comment/baseline/allowlist-only for the two edge functions — no runtime change, no edge deploy.

Out of scope (separate pre-existing debt, not a strict-grep gate): `navTabGate.test.ts` references a removed `BRAND_ROLE_RANK.account_owner` (TS error) — flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)