### PR TITLE
Close ORCH-1062 [deploy]: brand-delete render-loop crash + account-list event-count lie

### DIFF
--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1062_BRAND_DELETE_CRASH_AND_COUNT_LIE.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1062_BRAND_DELETE_CRASH_AND_COUNT_LIE.md
@@ -1,0 +1,105 @@
+# ORCH-1062 — Brand delete "maximum depth exceeded" + account-list event-count lie
+
+**Status:** INVESTIGATE + IMPLEMENT + on-device VERIFY complete.
+**Affected Surfaces:** business-iOS, business-Android (`mingla-business/` native; the
+account/switcher/brand-profile delete flow + the account brand-list badge). NOT in scope:
+consumer apps, buyer-web, admin-web (no business brand-delete/account-list there).
+**Owner:** Claude `mingla-orchestrator` (drove audit → fix → sim verify).
+
+---
+
+## Bug 1 — "Maximum update depth exceeded" when deleting a brand (sometimes silent)
+
+### Root cause (PROVEN on iOS sim, not source-only)
+Reproduced on iPhone 17 Pro (iOS 26.4), business dev build, logged in as
+sethogieva@gmail.com. Deleting the **currently-selected** brand red-boxes with
+`Maximum update depth exceeded` — React's infinite-setState-in-render guard. The
+red box named the exact frames: `useCurrentBrandRecovery.ts:73` (`setErrorMessage(null)`)
+and `_layout.tsx:105` (`useBrand(currentBrandId)`), component stack `<RootLayoutInner />`.
+
+It is a **two-writer race on stale React Query cache**:
+
+1. `useSoftDeleteBrand.onSuccess` only **invalidated** `brandKeys.list` — React Query keeps
+   serving the **stale** list (still containing the just-deleted brand) during the
+   background refetch, and `creator_accounts.default_brand_id` cache still points at it.
+2. `useCurrentBrand` (`useCurrentBrand.ts:44-45`) sees its detail fetch return `null`
+   (the brand is gone) → `setCurrentBrandId(null)`.
+3. `useCurrentBrandRecovery` (`useCurrentBrandRecovery.ts:59-101`) sees `currentBrandId === null`
+   + the **stale** list / **stale** default still containing the deleted brand →
+   `resolveCurrentBrandId` returns the **just-deleted brand** → `setCurrentBrandId(deleted)`.
+4. → back to step 2 → synchronous ping-pong between `null` and the deleted id, past React's
+   ~50 nested-update cap → crash.
+
+This is why it "sometimes fails silently": deleting a **non-current** brand never trips the
+race (currentBrandId stays valid → resolver returns `keep-local` → no loop).
+
+### Ruled out (with evidence)
+- **Postgres recursion / "stack depth limit exceeded":** FALSE. The soft-delete is an
+  `UPDATE brands SET deleted_at` (never the DELETE policy or `ON DELETE CASCADE`). DB probes:
+  **zero triggers** in the entire `public` schema; the brands/team RLS helper functions
+  (`biz_is_brand_admin_plus_for_caller`, `biz_brand_effective_rank`, …) are all
+  `SECURITY DEFINER` owned by `postgres` (`rolbypassrls = true`) → they bypass RLS and
+  cannot recurse. Postgres logs show no stack-depth error. The Explore agent's
+  "CASCADE → RLS recursion" theory was falsified.
+
+### Fix (root cause)
+`mingla-business/src/hooks/useBrands.ts` — `useSoftDeleteBrand.onSuccess` now
+**synchronously evicts** the deleted brand from the list cache and clears a stale
+`default_brand_id` pointer BEFORE the invalidate backstop, so the resolver immediately
+sees fresh data and lands on a valid brand:
+
+```ts
+queryClient.setQueryData<Brand[]>(brandKeys.list(accountId), (prev) =>
+  prev !== undefined ? prev.filter((b) => b.id !== brandId) : prev);
+queryClient.setQueryData<CreatorAccountRow | null>(creatorAccountKeys.byId(accountId),
+  (prev) => (prev != null && prev.default_brand_id === brandId
+    ? { ...prev, default_brand_id: null } : prev));
+// invalidate stays as a server-truth backstop
+```
+
+### On-device verification
+After the fix, deleting the **current** brand ("rrrr") completes cleanly: NO red box,
+the app auto-recovers the current brand to a valid one ("Lantern & Vine"), Metro log shows
+zero errors. Re-tested the exact crash path.
+
+---
+
+## Bug 2 — Account brand list "lies": shows events when the hub is empty
+
+### Root cause (PROVEN with live data)
+`brandsService.ts` `getEventCountsByBrandIds` counted **all** non-deleted events
+(`deleted_at IS NULL` only) — including **drafts**. The hub events list
+(`businessEvents.ts` → `business_management_events_view`) only surfaces
+`status IN ('scheduled','live','ended','cancelled')`. So a brand with only draft events
+showed "N events" on the account card while its hub was empty.
+
+Live data for sethogieva@gmail.com confirmed it: "rrrr" old badge **2** vs hub **0**
+(both drafts); "Lumen Wine Bar" **2** vs **0**; "A gloat" **1** vs **0**; "Travel Brand"
+**32** vs **2** (30 drafts).
+
+### Fix
+`getEventCountsByBrandIds` now applies the hub's exact status filter
+(`.in("status", HUB_VISIBLE_EVENT_STATUSES)` where
+`HUB_VISIBLE_EVENT_STATUSES = ['scheduled','live','ended','cancelled']`) alongside
+`deleted_at IS NULL`. Stays type-agnostic (no `event_type` filter — the ORCH-0859
+events-vs-trips badge question is untouched). Verified live: every brand's badge now equals
+its true hub-visible count. Confirmed on the sim — "rrrr" and "Lumen Wine Bar" now show
+"0 events".
+
+---
+
+## Regression tests
+- `src/hooks/__tests__/useSoftDeleteBrand.orch1062.test.ts` — impl happy-path: onSuccess
+  evicts the deleted brand from the list cache + clears the matching default pointer.
+- `src/hooks/__tests__/useSoftDeleteBrand.orch1062.adversarial.test.ts` — tester adversarial:
+  rejected-delete leaves cache untouched; non-matching default preserved; absent-brand no-op.
+- `src/services/__tests__/brandsService.orch1062.eventCount.test.ts` — count fix: events
+  count query filters to hub-visible statuses (excludes drafts).
+All fail-on-revert by exercising the changed behavior.
+
+## Live data action (operator-requested, "junk + dupes only")
+Deleted via the app UI on the sim (sethogieva@gmail.com): the empty + duplicate test brands
+(checking, rrrr, A gloat, Lumen Wine Bar, Fine Dining Raleigh, QA SubB Event 1456g,
+Sub-E Smoke Test, Perry's Steakhouse & Grille ×2, The Tuscanny Place, The Tuscany And Co).
+KEPT brands with live/paid events (Leggo This, Travel Brand, Lantern & Vine, testtttt) so
+real events are not yanked from the consumer/marketing decks.

--- a/mingla-business/src/hooks/__tests__/useSoftDeleteBrand.orch1062.adversarial.test.ts
+++ b/mingla-business/src/hooks/__tests__/useSoftDeleteBrand.orch1062.adversarial.test.ts
@@ -1,0 +1,158 @@
+/* eslint-disable import/first */
+/**
+ * ORCH-1062 — tester ADVERSARIAL regression test for the brand-delete
+ * render-loop fix. Attacks DIFFERENT angles than the implementor happy-path
+ * (which proves the deleted brand is evicted from the list cache):
+ *
+ *  1. REJECTED delete (active events block it) must NOT mutate any cache —
+ *     the brand was never deleted, so evicting it from the list would make a
+ *     still-live brand vanish from the UI.
+ *  2. PRECISION: default_brand_id is cleared ONLY when it equals the deleted
+ *     brand. A default pointing at a DIFFERENT brand must be preserved
+ *     (over-clearing would silently drop the user's chosen default).
+ *  3. SAFETY: deleting a brand that is NOT in the cached list is a no-op on the
+ *     surviving members (no throw, no corruption) — guards the cold-cache path.
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { QueryClient } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+let softDeleteConfig: {
+  onSuccess: (result: unknown, vars: unknown) => void;
+} | null = null;
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+jest.mock("../../services/supabase", () => ({
+  supabase: {
+    from: jest.fn(),
+    channel: jest.fn(() => ({ on: jest.fn(), subscribe: jest.fn() })),
+    removeChannel: jest.fn(),
+  },
+}));
+jest.mock("../../services/appsFlyerService", () => ({
+  logAppsFlyerEvent: jest.fn(),
+}));
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({ isAuthReady: true, user: null, authStatus: "ready" }),
+}));
+// usePublicEvents transitively imports the @mingla/event-rendering workspace
+// package, which jest can't resolve in the worktree. useSoftDeleteBrand only
+// needs the key factory — stub it.
+jest.mock("../usePublicEvents", () => ({
+  publicEventKeys: { brandBySlug: (slug: string) => ["public-brand", slug] },
+}));
+jest.mock("@tanstack/react-query", () => {
+  const actual =
+    jest.requireActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQueryClient: () => queryClient,
+    useMutation: (config: typeof softDeleteConfig) => {
+      softDeleteConfig = config;
+      return { mutateAsync: jest.fn(), isPending: false };
+    },
+    useQuery: () => ({
+      data: undefined,
+      isError: false,
+      isFetched: false,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    }),
+  };
+});
+
+import { useSoftDeleteBrand, brandKeys } from "../useBrands";
+import { creatorAccountKeys } from "../useCreatorAccount";
+
+const mkBrand = (id: string): unknown => ({
+  id,
+  displayName: id,
+  slug: id,
+  role: "owner",
+  stats: { events: 0, followers: 0, rev: 0, rev7d: 0, attendees: 0 },
+  currentLiveEvent: null,
+});
+const mkAccount = (defaultBrandId: string | null): unknown => ({
+  id: "acc-1",
+  email: null,
+  display_name: null,
+  avatar_url: null,
+  marketing_opt_in: false,
+  default_brand_id: defaultBrandId,
+  deleted_at: null,
+});
+const ids = (key: readonly unknown[]): string[] =>
+  (queryClient.getQueryData(key) as Array<{ id: string }>).map((b) => b.id);
+
+const registerHook = (): void => {
+  softDeleteConfig = null;
+  useSoftDeleteBrand();
+  if (softDeleteConfig === null) throw new Error("mutation config not captured");
+};
+
+describe("ORCH-1062 adversarial — soft-delete cache mutation boundaries", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    registerHook();
+  });
+
+  test("REJECTED delete leaves the list cache untouched (brand stays visible)", () => {
+    queryClient.setQueryData(brandKeys.list("acc-1"), [
+      mkBrand("brand-A"),
+      mkBrand("brand-B"),
+    ]);
+
+    softDeleteConfig!.onSuccess(
+      { rejected: true, reason: "upcoming_events", upcomingEventCount: 3 },
+      { brandId: "brand-A", accountId: "acc-1" },
+    );
+
+    expect(ids(brandKeys.list("acc-1"))).toEqual(["brand-A", "brand-B"]);
+  });
+
+  test("a default_brand_id pointing at a DIFFERENT brand is preserved", () => {
+    queryClient.setQueryData(brandKeys.list("acc-1"), [
+      mkBrand("brand-A"),
+      mkBrand("brand-B"),
+    ]);
+    queryClient.setQueryData(creatorAccountKeys.byId("acc-1"), mkAccount("brand-B"));
+
+    // Delete brand-A; default points at brand-B and must NOT be cleared.
+    softDeleteConfig!.onSuccess(
+      { rejected: false, brandId: "brand-A" },
+      { brandId: "brand-A", accountId: "acc-1" },
+    );
+
+    const account = queryClient.getQueryData(
+      creatorAccountKeys.byId("acc-1"),
+    ) as { default_brand_id: string | null };
+    expect(account.default_brand_id).toBe("brand-B");
+    expect(ids(brandKeys.list("acc-1"))).toEqual(["brand-B"]);
+  });
+
+  test("deleting a brand absent from the cached list is a safe no-op", () => {
+    queryClient.setQueryData(brandKeys.list("acc-1"), [
+      mkBrand("brand-B"),
+      mkBrand("brand-C"),
+    ]);
+
+    expect(() =>
+      softDeleteConfig!.onSuccess(
+        { rejected: false, brandId: "brand-A" },
+        { brandId: "brand-A", accountId: "acc-1" },
+      ),
+    ).not.toThrow();
+
+    expect(ids(brandKeys.list("acc-1"))).toEqual(["brand-B", "brand-C"]);
+  });
+});

--- a/mingla-business/src/hooks/__tests__/useSoftDeleteBrand.orch1062.test.ts
+++ b/mingla-business/src/hooks/__tests__/useSoftDeleteBrand.orch1062.test.ts
@@ -1,0 +1,147 @@
+/* eslint-disable import/first */
+/**
+ * ORCH-1062 — implementor happy-path regression test for the brand-delete
+ * "Maximum update depth exceeded" render-loop fix.
+ *
+ * Root cause (proven on the iOS sim 2026-06-02): deleting the CURRENTLY-selected
+ * brand crashed RootLayoutInner with "Maximum update depth exceeded". The old
+ * `useSoftDeleteBrand.onSuccess` only INVALIDATED `brandKeys.list`, so React
+ * Query kept serving the STALE list (still containing the just-deleted brand)
+ * during the background refetch. In that window `useCurrentBrandRecovery`
+ * re-resolved the deleted brand (from the stale list / stale default_brand_id)
+ * while `useCurrentBrand` cleared currentBrandId to null — the two hooks
+ * ping-ponged synchronously past React's nested-update cap.
+ *
+ * Fix: onSuccess SYNCHRONOUSLY evicts the deleted brand from the list cache and
+ * clears a stale default_brand_id pointer, so the resolver immediately sees
+ * fresh data and lands on a valid brand.
+ *
+ * This test exercises the real onSuccess against a real QueryClient.
+ * Fails-on-revert: with the old (invalidate-only) onSuccess the list cache still
+ * contains the deleted brand synchronously, so the first assertion fails.
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { QueryClient } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+let softDeleteConfig: {
+  onSuccess: (result: unknown, vars: unknown) => void;
+} | null = null;
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+jest.mock("../../services/supabase", () => ({
+  supabase: {
+    from: jest.fn(),
+    channel: jest.fn(() => ({ on: jest.fn(), subscribe: jest.fn() })),
+    removeChannel: jest.fn(),
+  },
+}));
+jest.mock("../../services/appsFlyerService", () => ({
+  logAppsFlyerEvent: jest.fn(),
+}));
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({ isAuthReady: true, user: null, authStatus: "ready" }),
+}));
+// usePublicEvents transitively imports the @mingla/event-rendering workspace
+// package, which jest can't resolve in the worktree. useSoftDeleteBrand only
+// needs the key factory — stub it.
+jest.mock("../usePublicEvents", () => ({
+  publicEventKeys: { brandBySlug: (slug: string) => ["public-brand", slug] },
+}));
+jest.mock("@tanstack/react-query", () => {
+  const actual =
+    jest.requireActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQueryClient: () => queryClient,
+    useMutation: (config: typeof softDeleteConfig) => {
+      softDeleteConfig = config;
+      return { mutateAsync: jest.fn(), isPending: false };
+    },
+    useQuery: () => ({
+      data: undefined,
+      isError: false,
+      isFetched: false,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    }),
+  };
+});
+
+import { useSoftDeleteBrand, brandKeys } from "../useBrands";
+import { creatorAccountKeys } from "../useCreatorAccount";
+
+const mkBrand = (id: string, name: string): unknown => ({
+  id,
+  displayName: name,
+  slug: name.toLowerCase(),
+  role: "owner",
+  stats: { events: 0, followers: 0, rev: 0, rev7d: 0, attendees: 0 },
+  currentLiveEvent: null,
+});
+
+const mkAccount = (defaultBrandId: string | null): unknown => ({
+  id: "acc-1",
+  email: null,
+  display_name: null,
+  avatar_url: null,
+  marketing_opt_in: false,
+  default_brand_id: defaultBrandId,
+  deleted_at: null,
+});
+
+const registerHook = (): void => {
+  softDeleteConfig = null;
+  // Calling the hook outside a renderer is safe: it only calls the (mocked)
+  // useQueryClient + useMutation — no useState/useEffect/useRef.
+  useSoftDeleteBrand();
+  if (softDeleteConfig === null) throw new Error("mutation config not captured");
+};
+
+describe("ORCH-1062 — soft-delete evicts the deleted brand from the list cache", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    registerHook();
+  });
+
+  test("onSuccess synchronously removes the deleted brand from brandKeys.list", () => {
+    queryClient.setQueryData(brandKeys.list("acc-1"), [
+      mkBrand("brand-A", "Alpha"),
+      mkBrand("brand-B", "Beta"),
+    ]);
+
+    softDeleteConfig!.onSuccess(
+      { rejected: false, brandId: "brand-A" },
+      { brandId: "brand-A", accountId: "acc-1" },
+    );
+
+    const list = queryClient.getQueryData(brandKeys.list("acc-1")) as Array<{
+      id: string;
+    }>;
+    expect(list.map((b) => b.id)).toEqual(["brand-B"]);
+  });
+
+  test("onSuccess clears default_brand_id when it pointed at the deleted brand", () => {
+    queryClient.setQueryData(creatorAccountKeys.byId("acc-1"), mkAccount("brand-A"));
+
+    softDeleteConfig!.onSuccess(
+      { rejected: false, brandId: "brand-A" },
+      { brandId: "brand-A", accountId: "acc-1" },
+    );
+
+    const account = queryClient.getQueryData(
+      creatorAccountKeys.byId("acc-1"),
+    ) as { default_brand_id: string | null };
+    expect(account.default_brand_id).toBeNull();
+  });
+});

--- a/mingla-business/src/hooks/useBrands.ts
+++ b/mingla-business/src/hooks/useBrands.ts
@@ -46,6 +46,10 @@ import type { Brand } from "../store/currentBrandStore";
 // the hardcoded `["brand-role", brandId]` literal in useSoftDeleteBrand.onSuccess
 // (Constitutional #4 — one query key per entity).
 import { brandRoleKeys } from "./useCurrentBrandRole";
+// ORCH-1062 — soft-delete must synchronously evict the deleted brand from the
+// list cache + clear a stale default_brand_id pointer so useCurrentBrandRecovery
+// cannot re-resolve the just-deleted brand (the render-loop root cause).
+import { creatorAccountKeys, type CreatorAccountRow } from "./useCreatorAccount";
 
 // ORCH-0816 — brand stats (rev, rev7d, attendees) follow ticket sales, which
 // change frequently. Combined with the Realtime subscription on `orders`
@@ -418,7 +422,31 @@ export const useSoftDeleteBrand = (): UseSoftDeleteBrandResult => {
     },
     onSuccess: (result, { brandId, accountId }) => {
       if (!result.rejected) {
-        // Invalidate list — re-fetch shows brand absent (deleted_at IS NULL filter)
+        // ORCH-1062 — ROOT-CAUSE fix for the "Maximum update depth exceeded"
+        // crash when deleting the CURRENTLY-SELECTED brand. The old code only
+        // INVALIDATED the list, so React Query kept serving the STALE list (still
+        // containing the just-deleted brand) during the background refetch. In
+        // that window `useCurrentBrandRecovery` re-resolved the deleted brand
+        // (from the stale list / stale default_brand_id) while `useCurrentBrand`
+        // cleared currentBrandId to null (its detail fetch correctly returns
+        // null) — the two hooks ping-ponged currentBrandId synchronously until
+        // React's nested-update cap tripped the render-loop crash. Fix:
+        // SYNCHRONOUSLY drop the deleted brand from the list cache so the
+        // resolver immediately sees fresh data and lands on a valid brand.
+        queryClient.setQueryData<Brand[]>(brandKeys.list(accountId), (prev) =>
+          prev !== undefined ? prev.filter((b) => b.id !== brandId) : prev,
+        );
+        // Clear default_brand_id in the creator-account cache if it pointed at
+        // the deleted brand (softDeleteBrand Step 3 already cleared it server-
+        // side; this stops the cache from briefly re-resolving the dead pointer).
+        queryClient.setQueryData<CreatorAccountRow | null>(
+          creatorAccountKeys.byId(accountId),
+          (prev) =>
+            prev != null && prev.default_brand_id === brandId
+              ? { ...prev, default_brand_id: null }
+              : prev,
+        );
+        // Invalidate list — server-truth backstop (also reconciles any cascade).
         queryClient.invalidateQueries({ queryKey: brandKeys.list(accountId) });
         // Clear detail cache
         queryClient.removeQueries({ queryKey: brandKeys.detail(brandId) });

--- a/mingla-business/src/services/__tests__/brandsService.orch1062.eventCount.test.ts
+++ b/mingla-business/src/services/__tests__/brandsService.orch1062.eventCount.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable import/first */
+/**
+ * ORCH-1062 — the account-page brand-card "N events" badge LIED: it counted ALL
+ * non-deleted events including DRAFTS, so a brand whose hub showed zero events
+ * still rendered e.g. "2 events" (verified live: brand "rrrr" — both events were
+ * drafts). The hub events list only surfaces
+ * status IN ('scheduled','live','ended','cancelled'); drafts are excluded.
+ *
+ * This test asserts `getEventCountsByBrandIds` (via getBrands) now applies that
+ * exact status filter. Fails-on-revert: the old query only filtered
+ * `deleted_at IS NULL` with no status filter, so the `.in("status", ...)`
+ * assertion fails.
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const mockFrom = jest.fn();
+
+jest.mock("../supabase", () => ({
+  supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+}));
+jest.mock("../appsFlyerService", () => ({ logAppsFlyerEvent: jest.fn() }));
+
+import { getBrands, HUB_VISIBLE_EVENT_STATUSES } from "../brandsService";
+import type { BrandRow } from "../brandMapping";
+
+const brandRow = (id: string, name: string): BrandRow =>
+  ({
+    id,
+    account_id: "account-1",
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    description: null,
+    profile_photo_url: null,
+    contact_email: null,
+    contact_phone: null,
+    social_links: {},
+    custom_links: [],
+    display_attendee_count: true,
+    tax_settings: {},
+    default_currency: "GBP",
+    stripe_connect_id: null,
+    stripe_payouts_enabled: false,
+    stripe_charges_enabled: false,
+    address: null,
+    cover_hue: 25,
+    cover_media_url: null,
+    cover_media_type: null,
+    profile_photo_type: null,
+    created_at: "2026-05-09T00:00:00.000Z",
+    updated_at: "2026-05-09T00:00:00.000Z",
+    deleted_at: null,
+  }) as unknown as BrandRow;
+
+interface AnyBuilder {
+  select: jest.Mock;
+  eq: jest.Mock;
+  is: jest.Mock;
+  in: jest.Mock;
+  order: jest.Mock;
+  not: jest.Mock;
+}
+
+const brandsBuilder = (data: BrandRow[]): AnyBuilder => {
+  const b = {} as AnyBuilder;
+  b.select = jest.fn(() => b);
+  b.eq = jest.fn(() => b);
+  b.is = jest.fn(() => b);
+  b.in = jest.fn(() => b);
+  b.not = jest.fn(() => b);
+  b.order = jest.fn(() => Promise.resolve({ data, error: null }));
+  return b;
+};
+
+const eventsBuilder = (
+  data: { brand_id: string | null }[],
+): AnyBuilder => {
+  const b = {} as AnyBuilder;
+  b.select = jest.fn(() => b);
+  b.eq = jest.fn(() => b);
+  b.in = jest.fn(() => b);
+  b.not = jest.fn(() => b);
+  b.order = jest.fn(() => b);
+  // terminal: getEventCountsByBrandIds ends on .is("deleted_at", null)
+  b.is = jest.fn(() => Promise.resolve({ data, error: null }));
+  return b;
+};
+
+const ordersBuilder = (): AnyBuilder => {
+  const b = {} as AnyBuilder;
+  b.select = jest.fn(() => b);
+  b.eq = jest.fn(() => b);
+  b.is = jest.fn(() => b);
+  b.in = jest.fn(() => b);
+  b.order = jest.fn(() => b);
+  // terminal: aggregateBrandStatsByBrandIds ends on .not(...)
+  b.not = jest.fn(() => Promise.resolve({ data: [], error: null }));
+  return b;
+};
+
+describe("ORCH-1062 — brand event-count badge excludes drafts (hub parity)", () => {
+  beforeEach(() => {
+    mockFrom.mockReset();
+  });
+
+  test("getEventCountsByBrandIds filters events to hub-visible statuses only", async () => {
+    const eventsQ = eventsBuilder([{ brand_id: "brand-1" }]);
+    mockFrom.mockImplementation((table: unknown) => {
+      if (table === "brands") return brandsBuilder([brandRow("brand-1", "One")]);
+      if (table === "events") return eventsQ;
+      if (table === "orders") return ordersBuilder();
+      throw new Error(`unexpected table ${String(table)}`);
+    });
+
+    await getBrands("account-1");
+
+    // The status filter is the fix: drafts are excluded.
+    expect(eventsQ.in).toHaveBeenCalledWith("status", [
+      "scheduled",
+      "live",
+      "ended",
+      "cancelled",
+    ]);
+    expect(eventsQ.in).toHaveBeenCalledWith("status", HUB_VISIBLE_EVENT_STATUSES);
+    // And it is still scoped + non-deleted (regression guard for the rest).
+    expect(eventsQ.in).toHaveBeenCalledWith("brand_id", ["brand-1"]);
+    expect(eventsQ.is).toHaveBeenCalledWith("deleted_at", null);
+  });
+});

--- a/mingla-business/src/services/brandsService.ts
+++ b/mingla-business/src/services/brandsService.ts
@@ -242,6 +242,17 @@ export interface SoftDeleteSuccess {
 }
 export type SoftDeleteResult = SoftDeleteSuccess | SoftDeleteRejection;
 export const BRAND_DELETE_BLOCKING_EVENT_STATUSES = ["scheduled", "live"] as const;
+// ORCH-1062 — statuses the brand HUB surfaces (mirrors
+// business_management_events_view's `status IN (...)` filter). The account-page
+// brand-card "N events" badge counts ONLY these so it can never claim drafts the
+// hub hides. Keep in lockstep with the view definition
+// (supabase/migrations/...orch_0792_events_with_master_date_view.sql).
+export const HUB_VISIBLE_EVENT_STATUSES = [
+  "scheduled",
+  "live",
+  "ended",
+  "cancelled",
+] as const;
 
 // ----- createBrand -------------------------------------------------------
 
@@ -437,11 +448,22 @@ async function getEventCountsByBrandIds(
 ): Promise<Map<string, number>> {
   if (brandIds.length === 0) return new Map();
 
-  // orch-strict-grep-allow events-type-filter — getEventCountsByBrandIds is intentionally type-agnostic ("does this brand have ANY content"); operator decision pending per ORCH-0859 REWORK 3 dispatch (whether trips should count as "events" for brand-card badges or get their own count)
+  // ORCH-1062 — the account-page brand badge "lied": it counted ALL non-deleted
+  // events including DRAFTS, so a brand whose hub shows zero events still rendered
+  // "N events" (e.g. brand "rrrr" showed "2 events" while its hub was empty —
+  // both events were drafts). The hub events list
+  // (businessEvents.ts → business_management_events_view) only surfaces
+  // status IN ('scheduled','live','ended','cancelled') — drafts are excluded.
+  // Mirror that EXACT status filter here so the badge can't claim content the hub
+  // hides (verified live 2026-06-02). Stays type-agnostic (no event_type filter —
+  // trips/experiences still counted; the ORCH-0859 events-vs-trips badge question
+  // is unchanged, only the draft inflation is removed).
+  // orch-strict-grep-allow events-type-filter — intentionally type-agnostic "any published hub content" count; no event_type filter by design (ORCH-1062 removes only draft inflation)
   const { data, error } = await supabase
     .from("events")
     .select("brand_id")
     .in("brand_id", brandIds)
+    .in("status", HUB_VISIBLE_EVENT_STATUSES)
     .is("deleted_at", null);
 
   if (error) throw error;


### PR DESCRIPTION
## Summary
Two business-app bugs reported by Seth, both root-caused, fixed, and verified on the iOS sim (sethogieva@gmail.com).

### Bug 1 — "maximum depth exceeded" on brand delete (sometimes silent)
**Not a DB error.** Soft-delete is `UPDATE brands SET deleted_at`; the Postgres path is clean (zero schema triggers; RLS helpers are `SECURITY DEFINER`/`bypassrls` → no recursion). Real cause: a **two-writer race on stale React Query cache**. `useSoftDeleteBrand.onSuccess` only *invalidated* the brand list, so React Query kept serving the stale list (still containing the deleted brand). `useCurrentBrand` cleared the active brand to null while `useCurrentBrandRecovery` re-resolved the just-deleted brand from the stale list / stale `default_brand_id` — ping-ponging `currentBrandId` past React's nested-update cap. Only trips when deleting the **currently-selected** brand (hence "sometimes silent").

**Fix:** `onSuccess` synchronously evicts the deleted brand from the list cache and clears a stale default pointer, so the resolver immediately lands on a valid brand. **Reproduced the red box, then verified the fix on the sim** (deleting the current brand no longer crashes).

### Bug 2 — account brand list "lies" (events shown when hub is empty)
`getEventCountsByBrandIds` counted **draft** events; the hub hides drafts (`status IN scheduled/live/ended/cancelled`). Fix mirrors the hub's exact status filter. Verified live + on sim (e.g. "rrrr" 2→0, "Lumen Wine Bar" 2→0, "Travel Brand" 32→2).

## Tests (all fails-on-revert verified at `d0a6e08c1`)
- `useSoftDeleteBrand.orch1062.test.ts` — impl happy-path: list-cache eviction + default clear
- `useSoftDeleteBrand.orch1062.adversarial.test.ts` — rejected no-op / default precision / absent-brand
- `brandsService.orch1062.eventCount.test.ts` — count excludes drafts

## Scope
business-native + business-web. No migration. `[deploy]` for the mingla-business Vercel surface. Also performed the operator-requested cleanup: deleted 11 junk/dupe test brands through the app UI, kept the 4 brands with live events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)