### PR TITLE
Fix: Romantic/Scenic/Lively vibe categories return empty deck (400 at resolver)

### DIFF
--- a/supabase/functions/_shared/categoryPlaceTypes.ts
+++ b/supabase/functions/_shared/categoryPlaceTypes.ts
@@ -326,6 +326,20 @@ const CATEGORY_ALIASES: Record<string, string> = {
   'play_move': 'Play',
   'screen_relax': 'Movies',  // ORCH-0598: cinema intent → Movies chip
   'creative': 'Creative & Arts',
+
+  // ORCH-1062 Part 2 serving-gap fix: the three "vibe" categories
+  // (romantic / scenic / lively) are SIGNAL-served via CATEGORY_TO_SIGNAL in
+  // discover-cards — they are quality-grounded, NOT place-type-grounded, so they
+  // were intentionally never added to MINGLA_CATEGORY_PLACE_TYPES. But that left
+  // resolveCategory() returning null for them, so discover-cards' front-door
+  // resolveCategories() stripped them and returned a 400 "No recognized
+  // categories" → empty deck for every user who picked Romantic/Scenic/Lively
+  // (confirmed via edge-function 400s + 400+ qualifying Raleigh places per vibe).
+  // Map each slug/display name to its exact CATEGORY_TO_SIGNAL key so the request
+  // survives validation and routes to query_servable_places_by_signal.
+  'romantic': 'Romantic',
+  'scenic': 'Scenic',
+  'lively': 'Lively',
 };
 
 /**


### PR DESCRIPTION
## Symptom
Selecting **Romantic**, **Scenic**, or **Lively** in the consumer deck returns **zero cards** — for everyone, in every city (reported from Raleigh).

## Root cause
ORCH-1062 Part 2 (#334) made romantic/scenic/lively user-pickable category pills and added their signal routing to `discover-cards`'s `CATEGORY_TO_SIGNAL` map — but never added them to the **shared category resolver** (`_shared/categoryPlaceTypes.ts`). They're quality-grounded signal categories with no Google place-types, so they were absent from `MINGLA_CATEGORY_PLACE_TYPES`, and `resolveCategory()` returned `null` for them.

`discover-cards` validates the request up front:
```ts
const categories = resolveCategories(rawCategories).filter(c => !HIDDEN_CATEGORIES.has(c));
if (categories.length === 0) {
  return new Response(JSON.stringify({ error: `No recognized categories in: ${rawCategories.join(', ')}`, cards: [] }), { status: 400, ... });
}
```
So a request of `['Romantic']` resolved to `[]` → **HTTP 400** before the (correct) signal routing ran. Confirmed in edge-function logs (4× `discover-cards` 400s, ~100ms each).

**Not a data/coverage problem:** the deployed RPC `query_servable_places_by_signal` finds **411 romantic / 472 scenic / 506 lively** qualifying places within 25 km of Raleigh (hundreds even at a 2 km radius).

## Fix
Add three slug→display-name aliases so `resolveCategory()` returns the exact `CATEGORY_TO_SIGNAL` key, the request survives validation, and the deck routes to signal serving. Additive only.

## Verification
- `deno run` against the shared module: `resolveCategory('Romantic'|'romantic'|'Scenic'|'scenic'|'Lively'|'lively')` → canonical key; `resolveCategories(['Romantic'])` → `['Romantic']`; existing categories + unknown-category(`null`) path unchanged.
- Already deployed to prod `discover-cards` out-of-band to restore the live feature; this PR reconciles `main` so the next deploy doesn't regress it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)