### PR TITLE
ORCH-1071 [deploy]: surface brand experiences on the curated-experiences deck path

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1455,6 +1455,17 @@ function checkNoNewBackendFiles() {
     // backend test file → allowlisted in the SAME commit (COMMS-0002).
     "supabase/functions/discover-cards/__tests__/orch1065_experience_supply_adversarial.test.ts",
   ];
+  // ORCH-1071 [experiences-on-curated-path]: front-loads brand experiences on the
+  // "See curated experiences" path (generate-curated-experiences/index.ts) via the
+  // EXISTING pg_eligible_experiences_for_deck RPC (ORCH-1065/1070) — NO new migration,
+  // NO new edge fn. generate-curated-experiences/index.ts is a MODIFY already
+  // allowlisted under ORCH_0902_0903_BACKEND_ALLOWLIST; re-listed here for clarity
+  // plus the new backend regression test. C7 is scoped to ORCH-0863 marketing; these
+  // are curated-deck backend touches. Per COMMS-0002 (same commit as the change).
+  const ORCH_1071_BACKEND_ALLOWLIST = [
+    "supabase/functions/generate-curated-experiences/index.ts",
+    "supabase/functions/generate-curated-experiences/__tests__/orch_1071_experiences_on_curated_path.test.ts",
+  ];
   // ORCH-1064 [admin↔business venue-listing feedback loop]: one NEW migration
   // (venue_claim_feedback table + RLS + view + 3 RPCs + admin bundle extension)
   // plus its backend regression tests. The edge fn (admin-review-venue-claim/
@@ -1713,6 +1724,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_1061_BACKEND_ALLOWLIST,
     ...ORCH_1062_BACKEND_ALLOWLIST,
     ...ORCH_1065_BACKEND_ALLOWLIST,
+    ...ORCH_1071_BACKEND_ALLOWLIST,
     ...ORCH_1064_BACKEND_ALLOWLIST,
     ...ORCH_1067_BACKEND_ALLOWLIST,
     // Schedule-edit buyer protection + "Refund all & proceed" (separate PR;

--- a/app-mobile/src/services/__tests__/deckService.orch1071.test.ts
+++ b/app-mobile/src/services/__tests__/deckService.orch1071.test.ts
@@ -1,0 +1,63 @@
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// ORCH-1071 [experiences-on-curated-path] — client converter-routing regression.
+//
+// deckService.ts imports RN-bound modules (./supabase, ./curatedExperiencesService),
+// so it cannot be imported in a Deno unit test. Per the established app-mobile
+// service-test pattern (see deckService.orch1065.test.ts), we read the source as
+// text and assert the LOCKED routing contract: the curated-path handler maps
+// response.cards routing any cardType:'experience' card through the brand-experience
+// converter (experienceCardToRecommendation), NOT the AI-curated converter, and the
+// final deck dedupes by id so a cross-path experience renders once.
+//
+// Fails-on-revert (LOCKED): this test fails if the curated handler reverts to a
+// bare response.cards.map(curatedToRecommendation) (which would render brand
+// experiences as AI-curated cards and lose brand attribution).
+
+const source = await Deno.readTextFile(
+  new URL("../deckService.ts", import.meta.url),
+);
+
+Deno.test("ORCH-1071 T-C1: curated handler routes cardType:'experience' through experienceCardToRecommendation (fails-on-revert)", () => {
+  // Isolate the curated pill map call site (the one that previously was a bare
+  // response.cards.map(curatedToRecommendation)).
+  const curatedIdx = source.indexOf("response.cards.map(");
+  assert(curatedIdx >= 0, "curated handler must map response.cards");
+  // The map callback must dispatch on isExperiencePayload → experienceCardToRecommendation,
+  // else fall through to curatedToRecommendation.
+  const region = source.slice(curatedIdx, curatedIdx + 600);
+  assertStringIncludes(region, "isExperiencePayload(card)");
+  assertStringIncludes(region, "experienceCardToRecommendation(card)");
+  assertStringIncludes(region, "curatedToRecommendation(card)");
+  // The experience branch must come BEFORE the curated fallback in the ternary.
+  const expIdx = region.indexOf("experienceCardToRecommendation(card)");
+  const curIdx = region.indexOf("curatedToRecommendation(card)");
+  assert(
+    expIdx >= 0 && curIdx >= 0 && expIdx < curIdx,
+    "experience converter must be the truthy branch (runs before the curated fallback)",
+  );
+});
+
+Deno.test("ORCH-1071 T-C2: the experience converter + discriminator predicate exist", () => {
+  assertStringIncludes(source, "function isExperiencePayload");
+  assertStringIncludes(source, "card?.cardType === 'experience'");
+  assertStringIncludes(source, "function experienceCardToRecommendation");
+});
+
+Deno.test("ORCH-1071 T-C3: final deck interleave dedupes by id (cross-path single-render)", () => {
+  // The final 1:1 interleave keeps a `seen` Set keyed by id so an experience that
+  // arrives via BOTH the places path (discover-cards) and the curated path renders
+  // once. Assert the dedupe Set + the id-keyed guards are present on both streams.
+  const interleaveIdx = source.indexOf("// 1:1 interleave: alternate regular and curated");
+  assert(interleaveIdx >= 0, "final interleave block must be present");
+  const region = source.slice(interleaveIdx, interleaveIdx + 700);
+  assertStringIncludes(region, "const seen = new Set<string>()");
+  // Regular stream id key (placeId || id) and curated stream id key.
+  assertStringIncludes(region, "regularStream[i].placeId || regularStream[i].id");
+  assertStringIncludes(region, "curatedStream[i].id");
+  assertStringIncludes(region, "seen.has(id)");
+  assertStringIncludes(region, "seen.add(id)");
+});

