### PR TITLE
Schedule-edit buyer protection + Refund-all & proceed (event date/time edits on sold events)

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1565,6 +1565,11 @@ function checkNoNewBackendFiles() {
     ...ORCH_1040_BACKEND_ALLOWLIST,
     ...ORCH_1061_BACKEND_ALLOWLIST,
     ...ORCH_1062_BACKEND_ALLOWLIST,
+    // Schedule-edit buyer protection + "Refund all & proceed" (separate PR;
+    // shares the ORCH-1047 work id used in code). New migration recording the
+    // already-live business_patch_event_when change — not ORCH-0863 marketing
+    // scope; same C7-scoping caveat as the allowlists above.
+    "supabase/migrations/20260820000000_schedule_change_buyer_protection_refund_all.sql",
   ];
   const forbidden = changed.filter(
     (p) =>

--- a/mingla-business/src/components/event/EditPublishedScreen.tsx
+++ b/mingla-business/src/components/event/EditPublishedScreen.tsx
@@ -68,7 +68,8 @@ import {
   type LiveEvent,
   type UpdateLiveEventResult,
 } from "../../store/liveEventStore";
-import { getSoldCountContextForEvent } from "../../store/orderStoreHelpers";
+import { buildSoldCountContextFromOrders } from "../../services/eventOrdersService";
+import { refundAllEventOrders } from "../../services/orderRefundService";
 import {
   computeRichFieldDiffs,
   computeTicketDiffs,
@@ -119,7 +120,10 @@ import {
 } from "../../services/businessEvents";
 import { businessEventKeys } from "../../hooks/useBusinessEvents";
 import { publicEventKeys } from "../../hooks/usePublicEvents";
-import { useEventHasWebPurchases } from "../../hooks/useEventOrders";
+import {
+  useEventHasWebPurchases,
+  useEventReconciliation,
+} from "../../hooks/useEventOrders";
 import { ThemeEditorSection } from "../theme/ThemeEditorSection";
 
 // ---- Section configuration -----------------------------------------
@@ -152,6 +156,12 @@ const SECTIONS: readonly SectionConfig[] = [
 
 const SAVE_PROCESSING_MS = 800;
 const TOAST_NAV_DELAY_MS = 600;
+// ORCH-1047 — iOS cannot present a second native Modal while the reason sheet
+// (ChangeSummaryModal → Sheet → RN Modal) is still dismissing; the OS silently
+// drops it. We therefore close the reason sheet, wait for its dismiss animation
+// to finish, THEN present the "Refund first" reject dialog (ConfirmDialog → RN
+// Modal) so it reliably appears instead of vanishing into a silent no-op.
+const REJECT_DIALOG_HANDOFF_MS = 450;
 const COVER_MEDIA_PATCH_KEYS = new Set<keyof EditableLiveEventFields>([
   "coverMediaUrl",
   "coverMediaType",
@@ -265,6 +275,11 @@ interface RejectDialogContent {
   body: string;
   primaryLabel: string;
   primaryAction: () => void;
+  /** ORCH-1047 — schedule-with-sales reject uses a hold-to-confirm destructive
+   * variant so "Refund all & change" can't be fat-fingered. Other rejects stay
+   * the simple "Open Orders" dialog. */
+  variant?: "simple" | "holdToConfirm";
+  destructive?: boolean;
 }
 
 export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
@@ -326,10 +341,18 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     });
   }, []);
 
-  // ---- Sold-count context (ORCH-0704: stub returns zeros; 9c flips live) ----
+  // ---- Sold-count context (server-backed) ----------------------------------
+  // Was an ORCH-0704 stub that read the empty client order store and returned
+  // zeros for server-loaded events, leaving the buyer-protection edit guards
+  // blind (they let date moves / tier changes on sold events reach the server,
+  // which then rejected with a bare toast). Now sourced from the live event
+  // orders so validateLiveEventFieldUpdate reliably fires the "Refund first"
+  // dialog. serverEventId === null → query disabled → empty (the server RPC
+  // still backstops every structural change).
+  const serverOrders = useEventReconciliation(liveEvent.serverEventId);
   const soldCountCtx = useMemo(
-    () => getSoldCountContextForEvent(liveEvent),
-    [liveEvent],
+    () => buildSoldCountContextFromOrders(serverOrders),
+    [serverOrders],
   );
 
   // Cycle 13a J-T6 G2: ticket price editability gated on EDIT_TICKET_PRICE
@@ -484,6 +507,103 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     queryClient,
   ]);
 
