### PR TITLE
Close ORCH-1061: curated stop quality blend + deterministic activity rotation + solo open-hours gate

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1332,6 +1332,20 @@ function checkNoNewBackendFiles() {
   const ORCH_1040_BACKEND_ALLOWLIST = [
     "supabase/migrations/20260814000000_orch_1040_brand_has_physical_location.sql",
   ];
+  // ORCH-1061 [Curated stop variety + quality blend + solo hours gate].
+  // C7 is scoped to ORCH-0863 marketing; these backend touches are ORCH-1061
+  // scope: the extracted shared curated-hours module + its tests + the curated
+  // generator's new blend/rotation tests. (No migration — pure edge-fn logic.)
+  // The two MODIFIED index.ts (generate-curated-experiences, discover-cards) are
+  // not new files, so C7 (no-new-backend-files) does not fire on them.
+  // Per COMMS-0002.
+  const ORCH_1061_BACKEND_ALLOWLIST = [
+    "supabase/functions/_shared/curatedStopHours.ts",
+    "supabase/functions/_shared/__tests__/curatedStopHours.test.ts",
+    "supabase/functions/_shared/__tests__/curatedStopHours.adversarial.test.ts",
+    "supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts",
+    "supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_rotation.adversarial.test.ts",
+  ];
   // ORCH-1032 [Intelligence pipeline concurrency cap + chunked enqueue]:
   // adds the additive 'queued'-status migration (status CHECK widen + per-city
   // unique active index widen + tg_kick_pending_trial_runs promotion built on
@@ -1498,6 +1512,7 @@ function checkNoNewBackendFiles() {
     ...META_ORCH_1009_SUB_E_BACKEND_ALLOWLIST,
     ...ORCH_1030_BACKEND_ALLOWLIST,
     ...ORCH_1040_BACKEND_ALLOWLIST,
+    ...ORCH_1061_BACKEND_ALLOWLIST,
   ];
   const forbidden = changed.filter(
     (p) =>

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md
@@ -1,0 +1,242 @@
+# IMPLEMENTATION REPORT — ORCH-1061 [Curated stop variety + quality blend + solo hours gate]
+
+**Status:** implemented and verified
+**Author:** mingla-implementor (Claude)
+**Date:** 2026-06-02
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1061-[curated-variety-quality]/` on branch `ORCH-1061-curated-variety-quality`
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md` (`ab839a953`)
+**Base:** branched from `origin/main` `ef88b93c2`; pre-fix HEAD = SPEC commit `ab839a953`.
+**Implement commit:** `aba3d22b7` (+ lint-cleanup follow-up commit; see Files changed).
+
+---
+
+## 0. Layman summary
+
+Three backend changes to the consumer "curated" outing cards (the multi-stop
+Romantic / First Date / Adventurous / Group Fun / Take-a-Stroll / Picnic plans):
+
+1. Stops after the anchor now pick a **good place that's also close** (60% quality
+   / 40% proximity blend) instead of just the nearest.
+2. The order the plan combos are tried is now **deterministic** (was a random
+   shuffle that broke collaborative decks) and **rotates the main activity** card-
+   to-card so the deck shows variety.
+3. **Solo** curated cards now get the same **"is this place open when I'd arrive?"**
+   filter that collaborative cards already had — and that filter was fixed so it
+   actually reads the real (Google v1 `periods`) hours shape.
+
+No combo expansion, no DB migration, no client/app-mobile changes, no new external API.
+
+---
+
+## 1. Comms ledger
+
+Read on entry. Acknowledged **COMMS-0002** (ORCH-0863 strict-grep backend allowlist
+— added `ORCH_1061_BACKEND_ALLOWLIST`, gate green) and **COMMS-0003** (external-API
+docs — this ORCH introduces NO new external-API calls; PART 1A/1B are pure
+arithmetic, PART 2 parses internally-stored hours strings). Both were WARN+OPEN to
+ALL and already factored in spec §9/§10.
+
+---
+
+## 2. Files changed (Old → New receipts)
+
+### `supabase/functions/_shared/curatedStopHours.ts` (NEW)
+**Before:** did not exist.
+**Now:** single source of truth for the curated open-hours cascade. Exports
+`parseSingleRange`, `parseHoursText`, `hourInRanges`, `DAY_NAMES`,
+`CURATED_STOP_DURATION`, `ALWAYS_OPEN_TYPES`, `isStopOpenAtHour`,
+`filterCuratedByStopHours`. The hours-text parsers + duration/always-open tables
+are extracted verbatim from `discover-cards/index.ts`. `isStopOpenAtHour` carries
+the **D-1 fix**: a 5-path cascade (ALWAYS_OPEN → no-object→open → Google v1
+`periods` → legacy `_periods` → text shape), honest-unknown → OPEN. Previously the
+reader only evaluated the legacy text shape, so it fell through to "assume open"
+for the ~99.9% periods-shape rows.
+**Why:** spec §6.2 (single source of truth, Constitution #6) + D-1 (OQ-3 ACCEPTED).
+**Lines:** ~235.
+
+### `supabase/functions/discover-cards/index.ts` (MODIFIED)
+**Before:** defined its own `parseSingleRange`/`parseHoursText`/`hourInRanges`/
+`DAY_NAMES` (147-221) AND its own curated-specific `CURATED_STOP_DURATION`/
+`ALWAYS_OPEN_TYPES`/`isStopOpenAtHour`/`filterCuratedByStopHours` (464-532). The
+curated reader was text-only (D-1 bug). `filterByDateTime` used the local parsers.
+**Now:** imports all eight symbols from `_shared/curatedStopHours.ts`; the local
+definitions are deleted. `filterByDateTime` and both `filterCuratedByStopHours`
+call sites (lines ~1363 + ~2150) now resolve to the shared (D-1-fixed) versions —
+option (a) per spec §6.3 (ONE parser shared by curated + filterByDateTime).
+**Why:** spec §6.3 single-source-of-truth + D-1.
+**Lines:** ~145 deleted, ~25 added (imports + comments).
+
+### `supabase/functions/generate-curated-experiences/index.ts` (MODIFIED)
+**Before:** post-anchor stops picked by pure-nearest `selectClosestHighestRated`
+(both branches); combo ordering via `Math.random` `shuffle()`; `batchSeed`
+destructured but never passed to `generateCardsForType`; NO open-hours filter
+anywhere (solo gap); `buildCardFromStops` set no card-level `utcOffsetMinutes`/
+`lat`/`lng`; `serve()` ran unconditionally at module load.
+**Now:**
+- **PART 1A:** added pure `selectBlendedStop(available, refLat, refLng, radiusMeters)`
+  (0.60 quality / 0.40 proximity; quality = 0.75 vibe-rank-norm + 0.25 rating×log-
+  review) + deterministic `tieBreakWins` chain (_rankScore → rating → review_count
+  → lexicographic google_place_id). Both post-anchor call sites repointed
+  (standard branch → `clampedRadius`; reverse-anchor branch → `3000`). The
+  pure-nearest `selectClosestHighestRated` is DELETED (re-grep confirmed it had no
+  other call site). First non-optional stop selection (`available[0]`) UNCHANGED.
+- **PART 1B:** added pure `mainActivitySlotIndex(typeDef)` + `buildDeterministicComboList(typeDef, batchSeed, limit)`; the `Math.random` shuffle ordering is replaced;
+  `shuffle()` is DELETED (unreferenced after the change). `batchSeed` threaded as a
+  new (default-0) parameter of `generateCardsForType` and passed at the handler call
+  site.
+- **PART 2:** imports `filterCuratedByStopHours` from the shared module; the handler
+  applies it after `generateCardsForType` returns (`curatedUtcNow = datetimePref ?
+  new Date(datetimePref) : new Date()`), with the empty→summary fallback.
+  `buildCardFromStops` now emits top-level `utcOffsetMinutes`/`lat`/`lng` (from the
+  first main stop) so the shared filter resolves the arrival timezone for solo cards
+  the same way it does for collab cards.
+- **Testability:** the handler is exported as `handler` and `serve(handler)` is
+  guarded by `import.meta.main` (mirrors check-launch-city / places-autocomplete).
+  Production behavior is identical (entry module → `import.meta.main` true);
+  Deno unit tests can import the pure helpers without starting the server. Exported
+  `selectBlendedStop`, `tieBreakWins`, `mainActivitySlotIndex`,
+  `buildDeterministicComboList`, `EXPERIENCE_TYPE_MAP` for tests.
+**Why:** spec PART 1A §4, PART 1B §5, PART 2 §6.4.
+**Lines:** ~+150 / ~-40.
+
+### `supabase/functions/_shared/__tests__/curatedStopHours.test.ts` (NEW)
+Implementor happy-path: T-2-01 (closed periods-shape stop dropped, fails-on-revert),
+T-2-02 (all-open retained), T-2-02b (no-hours → open), T-2 D-1 (periods read),
+empty-after-filter.
+
+### `supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts` (NEW)
+Implementor happy-path: T-1A-01 (quality-weighted, fails-on-revert), T-1A-03
+(deterministic), T-1A-05 (empty/single), T-1B-MAP (slot mapping), T-1B-01
+(deterministic ordering), T-1B-02 + T-1B-02b (rotation; stroll rotates food),
+T-1B-04 (picnic no rotation), T-1B-05 (batchSeed offset), T-2-07 (empty→summary).
+
+### `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` (MODIFIED)
+Added `ORCH_1061_BACKEND_ALLOWLIST` (5 NEW files) + spread (COMMS-0002).
+
+---
+
+## 3. Spec traceability (success criteria)
+
+| SC | Status | Evidence |
+|---|---|---|
+| SC-1A-1 quality-weighted pick | PASS | T-1A-01 (farther high-quality beats closer weak) |
+| SC-1A-2 deterministic | PASS | T-1A-03 |
+| SC-1A-3 first stop unchanged | PASS | call-site diff: `isFirstMainStop ? available[0] : selectBlendedStop(...)` |
+| SC-1A-4 null/single guards | PASS | T-1A-05 |
+| SC-1B-1 deterministic ordering | PASS | T-1B-01 |
+| SC-1B-2 main activity rotates | PASS | T-1B-02 |
+| SC-1B-3 stroll rotates food, nature constant | PASS | T-1B-02b |
+| SC-1B-4 picnic no rotation | PASS | T-1B-04 |
+| SC-1B-5 batchSeed changes start offset | PASS | T-1B-05 |
+| SC-1B-6 slot mapping | PASS | T-1B-MAP |
+| SC-2-1 solo closed stop dropped | PASS | T-2-01 (fails-on-revert) |
+| SC-2-2 all-open retained | PASS | T-2-02 |
+| SC-2-3 no-hours → open | PASS | T-2-02b |
+| SC-2-4 D-1 periods detected | PASS | T-2 D-1 |
+| SC-2-5 collab/non-curated preserved | PASS | discover-cards regression suite (39 tests) |
+| SC-2-6 empty→summary verdict | PASS | T-2-07 + handler fallback |
+| SC-2-7 single source of truth | PASS | grep: defined only in `_shared/curatedStopHours.ts` |
+
+---
+
+## 4. Regression tests + fails-on-revert evidence
+
+Runner: Deno 2.7.14 (`/Users/sethogieva/.deno/bin/deno`).
+
+**All new + affected tests:** `61 passed | 0 failed` (5 curatedStopHours + 10
+blend/rotation + 4 curated passthrough + 39 discover-cards regression − overlaps).
+
+### Fails-on-revert (pre-fix base `ab839a953`)
+
+**T-1A-01** — temporarily reverted `selectBlendedStop` to pure-nearest (haversine
+min). Result: `T-1A-01 ... FAILED` (pure-nearest picked the closer weak candidate
+`A_close_weak` instead of `B_far_strong`). Restored → `T-1A-01 ... ok`.
+
+**T-2-01** — temporarily reverted the D-1 fix (removed Path A `periods` + Path B
+`_periods` from `isStopOpenAtHour`, leaving the text-only reader = pre-fix
+behavior). Result: `T-2-01 ... FAILED` (the closed periods-shape card slipped
+through → retained), plus `T-2 D-1` and the all-closed-empties test also failed.
+Restored → all `ok`. Revert method: in-place edit + re-run; base SHA `ab839a953`.
+
+### Discover-cards non-curated path (T-2-06)
+
+`orch_0903`, `orch_0906`, `orch_0909` (×2), `collab_determinism_under_ai_blend`:
+`39 passed | 0 failed` — proves the extraction did not break `filterByDateTime` or
+the collab determinism contract.
+
+---
+
+## 5. /goal self-assessment
+
+1. **Every SC implemented + demonstrated** — YES (§3 table, all PASS).
+2. **Regression test green + fails-on-revert** — YES (T-1A-01 + T-2-01 both proven
+   fail-on-revert at base `ab839a953`, restored green).
+3. **`deno check` clean on both touched edge fns; new test files lint-clean** — YES
+   (`deno check` green on both index.ts; `deno lint` clean on the two new test
+   files). NOTE: `deno lint` is NOT a CI gate for `supabase/functions/` (baseline
+   discover-cards/index.ts has 53 pre-existing `no-explicit-any` findings — the
+   edge-fn house style uses `any`). The new shared module uses `any` for `stop`/
+   `cards` to match the byte-for-byte extraction from discover-cards + house style;
+   `deno check` (the real type gate) passes.
+4. **Constitution scan** — PASS. #3 (no silent failures: filter is pure, no
+   swallowed catches), #6 (single source of truth: hours cascade in one file),
+   #9 (honest-unknown: no-hours → open, never fabricate closed; `isOpenNow` still
+   null when unknown). No UI/RLS/migration layers touched.
+5. **Edge fn deploy + verify-first-call** — DEFERRED to orchestrator per dispatch
+   (implementor must NOT deploy). Both `generate-curated-experiences` and
+   `discover-cards` need redeploy (the new `_shared/curatedStopHours.ts` bundles
+   into both). See §7.
+
+All four in-scope clauses hold; clause 5 is the orchestrator-owned deploy.
+
+---
+
+## 6. Preserved gates (spec §7)
+
+All preserved — none touched: `filterMin`, G3 photo gate, fine-dining ≥'bougie'
+floor (runs in the `available` filter BEFORE selection), first-stop travel
+≤constraint×1.5, dedup (`comboUsedIds` + `globalUsedPlaceIds`), reverse-anchor
+failed-anchor cycle (`selectBlendedStop` returns null exactly where
+`selectClosestHighestRated` did), empty→summary verdicts (extended for the hours-
+empty case). **Collab determinism (I-COLLAB-DECK-DETERMINISM):** NET IMPROVEMENT —
+the only request-time `Math.random` in the ordering/selection path (the shuffle)
+was REMOVED; blend + rotation are pure functions of request inputs.
+
+**Display-only `Math.random` left untouched (spec §5.5):** tagline pick in
+`buildCardFromStops`, the per-card `id` suffix, and the cosmetic `matchScore`. None
+affect deck card ordering/identity/selection, so collab determinism is unaffected.
+
+---
+
+## 7. Deploy notes (orchestrator-owned — DO NOT deploy from implementor)
+
+After CLOSE promotes to main, redeploy BOTH (the new shared module bundles into both):
+```
+supabase functions deploy generate-curated-experiences --project-ref gqnoajqerqhnvulmnyvv
+supabase functions deploy discover-cards --project-ref gqnoajqerqhnvulmnyvv
+```
+No `supabase db push` — zero migrations in this ORCH.
+
+---
+
+## 8. Discoveries for orchestrator
+
+- **`import.meta.main` guard added to generate-curated-experiences** to make the
+  pure helpers unit-testable. This is the established codebase pattern
+  (check-launch-city etc.) and is production-safe, but it is a structural change to
+  the entry module worth noting for the tester's smoke pass.
+- **D-1 fix now actually filters collab curated decks too.** Before this ORCH the
+  collab curated-hours filter was a near-no-op (text-only reader vs periods-shape
+  data). After the fix, collab decks will now drop closed-on-arrival curated cards
+  that previously slipped through — expected + correct, but it is a real behavior
+  change on the collab path, not just solo. Tester should eyeball that collab
+  curated decks aren't over-pruned.
+
+---
+
+## 9. Cross-surface impact
+
+Consumer iOS + Consumer Android only (covered, parity automatic — shared edge fn,
+zero client code). Buyer-web / Business iOS / Business Android / Admin / Business-
+web-preview: not affected (no curated deck surface). Tester must still eyeball a
+real curated deck on one iOS sim AND one Android emulator per the parity rule.

