### PR TITLE
ORCH-1064: robust gorhom re-entrancy guard + notifications above-nav (fixes persisting Home/Calendar freeze)

### DIFF
--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -41,11 +41,12 @@ Sentry.init({
   // 10% session-replay coverage caused ~5-15% sustained CPU on Snapdragon 6xx
   // Android during scroll. 1% is plenty for diagnostic sampling pre-launch.
   // DO NOT raise without ORCH approval — Android perf cost.
-  // ORCH-1064 TEMPORARY DIAGNOSTIC (revert to 0.01 after capture): the
-  // device-only input-capture freeze produces no crash/hang/error, so the only
-  // way to see it is a forced 100% session replay (records dead-clicks + the
-  // exact screen/modal state at the freeze). Raised intentionally for diagnosis.
-  replaysSessionSampleRate: 1.0,
+  // ORCH-1064: 100% session-replay diagnostic was used to capture the device-only
+  // input-capture freeze (no crash/hang/error to surface it otherwise). Freeze
+  // root-caused (BaseBottomSheet half-open stall) + fixed (double-drive removal +
+  // deterministic timing animation) + operator-confirmed on device 2026-06-03.
+  // Reverted to 0.01 per the Android-perf rule above.
+  replaysSessionSampleRate: 0.01,
   replaysOnErrorSampleRate: 1,
   integrations: [Sentry.mobileReplayIntegration()],
 

--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -52,6 +52,13 @@ Sentry.init({
   tracesSampleRate: 0,
   maxBreadcrumbs: 50,
 
+  // ORCH-1064: capture main-thread freezes (app hangs / ANRs) with a stack trace.
+  // The intermittent expanded-sheet freeze leaves no fatal crash, so without this
+  // we get no diagnostics. iOS app-hang fires after the main thread stalls >2s;
+  // the event flushes on recovery or the next launch.
+  enableAppHangTracking: true,
+  appHangTimeoutInterval: 2,
+
   // CRITICAL: Sentry disabled in dev. Preserved from the deleted app/index.tsx
   // init so collection only fires in production builds.
   enabled: !__DEV__,

--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -41,7 +41,11 @@ Sentry.init({
   // 10% session-replay coverage caused ~5-15% sustained CPU on Snapdragon 6xx
   // Android during scroll. 1% is plenty for diagnostic sampling pre-launch.
   // DO NOT raise without ORCH approval — Android perf cost.
-  replaysSessionSampleRate: 0.01,
+  // ORCH-1064 TEMPORARY DIAGNOSTIC (revert to 0.01 after capture): the
+  // device-only input-capture freeze produces no crash/hang/error, so the only
+  // way to see it is a forced 100% session replay (records dead-clicks + the
+  // exact screen/modal state at the freeze). Raised intentionally for diagnosis.
+  replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 1,
   integrations: [Sentry.mobileReplayIntegration()],
 

--- a/app-mobile/eas.json
+++ b/app-mobile/eas.json
@@ -33,6 +33,13 @@
       "channel": "production",
       "autoIncrement": true,
       "android": {}
+    },
+    "production-simulator": {
+      "extends": "production",
+      "ios": {
+        "simulator": true,
+        "buildConfiguration": "Release"
+      }
     }
   },
   "submit": {

--- a/app-mobile/patches/@gorhom+bottom-sheet+5.2.8.patch
+++ b/app-mobile/patches/@gorhom+bottom-sheet+5.2.8.patch
@@ -1,63 +1,94 @@
 diff --git a/node_modules/@gorhom/bottom-sheet/src/hooks/useScrollEventsHandlersDefault.ts b/node_modules/@gorhom/bottom-sheet/src/hooks/useScrollEventsHandlersDefault.ts
-index c059449..0290160 100644
+index c059449..7895453 100644
 --- a/node_modules/@gorhom/bottom-sheet/src/hooks/useScrollEventsHandlersDefault.ts
 +++ b/node_modules/@gorhom/bottom-sheet/src/hooks/useScrollEventsHandlersDefault.ts
-@@ -55,8 +55,17 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
+@@ -1,6 +1,6 @@
+ import { useCallback } from 'react';
+ import { State } from 'react-native-gesture-handler';
+-import { scrollTo } from 'react-native-reanimated';
++import { scrollTo, useSharedValue } from 'react-native-reanimated';
+ import { ANIMATION_STATUS, SCROLLABLE_STATUS, SHEET_STATE } from '../constants';
+ import type {
+   ScrollEventHandlerCallbackType,
+@@ -26,6 +26,10 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
+     animatedHandleGestureState,
+   } = useBottomSheetInternal();
+ 
++  // ORCH-1064: re-entrancy flag for the reanimated-v4 scroll-lock recursion
++  // (gorhom #2546/#2617). See the guarded scrollTo() sites below.
++  const isLockingScroll = useSharedValue(false);
++
+   //#region callbacks
+   const handleOnScroll: ScrollEventHandlerCallbackType<ScrollEventContextType> =
+     useCallback(
+@@ -55,8 +59,21 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
            const lockPosition = context.shouldLockInitialPosition
              ? (context.initialContentOffsetY ?? 0)
              : 0;
 -          // @ts-ignore
 -          scrollTo(scrollableRef, 0, lockPosition, false);
-+          // ORCH-1063: react-native-reanimated v4 + New Architecture re-entrancy guard
-+          // (gorhom #2546 / #2617). Under reanimated v4, scrollTo() synchronously
-+          // re-fires the scroll event, which re-enters this same worklet while the
-+          // scrollable is LOCKED, calling scrollTo() again → unbounded recursion →
-+          // "Maximum call stack size exceeded (native stack depth)" fatal crash.
-+          // Skipping the redundant scrollTo once already at lockPosition breaks the
-+          // loop while preserving the lock behavior (the first call still snaps back).
-+          if (y !== lockPosition) {
++          // ORCH-1064: react-native-reanimated v4 + New Architecture re-entrancy
++          // guard (gorhom #2546 / #2617). scrollTo() synchronously re-fires the
++          // scroll event, re-entering this worklet while still LOCKED → it calls
++          // scrollTo() again → unbounded recursion → "Maximum call stack size
++          // exceeded (native stack depth)" fatal crash. A position check
++          // (y !== lockPosition) is NOT reliable: the native re-emit can replay
++          // the ORIGINAL offset, so the check passes and the loop continues. The
++          // re-entrancy flag is robust — the synchronous nested invocation sees
++          // isLockingScroll.value === true and skips the call, regardless of y.
++          if (!isLockingScroll.value) {
++            isLockingScroll.value = true;
 +            // @ts-ignore
 +            scrollTo(scrollableRef, 0, lockPosition, false);
++            isLockingScroll.value = false;
 +          }
            scrollableContentOffsetY.value = lockPosition;
            return;
          }
-@@ -104,8 +113,17 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
+@@ -104,8 +121,21 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
            const lockPosition = context.shouldLockInitialPosition
              ? (context.initialContentOffsetY ?? 0)
              : 0;
 -          // @ts-ignore
 -          scrollTo(scrollableRef, 0, lockPosition, false);
-+          // ORCH-1063: react-native-reanimated v4 + New Architecture re-entrancy guard
-+          // (gorhom #2546 / #2617). Under reanimated v4, scrollTo() synchronously
-+          // re-fires the scroll event, which re-enters this same worklet while the
-+          // scrollable is LOCKED, calling scrollTo() again → unbounded recursion →
-+          // "Maximum call stack size exceeded (native stack depth)" fatal crash.
-+          // Skipping the redundant scrollTo once already at lockPosition breaks the
-+          // loop while preserving the lock behavior (the first call still snaps back).
-+          if (y !== lockPosition) {
++          // ORCH-1064: react-native-reanimated v4 + New Architecture re-entrancy
++          // guard (gorhom #2546 / #2617). scrollTo() synchronously re-fires the
++          // scroll event, re-entering this worklet while still LOCKED → it calls
++          // scrollTo() again → unbounded recursion → "Maximum call stack size
++          // exceeded (native stack depth)" fatal crash. A position check
++          // (y !== lockPosition) is NOT reliable: the native re-emit can replay
++          // the ORIGINAL offset, so the check passes and the loop continues. The
++          // re-entrancy flag is robust — the synchronous nested invocation sees
++          // isLockingScroll.value === true and skips the call, regardless of y.
++          if (!isLockingScroll.value) {
++            isLockingScroll.value = true;
 +            // @ts-ignore
 +            scrollTo(scrollableRef, 0, lockPosition, false);
++            isLockingScroll.value = false;
 +          }
            scrollableContentOffsetY.value = lockPosition;
            return;
          }
-@@ -134,8 +152,17 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
+@@ -134,8 +164,21 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
            const lockPosition = context.shouldLockInitialPosition
              ? (context.initialContentOffsetY ?? 0)
              : 0;
 -          // @ts-ignore
 -          scrollTo(scrollableRef, 0, lockPosition, false);
-+          // ORCH-1063: react-native-reanimated v4 + New Architecture re-entrancy guard
-+          // (gorhom #2546 / #2617). Under reanimated v4, scrollTo() synchronously
-+          // re-fires the scroll event, which re-enters this same worklet while the
-+          // scrollable is LOCKED, calling scrollTo() again → unbounded recursion →
-+          // "Maximum call stack size exceeded (native stack depth)" fatal crash.
-+          // Skipping the redundant scrollTo once already at lockPosition breaks the
-+          // loop while preserving the lock behavior (the first call still snaps back).
-+          if (y !== lockPosition) {
++          // ORCH-1064: react-native-reanimated v4 + New Architecture re-entrancy
++          // guard (gorhom #2546 / #2617). scrollTo() synchronously re-fires the
++          // scroll event, re-entering this worklet while still LOCKED → it calls
++          // scrollTo() again → unbounded recursion → "Maximum call stack size
++          // exceeded (native stack depth)" fatal crash. A position check
++          // (y !== lockPosition) is NOT reliable: the native re-emit can replay
++          // the ORIGINAL offset, so the check passes and the loop continues. The
++          // re-entrancy flag is robust — the synchronous nested invocation sees
++          // isLockingScroll.value === true and skips the call, regardless of y.
++          if (!isLockingScroll.value) {
++            isLockingScroll.value = true;
 +            // @ts-ignore
 +            scrollTo(scrollableRef, 0, lockPosition, false);
++            isLockingScroll.value = false;
 +          }
            scrollableContentOffsetY.value = 0;
            return;

--- a/app-mobile/src/components/NotificationsSheet.tsx
+++ b/app-mobile/src/components/NotificationsSheet.tsx
@@ -780,10 +780,12 @@ export default function NotificationsSheet({
       // ORCH-1064: was wrapInRNModal={false} (inline) — which rendered the sheet
       // BELOW the app-root GlassBottomNav (zIndex 50) so it opened "behind the
       // nav menu", AND left its wrapped sectionlist scroll unbound (maxScroll==0
-      // frozen body). Wrapping in an RN <Modal> lifts it into a separate OS window
-      // ABOVE the nav and gives gorhom a bounded full-screen parent so the list
-      // scrolls. tabBarAware is now redundant (the nav no longer overlaps the
-      // sheet) and is dropped.
+      // frozen body). Enabling the BaseBottomSheet RN-modal wrapper (prop below)
+      // lifts it into a separate OS window ABOVE the nav and gives gorhom a
+      // bounded full-screen parent so the list scrolls. tabBarAware is now
+      // redundant (the nav no longer overlaps the sheet) and is dropped.
+      // NOTE: this sheet still imports NO RN Modal — the wrapper lives inside
+      // BaseBottomSheet (ORCH-0975 / META-ORCH-0991 sole-gorhom-consumer invariant).
       wrapInRNModal={true}
       snapPoints={SHEET_SNAP_POINTS}
       backdropOpacity={0.32}

--- a/app-mobile/src/components/NotificationsSheet.tsx
+++ b/app-mobile/src/components/NotificationsSheet.tsx
@@ -777,14 +777,14 @@ export default function NotificationsSheet({
       visible={visible}
       onClose={onClose}
       theme="light"
-      wrapInRNModal={false}
-      // META-ORCH-0991 Bug 4 (tab-bar awareness): this sheet is z-stacked by
-      // HomePage as a NON-wrapInRNModal sheet, so Mingla's floating GlassBottomNav
-      // (app-root absolute, zIndex 50) stays VISIBLE and overlaps the sheet's
-      // bottom. tabBarAware makes the primitive add the nav-capsule clearance to
-      // the notifications list's bottom padding (Math.max with the existing
-      // insets.bottom+16) so the last notification row clears the floating menu.
-      tabBarAware
+      // ORCH-1064: was wrapInRNModal={false} (inline) — which rendered the sheet
+      // BELOW the app-root GlassBottomNav (zIndex 50) so it opened "behind the
+      // nav menu", AND left its wrapped sectionlist scroll unbound (maxScroll==0
+      // frozen body). Wrapping in an RN <Modal> lifts it into a separate OS window
+      // ABOVE the nav and gives gorhom a bounded full-screen parent so the list
+      // scrolls. tabBarAware is now redundant (the nav no longer overlaps the
+      // sheet) and is dropped.
+      wrapInRNModal={true}
       snapPoints={SHEET_SNAP_POINTS}
       backdropOpacity={0.32}
       backgroundStyle={styles.sheetBackground}

--- a/app-mobile/src/components/SwipeableCards.tsx
+++ b/app-mobile/src/components/SwipeableCards.tsx
@@ -553,6 +553,11 @@ export default function SwipeableCards({
   // deck tap (reviewCards is the whole session-swiped list, so it is non-empty
   // after any swipe — it cannot be used alone to detect review mode).
   const [isReviewMode, setIsReviewMode] = useState(false);
+  // ORCH-1064: timestamp of the last expanded-card close. Used to block a
+  // re-open within ~500ms so the wrapInRNModal RN <Modal> is never re-presented
+  // while the prior dismissal is still in flight on iOS (the intermittent
+  // release-build present-during-dismiss freeze on rapid open/close).
+  const lastModalCloseAtRef = useRef(0);
 
   const previousBatchRefreshKeyRef = useRef<number | string | undefined>(
     refreshKey
@@ -1502,6 +1507,9 @@ export default function SwipeableCards({
 
   const handleCardExpand = async () => {
     if (!currentRec) return;
+    // ORCH-1064: re-open guard — ignore an open within 500ms of the last close so
+    // the modal can't be re-presented mid-dismiss (intermittent freeze).
+    if (Date.now() - lastModalCloseAtRef.current < 500) return;
     setIsReviewMode(false); // ORCH-1064: normal deck tap — no review chrome
     setIsExpandedModalVisible(true);
 
@@ -1581,6 +1589,7 @@ export default function SwipeableCards({
     setIsExpandedModalVisible(false);
     setSelectedCardForExpansion(null);
     setIsReviewMode(false); // ORCH-1064: reset review mode on close
+    lastModalCloseAtRef.current = Date.now(); // ORCH-1064: re-open guard window
   };
 
   const handleSwipe = async (

--- a/app-mobile/src/components/SwipeableCards.tsx
+++ b/app-mobile/src/components/SwipeableCards.tsx
@@ -548,6 +548,11 @@ export default function SwipeableCards({
   const [showNextBatchLoader, setShowNextBatchLoader] = useState(false);
   const [dismissedSheetVisible, setDismissedSheetVisible] = useState(false);
   const [reviewIndex, setReviewIndex] = useState(0);
+  // ORCH-1064: true ONLY when the expanded card was opened from swipe-history
+  // review. Gates the prev/next review chrome so it never appears on a normal
+  // deck tap (reviewCards is the whole session-swiped list, so it is non-empty
+  // after any swipe — it cannot be used alone to detect review mode).
+  const [isReviewMode, setIsReviewMode] = useState(false);
 
   const previousBatchRefreshKeyRef = useRef<number | string | undefined>(
     refreshKey
@@ -1497,6 +1502,7 @@ export default function SwipeableCards({
 
   const handleCardExpand = async () => {
     if (!currentRec) return;
+    setIsReviewMode(false); // ORCH-1064: normal deck tap — no review chrome
     setIsExpandedModalVisible(true);
 
     // ORCH-0408 Phase 4: Record expand — counter + user interaction log (fire-and-forget)
@@ -1574,6 +1580,7 @@ export default function SwipeableCards({
   const handleCloseExpandedModal = () => {
     setIsExpandedModalVisible(false);
     setSelectedCardForExpansion(null);
+    setIsReviewMode(false); // ORCH-1064: reset review mode on close
   };
 
   const handleSwipe = async (
@@ -2017,6 +2024,7 @@ export default function SwipeableCards({
     const reversedCards = [...sessionSwipedCards].reverse();
     const idx = reversedCards.findIndex(c => c.id === card.id);
     setReviewIndex(idx >= 0 ? idx : 0);
+    setIsReviewMode(true); // ORCH-1064: opened from swipe history — show review chrome
 
     setDismissedSheetVisible(false);
     setTimeout(() => {
@@ -2806,12 +2814,16 @@ export default function SwipeableCards({
         }}
         userPreferences={userPreferences}
         accountPreferences={accountPreferences}
-        // ORCH-1063: review-navigation props from the former EXHAUSTED-case
-        // modal instance. Inert when reviewCards is empty (normal deck tap).
-        onNavigateNext={reviewIndex < reviewCards.length - 1 ? handleReviewNext : undefined}
-        onNavigatePrevious={reviewIndex > 0 ? handleReviewPrevious : undefined}
-        navigationIndex={reviewIndex}
-        navigationTotal={reviewCards.length}
+        // ORCH-1064: review-navigation chrome shows ONLY when opened from swipe
+        // history (isReviewMode). reviewCards is the whole session-swiped list, so
+        // it is non-empty after any swipe — gating on it alone wrongly showed the
+        // "X of Y" prev/next header on normal deck taps (the regression). All four
+        // props are gated on isReviewMode (navigationIndex/Total too, because the
+        // header also renders when those are non-null).
+        onNavigateNext={isReviewMode && reviewIndex < reviewCards.length - 1 ? handleReviewNext : undefined}
+        onNavigatePrevious={isReviewMode && reviewIndex > 0 ? handleReviewPrevious : undefined}
+        navigationIndex={isReviewMode ? reviewIndex : undefined}
+        navigationTotal={isReviewMode ? reviewCards.length : undefined}
         canAccessCurated={canAccess('curated_cards')}
         onPaywallRequired={() => {
           handleCloseExpandedModal();

--- a/app-mobile/src/components/activity/CalendarTab.tsx
+++ b/app-mobile/src/components/activity/CalendarTab.tsx
@@ -197,6 +197,9 @@ const CalendarTab = ({
   const [entryToReschedule, setEntryToReschedule] =
     useState<CalendarEntry | null>(null);
   const [isExpandedModalVisible, setIsExpandedModalVisible] = useState(false);
+  // ORCH-1064: re-open guard window (block re-present within 500ms of close so the
+  // wrapInRNModal modal isn't re-presented mid-dismiss → intermittent freeze).
+  const lastModalCloseAtRef = useRef(0);
   const [selectedCardForExpansion, setSelectedCardForExpansion] =
     useState<ExpandedCardData | null>(null);
   const [isScheduling, setIsScheduling] = useState(false);
@@ -1497,6 +1500,8 @@ const CalendarTab = ({
   };
 
   const handleCardExpand = (entry: CalendarEntry) => {
+    // ORCH-1064: ignore a re-open within 500ms of the last close (re-present-mid-dismiss freeze)
+    if (Date.now() - lastModalCloseAtRef.current < 500) return;
     HapticFeedback.buttonPress();
     // Transform CalendarEntry to ExpandedCardData format
     const experience = entry.experience || entry;
@@ -1601,6 +1606,7 @@ const CalendarTab = ({
   const handleCloseExpandedModal = () => {
     setIsExpandedModalVisible(false);
     setSelectedCardForExpansion(null);
+    lastModalCloseAtRef.current = Date.now(); // ORCH-1064: re-open guard window
   };
 
   const handleSaveFromModal = async (card: ExpandedCardData) => {

--- a/app-mobile/src/components/ui/BaseBottomSheet.tsx
+++ b/app-mobile/src/components/ui/BaseBottomSheet.tsx
@@ -47,8 +47,10 @@ import BottomSheet, {
   BottomSheetSectionList,
   BottomSheetTextInput,
   BottomSheetView,
+  useBottomSheetTimingConfigs,
   type BottomSheetBackdropProps,
 } from '@gorhom/bottom-sheet';
+import { Easing } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 // META-ORCH-0991 (sheet rework — Bug 1): GestureHandlerRootView must wrap the
 // sheet INSIDE the RN <Modal> window so gorhom's pan-down-to-dismiss
@@ -338,6 +340,21 @@ function BaseBottomSheetComponent(props: BaseBottomSheetProps): React.ReactEleme
   } = props;
 
   const effectiveBackdropOpacity = useEffectiveBackdropOpacity(theme, backdropOpacity);
+
+  // ORCH-1064: DETERMINISTIC timing open/close, replacing gorhom's default SPRING.
+  // Replay 6a970e63 + 1d7caee1 (release, on-device) proved the sheet STALLED
+  // mid-animation — stuck half-open, or "didn't close fully" — leaving its dimmed
+  // backdrop capturing every touch (app frozen, no crash/hang/error). A reanimated
+  // SPRING can settle/stall partway when interrupted on a fast release build; a
+  // TIMING animation always interpolates fully to the target snap index, so the
+  // sheet can never stall partway and a CLOSE always reaches index -1 (which fires
+  // onClose → the wrapInRNModal RN <Modal> actually unmounts instead of lingering
+  // half-drawn). This supersedes the META-ORCH-0991 "stock default spring" choice
+  // for correctness (the freeze outranks the spring feel).
+  const sheetAnimationConfigs = useBottomSheetTimingConfigs({
+    duration: 280,
+    easing: Easing.out(Easing.cubic),
+  });
 
   // ORCH-1064 (replay-confirmed "half-open stall" freeze, release-only): the
   // declarative `index={visible ? initialIndex : -1}` prop on <BottomSheet>
@@ -686,6 +703,7 @@ function BaseBottomSheetComponent(props: BaseBottomSheetProps): React.ReactEleme
     <BottomSheet
       ref={sheetRef}
       index={visible ? initialIndex : -1}
+      animationConfigs={sheetAnimationConfigs}
       snapPoints={snapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}

--- a/app-mobile/src/components/ui/BaseBottomSheet.tsx
+++ b/app-mobile/src/components/ui/BaseBottomSheet.tsx
@@ -339,16 +339,18 @@ function BaseBottomSheetComponent(props: BaseBottomSheetProps): React.ReactEleme
 
   const effectiveBackdropOpacity = useEffectiveBackdropOpacity(theme, backdropOpacity);
 
-  // Open/close mirror of the proven pattern (SPEC §3.3): snapToIndex on open,
-  // close on hide. Declarative `index` covers first mount; this covers
-  // mid-life visible toggles.
-  useEffect(() => {
-    if (visible) {
-      sheetRef.current?.snapToIndex(initialIndex);
-    } else {
-      sheetRef.current?.close();
-    }
-  }, [visible, initialIndex]);
+  // ORCH-1064 (replay-confirmed "half-open stall" freeze, release-only): the
+  // declarative `index={visible ? initialIndex : -1}` prop on <BottomSheet>
+  // ALREADY drives open/close — gorhom reacts to an index-prop change internally
+  // (BottomSheet.tsx ~L1773 `handleSnapToIndex(_providedIndex)` on _providedIndex
+  // change). The previous imperative snapToIndex/close effect here was a SECOND,
+  // redundant drive that raced gorhom's own animation on the same `visible` tick.
+  // On a fast release build the default spring got interrupted mid-flight and
+  // STALLED the sheet half-open, leaving its dimmed full-screen backdrop
+  // capturing every touch — "app frozen, no crash, no hang" (Sentry replay
+  // 6a970e63: "Tapped repeatedly on Modal view" 00:15→03:06 on a half-drawn
+  // sheet). Removed: the single declarative drive opens/closes cleanly, no race.
+  // DO NOT re-add an imperative snapToIndex/close keyed on `visible`.
 
   // ORCH-1016 — hide the floating GlassBottomNav while a full detail/checkout sheet
   // is open, so its bottom content/CTA isn't painted over by the nav. Ref-counted


### PR DESCRIPTION
Follow-up to ORCH-1063. The v1 `y !== lockPosition` scroll guard was not guaranteed to break the reanimated-v4 recursion (the native re-emit can replay the original offset). Replaced with a `useSharedValue` **re-entrancy flag** in gorhom's useScrollEventsHandlersDefault — the synchronous nested scroll worklet sees the flag set and skips scrollTo, robust regardless of `y`. Also flips NotificationsSheet to `wrapInRNModal={true}` (lifts above the zIndex-50 nav + binds the wrapped sectionlist scroll; drops redundant tabBarAware). Home expanded-card + Calendar archived-card both route through this same gorhom path, so the flag guard covers all three. JS-only → OTA'd to build 22 (iOS 2e39e5d7, Android c12e953a).