+  // ORCH-1047 — captured reason for the "Refund all & proceed" path (the
+  // reject dialog is presented after the reason sheet closes, so the reason
+  // text must be stashed when the save is blocked).
+  const reasonRef = useRef<string>("");
+
+  // ORCH-1047 — "Refund all & proceed": refund every buyer for this event in
+  // full, then re-apply the schedule change with the server's
+  // acknowledge_sold_impact bypass. Operator-chosen partial-failure policy:
+  // change anyway, and surface any buyer whose refund failed so they can be
+  // refunded manually in Orders. This fires REAL refunds — it is only reachable
+  // behind the hold-to-confirm destructive dialog.
+  const runRefundAllAndProceed = useCallback(
+    async (reason: string): Promise<void> => {
+      setRejectDialog(null);
+      if (liveEvent.serverEventId === null) {
+        showToast("Can't change — this event is missing its server id.");
+        return;
+      }
+      setSubmitting(true);
+      const patch = currentPatch;
+      try {
+        const refund = await refundAllEventOrders(serverOrders, reason);
+        // All-or-nothing (buyer protection): if ANY refund failed, do NOT change
+        // the schedule — moving the event would strand the un-refunded buyers.
+        // Abort, leave the schedule untouched, and report who still needs a
+        // refund + the actual Stripe reason so the operator can act.
+        if (refund.failed.length > 0) {
+          setSubmitting(false);
+          setModal((prev) => ({ ...prev, visible: false }));
+          const names = refund.failed.map((f) => f.buyerName).join(", ");
+          const why = refund.failed[0]?.error ?? "";
+          showToast(
+            `Refunds incomplete — ${refund.failed.length} failed (${names}). Schedule NOT changed. ${why}`.trim(),
+          );
+          return;
+        }
+        // Every buyer refunded → now it's safe to apply the schedule change.
+        await patchPublishedEventWhen({
+          eventId: liveEvent.serverEventId,
+          whenPayload: {
+            whenMode: patch.whenMode ?? liveEvent.whenMode,
+            timezone: patch.timezone ?? liveEvent.timezone,
+            when: {
+              date: patch.date !== undefined ? patch.date : liveEvent.date,
+              doorsOpen:
+                patch.doorsOpen !== undefined
+                  ? patch.doorsOpen
+                  : liveEvent.doorsOpen,
+              endsAt:
+                patch.endsAt !== undefined ? patch.endsAt : liveEvent.endsAt,
+            },
+            multiDates:
+              patch.multiDates !== undefined
+                ? patch.multiDates
+                : liveEvent.multiDates,
+            recurrenceRule:
+              patch.recurrenceRule !== undefined
+                ? patch.recurrenceRule
+                : liveEvent.recurrenceRule,
+          },
+          reason,
+          clientRevision: null,
+          acknowledgeSoldImpact: true,
+        });
+        invalidateServerEventCaches();
+        setSubmitting(false);
+        setModal((prev) => ({ ...prev, visible: false }));
+        const okCount = refund.refundedOrderIds.length;
+        showToast(
+          `Refunded all ${okCount} buyer${okCount === 1 ? "" : "s"}. Schedule updated.`,
+        );
+        setTimeout(() => {
+          if (router.canGoBack()) {
+            router.back();
+          } else {
+            // orch-strict-grep-allow route-by-event-type — events-only screen
+            router.replace(`/event/${liveEvent.id}` as never);
+          }
+        }, TOAST_NAV_DELAY_MS);
+      } catch (error) {
+        setSubmitting(false);
+        const code = error instanceof Error ? error.message : "save_failed";
+        showToast(
+          `Refunds attempted but the schedule change failed (${code}). Check Orders.`,
+        );
+      }
+    },
+    [
+      currentPatch,
+      invalidateServerEventCaches,
+      liveEvent,
+      router,
+      serverOrders,
+      showToast,
+    ],
+  );
+
   // ---- Map rejection result to dialog content ----
   const buildRejectDialog = useCallback(
     (result: Extract<UpdateLiveEventResult, { ok: false }>): RejectDialogContent => {
@@ -495,6 +615,23 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       };
 
       const closeOnly = (): void => setRejectDialog(null);
+
+      // ORCH-1047 — schedule-with-sales: offer "Refund all & change" as a
+      // hold-to-confirm destructive action. Per-order manual refunds remain
+      // reachable from the event's Orders screen.
+      const refundAllAndChange = (
+        n: number,
+        whatChanges: string,
+      ): RejectDialogContent => ({
+        title: "Refund all & change?",
+        body: `${n} ${n === 1 ? "buyer has" : "buyers have"} tickets for this event. To ${whatChanges}, all ${n} ${n === 1 ? "buyer" : "buyers"} are refunded in full first — this is permanent. If any refund fails, nothing changes and you'll see who still needs refunding. Hold to confirm.`,
+        primaryLabel: "Refund all & change",
+        variant: "holdToConfirm",
+        destructive: true,
+        primaryAction: () => {
+          void runRefundAllAndProceed(reasonRef.current);
+        },
+      });
 
       switch (result.reason) {
         case "event_not_found":
@@ -555,60 +692,41 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
             primaryAction: closeAndOpenOrders,
           };
         }
