### PR TITLE
Fix event Where address autocomplete: Google Places (REQUEST_DENIED) → Mapbox

### DIFF
--- a/mingla-business/src/components/event/CreatorStep3Where.tsx
+++ b/mingla-business/src/components/event/CreatorStep3Where.tsx
@@ -29,8 +29,13 @@ import {
 import { GlassCard } from "../ui/GlassCard";
 import { Icon } from "../ui/Icon";
 import { Input } from "../ui/Input";
-import { AddressAutocompleteInput } from "./AddressAutocompleteInput";
-import type { PlaceDetails } from "../../services/googlePlacesService";
+// ORCH-1047: the event Where step now uses the Mapbox address autocomplete
+// (META-ORCH-1059's mapbox-geocode edge fn + MapboxAddressInput) — the legacy
+// Google Places path was REQUEST_DENIED, leaving an empty suggestions dropdown.
+// MapboxAddressInput is a drop-in for AddressAutocompleteInput (same props +
+// the same PlaceDetails boundary: formattedAddress / city / location).
+import { MapboxAddressInput } from "../location/MapboxAddressInput";
+import type { PlaceDetails } from "../../services/mapboxGeocodeService";
 
 import { errorForKey, type StepBodyProps } from "./types";
 
@@ -74,7 +79,7 @@ export const CreatorStep3Where: React.FC<StepBodyProps> = ({
               from the suggestions." */}
           <View style={styles.field}>
             <Text style={styles.fieldLabel}>Address</Text>
-            <AddressAutocompleteInput
+            <MapboxAddressInput
               value={draft.address ?? ""}
               onChangeText={(v) => updateDraft({ address: v, city: null, locationGeo: null })}
               onPick={(details: PlaceDetails): void => {

--- a/mingla-business/src/components/location/MapboxAddressInput.tsx
+++ b/mingla-business/src/components/location/MapboxAddressInput.tsx
@@ -1,0 +1,319 @@
+/**
+ * META-ORCH-1059 [experiences-business-parity] · SUB-A · LAYER 4
+ *
+ * MapboxAddressInput — address field with Mapbox Search Box autocomplete +
+ * retrieve-on-pick for the experience stops builder. A drop-in sibling of
+ * AddressAutocompleteInput (the event venue picker): SAME props, SAME Status
+ * state machine, SAME StyleSheet tokens, SAME 250ms debounce / ≥3-char gate /
+ * ≤5-suggestion dropdown / inline pick spinner / loud pick error / silent
+ * autocomplete failures / combobox a11y.
+ *
+ * WHY a new component (not a `provider` prop on AddressAutocompleteInput):
+ * the existing event picker is Google-wired (hardcoded "Venue address" label,
+ * Google service import). A clean sibling keeps the proven event path
+ * untouched (lower blast radius). Both satisfy the same PlaceDetails boundary,
+ * so a future consolidation is trivial (v1.1 cleanup, not Sub-A scope).
+ *
+ * Differences from AddressAutocompleteInput:
+ *   - Calls autocompleteMapbox / retrieveMapboxPlace with a per-session UUID
+ *     held in a ref (one token per typing session → suggest+retrieve = one
+ *     Mapbox billing session).
+ *   - accessibilityLabel is parametrized (parent passes "Stop {n} address").
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import {
+  accent,
+  glass,
+  radius as radiusTokens,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+
+import { Icon } from "../ui/Icon";
+import {
+  autocompleteMapbox,
+  newMapboxSessionToken,
+  retrieveMapboxPlace,
+  type PlaceAutocompleteSuggestion,
+  type PlaceDetails,
+} from "../../services/mapboxGeocodeService";
+
+const AUTOCOMPLETE_DEBOUNCE_MS = 250;
+const MIN_QUERY_LENGTH = 3;
+
+interface MapboxAddressInputProps {
+  /** Current displayed value (formatted address or in-progress typing). */
+  value: string;
+  /** Fires on every keystroke so the parent can keep the stop's address in sync. */
+  onChangeText: (next: string) => void;
+  /** Fires when the user picks a suggestion AND retrieve succeeds. */
+  onPick: (details: PlaceDetails) => void;
+  /** Fires when the user clears the field (X icon). Parent zeroes address+geo. */
+  onClear: () => void;
+  /** Inline error from parent-side validation. */
+  error?: string;
+  placeholder?: string;
+  /** Parametrized a11y label (e.g. "Stop 2 address"). */
+  accessibilityLabel?: string;
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "loading_suggestions" }
+  | { kind: "suggestions_open"; results: PlaceAutocompleteSuggestion[] }
+  | { kind: "fetching_details" }
+  | { kind: "pick_error"; message: string };
+
+export const MapboxAddressInput: React.FC<MapboxAddressInputProps> = ({
+  value,
+  onChangeText,
+  onPick,
+  onClear,
+  error,
+  placeholder = "Pick a place",
+  accessibilityLabel = "Address",
+}) => {
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // One Mapbox session token per typing session; reused across suggest→retrieve.
+  const sessionToken = useRef<string>(newMapboxSessionToken());
+
+  const clearDebounceTimer = useCallback((): void => {
+    if (debounceTimer.current !== null) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+  }, []);
+
+  useEffect((): (() => void) => {
+    return (): void => {
+      clearDebounceTimer();
+    };
+  }, [clearDebounceTimer]);
+
+  const handleChangeText = useCallback(
+    (next: string): void => {
+      onChangeText(next);
+      clearDebounceTimer();
+      if (next.trim().length < MIN_QUERY_LENGTH) {
+        setStatus({ kind: "idle" });
+        return;
+      }
+      setStatus({ kind: "loading_suggestions" });
+      debounceTimer.current = setTimeout(async (): Promise<void> => {
+        const results = await autocompleteMapbox(next, sessionToken.current);
+        if (results.length === 0) {
+          setStatus({ kind: "idle" });
+        } else {
+          setStatus({ kind: "suggestions_open", results });
+        }
+      }, AUTOCOMPLETE_DEBOUNCE_MS);
+    },
+    [clearDebounceTimer, onChangeText],
+  );
+
+  const handlePickSuggestion = useCallback(
+    async (s: PlaceAutocompleteSuggestion): Promise<void> => {
+      clearDebounceTimer();
+      setStatus({ kind: "fetching_details" });
+      try {
+        const details = await retrieveMapboxPlace(s.placeId, sessionToken.current);
+        // Fire ONLY onPick on a successful pick — the parent writes
+        // address + city + region + countryCode + lat/lng atomically and the
+        // controlled TextInput re-renders from the parent's value next tick.
+        onPick(details);
+        setStatus({ kind: "idle" });
+        // Rotate the session token AFTER a completed suggest→retrieve pair so
+        // the next typing session bills as a fresh Mapbox session.
+        sessionToken.current = newMapboxSessionToken();
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : "MAPBOX_UNKNOWN";
+        console.warn("[MapboxAddressInput] pick failure:", message);
+        setStatus({
+          kind: "pick_error",
+          message: "Couldn't fetch address details. Tap to try again.",
+        });
+      }
+    },
+    [clearDebounceTimer, onPick],
+  );
+
+  const handleClear = useCallback((): void => {
+    clearDebounceTimer();
+    setStatus({ kind: "idle" });
+    onClear();
+  }, [clearDebounceTimer, onClear]);
+
+  const handleRetry = useCallback((): void => {
+    setStatus({ kind: "idle" });
+  }, []);
+
+  const showClear =
+    value.length > 0 &&
+    status.kind !== "fetching_details" &&
+    status.kind !== "loading_suggestions";
+
+  return (
+    <View>
+      <View
+        style={[
+          styles.inputWrap,
+          (error !== undefined || status.kind === "pick_error") &&
+            styles.inputWrapError,
+        ]}
+      >
+        <TextInput
+          value={value}
+          onChangeText={handleChangeText}
+          placeholder={placeholder}
+          placeholderTextColor={textTokens.quaternary}
+          autoCorrect={false}
+          autoCapitalize="words"
+          style={styles.input}
+          accessibilityRole="combobox"
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint="Type at least 3 characters to see suggestions, then pick one."
+        />
+        {status.kind === "loading_suggestions" || status.kind === "fetching_details" ? (
+          <ActivityIndicator size="small" color={accent.warm} style={styles.indicator} />
+        ) : showClear ? (
+          <Pressable
+            onPress={handleClear}
+            accessibilityRole="button"
+            accessibilityLabel="Clear address"
+            hitSlop={8}
+            style={styles.clearBtn}
+          >
+            <Icon name="close" size={16} color={textTokens.tertiary} />
+          </Pressable>
+        ) : null}
+      </View>
+
+      {error !== undefined ? (
+        <Text style={styles.helperError}>{error}</Text>
+      ) : status.kind === "pick_error" ? (
+        <Pressable
+          onPress={handleRetry}
+          accessibilityRole="button"
+          accessibilityLabel={`Retry: ${status.message}`}
+          hitSlop={4}
+        >
+          <Text style={styles.helperError}>{status.message}</Text>
+        </Pressable>
+      ) : null}
+
+      {status.kind === "suggestions_open" ? (
+        <View style={styles.dropdown}>
+          {status.results.map((s) => (
+            <Pressable
+              key={s.placeId}
+              onPress={() => handlePickSuggestion(s)}
+              accessibilityRole="button"
+              accessibilityLabel={s.fullAddress}
+              style={({ pressed }) => [
+                styles.suggestionRow,
+                pressed && styles.suggestionRowPressed,
+              ]}
+            >
+              <Icon name="location" size={14} color={textTokens.tertiary} />
+              <View style={styles.suggestionTextCol}>
+                <Text style={styles.suggestionMain} numberOfLines={1}>
+                  {s.displayName}
+                </Text>
+                {s.fullAddress !== s.displayName ? (
+                  <Text style={styles.suggestionSub} numberOfLines={1}>
+                    {s.fullAddress}
+                  </Text>
+                ) : null}
+              </View>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  inputWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    backgroundColor: glass.tint.profileBase,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  inputWrapError: {
+    borderColor: semantic.error,
+  },
+  input: {
+    flex: 1,
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    color: textTokens.primary,
+    padding: 0,
+  },
+  indicator: {
+    marginLeft: spacing.xs,
+  },
+  clearBtn: {
+    marginLeft: spacing.xs,
+    width: 24,
+    height: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  helperError: {
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight,
+    color: semantic.error,
+    marginTop: spacing.xs,
+  },
+  dropdown: {
+    marginTop: spacing.xs,
+    borderRadius: radiusTokens.md,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    backgroundColor: glass.tint.profileBase,
+    overflow: "hidden",
+  },
+  suggestionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  suggestionRowPressed: {
+    backgroundColor: accent.tint,
+  },
+  suggestionTextCol: {
+    flex: 1,
+  },
+  suggestionMain: {
+    fontSize: typography.body.fontSize,
+    color: textTokens.primary,
+  },
+  suggestionSub: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+    marginTop: 2,
+  },
+});
+
+export default MapboxAddressInput;

--- a/mingla-business/src/services/mapboxGeocodeService.ts
+++ b/mingla-business/src/services/mapboxGeocodeService.ts
@@ -1,0 +1,120 @@
+/**
+ * META-ORCH-1059 [experiences-business-parity] · SUB-A · LAYER 4
+ *
+ * mapboxGeocodeService — Mapbox Search Box autocomplete + retrieve for the
+ * experience stops builder's address field. Mirrors googlePlacesService.ts
+ * (events keep Google; experiences use Mapbox per operator lock).
+ *
+ * All calls proxy through the `mapbox-geocode` Supabase edge fn so the
+ * MAPBOX_ACCESS_TOKEN stays server-side (never shipped in the client bundle).
+ *
+ * Edge fn contract (single endpoint, action discriminator):
+ *   supabase.functions.invoke("mapbox-geocode", {
+ *     body: { action: "suggest",  query, session_token }
+ *   }) → { suggestions: PlaceAutocompleteSuggestion[] } | { error }
+ *   supabase.functions.invoke("mapbox-geocode", {
+ *     body: { action: "retrieve", mapbox_id, session_token }
+ *   }) → { details: PlaceDetails } | { error }
+ *
+ * Session token: one client-generated UUID per autocomplete session, reused
+ * across the suggest→retrieve pair (Mapbox bills the pair as ONE session —
+ * https://docs.mapbox.com/api/search/search-box/#session-billing).
+ *
+ * Error contract (mirrors googlePlacesService):
+ *   - autocompleteMapbox() returns [] on failure (silent type-ahead fallback).
+ *   - retrieveMapboxPlace() THROWS on failure, preserving the edge fn's error
+ *     code (mapbox_access_token_missing | no_locality | no_location |
+ *     mapbox_<status>) so MapboxAddressInput can map to user-friendly copy.
+ *
+ * The PlaceAutocompleteSuggestion + PlaceDetails shapes are STRUCTURALLY
+ * IDENTICAL to googlePlacesService's, so MapboxAddressInput is a drop-in for
+ * the AddressAutocompleteInput onPick(details: PlaceDetails) contract.
+ */
+
+import { supabase } from "./supabase";
+
+export interface PlaceAutocompleteSuggestion {
+  placeId: string;
+  displayName: string;
+  fullAddress: string;
+}
+
+export interface PlaceDetails {
+  placeId: string;
+  formattedAddress: string;
+  /** Locality (city) — required; the edge fn 500s if not derivable. */
+  city: string;
+  /** Region (e.g. "England", "CA") — nullable. */
+  region: string | null;
+  /** ISO 3166-1 alpha-2 (e.g. "GB", "US") — nullable. */
+  countryCode: string | null;
+  location: { lat: number; lng: number };
+}
+
+const MIN_QUERY_LENGTH = 3;
+
+/** Generate one Mapbox session token (UUID) per autocomplete session. Reuse
+ *  the SAME token across the suggest→retrieve pair for correct session billing. */
+export function newMapboxSessionToken(): string {
+  // RN runtimes lack crypto.randomUUID; build a v4-shaped UUID from Math.random.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Type-ahead autocomplete. Returns up to 5 suggestions. Empty array on any
+ * failure or when query.length < 3 (signal to UI: don't show dropdown).
+ * Silent fallback — type-ahead failures during keystrokes are not
+ * user-actionable. retrieveMapboxPlace() throws loudly when the user picks.
+ */
+export async function autocompleteMapbox(
+  query: string,
+  sessionToken: string,
+): Promise<PlaceAutocompleteSuggestion[]> {
+  const q = query.trim();
+  if (q.length < MIN_QUERY_LENGTH) return [];
+
+  try {
+    const { data, error } = await supabase.functions.invoke("mapbox-geocode", {
+      body: { action: "suggest", query: q, session_token: sessionToken },
+    });
+    if (error) {
+      console.warn("[mapboxGeocodeService] suggest error:", error.message);
+      return [];
+    }
+    if (!data || !Array.isArray(data.suggestions)) return [];
+    return data.suggestions as PlaceAutocompleteSuggestion[];
+  } catch (e) {
+    console.warn("[mapboxGeocodeService] suggest throw:", e);
+    return [];
+  }
+}
+
+/**
+ * Retrieve full place details after the user picks a suggestion. Extracts
+ * structured city + region + countryCode + lat/lng. THROWS on any failure
+ * (callers must surface the error to the user, per Constitution #3).
+ */
+export async function retrieveMapboxPlace(
+  placeId: string,
+  sessionToken: string,
+): Promise<PlaceDetails> {
+  if (!placeId) throw new Error("MAPBOX_ID_REQUIRED");
+
+  const { data, error } = await supabase.functions.invoke("mapbox-geocode", {
+    body: { action: "retrieve", mapbox_id: placeId, session_token: sessionToken },
+  });
+
+  if (error) {
+    // Preserve the upstream error code so the picker maps to the right copy:
+    //   mapbox_access_token_missing | no_locality | no_location | mapbox_<status>
+    throw new Error(error.message ?? "mapbox_proxy_failed");
+  }
+  if (!data || !data.details) {
+    throw new Error("mapbox_proxy_empty_response");
+  }
+  return data.details as PlaceDetails;
+}


### PR DESCRIPTION
## Problem
The **Address** suggestions dropdown in the event create/edit **Where** step is **empty in prod**. The `places-autocomplete` edge function's Google path returns **`REQUEST_DENIED`** (legacy Places API), and `autocompletePlaces()` silently returns `[]` → no suggestions. Affects create *and* edit.

## Fix
Swap `CreatorStep3Where` from `AddressAutocompleteInput` (Google) → **`MapboxAddressInput`** (Mapbox Search Box via the **already-deployed** `mapbox-geocode` edge fn). It's a true drop-in — identical props and the same `PlaceDetails` shape (`formattedAddress`/`city`/`location`).

## Coordination note
`MapboxAddressInput` + `mapboxGeocodeService` come from the unmerged **`meta-orch-1059`** branch and are vendored here verbatim so this prod fix can ship now. When `meta-orch-1059` merges, those two files are identical (clean), and its `CreatorStep3Where` (still Google) should resolve in favor of this Mapbox version.

## Verification
- `mapbox-geocode` edge fn confirmed returning live suggestions (e.g. "Lagos, Nigeria").
- tsc clean for the swapped/added files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)