### PR TITLE
ORCH-1070: strict intent gating for deck experiences

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1615,7 +1615,14 @@ function checkNoNewBackendFiles() {
   const ORCH_1069_BACKEND_ALLOWLIST = [
     "supabase/migrations/20260906000000_orch_1069_live_edit_persists_experience_intents.sql",
   ];
+  // ORCH-1070 [deck experiences strict-intent]: one CREATE-OR-REPLACE migration
+  // tightening pg_eligible_experiences_for_deck to strict intent-overlap (no
+  // permissive empty-p_intents pass). No edge fn, no new tests. COMMS-0002.
+  const ORCH_1070_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260907000000_orch_1070_deck_experiences_strict_intent.sql",
+  ];
   const ALLOWLIST = [
+    ...ORCH_1070_BACKEND_ALLOWLIST,
     ...ORCH_1069_BACKEND_ALLOWLIST,
     ...ORCH_1068_BACKEND_ALLOWLIST,
     ...ORCH_1066_BACKEND_ALLOWLIST,

--- a/supabase/migrations/20260906000000_orch_1069_live_edit_persists_experience_intents.sql
+++ b/supabase/migrations/20260906000000_orch_1069_live_edit_persists_experience_intents.sql
@@ -588,6 +588,6 @@ BEGIN
     'eventDates', v_event_dates_rows
   );
 END;
-$function$
+$function$;
 
 GRANT EXECUTE ON FUNCTION public.biz_update_live_experience(uuid, jsonb, text) TO authenticated;

--- a/supabase/migrations/20260907000000_orch_1070_deck_experiences_strict_intent.sql
+++ b/supabase/migrations/20260907000000_orch_1070_deck_experiences_strict_intent.sql
@@ -150,6 +150,6 @@ AS $function$
   WHERE b.deleted_at IS NULL
   ORDER BY el.next_start_at ASC NULLS LAST, el.published_at DESC
   LIMIT LEAST(GREATEST(p_limit, 0), 30);
-$function$
+$function$;
 
 GRANT EXECUTE ON FUNCTION public.pg_eligible_experiences_for_deck(double precision, double precision, double precision, text[], timestamptz, uuid[], integer) TO service_role;