--- a/Mingla_Artifacts/reports/QA_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md
@@ -1,0 +1,172 @@
+# QA REPORT — ORCH-1061 [Curated stop variety + quality blend + solo hours gate]
+
+**Status:** COMPLETE
+**Author:** mingla-tester (Claude)
+**Date:** 2026-06-02
+**Mode:** TARGETED (server-only / edge-function change)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1061-[curated-variety-quality]/` on branch `ORCH-1061-curated-variety-quality`
+**Implement commits:** `aba3d22b7` (logic) + `b62753063` (lint-clean tests/report)
+**Test commit (this phase):** `fec7d3f9e` (adversarial deno tests + QA)
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md`
+**Implementation report:** `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md`
+
+---
+
+## VERDICT: PASS
+
+- **P0:** 0 | **P1:** 0 | **P2:** 0 | **P3:** 1 (pre-existing, inherited — not introduced by this ORCH) | **P4:** 2 (praise)
+- **Regression tests:** implementor = `orch_1061_blend_and_rotation.test.ts` + `curatedStopHours.test.ts` (15 tests, happy-path, implementor fails-on-revert cited at base `ab839a953`); tester = `orch_1061_blend_rotation.adversarial.test.ts` + `curatedStopHours.adversarial.test.ts` (10 tests, adversarial — different angles). Both sides present in `git diff origin/main...HEAD --name-only`.
+- **Sim evidence:** EXEMPT — backend/edge-function-only change (Phase 0.A exemption). No client code changed. The live new-behavior smoke is a POST-DEPLOY operator-assisted step (edge fns not yet deployed; prod still runs old logic). See §6.
+
+---
+
+## 1. Comms ledger
+
+Read on entry. Acknowledged **COMMS-0002** (ORCH-0863 strict-grep backend allowlist — my two adversarial filenames are already in the `ORCH_1061_BACKEND_ALLOWLIST` block at gate lines 1345 + 1347; the gate runs GREEN, C7 reports 0 offenders) and **COMMS-0003** (external-API docs — N/A; this ORCH introduces no external-API enum/payload/endpoint; PART 1A/1B are pure arithmetic, PART 2 parses internally-stored hours strings). No new ledger entry needed — no cross-ORCH discovery.
+
+---
+
+## 2. Independent test results (re-run, not trusted from the report)
+
+Runner: Deno 2.7.14 (`/Users/sethogieva/.deno/bin/deno`), `--allow-read --allow-env --no-check`.
+
+| Suite | Tests | Result |
+|---|---|---|
+| `orch_1061_blend_and_rotation.test.ts` (implementor happy) | 10 | 10 passed |
+| `curatedStopHours.test.ts` (implementor happy) | 5 | 5 passed |
+| `orch_1061_blend_rotation.adversarial.test.ts` (tester) | 5 | 5 passed |
+| `curatedStopHours.adversarial.test.ts` (tester) | 5 | 5 passed |
+| `discover-cards/__tests__/` regression (T-2-06) | 48 | 48 passed |
+| **TOTAL (single combined run)** | **73** | **73 passed / 0 failed** |
+
+- `deno check` clean on `_shared/curatedStopHours.ts`, `generate-curated-experiences/index.ts`, `discover-cards/index.ts`, and both new adversarial test files.
+- `deno lint` clean on both new adversarial test files.
+- `deno lint` is NOT a CI gate for `supabase/functions/` (baseline `no-explicit-any` house style); `deno check` is the real type gate and passes.
+
+### 2.1 Tester adversarial coverage (different angle than implementor)
+
+| Test | Angle attacked (distinct from happy-path) |
+|---|---|
+| T-1A-02 | Pure-nearest would have **decisively lost** — nearest candidate is the **worst** (on-top, lowest rank/rating), proving the blend changed the pick, not just tie-broke. 3-element realistic pool. |
+| T-1A-04 | The **full** tie-break chain — every rung exercised individually (`_rankScore` dominates rating+reviews; rating beats review_count; review_count; lexicographic id final arbiter; total-tie stability) + end-to-end order-independence through `selectBlendedStop`. |
+| T-1B-03 | Proves rotation is the **FOOD slot, NOT the anchor** — anchor constant across the whole list (5 seeds), all 3 foods appear, adjacent foods differ. Attacks the "accidentally rotated nature" failure. |
+| T-1B-05 | Start offset follows the locked `seed % groupCount` formula (independently predicted), across 7 seeds, plus **negative/NaN seed coercion** determinism (collab-agg defense). |
+| T-1B-06 | Source-grep: NO `Math.random(` call in `buildDeterministicComboList`/`mainActivitySlotIndex`/`selectBlendedStop`/`tieBreakWins` (comment-stripped); `shuffle()` deleted; comboList built by the deterministic builder. (I-COLLAB-DECK-DETERMINISM) |
+| T-2-03 | Honest-unknown across **every** no-data shape (absent / empty object / null / string / empty-periods-array / missing-day-text / ALWAYS_OPEN). Attacks the "fabricate closed" failure (Constitution #9). |
+| T-2-04 | D-1 periods CLOSED detection + **boundary correctness** (open at 09:00, closed at 17:00 half-open) + **wrong-day** closed + legacy `_periods` + explicit "Closed" text. Fails-on-revert. |
+| T-2-04b | A **downstream** stop closed at projected arrival (after dwell+travel accumulation) drops the card; control proves no over-pruning. |
+| T-2-05 | Single source of truth — neither consumer redefines the cascade; both import the shared module. |
+| T-2-01 | Solo handler **wiring** fails-on-revert — the load-bearing `cards = filterCuratedByStopHours(...)` call + start-time source + empty-summary fallback. |
+
+---
+
+## 3. Fails-on-revert proofs (performed BY the tester, this phase)
+
+I independently reverted each of the two highest-risk production changes, ran the dependent test, observed FAIL, restored, observed PASS. Production code is byte-identical to HEAD afterward (verified `git status --short` shows ONLY the two new untracked/committed adversarial test files; no production file modified).
+
+### 3.1 T-2-04 — D-1 periods-shape fix (`_shared/curatedStopHours.ts`)
+
+- **Revert method:** in-place edit — deleted Path A (`periods`) + Path B (`_periods`) blocks from `isStopOpenAtHour`, leaving the pre-fix text-only reader. Backup `/tmp/curatedStopHours.ts.bak`; base HEAD = `aba3d22b7`.
+- **Reverted run:** `T-2-04 ... FAILED` + `T-2-04b ... FAILED` — `AssertionError: D-1: periods-shape stop closed at 18:00 must read CLOSED (pre-fix: false-OK open)`. With Path A/B gone, the closed periods-shape stop falls through to honest-unknown → OPEN → card NOT dropped (the exact bug).
+- **Restored run:** `4 passed | 0 failed`. `git diff --stat` on the file = empty (byte-identical).
+
+### 3.2 T-2-01 — solo `filterCuratedByStopHours` wiring (`generate-curated-experiences/index.ts`)
+
+- **Revert method:** in-place edit — replaced the handler line `cards = filterCuratedByStopHours(cards, curatedUtcNow);` with `void curatedUtcNow;` (the solo gap as it existed pre-ORCH). Backup `/tmp/gce-index.ts.bak`.
+- **Baseline (real wiring):** `T-2-01 ... ok`.
+- **Reverted run:** `T-2-01 ... FAILED` — `AssertionError: solo handler must call cards = filterCuratedByStopHours(cards, ...) — removing this reverts the solo gap`.
+- **Restored run:** `5 passed | 0 failed`. `git status --short` confirms no production file modified.
+
+(The implementor additionally cited fails-on-revert for T-1A-01 + T-2-01 at base `ab839a953` in the implementation report §4 — I did not re-run those, but independently proved the two highest-risk cases above.)
+
+---
+
+## 4. Production-diff independent confirmations (re-read `git show aba3d22b7`)
+
+| Required confirmation | Result | Evidence |
+|---|---|---|
+| (a) First non-optional stop selection UNCHANGED | CONFIRMED | `index.ts:915-918` — `isFirstMainStop ? available[0] : selectBlendedStop(...)`. PART 1A touches only the `else` (post-anchor) branch in both the standard (`clampedRadius`) and reverse-anchor (`3000`) call sites. |
+| (b) No request-time `Math.random` in ordering/selection path (I-COLLAB-DECK-DETERMINISM) | CONFIRMED | `selectBlendedStop`, `tieBreakWins`, `buildDeterministicComboList`, `mainActivitySlotIndex` are pure; `shuffle()` deleted. The 3 remaining `Math.random` uses (tagline pick L621, card `id` suffix L637, cosmetic `matchScore` L657) are display/identity-noise, do NOT affect deck ordering/place selection — carved out by spec §5.5 and verified by T-1B-06. **Net improvement to determinism** (the shuffle was the only ordering randomness; it's gone). |
+| (c) Every preserved gate (spec §7) still fires | CONFIRMED | filterMin + G3 photo → `signalRankFetch.ts` NOT in the diff (untouched). Fine-dining ≥'bougie' floor → `index.ts:898` inside the `available` filter BEFORE selection. Per-stop budget → `index.ts:895`. Travel constraint ×1.5 → `index.ts:955`. Dedup (`comboUsedIds`/`globalUsedPlaceIds`/`failedAnchorIds`) → `index.ts:768/775/796/810/823/853`. Reverse-anchor failed-anchor cycle → `index.ts:860/870`. Empty→summary → preserved + extended for hours-empty. |
+| (d) Hours cascade in EXACTLY ONE file | CONFIRMED | `function isStopOpenAtHour`/`filterCuratedByStopHours`/`parseHoursText`/`parseSingleRange`/`hourInRanges` defined ONLY in `_shared/curatedStopHours.ts`. `discover-cards` imports all 8 symbols; `generate-curated` imports `filterCuratedByStopHours`. No duplicate defs (verified by grep + tester T-2-05). |
+
+---
+
+## 5. Constitution scan (14 rules)
+
+| Rule | Verdict | Note |
+|---|---|---|
+| #2 One owner per truth | PASS | Hours cascade now single-source in `_shared/curatedStopHours.ts`. |
+| #3 No silent failures | PASS | Filter is pure; no swallowed catches added. |
+| #6 (single source of truth, per spec usage) | PASS | One parser shared by curated + `filterByDateTime`. |
+| #9 No fabricated data | PASS | Honest-unknown → OPEN (never fabricate closed); `isOpenNow` stays null when unknown. Verified by adversarial T-2-03. |
+| #13 Exclusion consistency | PASS | Solo + collab now share the SAME hours cascade; generation/serving aligned. |
+| Others (#1,#4,#5,#7,#8,#10,#11,#12,#14) | N/A | No UI / state / auth / currency / hydration / dead-tap surface touched (server-only). #7: no `[TRANSITIONAL]` dead code — `selectClosestHighestRated` + `shuffle()` were DELETED, not left dangling. |
+
+---
+
+## 6. Cross-platform / forward-compat assessment
+
+**Affected surfaces:** Consumer iOS + Consumer Android only (shared edge fn, zero client code). Parity automatic.
+
+### 6.1 Payload-forward-compat (source-verifiable, HIGH confidence)
+
+The change adds three additive top-level fields to the curated card: `utcOffsetMinutes`, `lat`, `lng` (`buildCardFromStops`, from the first main stop).
+
+- `app-mobile/src/types/curatedExperience.ts` `CuratedExperienceCard` is a plain TS `interface` consumed from JSON. It does NOT declare the new fields, but TS interfaces are structurally open at runtime — extra JSON keys are ignored.
+- `app-mobile/src/services/deckService.ts` consumes `response.cards` by reading named fields. **No runtime schema validation** (verified: zero `zod`/`safeParse`/`Object.keys`-iteration/`assertCurated` in deckService) → unknown top-level keys cannot crash the parser or renderer.
+- `utcOffsetMinutes` already exists at the STOP level (`CuratedStop.utcOffsetMinutes`) — the concept is familiar; only the card top-level is new.
+- The client already sends `datetimePref` + `batchSeed` (confirmed at the deckService call site), so PART 1B/PART 2 inputs require no client change.
+
+**Conclusion:** the additive fields are forward-compatible with the existing mobile parser. **Confidence: HIGH** (this is type/serialization source-reasoning under the backend-only exemption, not a UI/runtime behavior claim).
+
+### 6.2 Live new-behavior smoke — POST-DEPLOY operator-assisted (NOT faked)
+
+The new behavior (quality-blended stops, deterministic rotation, solo hours filtering) only manifests once `generate-curated-experiences` + `discover-cards` are DEPLOYED. The orchestrator deploys post-merge; the tester must NOT deploy. Prod currently runs the OLD logic, so a sim run today would only confirm the existing deck renders (a regression check against unchanged prod behavior), not the new behavior. Per the simulator-repro rule, source-only reasoning caps at "suspected" for runtime — so I am explicitly marking the live new-behavior verification as a **post-deploy operator step**, NOT claiming a sim repro I did not perform.
+
+**Recommended post-deploy smoke (for the orchestrator/operator):** after deploying both edge fns, open a curated deck on an iOS sim AND an Android emulator; confirm (1) the deck still renders with no crash, (2) consecutive cards of the same intent show different main activities (rotation), (3) at a late `datetimePref` (e.g. 23:00) curated cards with closed stops are pruned (solo hours gate). Also eyeball that collab curated decks are not OVER-pruned (the D-1 fix now actually filters collab periods-shape rows — implementation report §8 flagged this expected behavior change on the collab path).
+
+---
+
+## 7. Findings
+
+### P3-01 (PRE-EXISTING, inherited — NOT introduced by this ORCH) — `filterCuratedByStopHours` does not advance the day across midnight
+`filterCuratedByStopHours` (`_shared/curatedStopHours.ts:206-219`) advances `currentHour` cumulatively but never advances `localDay`. A multi-stop curated plan that crosses local midnight evaluates the later stop's hours against the START day. This is extracted **byte-for-behavior** from the original `discover-cards` implementation (spec §6.2 mandates verbatim extraction) — it is PRESERVED behavior, not a regression. The overnight wraparound IS handled within a single day (`closeH += 24`), so the typical evening outing is correct; only a plan spanning past 24:00 into the next calendar day is affected. **Recommendation:** out of scope for ORCH-1061 (would change behavior the spec locked as a pure move); register as a future hardening ORCH if curated plans routinely cross midnight. Does NOT block.
+
+### P4-01 (praise) — Tie-break determinism is textbook
+`tieBreakWins` gives a fully-ordered, pool-independent arbiter (down to lexicographic `google_place_id`), so `selectBlendedStop` is order-independent — exactly what the collab-determinism contract needs. Verified order-independent in T-1A-04.
+
+### P4-02 (praise) — `import.meta.main` testability guard
+Exporting `handler` + guarding `serve(handler)` behind `import.meta.main` (matching check-launch-city) made the pure helpers unit-testable without booting the HTTP server, with zero production behavior change (entry module → `import.meta.main` true). Clean, idiomatic.
+
+---
+
+## 8. Spec success-criteria compliance (independently verified)
+
+All 17 SCs (SC-1A-1..4, SC-1B-1..6, SC-2-1..7) verified PASS — each backed by a re-run test (happy and/or adversarial) listed in §2, plus the production-diff confirmations in §4. The implementor's §3 traceability table is accurate; I re-ran every cited test rather than trusting the table.
+
+---
+
+## 9. /goal self-assessment (machine-verified, not honor-system)
+
+1. **Every independent test green — paths + output captured** — YES. 73/73 in a single combined run (§2); output captured.
+2. **`deno check` clean + lint clean on touched files** — YES. `deno check` green on all 3 production files + both adversarial tests; `deno lint` clean on both adversarial tests (the real CI gate for edge fns is `deno check`). Output captured.
+3. **Both regression tests in `git diff origin/main...HEAD --name-only`; adversarial attacks a different angle; implementor fails-on-revert at a cited commit** — YES. All four test files present in the diff (§verified); adversarial angles distinct (§2.1); implementor fails-on-revert cited at `ab839a953`; tester independently proved fails-on-revert for the two highest-risk cases at HEAD `aba3d22b7` (§3).
+4. **UI/runtime platform legs at `proven`** — N/A by exemption. Backend/edge-function-only change (Phase 0.A exemption); zero client code. Forward-compat assessed source-only at HIGH confidence (§6.1); live new-behavior smoke explicitly deferred to a POST-DEPLOY operator step, not faked (§6.2).
+5. **Zero open P0 and zero open P1** — YES. 0 P0, 0 P1. The single P3 is pre-existing inherited behavior the spec locked as a verbatim move.
+
+All five clauses hold → **PASS**.
+
+---
+
+## 10. Discoveries for orchestrator
+
+- **D-1 fix changes the COLLAB path too** (not just solo): before this ORCH the collab curated-hours filter was a near-no-op (text-only reader vs periods-shape data). After deploy, collab curated decks will now correctly drop closed-on-arrival cards that previously slipped through. Expected + correct, but it IS a real behavior change on the collab path — the post-deploy smoke (§6.2) should confirm collab decks are not over-pruned.
+- **Deploy ordering:** both `generate-curated-experiences` AND `discover-cards` must be redeployed together (the new `_shared/curatedStopHours.ts` bundles into both). No `supabase db push` (zero migrations).
+- **Pre-existing midnight-rollover behavior** (P3-01) preserved verbatim — candidate for a future hardening ORCH, not a blocker here.
+
+---
+
+## 11. Routing
+
+Route back to **mingla-orchestrator (CLOSE)**: rebase onto current `origin/main`, run the pre-merge gate (all required checks green incl. ORCH-0863 strict-grep, mergeable CLEAN, not BEHIND), `--squash` merge, confirm `origin/main` advanced to the squash commit + content probe, THEN deploy `generate-curated-experiences` + `discover-cards` from updated main (per COMMS-0015 / ship-verify-merge-before-reap), THEN run the post-deploy smoke (§6.2), THEN reap.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1061_CURATED_VARIETY_QUALITY_SOLO_HOURS.md
@@ -1,0 +1,482 @@
+# SPEC — ORCH-1061 [Curated stop variety + quality blend + solo hours gate]
+
+**Status:** READY FOR IMPLEMENT
+**Author:** mingla-forensics (SPEC mode)
+**Date:** 2026-06-02
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1061-[curated-variety-quality]/` on branch `ORCH-1061-curated-variety-quality` (branched from `origin/main` `ef88b93c2`)
+**Affected surfaces:** Consumer iOS + Consumer Android only (delivered via the edge function; zero client code in scope). NOT business/admin/buyer-web.
+
+---
+
+## 0. Layman summary
+
+Three tightly-scoped backend changes to the consumer "curated" outing cards (the multi-stop Romantic / First Date / Adventurous / Group Fun / Take-a-Stroll / Picnic plans on the swipe deck):
+
+1. **PART 1A** — Stops after the anchor are currently picked by *nearest only*, ignoring quality. Change them to a **60% quality / 40% proximity blend** so the second/third stop is a good place that's also reasonably close, not just whatever is physically closest.
+2. **PART 1B** — The order combos are tried is currently a `Math.random` shuffle (non-deterministic, breaks collab decks). Replace it with a **deterministic ordering seeded off `batchSeed`** that (a) rotates the intent's *main activity* across cards so the deck shows variety, and (b) descends quality.
+3. **PART 2** — Solo curated cards never get the "is this place open when I'd arrive?" filter that collab cards already get. **Extract the open-hours cascade into a shared module** so both solo and collab inherit it from inside `generate-curated-experiences`.
+
+**Hard scope guard:** NO combo expansion. Combos and intents are frozen exactly as they are today.
+
+---
+
+## 1. Investigation basis — CONFIRMED by re-read
+
+Every cite below was re-read in this worktree (not taken on faith). Line numbers are the current state of `supabase/functions/generate-curated-experiences/index.ts` unless noted.
+
+| Claim | Confirmed location | Note |
+|---|---|---|
+| 6 experience types + combos | `index.ts:207-355` (`EXPERIENCE_TYPES`) | Actual combo counts: Adventurous **6**, First Date **5**, Romantic **2**, Group Fun **5**, Picnic **1**, Take-a-Stroll **3**. (Dispatch said "22 combos" — actual total is **22** ✓: 6+5+2+5+1+3=22.) |
+| First non-optional stop = `available[0]` (top by vibe rank) | `index.ts:894-896` (`isFirstMainStop ? available[0] : …`) | Optional stops reached before it also use the `available` filter; flowers (optional) is selected at `index.ts:885` skip-or-take but is itself `available[0]`-ordered upstream. |
+| Every later stop = `selectClosestHighestRated` (pure nearest) | standard branch `index.ts:897`; reverse-anchor branch `index.ts:847` | Function at `index.ts:1036-1054` — pure haversine nearest; rating/quality IGNORED despite the misleading name. |
+| Combo order = `Math.random` shuffle ×(limit\*2) | `index.ts:741-746` via `shuffle()` at `index.ts:1016-1023` | `shuffle` uses `Math.floor(Math.random()*…)`. |
+| `globalUsedPlaceIds` per-request, accumulates across all cards | declared `index.ts:750`; seeded per-card `index.ts:778`; updated `index.ts:983-986` | Anchor descends best→2nd→3rd across cards because each card seeds `comboUsedIds` from the global set. |
+| Vibe rank overrides | `index.ts:403-461` (`EXPERIENCE_RANK_SIGNAL_OVERRIDE`) | resolver `resolveStopRankSignal` `index.ts:467-469`. |
+| Candidate fetch carries `_rankScore` | `fetchSinglesForSignalRank` → RPC `fetch_local_signal_ranked`; helper `_shared/signalRankFetch.ts:257-406` | Row shape `SignalRankResult` (`signalRankFetch.ts:40-70`) carries `_rankScore` (number), `rating` (number), `review_count` (number), `lat`, `lng`. Rows arrive **sorted by `_rankScore` DESC then sliced to `limit`** (`signalRankFetch.ts:402-403`). |
+| Reverse-anchor (picnic) finds Picnic Spot first, fetches others within 3km | `index.ts:783-866`; per-card near-fetch radius `3000` `index.ts:814` | Anchor stop built directly (`index.ts:823-831`); companions via `selectClosestHighestRated` (`index.ts:847`). |
+| Each stop carries honest `isOpenNow`/`openingHours`/`utcOffsetMinutes` | `buildCardStop` `index.ts:567-575` | `isOpenNow` null when unknown (Constitution #9). `openingHours` = `card.opening_hours || {}`. `utcOffsetMinutes` = `card.utc_offset_minutes ?? null`. |
+| **Solo path** = DIRECT call to generate-curated-experiences, NO hours filter | client `app-mobile/src/services/deckService.ts:570-581` (`skipDescriptions:true`, `batchSeed`, `datetimePref` all sent) | This edge fn applies **no** open-hours filter anywhere. Confirmed by full read. |
+| **Collab path** = via discover-cards, which DOES apply `filterCuratedByStopHours` | `discover-cards/index.ts:1363`; helpers `isStopOpenAtHour` `460-502`, `filterCuratedByStopHours` `504-532`, `CURATED_STOP_DURATION` `464-478`, `ALWAYS_OPEN_TYPES` `480-485`, `parseHoursText`/`hourInRanges`/`parseSingleRange` `147-219` | `curatedUtcNow = agg.datetimePref ? new Date(agg.datetimePref) : new Date()` (`discover-cards/index.ts:1362`). |
+| `batchSeed` is a request param | handler destructure `index.ts:1261` (`batchSeed = 0`) | **NEW FINDING:** `batchSeed` is destructured but is **NOT** currently passed into `generateCardsForType` (single call site `index.ts:1351-1356`). Today the function never sees it. PART 1B must thread it through as a new parameter. |
+
+### 1.1 Discoveries during this SPEC (registered, not silently fixed)
+
+- **D-1 (Hidden flaw, 🟡 — relevant to PART 2).** The collab curated-hours reader `isStopOpenAtHour` (`discover-cards/index.ts:487-502`) ONLY reads the **text-based** `openingHours[dayName]` shape (lowercase day key → `parseHoursText`). It does **NOT** handle the canonical Google v1 `openingHours.periods` array shape, unlike the sibling `filterByDateTime.isOpenAtHour` (`discover-cards/index.ts:285-335`) which checks `oh.periods` first. Since `place_pool.opening_hours` is the unwrapped Google v1 shape (`{ openNow, periods, weekdayDescriptions, … }` per the `[CRITICAL — ORCH-0641]` comment at `discover-cards/index.ts:263-276`), `isStopOpenAtHour` falls to its "no `dayText` → assume open" branch (`index.ts:497`) for ~99.9% of rows. **This means the collab curated-hours filter is largely a no-op today** — it only meaningfully filters the ~37 legacy text-shape rows. This is the SAME bug class ORCH-1019 fixed on the mobile client (see `I-CURATED-HOURS-VIA-CANONICAL-READER`). PART 2 of THIS spec MUST fix it while extracting (it would be malpractice to extract a broken reader into a shared module and ship it to the solo path too). The shared reader MUST handle `periods` first, then `_periods`, then text `weekdayDescriptions`/lowercase-day fallback — mirroring the all-shape-tolerant `filterByDateTime.isOpenAtHour`. Honest-unknown rule preserved: genuinely no data → assume open. See §5 PART 2 for the exact contract.
+
+---
+
+## 2. Scope, non-goals, assumptions
+
+### 2.1 In scope
+- `supabase/functions/generate-curated-experiences/index.ts` — the curated generator (PART 1A blend, PART 1B deterministic rotation, PART 2 hours filter call).
+- A NEW shared module `supabase/functions/_shared/curatedStopHours.ts` — extracted open-hours cascade (PART 2), imported by BOTH `discover-cards` and `generate-curated-experiences`.
+- `supabase/functions/discover-cards/index.ts` — repoint its existing `filterCuratedByStopHours` call to the shared module; delete the now-duplicated local helpers (PART 2 single-source-of-truth).
+- New Deno tests under `supabase/functions/generate-curated-experiences/__tests__/` and `supabase/functions/_shared/__tests__/`.
+- C7 backend allowlist + (optionally) a new strict-grep gate.
+
+### 2.2 Non-goals (explicit)
+- **NO combo expansion.** Romantic stays 2 combos, Picnic stays 1, etc. No combo/intent added, removed, or reordered in `EXPERIENCE_TYPES`.
+- **No change to the first-stop selection** (`available[0]` by vibe rank stays exactly as is — PART 1A touches ONLY post-first-non-optional-stop picks).
+- **No change to the candidate fetch / RPC / signal system** (`fetchSinglesForSignalRank`, `fetch_local_signal_ranked`, `EXPERIENCE_RANK_SIGNAL_OVERRIDE`, filter_min, primary-type gate all unchanged).
+- **No change to any preserved gate** (see §6).
+- **No client (`app-mobile`) code changes.** Solo client already sends `datetimePref` + `batchSeed`; it inherits the fix server-side. No mobile parity work.
+- **No new external-API calls.** (See §9.)
+- **No DB migration.** All three parts are pure edge-function logic over data the candidate rows already carry.
+
+### 2.3 Assumptions
+- `batchSeed` sent by the solo client (`deckService.ts:577` `batchSeed: params.batchSeed`) is a stable per-batch integer; collab path sets it via session aggregation OR defaults to 0. The rotation must be correct AND deterministic for `batchSeed=0` (default) too.
+- Candidate `_rankScore` is a non-negative number on the scale produced by `fetch_local_signal_ranked` (rank-signal score). `rating` ∈ [0,5], `review_count` ≥ 0. All may be 0; none are negative.
+- The 3km reverse-anchor companion fetch radius (`index.ts:814`) is the proximity-normalization denominator for the reverse-anchor branch; the standard branch uses `clampedRadius` (`index.ts:667`).
+
+---
+
+## 3. Cross-Surface Impact (MANDATORY)
+
+| Surface | Covered? | Behavior / files / parity |
+|---|---|---|
+| 1. Consumer iOS (`app-mobile` iOS) | YES | Curated deck cards get quality-blended post-anchor stops, deterministic main-activity rotation, and open-hours filtering. Parity is **automatic** — all logic is server-side in the edge fn; iOS calls the same edge fn. No iOS file touched. SC-1A/1B/2 apply. |
+| 2. Consumer Android (`app-mobile` Android) | YES | Identical to iOS — same edge fn, same payload. Parity **automatic**. No Android file touched. |
+| 3. Buyer/anon Web | NO | Buyer-web checkout/public pages do not render the curated deck. No curated pipeline exposure. |
+| 4. Business iOS | NO | Business app has no consumer curated deck. |
+| 5. Business Android | NO | Same as Business iOS. |
+| 6. Admin Web | NO | Admin does not render or generate curated cards. |
+| 7. Business Web preview | NO | No curated deck surface. |
+
+Because the only two covered surfaces both consume the SAME edge function with NO separate client code, parity is automatic and per-surface success criteria are identical. No manual per-surface (SC-N-iOS / SC-N-Android) split is required — but the tester MUST still confirm a real curated deck renders the new behavior on BOTH an iOS sim and an Android emulator (the edge fn is shared, but the *rendering* of the resulting payload must be eyeballed on each platform per the parity rule).
+
+---
+
+## 4. PART 1A — Quality-aware proximity blend for post-anchor stops
+
+### 4.1 Goal
+Replace pure-nearest `selectClosestHighestRated` (used for every stop AFTER the first non-optional stop) with a **proximity + quality blend**, default **60% quality / 40% proximity** (operator-approved knob). Deterministic. Used in BOTH branches (standard `index.ts:897`, reverse-anchor `index.ts:847`).
+
+### 4.2 New function (replaces `selectClosestHighestRated` usage)
+
+Add a new pure helper `selectBlendedStop(available, refLat, refLng, radiusMeters)` and route both post-anchor call sites through it. Do NOT delete `selectClosestHighestRated` yet if any OTHER call site exists — grep confirms it is used ONLY at `index.ts:847` and `index.ts:897`, so it MAY be deleted, but the implementor must re-grep at implement time and delete only if still unreferenced. If kept, it must not be silently left as dead code without a `[TRANSITIONAL]` marker (Constitution #7) — prefer deletion.
+
+#### 4.2.1 Quality sub-score `Q(p)` (🔒 LOCKED)
+
+Quality is a normalized 0..1 value derived from data the candidate already carries (`signalRankFetch.ts:40-70`):
+
+```
+// Primary: vibe rank score, normalized within THIS candidate set.
+// `available` arrived sorted by _rankScore DESC; normalize against the set's own max
+// so the scale is self-relative (rank scores differ wildly across signals).
+const rankMax = Math.max(...available.map(p => p._rankScore ?? 0), 0);
+const rankNorm = rankMax > 0 ? ((p._rankScore ?? 0) / rankMax) : 0;   // 0..1
+
+// Secondary: rating × log-dampened review_count, normalized 0..1.
+// rating/5 gives 0..1; review weight saturates so a 5.0 with 3 reviews
+// does not beat a 4.6 with 2,000 reviews.
+const ratingNorm = Math.min(Math.max((p.rating ?? 0) / 5, 0), 1);     // 0..1
+const reviewWeight = Math.min(Math.log10((p.review_count ?? 0) + 1) / 3, 1); // 0..1, saturates at 1000 reviews
+const ratingScore = ratingNorm * (0.5 + 0.5 * reviewWeight);          // 0..1; ratings with no reviews keep half weight
+
+// Quality = primary (vibe rank) dominant, rating/reviews as a secondary tie-shaper.
+const Q = 0.75 * rankNorm + 0.25 * ratingScore;                       // 0..1
+```
+
+Rationale: `_rankScore` IS the signal-tuned "is this the right vibe" measure the pipeline already trusts for the first stop; it must dominate quality. Rating/review is the secondary discriminator that the dispatch named. The 0.75/0.25 internal split of *quality* is LOCKED; it is distinct from the 60/40 quality-vs-proximity blend below.
+
+#### 4.2.2 Proximity sub-score `P(p)` (🔒 LOCKED)
+
+```
+const distKm = haversineKm(refLat, refLng, p.lat ?? 0, p.lng ?? 0);   // existing _shared/distanceMath helper
+const radiusKm = Math.max(radiusMeters / 1000, 0.001);               // avoid /0
+// Linear closeness within the candidate radius; clamp to [0,1].
+const P = Math.min(Math.max(1 - (distKm / radiusKm), 0), 1);          // 1 = at ref point, 0 = at/beyond radius edge
+```
+
+`radiusMeters` passed in = `clampedRadius` for the standard branch (the radius the candidates were fetched within, `index.ts:667`), and `3000` for the reverse-anchor branch (the per-card near-fetch radius, `index.ts:814`). This makes proximity self-relative to the pool the candidates came from.
+
+#### 4.2.3 Blend + selection (🔒 LOCKED)
+
+```
+const BLEND_QUALITY = 0.60;   // operator-approved knob
+const BLEND_PROXIMITY = 0.40;
+const score = BLEND_QUALITY * Q + BLEND_PROXIMITY * P;
+// pick the MAX score; deterministic tie-break chain below.
+```
+
+**Tie-breaks (🔒 LOCKED, deterministic — no `Math.random`):** when two candidates' blended `score` are within `1e-9`:
+1. higher `_rankScore` wins;
+2. then higher `rating`;
+3. then higher `review_count`;
+4. then lexicographically smaller `google_place_id` (stable, pool-independent final arbiter).
+
+The whole function is a pure function of `available` (whose order + contents are themselves deterministic given request inputs + the global dedup state) and the ref point — **no request-time randomness**. This is what keeps collab decks reproducible (§6, collab-determinism invariant).
+
+#### 4.2.4 Empty / single guards (🔒 LOCKED)
+- `available.length === 0` → return `null` (caller already handles null → optional-skip or combo-invalid; preserves the existing failed-anchor cycle logic at `index.ts:842/850`).
+- `available.length === 1` → return `available[0]` (no blend needed).
+
+### 4.3 Call-site edits
+- `index.ts:897` (standard branch): `selectClosestHighestRated(available, prevLat, prevLng)` → `selectBlendedStop(available, prevLat, prevLng, clampedRadius)`. `clampedRadius` is in scope at `generateCardsForType` (`index.ts:667`).
+- `index.ts:847` (reverse-anchor branch): `selectClosestHighestRated(available, prevLat, prevLng)` → `selectBlendedStop(available, prevLat, prevLng, 3000)`. (3000 = the per-card near-fetch radius used at `index.ts:814`.)
+
+### 4.4 PART 1A success criteria
+- **SC-1A-1:** For a post-anchor stop with ≥2 candidates, the selected place maximizes `0.6·Q + 0.4·P` (not pure nearest). Observable: a closer-but-low-rank candidate loses to a slightly-farther-but-high-rank candidate when the blend math says so.
+- **SC-1A-2:** Selection is deterministic — same `available` + same ref point → same pick across runs (no `Math.random`).
+- **SC-1A-3:** First non-optional stop is UNCHANGED (still `available[0]` by vibe rank) — PART 1A does not touch `index.ts:895-896`.
+- **SC-1A-4:** Null/single-candidate behavior matches the old helper (null on empty → preserves failed-anchor + optional-skip logic).
+
+---
+
+## 5. PART 1B — Deterministic best→2nd-best rotation that rotates the main activity
+
+### 5.1 Goal
+Replace the random combo shuffle (`index.ts:741-746`) with a **deterministic ordering** that (a) rotates the intent's *main activity* across cards and (b) descends quality, seeded off `batchSeed` so collab decks stay reproducible.
+
+### 5.2 Per-intent main-activity rotation table (🔒 LOCKED — CONFIRMED against `EXPERIENCE_TYPES` `index.ts:207-355`)
+
+For each intent, the "main activity" is the combo slot whose *category* we rotate across cards. The rotation key = the slug at that slot index.
+
+| Intent (`id`) | Combos (count) | Main-activity slot | Distinct main-activity slugs (rotation order = first appearance, then quality) |
+|---|---|---|---|
+| `adventurous` | 6 | stop-1 (index 0) | `play`, `theatre`, `hiking`, `creative_arts`, `museum` (note: `theatre` appears twice — combos `['theatre','casual_food']` + `['theatre','upscale_fine_dining']`) |
+| `first-date` | 5 | the **Activity** stop = index 1 (index 0 is optional Flowers) | `brunch`, `theatre`, `movies`, `play` (`play` appears twice — `['flowers','play','drinks_and_music']` + `['flowers','play','upscale_fine_dining']`) |
+| `romantic` | 2 | the **Experience** stop = index 1 (index 0 is optional Flowers) | `creative_arts`, `theatre` |
+| `group-fun` | 5 | stop-1 (index 0) | `play`, `theatre`, `brunch`, `movies` (`play` appears twice) |
+| `take-a-stroll` | 3 | **Nature anchor is CONSTANT (`nature` in all 3)** → rotate the **FOOD stop** = index 1 | `brunch`, `casual_food`, `upscale_fine_dining` |
+| `picnic-dates` | 1 | single combo → **NO rotation**; pure park-quality descent (reverse-anchor already descends anchor best→2nd via `globalUsedPlaceIds`). Keep as-is. |
+
+**Main-activity slot index resolver (🔒 LOCKED):** the implementor MUST derive the slot index from the typeDef, not hardcode per-intent magic numbers in the loop:
+
+```
+function mainActivitySlotIndex(typeDef): number {
+  // Reverse-anchor (picnic): no rotation — return -1 sentinel.
+  if (typeDef.stops.some(s => s.reverseAnchor)) return -1;
+  // take-a-stroll: nature anchor constant → rotate the food slot.
+  //   Defined as: the first stop slot whose slug VARIES across combos.
+  // General rule for all non-anchor intents: rotate the FIRST non-optional slot
+  //   whose slug is NOT constant across all combos.
+  const firstNonOptional = typeDef.stops.findIndex(s => !s.optional);
+  for (let i = firstNonOptional; i < typeDef.stops.length; i++) {
+    const slugsAtI = new Set(typeDef.combos.map(c => c[i]));
+    if (slugsAtI.size > 1) return i;   // first varying non-optional slot
+  }
+  return firstNonOptional; // all-constant fallback (shouldn't happen for current table)
+}
+```
+
+Verify this resolver yields: adventurous→0, first-date→1, romantic→1, group-fun→0, take-a-stroll→1, picnic→-1. (A Deno test pins this exact mapping — see §8 T-1B-MAP.) This is the SINGLE source of the per-intent slot; the table above is the human-readable expectation the test asserts.
+
+### 5.3 Deterministic ordering algorithm (🔒 LOCKED)
+
+Replace `index.ts:741-746` with `buildDeterministicComboList(typeDef, batchSeed, limit)`:
+
+```
+function buildDeterministicComboList(typeDef, batchSeed, limit): string[][] {
+  const combos = typeDef.combos;                  // FROZEN order from EXPERIENCE_TYPES
+  const slotIdx = mainActivitySlotIndex(typeDef);
+
+  // Picnic / no-rotation: deterministic single-combo repeat to limit*2.
+  if (slotIdx < 0 || combos.length <= 1) {
+    const out = [];
+    while (out.length < limit * 2) out.push(...combos);   // combos has 1 entry for picnic
+    return out;
+  }
+
+  // 1. Group combos by main-activity slug, preserving FIRST-appearance order of slugs.
+  const groupOrder = [];                          // ordered distinct slugs
+  const groups = new Map();                       // slug -> combos[] (in EXPERIENCE_TYPES order)
+  for (const c of combos) {
+    const slug = c[slotIdx];
+    if (!groups.has(slug)) { groups.set(slug, []); groupOrder.push(slug); }
+    groups.get(slug).push(c);
+  }
+  // Within each group, combos retain their EXPERIENCE_TYPES order (quality proxy:
+  // the combo table is authored best-first; this is the deterministic "descend
+  // quality" axis at combo granularity). Do NOT sort by a runtime score — the
+  // per-card quality descent is delivered by globalUsedPlaceIds (anchor best->2nd)
+  // + PART 1A blend, NOT by reordering combos at runtime.
+
+  // 2. Deterministic rotation offset from batchSeed (NO Math.random).
+  const startOffset = ((batchSeed % groupOrder.length) + groupOrder.length) % groupOrder.length;
+
+  // 3. Round-robin across groups, starting at startOffset, cycling group order,
+  //    pulling one combo per group per pass (so the MAIN ACTIVITY rotates card-to-card),
+  //    descending within each group as passes advance.
+  const out = [];
+  const cursors = new Map(groupOrder.map(s => [s, 0]));
+  let exhaustedGuard = 0;
+  while (out.length < limit * 2) {
+    let pushedThisCycle = 0;
+    for (let k = 0; k < groupOrder.length; k++) {
+      const slug = groupOrder[(startOffset + k) % groupOrder.length];
+      const arr = groups.get(slug);
+      const cur = cursors.get(slug);
+      if (cur < arr.length) { out.push(arr[cur]); cursors.set(slug, cur + 1); pushedThisCycle++; }
+      if (out.length >= limit * 2) break;
+    }
+    // When every group is exhausted, reset cursors to repeat the full deterministic
+    // sequence (mirrors today's "repeat shuffle to limit*2" behavior) — still no randomness.
+    if (pushedThisCycle === 0) {
+      for (const s of groupOrder) cursors.set(s, 0);
+      if (++exhaustedGuard > limit * 2) break;   // hard stop, can't happen with ≥1 combo
+    }
+  }
+  return out;
+}
+```
+
+**Why round-robin-across-groups delivers "rotate the main activity":** card 1 uses group[startOffset]'s first combo (main activity A), card 2 uses group[startOffset+1]'s first combo (main activity B), etc. — so consecutive cards show different main activities. The anchor place itself descends best→2nd→3rd across cards via the existing `globalUsedPlaceIds` accumulation (`index.ts:778/983-986`), which is untouched. Together: variety across main activity (1B) + quality descent within an activity (existing global dedup) + quality-blended companions (1A).
+
+### 5.4 Threading `batchSeed` through (🔒 LOCKED)
+`batchSeed` is destructured at `index.ts:1261` but NOT passed to `generateCardsForType` today (single call site `index.ts:1351-1356`). The implementor MUST:
+1. Add `batchSeed: number` as a new parameter to `generateCardsForType` (`index.ts:651-661`), defaulting to `0`.
+2. Pass `batchSeed` at the call site (`index.ts:1351-1356`).
+3. Pass `batchSeed` into `buildDeterministicComboList`.
+
+`batchSeed` is coerced to a safe integer at the top of `buildDeterministicComboList`: `const seed = Number.isFinite(batchSeed) ? Math.floor(Math.abs(batchSeed)) : 0;` (defensive — collab agg or a bad client value can't break determinism).
+
+### 5.5 Delete the random shuffle for ordering
+- `shuffle()` (`index.ts:1016-1023`) is used at `index.ts:743` and `745` for combo ordering. After PART 1B those two usages are removed. The implementor MUST re-grep `shuffle(` — if `index.ts:616` `buildCardFromStops` tagline pick (`Math.random`) or `matchScore` (`index.ts:644` `Math.random`) are the only remaining `Math.random` uses, those are **display-only, non-ordering** randomness (tagline + cosmetic match score) and are OUT OF SCOPE — do NOT touch them (they don't affect deck card identity/order, so collab determinism is unaffected; note this explicitly in the implementation report). If `shuffle()` becomes unreferenced, delete it; otherwise leave it.
+
+### 5.6 PART 1B success criteria
+- **SC-1B-1:** Combo ordering is deterministic — identical `(typeDef, batchSeed, limit)` → identical `comboList` across runs (no `Math.random` in the ordering path).
+- **SC-1B-2:** Consecutive cards rotate the main activity for multi-main-activity intents (adventurous/first-date/romantic/group-fun): card N and card N+1 have different main-activity slugs while distinct activities remain.
+- **SC-1B-3:** Take-a-Stroll rotates the **food** slot (`brunch`→`casual_food`→`upscale_fine_dining`) while the nature anchor descends in quality (anchor stays `nature`, place descends via global dedup).
+- **SC-1B-4:** Picnic produces a deterministic single-combo list (no rotation) and the park anchor still descends best→2nd→3rd across cards.
+- **SC-1B-5:** Changing `batchSeed` changes the rotation START offset deterministically (different `batchSeed` → different but reproducible first main activity).
+- **SC-1B-6:** `mainActivitySlotIndex` yields the exact table in §5.2.
+
+---
+
+## 6. PART 2 — Apply the open-hours cascade to the solo path (via shared extraction)
+
+### 6.1 Goal
+Apply the "open during the outing" cascade INSIDE `generate-curated-experiences` so BOTH solo and collab inherit it. Extract the logic into a NEW shared module (single source of truth, Constitution #6) imported by BOTH `discover-cards` and `generate-curated-experiences`. Fix D-1 (periods-shape reader) during extraction.
+
+### 6.2 New shared module: `supabase/functions/_shared/curatedStopHours.ts` (🔒 LOCKED contract)
+
+Export the following, extracted from `discover-cards/index.ts` (lines cited) with the D-1 fix:
+
+```ts
+// Extracted verbatim from discover-cards/index.ts unless noted:
+export function parseSingleRange(range: string): { open: number; close: number } | null  // discover-cards:150-195
+export function parseHoursText(text: string): { open: number; close: number }[] | null   // discover-cards:200-214
+export function hourInRanges(hour: number, ranges: {open:number;close:number}[]): boolean // discover-cards:217-219
+export const CURATED_STOP_DURATION: Record<string, number>                                // discover-cards:464-478
+export const ALWAYS_OPEN_TYPES: ReadonlySet<string>                                       // discover-cards:480-485
+export function isStopOpenAtHour(stop, hour, dayOfWeek): boolean                          // discover-cards:487-502 + D-1 FIX
+export function filterCuratedByStopHours(cards: any[], utcNow: Date): any[]               // discover-cards:504-532
+const DAY_NAMES = ['sunday','monday',…]                                                   // discover-cards:221 (module-local)
+```
+
+**D-1 FIX inside `isStopOpenAtHour` (🔒 LOCKED — this is a correctness fix, not just a move):** the extracted `isStopOpenAtHour` MUST evaluate hours in this cascade (mirroring the all-shape-tolerant `filterByDateTime.isOpenAtHour` at `discover-cards/index.ts:285-335`):
+
+1. `ALWAYS_OPEN_TYPES.has(stop.placeType)` → `true`.
+2. `const oh = stop.openingHours;` if not an object → `true` (honest-unknown → assume open).
+3. **Path A — canonical Google v1 `periods`:** if `Array.isArray(oh.periods) && oh.periods.length > 0` → evaluate against `periods` (open.day === dayOfWeek; openH = open.hour + open.minute/60; closeH = close.hour + close.minute/60; closeH===0→24; closeH<=openH→+24; return `hourFrac >= openH && hourFrac < closeH` for any period). **(This is the D-1 fix — today's reader skips this and falls through.)**
+4. **Path B — legacy `_periods`:** same eval against `oh._periods`.
+5. **Path C — text shape:** `dayText = oh[DAY_NAMES[dayOfWeek]]`; if absent → `true` (honest-unknown); `parsed = parseHoursText(dayText)`; if null ("Closed"/unparseable) → `false`; else `hourInRanges(hour, parsed)`.
+
+The **honest-unknown rule is LOCKED**: genuinely no hours data (no periods, no `_periods`, no day text) → assume OPEN (never fabricate closed). This matches Constitution #9 in the inclusive direction the existing curated filter intends (curated cards are precious; don't drop a venue for missing data).
+
+`filterCuratedByStopHours` is extracted byte-for-byte (`discover-cards:504-532`) — its `utcOffsetMinutes` fallback (`card.utcOffsetMinutes ?? Math.round(card.lng/15)*60`), per-stop duration accumulation, and optional-stop skip stay identical. It calls the FIXED `isStopOpenAtHour`.
+
+### 6.3 `discover-cards/index.ts` edits
+- DELETE the local `parseSingleRange`, `parseHoursText`, `hourInRanges`, `CURATED_STOP_DURATION`, `ALWAYS_OPEN_TYPES`, `isStopOpenAtHour`, `filterCuratedByStopHours` (the curated-specific copies at `147-219`, `464-532`). **CAUTION:** `parseSingleRange`/`parseHoursText`/`hourInRanges`/`DAY_NAMES`/`ALWAYS_OPEN_TYPES` are ALSO used by the NON-curated `filterByDateTime` path (`discover-cards:277-457`). The implementor MUST either (a) import them from the shared module into `discover-cards` and keep `filterByDateTime` working against the imported versions, OR (b) keep `filterByDateTime`'s own copies and extract ONLY the curated-specific `isStopOpenAtHour`/`CURATED_STOP_DURATION`/`filterCuratedByStopHours` + the shared parse helpers. **Decision (🔒 LOCKED): option (a)** — import `parseSingleRange`, `parseHoursText`, `hourInRanges`, `ALWAYS_OPEN_TYPES`, `DAY_NAMES` from the shared module and point BOTH `filterByDateTime` and the curated path at them, so there is ONE parser. Re-grep every reference before deleting. Re-run discover-cards' existing Deno tests (`orch_0903_…`, `orch_0906_…`, `orch_0909_…`, `collab_determinism_under_ai_blend`) to prove the non-curated path still passes.
+- The call at `discover-cards:1363` `filterCuratedByStopHours(timeFilteredCards, curatedUtcNow)` now resolves to the shared import. UNCHANGED behavior except the D-1 fix now makes it ACTUALLY filter periods-shape rows.
+
+### 6.4 `generate-curated-experiences/index.ts` edits — apply to solo path
+After cards are assembled and BEFORE the function returns (i.e., wrap the `cards` produced inside `generateCardsForType`, or filter at the handler after `generateCardsForType` returns — **Decision (🔒 LOCKED): filter at the handler**, `index.ts:1351-1356`, right after `generateCardsForType` returns and before `console.log`/response, so the empty-summary verdict logic still sees the FINAL card set):
+
+```
+import { filterCuratedByStopHours } from '../_shared/curatedStopHours.ts';
+…
+let { cards, summary } = await generateCardsForType(typeDef, …, batchSeed, …);
+// PART 2: open-during-outing filter — solo path inherits the same cascade collab gets.
+const curatedUtcNow = datetimePref ? new Date(datetimePref) : new Date();
+cards = filterCuratedByStopHours(cards, curatedUtcNow);
+// If filtering emptied the deck, surface the existing empty verdict shape.
+if (cards.length === 0 && !summary) {
+  summary = { emptyReason: 'pool_empty', candidateAnchorCount: 0, failedAnchorCount: 0 };
+}
+```
+
+**Start-time source (🔒 LOCKED):** `datetimePref ? new Date(datetimePref) : new Date()` — EXACTLY mirroring `discover-cards:1362`. Each stop's local arrival time is computed inside `filterCuratedByStopHours` using `card.utcOffsetMinutes` (already on each stop via `buildCardStop` `index.ts:568`) — the curated card's top-level `utcOffsetMinutes` is read from the FIRST stop; confirm the assembled card carries a top-level `utcOffsetMinutes` (it does NOT today — `buildCardFromStops` `index.ts:631-646` does not set a card-level `utcOffsetMinutes`/`lng`). **Therefore (🔒 LOCKED):** `filterCuratedByStopHours` currently reads `card.utcOffsetMinutes`/`card.lng` at `discover-cards:512`. For the solo path the assembled curated card must expose those. The implementor MUST add to `buildCardFromStops` (`index.ts:631-646`) a top-level `utcOffsetMinutes: mainStops[0]?.utcOffsetMinutes ?? null` and `lat`/`lng: mainStops[0]?.lat/lng ?? null` so `filterCuratedByStopHours` resolves the timezone the same way for solo as collab. (Collab cards get these from the discover-cards card shape; solo cards are built here — this closes the gap. Confirm the collab card shape that reaches `filterCuratedByStopHours` carries `utcOffsetMinutes` — it does, via the discover-cards transformer.) This is additive (new top-level fields), does NOT change stop-level data, and mobile ignores unknown top-level fields.
+
+### 6.5 Is discover-cards' own call now redundant? (Decision — JUSTIFIED)
+**No — keep both (belt-and-suspenders, 🔒 LOCKED).** The collab path (`discover-cards`) calls `filterCuratedByStopHours` AFTER its own `filterByDateTime`/`filterByDateWindows` AND on a candidate set that discover-cards assembles independently (it does NOT always go through `generate-curated-experiences` for every collab card — discover-cards has its own curated assembly + fallback paths, e.g. `fallbackToCuratedAfterSingleExhaustion` at `discover-cards:1369`). Removing the discover-cards call would drop hours-filtering on those discover-cards-native curated paths. Keeping both is idempotent (filtering an already-open card again is a no-op) and costs nothing. The solo filter added in §6.4 covers the DIRECT solo call that bypasses discover-cards entirely (`deckService.ts:570`). Both call sites now share ONE implementation.
+
+### 6.6 PART 2 success criteria
+- **SC-2-1 (the regression that proves the gap):** A solo curated card whose a stop is CLOSED at the computed arrival time is now EXCLUDED from the solo `generate-curated-experiences` response. (Today it is served — that is the bug.)
+- **SC-2-2:** A solo curated card all of whose stops are open at arrival is RETAINED.
+- **SC-2-3:** A stop with NO hours data (and not an always-open type) is treated as OPEN (honest-unknown) — card retained.
+- **SC-2-4:** `isStopOpenAtHour` now correctly evaluates the canonical Google v1 `periods` shape (D-1 fix) — a closed periods-shape stop is detected as closed (previously false-OK).
+- **SC-2-5:** Collab path behavior is preserved (discover-cards still filters; non-curated `filterByDateTime` still passes its existing tests).
+- **SC-2-6:** When hours-filtering empties the solo deck, the response carries a `summary` empty verdict (mobile routes to EMPTY UI, not stuck loading).
+- **SC-2-7:** Single source of truth — `parseHoursText`/`isStopOpenAtHour`/`filterCuratedByStopHours`/`CURATED_STOP_DURATION`/`ALWAYS_OPEN_TYPES` exist in exactly ONE file (`_shared/curatedStopHours.ts`); no duplicate definitions remain in `discover-cards` or `generate-curated-experiences`.
+
+---
+
+## 7. Preserved gates & invariants (🔒 LOCKED — MUST NOT regress)
+
+All of the following MUST behave identically after the change. Each has a test obligation in §8.
+
+| Gate / invariant | Location | Preservation requirement |
+|---|---|---|
+| `filterMin` thresholds | `signalRankFetch.ts:150-153` + RPC | Untouched — PART 1A/1B operate on already-filtered candidates. |
+| G3 photo gate | `signalRankFetch.ts:342-348` | Untouched. |
+| Fine-dining ≥'bougie' floor | `index.ts:876-880` | Untouched (runs in the `available` filter BEFORE selection). PART 1A only changes which of the surviving candidates is picked. |
+| First-stop travel ≤ constraint×1.5 | `index.ts:933-939` | Untouched — runs after stops built; PART 1A/1B do not change the first stop. |
+| Dedup (per-card `comboUsedIds` + global `globalUsedPlaceIds`) | `index.ts:778`, `805/855/905`, `941-948`, `983-986` | Untouched. PART 1A picks from `available` which is already dedup-filtered; PART 1B does not change dedup. |
+| Reverse-anchor failed-anchor cycle prevention | `index.ts:757`, `787-794`, `842/850`, `923/937/946` | Untouched. PART 1A's `selectBlendedStop` returns null exactly where `selectClosestHighestRated` did → same failed-anchor marking. |
+| Empty→summary verdicts | `index.ts:991-1011` | Preserved + extended for the hours-filter-emptied case (§6.4). |
+| **I-COLLAB-DECK-DETERMINISM-PRESERVED-UNDER-AI-BLEND** | `INVARIANT_REGISTRY.md:127-145`; memory `[[collab-deck-determinism-contract]]` | PART 1A blend + PART 1B rotation are PURE functions of request inputs (location, batchSeed, excludePlacePoolIds, candidate set) — **no request-time `Math.random` in any ordering/selection path**. Today's `shuffle` DOES use `Math.random`; PART 1B REMOVES that nondeterminism. This is a NET IMPROVEMENT to determinism. The blend introduces no request-time randomness and no new request-time read that varies by request. |
+| **I-CURATED-HOURS-VIA-CANONICAL-READER** | `INVARIANT_REGISTRY.md:36-46` | This invariant scopes `app-mobile/` (client). PART 2 is server-side and does NOT touch app-mobile, so the existing gate is unaffected. The server-side D-1 fix brings the EDGE reader to the same all-shape-tolerant standard (philosophical parity, not gate-scoped). |
+| Honest-unknown / no-fabrication (Constitution #9) | `index.ts:571-575`; §6.2 | Hours-unknown → assume open (never fabricate closed); `isOpenNow` stays null when unknown. |
+
+---
+
+## 8. Test plan
+
+> **Step-0.5 regression-test requirement (🔒 LOCKED):** the implementor ships a **fails-on-revert happy-path** Deno test, and the tester writes a **distinct adversarial** Deno test. Both MUST be proven to FAIL when the production change is reverted (cite the revert commit SHA in the report, per the ORCH-1019 model `INVARIANT_REGISTRY.md:44`).
+
+Test runner: `deno test` (these edge fns already ship Deno tests — see `supabase/functions/discover-cards/__tests__/` and `supabase/functions/generate-curated-experiences/__tests__/`). Candidate paths below.
+
+| Test | Scenario | Input | Expected | Layer | Owner |
+|---|---|---|---|---|---|
+| **T-1A-01** | Post-anchor pick is quality-weighted, not nearest | `available` = [{closer, low `_rankScore`+low rating}, {slightly farther, high `_rankScore`+high rating}] within radius; refLat/Lng | `selectBlendedStop` returns the FARTHER high-quality one (blend math: 0.6·Q+0.4·P favors it) | unit | implementor (happy) |
+| **T-1A-02** | Pure-nearest would have lost | construct a case where nearest ≠ blended-max | returns blended-max, NOT nearest | unit | tester (adversarial) |
+| **T-1A-03** | Determinism | run T-1A-01 twice | identical pick | unit | implementor |
+| **T-1A-04** | Tie-break chain | two candidates equal blended score, differing `_rankScore` then rating then id | returns the `_rankScore`-then-rating-then-id winner | unit | tester (adversarial) |
+| **T-1A-05** | Empty/single | `[]` → null; `[x]` → x | matches old helper | unit | implementor |
+| **T-1B-MAP** | `mainActivitySlotIndex` mapping | each of the 6 typeDefs | adventurous→0, first-date→1, romantic→1, group-fun→0, take-a-stroll→1, picnic→-1 | unit | implementor (happy) |
+| **T-1B-01** | Ordering deterministic | `buildDeterministicComboList(typeDef, batchSeed=7, limit=20)` twice | identical arrays; NO `Math.random` reachable | unit | implementor |
+| **T-1B-02** | Main activity rotates | adventurous, limit large | consecutive entries (while distinct activities remain) have different `[slotIdx]` slug | unit | implementor |
+| **T-1B-03** | Take-a-Stroll rotates FOOD while nature constant | take-a-stroll | slot index = 1 (food); entry[0]=nature constant; food slug rotates brunch→casual_food→upscale_fine_dining | unit | tester (adversarial — proves it's not rotating nature) |
+| **T-1B-04** | Picnic = no rotation, single combo repeat | picnic-dates, limit=20 | every entry === `['groceries','flowers','nature']`; length ≥ limit\*2 | unit | implementor |
+| **T-1B-05** | batchSeed changes start offset deterministically | adventurous, batchSeed 0 vs 1 vs 2 | different first main-activity slug, each reproducible | unit | tester (adversarial) |
+| **T-1B-06** | No request-time Math.random in ordering | source-text assert: `buildDeterministicComboList` body contains no `Math.random` | passes | source-grep unit | tester |
+| **T-2-01 (THE GAP)** | Solo curated card with a CLOSED stop is dropped | card with stop closed at arrival hour (periods shape) + `datetimePref` | `filterCuratedByStopHours` excludes it; on revert (no solo filter) it is RETAINED → test FAILS on revert | unit + integration | implementor (happy, fails-on-revert) |
+| **T-2-02** | All-open card retained | all stops open at arrival | retained | unit | implementor |
+| **T-2-03** | No-hours stop assumed open | stop with no periods/text, non-always-open type | retained (honest-unknown) | unit | tester (adversarial — proves we don't fabricate closed) |
+| **T-2-04 (D-1)** | periods-shape closed stop detected | stop with `openingHours.periods` closed at hour | `isStopOpenAtHour` → false (pre-fix: false-OK true) → card dropped | unit | tester (adversarial, fails-on-revert of D-1 fix) |
+| **T-2-05** | Single source of truth | source-grep: `filterCuratedByStopHours`/`isStopOpenAtHour`/`parseHoursText` defined ONLY in `_shared/curatedStopHours.ts` | no duplicate defs in discover-cards / generate-curated | source-grep unit | tester |
+| **T-2-06** | discover-cards non-curated path unbroken | run existing `orch_0903`/`orch_0906`/`orch_0909`/`collab_determinism_under_ai_blend` tests | all PASS | regression | implementor |
+| **T-2-07** | Empty after hours filter → summary verdict | solo response where filter empties cards | response carries `summary.emptyReason` | integration | tester |
+
+**Candidate test file paths:**
+- `supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts` (T-1A-\*, T-1B-\*) — implementor happy-path.
+- `supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_rotation.adversarial.test.ts` (T-1A-02/04, T-1B-03/05/06) — tester adversarial.
+- `supabase/functions/_shared/__tests__/curatedStopHours.test.ts` (T-2-01/02/03/05) — implementor happy-path.
+- `supabase/functions/_shared/__tests__/curatedStopHours.adversarial.test.ts` (T-2-03/04) — tester adversarial.
+- Reuse existing `supabase/functions/discover-cards/__tests__/*.test.ts` for T-2-06.
+
+---
+
+## 9. External-API-docs note (COMMS-0003)
+
+**This ORCH introduces NO new external-API calls.** PART 1A/1B are pure arithmetic over candidate rows already fetched. PART 2 parses hours strings already stored in `place_pool.opening_hours` (internal data; the parser is internal text logic). The OpenAI prompt (`generatePicnicShoppingList` `index.ts:1071-1091`) and the `fetch_local_signal_ranked` RPC are UNCHANGED. No provider enum/payload/endpoint is introduced or modified. COMMS-0003 is satisfied by this explicit declaration. (Acked.)
+
+---
+
+## 10. Strict-grep / backend allowlist (COMMS-0002)
+
+This ORCH adds NEW files under `supabase/functions/` — the ORCH-0863 C7 `no-new-backend-files` strict-grep gate will block the PR unless they are allowlisted **in the same commit**.
+
+**Exact allowlist file:** `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs`.
+**Exact mechanism:** add a new block (alphabetically/numerically after the existing `ORCH_1040_BACKEND_ALLOWLIST` at `~line 372` region) and spread it into the combined allowlist array at `~line 1453-1491`:
+
+```js
+// ORCH-1061 [Curated stop variety + quality blend + solo hours gate].
+// C7 is scoped to ORCH-0863 marketing; these backend touches are ORCH-1061
+// scope: the extracted shared curated-hours module + its tests + the curated
+// generator's new blend/rotation tests. (No migration — pure edge-fn logic.)
+const ORCH_1061_BACKEND_ALLOWLIST = [
+  "supabase/functions/_shared/curatedStopHours.ts",
+  "supabase/functions/_shared/__tests__/curatedStopHours.test.ts",
+  "supabase/functions/_shared/__tests__/curatedStopHours.adversarial.test.ts",
+  "supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts",
+  "supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_rotation.adversarial.test.ts",
+];
+```
+…and add `...ORCH_1061_BACKEND_ALLOWLIST,` to the spread block (after `...ORCH_1040_BACKEND_ALLOWLIST,` at `index.ts`-of-the-gate `~line 1491`).
+
+> NOTE: `generate-curated-experiences/index.ts` and `discover-cards/index.ts` are MODIFIED, not new — C7 (`no-new-backend-files`) only fires on NEW files, so the two modified `index.ts` files do NOT need allowlisting (they already exist; they appear in earlier allowlists e.g. ORCH-0902/0903). Only the 5 NEW files above need entries. The implementor MUST run the gate locally (`node .github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs`) before pushing.
+
+**Optional new invariant gate (🎨 OPEN to implementor judgment):** consider a small strict-grep `i-curated-hours-shared-sole-owner.mjs` asserting `filterCuratedByStopHours`/`isStopOpenAtHour` are defined ONLY in `_shared/curatedStopHours.ts` (mirrors the existing `i-curated-hours-via-canonical-reader.mjs` pattern). If added, it ALSO needs its own allowlist entry + a workflow job line. T-2-05 covers this contract via Deno test regardless, so the gate is a nice-to-have, not required. (Acked COMMS-0002.)
+
+---
+
+## 11. Implementation order
+
+1. **PART 2 extraction first** — create `_shared/curatedStopHours.ts` (with D-1 fix), repoint `discover-cards` imports, delete its dupes, run discover-cards Deno tests (T-2-06) to prove the non-curated path is intact. (Lowest-risk, isolates the move.)
+2. **PART 2 solo wiring** — add the `filterCuratedByStopHours` call in the `generate-curated-experiences` handler + the top-level `utcOffsetMinutes`/`lat`/`lng` on `buildCardFromStops`. Write T-2-01/02/03/07.
+3. **PART 1A** — add `selectBlendedStop`, route both call sites, (delete `selectClosestHighestRated` if unreferenced). Write T-1A-\*.
+4. **PART 1B** — add `mainActivitySlotIndex` + `buildDeterministicComboList`, thread `batchSeed` into `generateCardsForType`, replace the shuffle. Write T-1B-\*.
+5. **Allowlist** — add `ORCH_1061_BACKEND_ALLOWLIST` block + spread (same commit). Run the gate locally.
+6. **Run all Deno tests** + the discover-cards regression suite. Confirm fails-on-revert for T-2-01 (solo gap) and T-1A-01.
+
+---
+
+## 12. Regression prevention
+- **Determinism guard:** T-1B-06 source-grep asserts no `Math.random` in the ordering path; the blend/rotation are pure functions (no I/O).
+- **Single-source-of-truth guard:** T-2-05 source-grep (and optional strict-grep gate §10) prevents the hours cascade from being re-duplicated.
+- **The solo-gap guard:** T-2-01 fails-on-revert — if a future change removes the solo `filterCuratedByStopHours` call, CI goes red.
+- **Protective comments:** each new function carries a `// ORCH-1061:` header explaining WHY (blend over nearest; deterministic rotation off batchSeed for collab; shared hours cascade for solo+collab parity).
+
+---
+
+## 13. Open questions for the operator
+- **OQ-1:** The 0.75/0.25 internal split of *quality* (vibe-rank vs rating×reviews) is my proposed default to keep the signal-tuned `_rankScore` dominant. The 60/40 quality-vs-proximity is operator-locked; the 75/25 internal is a SPEC choice. Confirm acceptable, or specify a different internal weighting.
+- **OQ-2:** PART 1B "descend quality within a main-activity group" is delivered at COMBO granularity by the authored EXPERIENCE_TYPES order (best-first) + at PLACE granularity by the existing `globalUsedPlaceIds` best→2nd descent. I did NOT add a runtime combo re-sort by score (that would re-introduce request-coupled ordering risk and isn't needed since place-level descent already happens). Confirm this interpretation of "descends quality" matches intent.
+- **OQ-3 (D-1):** I am fixing the latent collab periods-shape reader bug (D-1) inside the extraction because shipping a known-broken reader to the solo path would be malpractice. This slightly widens PART 2 beyond a pure move. Confirm you want the fix included (recommended) vs. extract-as-is + separate follow-up ORCH for D-1.
+
+---
+
+## 14. /goal self-assessment (SPEC completion predicate)
+
+1. **Functional contract complete for every touched layer** — YES. Edge fn (both branches, handler, card builder), new shared module (full export contract + D-1 fix cascade), discover-cards edits, allowlist. No DB/RLS/hook/component layer touched (server-only; declared). ✓
+2. **UI visual/UX contract** — N/A: zero UI surface touched (server-only payload change; mobile renders unchanged payload shape). Cross-Surface §3 declares this explicitly; no `mingla-designer` pass required. ✓
+3. **No-AI-slop / References examined** — N/A (no UI). ✓
+4. **Every requirement tagged 🔒/🎨** — formulas, rotation algorithm, slot resolver, hours cascade, start-time source, belt-and-suspenders decision are 🔒 LOCKED; the optional strict-grep gate + adversarial-test creativity are 🎨 OPEN. ✓
+5. **Cross-Surface §3 present; SCs observable/testable/unambiguous** — YES (SC-1A-\*, SC-1B-\*, SC-2-\*). Parity automatic (shared edge fn). ✓
+6. **Invariants named; happy/error/edge tests per criterion; impl order; regression prevention** — YES (§7, §8, §11, §12). ✓
+7. **Zero hand-wave** — formulas are explicit arithmetic; rotation is full pseudocode; hours cascade is a 5-path explicit ladder. ✓
+
+**Bounded:** NO combo expansion; NO migration; NO client code; NO new external API; 1 new shared file + 2 modified edge fns + tests + 1 allowlist block. **Complete:** all three parts + the latent D-1 fix + every preserved gate enumerated with a test obligation. Confidence: HIGH (every cite re-read in-worktree; the only judgment calls are surfaced as OQ-1/2/3).

--- a/supabase/functions/_shared/__tests__/curatedStopHours.adversarial.test.ts
+++ b/supabase/functions/_shared/__tests__/curatedStopHours.adversarial.test.ts
@@ -1,0 +1,212 @@
+// ORCH-1061 PART 2 — TESTER adversarial Deno tests for the shared curated
+// open-hours cascade (_shared/curatedStopHours.ts).
+//
+// These attack DIFFERENT angles than the implementor's happy-path file
+// (curatedStopHours.test.ts):
+//   T-2-03 — the honest-unknown direction: a stop with NO usable hours data
+//            (and not an always-open type) must be assumed OPEN. We attack the
+//            failure where a buggy reader fabricates "closed" for missing data —
+//            across every no-data shape (no object, empty object, missing-day
+//            text, empty periods array). Constitution #9.
+//   T-2-04 (D-1 fails-on-revert) — a CLOSED periods-shape stop MUST be detected
+//            as closed. If the D-1 fix (Path A periods evaluation) is reverted,
+//            the reader falls through to "assume open" and this test FAILS. This
+//            is the tester-owned fails-on-revert proof of the D-1 correctness fix.
+//
+// Run: cd supabase && deno test --allow-read --allow-env --no-check \
+//   functions/_shared/__tests__/curatedStopHours.adversarial.test.ts
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  filterCuratedByStopHours,
+  isStopOpenAtHour,
+} from '../curatedStopHours.ts';
+
+// Wednesday (day=3) 18:00 UTC; with utcOffsetMinutes=0 the local arrival is Wed 18:00.
+const WED_1800_UTC = new Date(Date.UTC(2026, 5, 3, 18, 0, 0));
+
+function curatedCard(stops: Record<string, unknown>[]): Record<string, unknown> {
+  return { cardType: 'curated', utcOffsetMinutes: 0, lng: 0, stops };
+}
+
+// ─── T-2-03 (adversarial): honest-unknown → OPEN; never fabricate closed ──────
+Deno.test('T-2-03 (adversarial): no-hours stop is assumed OPEN across every no-data shape', () => {
+  // (a) openingHours entirely absent.
+  assert(isStopOpenAtHour({ placeType: 'restaurant' }, 18, 3),
+    'absent openingHours → open (honest-unknown)');
+
+  // (b) openingHours present but empty object (no periods, no _periods, no day text).
+  assert(isStopOpenAtHour({ placeType: 'restaurant', openingHours: {} }, 18, 3),
+    'empty openingHours object → open');
+
+  // (c) openingHours is a non-object (defensive: null / string / number).
+  assert(isStopOpenAtHour({ placeType: 'restaurant', openingHours: null }, 18, 3),
+    'null openingHours → open');
+  assert(isStopOpenAtHour({ placeType: 'restaurant', openingHours: 'unknown' as unknown as object }, 18, 3),
+    'string openingHours → open (treated as no usable object)');
+
+  // (d) periods array exists but is EMPTY → not usable → falls through to open.
+  assert(isStopOpenAtHour({ placeType: 'restaurant', openingHours: { periods: [] } }, 18, 3),
+    'empty periods array → open (no usable data)');
+
+  // (e) text shape present but the CURRENT day has no entry → honest-unknown → open.
+  //     (Other days populated; Wednesday/day=3 missing.)
+  assert(isStopOpenAtHour(
+    { placeType: 'restaurant', openingHours: { monday: '9:00 AM – 5:00 PM' } }, 18, 3),
+    'missing current-day text → open (honest-unknown)');
+
+  // (f) ALWAYS_OPEN type with no hours data → open (parks etc. never dropped).
+  assert(isStopOpenAtHour({ placeType: 'park' }, 3, 3),
+    'always-open type → open even at 3am with no data');
+
+  // End-to-end through the filter: a card whose ONLY stop has no data is RETAINED.
+  const retained = filterCuratedByStopHours(
+    [curatedCard([{ placeType: 'restaurant', openingHours: {}, travelTimeFromPreviousStopMin: 0 }])],
+    WED_1800_UTC,
+  );
+  assertEquals(retained.length, 1, 'no-data card must be retained, never fabricated-closed');
+});
+
+// ─── T-2-04 (adversarial, D-1 fails-on-revert): periods-shape CLOSED detected ──
+Deno.test('T-2-04 (adversarial / D-1 fails-on-revert): periods-shape CLOSED stop is detected as closed', () => {
+  // Canonical Google v1 periods: open Wed 09:00–17:00 → CLOSED at the 18:00 arrival.
+  // With the D-1 fix (Path A periods evaluation) this reads as CLOSED.
+  // REVERT THE D-1 FIX (drop Path A `periods` + Path B `_periods` from
+  // isStopOpenAtHour) and the reader falls through to honest-unknown → OPEN, so
+  // BOTH assertions below flip and this test FAILS — the tester-owned D-1 proof.
+  const closedPeriods = {
+    placeType: 'restaurant',
+    openingHours: { periods: [{ open: { day: 3, hour: 9, minute: 0 }, close: { day: 3, hour: 17, minute: 0 } }] },
+  };
+  assert(!isStopOpenAtHour(closedPeriods, 18, 3),
+    'D-1: periods-shape stop closed at 18:00 must read CLOSED (pre-fix: false-OK open)');
+
+  // And the open-window boundary is honored (open exactly at 09:00, closed at 17:00).
+  assert(isStopOpenAtHour(closedPeriods, 9, 3), 'open at the 09:00 boundary');
+  assert(isStopOpenAtHour(closedPeriods, 16.99, 3), 'open just before 17:00');
+  assert(!isStopOpenAtHour(closedPeriods, 17, 3), 'closed exactly at the 17:00 close (half-open interval)');
+
+  // Wrong DAY: periods only cover Wednesday; querying Thursday (day=4) → no matching
+  // period → CLOSED (proves the day filter inside evalPeriods, not just the hour).
+  assert(!isStopOpenAtHour(closedPeriods, 12, 4),
+    'D-1: a Wed-only period must read CLOSED on Thursday');
+
+  // Legacy `_periods` shape (Path B) must behave identically.
+  const closedUnderscorePeriods = {
+    placeType: 'restaurant',
+    openingHours: { _periods: [{ open: { day: 3, hour: 9, minute: 0 }, close: { day: 3, hour: 17, minute: 0 } }] },
+  };
+  assert(!isStopOpenAtHour(closedUnderscorePeriods, 18, 3),
+    'D-1: legacy _periods closed stop must read CLOSED at 18:00');
+
+  // Text-shape explicit "Closed" → CLOSED (proves Path C still fabricates nothing
+  // but DOES honor an explicit closed declaration).
+  const explicitlyClosed = { placeType: 'restaurant', openingHours: { wednesday: 'Closed' } };
+  assert(!isStopOpenAtHour(explicitlyClosed, 18, 3),
+    'explicit "Closed" text for the day must read CLOSED');
+
+  // End-to-end: a curated card whose first stop is periods-closed is DROPPED.
+  const dropped = filterCuratedByStopHours(
+    [curatedCard([{ ...closedPeriods, travelTimeFromPreviousStopMin: 0 }])],
+    WED_1800_UTC,
+  );
+  assertEquals(dropped.length, 0, 'periods-closed card must be dropped end-to-end');
+});
+
+// ─── T-2-04b (adversarial): a LATER stop closed-on-arrival drops the card ──────
+// Attacks the cumulative-duration accumulation: the FIRST stop is open at 18:00,
+// but by the time the user reaches the SECOND stop (after duration + travel) it
+// is past that stop's close → the whole card must be dropped, proving the filter
+// evaluates downstream stops at their projected arrival hour, not just stop 0.
+Deno.test('T-2-04b (adversarial): a downstream stop closed at projected arrival drops the card', () => {
+  // Stop 0: restaurant open Wed 11:00–23:00 (open at 18:00 arrival; 60min dwell).
+  // Stop 1: museum open Wed 09:00–18:30, reached ~18:00 + 60min dwell + 15min
+  //   travel ≈ 19:15 → CLOSED → card dropped.
+  const card = curatedCard([
+    {
+      placeType: 'restaurant',
+      openingHours: { periods: [{ open: { day: 3, hour: 11, minute: 0 }, close: { day: 3, hour: 23, minute: 0 } }] },
+      travelTimeFromPreviousStopMin: 0,
+    },
+    {
+      placeType: 'museum',
+      openingHours: { periods: [{ open: { day: 3, hour: 9, minute: 0 }, close: { day: 3, hour: 18, minute: 30 } }] },
+      travelTimeFromPreviousStopMin: 15,
+    },
+  ]);
+  const result = filterCuratedByStopHours([card], WED_1800_UTC);
+  assertEquals(result.length, 0, 'card dropped because the museum is closed by projected arrival');
+
+  // Control: widen the museum close to 23:00 → now open on arrival → card retained.
+  const cardOk = curatedCard([
+    {
+      placeType: 'restaurant',
+      openingHours: { periods: [{ open: { day: 3, hour: 11, minute: 0 }, close: { day: 3, hour: 23, minute: 0 } }] },
+      travelTimeFromPreviousStopMin: 0,
+    },
+    {
+      placeType: 'museum',
+      openingHours: { periods: [{ open: { day: 3, hour: 9, minute: 0 }, close: { day: 3, hour: 23, minute: 0 } }] },
+      travelTimeFromPreviousStopMin: 15,
+    },
+  ]);
+  assertEquals(filterCuratedByStopHours([cardOk], WED_1800_UTC).length, 1,
+    'control: open-late museum → card retained (filter is not over-pruning)');
+});
+
+// ─── T-2-05 (adversarial source-grep): single source of truth ─────────────────
+// The hours cascade must be defined in EXACTLY ONE file. Re-duplication in
+// discover-cards or generate-curated would re-introduce drift (the exact bug
+// class this ORCH eliminates). Grep both consumers' source.
+Deno.test('T-2-05 (adversarial source-grep): hours cascade defined only in _shared/curatedStopHours.ts', async () => {
+  const here = new URL('.', import.meta.url);
+  const discover = await Deno.readTextFile(new URL('../../discover-cards/index.ts', here));
+  const curated = await Deno.readTextFile(new URL('../../generate-curated-experiences/index.ts', here));
+
+  for (const [name, src] of [['discover-cards', discover], ['generate-curated', curated]] as const) {
+    assert(!/function\s+isStopOpenAtHour\s*\(/.test(src),
+      `${name} must NOT define isStopOpenAtHour (single source of truth)`);
+    assert(!/function\s+filterCuratedByStopHours\s*\(/.test(src),
+      `${name} must NOT define filterCuratedByStopHours`);
+    assert(!/function\s+parseHoursText\s*\(/.test(src),
+      `${name} must NOT define parseHoursText`);
+    assert(!/function\s+parseSingleRange\s*\(/.test(src),
+      `${name} must NOT define parseSingleRange`);
+  }
+
+  // discover-cards must IMPORT from the shared module.
+  assert(/from '\.\.\/_shared\/curatedStopHours\.ts'/.test(discover),
+    'discover-cards must import the shared curated-hours module');
+  assert(/from '\.\.\/_shared\/curatedStopHours\.ts'/.test(curated),
+    'generate-curated must import the shared curated-hours module');
+});
+
+// ─── T-2-01 (adversarial / solo-wiring fails-on-revert): the SOLO handler must ─
+// actually CALL filterCuratedByStopHours on the assembled cards before responding.
+// This is the wiring that closes the solo gap (deckService.ts → generate-curated
+// bypassed discover-cards entirely, so it never got the hours filter). Removing
+// the handler call line reverts the solo gap → this source-grep FAILS, proving
+// the wiring is load-bearing (the dispatch-named T-2-01 fails-on-revert).
+Deno.test('T-2-01 (adversarial / solo-wiring fails-on-revert): solo handler applies the hours filter', async () => {
+  const src = await Deno.readTextFile(
+    new URL('../../generate-curated-experiences/index.ts', import.meta.url),
+  );
+  // Strip comments so we assert against EXECUTABLE wiring, not the explanatory header.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+
+  // (a) the import exists.
+  assert(/import\s*\{\s*filterCuratedByStopHours\s*\}\s*from\s*'\.\.\/_shared\/curatedStopHours\.ts'/.test(code),
+    'solo handler must import filterCuratedByStopHours');
+
+  // (b) the handler reassigns cards through the filter (the load-bearing wiring).
+  assert(/cards\s*=\s*filterCuratedByStopHours\s*\(\s*cards\s*,/.test(code),
+    'solo handler must call cards = filterCuratedByStopHours(cards, ...) — removing this reverts the solo gap');
+
+  // (c) the start-time source mirrors discover-cards (datetimePref ? new Date(...) : new Date()).
+  assert(/datetimePref\s*\?\s*new Date\(datetimePref\)\s*:\s*new Date\(\)/.test(code),
+    'solo filter start time must mirror discover-cards (datetimePref || now)');
+
+  // (d) the empty-after-filter summary fallback is present (mobile routes to EMPTY UI).
+  assert(/cards\.length\s*===\s*0\s*&&\s*!summary/.test(code),
+    'empty-after-filter must set a summary verdict so mobile does not stick on loading');
+});

--- a/supabase/functions/_shared/__tests__/curatedStopHours.test.ts
+++ b/supabase/functions/_shared/__tests__/curatedStopHours.test.ts
@@ -1,0 +1,111 @@
+// ORCH-1061 PART 2 — happy-path Deno tests for the shared curated open-hours
+// cascade (_shared/curatedStopHours.ts).
+//
+// Covers (implementor-owned rows from SPEC §8):
+//   T-2-01 (THE GAP / fails-on-revert) — a curated card with a CLOSED periods-shape
+//           stop is DROPPED by filterCuratedByStopHours. Reverting the D-1 fix
+//           inside isStopOpenAtHour (the production change that makes the canonical
+//           Google v1 `periods` shape actually evaluated) makes this card slip
+//           through → test FAILS on revert. (See implementation report for the
+//           captured revert evidence.)
+//   T-2-02 — an all-open card is RETAINED.
+//   (T-2-07 empty-after-filter → summary verdict is exercised at the handler in
+//    orch_1061_blend_and_rotation.test.ts; here we prove the filter empties the
+//    list when every card has a closed stop.)
+//
+// Run: cd supabase && deno test --allow-read functions/_shared/__tests__/curatedStopHours.test.ts
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  filterCuratedByStopHours,
+  isStopOpenAtHour,
+} from '../curatedStopHours.ts';
+
+// A canonical Google v1 `periods` entry: open on `day` from openHour to closeHour.
+function periods(day: number, openHour: number, closeHour: number) {
+  return {
+    periods: [
+      {
+        open: { day, hour: openHour, minute: 0 },
+        close: { day, hour: closeHour, minute: 0 },
+      },
+    ],
+  };
+}
+
+// Fixed reference instant: 2026-06-03 (Wednesday) 18:00 UTC. With utcOffsetMinutes=0
+// the place-local arrival of the FIRST stop is Wednesday (day=3) 18:00.
+const WED_1800_UTC = new Date(Date.UTC(2026, 5, 3, 18, 0, 0));
+
+function curatedCard(stops: any[]): any {
+  return {
+    cardType: 'curated',
+    utcOffsetMinutes: 0,
+    lng: 0,
+    stops,
+  };
+}
+
+Deno.test('T-2-01 (THE GAP): curated card with a CLOSED periods-shape stop is DROPPED', () => {
+  // First stop is a restaurant whose periods say it is open Wed 09:00–17:00, i.e.
+  // CLOSED at the 18:00 arrival. With the D-1 fix this periods shape is evaluated
+  // and the card is dropped. (Pre-fix: the text-only reader skips `periods`, falls
+  // to its honest-unknown branch → returns OPEN → card RETAINED → bug.)
+  const closedCard = curatedCard([
+    {
+      placeType: 'restaurant',
+      openingHours: periods(3, 9, 17), // Wed 9am–5pm → closed at 6pm
+      travelTimeFromPreviousStopMin: 0,
+    },
+  ]);
+
+  const result = filterCuratedByStopHours([closedCard], WED_1800_UTC);
+  assertEquals(result.length, 0, 'closed-on-arrival curated card must be dropped');
+});
+
+Deno.test('T-2-02: all-open curated card is RETAINED', () => {
+  // Restaurant open Wed 11:00–23:00 → open at 18:00 arrival; second stop (bar)
+  // open until late too. Card survives.
+  const openCard = curatedCard([
+    {
+      placeType: 'restaurant',
+      openingHours: periods(3, 11, 23),
+      travelTimeFromPreviousStopMin: 0,
+    },
+    {
+      placeType: 'bar',
+      openingHours: periods(3, 16, 2), // 4pm–2am (overnight wrap)
+      travelTimeFromPreviousStopMin: 15,
+    },
+  ]);
+
+  const result = filterCuratedByStopHours([openCard], WED_1800_UTC);
+  assertEquals(result.length, 1, 'all-open curated card must be retained');
+});
+
+Deno.test('T-2-02b: stop with NO hours data (non-always-open) is treated OPEN (honest-unknown)', () => {
+  const noHoursCard = curatedCard([
+    { placeType: 'restaurant', openingHours: {}, travelTimeFromPreviousStopMin: 0 },
+  ]);
+  const result = filterCuratedByStopHours([noHoursCard], WED_1800_UTC);
+  assertEquals(result.length, 1, 'no-hours stop must be assumed open (never fabricate closed)');
+});
+
+Deno.test('T-2 D-1: isStopOpenAtHour evaluates canonical Google v1 periods shape', () => {
+  const closedStop = { placeType: 'restaurant', openingHours: periods(3, 9, 17) };
+  const openStop = { placeType: 'restaurant', openingHours: periods(3, 11, 23) };
+  // Wed (day=3) at 18:00.
+  assert(!isStopOpenAtHour(closedStop, 18, 3), 'periods-shape closed stop must read as closed');
+  assert(isStopOpenAtHour(openStop, 18, 3), 'periods-shape open stop must read as open');
+});
+
+Deno.test('T-2: filtering all-closed cards empties the list (drives empty-summary verdict)', () => {
+  const c1 = curatedCard([
+    { placeType: 'restaurant', openingHours: periods(3, 9, 17), travelTimeFromPreviousStopMin: 0 },
+  ]);
+  const c2 = curatedCard([
+    { placeType: 'cafe', openingHours: periods(3, 6, 14), travelTimeFromPreviousStopMin: 0 },
+  ]);
+  const result = filterCuratedByStopHours([c1, c2], WED_1800_UTC);
+  assertEquals(result.length, 0, 'all-closed deck empties → handler emits summary verdict');
+});

--- a/supabase/functions/_shared/__tests__/curatedStopHours.test.ts
+++ b/supabase/functions/_shared/__tests__/curatedStopHours.test.ts
@@ -37,7 +37,7 @@ function periods(day: number, openHour: number, closeHour: number) {
 // the place-local arrival of the FIRST stop is Wednesday (day=3) 18:00.
 const WED_1800_UTC = new Date(Date.UTC(2026, 5, 3, 18, 0, 0));
 
-function curatedCard(stops: any[]): any {
+function curatedCard(stops: Record<string, unknown>[]): Record<string, unknown> {
   return {
     cardType: 'curated',
     utcOffsetMinutes: 0,

--- a/supabase/functions/_shared/curatedStopHours.ts
+++ b/supabase/functions/_shared/curatedStopHours.ts
@@ -1,0 +1,223 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// curatedStopHours.ts — Shared open-during-the-outing cascade for curated cards.
+//
+// ORCH-1061 PART 2: extracted (single source of truth, Constitution #6) from
+// discover-cards/index.ts so BOTH the collab path (discover-cards) and the
+// SOLO path (generate-curated-experiences) inherit the SAME open-hours gate.
+//
+// Before ORCH-1061 the solo curated path (generate-curated-experiences called
+// directly by deckService.ts) applied NO open-hours filter — so a solo user
+// could be served a curated plan whose stop was closed when they'd arrive.
+// Collab cards (via discover-cards) did get filtered, but the reader only ever
+// looked at the legacy text-shape hours, so it was largely a no-op (D-1 below).
+//
+// D-1 FIX (correctness, not just a move): the prior `isStopOpenAtHour` ONLY read
+// the text-based lowercase-day shape (`openingHours[dayName]` → parseHoursText).
+// place_pool.opening_hours is the UNWRAPPED Google v1 shape
+// ({ openNow, periods, weekdayDescriptions, … }) for ~99.9% of rows, so the old
+// reader fell through to its "no dayText → assume open" branch for almost every
+// row — i.e. the curated hours filter barely filtered anything. This module
+// reads `periods` first (canonical Google v1), then legacy `_periods`, then the
+// text fallback — mirroring the all-shape-tolerant filterByDateTime.isOpenAtHour
+// (discover-cards:285-335). Same bug class ORCH-1019 fixed on the mobile client
+// (I-CURATED-HOURS-VIA-CANONICAL-READER).
+//
+// Honest-unknown rule (Constitution #9, LOCKED): genuinely no hours data
+// (no periods, no _periods, no day text) → assume OPEN. Curated cards are
+// precious; never fabricate "closed" for a venue we simply lack data on.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Parse a single time range like "9:00 AM – 5:00 PM" or "5:00 – 9:30 PM" (Google PM-only format).
+ *  Returns { open, close } in fractional 24h hours, or null if unparseable.
+ *  Handles overnight wraparound: "5 PM - 2 AM" → { open: 17, close: 26 }. */
+export function parseSingleRange(range: string): { open: number; close: number } | null {
+  // Pattern 1: AM/PM on BOTH sides — "9:00 AM – 5:00 PM"
+  const fullMatch = range.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)\s*[–\-]\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
+  if (fullMatch) {
+    let openH = parseInt(fullMatch[1]);
+    const openMin = parseInt(fullMatch[2] || '0');
+    const openAmPm = fullMatch[3].toUpperCase();
+    let closeH = parseInt(fullMatch[4]);
+    const closeMin = parseInt(fullMatch[5] || '0');
+    const closeAmPm = fullMatch[6].toUpperCase();
+    if (openAmPm === 'PM' && openH !== 12) openH += 12;
+    if (openAmPm === 'AM' && openH === 12) openH = 0;
+    if (closeAmPm === 'PM' && closeH !== 12) closeH += 12;
+    if (closeAmPm === 'AM' && closeH === 12) closeH = 0;
+    const open = openH + openMin / 60;
+    let close = closeH + closeMin / 60;
+    if (close <= open) close += 24;
+    return { open, close };
+  }
+
+  // Pattern 2: AM/PM only on closing — "5:00 – 9:30 PM" (Google PM-only format)
+  const partialMatch = range.match(/(\d{1,2})(?::(\d{2}))?\s*[–\-]\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
+  if (partialMatch) {
+    let openH = parseInt(partialMatch[1]);
+    const openMin = parseInt(partialMatch[2] || '0');
+    let closeH = parseInt(partialMatch[3]);
+    const closeMin = parseInt(partialMatch[4] || '0');
+    const closeAmPm = partialMatch[5].toUpperCase();
+    if (closeAmPm === 'PM' && closeH !== 12) closeH += 12;
+    if (closeAmPm === 'AM' && closeH === 12) closeH = 0;
+    // Infer opening AM/PM: if close is PM and open <= close (in 12h), open is PM too
+    // If close is AM (late night), open is PM (crossed midnight)
+    if (closeAmPm === 'PM') {
+      if (openH !== 12 && openH < 12) openH += 12; // Infer PM
+    } else {
+      // Close is AM (e.g., "10:00 – 1:00 AM") → open is PM
+      if (openH !== 12 && openH < 12) openH += 12;
+    }
+    const open = openH + openMin / 60;
+    let close = closeH + closeMin / 60;
+    if (close <= open) close += 24;
+    return { open, close };
+  }
+
+  return null;
+}
+
+/** Parse hours text into an array of time ranges.
+ *  Handles split hours: "11:00 AM – 2:30 PM, 5:00 – 10:00 PM" → two ranges.
+ *  Returns null if closed or empty. */
+export function parseHoursText(text: string): { open: number; close: number }[] | null {
+  if (!text || text.toLowerCase().includes('closed')) return null;
+  if (text.toLowerCase().includes('open 24') || text.toLowerCase().includes('24 hours')) {
+    return [{ open: 0, close: 24 }];
+  }
+
+  // Split on comma for multi-range hours
+  const parts = text.split(/,\s*/);
+  const ranges: { open: number; close: number }[] = [];
+  for (const part of parts) {
+    const parsed = parseSingleRange(part.trim());
+    if (parsed) ranges.push(parsed);
+  }
+  return ranges.length > 0 ? ranges : null;
+}
+
+/** Check if a target hour falls within any of the parsed ranges. */
+export function hourInRanges(hour: number, ranges: { open: number; close: number }[]): boolean {
+  return ranges.some((r) => hour >= r.open && hour < r.close);
+}
+
+export const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+// ── Curated stop duration table (minutes), keyed by Google primary type ──────
+export const CURATED_STOP_DURATION: Record<string, number> = {
+  park: 60, botanical_garden: 60, hiking_area: 90, beach: 90,
+  national_park: 90, state_park: 90, garden: 45,
+  bar: 60, pub: 60, wine_bar: 60, cocktail_bar: 60, brewery: 60,
+  restaurant: 60, fine_dining_restaurant: 90, french_restaurant: 90,
+  steak_house: 90, italian_restaurant: 75, seafood_restaurant: 60,
+  movie_theater: 150, art_gallery: 60, museum: 90,
+  performing_arts_theater: 120, concert_hall: 120, opera_house: 150,
+  bowling_alley: 60, karaoke: 90, video_arcade: 60,
+  amusement_center: 60, amusement_park: 180,
+  spa: 90, massage_spa: 90,
+  cafe: 30, coffee_shop: 30, bakery: 20,
+  grocery_store: 30, supermarket: 30, florist: 15,
+  picnic_ground: 120,
+};
+
+export const ALWAYS_OPEN_TYPES: ReadonlySet<string> = new Set([
+  'park', 'national_park', 'state_park', 'hiking_area', 'beach',
+  'botanical_garden', 'city_park', 'garden', 'nature_preserve',
+  'picnic_ground', 'scenic_spot', 'tourist_attraction', 'plaza',
+  'lake', 'river', 'woods', 'mountain_peak',
+]);
+
+// ── Hours evaluation cascade (ORCH-1061 D-1 FIX) ─────────────────────────────
+// Evaluate a periods array (same shape whether `periods` or `_periods`) against
+// a target day + fractional hour. Mirrors filterByDateTime.isOpenAtHour's
+// evalPeriods (discover-cards:306-315): minute-aware, midnight + overnight safe.
+function evalPeriods(
+  periodsArr: Array<{ open?: { day?: number; hour?: number; minute?: number }; close?: { hour?: number; minute?: number } }>,
+  day: number,
+  hourFrac: number,
+): boolean {
+  return periodsArr.some((period) => {
+    if (period.open?.day !== day) return false;
+    const openH = (period.open?.hour ?? 0) + (period.open?.minute ?? 0) / 60;
+    let closeH = (period.close?.hour ?? 24) + (period.close?.minute ?? 0) / 60;
+    if (closeH === 0) closeH = 24;
+    if (closeH <= openH) closeH += 24;
+    return hourFrac >= openH && hourFrac < closeH;
+  });
+}
+
+/**
+ * Is this curated stop open at `hour` (fractional 24h) on `dayOfWeek` (0=Sun)?
+ *
+ * ORCH-1061 D-1 cascade (LOCKED), honest-unknown → OPEN:
+ *  1. ALWAYS_OPEN_TYPES → true.
+ *  2. No openingHours object → true (honest-unknown).
+ *  3. Path A — canonical Google v1 `periods` (the ~99.9% shape).  ← D-1 FIX
+ *  4. Path B — legacy `_periods`.
+ *  5. Path C — text shape (lowercase day key → parseHoursText). Missing day text
+ *     → true (honest-unknown); "Closed"/unparseable → false; else hourInRanges.
+ */
+export function isStopOpenAtHour(stop: any, hour: number, dayOfWeek: number): boolean {
+  // 1. Always-open outdoor types.
+  const pType = stop.placeType || '';
+  if (ALWAYS_OPEN_TYPES.has(pType)) return true;
+
+  // 2. No data → assume open (honest-unknown).
+  const oh = stop.openingHours;
+  if (!oh || typeof oh !== 'object') return true;
+
+  // 3. Path A — canonical Google v1 `periods` (D-1 FIX: prior reader skipped this).
+  if (Array.isArray(oh.periods) && oh.periods.length > 0) {
+    return evalPeriods(oh.periods, dayOfWeek, hour);
+  }
+
+  // 4. Path B — legacy underscore-prefixed `_periods`.
+  if (Array.isArray(oh._periods) && oh._periods.length > 0) {
+    return evalPeriods(oh._periods, dayOfWeek, hour);
+  }
+
+  // 5. Path C — text shape (legacy lowercase-day rows).
+  const dayName = DAY_NAMES[dayOfWeek];
+  const dayText = oh[dayName];
+  if (!dayText) return true; // No data for this day → honest-unknown → open.
+
+  const parsed = parseHoursText(dayText);
+  if (!parsed) return false; // "Closed" or unparseable.
+  return hourInRanges(hour, parsed);
+}
+
+/**
+ * Drop curated cards whose any non-optional stop is CLOSED at the time the user
+ * would actually arrive there (start time + cumulative prior-stop duration +
+ * travel). Idempotent: re-filtering an already-open card is a no-op.
+ *
+ * Extracted byte-for-behavior from discover-cards/index.ts:504-532 (it now calls
+ * the D-1-fixed isStopOpenAtHour above). utcOffsetMinutes fallback, per-stop
+ * duration accumulation, and optional-stop skip are unchanged.
+ */
+export function filterCuratedByStopHours(cards: any[], utcNow: Date): any[] {
+  return cards.filter((card) => {
+    if (card.cardType !== 'curated' || !card.stops?.length) return true;
+
+    // Compute place-local start time using card's timezone offset.
+    const offsetMin = card.utcOffsetMinutes ?? (card.lng != null ? Math.round(card.lng / 15) * 60 : 0);
+    const localMs = utcNow.getTime() + offsetMin * 60 * 1000;
+    const localDate = new Date(localMs);
+    let currentHour = localDate.getUTCHours() + localDate.getUTCMinutes() / 60;
+    const localDay = localDate.getUTCDay();
+
+    for (let i = 0; i < card.stops.length; i++) {
+      const stop = card.stops[i];
+      if (stop.optional) continue;
+
+      if (!isStopOpenAtHour(stop, currentHour, localDay)) return false;
+
+      const duration = CURATED_STOP_DURATION[stop.placeType] || 45;
+      const travelToNext = (i < card.stops.length - 1)
+        ? (card.stops[i + 1]?.travelTimeFromPreviousStopMin || 15)
+        : 0;
+      currentHour += (duration + travelToNext) / 60;
+    }
+    return true;
+  });
+}

--- a/supabase/functions/discover-cards/index.ts
+++ b/supabase/functions/discover-cards/index.ts
@@ -17,6 +17,20 @@ import { decideTypeAndPill } from '../_shared/mixedTypeInterleave.ts';
 // Single owner: _shared/distanceMath.ts. See
 // Mingla_Artifacts/specs/SPEC_ORCH-0659_0660_DECK_DISTANCE_TRAVELTIME.md.
 import { haversineKm, estimateTravelMinutes, radiusKmForConstraint, type TravelMode } from '../_shared/distanceMath.ts';
+// ORCH-1061 PART 2: single source of truth for the curated open-hours cascade +
+// the shared hours-text parsers. filterByDateTime AND the curated path both read
+// these — there is now exactly ONE parser (no duplicate defs). The shared
+// isStopOpenAtHour also carries the D-1 periods-shape fix.
+import {
+  parseSingleRange,
+  parseHoursText,
+  hourInRanges,
+  DAY_NAMES,
+  CURATED_STOP_DURATION,
+  ALWAYS_OPEN_TYPES,
+  isStopOpenAtHour,
+  filterCuratedByStopHours,
+} from '../_shared/curatedStopHours.ts';
 
 // ─── ORCH-0588 Slice 1: cohort cache for signal-serving rollout ───────────────
 // Module-scoped 60s cache for the admin-config cohort pct. 60s = balance between
@@ -143,82 +157,10 @@ const corsHeaders = {
 // _shared/distanceMath.ts. See ORCH-0903 close banner in WORLD_MAP.md.
 
 // ── DateTime Filter ─────────────────────────────────────────────────────────
-
-/** Parse a single time range like "9:00 AM – 5:00 PM" or "5:00 – 9:30 PM" (Google PM-only format).
- *  Returns { open, close } in fractional 24h hours, or null if unparseable.
- *  Handles overnight wraparound: "5 PM - 2 AM" → { open: 17, close: 26 }. */
-function parseSingleRange(range: string): { open: number; close: number } | null {
-  // Pattern 1: AM/PM on BOTH sides — "9:00 AM – 5:00 PM"
-  const fullMatch = range.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)\s*[–\-]\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
-  if (fullMatch) {
-    let openH = parseInt(fullMatch[1]);
-    const openMin = parseInt(fullMatch[2] || '0');
-    const openAmPm = fullMatch[3].toUpperCase();
-    let closeH = parseInt(fullMatch[4]);
-    const closeMin = parseInt(fullMatch[5] || '0');
-    const closeAmPm = fullMatch[6].toUpperCase();
-    if (openAmPm === 'PM' && openH !== 12) openH += 12;
-    if (openAmPm === 'AM' && openH === 12) openH = 0;
-    if (closeAmPm === 'PM' && closeH !== 12) closeH += 12;
-    if (closeAmPm === 'AM' && closeH === 12) closeH = 0;
-    const open = openH + openMin / 60;
-    let close = closeH + closeMin / 60;
-    if (close <= open) close += 24;
-    return { open, close };
-  }
-
-  // Pattern 2: AM/PM only on closing — "5:00 – 9:30 PM" (Google PM-only format)
-  const partialMatch = range.match(/(\d{1,2})(?::(\d{2}))?\s*[–\-]\s*(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i);
-  if (partialMatch) {
-    let openH = parseInt(partialMatch[1]);
-    const openMin = parseInt(partialMatch[2] || '0');
-    let closeH = parseInt(partialMatch[3]);
-    const closeMin = parseInt(partialMatch[4] || '0');
-    const closeAmPm = partialMatch[5].toUpperCase();
-    if (closeAmPm === 'PM' && closeH !== 12) closeH += 12;
-    if (closeAmPm === 'AM' && closeH === 12) closeH = 0;
-    // Infer opening AM/PM: if close is PM and open <= close (in 12h), open is PM too
-    // If close is AM (late night), open is PM (crossed midnight)
-    if (closeAmPm === 'PM') {
-      if (openH !== 12 && openH < 12) openH += 12; // Infer PM
-    } else {
-      // Close is AM (e.g., "10:00 – 1:00 AM") → open is PM
-      if (openH !== 12 && openH < 12) openH += 12;
-    }
-    const open = openH + openMin / 60;
-    let close = closeH + closeMin / 60;
-    if (close <= open) close += 24;
-    return { open, close };
-  }
-
-  return null;
-}
-
-/** Parse hours text into an array of time ranges.
- *  Handles split hours: "11:00 AM – 2:30 PM, 5:00 – 10:00 PM" → two ranges.
- *  Returns null if closed or empty. */
-function parseHoursText(text: string): { open: number; close: number }[] | null {
-  if (!text || text.toLowerCase().includes('closed')) return null;
-  if (text.toLowerCase().includes('open 24') || text.toLowerCase().includes('24 hours')) {
-    return [{ open: 0, close: 24 }];
-  }
-
-  // Split on comma for multi-range hours
-  const parts = text.split(/,\s*/);
-  const ranges: { open: number; close: number }[] = [];
-  for (const part of parts) {
-    const parsed = parseSingleRange(part.trim());
-    if (parsed) ranges.push(parsed);
-  }
-  return ranges.length > 0 ? ranges : null;
-}
-
-/** Check if a target hour falls within any of the parsed ranges. */
-function hourInRanges(hour: number, ranges: { open: number; close: number }[]): boolean {
-  return ranges.some(r => hour >= r.open && hour < r.close);
-}
-
-const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+// ORCH-1061 PART 2: parseSingleRange / parseHoursText / hourInRanges / DAY_NAMES
+// were moved to _shared/curatedStopHours.ts (single source of truth) and are
+// imported at the top of this file. filterByDateTime below uses the imported
+// versions. Do NOT re-declare them here.
 
 /**
  * ORCH-0446: AND date filtering for collab sessions.
@@ -458,78 +400,13 @@ function filterByDateTime(
 }
 
 // ── Cascading Hours Filter for Curated Cards ───────────────────────────────
-// Before serving curated cards, check that each stop is open when the user
-// would actually arrive there (accounting for previous stop duration + travel).
-
-const CURATED_STOP_DURATION: Record<string, number> = {
-  park: 60, botanical_garden: 60, hiking_area: 90, beach: 90,
-  national_park: 90, state_park: 90, garden: 45,
-  bar: 60, pub: 60, wine_bar: 60, cocktail_bar: 60, brewery: 60,
-  restaurant: 60, fine_dining_restaurant: 90, french_restaurant: 90,
-  steak_house: 90, italian_restaurant: 75, seafood_restaurant: 60,
-  movie_theater: 150, art_gallery: 60, museum: 90,
-  performing_arts_theater: 120, concert_hall: 120, opera_house: 150,
-  bowling_alley: 60, karaoke: 90, video_arcade: 60,
-  amusement_center: 60, amusement_park: 180,
-  spa: 90, massage_spa: 90,
-  cafe: 30, coffee_shop: 30, bakery: 20,
-  grocery_store: 30, supermarket: 30, florist: 15,
-  picnic_ground: 120,
-};
-
-const ALWAYS_OPEN_TYPES = new Set([
-  'park', 'national_park', 'state_park', 'hiking_area', 'beach',
-  'botanical_garden', 'city_park', 'garden', 'nature_preserve',
-  'picnic_ground', 'scenic_spot', 'tourist_attraction', 'plaza',
-  'lake', 'river', 'woods', 'mountain_peak',
-]);
-
-function isStopOpenAtHour(stop: any, hour: number, dayOfWeek: number): boolean {
-  // Always-open outdoor types
-  const pType = stop.placeType || '';
-  if (ALWAYS_OPEN_TYPES.has(pType)) return true;
-
-  const oh = stop.openingHours;
-  if (!oh || typeof oh !== 'object') return true; // No data → assume open
-
-  const dayName = DAY_NAMES[dayOfWeek];
-  const dayText = oh[dayName];
-  if (!dayText) return true;
-
-  const parsed = parseHoursText(dayText);
-  if (!parsed) return false; // "Closed" or unparseable
-  return hourInRanges(hour, parsed);
-}
-
-function filterCuratedByStopHours(
-  cards: any[],
-  utcNow: Date,
-): any[] {
-  return cards.filter(card => {
-    if (card.cardType !== 'curated' || !card.stops?.length) return true;
-
-    // Compute place-local start time using card's timezone offset
-    const offsetMin = card.utcOffsetMinutes ?? (card.lng != null ? Math.round(card.lng / 15) * 60 : 0);
-    const localMs = utcNow.getTime() + offsetMin * 60 * 1000;
-    const localDate = new Date(localMs);
-    let currentHour = localDate.getUTCHours() + localDate.getUTCMinutes() / 60;
-    const localDay = localDate.getUTCDay();
-
-    for (let i = 0; i < card.stops.length; i++) {
-      const stop = card.stops[i];
-      if (stop.optional) continue;
-
-      if (!isStopOpenAtHour(stop, currentHour, localDay)) return false;
-
-      const duration = CURATED_STOP_DURATION[stop.placeType] || 45;
-      const travelToNext = (i < card.stops.length - 1)
-        ? (card.stops[i + 1]?.travelTimeFromPreviousStopMin || 15)
-        : 0;
-      currentHour += (duration + travelToNext) / 60;
-    }
-    return true;
-  });
-}
+// ORCH-1061 PART 2: CURATED_STOP_DURATION / ALWAYS_OPEN_TYPES / isStopOpenAtHour /
+// filterCuratedByStopHours were moved to _shared/curatedStopHours.ts (single
+// source of truth, shared with the SOLO generate-curated-experiences path) and
+// are imported at the top of this file. The extracted isStopOpenAtHour also
+// carries the D-1 periods-shape fix (it now actually filters the ~99.9% of
+// canonical Google v1 periods-shape rows the old text-only reader skipped).
+// Do NOT re-declare them here.
 
 // ─── ORCH-0588 Slice 1: signal-serving response shape ────────────────────────
 // Maps the new query_servable_places_by_signal RPC row → the same card shape

--- a/supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts
+++ b/supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts
@@ -1,0 +1,180 @@
+// ORCH-1061 — implementor happy-path Deno tests for PART 1A (quality+proximity
+// blend), PART 1B (deterministic main-activity rotation), and the PART 2 solo
+// empty-summary contract.
+//
+// The module is imported directly; its serve() is guarded by `import.meta.main`
+// (ORCH-1061) so importing it does NOT start the HTTP server.
+//
+// Covers (implementor-owned rows from SPEC §8):
+//   T-1A-01 (fails-on-revert) — post-anchor pick is quality-weighted, not nearest.
+//   T-1A-03 — selection is deterministic.
+//   T-1A-05 — empty/single guards match the old helper.
+//   T-1B-MAP — mainActivitySlotIndex yields the exact §5.2 mapping.
+//   T-1B-01 — combo ordering is deterministic.
+//   T-1B-02 — main activity rotates card-to-card.
+//   T-1B-04 — picnic = no rotation, single-combo repeat.
+//   T-2-07 — when the hours filter empties the deck, a summary verdict is emitted.
+//
+// Run: cd supabase && deno test --allow-read --allow-env functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  selectBlendedStop,
+  mainActivitySlotIndex,
+  buildDeterministicComboList,
+  EXPERIENCE_TYPE_MAP,
+} from '../index.ts';
+import { filterCuratedByStopHours } from '../../_shared/curatedStopHours.ts';
+
+// ─── PART 1A — blend ──────────────────────────────────────────────────────────
+
+Deno.test('T-1A-01 (fails-on-revert): post-anchor pick is quality-weighted, not nearest', () => {
+  // Ref point at (0,0). Candidate A is CLOSER but LOW quality. Candidate B is
+  // slightly farther but MUCH higher vibe rank + rating + reviews. With the
+  // 0.6·Q + 0.4·P blend, B must win. Pure-nearest (the reverted behavior) would
+  // pick A → test FAILS on revert.
+  const radiusMeters = 5000; // 5km radius
+  const ref = { lat: 0, lng: 0 };
+
+  // ~0.5km away, weak signal.
+  const closeWeak = {
+    google_place_id: 'A_close_weak',
+    lat: 0.0045, lng: 0, // ~0.5km north
+    _rankScore: 10,
+    rating: 3.6,
+    review_count: 12,
+  };
+  // ~2km away, strong signal.
+  const fartherStrong = {
+    google_place_id: 'B_far_strong',
+    lat: 0.018, lng: 0, // ~2km north
+    _rankScore: 100,
+    rating: 4.8,
+    review_count: 2400,
+  };
+
+  const pick = selectBlendedStop([closeWeak, fartherStrong], ref.lat, ref.lng, radiusMeters);
+  assertEquals(pick?.google_place_id, 'B_far_strong',
+    'blend must prefer the farther high-quality candidate over the closer weak one');
+});
+
+Deno.test('T-1A-03: blended selection is deterministic across runs', () => {
+  const ref = { lat: 35.78, lng: -78.64 };
+  const candidates = [
+    { google_place_id: 'p1', lat: 35.79, lng: -78.65, _rankScore: 80, rating: 4.5, review_count: 300 },
+    { google_place_id: 'p2', lat: 35.781, lng: -78.641, _rankScore: 40, rating: 4.9, review_count: 50 },
+    { google_place_id: 'p3', lat: 35.80, lng: -78.66, _rankScore: 95, rating: 4.2, review_count: 900 },
+  ];
+  const a = selectBlendedStop(candidates, ref.lat, ref.lng, 8000);
+  const b = selectBlendedStop(candidates, ref.lat, ref.lng, 8000);
+  assertEquals(a?.google_place_id, b?.google_place_id, 'same inputs → same pick');
+});
+
+Deno.test('T-1A-05: empty → null; single → that element', () => {
+  assertEquals(selectBlendedStop([], 0, 0, 3000), null, 'empty must return null');
+  const only = { google_place_id: 'solo', lat: 1, lng: 1, _rankScore: 5, rating: 4, review_count: 10 };
+  assertEquals(selectBlendedStop([only], 0, 0, 3000), only, 'single must return that element');
+});
+
+// ─── PART 1B — deterministic rotation ────────────────────────────────────────
+
+Deno.test('T-1B-MAP: mainActivitySlotIndex yields the exact SPEC §5.2 mapping', () => {
+  const expect: Record<string, number> = {
+    'adventurous': 0,
+    'first-date': 1,
+    'romantic': 1,
+    'group-fun': 0,
+    'take-a-stroll': 1,
+    'picnic-dates': -1,
+  };
+  for (const [id, idx] of Object.entries(expect)) {
+    const typeDef = EXPERIENCE_TYPE_MAP[id];
+    assert(typeDef, `typeDef ${id} must exist`);
+    assertEquals(mainActivitySlotIndex(typeDef), idx, `${id} main-activity slot index`);
+  }
+});
+
+Deno.test('T-1B-01: combo ordering is deterministic for identical (typeDef, batchSeed, limit)', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['adventurous'];
+  const a = buildDeterministicComboList(typeDef, 7, 20);
+  const b = buildDeterministicComboList(typeDef, 7, 20);
+  assertEquals(JSON.stringify(a), JSON.stringify(b), 'same inputs → identical ordering');
+  assert(a.length >= 40, 'list must be at least limit*2 long');
+});
+
+Deno.test('T-1B-02: main activity rotates card-to-card while distinct activities remain', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['adventurous'];
+  const slotIdx = mainActivitySlotIndex(typeDef);
+  const distinct = new Set(typeDef.combos.map((c) => c[slotIdx])).size; // distinct main activities
+  const list = buildDeterministicComboList(typeDef, 0, 20);
+  // For the first `distinct` cards, consecutive main-activity slugs must differ.
+  for (let i = 1; i < distinct; i++) {
+    assert(
+      list[i][slotIdx] !== list[i - 1][slotIdx],
+      `card ${i} main activity (${list[i][slotIdx]}) must differ from card ${i - 1} (${list[i - 1][slotIdx]})`,
+    );
+  }
+});
+
+Deno.test('T-1B-02b: take-a-stroll rotates the FOOD slot while nature anchor stays constant', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['take-a-stroll'];
+  const slotIdx = mainActivitySlotIndex(typeDef);
+  assertEquals(slotIdx, 1, 'take-a-stroll rotates the food slot (index 1), not the nature anchor');
+  const list = buildDeterministicComboList(typeDef, 0, 20);
+  // Nature anchor (index 0) is constant across all entries.
+  for (const combo of list) {
+    assertEquals(combo[0], 'nature', 'nature anchor must stay constant');
+  }
+  // Food slug rotates across the 3 distinct foods in the first 3 cards.
+  const firstThreeFoods = [list[0][1], list[1][1], list[2][1]];
+  assertEquals(new Set(firstThreeFoods).size, 3, 'first 3 cards rotate through all 3 foods');
+});
+
+Deno.test('T-1B-04: picnic = no rotation, single-combo repeat to limit*2', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['picnic-dates'];
+  const list = buildDeterministicComboList(typeDef, 5, 20);
+  assert(list.length >= 40, 'list must be at least limit*2 long');
+  for (const combo of list) {
+    assertEquals(JSON.stringify(combo), JSON.stringify(['groceries', 'flowers', 'nature']),
+      'every picnic entry must be the single frozen combo');
+  }
+});
+
+Deno.test('T-1B-05: batchSeed changes the start offset deterministically', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['adventurous'];
+  const slotIdx = mainActivitySlotIndex(typeDef);
+  const first0 = buildDeterministicComboList(typeDef, 0, 20)[0][slotIdx];
+  const first1 = buildDeterministicComboList(typeDef, 1, 20)[0][slotIdx];
+  // adventurous has ≥2 distinct main activities → seed 0 vs 1 start differently.
+  assert(first0 !== first1, 'different batchSeed → different first main activity');
+  // ...and each is reproducible.
+  assertEquals(buildDeterministicComboList(typeDef, 1, 20)[0][slotIdx], first1, 'seed 1 reproducible');
+});
+
+// ─── PART 2 — solo empty-summary contract ────────────────────────────────────
+
+Deno.test('T-2-07: when the hours filter empties the deck, a summary verdict is produced', () => {
+  // Replicate the handler post-filter logic (index.ts handler):
+  //   cards = filterCuratedByStopHours(cards, curatedUtcNow);
+  //   if (cards.length === 0 && !summary) summary = { emptyReason: 'pool_empty', ... }
+  const WED_1800_UTC = new Date(Date.UTC(2026, 5, 3, 18, 0, 0));
+  const closedCard = {
+    cardType: 'curated', utcOffsetMinutes: 0, lng: 0,
+    stops: [{
+      placeType: 'restaurant',
+      openingHours: { periods: [{ open: { day: 3, hour: 9, minute: 0 }, close: { day: 3, hour: 17, minute: 0 } }] },
+      travelTimeFromPreviousStopMin: 0,
+    }],
+  };
+
+  let cards: any[] = [closedCard];
+  let summary: any = undefined; // generateCardsForType returned cards>0, so no summary yet
+  cards = filterCuratedByStopHours(cards, WED_1800_UTC);
+  if (cards.length === 0 && !summary) {
+    summary = { emptyReason: 'pool_empty', candidateAnchorCount: 0, failedAnchorCount: 0 };
+  }
+
+  assertEquals(cards.length, 0, 'closed card filtered out');
+  assert(summary, 'summary verdict must be set so mobile routes to EMPTY UI');
+  assertEquals(summary.emptyReason, 'pool_empty');
+});

--- a/supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts
+++ b/supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_and_rotation.test.ts
@@ -167,8 +167,9 @@ Deno.test('T-2-07: when the hours filter empties the deck, a summary verdict is 
     }],
   };
 
-  let cards: any[] = [closedCard];
-  let summary: any = undefined; // generateCardsForType returned cards>0, so no summary yet
+  let cards: Record<string, unknown>[] = [closedCard];
+  let summary: { emptyReason: string; candidateAnchorCount: number; failedAnchorCount: number } | undefined =
+    undefined; // generateCardsForType returned cards>0, so no summary yet
   cards = filterCuratedByStopHours(cards, WED_1800_UTC);
   if (cards.length === 0 && !summary) {
     summary = { emptyReason: 'pool_empty', candidateAnchorCount: 0, failedAnchorCount: 0 };

--- a/supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_rotation.adversarial.test.ts
+++ b/supabase/functions/generate-curated-experiences/__tests__/orch_1061_blend_rotation.adversarial.test.ts
@@ -1,0 +1,276 @@
+// ORCH-1061 — TESTER adversarial Deno tests for PART 1A (quality+proximity blend)
+// and PART 1B (deterministic main-activity rotation).
+//
+// These attack DIFFERENT angles than the implementor's happy-path file
+// (orch_1061_blend_and_rotation.test.ts): they hunt the failure modes the
+// happy-path does not exercise — a case where pure-nearest would WIN (proving
+// the blend actually changed the pick), the full deterministic tie-break CHAIN
+// (every rung: _rankScore → rating → review_count → smaller google_place_id),
+// proof that take-a-stroll rotates the FOOD slot and NOT the nature anchor,
+// batchSeed start-offset determinism across multiple seeds, and a source-grep
+// asserting NO Math.random is reachable in the ordering/selection path
+// (I-COLLAB-DECK-DETERMINISM).
+//
+// The module's serve() is guarded by `import.meta.main` (ORCH-1061) so importing
+// it does NOT start the HTTP server.
+//
+// Run: cd supabase && deno test --allow-read --allow-env --no-check \
+//   functions/generate-curated-experiences/__tests__/orch_1061_blend_rotation.adversarial.test.ts
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  selectBlendedStop,
+  tieBreakWins,
+  mainActivitySlotIndex,
+  buildDeterministicComboList,
+  EXPERIENCE_TYPE_MAP,
+} from '../index.ts';
+
+// ─── T-1A-02 (adversarial): pure-nearest would have LOST → the blend wins ──────
+// Construct a case where the CLOSEST candidate is decisively the WRONG pick: it
+// sits almost on top of the ref point (so pure-nearest picks it every time) but
+// has the weakest quality, while a candidate near the radius edge has dominant
+// vibe rank + rating + reviews. Pure-nearest (the reverted production behavior)
+// returns the on-top weak one; the 0.6·Q + 0.4·P blend must return the strong one.
+Deno.test('T-1A-02 (adversarial): blend overrides pure-nearest when nearest is the worst candidate', () => {
+  const radiusMeters = 10000; // 10km radius
+  const ref = { lat: 40.0, lng: -75.0 };
+
+  // ~50m away (essentially at the ref point) — would ALWAYS win pure-nearest.
+  const nearestWorst = {
+    google_place_id: 'NEAREST_BUT_WORST',
+    lat: 40.00045, lng: -75.0, // ~50m north
+    _rankScore: 1,             // bottom of the pool
+    rating: 3.0,
+    review_count: 2,
+  };
+  // ~4km away — far from the ref but the clearly-best venue.
+  const farButBest = {
+    google_place_id: 'FAR_BUT_BEST',
+    lat: 40.036, lng: -75.0, // ~4km north
+    _rankScore: 100,
+    rating: 4.9,
+    review_count: 5000,
+  };
+  // A mid candidate to make the pool realistic (not a 2-element edge case).
+  const midMeh = {
+    google_place_id: 'MID_MEH',
+    lat: 40.009, lng: -75.0, // ~1km north
+    _rankScore: 30,
+    rating: 4.0,
+    review_count: 100,
+  };
+
+  // Sanity: confirm nearestWorst really IS the nearest (so this is a true
+  // pure-nearest-would-lose scenario, not an accidental tie).
+  const pool = [nearestWorst, midMeh, farButBest];
+  const pick = selectBlendedStop(pool, ref.lat, ref.lng, radiusMeters);
+  assertEquals(
+    pick?.google_place_id,
+    'FAR_BUT_BEST',
+    'blend must reject the on-top weakest candidate that pure-nearest would have picked',
+  );
+});
+
+// ─── T-1A-04 (adversarial): the FULL deterministic tie-break chain ────────────
+// Exercise EVERY rung of tieBreakWins (the arbiter invoked when blended scores
+// are within 1e-9): _rankScore → rating → review_count → lexicographically
+// smaller google_place_id. Plus an end-to-end selectBlendedStop tie where two
+// candidates are byte-identical except google_place_id, forcing the lexicographic
+// final arbiter through the real selection loop.
+Deno.test('T-1A-04 (adversarial): deterministic tie-break chain _rankScore→rating→review_count→id', () => {
+  const base = { google_place_id: 'zzz', _rankScore: 50, rating: 4.0, review_count: 100 };
+
+  // Rung 1 — _rankScore dominates everything below it.
+  assert(
+    tieBreakWins({ ...base, _rankScore: 51 }, { ...base, rating: 5.0, review_count: 99999 }),
+    'higher _rankScore wins even against higher rating + reviews',
+  );
+  assert(
+    !tieBreakWins({ ...base, _rankScore: 49 }, base),
+    'lower _rankScore loses',
+  );
+
+  // Rung 2 — equal _rankScore → higher rating wins (despite fewer reviews).
+  assert(
+    tieBreakWins({ ...base, rating: 4.7, review_count: 1 }, { ...base, rating: 4.6, review_count: 99999 }),
+    'with equal _rankScore, higher rating wins regardless of review_count',
+  );
+
+  // Rung 3 — equal _rankScore + rating → higher review_count wins.
+  assert(
+    tieBreakWins({ ...base, review_count: 500 }, { ...base, review_count: 499 }),
+    'with equal _rankScore + rating, higher review_count wins',
+  );
+
+  // Rung 4 — equal _rankScore + rating + review_count → smaller google_place_id wins.
+  assert(
+    tieBreakWins({ ...base, google_place_id: 'aaa' }, { ...base, google_place_id: 'bbb' }),
+    'all else equal, lexicographically smaller google_place_id wins',
+  );
+  assert(
+    !tieBreakWins({ ...base, google_place_id: 'ccc' }, { ...base, google_place_id: 'bbb' }),
+    'all else equal, lexicographically larger google_place_id loses',
+  );
+  // Total tie (identical id) → tieBreakWins returns false (no displacement).
+  assert(
+    !tieBreakWins({ ...base }, { ...base }),
+    'a total tie does not displace the incumbent (stable)',
+  );
+
+  // End-to-end: two candidates identical in EVERY blend input (same coords, same
+  // rating/reviews/rank) differing only in id → selectBlendedStop must return the
+  // lexicographically smaller id, deterministically, regardless of array order.
+  const same = { lat: 1.234, lng: 5.678, _rankScore: 70, rating: 4.4, review_count: 800 };
+  const alpha = { ...same, google_place_id: 'alpha' };
+  const omega = { ...same, google_place_id: 'omega' };
+  assertEquals(
+    selectBlendedStop([omega, alpha], 0, 0, 3000)?.google_place_id,
+    'alpha',
+    'tied score → smaller id wins (array order [omega, alpha])',
+  );
+  assertEquals(
+    selectBlendedStop([alpha, omega], 0, 0, 3000)?.google_place_id,
+    'alpha',
+    'tied score → smaller id wins (array order [alpha, omega]) — order-independent',
+  );
+});
+
+// ─── T-1B-03 (adversarial): take-a-stroll rotates FOOD, never the nature anchor ─
+// The happy-path proves the food slot rotates; this adversarial version ATTACKS
+// the opposite failure: that a sloppy implementation rotated the ANCHOR (index 0)
+// instead of the food slot. It pins (a) the resolved slot is the food slot, NOT
+// index 0; (b) the index-0 nature anchor is provably CONSTANT across the entire
+// generated list; (c) the food slug genuinely cycles (adjacent cards differ)
+// across multiple seeds.
+Deno.test('T-1B-03 (adversarial): take-a-stroll rotates the FOOD slot, anchor stays nature', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['take-a-stroll'];
+  const slotIdx = mainActivitySlotIndex(typeDef);
+
+  // It must NOT be rotating the anchor (index 0).
+  assert(slotIdx !== 0, 'must not rotate the nature anchor (index 0)');
+  assertEquals(slotIdx, 1, 'rotation slot is the food slot (index 1)');
+
+  for (const seed of [0, 1, 2, 7, 13]) {
+    const list = buildDeterministicComboList(typeDef, seed, 20);
+    assert(list.length >= 40, `seed ${seed}: list >= limit*2`);
+
+    // (a) anchor is constant across EVERY entry.
+    const anchorSlugs = new Set(list.map((c) => c[0]));
+    assertEquals(anchorSlugs.size, 1, `seed ${seed}: nature anchor must be constant`);
+    assertEquals([...anchorSlugs][0], 'nature', `seed ${seed}: anchor must be 'nature'`);
+
+    // (b) the food slot genuinely uses ALL three distinct foods.
+    const foods = new Set(list.map((c) => c[1]));
+    assertEquals(foods.size, 3, `seed ${seed}: all 3 foods must appear in the food slot`);
+    assert(foods.has('brunch') && foods.has('casual_food') && foods.has('upscale_fine_dining'),
+      `seed ${seed}: foods must be the exact stroll set`);
+
+    // (c) adjacent cards rotate (food differs) for the first 3 cards.
+    assert(list[0][1] !== list[1][1], `seed ${seed}: card1 vs card0 food must differ`);
+    assert(list[1][1] !== list[2][1], `seed ${seed}: card2 vs card1 food must differ`);
+  }
+});
+
+// ─── T-1B-05 (adversarial): batchSeed changes the start offset deterministically ─
+// The happy-path checks seed 0 vs 1. This attacks determinism harder: across many
+// seeds (a) every run for a given seed is byte-identical (reproducible), and
+// (b) seed N and seed N+1 start on a DIFFERENT main-activity group offset, with
+// the start offset following the locked modulo formula (seed % groupCount).
+Deno.test('T-1B-05 (adversarial): batchSeed start-offset is deterministic + follows the modulo formula', () => {
+  const typeDef = EXPERIENCE_TYPE_MAP['adventurous'];
+  const slotIdx = mainActivitySlotIndex(typeDef);
+
+  // Build the group order the production code derives (first-appearance distinct
+  // main-activity slugs) to predict the start offset independently.
+  const groupOrder: string[] = [];
+  for (const c of typeDef.combos) {
+    const slug = c[slotIdx];
+    if (!groupOrder.includes(slug)) groupOrder.push(slug);
+  }
+  const groupCount = groupOrder.length;
+  assert(groupCount >= 2, 'adventurous must have >=2 distinct main activities for this test');
+
+  for (const seed of [0, 1, 2, 3, 5, 8, 100]) {
+    const a = buildDeterministicComboList(typeDef, seed, 20);
+    const b = buildDeterministicComboList(typeDef, seed, 20);
+    assertEquals(JSON.stringify(a), JSON.stringify(b), `seed ${seed}: reproducible`);
+
+    // Predicted first main activity = groupOrder[seed % groupCount].
+    const predicted = groupOrder[seed % groupCount];
+    assertEquals(a[0][slotIdx], predicted,
+      `seed ${seed}: first main activity must equal groupOrder[seed % ${groupCount}]`);
+  }
+
+  // Adjacent seeds start on different offsets (until they wrap at groupCount).
+  for (let seed = 0; seed < groupCount - 1; seed++) {
+    const s0 = buildDeterministicComboList(typeDef, seed, 20)[0][slotIdx];
+    const s1 = buildDeterministicComboList(typeDef, seed + 1, 20)[0][slotIdx];
+    assert(s0 !== s1, `seed ${seed} vs ${seed + 1}: first main activity must differ`);
+  }
+
+  // Negative / non-finite seeds are coerced (Math.floor(Math.abs)) — must not throw
+  // and must stay deterministic (defensive against collab agg / bad client values).
+  const neg = buildDeterministicComboList(typeDef, -3, 20);
+  assertEquals(JSON.stringify(neg), JSON.stringify(buildDeterministicComboList(typeDef, 3, 20)),
+    'negative seed -3 coerces to abs(3) deterministically');
+  const nan = buildDeterministicComboList(typeDef, Number.NaN, 20);
+  assertEquals(JSON.stringify(nan), JSON.stringify(buildDeterministicComboList(typeDef, 0, 20)),
+    'NaN seed coerces to 0 deterministically');
+});
+
+// ─── T-1B-06 (adversarial source-grep): NO Math.random in the ordering path ────
+// I-COLLAB-DECK-DETERMINISM: the combo-ordering + stop-selection helpers must be
+// pure (no request-time randomness), else collab decks diverge between
+// participants. This greps the SOURCE of the actual production functions —
+// buildDeterministicComboList, mainActivitySlotIndex, selectBlendedStop,
+// tieBreakWins — and asserts none contains `Math.random`. It also asserts the old
+// `shuffle(` (the deleted Math.random combo shuffle) is no longer called in the
+// ordering path.
+Deno.test('T-1B-06 (adversarial source-grep): ordering/selection path has no Math.random', async () => {
+  const src = await Deno.readTextFile(new URL('../index.ts', import.meta.url));
+
+  // Helper: extract a function/const body by name up to a heuristic end marker.
+  function slice(from: string): string {
+    const i = src.indexOf(from);
+    assert(i >= 0, `must find '${from}' in source`);
+    // Grab a generous window (the largest of these functions is well under 4k chars).
+    return src.slice(i, i + 4000);
+  }
+
+  // Strip line + block comments so the assertion targets executable code only —
+  // the production functions carry comments that literally say "NO Math.random",
+  // which is documentation, not a call.
+  function stripComments(s: string): string {
+    return s
+      .replace(/\/\*[\s\S]*?\*\//g, '')   // block comments
+      .replace(/\/\/[^\n]*/g, '');         // line comments
+  }
+
+  for (const fnStart of [
+    'export function buildDeterministicComboList(',
+    'export function mainActivitySlotIndex(',
+    'export function selectBlendedStop(',
+    'export function tieBreakWins(',
+  ]) {
+    const rawBody = slice(fnStart).split('\nexport function')[0].split('\nfunction')[0];
+    const codeOnly = stripComments(rawBody);
+    // Assert no EXECUTABLE Math.random call (the call form `Math.random(`); the
+    // ordering/selection path must be pure for collab determinism.
+    assert(
+      !/Math\.random\s*\(/.test(codeOnly),
+      `${fnStart} body must not call Math.random`,
+    );
+  }
+
+  // The combo ordering must be driven by the deterministic builder, not a shuffle.
+  assert(
+    /const comboList: string\[\]\[\] = buildDeterministicComboList\(/.test(src),
+    'comboList must be built by buildDeterministicComboList',
+  );
+  // The old Math.random shuffle() function must be deleted (no definition left).
+  assert(
+    !/function shuffle\s*<|function shuffle\s*\(/.test(src),
+    'the Math.random shuffle() helper must be deleted',
+  );
+});

--- a/supabase/functions/generate-curated-experiences/index.ts
+++ b/supabase/functions/generate-curated-experiences/index.ts
@@ -18,6 +18,11 @@ import {
   CATEGORY_DURATION_MINUTES,
   CATEGORY_DEFAULT_DURATION,
 } from '../_shared/curatedConstants.ts';
+// ORCH-1061 PART 2: shared open-during-the-outing cascade. The SOLO curated path
+// (this fn, called directly by deckService.ts) previously applied NO open-hours
+// filter — solo users could be served a plan whose stop was closed on arrival.
+// Now solo inherits the SAME gate collab already gets via discover-cards.
+import { filterCuratedByStopHours } from '../_shared/curatedStopHours.ts';
 
 /* ─────────────────────────────────────────────────────────────────────────────
  * generate-curated-experiences  –  Pool-Only Curated Card Generator
@@ -356,7 +361,7 @@ export const EXPERIENCE_TYPES: ExperienceTypeDef[] = [
 
 // ── Derived constants ──────────────────────────────────────────────────────
 
-const EXPERIENCE_TYPE_MAP: Record<string, ExperienceTypeDef> = {};
+export const EXPERIENCE_TYPE_MAP: Record<string, ExperienceTypeDef> = {};
 for (const et of EXPERIENCE_TYPES) {
   EXPERIENCE_TYPE_MAP[et.id] = et;
 }
@@ -637,6 +642,14 @@ function buildCardFromStops(
     tagline,
     categoryLabel: CURATED_TYPE_LABELS[experienceType] || 'Explore',
     imageUrl: mainStops.find(s => s.imageUrl)?.imageUrl ?? null,
+    // ORCH-1061 PART 2: expose first-stop timezone + coords at the card level so
+    // the shared filterCuratedByStopHours can resolve the arrival timezone for
+    // SOLO cards exactly as it does for collab cards (discover-cards card shape
+    // already carries these). Additive top-level fields; mobile ignores unknown
+    // top-level keys, and stop-level data is unchanged.
+    utcOffsetMinutes: mainStops[0]?.utcOffsetMinutes ?? null,
+    lat: mainStops[0]?.lat ?? null,
+    lng: mainStops[0]?.lng ?? null,
     stops,
     totalPriceMin,
     totalPriceMax,
@@ -658,6 +671,11 @@ async function generateCardsForType(
   limit: number,
   skipDescriptions: boolean,
   excludePlacePoolIds: string[] = [],
+  // ORCH-1061 PART 1B: stable per-batch integer used to seed the deterministic
+  // combo rotation. Threaded from the handler (was destructured but never passed
+  // before ORCH-1061). Defaults to 0 so collab agg / a bad client value can't
+  // break determinism. Collab decks stay reproducible (no Math.random).
+  batchSeed = 0,
 ): Promise<{ cards: any[]; summary?: CuratedSummary }> {
   // ORCH-0903 (2026-05-21): curated path uses unified TRAVEL_CONFIG via
   // radiusKmForConstraint(generosity=1.0). Curated multi-stop trips need
@@ -738,12 +756,12 @@ async function generateCardsForType(
     );
   }
 
-  // Build round-robin combo list
-  const comboList: string[][] = [];
-  const shuffled = shuffle([...typeDef.combos]);
-  while (comboList.length < limit * 2) {
-    comboList.push(...shuffle([...typeDef.combos]));
-  }
+  // ORCH-1061 PART 1B: deterministic combo ordering that rotates the intent's
+  // MAIN ACTIVITY across cards (so the deck shows variety) and descends quality,
+  // seeded off batchSeed. Replaces the old Math.random shuffle (which broke
+  // collab decks). The anchor PLACE still descends best→2nd→3rd across cards via
+  // the existing globalUsedPlaceIds accumulation; PART 1A blends the companions.
+  const comboList: string[][] = buildDeterministicComboList(typeDef, batchSeed, limit);
 
   // Build cards
   const cards: any[] = [];
@@ -844,7 +862,9 @@ async function generateCardsForType(
             }
             if (available.length === 0 && stopDef.optional) continue;
 
-            const place = selectClosestHighestRated(available, prevLat, prevLng);
+            // ORCH-1061 PART 1A: reverse-anchor companions blend quality+proximity.
+            // 3000 = the per-card near-fetch radius used at the fetch above.
+            const place = selectBlendedStop(available, prevLat, prevLng, 3000);
             if (!place && !stopDef.optional) {
               // ORCH-0677 RC-1: companion selection failed — mark anchor failed.
               failedAnchorIds.add(anchor.google_place_id);
@@ -890,11 +910,12 @@ async function generateCardsForType(
           break;
         }
 
-        // Stop 1 (first non-optional): highest quality. Stop 2+: proximity-chained.
+        // Stop 1 (first non-optional): highest quality (UNCHANGED — vibe rank top).
+        // Stop 2+: ORCH-1061 PART 1A quality+proximity blend within the fetch radius.
         const isFirstMainStop = stops.filter(s => !s.optional).length === 0;
         const place = isFirstMainStop
           ? available[0]
-          : selectClosestHighestRated(available, prevLat, prevLng);
+          : selectBlendedStop(available, prevLat, prevLng, clampedRadius);
 
         if (!place) {
           if (stopDef.optional) continue;
@@ -1013,44 +1034,179 @@ async function generateCardsForType(
 
 // ── Utility functions ──────────────────────────────────────────────────────
 
-function shuffle<T>(array: T[]): T[] {
-  const arr = [...array];
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
+// ORCH-1061 PART 1B: the Math.random shuffle() (used only for combo ordering)
+// was DELETED — combo ordering is now deterministic via buildDeterministicComboList
+// (seeded off batchSeed) so collab decks are reproducible. The remaining
+// Math.random uses in this file (tagline pick in buildCardFromStops, the
+// per-card id suffix, the cosmetic matchScore) are display-only / identity-noise
+// and do NOT affect deck card ordering or selection — left untouched per spec §5.5.
+
+// ── ORCH-1061 PART 1B: deterministic main-activity rotation ─────────────────
+
+// Resolve the combo slot index whose CATEGORY we rotate across cards (the intent's
+// "main activity"). Derived from the typeDef, not hardcoded per-intent magic.
+//  - reverse-anchor (picnic): no rotation → -1 sentinel.
+//  - else: the first NON-OPTIONAL slot whose slug VARIES across combos
+//    (take-a-stroll's nature anchor is constant → rotates the food slot instead).
+// Expected mapping (pinned by T-1B-MAP): adventurous→0, first-date→1, romantic→1,
+// group-fun→0, take-a-stroll→1, picnic→-1.
+export function mainActivitySlotIndex(typeDef: ExperienceTypeDef): number {
+  if (typeDef.stops.some((s) => s.reverseAnchor)) return -1;
+  const firstNonOptional = typeDef.stops.findIndex((s) => !s.optional);
+  if (firstNonOptional < 0) return -1;
+  for (let i = firstNonOptional; i < typeDef.stops.length; i++) {
+    const slugsAtI = new Set(typeDef.combos.map((c) => c[i]));
+    if (slugsAtI.size > 1) return i; // first varying non-optional slot
   }
-  return arr;
+  return firstNonOptional; // all-constant fallback (not hit by the current table)
+}
+
+// Build a deterministic combo ordering (length ≥ limit*2) that rotates the main
+// activity across cards and descends quality WITHIN an activity (combos retain
+// their authored EXPERIENCE_TYPES order = best-first). PURE: no Math.random.
+export function buildDeterministicComboList(
+  typeDef: ExperienceTypeDef,
+  batchSeed: number,
+  limit: number,
+): string[][] {
+  const seed = Number.isFinite(batchSeed) ? Math.floor(Math.abs(batchSeed)) : 0;
+  const combos = typeDef.combos; // FROZEN order from EXPERIENCE_TYPES
+  const slotIdx = mainActivitySlotIndex(typeDef);
+  const target = Math.max(limit, 1) * 2;
+
+  // Picnic / no-rotation / single combo: deterministic repeat to target length.
+  if (slotIdx < 0 || combos.length <= 1) {
+    const out: string[][] = [];
+    let guard = 0;
+    while (out.length < target) {
+      out.push(...combos);
+      if (++guard > target + combos.length) break; // can't happen with ≥1 combo
+    }
+    return out;
+  }
+
+  // 1. Group combos by main-activity slug, preserving FIRST-appearance order.
+  const groupOrder: string[] = [];
+  const groups = new Map<string, string[][]>();
+  for (const c of combos) {
+    const slug = c[slotIdx];
+    if (!groups.has(slug)) { groups.set(slug, []); groupOrder.push(slug); }
+    groups.get(slug)!.push(c);
+  }
+
+  // 2. Deterministic rotation offset from batchSeed (NO Math.random).
+  const startOffset = ((seed % groupOrder.length) + groupOrder.length) % groupOrder.length;
+
+  // 3. Round-robin across groups starting at startOffset → MAIN ACTIVITY rotates
+  //    card-to-card; descend within each group as passes advance.
+  const out: string[][] = [];
+  const cursors = new Map<string, number>(groupOrder.map((s) => [s, 0]));
+  let exhaustedGuard = 0;
+  while (out.length < target) {
+    let pushedThisCycle = 0;
+    for (let k = 0; k < groupOrder.length; k++) {
+      const slug = groupOrder[(startOffset + k) % groupOrder.length];
+      const arr = groups.get(slug)!;
+      const cur = cursors.get(slug)!;
+      if (cur < arr.length) {
+        out.push(arr[cur]);
+        cursors.set(slug, cur + 1);
+        pushedThisCycle++;
+      }
+      if (out.length >= target) break;
+    }
+    // Every group exhausted → reset cursors to repeat the full deterministic
+    // sequence (mirrors the old "repeat to limit*2"). Still no randomness.
+    if (pushedThisCycle === 0) {
+      for (const s of groupOrder) cursors.set(s, 0);
+      if (++exhaustedGuard > target) break; // hard stop, can't happen with ≥1 combo
+    }
+  }
+  return out;
 }
 
 // ORCH-0659/0660: haversineKm + estimateTravelMinutes moved to
 // _shared/distanceMath.ts as the canonical owner. Imported above.
 
-// NEAREST-PLACE SELECTION (Block 8 — hardened 2026-03-22)
-// Picks the closest candidate by haversine distance. Pre-sorted array
-// means equidistant ties break to highest-rated. Replaces tiered 3km/5km logic.
-/**
- * Select the nearest place to a reference point by haversine distance.
- * Pure proximity — no tier thresholds. Quality is handled upstream:
- * first stop picks highest-rated; subsequent stops pick nearest.
- */
-function selectClosestHighestRated(
+// ORCH-1061 PART 1A — QUALITY-AWARE PROXIMITY BLEND for post-anchor stops.
+//
+// Replaces the old pure-nearest selectClosestHighestRated (which IGNORED quality
+// despite its name). Every stop AFTER the first non-optional stop is now picked
+// by a 60% quality / 40% proximity blend, so the 2nd/3rd stop is a good place
+// that's also reasonably close — not just whatever is physically nearest.
+//
+// PURE function of `available` + the ref point + radius — NO request-time
+// Math.random. `available` order/contents are themselves deterministic given the
+// request inputs + the dedup state, so collab decks stay reproducible
+// (I-COLLAB-DECK-DETERMINISM-PRESERVED-UNDER-AI-BLEND).
+//
+// Quality internal split 0.75 vibe-rank / 0.25 rating×reviews (LOCKED, OQ-1).
+// Quality-vs-proximity blend 0.60 / 0.40 (operator-approved, LOCKED).
+export function selectBlendedStop(
   available: any[],
   refLat: number,
   refLng: number,
+  radiusMeters: number,
 ): any | null {
+  // Empty / single guards — match the old helper so the failed-anchor cycle +
+  // optional-skip logic at the call sites is preserved exactly.
   if (available.length === 0) return null;
   if (available.length === 1) return available[0];
 
-  let closest = available[0];
-  let closestDist = haversineKm(refLat, refLng, available[0].lat ?? 0, available[0].lng ?? 0);
+  // Quality primary axis: vibe rank score normalized within THIS candidate set.
+  const rankMax = Math.max(...available.map((p) => p._rankScore ?? 0), 0);
+  const radiusKm = Math.max(radiusMeters / 1000, 0.001); // avoid /0
+
+  const BLEND_QUALITY = 0.60;   // operator-approved knob
+  const BLEND_PROXIMITY = 0.40;
+
+  const scoreOf = (p: any): number => {
+    const rankNorm = rankMax > 0 ? ((p._rankScore ?? 0) / rankMax) : 0; // 0..1
+
+    // Secondary: rating × log-dampened review_count, normalized 0..1.
+    const ratingNorm = Math.min(Math.max((p.rating ?? 0) / 5, 0), 1);
+    const reviewWeight = Math.min(Math.log10((p.review_count ?? 0) + 1) / 3, 1); // saturates ~1000 reviews
+    const ratingScore = ratingNorm * (0.5 + 0.5 * reviewWeight); // ratings with no reviews keep half weight
+
+    const Q = 0.75 * rankNorm + 0.25 * ratingScore; // 0..1
+
+    const distKm = haversineKm(refLat, refLng, p.lat ?? 0, p.lng ?? 0);
+    const P = Math.min(Math.max(1 - (distKm / radiusKm), 0), 1); // 1=at ref, 0=at/beyond radius edge
+
+    return BLEND_QUALITY * Q + BLEND_PROXIMITY * P;
+  };
+
+  // Deterministic tie-break chain (LOCKED, no Math.random): when blended scores
+  // are within 1e-9 → higher _rankScore, then rating, then review_count, then
+  // lexicographically smaller google_place_id (pool-independent final arbiter).
+  let best = available[0];
+  let bestScore = scoreOf(best);
   for (let i = 1; i < available.length; i++) {
-    const dist = haversineKm(refLat, refLng, available[i].lat ?? 0, available[i].lng ?? 0);
-    if (dist < closestDist) {
-      closestDist = dist;
-      closest = available[i];
+    const cand = available[i];
+    const candScore = scoreOf(cand);
+    if (candScore > bestScore + 1e-9) {
+      best = cand;
+      bestScore = candScore;
+    } else if (Math.abs(candScore - bestScore) <= 1e-9) {
+      if (tieBreakWins(cand, best)) {
+        best = cand;
+        bestScore = candScore;
+      }
     }
   }
-  return closest;
+  return best;
+}
+
+// ORCH-1061 PART 1A — deterministic tie-break: does `a` beat `b`? (pure)
+export function tieBreakWins(a: any, b: any): boolean {
+  const ar = a._rankScore ?? 0, br = b._rankScore ?? 0;
+  if (ar !== br) return ar > br;
+  const arat = a.rating ?? 0, brat = b.rating ?? 0;
+  if (arat !== brat) return arat > brat;
+  const arc = a.review_count ?? 0, brc = b.review_count ?? 0;
+  if (arc !== brc) return arc > brc;
+  const aid = a.google_place_id ?? '', bid = b.google_place_id ?? '';
+  return aid < bid; // lexicographically smaller id wins
 }
 
 // ── Picnic shopping list ───────────────────────────────────────────────────
@@ -1235,7 +1391,13 @@ ${stopList}`;
 
 // ── Main serve() handler ───────────────────────────────────────────────────
 
-serve(async (req) => {
+// ORCH-1061: exported as `handler` and guarded by `import.meta.main` so the
+// module can be imported by Deno unit tests (which exercise the PART 1A blend +
+// PART 1B rotation pure helpers) WITHOUT auto-starting the HTTP server. In the
+// deployed edge runtime `import.meta.main` is true (this file is the entry
+// module), so production behavior is identical. Mirrors the codebase's
+// check-launch-city / places-autocomplete testable-handler pattern.
+export const handler = async (req: Request): Promise<Response> => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
   supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
   try {
@@ -1348,12 +1510,25 @@ serve(async (req) => {
     const generateLimit = warmPool ? Math.min(limit, 15) : limit;
     // ORCH-0677: generateCardsForType now returns { cards, summary? }; summary
     // is set when cards.length === 0 to make the empty verdict explicit.
-    const { cards, summary } = await generateCardsForType(
+    let { cards, summary } = await generateCardsForType(
       typeDef,
       location.lat, location.lng, budgetMax, travelMode,
       travelConstraintValue, generateLimit, skipDescriptions,
       excludePlacePoolIds.filter((v: unknown): v is string => typeof v === 'string' && v.length > 0),
+      batchSeed,
     );
+
+    // ORCH-1061 PART 2: open-during-outing filter — solo path inherits the SAME
+    // cascade collab gets via discover-cards. Start time mirrors discover-cards
+    // (datetimePref ? new Date(datetimePref) : new Date()). filterCuratedByStopHours
+    // is idempotent, so the collab path filtering again downstream is a no-op.
+    const curatedUtcNow = datetimePref ? new Date(datetimePref) : new Date();
+    cards = filterCuratedByStopHours(cards, curatedUtcNow);
+    // If hours-filtering emptied the deck, surface the existing empty verdict
+    // shape so mobile routes to the EMPTY UI state instead of stuck-loading.
+    if (cards.length === 0 && !summary) {
+      summary = { emptyReason: 'pool_empty', candidateAnchorCount: 0, failedAnchorCount: 0 };
+    }
 
     console.log(`[curated-v2] Generated ${cards.length} ${experienceType} cards`);
 
@@ -1528,4 +1703,8 @@ serve(async (req) => {
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
     );
   }
-});
+};
+
+if (import.meta.main) {
+  serve(handler);
+}


### PR DESCRIPTION
## ORCH-1061 — Curated stop variety + quality blend + solo open-hours gate

Backend-only (edge functions). No DB migration, no client code, no Vercel surface (no `[deploy]` tag), no OTA.

### Changes
- **PART 1A** — post-anchor stops use a 60% quality / 40% proximity blend (was pure-nearest). Deterministic.
- **PART 1B** — combo ordering is deterministic + rotates the main activity card-to-card (removed the `Math.random` shuffle → collab decks reproducible). Seeded off `batchSeed`.
- **PART 2** — open-hours cascade extracted to `_shared/curatedStopHours.ts`, fixed to read the Google v1 `periods` shape (D-1), and wired into the solo path so solo curated cards are now open-hours filtered (was collab-only).

### Verification
- 80/80 Deno tests pass (15 new ORCH-1061 + adversarial + 48 discover-cards regression + passthrough).
- Fails-on-revert proven for the D-1 periods fix and the solo wiring.
- Strict-grep C7 gate green (5 new backend files allowlisted).
- No combo expansion; every preserved gate confirmed; no request-time `Math.random` in ordering/selection.

### Deploy (orchestrator, post-merge)
Deploy BOTH `generate-curated-experiences` + `discover-cards` (shared module bundles into both). No `supabase db push`.

Spec: `Mingla_Artifacts/specs/SPEC_ORCH-1061_*.md` · Report: `reports/IMPLEMENTATION_ORCH-1061_*.md` · QA: `reports/QA_ORCH-1061_*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)