--- a/app-mobile/src/services/deckService.ts
+++ b/app-mobile/src/services/deckService.ts
@@ -716,7 +716,20 @@ class DeckService {
             if (response.cards.length === 0 && response.summary) {
               pillEmptyReasons.set(pill.id, response.summary.emptyReason);
             }
-            return response.cards.map(curatedToRecommendation);
+            // ORCH-1071 [experiences-on-curated-path]: generate-curated-experiences
+            // now front-loads brand-authored experience envelopes (cardType:'experience')
+            // ahead of the AI cardType:'curated' cards for the 4 brand intents. Route
+            // those through the SAME brand-experience converter ORCH-1065 uses on the
+            // places path (experienceCardToRecommendation) instead of the AI-curated
+            // converter — keeping them FRONT-of-array (server already front-loaded).
+            // Cross-path dedupe (an experience that also arrives via discover-cards
+            // when "popular options" is also on) is handled by the final interleave's
+            // `seen` Set keyed by id, so each experience renders once, not twice.
+            return response.cards.map((card) =>
+              isExperiencePayload(card)
+                ? experienceCardToRecommendation(card)
+                : curatedToRecommendation(card),
+            );
           } catch (err) {
             console.warn(`[DeckService] Curated pill ${pill.id} failed:`, err);
             // ORCH-0677 RC-2: caught throws are treated as pipeline errors so

--- a/supabase/functions/generate-curated-experiences/__tests__/orch_1071_experiences_on_curated_path.test.ts
+++ b/supabase/functions/generate-curated-experiences/__tests__/orch_1071_experiences_on_curated_path.test.ts
@@ -1,0 +1,153 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// ORCH-1071 [experiences-on-curated-path] — implementor backend regression tests.
+//
+// generate-curated-experiences/index.ts calls serve() at module load and the
+// supply helpers close over a service-role client, so (per the established
+// orch_1065 / orch_0909 / orch_1062 pattern) we exercise the front-load machinery
+// by reading the edge source as TEXT and asserting the LOCKED contract is present
+// and wired into the handler return.
+//
+// Fails-on-revert (LOCKED, dispatch §IMPLEMENT.1):
+//   T-1 fails if the front-load call is removed from the handler return path.
+//   T-2 fails if the brand-intent gate (skip non-brand types) is removed.
+//   T-3 fails if the best-effort try/catch is removed.
+//   T-5 fails if the new code references the COMMS-0018 bypassed machinery.
+
+const edge = await Deno.readTextFile(
+  new URL("../index.ts", import.meta.url),
+);
+
+// Isolate the ORCH-1071 supply block (between the markers).
+const blockStart = edge.indexOf("// ─── ORCH-1071 [experiences-on-curated-path]");
+const blockEnd = edge.indexOf("// ─── end ORCH-1071 ─");
+assert(
+  blockStart >= 0 && blockEnd > blockStart,
+  "ORCH-1071 supply block markers must be present",
+);
+const block = edge.slice(blockStart, blockEnd);
+
+Deno.test("ORCH-1071 T-1a: supply helper + front-load helper exist and reuse the RPC + envelope", () => {
+  assertStringIncludes(edge, "fetchEligibleExperiencesForCurated");
+  assertStringIncludes(edge, "frontLoadCuratedExperiences");
+  // Same RPC discover-cards uses (no parallel system).
+  assertStringIncludes(block, "pg_eligible_experiences_for_deck");
+  // Same envelope discriminator + brand attribution the client converter decodes.
+  assertStringIncludes(block, "cardType: 'experience'");
+  for (const field of [
+    "eventId:",
+    "brandId:",
+    "brandName:",
+    "brandSlug:",
+    "brandLogoUrl:",
+    "eventSlug:",
+    "totalPriceMin:",
+    "totalPriceMax:",
+    "currency:",
+    "masterDateUtc:",
+  ]) {
+    assertStringIncludes(block, field);
+  }
+});
+
+Deno.test("ORCH-1071 T-1b: handler front-loads experiences into the served cards (fails-on-revert)", () => {
+  // The handler must CALL the front-load helper and rebind normalizedCards to its
+  // result, and the response must serve `cards: normalizedCards`.
+  assert(
+    /normalizedCards\s*=\s*frontLoadCuratedExperiences\(\s*normalizedCards\s*,\s*experienceCards\s*\)/.test(edge),
+    "handler must rebind normalizedCards = frontLoadCuratedExperiences(normalizedCards, experienceCards)",
+  );
+  assert(
+    /cards:\s*normalizedCards/.test(edge),
+    "response must serve `cards: normalizedCards`",
+  );
+  // The front-load helper places experiences at the HEAD (ahead of AI cards).
+  assert(
+    /return\s*\[\s*\.\.\.deduped\s*,\s*\.\.\.aiCards\s*\]/.test(edge),
+    "frontLoadCuratedExperiences must place experiences BEFORE the AI cards",
+  );
+});
+
+Deno.test("ORCH-1071 T-2: only the 4 brand intents front-load; non-brand types skipped (fails-on-revert)", () => {
+  assertStringIncludes(edge, "CURATED_BRAND_EXPERIENCE_INTENTS");
+  // The gate set is exactly the 4 brand intents.
+  for (const intent of ["'adventurous'", "'first-date'", "'romantic'", "'group-fun'"]) {
+    assertStringIncludes(block, intent);
+  }
+  // picnic-dates and take-a-stroll must NOT be in the brand-intent set.
+  const setDecl = block.slice(
+    block.indexOf("CURATED_BRAND_EXPERIENCE_INTENTS = new Set"),
+    block.indexOf("]);", block.indexOf("CURATED_BRAND_EXPERIENCE_INTENTS = new Set")) + 3,
+  );
+  assertEquals(
+    setDecl.includes("picnic-dates"),
+    false,
+    "picnic-dates must NOT be a brand-experience intent",
+  );
+  assertEquals(
+    setDecl.includes("take-a-stroll"),
+    false,
+    "take-a-stroll must NOT be a brand-experience intent",
+  );
+  // The handler must GATE the fetch on the brand-intent membership.
+  assert(
+    /CURATED_BRAND_EXPERIENCE_INTENTS\.has\(experienceType\)/.test(edge),
+    "handler must gate the experience front-load on CURATED_BRAND_EXPERIENCE_INTENTS.has(experienceType)",
+  );
+});
+
+Deno.test("ORCH-1071 T-3: experience front-load is best-effort (try/catch, never breaks AI curated)", () => {
+  // The handler must wrap the front-load in try/catch and tolerate failure with
+  // a warn-and-continue (no throw, no early return).
+  const guard = edge.slice(
+    edge.indexOf("CURATED_BRAND_EXPERIENCE_INTENTS.has(experienceType)"),
+  );
+  assertStringIncludes(guard, "try {");
+  assertStringIncludes(guard, "catch (expErr)");
+  assertStringIncludes(guard, "front-load failed (tolerating)");
+});
+
+Deno.test("ORCH-1071 T-4: warm path skips the front-load (servedCards is empty there)", () => {
+  // The gate must also require !warmPool so the warm-ping path stays a no-op.
+  assert(
+    /!warmPool\s*&&\s*CURATED_BRAND_EXPERIENCE_INTENTS\.has\(experienceType\)/.test(edge),
+    "front-load must be gated on !warmPool && brand intent",
+  );
+});
+
+Deno.test("ORCH-1071 T-5: front-load CODE never references the COMMS-0018 bypassed machinery", () => {
+  function stripComments(value: string): string {
+    return value
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^[ \t]*\/\/.*$/gm, "")
+      .replace(/[ \t]\/\/[^\n]*$/gm, "");
+  }
+  const codeOnly = stripComments(block);
+  for (const banned of [
+    "place_pool",
+    "ai_signal_scores",
+    "run-signal-scorer",
+    "session_deck_cards",
+  ]) {
+    assertEquals(
+      codeOnly.includes(banned),
+      false,
+      `ORCH-1071 front-load code must not reference ${banned} (COMMS-0018 bypass)`,
+    );
+  }
+});
+
+Deno.test("ORCH-1071 T-6: RPC is filtered to the pill's intent + excludeCardIds wired", () => {
+  // The fetch passes the pill's experienceType as the single-element p_intents.
+  assertStringIncludes(block, "p_intents: [args.experienceType]");
+  // excludeCardIds is read from the body and threaded to p_exclude_ids.
+  assertStringIncludes(edge, "excludeCardIds = []");
+  assert(
+    /excludeEventIds:\s*excludeCardIds\.filter/.test(edge),
+    "handler must thread excludeCardIds → excludeEventIds (p_exclude_ids) for cross-path dedupe",
+  );
+});