-        case "multi_date_remove_with_sales": {
-          const dropped = result.droppedDates ?? [];
-          const n = result.affectedOrderCount ?? 0;
-          const dateText =
-            dropped.length === 1
-              ? `the date ${dropped[0]}`
-              : `${dropped.length} dates`;
-          return {
-            title: "Refund first",
-            body: `Tickets sold for this event grant access to all dates. Refund ${n} order${n === 1 ? "" : "s"} before removing ${dateText}.`,
-            primaryLabel: "Open Orders",
-            primaryAction: closeAndOpenOrders,
-          };
-        }
-        case "when_mode_drops_active_date": {
-          const dropped = result.droppedDates ?? [];
-          const n = result.affectedOrderCount ?? 0;
-          const dateText =
-            dropped.length === 1
-              ? `the date ${dropped[0]}`
-              : `${dropped.length} dates`;
-          return {
-            title: "Refund first",
-            body: `Switching mode would drop ${dateText} from your schedule. ${n} buyer${n === 1 ? "" : "s"} paid for this event — refund them before switching.`,
-            primaryLabel: "Open Orders",
-            primaryAction: closeAndOpenOrders,
-          };
-        }
-        case "recurrence_drops_occurrence": {
-          const dropped = result.droppedDates ?? [];
-          const n = result.affectedOrderCount ?? 0;
-          const dateText =
-            dropped.length === 1
-              ? `the date ${dropped[0]}`
-              : `${dropped.length} occurrence${dropped.length === 1 ? "" : "s"}`;
-          return {
-            title: "Refund first",
-            body: `Your new recurrence rule drops ${dateText}. ${n} buyer${n === 1 ? "" : "s"} paid for this event — refund them first.`,
-            primaryLabel: "Open Orders",
-            primaryAction: closeAndOpenOrders,
-          };
-        }
+        case "multi_date_remove_with_sales":
+          return refundAllAndChange(
+            result.affectedOrderCount ?? 0,
+            "change the dates",
+          );
+        case "time_change_with_sales":
+          return refundAllAndChange(
+            result.affectedOrderCount ?? 0,
+            "change the time",
+          );
+        case "when_mode_drops_active_date":
+          return refundAllAndChange(
+            result.affectedOrderCount ?? 0,
+            "change the schedule",
+          );
+        case "recurrence_drops_occurrence":
+          return refundAllAndChange(
+            result.affectedOrderCount ?? 0,
+            "change the recurrence",
+          );
         default: {
           const _exhaust: never = result.reason;
           return _exhaust;
         }
       }
     },
-    [liveEvent.id, router],
+    [liveEvent.id, router, runRefundAllAndProceed],
   );
 
   const handleConfirmSave = useCallback(
     async (reason: string): Promise<void> => {
       if (submitting) return;
+      // ORCH-1047 — stash the reason so "Refund all & proceed" (fired from the
+      // deferred reject dialog) can reuse it for the refunds + re-save.
+      reasonRef.current = reason;
       setSubmitting(true);
       await sleep(SAVE_PROCESSING_MS);
       const patch = currentPatch;
@@ -621,7 +739,10 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       if (!validation.ok) {
         setSubmitting(false);
         setModal((prev) => ({ ...prev, visible: false }));
-        setRejectDialog(buildRejectDialog(validation));
+        // Defer so the reject dialog isn't dropped while the reason sheet is
+        // still dismissing on iOS (see REJECT_DIALOG_HANDOFF_MS).
+        const pendingReject = buildRejectDialog(validation);
+        setTimeout(() => setRejectDialog(pendingReject), REJECT_DIALOG_HANDOFF_MS);
         return;
       }
       const explicitCoverSet =
@@ -872,6 +993,8 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
                             code === "recurrence_drops_occurrence" ||
                             code === "multi_date_remove_with_sales"
                           ? "This change would drop a date with active tickets. Cancel or refund those tickets first."
+                          : code === "schedule_change_with_sales"
+                            ? "This event has sold tickets. Refund those buyers before changing its time."
                           : code === "stale_client_revision" ||
                               code === "event_not_editable_race"
                             ? "Someone else updated this event. Tap to reload."
@@ -980,8 +1103,10 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
         }, TOAST_NAV_DELAY_MS);
         return;
       }
