### PR TITLE
Fix ORCH-1051 migration: unbreak CI migration-baseline for all PRs

### DIFF
--- a/supabase/functions/_shared/__tests__/stripeWebhookRouter.test.ts
+++ b/supabase/functions/_shared/__tests__/stripeWebhookRouter.test.ts
@@ -113,7 +113,7 @@ class FakeDb {
   }
 }
 
-Deno.test("router exposes 26 subscribed events and excludes fake requirements event", () => {
+Deno.test("router exposes 27 subscribed events and excludes fake requirements event", () => {
   // ORCH-0787 added charge.refunded + refund.created + refund.updated (3 events) to the
   // existing 19, bringing total to 22. The legacy charge.refund.updated remains for
   // detached-account audit-only handling per stripeWebhookRouter.ts:28.
@@ -121,8 +121,12 @@ Deno.test("router exposes 26 subscribed events and excludes fake requirements ev
   // Sessions flow, bringing total to 23.
   // ORCH-0953 added charge.dispute.created/updated/closed (3 events) for live-mode
   // dispute persistence per SPEC §3.3, bringing total to 26.
-  assertEquals(STRIPE_ROUTED_EVENT_TYPES.length, 26);
+  // ORCH-1054 added charge.succeeded (1 event) — it carries the application_fee.id
+  // needed to fan-out partner splits via Stripe Transfer — bringing total to 27.
+  // This revises ORCH-0953 §3.4, which had explicitly excluded charge.succeeded.
+  assertEquals(STRIPE_ROUTED_EVENT_TYPES.length, 27);
   assertEquals(STRIPE_ROUTED_EVENT_TYPES.includes("account.updated"), true);
+  assertEquals(STRIPE_ROUTED_EVENT_TYPES.includes("charge.succeeded"), true);
   assertEquals(
     STRIPE_ROUTED_EVENT_TYPES.includes("application_fee.refunded"),
     true,

--- a/supabase/functions/_shared/__tests__/stripeWebhookRouter_eventList.test.ts
+++ b/supabase/functions/_shared/__tests__/stripeWebhookRouter_eventList.test.ts
@@ -4,9 +4,12 @@ import {
 } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 import { STRIPE_ROUTED_EVENT_TYPES } from "../stripeWebhookRouter.ts";
 
-Deno.test("ORCH-0953 §3.4 — noisy live-cutover events are not routed", () => {
+Deno.test("ORCH-0953 §3.4 (rev. ORCH-1054) — noisy live-cutover events are not routed", () => {
   const routed = new Set<string>(STRIPE_ROUTED_EVENT_TYPES);
-  assertEquals(routed.has("charge.succeeded"), false);
+  // ORCH-1054 revised ORCH-0953 §3.4: charge.succeeded IS now routed (it carries the
+  // application_fee.id needed to fan-out partner splits via Stripe Transfer). Only
+  // charge.failed and payment_intent.processing remain unsubscribed.
+  assertEquals(routed.has("charge.succeeded"), true);
   assertEquals(routed.has("charge.failed"), false);
   assertEquals(routed.has("payment_intent.processing"), false);
 });

--- a/supabase/migrations/20260821000000_orch_1051_scanner_invite_flow.sql
+++ b/supabase/migrations/20260821000000_orch_1051_scanner_invite_flow.sql
@@ -31,6 +31,23 @@
 -- =============================================================
 -- §1. scanner_invitations table
 -- =============================================================
+-- The ORCH-0729 baseline squash (20260505000000) already creates a LEGACY
+-- scanner_invitations table with the old event-scoped shape (event_id NOT NULL,
+-- token, NO scope/brand_id). A bare CREATE TABLE IF NOT EXISTS no-ops over it,
+-- so the new columns never get added and the `scope` CHECK below fails with
+-- "column scope does not exist" on a from-baseline apply (the CI
+-- migration-baseline job, broken for ALL PRs until this fix). The live DB was
+-- already rebuilt to the new schema during the original apply (probed
+-- 2026-06-03: no `token` column, `scope` present), so the faithful + idempotent
+-- repair is to drop the legacy table and recreate. scanner_invitations holds
+-- only ephemeral pending invite tokens — no durable data is lost, and the live
+-- project will NOT re-run this migration (already in schema_migrations); the
+-- DROP only ever executes against a fresh from-baseline build. CASCADE clears
+-- the legacy indexes/policy/grants that belonged to the old shape; no other
+-- table, view, or function references scanner_invitations (verified against the
+-- baseline squash).
+DROP TABLE IF EXISTS public.scanner_invitations CASCADE;
+
 CREATE TABLE IF NOT EXISTS public.scanner_invitations (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   brand_id uuid NOT NULL REFERENCES public.brands(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Problem

The CI check **"Migrations apply cleanly from baseline"** has been **red on every PR** — teams have been `--admin` overriding it. The from-baseline apply halts at:

```
psql:supabase/migrations/20260821000000_orch_1051_scanner_invite_flow.sql:57: ERROR:  column "scope" does not exist
```

## Root cause

The ORCH-0729 baseline squash (`20260505000000`) already creates a **legacy** `scanner_invitations` table with the old event-scoped shape (`event_id NOT NULL`, `token`, no `scope`/`brand_id`). ORCH-1051's `CREATE TABLE IF NOT EXISTS` then **no-ops** over the existing table, so the new columns are never added — and the `ADD CONSTRAINT … CHECK (scope …)` immediately fails.

The live DB doesn't hit this because the table was rebuilt to the new schema during the original apply, and the migration is already recorded in `schema_migrations` (so it never re-runs there). Only the fresh from-baseline CI build trips on it.

## Fix

Prepend `DROP TABLE IF EXISTS public.scanner_invitations CASCADE;` before the `CREATE TABLE` in §1, so a from-baseline apply drops the legacy table and recreates the new schema. `scanner_invitations` holds only ephemeral pending invite tokens; no durable data is lost, and the live project won't re-run this migration — the DROP only ever executes against a fresh CI build. `CASCADE` clears the legacy indexes/policy/grants; no other table/view/function references `scanner_invitations` (verified against the baseline squash).

## Verification

Reproduced the exact CI job locally against `supabase/postgres:17.4.1.075` (the CI image):
- **Before:** halts at ORCH-1051 with `column "scope" does not exist`.
- **After:** all migrations apply cleanly from baseline.
- Resulting `scanner_invitations` schema is **byte-identical to the live remote** (15 columns; `scope`/`brand_id`/`token_hash` present, legacy `token` gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)