### PR TITLE
ORCH-1069: persist experience_intents on live experience edit

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1609,7 +1609,14 @@ function checkNoNewBackendFiles() {
     "supabase/functions/_shared/curatedStopHours.ts",
     "supabase/functions/run-business-place-authoring-pipeline/index.ts",
   ];
+  // ORCH-1069 [experience live-edit drops vibe]: one CREATE-OR-REPLACE migration
+  // fixing biz_update_live_experience to persist experience_intents on edit.
+  // No new edge fn, no new test files. Per COMMS-0002 — same commit as migration.
+  const ORCH_1069_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260906000000_orch_1069_live_edit_persists_experience_intents.sql",
+  ];
   const ALLOWLIST = [
+    ...ORCH_1069_BACKEND_ALLOWLIST,
     ...ORCH_1068_BACKEND_ALLOWLIST,
     ...ORCH_1066_BACKEND_ALLOWLIST,
     ...META_ORCH_1059_BACKEND_ALLOWLIST,

--- a/supabase/migrations/20260906000000_orch_1069_live_edit_persists_experience_intents.sql
+++ b/supabase/migrations/20260906000000_orch_1069_live_edit_persists_experience_intents.sql
@@ -1,0 +1,593 @@
+-- ORCH-1069 [experience live-edit drops vibe] — FIX biz_update_live_experience
+-- to PERSIST experience_intents on edit-after-publish.
+--
+-- BUG: META-ORCH-1059 Sub-E's biz_update_live_experience (migration
+-- 20260902000000) accepted the wizard payload but had ZERO handling for
+-- experience_intents — so editing a published experience to change/add the
+-- curated vibe reported success while writing nothing, leaving the row
+-- deck-ineligible (the ORCH-1065 deck supply requires >=1 intent). Confirmed
+-- live: "Raleigh Wine and Dine Crawl" edited, intents stayed NULL.
+--
+-- FIX: read p_payload->'experience_intents' (1-4 of the 4 brand ids), validate
+-- + require >=1 (mirroring biz_publish_experience), write BOTH events.experience_intents
+-- (array) and events.experience_intent (back-compat mirror = [1]) in the
+-- UPDATE. Key absent => existing intents preserved. Idempotent CREATE OR REPLACE,
+-- no destructive DDL. Already applied to remote via Management API; this file
+-- reconciles the change onto main byte-faithfully so db push records it.
+--
+-- Docs (COMMS-0003): PostgreSQL CREATE FUNCTION / plpgsql
+--   https://www.postgresql.org/docs/current/sql-createfunction.html
+--   https://www.postgresql.org/docs/current/plpgsql.html
+
+CREATE OR REPLACE FUNCTION public.biz_update_live_experience(p_event_id uuid, p_payload jsonb, p_reason text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_user_id          uuid;
+  v_existing         public.events%ROWTYPE;
+  v_brand            record;
+  v_now              timestamptz := now();
+  v_trimmed_reason   text;
+  v_total_sold       int;
+  -- header / modes
+  v_title            text;
+  v_description      text;
+  v_intents          text[];
+  v_intent           text;
+  v_currency         char(3);
+  v_location_mode    text;
+  v_pricing_mode     text;
+  v_is_free          boolean;
+  v_capacity         integer;
+  v_whole_price      integer;
+  v_resolved_total   integer;
+  v_old_resolved     integer;
+  -- stops
+  v_stops            jsonb;
+  v_stop_count       integer;
+  v_stop             jsonb;
+  v_existing_stop_keys text[];
+  v_new_stop_keys    text[];
+  v_dropped_stops    text[];
+  -- single-mode shared place
+  v_shared_place_id     text;
+  v_shared_place_addr   text;
+  v_shared_city         text;
+  v_shared_region       text;
+  v_shared_country      text;
+  v_shared_lat          double precision;
+  v_shared_lng          double precision;
+  v_idx              integer;
+  v_s_place_id       text;
+  v_s_address        text;
+  v_s_city           text;
+  v_s_region         text;
+  v_s_country        text;
+  v_s_lat            double precision;
+  v_s_lng            double precision;
+  v_s_images         text[];
+  v_s_start          time;
+  v_s_price          integer;
+  -- dates
+  v_when_mode        text;
+  v_when             jsonb;
+  v_multi_dates      jsonb;
+  v_recurrence_rules jsonb;
+  v_timezone         text;
+  v_date_iso         text;
+  v_doors            text;
+  v_ends             text;
+  v_start            timestamptz;
+  v_end              timestamptz;
+  v_date_entry       jsonb;
+  v_min_start        timestamptz;
+  v_is_recurring     boolean;
+  v_is_multi_date    boolean;
+  v_next_occurrence  timestamptz;
+  v_new_date_starts  timestamptz[];
+  v_old_date_starts  timestamptz[];
+  v_old_date_ends    timestamptz[];
+  v_new_date_ends    timestamptz[];
+  v_dates_changed    boolean := false;
+  -- audit
+  v_severity         text;
+  v_changed_keys     text[];
+  v_log_id           uuid;
+  v_affected_order_ids uuid[];
+  -- return
+  v_event            public.events%ROWTYPE;
+  v_stop_rows        jsonb;
+  v_ticket_rows      jsonb;
+  v_event_dates_rows jsonb;
+BEGIN
+  -- ---------- 1. Auth + reason ----------
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  v_trimmed_reason := btrim(COALESCE(p_reason, ''));
+  IF v_trimmed_reason = '' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'missing_edit_reason');
+  END IF;
+  IF char_length(v_trimmed_reason) < 10 OR char_length(v_trimmed_reason) > 200 THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_edit_reason');
+  END IF;
+
+  -- ---------- 2. Load + permission + status gate ----------
+  SELECT * INTO v_existing
+  FROM public.events
+  WHERE id = p_event_id
+    AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'experience_not_found';
+  END IF;
+
+  IF v_existing.event_type <> 'experience' THEN
+    RAISE EXCEPTION 'event_not_an_experience'
+      USING HINT = 'biz_update_live_experience only handles event_type=experience rows.';
+  END IF;
+
+  IF v_existing.status NOT IN ('scheduled', 'live') THEN
+    -- Draft edits NEVER route here; non-live statuses are rejected so the live
+    -- guards can never trip a draft.
+    RETURN jsonb_build_object('ok', false, 'reason', 'experience_not_editable_status');
+  END IF;
+
+  IF public.biz_brand_effective_rank(v_existing.brand_id, v_user_id)
+       < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  SELECT id, slug, name, default_currency
+  INTO v_brand
+  FROM public.brands
+  WHERE id = v_existing.brand_id
+    AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found';
+  END IF;
+
+  -- ---------- 3. Sold-count context ----------
+  v_total_sold := public.biz_experience_sold_count(p_event_id);
+
+  -- ---------- 4. Parse payload (mirror biz_publish_experience) ----------
+  v_title := NULLIF(btrim(COALESCE(p_payload->>'title', '')), '');
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'experience_title_required';
+  END IF;
+  v_description := NULLIF(btrim(COALESCE(p_payload->>'description', '')), '');
+  IF v_description IS NULL OR char_length(v_description) < 10 OR char_length(v_description) > 500 THEN
+    RAISE EXCEPTION 'experience_description_invalid';
+  END IF;
+
+  -- META-ORCH-1059 Sub-E FIX (live-edit dropped the vibe): persist curated
+  -- experience_intents on edit, mirroring biz_publish_experience. The wizard
+  -- sends p_payload->'experience_intents' (1-4 of the 4 brand ids); validate +
+  -- require >=1 so a live/published experience stays deck-eligible. Key absent
+  -- => leave existing intents unchanged.
+  IF jsonb_typeof(p_payload->'experience_intents') = 'array' THEN
+    SELECT array_agg(DISTINCT btrim(elem))
+      INTO v_intents
+      FROM jsonb_array_elements_text(p_payload->'experience_intents') AS elem
+     WHERE btrim(elem) <> '';
+  ELSIF p_payload ? 'experience_intent'
+        AND NULLIF(btrim(p_payload->>'experience_intent'), '') IS NOT NULL THEN
+    v_intents := ARRAY[btrim(p_payload->>'experience_intent')];
+  ELSE
+    v_intents := v_existing.experience_intents;
+  END IF;
+  IF v_intents IS NOT NULL
+     AND NOT (v_intents <@ ARRAY['adventurous','first-date','romantic','group-fun']::text[]) THEN
+    RAISE EXCEPTION 'experience_intent_invalid';
+  END IF;
+  IF v_intents IS NULL OR array_length(v_intents, 1) IS NULL THEN
+    RAISE EXCEPTION 'experience_intent_required';
+  END IF;
+  v_intent := v_intents[1];
+
+  v_currency := upper(COALESCE(
+    NULLIF(p_payload->>'currency', ''),
+    NULLIF(v_existing.currency, '')::text,
+    v_brand.default_currency::text,
+    'USD'
+  ))::char(3);
+
+  v_location_mode := COALESCE(NULLIF(p_payload->>'location_mode', ''), 'single');
+  v_pricing_mode  := COALESCE(NULLIF(p_payload->>'pricing_mode', ''), 'whole');
+  IF v_location_mode NOT IN ('single','per_stop') OR v_pricing_mode NOT IN ('whole','per_stop') THEN
+    RAISE EXCEPTION 'invalid_mode';
+  END IF;
+
+  v_is_free  := COALESCE((p_payload->>'is_free')::boolean, false);
+  v_capacity := NULLIF(p_payload->>'capacity', '')::integer;
+  v_whole_price := COALESCE(NULLIF(p_payload->>'whole_price_cents', '')::integer, 0);
+
+  v_stops := COALESCE(p_payload->'stops', '[]'::jsonb);
+  IF jsonb_typeof(v_stops) IS DISTINCT FROM 'array' THEN
+    v_stops := '[]'::jsonb;
+  END IF;
+  v_stop_count := jsonb_array_length(v_stops);
+
+  -- Live experiences are published: enforce the same 2–5 stop gate.
+  IF v_stop_count < 2 OR v_stop_count > 5 THEN
+    RAISE EXCEPTION 'experience_stop_count_invalid';
+  END IF;
+
+  FOR v_stop IN SELECT value FROM jsonb_array_elements(v_stops)
+  LOOP
+    IF NULLIF(btrim(COALESCE(v_stop->>'place_name', '')), '') IS NULL THEN
+      RAISE EXCEPTION 'stop_name_required';
+    END IF;
+    IF (v_stop->'image_urls') IS NOT NULL
+       AND jsonb_typeof(v_stop->'image_urls') = 'array'
+       AND jsonb_array_length(v_stop->'image_urls') > 5 THEN
+      RAISE EXCEPTION 'stop_too_many_images';
+    END IF;
+    IF COALESCE((v_stop->>'price_cents')::integer, 0) < 0 THEN
+      RAISE EXCEPTION 'experience_price_invalid';
+    END IF;
+  END LOOP;
+
+  -- Resolve the new ONE-ticket total (I-1).
+  v_resolved_total :=
+    CASE
+      WHEN v_is_free THEN 0
+      WHEN v_pricing_mode = 'whole' THEN v_whole_price
+      ELSE (
+        SELECT COALESCE(sum(COALESCE((s->>'price_cents')::integer, 0)), 0)
+        FROM jsonb_array_elements(v_stops) s
+      )
+    END;
+
+  -- ---------- 5. REFUND-GATE (only when sold > 0, except capacity) ----------
+
+  -- 5a. Capacity can't drop below sold (applies whenever capacity present).
+  IF (p_payload ? 'capacity') AND v_capacity IS NOT NULL AND v_capacity < v_total_sold THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'reason', 'capacity_below_sold',
+      'affected_order_count', v_total_sold
+    );
+  END IF;
+
+  IF v_total_sold > 0 THEN
+    -- 5b. Price lock — the ONE ticket's resolved price can't change once sold.
+    SELECT price_cents INTO v_old_resolved
+    FROM public.ticket_types
+    WHERE event_id = p_event_id AND deleted_at IS NULL
+    ORDER BY display_order ASC
+    LIMIT 1;
+    v_old_resolved := COALESCE(v_old_resolved, 0);
+
+    IF v_resolved_total IS DISTINCT FROM v_old_resolved THEN
+      RETURN jsonb_build_object(
+        'ok', false,
+        'reason', 'price_change_with_sales',
+        'affected_order_count', v_total_sold
+      );
+    END IF;
+
+    -- 5c. Stop removal — removing an existing (by name) stop is destructive.
+    SELECT array_agg(lower(btrim(place_name)))
+      INTO v_existing_stop_keys
+      FROM public.experience_stops
+      WHERE event_id = p_event_id;
+    v_existing_stop_keys := COALESCE(v_existing_stop_keys, '{}'::text[]);
+
+    SELECT array_agg(lower(btrim(s->>'place_name')))
+      INTO v_new_stop_keys
+      FROM jsonb_array_elements(v_stops) s;
+    v_new_stop_keys := COALESCE(v_new_stop_keys, '{}'::text[]);
+
+    v_dropped_stops := (
+      SELECT COALESCE(array_agg(k), '{}'::text[])
+      FROM unnest(v_existing_stop_keys) k
+      WHERE NOT (k = ANY (v_new_stop_keys))
+    );
+
+    IF array_length(v_dropped_stops, 1) > 0 THEN
+      RETURN jsonb_build_object(
+        'ok', false,
+        'reason', 'stop_removed_with_sales',
+        'affected_order_count', v_total_sold,
+        'dropped_stops', to_jsonb(v_dropped_stops)
+      );
+    END IF;
+  END IF;
+
+  -- ---------- 6. Resolve the date model + date-shift gate ----------
+  v_when_mode := COALESCE(NULLIF(p_payload->>'whenMode', ''), 'single');
+  v_when := p_payload->'when';
+  v_multi_dates := p_payload->'multiDates';
+  v_recurrence_rules := p_payload->'recurrence_rules';
+  v_timezone := COALESCE(NULLIF(p_payload->>'timezone', ''), NULLIF(v_existing.timezone, ''), 'UTC');
+  v_is_recurring  := (v_when_mode = 'recurring');
+  v_is_multi_date := (v_when_mode = 'multi_date');
+
+  IF v_when_mode NOT IN ('single','multi_date','recurring') THEN
+    RAISE EXCEPTION 'event_date_required';
+  END IF;
+
+  -- Build the proposed occurrence start/end arrays (sorted by start).
+  IF v_when_mode IN ('single','recurring') THEN
+    v_date_iso := NULLIF(v_when->>'date', '');
+    IF v_date_iso IS NULL THEN
+      RAISE EXCEPTION 'event_date_required';
+    END IF;
+    v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+    v_ends  := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+    v_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+    v_end   := (v_date_iso || ' ' || v_ends  || ':00')::timestamp AT TIME ZONE v_timezone;
+    IF v_end <= v_start THEN
+      v_end := v_end + INTERVAL '1 day';
+    END IF;
+    v_new_date_starts := ARRAY[v_start];
+    v_new_date_ends   := ARRAY[v_end];
+  ELSE
+    IF v_multi_dates IS NULL
+       OR jsonb_typeof(v_multi_dates) IS DISTINCT FROM 'array'
+       OR jsonb_array_length(v_multi_dates) = 0 THEN
+      RAISE EXCEPTION 'event_date_required';
+    END IF;
+    v_new_date_starts := '{}'::timestamptz[];
+    v_new_date_ends := '{}'::timestamptz[];
+    FOR v_date_entry IN
+      SELECT value FROM jsonb_array_elements(v_multi_dates)
+      ORDER BY (value->>'date'), (value->>'startTime')
+    LOOP
+      v_date_iso := NULLIF(v_date_entry->>'date', '');
+      IF v_date_iso IS NULL THEN
+        RAISE EXCEPTION 'event_date_required';
+      END IF;
+      v_doors := COALESCE(NULLIF(v_date_entry->>'startTime', ''), '00:00');
+      v_ends  := COALESCE(NULLIF(v_date_entry->>'endTime', ''), v_doors);
+      v_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+      v_end   := (v_date_iso || ' ' || v_ends  || ':00')::timestamp AT TIME ZONE v_timezone;
+      IF v_end <= v_start THEN
+        v_end := v_end + INTERVAL '1 day';
+      END IF;
+      v_new_date_starts := v_new_date_starts || v_start;
+      v_new_date_ends := v_new_date_ends || v_end;
+    END LOOP;
+  END IF;
+
+  -- Date-shift gate (only with sales). Compare against current event_dates.
+  IF v_total_sold > 0 THEN
+    SELECT array_agg(start_at ORDER BY start_at), array_agg(end_at ORDER BY start_at)
+      INTO v_old_date_starts, v_old_date_ends
+      FROM public.event_dates
+      WHERE event_id = p_event_id;
+    v_old_date_starts := COALESCE(v_old_date_starts, '{}'::timestamptz[]);
+    v_old_date_ends   := COALESCE(v_old_date_ends, '{}'::timestamptz[]);
+
+    IF COALESCE(array_length(v_old_date_starts, 1), 0)
+         IS DISTINCT FROM COALESCE(array_length(v_new_date_starts, 1), 0) THEN
+      v_dates_changed := true;
+    ELSE
+      FOR v_idx IN 1 .. COALESCE(array_length(v_old_date_starts, 1), 0)
+      LOOP
+        IF v_old_date_starts[v_idx] IS DISTINCT FROM v_new_date_starts[v_idx]
+           OR v_old_date_ends[v_idx] IS DISTINCT FROM v_new_date_ends[v_idx] THEN
+          v_dates_changed := true;
+          EXIT;
+        END IF;
+      END LOOP;
+    END IF;
+
+    IF v_dates_changed THEN
+      RETURN jsonb_build_object(
+        'ok', false,
+        'reason', 'dates_shifted_with_sales',
+        'affected_order_count', v_total_sold,
+        'dropped_dates', (
+          SELECT COALESCE(jsonb_agg(to_char(d AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')), '[]'::jsonb)
+          FROM unnest(v_old_date_starts) d
+        )
+      );
+    END IF;
+  END IF;
+
+  -- ---------- 7. APPLY (all gates passed) ----------
+  IF v_location_mode = 'single' AND v_stop_count > 0 THEN
+    v_shared_place_id   := NULLIF(v_stops->0->>'place_id', '');
+    v_shared_place_addr := NULLIF(v_stops->0->>'address', '');
+    v_shared_city       := NULLIF(v_stops->0->>'city', '');
+    v_shared_region     := NULLIF(v_stops->0->>'region', '');
+    v_shared_country    := NULLIF(v_stops->0->>'country_code', '');
+    v_shared_lat        := NULLIF(v_stops->0->>'lat', '')::double precision;
+    v_shared_lng        := NULLIF(v_stops->0->>'lng', '')::double precision;
+  END IF;
+
+  UPDATE public.events SET
+    title             = v_title,
+    description       = v_description,
+    experience_intents = v_intents,
+    experience_intent  = v_intent,
+    currency          = v_currency,
+    timezone          = v_timezone,
+    location_mode     = v_location_mode,
+    pricing_mode      = v_pricing_mode,
+    whole_price_cents = CASE WHEN v_pricing_mode = 'whole' THEN v_resolved_total ELSE NULL END,
+    is_recurring      = v_is_recurring,
+    is_multi_date     = v_is_multi_date,
+    recurrence_rules  = v_recurrence_rules,
+    pass_tax          = CASE WHEN (p_payload ? 'pass_tax') THEN (p_payload->>'pass_tax')::boolean ELSE pass_tax END,
+    pass_mingla_fee   = CASE WHEN (p_payload ? 'pass_mingla_fee') THEN (p_payload->>'pass_mingla_fee')::boolean ELSE pass_mingla_fee END,
+    pass_service_fee  = CASE WHEN (p_payload ? 'pass_service_fee') THEN (p_payload->>'pass_service_fee')::boolean ELSE pass_service_fee END,
+    theme             = jsonb_set(
+                          COALESCE(theme, '{}'::jsonb),
+                          '{experience_meta,venue_text}',
+                          to_jsonb(COALESCE(NULLIF(v_stops->0->>'address', ''), '')),
+                          true
+                        ),
+    updated_at        = v_now
+  WHERE id = p_event_id;
+
+  -- Replace experience_stops.
+  DELETE FROM public.experience_stops WHERE event_id = p_event_id;
+  v_idx := 0;
+  FOR v_stop IN SELECT value FROM jsonb_array_elements(v_stops)
+  LOOP
+    IF v_location_mode = 'single' THEN
+      v_s_place_id := v_shared_place_id;
+      v_s_address  := v_shared_place_addr;
+      v_s_city     := v_shared_city;
+      v_s_region   := v_shared_region;
+      v_s_country  := v_shared_country;
+      v_s_lat      := v_shared_lat;
+      v_s_lng      := v_shared_lng;
+    ELSE
+      v_s_place_id := NULLIF(v_stop->>'place_id', '');
+      v_s_address  := NULLIF(v_stop->>'address', '');
+      v_s_city     := NULLIF(v_stop->>'city', '');
+      v_s_region   := NULLIF(v_stop->>'region', '');
+      v_s_country  := NULLIF(v_stop->>'country_code', '');
+      v_s_lat      := NULLIF(v_stop->>'lat', '')::double precision;
+      v_s_lng      := NULLIF(v_stop->>'lng', '')::double precision;
+    END IF;
+
+    v_s_images := COALESCE(
+      (SELECT array_agg(value::text)
+       FROM jsonb_array_elements_text(
+         CASE WHEN jsonb_typeof(v_stop->'image_urls') = 'array'
+              THEN v_stop->'image_urls' ELSE '[]'::jsonb END)),
+      ARRAY[]::text[]
+    );
+    v_s_start := NULLIF(v_stop->>'start_time', '')::time;
+    v_s_price := CASE WHEN v_pricing_mode = 'whole' THEN 0
+                      ELSE COALESCE((v_stop->>'price_cents')::integer, 0) END;
+
+    INSERT INTO public.experience_stops (
+      event_id, stop_order, place_id, place_name, address,
+      city, region, country_code, lat, lng,
+      image_urls, start_time, price_cents, ai_description
+    ) VALUES (
+      p_event_id,
+      COALESCE((v_stop->>'stop_order')::integer, v_idx),
+      v_s_place_id,
+      btrim(v_stop->>'place_name'),
+      COALESCE(v_s_address, ''),
+      v_s_city, v_s_region, v_s_country, v_s_lat, v_s_lng,
+      v_s_images, v_s_start, v_s_price,
+      COALESCE(NULLIF(v_stop->>'ai_description', ''), '')
+    );
+    v_idx := v_idx + 1;
+  END LOOP;
+
+  -- Rewrite the ONE ticket (I-1). Preserve identity by UPDATEing the live ticket
+  -- in place (so existing order_line_items.ticket_type_id stays valid) rather
+  -- than soft-delete + insert.
+  UPDATE public.ticket_types SET
+    name           = 'Standard',
+    price_cents    = v_resolved_total,
+    currency       = v_currency,
+    quantity_total = CASE WHEN v_capacity IS NULL OR v_capacity <= 0 THEN NULL ELSE v_capacity END,
+    is_unlimited   = (v_capacity IS NULL OR v_capacity <= 0),
+    is_free        = (v_resolved_total = 0),
+    updated_at     = v_now
+  WHERE event_id = p_event_id
+    AND deleted_at IS NULL;
+
+  -- Re-materialise event_dates (gated above; safe to replace).
+  DELETE FROM public.event_dates WHERE event_id = p_event_id;
+  v_min_start := NULL;
+  FOR v_idx IN 1 .. COALESCE(array_length(v_new_date_starts, 1), 0)
+  LOOP
+    IF v_min_start IS NULL OR v_new_date_starts[v_idx] < v_min_start THEN
+      v_min_start := v_new_date_starts[v_idx];
+    END IF;
+  END LOOP;
+  FOR v_idx IN 1 .. COALESCE(array_length(v_new_date_starts, 1), 0)
+  LOOP
+    INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+    VALUES (
+      p_event_id, v_new_date_starts[v_idx], v_new_date_ends[v_idx], v_timezone,
+      v_new_date_starts[v_idx] = v_min_start
+    );
+  END LOOP;
+  v_next_occurrence := v_min_start;
+
+  IF v_next_occurrence IS NOT NULL THEN
+    UPDATE public.events
+    SET theme = jsonb_set(
+          COALESCE(theme, '{}'::jsonb),
+          '{experience_meta,next_occurrence_at}',
+          to_jsonb(to_char(v_next_occurrence AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')),
+          true
+        ),
+        updated_at = v_now
+    WHERE id = p_event_id;
+  END IF;
+
+  -- ---------- 8. Audit log ----------
+  v_changed_keys := ARRAY(SELECT jsonb_object_keys(p_payload));
+
+  IF (p_payload ? 'capacity' OR p_payload ? 'stops' OR p_payload ? 'whenMode'
+      OR p_payload ? 'whole_price_cents' OR p_payload ? 'pricing_mode') THEN
+    v_severity := 'material';
+  ELSE
+    v_severity := 'additive';
+  END IF;
+
+  SELECT COALESCE(array_agg(id), '{}'::uuid[])
+    INTO v_affected_order_ids
+    FROM public.orders
+    WHERE event_id = p_event_id
+      AND payment_status NOT IN ('failed', 'cancelled');
+
+  INSERT INTO public.experience_edit_log
+    (event_id, brand_id, edited_by, reason, severity,
+     changed_field_keys, diff_summary, affected_order_ids, occurred_at)
+  VALUES (
+    p_event_id,
+    v_existing.brand_id,
+    v_user_id,
+    v_trimmed_reason,
+    v_severity,
+    v_changed_keys,
+    jsonb_build_object('changed_keys', to_jsonb(v_changed_keys)),
+    v_affected_order_ids,
+    v_now
+  ) RETURNING id INTO v_log_id;
+
+  -- ---------- 9. Return payload (mirror biz_publish_experience shape) ----------
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(es) ORDER BY es.stop_order), '[]'::jsonb)
+  INTO v_stop_rows
+  FROM public.experience_stops es
+  WHERE es.event_id = p_event_id;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(tt) ORDER BY tt.display_order), '[]'::jsonb)
+  INTO v_ticket_rows
+  FROM public.ticket_types tt
+  WHERE tt.event_id = p_event_id
+    AND tt.deleted_at IS NULL;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(ed) ORDER BY ed.start_at), '[]'::jsonb)
+  INTO v_event_dates_rows
+  FROM public.event_dates ed
+  WHERE ed.event_id = p_event_id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'edit_log_entry_id', v_log_id,
+    'severity', v_severity,
+    'changed_keys', to_jsonb(v_changed_keys),
+    'affected_order_count', COALESCE(array_length(v_affected_order_ids, 1), 0),
+    'event', to_jsonb(v_event),
+    'brand', jsonb_build_object('id', v_brand.id, 'slug', v_brand.slug, 'name', v_brand.name),
+    'stops', v_stop_rows,
+    'ticket', (v_ticket_rows->0),
+    'tickets', v_ticket_rows,
+    'eventDates', v_event_dates_rows
+  );
+END;
+$function$
+
+GRANT EXECUTE ON FUNCTION public.biz_update_live_experience(uuid, jsonb, text) TO authenticated;


### PR DESCRIPTION
## ORCH-1069 — experience live-edit drops the vibe

**Bug:** META-ORCH-1059 Sub-E's `biz_update_live_experience` (the edit-after-publish RPC) had zero handling for `experience_intents`. Editing a published experience to set/change its curated vibe **reported success but wrote nothing** — leaving the row untagged and therefore excluded from the ORCH-1065 consumer deck (which requires ≥1 intent). Confirmed live on "Raleigh Wine and Dine Crawl" (edit saved, intents stayed NULL).

**Fix:** the RPC now reads `p_payload->'experience_intents'`, validates to the 4 brand ids, requires ≥1 (mirroring `biz_publish_experience`), and writes both `events.experience_intents` (array) + `events.experience_intent` (back-compat mirror) in the UPDATE. Key absent → existing intents preserved. Idempotent `CREATE OR REPLACE`, no destructive DDL.

Already applied to the linked remote via the Management API (to unblock live editing); this PR reconciles the exact change onto `main` so it's recorded + permanent (avoids the deployed-but-not-merged orphan class).

Backend-only (one migration) — no client/web surface, no `[deploy]` needed. ORCH_1069 backend allowlist added in the same commit (COMMS-0002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)