-      // Guard-rail rejection — open dialog
-      setRejectDialog(buildRejectDialog(result));
+      // Guard-rail rejection — open dialog (deferred so it isn't dropped while
+      // the reason sheet dismisses on iOS; see REJECT_DIALOG_HANDOFF_MS).
+      const pendingReject = buildRejectDialog(result);
+      setTimeout(() => setRejectDialog(pendingReject), REJECT_DIALOG_HANDOFF_MS);
     },
     [
       submitting,
@@ -1253,7 +1378,8 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
         description={rejectDialog?.body ?? ""}
         confirmLabel={rejectDialog?.primaryLabel ?? "OK"}
         cancelLabel="Close"
-        variant="simple"
+        variant={rejectDialog?.variant ?? "simple"}
+        destructive={rejectDialog?.destructive ?? false}
       />
 
       {/* Toast (self-positioning portal) */}

--- a/mingla-business/src/components/event/__tests__/EditPublishedScreen_silent_save_signals.test.ts
+++ b/mingla-business/src/components/event/__tests__/EditPublishedScreen_silent_save_signals.test.ts
@@ -140,8 +140,12 @@ describe("ORCH-0980 — EditPublishedScreen save paths are never silent", () => 
 
     expect(localPath).toContain("if (result.ok) {");
     expect(localPath).toContain('showToast("Saved. Live now.");');
-    // Guard-rail rejection -> visible dialog, not a silent no-op.
-    expect(localPath).toContain("setRejectDialog(buildRejectDialog(result));");
+    // Guard-rail rejection -> visible dialog, not a silent no-op. ORCH-1047:
+    // the dialog is now presented on a deferred tick (REJECT_DIALOG_HANDOFF_MS)
+    // so iOS doesn't drop it while the reason sheet is still dismissing — but it
+    // is still unconditionally opened (never a silent pass).
+    expect(localPath).toContain("buildRejectDialog(result)");
+    expect(localPath).toContain("setRejectDialog(pendingReject)");
   });
 });
 

--- a/mingla-business/src/services/businessEvents.ts
+++ b/mingla-business/src/services/businessEvents.ts
@@ -912,6 +912,13 @@ export interface PatchEventWhenInput {
   };
   reason: string;
   clientRevision: number | null;