--- a/supabase/migrations/20260907000000_orch_1070_deck_experiences_strict_intent.sql
+++ b/supabase/migrations/20260907000000_orch_1070_deck_experiences_strict_intent.sql
@@ -1,0 +1,155 @@
+-- ORCH-1070 [deck experiences strict-intent] — surface brand experiences on the
+-- consumer deck ONLY for a SELECTED matching vibe (operator-directed 2026-06-04).
+--
+-- CHANGE: pg_eligible_experiences_for_deck (ORCH-1065 deck supply) previously
+-- surfaced every geo-eligible published experience when the request carried NO
+-- intent (permissive empty-p_intents pass). Operator chose STRICT intent gating:
+-- an experience appears only when its experience_intents OVERLAP the user's active
+-- deck vibes. Predicate `(p_intents = '{}' OR e.experience_intents && p_intents)`
+-- becomes `e.experience_intents && p_intents` (empty p_intents → zero experiences).
+-- Ordering unchanged (soonest future date, then published_at DESC).
+--
+-- Idempotent CREATE OR REPLACE; grant preserved. Already applied to remote via
+-- Management API; this file reconciles it onto main. Verified: vibe=[romantic|
+-- first-date] → Raleigh crawl; vibe=[adventurous] or [] → none.
+--
+-- Docs (COMMS-0003): https://www.postgresql.org/docs/current/functions-array.html (&&)
+
+CREATE OR REPLACE FUNCTION public.pg_eligible_experiences_for_deck(p_lat double precision, p_lng double precision, p_radius_m double precision, p_intents text[], p_now timestamp with time zone, p_exclude_ids uuid[], p_limit integer)
+ RETURNS TABLE(event_id uuid, event_slug text, title text, experience_intents text[], tagline text, currency text, timezone text, brand_id uuid, brand_name text, brand_slug text, brand_logo_url text, master_date_utc timestamp with time zone, master_end_at_utc timestamp with time zone, total_price_cents integer, stops jsonb)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH eligible AS (
+    SELECT
+      e.id,
+      e.slug,
+      e.title,
+      e.experience_intents,
+      e.currency,
+      e.timezone,
+      e.brand_id,
+      -- per-event soonest FUTURE master/active date (next-occurring first):
+      (
+        SELECT ed.start_at
+        FROM public.event_dates ed
+        WHERE ed.event_id = e.id
+          AND ed.end_at > p_now
+        ORDER BY ed.start_at ASC
+        LIMIT 1
+      ) AS next_start_at,
+      (
+        SELECT ed.end_at
+        FROM public.event_dates ed
+        WHERE ed.event_id = e.id
+          AND ed.end_at > p_now
+        ORDER BY ed.start_at ASC
+        LIMIT 1
+      ) AS next_end_at,
+      e.published_at,
+      -- best-effort per-event tagline from theme.experience_meta (honest '' default):
+      COALESCE(e.theme -> 'experience_meta' ->> 'tagline', '') AS tagline,
+      -- the single sellable all-in ticket the ORCH-1006 engine reads (I-1):
+      (
+        SELECT tt.price_cents
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+        ORDER BY tt.price_cents ASC, tt.id ASC
+        LIMIT 1
+      ) AS ticket_price_cents,
+      -- the all-in display price (tax/fee-inclusive) when the public view exposes it:
+      (
+        SELECT v.display_price_cents
+        FROM public.business_public_events_view v
+        WHERE v.id = e.id
+        LIMIT 1
+      ) AS display_price_cents
+    FROM public.events e
+    WHERE e.event_type   = 'experience'
+      AND e.visibility   = 'public'
+      AND e.status       = 'scheduled'
+      AND e.published_at IS NOT NULL
+      AND e.deleted_at   IS NULL
+      AND e.experience_intents IS NOT NULL
+      AND array_length(e.experience_intents, 1) >= 1
+      -- future master/active date (mirrors i-discover-excludes-ended-master-date):
+      AND EXISTS (
+        SELECT 1 FROM public.event_dates ed
+        WHERE ed.event_id = e.id
+          AND ed.end_at > p_now
+      )
+      -- exactly the one sellable ticket the all-in engine reads (gates unsellable drafts):
+      AND EXISTS (
+        SELECT 1 FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+      )
+      -- intent overlap with the user's active deck signals; empty p_intents ⇒ no intent filter:
+      AND e.experience_intents && p_intents  -- ORCH-1070: STRICT — only surface for a SELECTED matching vibe (no permissive)
+      -- geo: ≥1 stop within p_radius_m metres of the user (haversine fallback — no extension):
+      AND EXISTS (
+        SELECT 1 FROM public.experience_stops s
+        WHERE s.event_id = e.id
+          AND s.lat IS NOT NULL
+          AND s.lng IS NOT NULL
+          AND (
+            6371000.0 * 2.0 * ASIN(SQRT(
+              POWER(SIN(RADIANS(s.lat - p_lat) / 2.0), 2) +
+              COS(RADIANS(p_lat)) * COS(RADIANS(s.lat)) *
+              POWER(SIN(RADIANS(s.lng - p_lng) / 2.0), 2)
+            ))
+          ) <= p_radius_m
+      )
+      AND e.id <> ALL(p_exclude_ids)
+  ),
+  stops_agg AS (
+    SELECT
+      s.event_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'stop_order',   s.stop_order,
+          'place_id',     COALESCE(s.place_id, s.id::text),
+          'place_name',   s.place_name,
+          'address',      s.address,
+          'image_urls',   to_jsonb(s.image_urls),
+          'ai_description', s.ai_description,
+          'lat',          s.lat,
+          'lng',          s.lng,
+          'price_cents',  s.price_cents
+        )
+        ORDER BY s.stop_order ASC
+      ) AS stops
+    FROM public.experience_stops s
+    WHERE s.event_id IN (SELECT id FROM eligible)
+    GROUP BY s.event_id
+  )
+  SELECT
+    el.id                                   AS event_id,
+    el.slug                                 AS event_slug,
+    el.title,
+    el.experience_intents,
+    el.tagline,
+    el.currency,
+    COALESCE(el.timezone, 'UTC')            AS timezone,
+    el.brand_id,
+    b.name                                  AS brand_name,
+    b.slug                                  AS brand_slug,
+    b.profile_photo_url                     AS brand_logo_url,
+    el.next_start_at                        AS master_date_utc,
+    el.next_end_at                          AS master_end_at_utc,
+    -- prefer the all-in display price; fall back to the raw ticket price:
+    COALESCE(el.display_price_cents, el.ticket_price_cents, 0) AS total_price_cents,
+    COALESCE(sa.stops, '[]'::jsonb)         AS stops
+  FROM eligible el
+  JOIN public.brands b ON b.id = el.brand_id
+  LEFT JOIN stops_agg sa ON sa.event_id = el.id
+  WHERE b.deleted_at IS NULL
+  ORDER BY el.next_start_at ASC NULLS LAST, el.published_at DESC
+  LIMIT LEAST(GREATEST(p_limit, 0), 30);
+$function$
+
+GRANT EXECUTE ON FUNCTION public.pg_eligible_experiences_for_deck(double precision, double precision, double precision, text[], timestamptz, uuid[], integer) TO service_role;


### PR DESCRIPTION
Brand experiences surface on the consumer deck ONLY for a selected matching vibe (removes the permissive empty-intent pass). One CREATE OR REPLACE migration to pg_eligible_experiences_for_deck; ordering unchanged. Already applied to remote; this reconciles onto main. Backend-only, no [deploy]. ORCH_1070 allowlist same-commit (COMMS-0002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)