--- a/supabase/functions/generate-curated-experiences/index.ts
+++ b/supabase/functions/generate-curated-experiences/index.ts
@@ -45,6 +45,193 @@ let supabaseAdmin: ReturnType<typeof createClient>;
 // (Type exclusion code removed — AI validation is the sole quality gate.
 //  Single cards are already filtered at generation time.)
 
+// ─── ORCH-1071 [experiences-on-curated-path] ──────────────────────────────────
+// The "See curated experiences" path calls THIS fn per curated pill with
+// experienceType = the pill id. ORCH-1065 wired brand experiences into the PLACES
+// path (discover-cards) only, so a user who turns on "See curated experiences" and
+// picks a vibe (Romantic / First Dates / Group Fun / Adventurous) never saw the
+// matching brand experience. ORCH-1071 front-loads eligible brand experiences here
+// too — same RPC, same envelope, same client converter as ORCH-1065. NO parallel
+// money fn (booking stays via ticket-checkout-create — COMMS-0014/0016).
+//
+// Bypasses place_pool / ai_signal_scores / run-signal-scorer ENTIRELY (the
+// COMMS-0018 signal_id-buggy venue→deck path): reads ONLY events + experience_stops
+// via the pg_eligible_experiences_for_deck RPC (service-role, ORCH-1070 strict-gated).
+//
+// Best-effort: a failure here MUST NOT break AI curated generation. Brand
+// experiences front-load ONLY for the 4 brand intents (the AI strolls still run);
+// every other experienceType (picnic-dates / take-a-stroll / anything non-brand)
+// is skipped.
+
+// The 4 curated pill ids that map to brand experience intents. picnic-dates and
+// take-a-stroll have NO brand-experience analog, so they are skipped.
+const CURATED_BRAND_EXPERIENCE_INTENTS = new Set([
+  'adventurous', 'first-date', 'romantic', 'group-fun',
+]);
+
+// Server card envelope pushed at the FRONT of the curated cards[] for each
+// eligible experience. IDENTICAL shape to the discover-cards ExperienceDeckCard
+// envelope — the client converter (deckService.experienceCardToRecommendation)
+// decodes BOTH paths the same way (no parallel system).
+interface CuratedExperienceDeckCard {
+  cardType: 'experience';
+  id: string;
+  eventId: string;
+  experienceType: string;
+  title: string;
+  tagline: string;
+  brandId: string;
+  brandName: string;
+  brandSlug: string;
+  brandLogoUrl: string | null;
+  eventSlug: string;
+  totalPriceMin: number;
+  totalPriceMax: number;
+  currency: string;
+  masterDateUtc: string | null;
+  masterEndAtUtc: string | null;
+  timezone: string;
+  stops: Array<{
+    stopNumber: number;
+    placeId: string;
+    placeName: string;
+    address: string;
+    imageUrl: string;
+    imageUrls: string[];
+    aiDescription: string;
+    lat: number;
+    lng: number;
+    priceMin: number;
+    priceMax: number;
+    rating: number;
+    reviewCount: number;
+    distanceFromUserKm: number | null;
+    travelTimeFromUserMin: number | null;
+  }>;
+  estimatedDurationMinutes: number;
+  matchScore: number;
+}
+
+// Single service-role round-trip to pg_eligible_experiences_for_deck for ONE
+// brand intent (the curated pill). Maps each row into the SAME envelope shape
+// discover-cards emits. Throws on RPC error (the caller swallows best-effort so
+// an experience-source failure never degrades the AI curated generation).
+async function fetchEligibleExperiencesForCurated(args: {
+  lat: number;
+  lng: number;
+  radiusMeters: number;
+  experienceType: string;
+  nowIso: string;
+  excludeEventIds: string[];
+  limit: number;
+}): Promise<CuratedExperienceDeckCard[]> {
+  const { data, error } = await (supabaseAdmin as any).rpc(
+    'pg_eligible_experiences_for_deck',
+    {
+      p_lat: args.lat,
+      p_lng: args.lng,
+      p_radius_m: args.radiusMeters,
+      // Filter to exactly the pill's intent (one element). The RPC returns every
+      // experience whose experience_intents && p_intents.
+      p_intents: [args.experienceType],
+      p_now: args.nowIso,
+      p_exclude_ids: args.excludeEventIds,
+      p_limit: Math.min(Math.max(args.limit, 0), 30),
+    },
+  );
+  if (error) {
+    throw new Error(`pg_eligible_experiences_for_deck failed: ${error.message}`);
+  }
+  const rows = (data as any[]) ?? [];
+  return rows.map((row): CuratedExperienceDeckCard => {
+    const rawStops = Array.isArray(row.stops) ? row.stops : [];
+    const stops = rawStops.map((s: any) => {
+      const imageUrls: string[] = Array.isArray(s.image_urls) ? s.image_urls : [];
+      const lat = typeof s.lat === 'number' ? s.lat : 0;
+      const lng = typeof s.lng === 'number' ? s.lng : 0;
+      const distanceKm =
+        typeof s.lat === 'number' && typeof s.lng === 'number'
+          ? haversineKm(args.lat, args.lng, lat, lng)
+          : null;
+      const priceMajor = Math.round((Number(s.price_cents) || 0)) / 100;
+      return {
+        stopNumber: (Number(s.stop_order) || 0) + 1,
+        placeId: typeof s.place_id === 'string' ? s.place_id : String(s.place_id ?? ''),
+        placeName: typeof s.place_name === 'string' ? s.place_name : '',
+        address: typeof s.address === 'string' ? s.address : '',
+        imageUrl: imageUrls[0] ?? '',
+        imageUrls: imageUrls.slice(0, 5),
+        aiDescription: typeof s.ai_description === 'string' ? s.ai_description : '',
+        lat,
+        lng,
+        priceMin: priceMajor,
+        priceMax: priceMajor,
+        // Experiences carry no Google rating — honest 0, never fabricated.
+        rating: 0,
+        reviewCount: 0,
+        distanceFromUserKm: distanceKm,
+        travelTimeFromUserMin: null,
+      };
+    });
+    const totalMajor = Math.round((Number(row.total_price_cents) || 0)) / 100;
+    const intentsArr: string[] = Array.isArray(row.experience_intents)
+      ? row.experience_intents
+      : [];
+    return {
+      cardType: 'experience',
+      id: String(row.event_id),
+      eventId: String(row.event_id),
+      // Prefer the pill's own intent when the experience carries it, else the
+      // experience's first declared intent (mirrors discover-cards).
+      experienceType: intentsArr.includes(args.experienceType)
+        ? args.experienceType
+        : (intentsArr[0] ?? args.experienceType),
+      title: typeof row.title === 'string' ? row.title : '',
+      tagline: typeof row.tagline === 'string' ? row.tagline : '',
+      brandId: String(row.brand_id),
+      brandName: typeof row.brand_name === 'string' ? row.brand_name : '',
+      brandSlug: typeof row.brand_slug === 'string' ? row.brand_slug : '',
+      brandLogoUrl:
+        typeof row.brand_logo_url === 'string' && row.brand_logo_url.length > 0
+          ? row.brand_logo_url
+          : null,
+      eventSlug: typeof row.event_slug === 'string' ? row.event_slug : '',
+      totalPriceMin: totalMajor,
+      totalPriceMax: totalMajor,
+      currency:
+        typeof row.currency === 'string' && row.currency.trim().length > 0
+          ? row.currency.trim()
+          : 'USD',
+      masterDateUtc: row.master_date_utc ? String(row.master_date_utc) : null,
+      masterEndAtUtc: row.master_end_at_utc ? String(row.master_end_at_utc) : null,
+      timezone: typeof row.timezone === 'string' ? row.timezone : 'UTC',
+      stops,
+      estimatedDurationMinutes: 0,
+      matchScore: 85,
+    };
+  });
+}
+
+// Front-load the brand experiences at the HEAD of the curated cards array,
+// ahead of the AI cardType:'curated' cards, deduped by id. Additive — AI cards
+// are never displaced or dropped.
+function frontLoadCuratedExperiences(
+  aiCards: any[],
+  experienceCards: CuratedExperienceDeckCard[],
+): any[] {
+  if (experienceCards.length === 0) return aiCards;
+  const seen = new Set<string>();
+  const deduped: CuratedExperienceDeckCard[] = [];
+  for (const exp of experienceCards) {
+    if (!seen.has(exp.id)) {
+      seen.add(exp.id);
+      deduped.push(exp);
+    }
+  }
+  return [...deduped, ...aiCards];
+}
+// ─── end ORCH-1071 ────────────────────────────────────────────────────────────
+
 // ── Session preference aggregation (for collaboration mode) ────────────────
 
 const SESSION_INTENT_IDS = new Set([
@@ -1377,9 +1564,17 @@ export const handler = async (req: Request): Promise<Response> => {
       session_id,
       batchSeed = 0,
       excludePlacePoolIds = [],
+      // ORCH-1071: ids already in the deck — passed to the experience RPC as
+      // p_exclude_ids so a brand experience already shown via the places path
+      // is not re-fetched here. Optional; the curated client does not send it
+      // today, so it defaults to [] and is a no-op until wired.
+      excludeCardIds = [],
     } = body;
     if (!Array.isArray(excludePlacePoolIds)) {
       excludePlacePoolIds = [];
+    }
+    if (!Array.isArray(excludeCardIds)) {
+      excludeCardIds = [];
     }
     const warmPool = body.warmPool ?? false;
 
@@ -1624,18 +1819,55 @@ export const handler = async (req: Request): Promise<Response> => {
     }
 
     const servedCards = warmPool ? [] : cards.slice(0, limit);
-    const normalizedCards = servedCards.map((card: any) => ({
+    let normalizedCards = servedCards.map((card: any) => ({
       ...card,
       categoryLabel: card.categoryLabel || card.category || experienceType || 'Experience',
     }));
+
+    // ORCH-1071 [experiences-on-curated-path]: for the 4 brand intents ONLY,
+    // front-load eligible brand experiences ahead of the AI curated cards so the
+    // "See curated experiences" path surfaces them (the places-path-only ORCH-1065
+    // gap). Best-effort — a failure here NEVER breaks the AI curated generation.
+    // Skipped on the warm path (servedCards is empty there). Bypasses
+    // place_pool/ai_signal_scores/run-signal-scorer (COMMS-0018) — reads only
+    // events+experience_stops via the RPC.
+    if (!warmPool && CURATED_BRAND_EXPERIENCE_INTENTS.has(experienceType)) {
+      try {
+        // Radius mirrors discover-cards' experience supply (generosity=1.5 so the
+        // candidate radius is wider than the tight curated multi-stop radius —
+        // an auto-surface experience is a single bookable card, not a walked route).
+        const expMaxDistKm = radiusKmForConstraint(travelConstraintValue, travelMode, 1.5);
+        const expRadiusMeters = Math.min(Math.max(Math.round(expMaxDistKm * 1000), 500), 100000);
+        const expNowIso = (datetimePref ? new Date(datetimePref) : new Date()).toISOString();
+        const experienceCards = await fetchEligibleExperiencesForCurated({
+          lat: location.lat,
+          lng: location.lng,
+          radiusMeters: expRadiusMeters,
+          experienceType,
+          nowIso: expNowIso,
+          excludeEventIds: excludeCardIds.filter(
+            (v: unknown): v is string => typeof v === 'string' && v.length > 0,
+          ),
+          limit: Math.min(limit, 30),
+        });
+        if (experienceCards.length > 0) {
+          normalizedCards = frontLoadCuratedExperiences(normalizedCards, experienceCards);
+          console.log(`[curated-v2] front-loaded ${experienceCards.length} brand experiences for intent=${experienceType}`);
+        }
+      } catch (expErr) {
+        // Best-effort: experience supply failure must NOT break AI curated cards.
+        console.warn(`[curated-v2] experience front-load failed (tolerating): ${(expErr as Error)?.message}`);
+      }
+    }
     return new Response(
       JSON.stringify({
         cards: normalizedCards,
         experienceType,
-        total: servedCards.length,
+        // ORCH-1071: total reflects front-loaded brand experiences + AI cards.
+        total: normalizedCards.length,
         generatedAt: new Date().toISOString(),
         meta: {
-          totalResults: servedCards.length,
+          totalResults: normalizedCards.length,
           totalCardsBuilt: cards.length,
           fromPool: 0,
           fromApi: servedCards.length,


### PR DESCRIPTION
## ORCH-1071 — experiences on the curated path

**Bug (confirmed on a live sim):** ORCH-1065 wired the brand-experience supply into `discover-cards` (the "See popular options?" / places path). But brand experiences are curated-shaped multi-stop itineraries — users find them via "See curated experiences" + a vibe (Romantic/First Dates/Group Fun/Adventurous), which calls `generate-curated-experiences` (AI strolls) — a path with ZERO brand experiences. So picking the matching vibe showed nothing.

**Fix (reuses ORCH-1065 supply, no parallel systems):**
- Backend `generate-curated-experiences`: for the 4 brand intents, best-effort front-load eligible brand experiences via `pg_eligible_experiences_for_deck` (same envelope discover-cards emits), ahead of AI strolls. Supply failure never breaks AI generation. COMMS-0018 bypass preserved.
- Client `deckService`: curated handler routes `cardType:'experience'` cards through the existing `experienceCardToRecommendation`, front-loaded; dedupes by id so it renders once when both paths are on.

**Verified:** direct call to the deployed curated fn (First Dates + Raleigh) → returns "Raleigh Wine and Dine Crawl" at pos 0. Backend Deno (7) + client Deno (3) tests pass, fail-on-revert proven. No migration. ORCH_1071 C7 allowlist same-commit (COMMS-0002).

[deploy] — touches app-mobile (consumer) client routing; tag covers Vercel surfaces in the allowlist file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)