+  /**
+   * ORCH-1047 "Refund all & proceed": when true, the server bypasses the
+   * sold-ticket structural blocks (the organiser has refunded all buyers and
+   * chosen to change the schedule anyway). Defaults to undefined → false →
+   * conservative refund-first behaviour for every normal save.
+   */
+  acknowledgeSoldImpact?: boolean;
 }
 
 export interface PatchEventWhenResponse {
@@ -939,7 +946,13 @@ export const patchPublishedEventWhen = async (
 ): Promise<PatchEventWhenResponse> => {
   const { data, error } = await supabase.rpc("business_patch_event_when", {
     p_event_id: input.eventId,
-    p_when_payload: input.whenPayload,
+    // ORCH-1047: carry the "Refund all & proceed" sold-impact bypass inside the
+    // payload JSON (not a new RPC param) so the server change stays a plain
+    // CREATE OR REPLACE with no signature change / DROP.
+    p_when_payload: {
+      ...input.whenPayload,
+      acknowledgeSoldImpact: input.acknowledgeSoldImpact ?? false,
+    },
     p_reason: input.reason,
     p_client_revision: input.clientRevision,
   });

--- a/mingla-business/src/services/eventOrdersService.ts
+++ b/mingla-business/src/services/eventOrdersService.ts
@@ -319,6 +319,30 @@ export const getEventSoldCounts = (
   return counts;
 };
 
+/**
+ * Build a server-backed {@link SoldCountContext} from the live event orders.
+ *
+ * Replaces the legacy client-store reader (`getSoldCountContextForEvent`,
+ * ORCH-0704 stub that returned zeros for server-loaded events). The
+ * published-event edit guards (`validateLiveEventFieldUpdate`) consume this to
+ * decide whether a structural change (date move, tier delete, price/capacity
+ * change) collides with sold tickets — so it MUST reflect real server truth,
+ * not the empty client order store.
+ *
+ * - `soldCountByTier`: live ticket quantity per ticket-type (net of refunds).
+ * - `soldCountForEvent`: count of live orders (buyers) — matches the server
+ *   RPC's `count(*) … payment_status IN ('paid','partial_refund')` and the
+ *   "Refund N orders" copy in the reject dialog.
+ */
+export const buildSoldCountContextFromOrders = (
+  orders: OrderRecord[],
+): { soldCountByTier: Record<string, number>; soldCountForEvent: number } => ({
+  soldCountByTier: getEventSoldCounts(orders),
+  soldCountForEvent: orders.filter(
+    (o) => o.status === "paid" || o.status === "refunded_partial",
+  ).length,
+});
+
 export const getEventOrderActivity = (
   orders: OrderRecord[],
   sinceTs?: number,

--- a/mingla-business/src/services/orderRefundService.ts
+++ b/mingla-business/src/services/orderRefundService.ts
@@ -11,6 +11,8 @@
  */
 
 import { supabase } from "./supabase";
+import { randomId } from "../utils/randomId";
+import type { OrderRecord } from "../store/orderStore";
 
 export interface RefundOrderInput {
   orderId: string;
@@ -162,4 +164,65 @@ const userMessageFor = (code: string): string => {
     default:
       return "Couldn't issue the refund. Tap to try again.";
   }
+};
+
+// ============================================================
+// ORCH-1047 — "Refund all & proceed" bulk refund
+// ============================================================
+
+export interface BulkRefundResult {
+  refundedOrderIds: string[];
+  failed: Array<{ orderId: string; buyerName: string; error: string }>;
+}
+
+/**
+ * Full-refund line set for an order — every line's remaining (unrefunded)
+ * quantity at its purchase unit price. Mirrors RefundSheet's "full" mode line
+ * builder verbatim so the per-line cents match the tested single-refund path.
+ */
+const fullRefundLines = (order: OrderRecord): RefundOrderInput["lines"] =>
+  order.lines
+    .filter((l) => l.quantity - l.refundedQuantity > 0)
+    .map((l) => ({
+      orderLineItemId: l.orderLineItemId ?? "",
+      quantity: l.quantity - l.refundedQuantity,
+      amountCents: Math.round(
+        (l.quantity - l.refundedQuantity) * l.unitPriceGbpAtPurchase * 100,
+      ),
+    }));
+
+/**
+ * Refund every still-live order for an event in full, sequentially (respects
+ * Stripe rate limits; each call gets its own idempotency key so a retry of the
+ * whole batch doesn't double-charge a refund that already succeeded — failed
+ * ones simply re-attempt). Returns which orders refunded and which failed; the
+ * caller (EditPublishedScreen "Refund all & proceed") decides whether to apply
+ * the schedule change and how to report partial failure.
+ */
+export const refundAllEventOrders = async (
+  orders: OrderRecord[],
+  reason: string,
+): Promise<BulkRefundResult> => {
+  const result: BulkRefundResult = { refundedOrderIds: [], failed: [] };
+  for (const order of orders) {
+    if (order.status !== "paid" && order.status !== "refunded_partial") continue;
+    const lines = fullRefundLines(order);
+    if (lines.length === 0) continue;
+    try {
+      await issueOrderRefund({
+        orderId: order.id,
+        lines,
+        reason,
+        idempotencyKey: randomId(),
+      });
+      result.refundedOrderIds.push(order.id);
+    } catch (e) {
+      result.failed.push({
+        orderId: order.id,
+        buyerName: order.buyer?.name ?? "Buyer",
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+  return result;
 };

--- a/mingla-business/src/store/liveEventStore.ts
+++ b/mingla-business/src/store/liveEventStore.ts
@@ -135,7 +135,8 @@ export type UpdateLiveEventRejection =
   | "tier_free_toggle_with_sales"
   | "multi_date_remove_with_sales"
   | "when_mode_drops_active_date"
-  | "recurrence_drops_occurrence";
+  | "recurrence_drops_occurrence"
+  | "time_change_with_sales";
 
 export type UpdateLiveEventResult =
   | { ok: true; editLogEntryId: string }

--- a/mingla-business/src/utils/publishedEventEditGuards.ts
+++ b/mingla-business/src/utils/publishedEventEditGuards.ts
@@ -80,6 +80,23 @@ export const validateLiveEventFieldUpdate = (
     };
   }
 
+  // Buyer protection: a TIME / timezone change (door / start / end) on a sold
+  // event is just as material to ticket holders as a date move — the event they
+  // paid for is moving — so it must pass through the same "refund first" process
+  // rather than saving silently. Date-DAY moves are already caught by the
+  // droppedDates block above; this closes the time-of-day exception.
+  const timeChanged =
+    (patch.doorsOpen !== undefined && patch.doorsOpen !== event.doorsOpen) ||
+    (patch.endsAt !== undefined && patch.endsAt !== event.endsAt) ||
+    (patch.timezone !== undefined && patch.timezone !== event.timezone);
+  if (timeChanged && soldCountForEvent > 0) {
+    return {
+      ok: false,
+      reason: "time_change_with_sales",
+      affectedOrderCount: soldCountForEvent,
+    };
+  }
+
   if (patch.tickets !== undefined) {
     const oldById = new Map(event.tickets.map((t) => [t.id, t]));
     const newIds = new Set(patch.tickets.map((t) => t.id));

--- a/supabase/migrations/20260820000000_schedule_change_buyer_protection_refund_all.sql
+++ b/supabase/migrations/20260820000000_schedule_change_buyer_protection_refund_all.sql
@@ -1,0 +1,289 @@
+-- Schedule-change buyer protection + "Refund all & proceed" (shares the
+-- ORCH-1047 work id used in code comments; NOTE: the team also used
+-- orch_1047 for the the prior owner-role label→brand_owner rename — distinct work.)
+--
+-- business_patch_event_when: (1) blocks a same-day TIME/timezone change on a
+-- sold event (schedule_change_with_sales), mirroring the date-move block; and
+-- (2) honours payload "acknowledgeSoldImpact": true to bypass the sold-ticket
+-- blocks AFTER the client has refunded every buyer (Refund all & proceed,
+-- all-or-nothing). CREATE OR REPLACE, no signature change. Already live on prod.
+
+CREATE OR REPLACE FUNCTION public.business_patch_event_when(p_event_id uuid, p_when_payload jsonb, p_reason text, p_client_revision integer DEFAULT NULL::integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_user_id uuid;
+  v_event public.events%ROWTYPE;
+  v_now timestamptz := now();
+  v_trimmed_reason text;
+  v_reason_len integer;
+  v_when_mode text;
+  v_old_when_mode text;
+  v_when jsonb;
+  v_multi_dates jsonb;
+  v_date_iso text;
+  v_doors text;
+  v_ends text;
+  v_timezone text;
+  v_start timestamptz;
+  v_end timestamptz;
+  v_min_start timestamptz;
+  v_date_entry jsonb;
+  v_sold_count integer;
+  v_old_recurrence jsonb;
+  v_new_recurrence jsonb;
+  v_old_master_dates date[];
+  v_new_payload_dates date[];
+  v_updated public.events%ROWTYPE;
+BEGIN
+  -- 1. Authentication
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  -- 2. Fetch + lock the events row (concurrent edit/publish protection)
+  SELECT *
+  INTO v_event
+  FROM public.events
+  WHERE id = p_event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_not_found';
+  END IF;
+
+  -- 3. Soft-delete guard
+  IF v_event.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'event_deleted';
+  END IF;
+
+  -- 4. Status guard — only scheduled/live events are editable
+  IF v_event.status NOT IN ('scheduled', 'live') THEN
+    RAISE EXCEPTION 'event_not_editable_status';
+  END IF;
+
+  -- 5. Permission — event_manager+ for the brand
+  IF public.biz_brand_effective_rank(v_event.brand_id, v_user_id)
+       < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  -- 6. Reason validation (mirror publishedEventEditGuards.ts:26-32 — trim ∈ [10, 200])
+  IF p_reason IS NULL THEN
+    RAISE EXCEPTION 'missing_edit_reason';
+  END IF;
+  v_trimmed_reason := btrim(p_reason);
+  IF length(v_trimmed_reason) = 0 THEN
+    RAISE EXCEPTION 'missing_edit_reason';
+  END IF;
+  v_reason_len := length(v_trimmed_reason);
+  IF v_reason_len < 10 OR v_reason_len > 200 THEN
+    RAISE EXCEPTION 'invalid_edit_reason';
+  END IF;
+
+  -- 7. Client revision check (NO-OP — events.client_revision column does
+  --    not exist yet; param reserved for future optimistic-concurrency
+  --    extension. Service still passes the param per SPEC §4.8 contract.)
+  IF p_client_revision IS NOT NULL THEN
+    -- Future: SELECT client_revision FROM events WHERE id = p_event_id;
+    -- and raise stale_client_revision on mismatch. Currently a no-op.
+    NULL;
+  END IF;
+
+  -- 8. whenMode validation
+  v_when_mode := COALESCE(NULLIF(p_when_payload->>'whenMode', ''), 'single');
+  v_when := p_when_payload->'when';
+  v_multi_dates := p_when_payload->'multiDates';
+  v_timezone := COALESCE(NULLIF(p_when_payload->>'timezone', ''), v_event.timezone, 'UTC');
+
+  IF v_when_mode NOT IN ('single', 'multi_date', 'recurring') THEN
+    RAISE EXCEPTION 'event_date_required';
+  END IF;
+
+  -- 9. Buyer-protection (CONSERVATIVE) — block structural changes when sold>0
+  SELECT count(*)::integer INTO v_sold_count
+  FROM public.orders
+  WHERE event_id = p_event_id
+    AND payment_status IN ('paid', 'partial_refund');
+
+  v_old_when_mode := CASE
+    WHEN v_event.is_multi_date THEN 'multi_date'
+    WHEN v_event.is_recurring THEN 'recurring'
+    ELSE 'single'
+  END;
+
+  -- ORCH-1047 "Refund all & proceed": when the payload carries
+  -- "acknowledgeSoldImpact": true (organiser chose to refund all buyers and
+  -- change anyway), bypass every sold-ticket structural block below. Carried
+  -- inside p_when_payload (not a new param) so this stays a CREATE OR REPLACE
+  -- with no signature change / no DROP. Absent/false preserves the
+  -- conservative refund-first behaviour for all other callers. The client only
+  -- sets this true AFTER attempting to refund every order for the event.
+  IF v_sold_count > 0 AND NOT COALESCE((p_when_payload->>'acknowledgeSoldImpact')::boolean, false) THEN
+    -- Block whenMode change
+    IF v_when_mode <> v_old_when_mode THEN
+      RAISE EXCEPTION 'when_mode_drops_active_date';
+    END IF;
+
+    -- Block recurrenceRule structural change in recurring mode
+    IF v_when_mode = 'recurring' THEN
+      v_old_recurrence := v_event.recurrence_rules;
+      v_new_recurrence := p_when_payload->'recurrenceRule';
+      IF COALESCE(v_old_recurrence::text, '') <> COALESCE(v_new_recurrence::text, '') THEN
+        RAISE EXCEPTION 'recurrence_drops_occurrence';
+      END IF;
+    END IF;
+
+    -- Block multi-date structural removal OR single-mode date change
+    IF v_when_mode = 'multi_date' THEN
+      -- Compare existing event_dates dates with payload dates
+      SELECT array_agg(DISTINCT (start_at AT TIME ZONE v_timezone)::date ORDER BY (start_at AT TIME ZONE v_timezone)::date)
+      INTO v_old_master_dates
+      FROM public.event_dates
+      WHERE event_id = p_event_id;
+
+      SELECT array_agg(DISTINCT (entry->>'date')::date ORDER BY (entry->>'date')::date)
+      INTO v_new_payload_dates
+      FROM jsonb_array_elements(v_multi_dates) entry
+      WHERE NULLIF(entry->>'date', '') IS NOT NULL;
+
+      -- Reject if any existing date is missing from new payload
+      IF v_old_master_dates IS NOT NULL AND v_new_payload_dates IS NOT NULL THEN
+        IF EXISTS (
+          SELECT 1 FROM unnest(v_old_master_dates) AS d
+          WHERE d <> ALL(v_new_payload_dates)
+        ) THEN
+          RAISE EXCEPTION 'multi_date_remove_with_sales';
+        END IF;
+      END IF;
+    END IF;
+
+    IF v_when_mode = 'single' THEN
+      -- Reject date change in single mode with sold>0
+      v_date_iso := NULLIF(v_when->>'date', '');
+      IF v_date_iso IS NOT NULL THEN
+        IF EXISTS (
+          SELECT 1 FROM public.event_dates
+          WHERE event_id = p_event_id
+            AND is_master = true
+            AND (start_at AT TIME ZONE v_timezone)::date <> v_date_iso::date
+        ) THEN
+          RAISE EXCEPTION 'multi_date_remove_with_sales';
+        END IF;
+        -- ORCH-1047 buyer protection: a TIME / timezone change (same calendar
+        -- day) is just as material to a ticket holder as a date move — the
+        -- event they paid for is moving — so it must also pass through the
+        -- refund-first process rather than saving silently. Compute the
+        -- proposed master start/end instant (mirror the §10 midnight-wrap) and
+        -- reject if it differs from the current master row.
+        v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+        v_ends := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+        v_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+        v_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+        IF v_end <= v_start THEN
+          v_end := v_end + INTERVAL '1 day';
+        END IF;
+        IF EXISTS (
+          SELECT 1 FROM public.event_dates
+          WHERE event_id = p_event_id
+            AND is_master = true
+            AND (start_at <> v_start OR end_at <> v_end)
+        ) THEN
+          RAISE EXCEPTION 'schedule_change_with_sales';
+        END IF;
+      END IF;
+    END IF;
+  END IF;
+
+  -- 10. Atomic event_dates rewrite (mirror business_publish_event_draft:281-333)
+  DELETE FROM public.event_dates WHERE event_id = p_event_id;
+
+  IF v_when_mode IN ('single', 'recurring') THEN
+    v_date_iso := NULLIF(v_when->>'date', '');
+    IF v_date_iso IS NULL THEN
+      RAISE EXCEPTION 'event_date_required';
+    END IF;
+    v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+    v_ends := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+    v_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+    v_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+    -- Midnight wrap — IDENTICAL to business_publish_event_draft:292-294
+    IF v_end <= v_start THEN
+      v_end := v_end + INTERVAL '1 day';
+    END IF;
+    -- Zero-duration rejection (defensive — wizard should prevent this client-side)
+    IF v_end = v_start THEN
+      RAISE EXCEPTION 'event_end_must_differ_from_start';
+    END IF;
+    INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+    VALUES (p_event_id, v_start, v_end, v_timezone, true);
+
+  ELSIF v_when_mode = 'multi_date' THEN
+    IF v_multi_dates IS NULL
+      OR jsonb_typeof(v_multi_dates) IS DISTINCT FROM 'array'
+      OR jsonb_array_length(v_multi_dates) = 0
+    THEN
+      RAISE EXCEPTION 'event_date_required';
+    END IF;
+
+    -- Compute master = earliest start instant
+    SELECT min(
+      (entry->>'date' || ' ' || COALESCE(NULLIF(entry->>'startTime', ''), '00:00') || ':00')::timestamp AT TIME ZONE v_timezone
+    )
+    INTO v_min_start
+    FROM jsonb_array_elements(v_multi_dates) entry
+    WHERE NULLIF(entry->>'date', '') IS NOT NULL;
+
+    IF v_min_start IS NULL THEN
+      RAISE EXCEPTION 'event_date_required';
+    END IF;
+
+    FOR v_date_entry IN SELECT value FROM jsonb_array_elements(v_multi_dates)
+    LOOP
+      v_date_iso := NULLIF(v_date_entry->>'date', '');
+      IF v_date_iso IS NULL THEN
+        RAISE EXCEPTION 'event_date_required';
+      END IF;
+      v_doors := COALESCE(NULLIF(v_date_entry->>'startTime', ''), '00:00');
+      v_ends := COALESCE(NULLIF(v_date_entry->>'endTime', ''), v_doors);
+      v_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+      v_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+      -- Per-entry midnight wrap — IDENTICAL to business_publish_event_draft:327-329
+      IF v_end <= v_start THEN
+        v_end := v_end + INTERVAL '1 day';
+      END IF;
+      IF v_end = v_start THEN
+        RAISE EXCEPTION 'event_end_must_differ_from_start';
+      END IF;
+      INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+      VALUES (p_event_id, v_start, v_end, v_timezone, v_start = v_min_start);
+    END LOOP;
+  END IF;
+
+  -- 11. Update events row (timezone may have changed; updated_at bump)
+  UPDATE public.events
+  SET
+    timezone = v_timezone,
+    updated_at = v_now
+  WHERE id = p_event_id
+    AND status IN ('scheduled', 'live')
+    AND deleted_at IS NULL
+  RETURNING * INTO v_updated;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_not_editable_race';
+  END IF;
+
+  -- 12. Return canonical shape (mirror business_patch_event_taxonomy)
+  RETURN jsonb_build_object(
+    'event', to_jsonb(v_updated),
+    'when_mode', v_when_mode,
+    'sold_count', v_sold_count,
+    'updated_at', v_now
+  );
+END;
+$function$


### PR DESCRIPTION
## Problem
Editing a published event's schedule when it has sold tickets was broken and unsafe:
- **Guard was blind** — sold-count came from an empty client store (ORCH-0704 stub) → the buyer-protection guard never fired; bad edits hit the server and failed with a bare toast.
- **Time changes saved silently** — only date *moves* were guarded; a start/door/end time change on a sold event saved with no buyer protection.
- **The "Refund first" dialog was dropped on iOS** — it was a 2nd native modal opened while the reason sheet was still dismissing → silent no-op (looked like "save does nothing").

## Changes
- **Real sold-count** via `buildSoldCountContextFromOrders` (live orders) so the guard fires.
- **`time_change_with_sales`** — time/timezone changes on a sold event now hit the same refund-first flow as date moves (client `validateLiveEventFieldUpdate` + server RPC).
- **Deferred reject dialog** (`REJECT_DIALOG_HANDOFF_MS`) so it reliably renders.
- **"Refund all & proceed"** — hold-to-confirm; refunds every buyer then changes the schedule, **all-or-nothing**: any refund failure ⇒ schedule unchanged + operator sees who failed and the real Stripe reason.
- **Migration** (`business_patch_event_when`): blocks same-day time changes on sold events; honours `acknowledgeSoldImpact:true` to bypass after a full refund. CREATE OR REPLACE, no signature change — **already deployed live** (this file records it).

## Verification
- tsc clean; **18** guard/edit/refund/orders tests pass.
- Refund path confirmed end-to-end on a real test charge through the live `refund-order` function (after the Stripe restricted-key Connect permission was enabled).

## Notes for reviewer
- Code comments reference **ORCH-1047**, which **collides** with the team's `account_owner→brand_owner` rename (also tagged orch_1047) — different work; please reconcile the label.
- Dependent (separate PR): swapping the event **Where** step to the Mapbox autocomplete (Google Places is REQUEST_DENIED in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)