### PR TITLE
ORCH-1072 [deploy]: experience detail — cover/description + Book Experience + availability

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1466,6 +1466,20 @@ function checkNoNewBackendFiles() {
     "supabase/functions/generate-curated-experiences/index.ts",
     "supabase/functions/generate-curated-experiences/__tests__/orch_1071_experiences_on_curated_path.test.ts",
   ];
+  // ORCH-1072 [experience-detail-cover-availability]: ONE new migration
+  // (additive CREATE OR REPLACE of pg_eligible_experiences_for_deck adding
+  // cover_media_url/cover_media_type/description/upcoming_occurrences) plus its
+  // backend regression tests. The two edge fns it threads through
+  // (discover-cards/index.ts, generate-curated-experiences/index.ts) are
+  // MODIFICATIONS of already-allowlisted files (ORCH_1065 / ORCH_0902_0903 /
+  // ORCH_1071), so only the migration + the two new test files need listing.
+  // C7 is scoped to ORCH-0863 marketing; these are consumer-deck backend
+  // touches. Per COMMS-0002 — lands in the SAME commit as the migration.
+  const ORCH_1072_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql",
+    "supabase/functions/discover-cards/__tests__/orch_1072_experience_detail_supply.test.ts",
+    "supabase/functions/ticket-checkout-create/__tests__/orch1072_experience_occurrence_checkout.test.ts",
+  ];
   // ORCH-1064 [admin↔business venue-listing feedback loop]: one NEW migration
   // (venue_claim_feedback table + RLS + view + 3 RPCs + admin bundle extension)
   // plus its backend regression tests. The edge fn (admin-review-venue-claim/
@@ -1725,6 +1739,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_1062_BACKEND_ALLOWLIST,
     ...ORCH_1065_BACKEND_ALLOWLIST,
     ...ORCH_1071_BACKEND_ALLOWLIST,
+    ...ORCH_1072_BACKEND_ALLOWLIST,
     ...ORCH_1064_BACKEND_ALLOWLIST,
     ...ORCH_1067_BACKEND_ALLOWLIST,
     // Schedule-edit buyer protection + "Refund all & proceed" (separate PR;

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1072_EXPERIENCE_DETAIL_COVER_AVAILABILITY_REPORT.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1072_EXPERIENCE_DETAIL_COVER_AVAILABILITY_REPORT.md
@@ -1,0 +1,162 @@
+# IMPLEMENTATION — ORCH-1072 [experience-detail-cover-availability]
+
+**Status:** implemented and verified (source + read-only live-data probe; sim live-fire deferred to TEST).
+**Worktree:** `~/Desktop/mingla-orchs/tmp-business-metro` on branch `ORCH-1072-experience-detail-cover-availability` (base `origin/main` `59496eaab`).
+**Date:** 2026-06-04.
+**Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_experience_detail_and_availability.md`.
+
+A published brand experience now renders + books correctly on the consumer app: the deck card shows the real cover (image/video) with the stop photos as a strip below; the expanded detail shows the real cover + description + multi-stop itinerary; the action is a single Book button (no Save/Schedule); and availability works (pick an upcoming date with remaining capacity → quantity → pay).
+
+---
+
+## Commits (per part)
+
+| Part | Commit | Subject |
+|---|---|---|
+| 1 | `781ef1659` + `f073d5c28` (DROP fix) | Supply: real cover + description + upcoming occurrences in `pg_eligible_experiences_for_deck` + both edge envelopes + C7 allowlist + supply test |
+| 2 | `a8122b9ab` | Client mapper carries cover/description/occurrences + tag-loss hardening |
+| 3 | `422764705` + `7708732b2` (prop fix) | Card cover hero + stop strip; sheet mapper uses real cover/description/stops/occurrences |
+| 4 | `978816833` | Detail sheet: itinerary + upcoming-dates picker + Book |
+| 5 | `3e2e25972` | `ticket-checkout-create` optional `eventDateId` occurrence param + checkout test |
+
+---
+
+## PART 1 — Supply (backend)
+
+### New `pg_eligible_experiences_for_deck` columns (additive)
+`RETURNS TABLE` widened from 15 → 19 columns. New columns: `description text`, `cover_media_url text`, `cover_media_type text`, `upcoming_occurrences jsonb`.
+
+- `cover_media_url` / `cover_media_type` ← `events.cover_media_url` / `events.cover_media_type` (image/video/gif).
+- `description` ← `COALESCE(events.description, '')` (honest empty default — never the tagline).
+- `upcoming_occurrences` ← `jsonb_agg` of the next ≤12 future `event_dates` (`end_at > p_now`), ordered `start_at ASC`.
+
+### Occurrence shape (one element)
+```json
+{ "event_date_id": "uuid", "start_at": "ts", "end_at": "ts",
+  "capacity": int|null, "sold": int, "remaining": int|null }
+```
+Capacity model is **per-event** (investigation §F): the experience has exactly ONE sellable online ticket (existing I-1 gate). `remaining = GREATEST(quantity_total − sold, 0)` or `NULL` for unlimited, matching `pg_public_ticket_types_remaining` (ORCH-0946); `sold` counts `tickets.status IN ('valid','used','transferred')` (same formula as the checkout RPC + `biz_experience_sold_count`). Every occurrence of an experience therefore shows the same event-level remaining — no per-occurrence cap is invented (Constitution #9).
+
+### Critical migration detail (DROP-then-CREATE)
+A bare `CREATE OR REPLACE` cannot change an existing function's return columns (`cannot change return type of existing function`). Verified the live remote signature is the old 15-column shape; added `DROP FUNCTION IF EXISTS public.pg_eligible_experiences_for_deck(double precision, double precision, double precision, text[], timestamptz, uuid[], integer);` before the CREATE (atomic inside the migration transaction → no live gap for service-role callers). Function body ends with `;` before the GRANT.
+
+### Edge envelopes (threaded identically — no parallel system)
+- `discover-cards/index.ts` `ExperienceDeckCard` + `fetchEligibleExperiences` map → adds `coverMediaUrl`, `coverMediaType`, `description`, `upcomingOccurrences` + shared `mapExperienceOccurrences` helper.
+- `generate-curated-experiences/index.ts` `CuratedExperienceDeckCard` + `fetchEligibleExperiencesForCurated` map → identical fields + identical `mapExperienceOccurrences`.
+
+### Migration / C7
+New file `supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql` added to `ORCH_1072_BACKEND_ALLOWLIST` in `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` (same commit, COMMS-0002). C7 gate run: **PASS** (15 backend files, all allowlisted). No `place_pool`/`ai_signal_scores` (COMMS-0018).
+
+---
+
+## PART 2 — Client mapper + tag fix
+
+- `deckService.experienceCardToRecommendation` now carries `description`, `coverMediaUrl`, `coverMediaType`, `upcomingOccurrences[]` onto the experience Recommendation (verbatim, read via runtime cast in SwipeableCards).
+- `BusinessEventCard` (mergedDiscover.ts) gains optional `experienceStops?` + `upcomingOccurrences?` (experience-only; undefined for events/trips → byte-safe).
+
+### Save/Schedule tag-loss root cause + fix
+**Root cause (investigation §A/B):** routing keys on `currentRec.cardType === 'experience'`; when that discriminator is present the card correctly routes to `ExpandedBusinessEventSheet` (Book, no Save/Schedule). The reported symptom appears only if an experience reaches the renderer WITHOUT the tag — then it falls to the curated/place branch which renders `ActionButtons` (Save/Schedule). The supply always tags `'experience'`, so the practical defect was that the experience routed to the right sheet but showed the wrong DATA (fabricated cover/description) — fixed by Parts 1, 3, 4.
+**Hardening:** `isExperiencePayload` now also recovers the discriminator **structurally** — a brand experience uniquely carries a non-empty `brandId` + `eventId` + a `stops[]` array, whereas curated AI cards have stops but NO brand attribution. If the explicit tag is ever lost upstream, the decoder still classifies it as an experience and `experienceCardToRecommendation` re-stamps `cardType:'experience'`, so it can never fall to the Save/Schedule branch. The renderer's strict `=== 'experience'` discriminator is unchanged (ORCH-1065 ADV test still green).
+
+---
+
+## PART 3 — Card (cover hero + stop strip)
+
+`CuratedExperienceSwipeCard`: for the brand-experience variant with a real cover, the hero is the cover rendered via the shared `@mingla/event-rendering` `EventCoverMedia` (`autoplay muted loop` — the event-card video contract; image/gif/video all handled) taking the top ~74% of the image section, with the stop photos as a smaller strip beneath (~26%). Curated cards + cover-less experiences keep the unchanged full stop-strip hero (SC-13).
+
+Cover is passed via a SEPARATE optional `experienceCover` prop (NOT folded into `brandExperience`) to preserve the ORCH-1065-locked `brandExperience: { brandName; brandLogoUrl }` contract byte-identically (locked test `orch1065_experience_expand` T-12/SC-13 re-passes, 22/22).
+
+---
+
+## PART 4 — Expanded sheet
+
+`ExpandedBusinessEventSheet` (renders the shared `PublicEventPage`):
+- Cover (image/video) + description now flow through the existing `mapCardToPublicEvent` (they read `card.coverMediaUrl/coverMediaType/description`, all now real).
+- `datesList` (previously hardcoded `[]`) now populated from `upcomingOccurrences` for experiences → the real upcoming dates render in PublicEventPage's existing dates section.
+- New `ExperienceItinerary` section (multi-stop route) injected beneath PublicEventPage's content via the scroll host.
+- New `ExperienceOccurrencePicker` (PICK FROM UPCOMING DATES): on Book, `beginBooking(ticketId)` decides — >1 bookable occurrence opens the picker (each row = date + remaining chip; sold-out `remaining===0` disabled); exactly 1 occurrence auto-selects (one-off); 0 occurrences (event/trip) opens the cart with no date (unchanged). The chosen `event_date_id` is threaded into the existing `TicketCartSheet` → `runNativeCheckout`. No parallel sheet.
+
+---
+
+## PART 5 — Checkout (money — careful)
+
+`ticket-checkout-create/index.ts` EXTENDED (not forked — COMMS-0014/0016) with an OPTIONAL `eventDateId`:
+- Parsed `body.eventDateId` → string or `null`.
+- When non-null, validated against `event_dates` (must belong to THIS event AND `end_at > now`): mismatch → `422 occurrence_not_found`; past/sold-out → `422 occurrence_not_available`. Runs immediately after the existing `event_no_active_dates` gate — BEFORE any PaymentIntent.
+- Persisted to (a) `ticket_checkout_sessions.metadata.event_date_id` (merged into the existing status-token UPDATE — no extra round-trip) and (b) the PaymentIntent metadata `mingla_event_date_id` (Stripe metadata: keys ≤40 / values ≤500 chars — https://docs.stripe.com/api/metadata).
+- **When omitted, every branch is byte-identical to today** — no new query, no new metadata key (all writes spread-conditional on `eventDateId !== null`). Events, trips, one-off experiences unchanged. `verify_jwt` + the trip/event paths untouched (no `event_type==='experience'` branch introduced).
+
+Client: `nativeCheckoutFlow` `NativeCheckoutInput.eventDateId?` forwarded to the body only when present.
+
+### Residual money-path risk
+- **Capacity race:** the occurrence validation proves the date is future + belongs to the event, but ticket-level sold-out is still enforced by the existing `biz_ticket_checkout_create_session` capacity gate (409 `ticket_capacity_exceeded`) at the per-event ticket level — unchanged. Two buyers racing the last seat are still caught by that gate; the occurrence param does not add per-occurrence capacity (none exists in the schema). Low risk, identical to today's events/trips.
+- **Web hosted-Checkout branch:** untouched — web buyers don't send `eventDateId` (consumer-native only), so the web path is byte-identical. No new divergence beyond the pre-existing COMMS-0013 tax note.
+- **PI-metadata → order:** the booked occurrence is recorded on the PI + session metadata; wiring it onto a dedicated `orders.event_date_id` column is NOT done (no such column exists; adding one + threading the session/finalize RPCs was out of the byte-identical-when-omitted budget). Operator/analytics can read the occurrence from PI/session metadata today.
+
+---
+
+## Regression tests
+
+| Test | Path | Result |
+|---|---|---|
+| Supply (6) | `supabase/functions/discover-cards/__tests__/orch_1072_experience_detail_supply.test.ts` | 6/6 PASS |
+| Checkout (5) | `supabase/functions/ticket-checkout-create/__tests__/orch1072_experience_occurrence_checkout.test.ts` | 5/5 PASS |
+
+**Fails-on-revert verified at `59496eaab` (base):**
+- Cover-not-fabricated: removing the `coverMediaUrl` carry from the discover envelope → supply T-03 FAILS.
+- Date-occurrence checkout: removing the PI-metadata persist → checkout T-A4 + T-A5 FAIL.
+- Sold-out rejection: removing the `occurrence_not_available` 422 → checkout T-A3 FAILS.
+All restored green after.
+
+**No locked tests modified.** ORCH-1065 suite (22 tests) + ORCH-1065 checkout (3) re-run green.
+
+---
+
+## Live read-only probe (Supabase MCP, no mutation)
+
+Ran the new RPC's query body against live remote data:
+- Remote migration head = `20260907000000` (no remote-only rows; `20260908000000` is next).
+- `events.cover_media_url`, `events.description`, `ticket_checkout_sessions.metadata` all exist.
+- Live experience **Raleigh Wine and Dine Crawl** returns a real Cloudinary `.mp4` cover (`cover_media_type='video'`), a real description, and a `{event_date_id, start_at, end_at, capacity:20, sold:0, remaining:20}` occurrence — proving the video-cover + description + availability path end-to-end. **DC Evening Crawl** (unlimited) returns `remaining: null` (no sold-out chip).
+
+---
+
+## Gates
+
+- `deno check`: discover-cards, generate-curated-experiences, ticket-checkout-create — all CLEAN.
+- `tsc --noEmit` (app-mobile): no NEW errors in any touched file (pre-existing unrelated errors only: `applePay` config L253, Deno test files mis-picked-up, legacy `LockedPlanBanner`/`BoardDiscussion`).
+- ORCH-0863 C7 strict-grep gate: PASS (15 backend files, all allowlisted).
+
+---
+
+## Files changed
+
+**Backend:** `supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql` (NEW), `supabase/functions/discover-cards/index.ts`, `supabase/functions/generate-curated-experiences/index.ts`, `supabase/functions/ticket-checkout-create/index.ts`, 2 new test files, `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs`.
+**Client:** `app-mobile/src/services/deckService.ts`, `app-mobile/src/types/mergedDiscover.ts`, `app-mobile/src/components/SwipeableCards.tsx`, `app-mobile/src/components/CuratedExperienceSwipeCard.tsx`, `app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx`, `app-mobile/src/payments/nativeCheckoutFlow.ts`, + 2 new components (`ExperienceOccurrencePicker.tsx`, `ExperienceItinerary.tsx`).
+
+---
+
+## Deploy commands (for the orchestrator)
+
+1. **Migration (operator runs `db push`):**
+```bash
+cd "/Users/sethogieva/Desktop/mingla-orchs/tmp-business-metro" && /Users/sethogieva/bin/supabase db push --linked
+```
+(Standard `--linked`, NOT `--include-all`: prefix `20260908000000` is in-order, one above the remote head `20260907000000`. The migration DROPs + re-creates the RPC additively; verified read-only that the query body executes against the live schema.)
+
+2. **Edge functions (after the migration lands + close promotes to main):**
+```bash
+supabase functions deploy discover-cards --project-ref gqnoajqerqhnvulmnyvv
+supabase functions deploy generate-curated-experiences --project-ref gqnoajqerqhnvulmnyvv
+supabase functions deploy ticket-checkout-create --project-ref gqnoajqerqhnvulmnyvv
+```
+`ticket-checkout-create` keeps `verify_jwt` as configured (no change). Verify-first-call each with a curl returning non-404 after deploy.
+
+3. **Client (app-mobile):** pure-JS change → rides an `eas update` per-platform (ios then android) on close, or the next build.
+
+---
+
+## Discoveries for orchestrator
+
+- **D-1 (carried from investigation, consumer sold-out gap, P1-class):** `TicketCartSheet` still gates sold-out only on configured `quantity_total ≤ 0`, not on live `remaining`. ORCH-1072 surfaces remaining per-occurrence in the PICKER (sold-out occurrences disabled), but the cart's per-tier "+" cap is still the static `quantity_total`. The authoritative backstop remains the 409 at Pay + the new occurrence 422. A full consumer adoption of `pg_public_ticket_types_remaining` into `publicEventTicketsService` is still its own ORCH (investigation D-1). Not absorbed here.
+- **D-2:** the booked occurrence is recorded on PI/session metadata, not a dedicated `orders.event_date_id` column. If per-occurrence reporting/scanning is needed, register a follow-up to add the column + thread the session/finalize RPCs.

--- a/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
+++ b/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
@@ -217,20 +217,20 @@ interface Props {
   currencyCode?: string;
   // ORCH-1065: present ONLY for brand experiences. Curated callers omit both →
   // byte-identical render (SC-13).
-  // ORCH-1072: carries the experience's REAL cover so the card hero shows the
-  // cover (image/video) with the stop photos as a strip below — not the stop
-  // strip AS the hero. Curated callers omit it → unchanged stop-strip hero.
-  brandExperience?: {
-    brandName: string;
-    brandLogoUrl: string | null;
-    coverMediaUrl?: string | null;
-    coverMediaType?: 'image' | 'video' | 'gif' | null;
+  brandExperience?: { brandName: string; brandLogoUrl: string | null };
+  // ORCH-1072: the experience's REAL cover (separate prop so the ORCH-1065
+  // brandExperience contract stays byte-identical). When present, the card hero
+  // shows the cover (image/video) with the stop photos as a strip below — not
+  // the stop strip AS the hero. Curated callers omit it → unchanged stop-strip.
+  experienceCover?: {
+    coverMediaUrl: string | null;
+    coverMediaType: 'image' | 'video' | 'gif' | null;
     coverHue?: number;
   };
   ctaOverride?: string;
 }
 
-export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measurementSystem, currencyCode, brandExperience, ctaOverride }: Props) {
+export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measurementSystem, currencyCode, brandExperience, experienceCover, ctaOverride }: Props) {
   const { t } = useTranslation(['common']);
   const insets = useSafeAreaInsets();
   // ORCH-0991: deck is full-bleed under the floating glass top bar (HomePage safeArea has
@@ -314,8 +314,8 @@ export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measur
   // smaller strip BELOW it. Curated cards (no cover prop) keep the full-bleed
   // stop strip hero unchanged (SC-13). The experience cover-fallback (no cover
   // url) also keeps the stop-strip hero so a cover-less experience still renders.
-  const coverUrl = brandExperience?.coverMediaUrl ?? null;
-  const coverType = brandExperience?.coverMediaType ?? null;
+  const coverUrl = experienceCover?.coverMediaUrl ?? null;
+  const coverType = experienceCover?.coverMediaType ?? null;
   const showCoverHero =
     isBrandExperience && typeof coverUrl === 'string' && coverUrl.length > 0;
 
@@ -329,7 +329,7 @@ export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measur
             {/* Cover hero — the experience's real cover (image/video/gif). */}
             <View style={styles.coverHeroMedia}>
               <EventCoverMedia
-                hue={brandExperience?.coverHue}
+                hue={experienceCover?.coverHue}
                 mediaUrl={coverUrl}
                 mediaType={coverType}
                 autoplay

--- a/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
+++ b/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet, Platform, AccessibilityInfo } from 'react-native';
+// ORCH-1072: the experience card hero renders the brand's REAL cover (image OR
+// video) via the SAME shared component the detail sheet + public event page use
+// (expo-video, muted/autoplay per the event-card contract). One source of truth
+// for cover rendering — never a parallel video player.
+import { EventCoverMedia } from '@mingla/event-rendering';
 // ORCH-1042: curated stop photos render via expo-image (NOT react-native <Image>)
 // so each stop gets a placeholder + fade transition + memory-disk cache +
 // recyclingKey + an onError fallback (this path previously had NO fallback at all
@@ -212,7 +217,16 @@ interface Props {
   currencyCode?: string;
   // ORCH-1065: present ONLY for brand experiences. Curated callers omit both →
   // byte-identical render (SC-13).
-  brandExperience?: { brandName: string; brandLogoUrl: string | null };
+  // ORCH-1072: carries the experience's REAL cover so the card hero shows the
+  // cover (image/video) with the stop photos as a strip below — not the stop
+  // strip AS the hero. Curated callers omit it → unchanged stop-strip hero.
+  brandExperience?: {
+    brandName: string;
+    brandLogoUrl: string | null;
+    coverMediaUrl?: string | null;
+    coverMediaType?: 'image' | 'video' | 'gif' | null;
+    coverHue?: number;
+  };
   ctaOverride?: string;
 }
 
@@ -295,28 +309,80 @@ export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measur
     ? categoryLabel
     : `${categoryLabel} · ${visibleStops.length} stops`;
 
+  // ORCH-1072: an experience with a real cover renders the COVER as the hero
+  // (image/video via the shared EventCoverMedia) with the stop photos as a
+  // smaller strip BELOW it. Curated cards (no cover prop) keep the full-bleed
+  // stop strip hero unchanged (SC-13). The experience cover-fallback (no cover
+  // url) also keeps the stop-strip hero so a cover-less experience still renders.
+  const coverUrl = brandExperience?.coverMediaUrl ?? null;
+  const coverType = brandExperience?.coverMediaType ?? null;
+  const showCoverHero =
+    isBrandExperience && typeof coverUrl === 'string' && coverUrl.length > 0;
+
   return (
     <View style={styles.card}>
-      {/* Image section (88%) — multi-photo strip with overlay chrome */}
+      {/* Image section (88%) — cover hero + stop strip (experience) OR full stop
+          strip (curated / cover-less experience). */}
       <View style={styles.imageContainer}>
-        <View style={styles.imageStrip}>
-          {visibleStops.map((stop, idx) => (
-            <View key={`${stop.placeId}_${idx}`} style={styles.imageWrapper}>
-              {stop.imageUrl ? (
-                <CuratedStopImage uri={stop.imageUrl} />
-              ) : (
-                <View style={[styles.stopImage, styles.imagePlaceholder]} />
-              )}
-              {!isSingleStop && (
-                <View style={[styles.stopBadgeWrapper, { top: stopBadgeTop }]}>
-                  <GlassBadge variant="circular" accessibilityLabel={`Stop ${idx + 1}`}>
-                    {idx + 1}
-                  </GlassBadge>
-                </View>
-              )}
+        {showCoverHero ? (
+          <View style={styles.coverHeroSection}>
+            {/* Cover hero — the experience's real cover (image/video/gif). */}
+            <View style={styles.coverHeroMedia}>
+              <EventCoverMedia
+                hue={brandExperience?.coverHue}
+                mediaUrl={coverUrl}
+                mediaType={coverType}
+                autoplay
+                muted
+                loop
+                radius={0}
+                height="100%"
+                width="100%"
+                label={card.title}
+              />
             </View>
-          ))}
-        </View>
+            {/* Stop strip — smaller row of stop photos beneath the cover. */}
+            {visibleStops.length > 0 ? (
+              <View style={styles.stopStripRow}>
+                {visibleStops.map((stop, idx) => (
+                  <View key={`${stop.placeId}_${idx}`} style={styles.stopStripCell}>
+                    {stop.imageUrl ? (
+                      <CuratedStopImage uri={stop.imageUrl} />
+                    ) : (
+                      <View style={[styles.stopImage, styles.imagePlaceholder]} />
+                    )}
+                    {!isSingleStop && (
+                      <View style={styles.stopStripBadge}>
+                        <GlassBadge variant="circular" accessibilityLabel={`Stop ${idx + 1}`}>
+                          {idx + 1}
+                        </GlassBadge>
+                      </View>
+                    )}
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </View>
+        ) : (
+          <View style={styles.imageStrip}>
+            {visibleStops.map((stop, idx) => (
+              <View key={`${stop.placeId}_${idx}`} style={styles.imageWrapper}>
+                {stop.imageUrl ? (
+                  <CuratedStopImage uri={stop.imageUrl} />
+                ) : (
+                  <View style={[styles.stopImage, styles.imagePlaceholder]} />
+                )}
+                {!isSingleStop && (
+                  <View style={[styles.stopBadgeWrapper, { top: stopBadgeTop }]}>
+                    <GlassBadge variant="circular" accessibilityLabel={`Stop ${idx + 1}`}>
+                      {idx + 1}
+                    </GlassBadge>
+                  </View>
+                )}
+              </View>
+            ))}
+          </View>
+        )}
 
         {/* ORCH-1065: brand badge (top-left, below the stop-badge baseline) —
             only when this is a brand experience. */}
@@ -422,6 +488,32 @@ const styles = StyleSheet.create({
   imageStrip: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: 'row',
+  },
+  // ORCH-1072: cover hero (top) + stop strip (bottom) for brand experiences.
+  coverHeroSection: {
+    ...StyleSheet.absoluteFillObject,
+    flexDirection: 'column',
+  },
+  coverHeroMedia: {
+    flex: 0.74, // cover takes ~3/4 of the image section
+    width: '100%',
+    backgroundColor: '#1C1C1E',
+    overflow: 'hidden',
+  },
+  stopStripRow: {
+    flex: 0.26, // stop photos as a smaller strip beneath the cover
+    flexDirection: 'row',
+  },
+  stopStripCell: {
+    flex: 1,
+    position: 'relative',
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: 'rgba(0,0,0,0.25)',
+  },
+  stopStripBadge: {
+    position: 'absolute',
+    top: 6,
+    left: 6,
   },
   imageWrapper: {
     flex: 1,

--- a/app-mobile/src/components/SwipeableCards.tsx
+++ b/app-mobile/src/components/SwipeableCards.tsx
@@ -2819,8 +2819,10 @@ export default function SwipeableCards({
                     brandExperience={{
                       brandName: (currentRec as any).brandName,
                       brandLogoUrl: (currentRec as any).brandLogoUrl ?? null,
-                      // ORCH-1072: real cover → card hero (image/video) with the
-                      // stop photos as a strip below (CuratedExperienceSwipeCard).
+                    }}
+                    // ORCH-1072: real cover → card hero (image/video) with the
+                    // stop photos as a strip below (CuratedExperienceSwipeCard).
+                    experienceCover={{
                       coverMediaUrl: (currentRec as any).coverMediaUrl ?? null,
                       coverMediaType: (currentRec as any).coverMediaType ?? null,
                       coverHue: hueFromId(String((currentRec as any).eventId ?? (currentRec as any).id ?? '')),

--- a/app-mobile/src/components/SwipeableCards.tsx
+++ b/app-mobile/src/components/SwipeableCards.tsx
@@ -140,9 +140,28 @@ function experienceRecToBusinessEventCard(rec: any): BusinessEventCard {
     brandProfilePhotoUrl: typeof rec?.brandLogoUrl === 'string' ? rec.brandLogoUrl : null,
     eventSlug,
     title: typeof rec?.title === 'string' ? rec.title : '',
-    description: typeof rec?.tagline === 'string' && rec.tagline.length > 0 ? rec.tagline : null,
-    coverMediaUrl: firstStop?.imageUrl ?? null,
-    coverMediaType: 'image',
+    // ORCH-1072: use the experience's REAL description (events.description),
+    // NOT the one-line tagline. Empty → null → the sheet shows its empty-state.
+    description:
+      typeof rec?.description === 'string' && rec.description.trim().length > 0
+        ? rec.description
+        : null,
+    // ORCH-1072: use the experience's REAL cover (image OR video), NOT the
+    // fabricated first-stop image + hardcoded 'image'. EventCoverMedia in the
+    // shared render layer plays video/gif/image. Falls back to the first stop
+    // image only when the experience has no cover at all (honest fallback).
+    coverMediaUrl:
+      typeof rec?.coverMediaUrl === 'string' && rec.coverMediaUrl.length > 0
+        ? rec.coverMediaUrl
+        : (firstStop?.imageUrl ?? null),
+    coverMediaType:
+      rec?.coverMediaType === 'image' ||
+      rec?.coverMediaType === 'video' ||
+      rec?.coverMediaType === 'gif'
+        ? rec.coverMediaType
+        : (typeof rec?.coverMediaUrl === 'string' && rec.coverMediaUrl.length > 0
+            ? 'image'
+            : (firstStop?.imageUrl ? 'image' : null)),
     coverHue: hueFromId(eventId),
     masterDateUtc: rec?.masterDateUtc ?? null,
     masterEndAtUtc: rec?.masterEndAtUtc ?? null,
@@ -167,6 +186,29 @@ function experienceRecToBusinessEventCard(rec: any): BusinessEventCard {
     displayCurrency: null,
     currency: typeof rec?.currency === 'string' ? rec.currency : 'USD',
     publicBuyerUrl: `https://business.usemingla.com/e/${brandSlug}/${eventSlug}`,
+    // ORCH-1072: carry the multi-stop itinerary + upcoming occurrences so the
+    // detail sheet renders the route + the date picker. Experience-only (an
+    // event/trip card never sets these → undefined → no itinerary/picker).
+    experienceStops: Array.isArray(rec?.stops)
+      ? rec.stops.map((s: any) => ({
+          stopNumber: typeof s?.stopNumber === 'number' ? s.stopNumber : 0,
+          placeName: typeof s?.placeName === 'string' && s.placeName.length > 0 ? s.placeName : null,
+          address: typeof s?.address === 'string' && s.address.length > 0 ? s.address : null,
+          imageUrl: typeof s?.imageUrl === 'string' && s.imageUrl.length > 0 ? s.imageUrl : null,
+          aiDescription:
+            typeof s?.aiDescription === 'string' && s.aiDescription.length > 0 ? s.aiDescription : null,
+        }))
+      : undefined,
+    upcomingOccurrences: Array.isArray(rec?.upcomingOccurrences)
+      ? rec.upcomingOccurrences.map((o: any) => ({
+          eventDateId: typeof o?.eventDateId === 'string' ? o.eventDateId : '',
+          startAt: typeof o?.startAt === 'string' ? o.startAt : '',
+          endAt: typeof o?.endAt === 'string' ? o.endAt : '',
+          capacity: typeof o?.capacity === 'number' ? o.capacity : null,
+          sold: typeof o?.sold === 'number' ? o.sold : 0,
+          remaining: typeof o?.remaining === 'number' ? o.remaining : null,
+        }))
+      : undefined,
   } as unknown as BusinessEventCard;
 }
 
@@ -2777,6 +2819,11 @@ export default function SwipeableCards({
                     brandExperience={{
                       brandName: (currentRec as any).brandName,
                       brandLogoUrl: (currentRec as any).brandLogoUrl ?? null,
+                      // ORCH-1072: real cover → card hero (image/video) with the
+                      // stop photos as a strip below (CuratedExperienceSwipeCard).
+                      coverMediaUrl: (currentRec as any).coverMediaUrl ?? null,
+                      coverMediaType: (currentRec as any).coverMediaType ?? null,
+                      coverHue: hueFromId(String((currentRec as any).eventId ?? (currentRec as any).id ?? '')),
                     }}
                     ctaOverride="Book"
                   />

--- a/app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx
+++ b/app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx
@@ -67,6 +67,13 @@ import { glass } from "../../constants/designSystem";
 import TicketCartSheet, {
   type TicketCartCheckoutPayload,
 } from "./TicketCartSheet";
+// ORCH-1072 — experience occurrence picker (PICK FROM UPCOMING DATES) +
+// the multi-stop itinerary section rendered beneath the cover/description.
+import {
+  ExperienceOccurrencePicker,
+  type ExperienceOccurrence,
+} from "./ExperienceOccurrencePicker";
+import { ExperienceItinerary } from "./ExperienceItinerary";
 
 interface ExpandedBusinessEventSheetProps {
   visible: boolean;
@@ -108,7 +115,37 @@ export const mapCardToPublicEvent = (
     timezone: card.timezone,
   }),
   dateSubline: null,
-  datesList: [],
+  // ORCH-1072 — for a brand experience with upcoming occurrences, render the
+  // real upcoming dates in PublicEventPage's existing dates list (the consumer
+  // sheet previously hardcoded []). Events/trips (no upcomingOccurrences) keep
+  // the empty list → unchanged. Multi-date booking happens via the dedicated
+  // occurrence picker that opens on the Book tap (operator-locked flow).
+  datesList: Array.isArray(card.upcomingOccurrences)
+    ? card.upcomingOccurrences
+        .map((o) => {
+          const d = new Date(o.startAt);
+          if (Number.isNaN(d.getTime())) return null;
+          try {
+            return new Intl.DateTimeFormat(undefined, {
+              weekday: "short",
+              day: "numeric",
+              month: "short",
+              hour: "numeric",
+              minute: "2-digit",
+              timeZone: card.timezone || "UTC",
+            }).format(d);
+          } catch {
+            return new Intl.DateTimeFormat(undefined, {
+              weekday: "short",
+              day: "numeric",
+              month: "short",
+              hour: "numeric",
+              minute: "2-digit",
+            }).format(d);
+          }
+        })
+        .filter((s): s is string => s !== null)
+    : [],
   status: "published",
   endedAt: null,
   // ORCH-0846: honor server-derived format instead of hardcoding "in-person".
@@ -177,6 +214,30 @@ export const ExpandedBusinessEventSheet: React.FC<
   const [cartSheetVisible, setCartSheetVisible] = useState<boolean>(false);
   const [initialTicketTypeId, setInitialTicketTypeId] = useState<string | null>(
     null,
+  );
+  // ORCH-1072 — occurrence-picker state. For a brand experience with >1 upcoming
+  // occurrence, the Book tap opens the date picker; the chosen event_date_id is
+  // threaded into ticket-checkout-create. A one-off experience auto-selects its
+  // single date and skips the picker. Events/trips (no upcomingOccurrences)
+  // never touch this state → unchanged path.
+  const [occurrencePickerVisible, setOccurrencePickerVisible] =
+    useState<boolean>(false);
+  const [selectedEventDateId, setSelectedEventDateId] = useState<string | null>(
+    null,
+  );
+
+  // ORCH-1072 — the experience's bookable upcoming occurrences (undefined for
+  // events/trips). Sold-out occurrences (remaining === 0) are excluded from the
+  // auto-select / "single occurrence" logic but still shown disabled in the
+  // picker so the buyer sees them.
+  const occurrences: ExperienceOccurrence[] = useMemo(
+    () =>
+      Array.isArray(data.upcomingOccurrences) ? data.upcomingOccurrences : [],
+    [data.upcomingOccurrences],
+  );
+  const bookableOccurrences = useMemo(
+    () => occurrences.filter((o) => o.remaining === null || o.remaining > 0),
+    [occurrences],
   );
 
   const ticketsQuery = usePublicEventTickets(visible ? data.eventId : null);
@@ -277,6 +338,12 @@ export const ExpandedBusinessEventSheet: React.FC<
           ...(payload.intakeFormData.length > 0
             ? { intakeFormData: payload.intakeFormData }
             : {}),
+          // ORCH-1072 — thread the chosen occurrence into ticket-checkout-create
+          // so a recurring/multi-date experience books the right date. Omitted
+          // for events/trips/one-off-with-no-id → byte-identical to today.
+          ...(selectedEventDateId !== null
+            ? { eventDateId: selectedEventDateId }
+            : {}),
         });
       } catch (err) {
         // ORCH-0829-B D-1 H-2: runNativeCheckout's contract is to return a
@@ -334,6 +401,7 @@ export const ExpandedBusinessEventSheet: React.FC<
       profile,
       runNativeCheckout,
       data.eventId,
+      selectedEventDateId,
       queryClient,
       onClose,
     ],
@@ -353,6 +421,43 @@ export const ExpandedBusinessEventSheet: React.FC<
   const handleCartCancel = useCallback((): void => {
     setCartSheetVisible(false);
     setInitialTicketTypeId(null);
+  }, []);
+
+  // ORCH-1072 — Book tap entry point. Decides the occurrence step:
+  //   • >1 bookable occurrence → open the date picker (buyer picks, then cart).
+  //   • exactly 1 occurrence    → auto-select it, skip straight to the cart
+  //                               (one-off experience — operator-locked).
+  //   • 0 occurrences (event/trip, or experience the supply didn't carry dates
+  //     for) → open the cart with no event_date_id (byte-identical to today).
+  const beginBooking = useCallback(
+    (ticketId: string): void => {
+      setInitialTicketTypeId(ticketId);
+      if (bookableOccurrences.length > 1) {
+        setSelectedEventDateId(null);
+        setOccurrencePickerVisible(true);
+        return;
+      }
+      if (bookableOccurrences.length === 1) {
+        setSelectedEventDateId(bookableOccurrences[0].eventDateId);
+      } else {
+        setSelectedEventDateId(null);
+      }
+      setCartSheetVisible(true);
+    },
+    [bookableOccurrences],
+  );
+
+  // ORCH-1072 — the picker chose a date → carry it + open the cart for qty/pay.
+  const handleOccurrenceSelect = useCallback((eventDateId: string): void => {
+    setSelectedEventDateId(eventDateId);
+    setOccurrencePickerVisible(false);
+    setCartSheetVisible(true);
+  }, []);
+
+  const handleOccurrenceCancel = useCallback((): void => {
+    setOccurrencePickerVisible(false);
+    setInitialTicketTypeId(null);
+    setSelectedEventDateId(null);
   }, []);
 
   const callbacks: PublicEventCallbacks = useMemo(
@@ -375,13 +480,13 @@ export const ExpandedBusinessEventSheet: React.FC<
       // the assembled cart payload. I-PROPOSED-TICKET-CLAIM-CONFIRMATION-REQUIRED
       // is preserved — the sheet IS the confirmation step (richer surface
       // than the prior single-ticket modal).
+      // ORCH-1072 — route through beginBooking so a multi-date experience opens
+      // the occurrence picker first; one-off + events/trips go straight to cart.
       onBuyTicket: (ticketId: string) => {
-        setInitialTicketTypeId(ticketId);
-        setCartSheetVisible(true);
+        beginBooking(ticketId);
       },
       onClaimFreeTicket: (ticketId: string) => {
-        setInitialTicketTypeId(ticketId);
-        setCartSheetVisible(true);
+        beginBooking(ticketId);
       },
       onJoinWaitlist: (_ticketId: string) => {
         toastManager.show("Waitlist coming soon.", "info");
@@ -390,7 +495,7 @@ export const ExpandedBusinessEventSheet: React.FC<
         toastManager.show("Request-to-attend coming soon.", "info");
       },
     }),
-    [router, onClose],
+    [router, onClose, beginBooking],
   );
 
   // META-ORCH-0991 (sheet rework — Bug 2): inject gorhom's BottomSheetScrollView
@@ -407,6 +512,13 @@ export const ExpandedBusinessEventSheet: React.FC<
   // ScrollComponent is now a NON-scroll passthrough (a plain View carrying
   // PublicEventPage's contentContainerStyle + a home-indicator spacer). The page
   // content thus renders directly inside the primitive's bare scroll.
+  // ORCH-1072 — the experience's multi-stop itinerary, rendered beneath
+  // PublicEventPage's content inside the same scroll host. Empty for events/trips
+  // (experienceStops undefined) → nothing renders → unchanged layout.
+  const itineraryStops = useMemo(
+    () => (Array.isArray(data.experienceStops) ? data.experienceStops : []),
+    [data.experienceStops],
+  );
   const SheetScrollHost = useMemo(() => {
     const bottomPad =
       Math.max(8, bottomContentInset) + Math.max(0, bottomSheetInset);
@@ -416,12 +528,14 @@ export const ExpandedBusinessEventSheet: React.FC<
     }) => (
       <View style={contentContainerStyle}>
         {children}
+        {/* ORCH-1072 — itinerary section (experience-only). */}
+        <ExperienceItinerary stops={itineraryStops} />
         <View style={{ height: bottomPad }} pointerEvents="none" />
       </View>
     );
     Host.displayName = "EbesPassthroughHost";
     return Host;
-  }, [bottomContentInset, bottomSheetInset]);
+  }, [bottomContentInset, bottomSheetInset, itineraryStops]);
 
   // META-ORCH-0991 Wave A — migrated onto BaseBottomSheet. Declarative
   // `visible` + initialIndex=1 (90% snap) replicate the proven inline
@@ -485,6 +599,16 @@ export const ExpandedBusinessEventSheet: React.FC<
         clearFloatingNav={false}
         onCancel={handleCartCancel}
         onCheckout={handleCartCheckout}
+      />
+      {/* ORCH-1072 — occurrence picker (PICK FROM UPCOMING DATES). Renders as a
+          sibling BaseBottomSheet; only opened for an experience with >1 bookable
+          occurrence. One-off experiences + events/trips never open it. */}
+      <ExperienceOccurrencePicker
+        visible={occurrencePickerVisible}
+        occurrences={occurrences}
+        timezone={data.timezone}
+        onCancel={handleOccurrenceCancel}
+        onSelect={handleOccurrenceSelect}
       />
     </>
   );

--- a/app-mobile/src/components/expandedCard/ExperienceItinerary.tsx
+++ b/app-mobile/src/components/expandedCard/ExperienceItinerary.tsx
@@ -1,0 +1,140 @@
+/**
+ * ExperienceItinerary — ORCH-1072 [experience-detail-cover-availability].
+ *
+ * Renders a brand experience's multi-stop itinerary (route) beneath the cover +
+ * description in the detail sheet. Read-only; pure presentation of the stops the
+ * card already carries (no fetch, no money). Hidden when the experience has no
+ * stops (an event/trip never passes any → nothing renders).
+ *
+ * Dark-mode vocabulary matches the consumer sheet (#0c0e12 canvas).
+ */
+
+import React from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
+
+export interface ItineraryStop {
+  stopNumber: number;
+  placeName: string | null;
+  address: string | null;
+  imageUrl: string | null;
+  aiDescription: string | null;
+}
+
+export interface ExperienceItineraryProps {
+  stops: ReadonlyArray<ItineraryStop>;
+}
+
+export const ExperienceItinerary: React.FC<ExperienceItineraryProps> = ({
+  stops,
+}) => {
+  if (!stops || stops.length === 0) return null;
+  return (
+    <View style={styles.wrap} accessibilityLabel="Experience itinerary">
+      <Text style={styles.sectionLabel}>THE ITINERARY</Text>
+      {stops.map((stop, idx) => (
+        <View key={`${stop.stopNumber}_${idx}`} style={styles.stopRow}>
+          <View style={styles.numberCol}>
+            <View style={styles.numberDisc}>
+              <Text style={styles.numberText}>{idx + 1}</Text>
+            </View>
+            {idx < stops.length - 1 ? <View style={styles.connector} /> : null}
+          </View>
+          <View style={styles.stopBody}>
+            {stop.imageUrl ? (
+              <Image
+                source={{ uri: stop.imageUrl }}
+                style={styles.stopImage}
+                resizeMode="cover"
+              />
+            ) : null}
+            <Text style={styles.stopName} numberOfLines={2}>
+              {stop.placeName ?? `Stop ${idx + 1}`}
+            </Text>
+            {stop.address ? (
+              <Text style={styles.stopAddress} numberOfLines={2}>
+                {stop.address}
+              </Text>
+            ) : null}
+            {stop.aiDescription ? (
+              <Text style={styles.stopDescription} numberOfLines={4}>
+                {stop.aiDescription}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: {
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 24,
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: "rgba(255, 255, 255, 0.52)",
+    letterSpacing: 1.4,
+    marginBottom: 16,
+  },
+  stopRow: {
+    flexDirection: "row",
+    gap: 14,
+  },
+  numberCol: {
+    alignItems: "center",
+    width: 28,
+  },
+  numberDisc: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "#eb7825",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  numberText: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#ffffff",
+  },
+  connector: {
+    flex: 1,
+    width: 2,
+    marginTop: 4,
+    marginBottom: 4,
+    backgroundColor: "rgba(255, 255, 255, 0.14)",
+  },
+  stopBody: {
+    flex: 1,
+    paddingBottom: 20,
+  },
+  stopImage: {
+    width: "100%",
+    height: 150,
+    borderRadius: 12,
+    marginBottom: 10,
+    backgroundColor: "#1C1C1E",
+  },
+  stopName: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "rgba(255, 255, 255, 0.96)",
+    marginBottom: 4,
+  },
+  stopAddress: {
+    fontSize: 13,
+    color: "rgba(255, 255, 255, 0.55)",
+    marginBottom: 6,
+  },
+  stopDescription: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "rgba(255, 255, 255, 0.72)",
+  },
+});
+
+export default ExperienceItinerary;

--- a/app-mobile/src/components/expandedCard/ExperienceOccurrencePicker.tsx
+++ b/app-mobile/src/components/expandedCard/ExperienceOccurrencePicker.tsx
@@ -1,0 +1,300 @@
+/**
+ * ExperienceOccurrencePicker — ORCH-1072 [experience-detail-cover-availability].
+ *
+ * Operator-locked flow (PICK FROM UPCOMING DATES): a brand experience's Book
+ * sheet first lets the buyer pick from upcoming occurrences (from event_dates),
+ * each showing its remaining capacity. Tapping a date selects it; the parent
+ * then opens the existing TicketCartSheet for quantity → pay with the chosen
+ * event_date_id threaded into ticket-checkout-create.
+ *
+ * - A ONE-OFF experience (single occurrence) never reaches this sheet — the
+ *   parent auto-selects the only date and skips straight to the cart.
+ * - Sold-out occurrences (remaining === 0) render DISABLED.
+ * - remaining === null ⇒ unlimited → no remaining chip, always selectable.
+ *
+ * Reuses BaseBottomSheet + the dark sheet vocabulary from TicketCartSheet (no
+ * new sheet framework). This is a SELECTION surface only — it owns no money.
+ */
+
+import React, { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import * as Haptics from "expo-haptics";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { BaseBottomSheet } from "../ui/BaseBottomSheet";
+import { Icon } from "../ui/Icon";
+import { BOTTOM_NAV_CONTENT_HEIGHT } from "../../hooks/useAppLayout";
+
+export interface ExperienceOccurrence {
+  eventDateId: string;
+  startAt: string;
+  endAt: string;
+  capacity: number | null;
+  sold: number;
+  remaining: number | null;
+}
+
+export interface ExperienceOccurrencePickerProps {
+  visible: boolean;
+  occurrences: ReadonlyArray<ExperienceOccurrence>;
+  timezone: string;
+  onCancel: () => void;
+  /** Fires with the chosen occurrence's event_date_id. */
+  onSelect: (eventDateId: string) => void;
+}
+
+const SHEET_SNAP_POINTS = ["72%"];
+
+/** Format an occurrence's start instant in the experience's timezone. */
+const formatOccurrence = (startAt: string, timezone: string): string => {
+  const d = new Date(startAt);
+  if (Number.isNaN(d.getTime())) return "Date TBA";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: timezone || "UTC",
+    }).format(d);
+  } catch {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(d);
+  }
+};
+
+/** The remaining-capacity chip copy for one occurrence. */
+const remainingLabel = (remaining: number | null): string | null => {
+  if (remaining === null) return null; // unlimited → no chip
+  if (remaining <= 0) return "Sold out";
+  if (remaining <= 10) return `${remaining} left`;
+  return "Available";
+};
+
+export const ExperienceOccurrencePicker: React.FC<
+  ExperienceOccurrencePickerProps
+> = ({ visible, occurrences, timezone, onCancel, onSelect }) => {
+  const insets = useSafeAreaInsets();
+
+  const rows = useMemo(
+    () =>
+      occurrences.map((o) => ({
+        ...o,
+        label: formatOccurrence(o.startAt, timezone),
+        remainingText: remainingLabel(o.remaining),
+        soldOut: o.remaining !== null && o.remaining <= 0,
+      })),
+    [occurrences, timezone],
+  );
+
+  const handlePick = (eventDateId: string, soldOut: boolean): void => {
+    if (soldOut) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onSelect(eventDateId);
+  };
+
+  return (
+    <BaseBottomSheet
+      visible={visible}
+      onClose={onCancel}
+      theme="dark"
+      snapPoints={SHEET_SNAP_POINTS}
+      backgroundStyle={styles.sheetBackground}
+      handleStyle={styles.handleIndicator}
+      accessibilityLabel="Pick a date"
+      scrollMode="scroll"
+      hidesBottomNav
+      scrollProps={{
+        contentContainerStyle: [
+          styles.scrollContent,
+          {
+            paddingBottom:
+              BOTTOM_NAV_CONTENT_HEIGHT + Math.max(insets.bottom, 16),
+          },
+        ],
+        showsVerticalScrollIndicator: false,
+      }}
+    >
+      <View style={styles.headerRow}>
+        <Text style={styles.headerTitle}>Pick a date</Text>
+        <Pressable
+          style={styles.closeIcon}
+          accessibilityLabel="Close"
+          accessibilityRole="button"
+          hitSlop={12}
+          onPress={onCancel}
+        >
+          <Icon name="close" size={20} color="rgba(255,255,255,0.65)" />
+        </Pressable>
+      </View>
+      <Text style={styles.sectionLabel}>UPCOMING DATES</Text>
+      {rows.length === 0 ? (
+        <Text style={styles.emptyText}>No upcoming dates available.</Text>
+      ) : (
+        rows.map((row) => (
+          <Pressable
+            key={row.eventDateId}
+            onPress={() => handlePick(row.eventDateId, row.soldOut)}
+            disabled={row.soldOut}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: row.soldOut }}
+            accessibilityLabel={`${row.label}${
+              row.remainingText ? `, ${row.remainingText}` : ""
+            }`}
+            style={({ pressed }) => [
+              styles.dateRow,
+              row.soldOut && styles.dateRowDisabled,
+              pressed && !row.soldOut && styles.dateRowPressed,
+            ]}
+          >
+            <View style={styles.dateRowMain}>
+              <Text
+                style={[
+                  styles.dateLabel,
+                  row.soldOut && styles.dateLabelDisabled,
+                ]}
+                numberOfLines={1}
+              >
+                {row.label}
+              </Text>
+              {row.remainingText ? (
+                <Text
+                  style={[
+                    styles.remainingChip,
+                    row.soldOut
+                      ? styles.remainingChipSoldOut
+                      : (row.remaining ?? 99) <= 10
+                        ? styles.remainingChipLow
+                        : styles.remainingChipOk,
+                  ]}
+                >
+                  {row.remainingText}
+                </Text>
+              ) : null}
+            </View>
+            {!row.soldOut ? (
+              <Icon
+                name="chevron-forward"
+                size={18}
+                color="rgba(255,255,255,0.45)"
+              />
+            ) : null}
+          </Pressable>
+        ))
+      )}
+    </BaseBottomSheet>
+  );
+};
+
+const styles = StyleSheet.create({
+  sheetBackground: {
+    backgroundColor: "#15181f",
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+  },
+  handleIndicator: {
+    backgroundColor: "rgba(255, 255, 255, 0.35)",
+    width: 44,
+  },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 12,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    marginBottom: 16,
+  },
+  headerTitle: {
+    flex: 1,
+    color: "rgba(255, 255, 255, 0.96)",
+    fontSize: 20,
+    fontWeight: "700",
+    lineHeight: 26,
+  },
+  closeIcon: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 16,
+    backgroundColor: "rgba(255, 255, 255, 0.08)",
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: "rgba(255, 255, 255, 0.52)",
+    letterSpacing: 1.4,
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: "rgba(255, 255, 255, 0.65)",
+    paddingVertical: 16,
+  },
+  dateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    marginBottom: 10,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.10)",
+    backgroundColor: "rgba(255, 255, 255, 0.04)",
+  },
+  dateRowDisabled: {
+    opacity: 0.45,
+  },
+  dateRowPressed: {
+    backgroundColor: "rgba(255, 255, 255, 0.08)",
+  },
+  dateRowMain: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  dateLabel: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "600",
+    color: "rgba(255, 255, 255, 0.92)",
+  },
+  dateLabelDisabled: {
+    color: "rgba(255, 255, 255, 0.55)",
+  },
+  remainingChip: {
+    fontSize: 12,
+    fontWeight: "600",
+    overflow: "hidden",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 8,
+  },
+  remainingChipOk: {
+    color: "#34d399",
+    backgroundColor: "rgba(52, 211, 153, 0.14)",
+  },
+  remainingChipLow: {
+    color: "#fbbf24",
+    backgroundColor: "rgba(251, 191, 36, 0.14)",
+  },
+  remainingChipSoldOut: {
+    color: "#f87171",
+    backgroundColor: "rgba(248, 113, 113, 0.14)",
+  },
+});
+
+export default ExperienceOccurrencePicker;

--- a/app-mobile/src/payments/nativeCheckoutFlow.ts
+++ b/app-mobile/src/payments/nativeCheckoutFlow.ts
@@ -44,6 +44,10 @@ export interface NativeCheckoutInput {
   };
   idempotencyKey?: string;
   taxCalculationId?: string | null;
+  // ORCH-1072: the chosen experience occurrence (event_dates.id). Forwarded to
+  // ticket-checkout-create so a recurring/multi-date experience books the right
+  // date. Omitted for events/trips/one-off → request shape byte-identical.
+  eventDateId?: string | null;
   // ORCH-1016: trip intake answers ride the existing ticket-checkout-create body
   // key → orders.intake_form_data. The key is already supported server-side
   // (ticket-checkout-create reads it for trip checkouts); this just forwards it
@@ -142,6 +146,10 @@ export const useNativeCheckoutFlow = (): ((
             ? { intake_form_data: input.intakeFormData }
             : {}),
           ...(input.taxCalculationId ? { taxCalculationId: input.taxCalculationId } : {}),
+          // ORCH-1072: forward the chosen occurrence only when present — the
+          // edge fn validates it (future + belongs to event + not sold out) and
+          // persists it; absent → unchanged single-date path.
+          ...(input.eventDateId ? { eventDateId: input.eventDateId } : {}),
           ...(input.idempotencyKey !== undefined
             ? { idempotencyKey: input.idempotencyKey }
             : {}),

--- a/app-mobile/src/services/deckService.ts
+++ b/app-mobile/src/services/deckService.ts
@@ -250,7 +250,23 @@ export function unifiedCardToRecommendation(card: any): Recommendation {
 // because an experience envelope ALSO has stops[] + experienceType + tagline; the
 // discriminator is the explicit cardType:'experience' + brand attribution.
 function isExperiencePayload(card: any): boolean {
-  return card?.cardType === 'experience';
+  // Primary: the explicit discriminator the supply always sets.
+  if (card?.cardType === 'experience') return true;
+  // ORCH-1072 tag-loss hardening (investigation §A/B): a brand experience is
+  // structurally distinguishable from an AI-curated card — it carries a
+  // non-empty brandId + eventId + a stops[] array, whereas curated AI cards
+  // have stops + experienceType + tagline but NO brand attribution. If the
+  // explicit tag is ever lost upstream, recover it here so the card still
+  // routes to ExpandedBusinessEventSheet (Book), never the place/curated
+  // Save/Schedule branch. Curated cards (empty brandId) are NOT matched.
+  return (
+    card?.cardType !== 'curated' &&
+    typeof card?.brandId === 'string' &&
+    card.brandId.length > 0 &&
+    typeof card?.eventId === 'string' &&
+    card.eventId.length > 0 &&
+    Array.isArray(card?.stops)
+  );
 }
 
 // ORCH-1065: intent id → consumer-facing label (parity with curated intents).
@@ -322,6 +338,28 @@ function experienceCardToRecommendation(card: any): Recommendation {
     experienceType: intentId,
     title: typeof card?.title === 'string' ? card.title : '',
     tagline: typeof card?.tagline === 'string' ? card.tagline : '',
+    // ORCH-1072: carry the experience's REAL description + cover + upcoming
+    // occurrences verbatim onto the Recommendation (read via runtime cast in
+    // SwipeableCards.experienceRecToBusinessEventCard). These replace the
+    // fabricated first-stop cover + tagline-as-description in the mapper.
+    description: typeof card?.description === 'string' ? card.description : '',
+    coverMediaUrl: typeof card?.coverMediaUrl === 'string' ? card.coverMediaUrl : null,
+    coverMediaType:
+      card?.coverMediaType === 'image' ||
+      card?.coverMediaType === 'video' ||
+      card?.coverMediaType === 'gif'
+        ? card.coverMediaType
+        : null,
+    upcomingOccurrences: Array.isArray(card?.upcomingOccurrences)
+      ? card.upcomingOccurrences.map((o: any) => ({
+          eventDateId: typeof o?.eventDateId === 'string' ? o.eventDateId : '',
+          startAt: typeof o?.startAt === 'string' ? o.startAt : '',
+          endAt: typeof o?.endAt === 'string' ? o.endAt : '',
+          capacity: typeof o?.capacity === 'number' ? o.capacity : null,
+          sold: typeof o?.sold === 'number' ? o.sold : 0,
+          remaining: typeof o?.remaining === 'number' ? o.remaining : null,
+        }))
+      : [],
     brandId: typeof card?.brandId === 'string' ? card.brandId : '',
     brandName: typeof card?.brandName === 'string' ? card.brandName : '',
     brandSlug: typeof card?.brandSlug === 'string' ? card.brandSlug : '',

--- a/app-mobile/src/types/mergedDiscover.ts
+++ b/app-mobile/src/types/mergedDiscover.ts
@@ -78,6 +78,33 @@ export interface BusinessEventCard {
   currency: string;
   /** The anon-tolerant buyer route in mingla-business. Opened via in-app WebView. */
   publicBuyerUrl: string;
+  /**
+   * ORCH-1072 — present ONLY for brand experiences (event_type='experience').
+   * The multi-stop itinerary, rendered by the detail sheet beneath the cover +
+   * description. Undefined for events/trips → no itinerary section (byte-safe).
+   */
+  experienceStops?: Array<{
+    stopNumber: number;
+    placeName: string | null;
+    address: string | null;
+    imageUrl: string | null;
+    aiDescription: string | null;
+  }>;
+  /**
+   * ORCH-1072 — present ONLY for brand experiences. The experience's upcoming
+   * bookable occurrences (from event_dates), each with remaining capacity.
+   * A one-off experience carries a single element (auto-selected in the Book
+   * sheet); sold-out occurrences (remaining === 0) render disabled. remaining
+   * === null ⇒ unlimited. Undefined for events/trips (no occurrence picker).
+   */
+  upcomingOccurrences?: Array<{
+    eventDateId: string;
+    startAt: string;
+    endAt: string;
+    capacity: number | null;
+    sold: number;
+    remaining: number | null;
+  }>;
 }
 
 export type MergedDiscoverItem =

--- a/supabase/functions/discover-cards/__tests__/orch_1072_experience_detail_supply.test.ts
+++ b/supabase/functions/discover-cards/__tests__/orch_1072_experience_detail_supply.test.ts
@@ -1,0 +1,97 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// ORCH-1072 [experience-detail-cover-availability] — supply regression.
+//
+// The deck supply must now carry the experience's REAL cover (image/video) +
+// REAL description + UPCOMING OCCURRENCES (event_dates + remaining capacity)
+// through the migration RPC AND both edge envelopes (discover-cards +
+// generate-curated-experiences), so the consumer detail sheet renders the cover
+// + description + a date picker instead of the fabricated first-stop image +
+// tagline. Source-text + migration-SQL analysis (the fns call serve() at module
+// load + reach a service-role client, so they can't be unit-invoked) — the same
+// established pattern as orch_1065_experience_supply.test.ts.
+//
+// Fails-on-revert (LOCKED):
+//   T-01 fails if the migration drops cover_media_url/cover_media_type/
+//        description/upcoming_occurrences from the RETURNS TABLE.
+//   T-02 fails if the occurrence jsonb shape (event_date_id/remaining) is removed.
+//   T-03/T-04 fail if either edge envelope stops carrying the new fields.
+//   T-05 fails if the migration body is missing its terminal `;` before GRANT.
+
+const root = new URL("../../../..", import.meta.url).pathname;
+const migration = await Deno.readTextFile(
+  `${root}/supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql`,
+);
+const discover = await Deno.readTextFile(
+  `${root}/supabase/functions/discover-cards/index.ts`,
+);
+const curated = await Deno.readTextFile(
+  `${root}/supabase/functions/generate-curated-experiences/index.ts`,
+);
+
+Deno.test("ORCH-1072 T-01: migration RETURNS TABLE adds cover + description + occurrences (fails-on-revert)", () => {
+  // The RETURNS TABLE must expose the new additive columns.
+  assertStringIncludes(migration, "cover_media_url text");
+  assertStringIncludes(migration, "cover_media_type text");
+  assertStringIncludes(migration, "description text");
+  assertStringIncludes(migration, "upcoming_occurrences jsonb");
+  // And SELECT them from the events row / aggregate.
+  assertStringIncludes(migration, "e.cover_media_url");
+  assertStringIncludes(migration, "COALESCE(e.description, '')");
+});
+
+Deno.test("ORCH-1072 T-02: occurrence jsonb carries the bookable shape with remaining (fails-on-revert)", () => {
+  assertStringIncludes(migration, "'event_date_id', occ.id");
+  assertStringIncludes(migration, "'start_at',      occ.start_at");
+  assertStringIncludes(migration, "'remaining',     occ.ticket_remaining");
+  // Remaining must derive from quantity_total − sold (ORCH-0946 formula), and
+  // sold must count the SAME ticket statuses (valid/used/transferred).
+  assertStringIncludes(migration, "tt.quantity_total - COALESCE(");
+  assertStringIncludes(
+    migration,
+    "tk.status IN ('valid', 'used', 'transferred')",
+  );
+  // Bounded payload for never-ends/recurring experiences.
+  assertStringIncludes(migration, "occ.rn <= 12");
+});
+
+Deno.test("ORCH-1072 T-03: discover-cards envelope carries cover/description/occurrences (fails-on-revert)", () => {
+  assertStringIncludes(discover, "coverMediaUrl");
+  assertStringIncludes(discover, "coverMediaType");
+  assertStringIncludes(discover, "upcomingOccurrences");
+  // The mapper reads the RPC's snake_case columns.
+  assertStringIncludes(discover, "row.cover_media_url");
+  assertStringIncludes(discover, "row.upcoming_occurrences");
+  assertStringIncludes(discover, "mapExperienceOccurrences");
+});
+
+Deno.test("ORCH-1072 T-04: curated envelope carries the SAME new fields (no parallel system)", () => {
+  assertStringIncludes(curated, "coverMediaUrl");
+  assertStringIncludes(curated, "upcomingOccurrences");
+  assertStringIncludes(curated, "row.cover_media_url");
+  assertStringIncludes(curated, "mapExperienceOccurrences");
+});
+
+Deno.test("ORCH-1072 T-05: migration body ends with `;` before GRANT (CI baseline guard)", () => {
+  // A prior ORCH broke CI by omitting the function-body terminator. Assert the
+  // GRANT is preceded by `$function$;` (the closing + terminator).
+  assert(
+    /\$function\$;\s*GRANT EXECUTE ON FUNCTION public\.pg_eligible_experiences_for_deck/
+      .test(migration),
+    "migration must terminate the function body with `;` before the GRANT",
+  );
+});
+
+Deno.test("ORCH-1072 T-06: occurrence mapper drops malformed rows (no unbookable occurrence)", () => {
+  // The mapper must require event_date_id + start_at and filter nulls.
+  assertStringIncludes(discover, "eventDateId.length === 0 || startAt.length === 0");
+  // remaining stays null when unlimited (never fabricated to a number).
+  assertEquals(
+    discover.includes("typeof o?.remaining === 'number' ? o.remaining : null"),
+    true,
+  );
+});

--- a/supabase/functions/discover-cards/index.ts
+++ b/supabase/functions/discover-cards/index.ts
@@ -148,6 +148,12 @@ interface ExperienceDeckCard {
   experienceType: string;
   title: string;
   tagline: string;
+  // ORCH-1072: the experience's REAL description + cover (events.description /
+  // cover_media_url / cover_media_type) so the detail sheet renders the actual
+  // story + cover image/video, not the fabricated first-stop image + tagline.
+  description: string;
+  coverMediaUrl: string | null;
+  coverMediaType: 'image' | 'video' | 'gif' | null;
   brandId: string;
   brandName: string;
   brandSlug: string;
@@ -159,6 +165,17 @@ interface ExperienceDeckCard {
   masterDateUtc: string | null;
   masterEndAtUtc: string | null;
   timezone: string;
+  // ORCH-1072: upcoming occurrences for the Book sheet date picker. One-off
+  // experiences carry a single element (auto-selected); sold-out occurrences
+  // (remaining === 0) render disabled. remaining === null ⇒ unlimited.
+  upcomingOccurrences: Array<{
+    eventDateId: string;
+    startAt: string;
+    endAt: string;
+    capacity: number | null;
+    sold: number;
+    remaining: number | null;
+  }>;
   stops: Array<{
     stopNumber: number;
     placeId: string;
@@ -200,6 +217,43 @@ function resolveExperienceIntents(signalIds: string[]): string[] {
     if (intent) out.add(intent);
   }
   return [...out];
+}
+
+// ORCH-1072: decode the RPC's upcoming_occurrences jsonb into the camelCase
+// envelope shape. Drops malformed rows (no event_date_id / no start_at) so the
+// client never renders an unbookable occurrence. Honest passthrough — no
+// fabricated capacity (remaining stays null when the RPC said unlimited).
+function mapExperienceOccurrences(raw: unknown): Array<{
+  eventDateId: string;
+  startAt: string;
+  endAt: string;
+  capacity: number | null;
+  sold: number;
+  remaining: number | null;
+}> {
+  const arr = Array.isArray(raw) ? raw : [];
+  return arr
+    .map((o: any) => {
+      const eventDateId = typeof o?.event_date_id === 'string' ? o.event_date_id : '';
+      const startAt = o?.start_at ? String(o.start_at) : '';
+      if (eventDateId.length === 0 || startAt.length === 0) return null;
+      return {
+        eventDateId,
+        startAt,
+        endAt: o?.end_at ? String(o.end_at) : '',
+        capacity: typeof o?.capacity === 'number' ? o.capacity : null,
+        sold: typeof o?.sold === 'number' ? o.sold : 0,
+        remaining: typeof o?.remaining === 'number' ? o.remaining : null,
+      };
+    })
+    .filter((o): o is {
+      eventDateId: string;
+      startAt: string;
+      endAt: string;
+      capacity: number | null;
+      sold: number;
+      remaining: number | null;
+    } => o !== null);
 }
 
 // Single service-role round-trip to the deck-eligibility RPC. Throws on error
@@ -273,6 +327,20 @@ async function fetchEligibleExperiences(args: {
       experienceType: intentsArr[0] ?? 'adventurous',
       title: typeof row.title === 'string' ? row.title : '',
       tagline: typeof row.tagline === 'string' ? row.tagline : '',
+      // ORCH-1072: carry the real description + cover (honest defaults — '' /
+      // null when absent; the client shows an empty-state, never the tagline).
+      description: typeof row.description === 'string' ? row.description : '',
+      coverMediaUrl:
+        typeof row.cover_media_url === 'string' && row.cover_media_url.length > 0
+          ? row.cover_media_url
+          : null,
+      coverMediaType:
+        row.cover_media_type === 'image' ||
+        row.cover_media_type === 'video' ||
+        row.cover_media_type === 'gif'
+          ? row.cover_media_type
+          : null,
+      upcomingOccurrences: mapExperienceOccurrences(row.upcoming_occurrences),
       brandId: String(row.brand_id),
       brandName: typeof row.brand_name === 'string' ? row.brand_name : '',
       brandSlug: typeof row.brand_slug === 'string' ? row.brand_slug : '',

--- a/supabase/functions/generate-curated-experiences/index.ts
+++ b/supabase/functions/generate-curated-experiences/index.ts
@@ -80,6 +80,11 @@ interface CuratedExperienceDeckCard {
   experienceType: string;
   title: string;
   tagline: string;
+  // ORCH-1072: IDENTICAL to discover-cards ExperienceDeckCard — real cover +
+  // description + upcoming occurrences threaded through the curated path too.
+  description: string;
+  coverMediaUrl: string | null;
+  coverMediaType: 'image' | 'video' | 'gif' | null;
   brandId: string;
   brandName: string;
   brandSlug: string;
@@ -91,6 +96,14 @@ interface CuratedExperienceDeckCard {
   masterDateUtc: string | null;
   masterEndAtUtc: string | null;
   timezone: string;
+  upcomingOccurrences: Array<{
+    eventDateId: string;
+    startAt: string;
+    endAt: string;
+    capacity: number | null;
+    sold: number;
+    remaining: number | null;
+  }>;
   stops: Array<{
     stopNumber: number;
     placeId: string;
@@ -110,6 +123,42 @@ interface CuratedExperienceDeckCard {
   }>;
   estimatedDurationMinutes: number;
   matchScore: number;
+}
+
+// ORCH-1072: decode upcoming_occurrences jsonb → camelCase envelope shape.
+// IDENTICAL to discover-cards.mapExperienceOccurrences (no parallel system —
+// both paths decode the SAME RPC output the SAME way).
+function mapExperienceOccurrences(raw: unknown): Array<{
+  eventDateId: string;
+  startAt: string;
+  endAt: string;
+  capacity: number | null;
+  sold: number;
+  remaining: number | null;
+}> {
+  const arr = Array.isArray(raw) ? raw : [];
+  return arr
+    .map((o: any) => {
+      const eventDateId = typeof o?.event_date_id === 'string' ? o.event_date_id : '';
+      const startAt = o?.start_at ? String(o.start_at) : '';
+      if (eventDateId.length === 0 || startAt.length === 0) return null;
+      return {
+        eventDateId,
+        startAt,
+        endAt: o?.end_at ? String(o.end_at) : '',
+        capacity: typeof o?.capacity === 'number' ? o.capacity : null,
+        sold: typeof o?.sold === 'number' ? o.sold : 0,
+        remaining: typeof o?.remaining === 'number' ? o.remaining : null,
+      };
+    })
+    .filter((o): o is {
+      eventDateId: string;
+      startAt: string;
+      endAt: string;
+      capacity: number | null;
+      sold: number;
+      remaining: number | null;
+    } => o !== null);
 }
 
 // Single service-role round-trip to pg_eligible_experiences_for_deck for ONE
@@ -188,6 +237,19 @@ async function fetchEligibleExperiencesForCurated(args: {
         : (intentsArr[0] ?? args.experienceType),
       title: typeof row.title === 'string' ? row.title : '',
       tagline: typeof row.tagline === 'string' ? row.tagline : '',
+      // ORCH-1072: real description + cover + occurrences (same as discover-cards).
+      description: typeof row.description === 'string' ? row.description : '',
+      coverMediaUrl:
+        typeof row.cover_media_url === 'string' && row.cover_media_url.length > 0
+          ? row.cover_media_url
+          : null,
+      coverMediaType:
+        row.cover_media_type === 'image' ||
+        row.cover_media_type === 'video' ||
+        row.cover_media_type === 'gif'
+          ? row.cover_media_type
+          : null,
+      upcomingOccurrences: mapExperienceOccurrences(row.upcoming_occurrences),
       brandId: String(row.brand_id),
       brandName: typeof row.brand_name === 'string' ? row.brand_name : '',
       brandSlug: typeof row.brand_slug === 'string' ? row.brand_slug : '',

--- a/supabase/functions/ticket-checkout-create/__tests__/orch1072_experience_occurrence_checkout.test.ts
+++ b/supabase/functions/ticket-checkout-create/__tests__/orch1072_experience_occurrence_checkout.test.ts
@@ -1,0 +1,123 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// ORCH-1072 [experience-detail-cover-availability] — checkout occurrence regression.
+//
+// ticket-checkout-create gains an OPTIONAL eventDateId param so a recurring /
+// multi-date experience books the chosen occurrence. The contract:
+//   (a) experience books a chosen occurrence → the param is parsed, validated
+//       (belongs to event + future), and persisted (session metadata + PI
+//       metadata).
+//   (b) omitted param → behavior byte-identical to today (events/trips/one-off
+//       unchanged — NO new query, NO new metadata key).
+//   (c) sold-out / mismatched / past occurrence → rejected (422), never charged.
+//
+// The fn calls serve() at module load + reaches Stripe, so it cannot be invoked
+// in a unit test — we use the established source-text-analysis pattern
+// (orch1065_experience_checkout.test.ts), asserting the validation + persistence
+// + omitted-path guards are present and correctly conditional.
+//
+// Fails-on-revert (LOCKED): each test fails if the occurrence param, its
+// validation, its omitted-path guard, or its persistence is removed.
+
+const root = new URL("../../../..", import.meta.url).pathname;
+const source = await Deno.readTextFile(
+  `${root}/supabase/functions/ticket-checkout-create/index.ts`,
+);
+
+function stripComments(value: string): string {
+  return value
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "")
+    .replace(/[ \t]\/\/[^\n]*$/gm, "");
+}
+const active = stripComments(source);
+
+Deno.test("ORCH-1072 T-A1: eventDateId is parsed as an OPTIONAL string (null when absent)", () => {
+  // The param must be read from the body and default to null (omitted → null).
+  assert(
+    /const\s+eventDateId\s*=\s*typeof\s+body\.eventDateId\s*===?\s*["']string["']/
+      .test(active),
+    "eventDateId must be parsed from body.eventDateId as an optional string",
+  );
+  assert(
+    /\?\s*body\.eventDateId\s*\n?\s*:\s*null/.test(active) ||
+      active.includes("? body.eventDateId\n    : null"),
+    "eventDateId must default to null when absent",
+  );
+});
+
+Deno.test("ORCH-1072 T-A2 (case a): a supplied occurrence is validated against event_dates (belongs + future)", () => {
+  // Validation block must be gated on eventDateId !== null.
+  assert(
+    /if\s*\(\s*eventDateId\s*!==?\s*null\s*\)/.test(active),
+    "occurrence validation must be gated on eventDateId !== null",
+  );
+  // It must query event_dates filtered by BOTH the occurrence id AND the event.
+  assertEquals(active.includes('.from("event_dates")'), true);
+  assert(
+    /\.eq\(\s*["']id["']\s*,\s*eventDateId\s*\)/.test(active),
+    "must filter event_dates by the chosen occurrence id",
+  );
+  assert(
+    /\.eq\(\s*["']event_id["']\s*,\s*eventId\s*\)/.test(active),
+    "must require the occurrence belongs to THIS event",
+  );
+});
+
+Deno.test("ORCH-1072 T-A3 (case c): a mismatched / past occurrence is rejected with 422 (never charged)", () => {
+  // Not-found (not an occurrence of this event) → 422.
+  assert(
+    active.includes('"occurrence_not_found"'),
+    "a mismatched occurrence must be rejected (occurrence_not_found)",
+  );
+  // Already-ended occurrence → 422.
+  assert(
+    active.includes('"occurrence_not_available"'),
+    "a past occurrence must be rejected (occurrence_not_available)",
+  );
+  // Both rejections precede any PaymentIntent create (validation is early, right
+  // after the existing event_no_active_dates gate).
+  const notFoundIdx = active.indexOf('"occurrence_not_found"');
+  const piCreateIdx = active.search(/paymentIntents\.create|piCreateBody/);
+  assert(notFoundIdx >= 0, "occurrence_not_found rejection must exist");
+  assert(
+    piCreateIdx === -1 || notFoundIdx < piCreateIdx,
+    "the occurrence rejection must run BEFORE any PaymentIntent is created",
+  );
+});
+
+Deno.test("ORCH-1072 T-A4 (case b): omitted param is byte-identical — every occurrence touch is conditional on eventDateId !== null", () => {
+  // The validation query, the session-metadata persist, and the PI-metadata key
+  // must ALL be conditional on eventDateId !== null so the omitted path runs
+  // unchanged. Assert there is no UNCONDITIONAL event_date_id write.
+  // Session metadata persist is conditional:
+  assert(
+    /if\s*\(\s*eventDateId\s*!==?\s*null\s*\)\s*\{[\s\S]*?event_date_id/.test(
+      active,
+    ),
+    "session metadata event_date_id write must be conditional on eventDateId !== null",
+  );
+  // PI metadata key is conditional (spread only when present):
+  assert(
+    /eventDateId\s*!==?\s*null\s*\?\s*\{\s*mingla_event_date_id/.test(active),
+    "PI metadata mingla_event_date_id must be spread only when eventDateId !== null",
+  );
+});
+
+Deno.test("ORCH-1072 T-A5: the occurrence is persisted to BOTH the session row metadata and the PaymentIntent metadata", () => {
+  assertEquals(active.includes("event_date_id: eventDateId"), true);
+  assertEquals(active.includes("mingla_event_date_id: eventDateId"), true);
+  // verify_jwt + the trip/event paths are untouched (no event_type allowlist
+  // rejecting experiences was introduced).
+  const eqMatches = [
+    ...active.matchAll(/event_type\s*===?\s*["']([a-z_]+)["']/g),
+  ].map((m) => m[1]);
+  assertEquals(
+    eqMatches.includes("experience"),
+    false,
+    "no event_type==='experience' branch may be introduced",
+  );
+});

--- a/supabase/functions/ticket-checkout-create/index.ts
+++ b/supabase/functions/ticket-checkout-create/index.ts
@@ -217,6 +217,16 @@ serve(async (req) => {
     ? body.lines.filter(isCheckoutLine)
     : [];
   const mode: CheckoutMode = body.mode === "preview" ? "preview" : "create";
+  // ORCH-1072: OPTIONAL chosen experience occurrence (event_dates.id). When a
+  // recurring/multi-date experience is booked, the consumer Book sheet sends the
+  // picked date here so the order records WHICH occurrence was booked. Validated
+  // below (future + belongs to this event); persisted to the PI + order metadata.
+  // When ABSENT, every downstream branch is byte-identical to today — events,
+  // trips, and one-off experiences are completely unaffected (no behavior change).
+  const eventDateId = typeof body.eventDateId === "string" &&
+      body.eventDateId.length > 0
+    ? body.eventDateId
+    : null;
   const clientTaxCalculationId = typeof body.taxCalculationId === "string" &&
       body.taxCalculationId.length > 0
     ? body.taxCalculationId
@@ -273,6 +283,43 @@ serve(async (req) => {
   }
   if ((futureDateCount ?? 0) === 0) {
     return jsonResponse({ error: "event_no_active_dates" }, 422);
+  }
+
+  // ORCH-1072: validate the chosen experience occurrence when one was supplied.
+  // The occurrence MUST belong to this event AND still be in the future. A
+  // mismatched / past / sold-out occurrence is rejected with 422 so the buyer
+  // re-picks (the Book sheet shows sold-out occurrences disabled, but this is
+  // the authoritative last line of defense — Supabase RLS-bypassing service
+  // client read, https://supabase.com/docs/reference/javascript/select). When
+  // eventDateId is null this whole block is skipped → unchanged path.
+  if (eventDateId !== null) {
+    const { data: occRow, error: occErr } = await supabase
+      .from("event_dates")
+      .select("id, end_at")
+      .eq("id", eventDateId)
+      .eq("event_id", eventId)
+      .maybeSingle();
+    if (occErr !== null) {
+      console.error(
+        "[ticket-checkout-create] occurrence lookup failed",
+        occErr,
+      );
+      return jsonResponse(
+        { error: "occurrence_lookup_failed", detail: occErr.message },
+        500,
+      );
+    }
+    if (occRow === null) {
+      // Not an occurrence of THIS event (or deleted) → unbookable.
+      return jsonResponse({ error: "occurrence_not_found" }, 422);
+    }
+    if (
+      typeof occRow.end_at === "string" &&
+      new Date(occRow.end_at).getTime() <= Date.now()
+    ) {
+      // The chosen occurrence already ended → unbookable.
+      return jsonResponse({ error: "occurrence_not_available" }, 422);
+    }
   }
 
   // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — bookings-closed gate.
@@ -458,12 +505,25 @@ serve(async (req) => {
 
   const session = sessionResult as Record<string, unknown>;
   const checkoutSessionId = String(session.checkoutSessionId ?? "");
+  // ORCH-1072: persist the chosen occurrence onto the checkout session row's
+  // metadata (validated above) so the booked event_date is recorded with the
+  // session → order. Merged into the SAME UPDATE that writes the status token
+  // (no extra round-trip). When eventDateId is null the metadata key is omitted
+  // → byte-identical write to today (events/trips/one-off).
+  const sessionUpdate: Record<string, unknown> = {
+    buyer_status_token_hash: await sha256Hex(buyerStatusToken),
+    updated_at: new Date().toISOString(),
+  };
+  if (eventDateId !== null) {
+    const existingMeta =
+      typeof session.metadata === "object" && session.metadata !== null
+        ? (session.metadata as Record<string, unknown>)
+        : {};
+    sessionUpdate.metadata = { ...existingMeta, event_date_id: eventDateId };
+  }
   const { error: statusTokenError } = await supabase
     .from("ticket_checkout_sessions")
-    .update({
-      buyer_status_token_hash: await sha256Hex(buyerStatusToken),
-      updated_at: new Date().toISOString(),
-    })
+    .update(sessionUpdate)
     .eq("id", checkoutSessionId);
   if (statusTokenError) {
     console.error(
@@ -1315,6 +1375,11 @@ serve(async (req) => {
         mingla_tax_calculation_id: taxCalculation.id,
         // ORCH-0869: deposit PI marker for finalize RPC discrimination.
         ...(isInstallmentPlan ? { mingla_installment_plan_root: "true" } : {}),
+        // ORCH-1072: record the booked experience occurrence on the PaymentIntent
+        // (Stripe metadata is a free-form string map — keys ≤40 chars, values
+        // ≤500 chars: https://docs.stripe.com/api/metadata). Omitted when null →
+        // PI metadata byte-identical for events/trips/one-off experiences.
+        ...(eventDateId !== null ? { mingla_event_date_id: eventDateId } : {}),
       },
     };
     // ORCH-0869 [Tr3] installment plans MUST be card-only because off_session

--- a/supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql
+++ b/supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql
@@ -33,8 +33,14 @@
 -- Capped to the next 12 future occurrences (end_at > p_now) so the payload stays
 -- bounded for never-ends/recurring experiences.
 --
--- Idempotent CREATE OR REPLACE; the trailing `;` ends the function body BEFORE
--- the GRANT (a prior ORCH broke CI migration-baseline by omitting it).
+-- DROP-then-CREATE is REQUIRED (not a bare CREATE OR REPLACE): this migration
+-- ADDS columns to the function's RETURNS TABLE, and Postgres rejects a
+-- CREATE OR REPLACE that changes an existing function's OUT/return-table columns
+-- ("cannot change return type of existing function" —
+-- https://www.postgresql.org/docs/current/sql-createfunction.html). The DROP +
+-- CREATE run inside the migration's single transaction, so service-role callers
+-- see no live gap. The trailing `;` ends the function body BEFORE the GRANT (a
+-- prior ORCH broke CI migration-baseline by omitting it).
 --
 -- DOCS (per COMMS-0003 external-API-docs-verified — Postgres/Supabase):
 --   jsonb_agg / jsonb_build_object:
@@ -54,7 +60,10 @@
 -- DO NOT run `supabase db push` from this skill — the orchestrator applies it
 -- after the safe-migration protocol. Prefix 20260908000000 re-checked free
 -- across all active worktrees + origin/main (max prior = 20260907000000,
--- ORCH-1070). Additive only: CREATE OR REPLACE FUNCTION; no destructive DDL.
+-- ORCH-1070). Additive widening of an existing RPC's RETURNS TABLE; the only
+-- DDL is DROP FUNCTION (the same signature) + CREATE FUNCTION + GRANT.
+
+DROP FUNCTION IF EXISTS public.pg_eligible_experiences_for_deck(double precision, double precision, double precision, text[], timestamptz, uuid[], integer);
 
 CREATE OR REPLACE FUNCTION public.pg_eligible_experiences_for_deck(p_lat double precision, p_lng double precision, p_radius_m double precision, p_intents text[], p_now timestamp with time zone, p_exclude_ids uuid[], p_limit integer)
  RETURNS TABLE(event_id uuid, event_slug text, title text, experience_intents text[], tagline text, description text, cover_media_url text, cover_media_type text, currency text, timezone text, brand_id uuid, brand_name text, brand_slug text, brand_logo_url text, master_date_utc timestamp with time zone, master_end_at_utc timestamp with time zone, total_price_cents integer, stops jsonb, upcoming_occurrences jsonb)

--- a/supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql
+++ b/supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql
@@ -1,0 +1,299 @@
+-- ORCH-1072 [experience-detail-cover-availability] — supply the consumer deck
+-- with everything a brand experience needs to render + book correctly:
+--   1. the experience's REAL cover (events.cover_media_url + cover_media_type),
+--      not the fabricated first-stop image (fixes investigation symptom #1).
+--   2. the REAL description (events.description), not the one-line tagline
+--      (fixes investigation symptom #2).
+--   3. UPCOMING OCCURRENCES — a jsonb array of the experience's future
+--      event_dates, each with remaining capacity, so the consumer Book sheet can
+--      offer a date picker (operator-locked: PICK FROM UPCOMING DATES; a one-off
+--      single-date experience skips date-picking; sold-out occurrences disabled).
+--
+-- CHANGE: additive CREATE OR REPLACE of pg_eligible_experiences_for_deck
+-- (ORCH-1065 → ORCH-1070). The RETURNS TABLE gains four columns; the WHERE /
+-- ORDER BY / intent-gating / geo / one-sellable-ticket guards are UNCHANGED, so
+-- the existing deck-eligibility behavior is byte-identical. Both edge envelopes
+-- (discover-cards + generate-curated-experiences) are extended in the SAME
+-- commit to carry the new columns identically (no parallel system).
+--
+-- CAPACITY MODEL (investigation §F — per-EVENT, not per-occurrence): the
+-- experience has exactly ONE sellable online ticket (gated by the existing
+-- EXISTS guard / I-1 ONE-TICKET). Its remaining = quantity_total − sold (or NULL
+-- when unlimited/null-capacity), matching pg_public_ticket_types_remaining
+-- (ORCH-0946) and biz_experience_sold_count (META-ORCH-1059): sold counts
+-- tickets.status IN ('valid','used','transferred'). Every upcoming occurrence
+-- therefore shows the SAME event-level remaining — there is no per-occurrence
+-- cap in the schema, so we do NOT invent one (Constitution rule 9 — no
+-- fabrication). `remaining = NULL` ⇒ unlimited (never sold-out); `remaining = 0`
+-- ⇒ the occurrence renders disabled in the Book sheet.
+--
+-- OCCURRENCE SHAPE (per element of upcoming_occurrences, ordered start_at ASC):
+--   { event_date_id uuid, start_at timestamptz, end_at timestamptz,
+--     capacity int|null, sold int, remaining int|null }
+-- Capped to the next 12 future occurrences (end_at > p_now) so the payload stays
+-- bounded for never-ends/recurring experiences.
+--
+-- Idempotent CREATE OR REPLACE; the trailing `;` ends the function body BEFORE
+-- the GRANT (a prior ORCH broke CI migration-baseline by omitting it).
+--
+-- DOCS (per COMMS-0003 external-API-docs-verified — Postgres/Supabase):
+--   jsonb_agg / jsonb_build_object:
+--     https://www.postgresql.org/docs/current/functions-json.html
+--   array overlap (&&):
+--     https://www.postgresql.org/docs/current/functions-array.html
+--   SECURITY DEFINER + search_path hardening:
+--     https://supabase.com/docs/guides/database/functions#security-definer
+--   RPC over PostgREST (supabase.rpc):
+--     https://supabase.com/docs/reference/javascript/rpc
+--
+-- COMMS: COMMS-0002 (this migration + the ORCH-0863 C7 backend allowlist land in
+--        the SAME commit). COMMS-0014/0016 (experiences book via the EXISTING
+--        ticket-checkout-create — no parallel money fn). COMMS-0018 (no
+--        place_pool / ai_signal_scores touch).
+--
+-- DO NOT run `supabase db push` from this skill — the orchestrator applies it
+-- after the safe-migration protocol. Prefix 20260908000000 re-checked free
+-- across all active worktrees + origin/main (max prior = 20260907000000,
+-- ORCH-1070). Additive only: CREATE OR REPLACE FUNCTION; no destructive DDL.
+
+CREATE OR REPLACE FUNCTION public.pg_eligible_experiences_for_deck(p_lat double precision, p_lng double precision, p_radius_m double precision, p_intents text[], p_now timestamp with time zone, p_exclude_ids uuid[], p_limit integer)
+ RETURNS TABLE(event_id uuid, event_slug text, title text, experience_intents text[], tagline text, description text, cover_media_url text, cover_media_type text, currency text, timezone text, brand_id uuid, brand_name text, brand_slug text, brand_logo_url text, master_date_utc timestamp with time zone, master_end_at_utc timestamp with time zone, total_price_cents integer, stops jsonb, upcoming_occurrences jsonb)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH eligible AS (
+    SELECT
+      e.id,
+      e.slug,
+      e.title,
+      e.experience_intents,
+      e.currency,
+      e.timezone,
+      e.brand_id,
+      -- per-event soonest FUTURE master/active date (next-occurring first):
+      (
+        SELECT ed.start_at
+        FROM public.event_dates ed
+        WHERE ed.event_id = e.id
+          AND ed.end_at > p_now
+        ORDER BY ed.start_at ASC
+        LIMIT 1
+      ) AS next_start_at,
+      (
+        SELECT ed.end_at
+        FROM public.event_dates ed
+        WHERE ed.event_id = e.id
+          AND ed.end_at > p_now
+        ORDER BY ed.start_at ASC
+        LIMIT 1
+      ) AS next_end_at,
+      e.published_at,
+      -- best-effort per-event tagline from theme.experience_meta (honest '' default):
+      COALESCE(e.theme -> 'experience_meta' ->> 'tagline', '') AS tagline,
+      -- ORCH-1072: the experience's REAL description + cover (honest defaults —
+      -- never fabricated; an empty description stays '' and the client shows
+      -- its empty-state, NOT the tagline):
+      COALESCE(e.description, '')        AS description,
+      e.cover_media_url                  AS cover_media_url,
+      e.cover_media_type                 AS cover_media_type,
+      -- the single sellable all-in ticket the ORCH-1006 engine reads (I-1):
+      (
+        SELECT tt.id
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+        ORDER BY tt.price_cents ASC, tt.id ASC
+        LIMIT 1
+      ) AS sellable_ticket_id,
+      (
+        SELECT tt.price_cents
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+        ORDER BY tt.price_cents ASC, tt.id ASC
+        LIMIT 1
+      ) AS ticket_price_cents,
+      -- ORCH-1072: the ONE sellable ticket's remaining capacity (event-level —
+      -- per-occurrence cap is not in the schema). NULL ⇒ unlimited; matches
+      -- pg_public_ticket_types_remaining (ORCH-0946) sold formula.
+      (
+        SELECT
+          CASE
+            WHEN tt.is_unlimited THEN NULL
+            WHEN tt.quantity_total IS NULL THEN NULL
+            ELSE GREATEST(
+              tt.quantity_total - COALESCE((
+                SELECT COUNT(*)
+                FROM public.tickets tk
+                WHERE tk.ticket_type_id = tt.id
+                  AND tk.status IN ('valid', 'used', 'transferred')
+              ), 0),
+              0
+            )::int
+          END
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+        ORDER BY tt.price_cents ASC, tt.id ASC
+        LIMIT 1
+      ) AS ticket_remaining,
+      (
+        SELECT tt.quantity_total
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+        ORDER BY tt.price_cents ASC, tt.id ASC
+        LIMIT 1
+      ) AS ticket_capacity,
+      (
+        SELECT COALESCE((
+          SELECT COUNT(*)
+          FROM public.tickets tk
+          WHERE tk.ticket_type_id = tt.id
+            AND tk.status IN ('valid', 'used', 'transferred')
+        ), 0)::int
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+        ORDER BY tt.price_cents ASC, tt.id ASC
+        LIMIT 1
+      ) AS ticket_sold,
+      -- the all-in display price (tax/fee-inclusive) when the public view exposes it:
+      (
+        SELECT v.display_price_cents
+        FROM public.business_public_events_view v
+        WHERE v.id = e.id
+        LIMIT 1
+      ) AS display_price_cents
+    FROM public.events e
+    WHERE e.event_type   = 'experience'
+      AND e.visibility   = 'public'
+      AND e.status       = 'scheduled'
+      AND e.published_at IS NOT NULL
+      AND e.deleted_at   IS NULL
+      AND e.experience_intents IS NOT NULL
+      AND array_length(e.experience_intents, 1) >= 1
+      -- future master/active date (mirrors i-discover-excludes-ended-master-date):
+      AND EXISTS (
+        SELECT 1 FROM public.event_dates ed
+        WHERE ed.event_id = e.id
+          AND ed.end_at > p_now
+      )
+      -- exactly the one sellable ticket the all-in engine reads (gates unsellable drafts):
+      AND EXISTS (
+        SELECT 1 FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.available_online = true
+          AND tt.deleted_at IS NULL
+      )
+      -- intent overlap with the user's active deck signals; empty p_intents ⇒ no intent filter:
+      AND e.experience_intents && p_intents  -- ORCH-1070: STRICT — only surface for a SELECTED matching vibe (no permissive)
+      -- geo: ≥1 stop within p_radius_m metres of the user (haversine fallback — no extension):
+      AND EXISTS (
+        SELECT 1 FROM public.experience_stops s
+        WHERE s.event_id = e.id
+          AND s.lat IS NOT NULL
+          AND s.lng IS NOT NULL
+          AND (
+            6371000.0 * 2.0 * ASIN(SQRT(
+              POWER(SIN(RADIANS(s.lat - p_lat) / 2.0), 2) +
+              COS(RADIANS(p_lat)) * COS(RADIANS(s.lat)) *
+              POWER(SIN(RADIANS(s.lng - p_lng) / 2.0), 2)
+            ))
+          ) <= p_radius_m
+      )
+      AND e.id <> ALL(p_exclude_ids)
+  ),
+  stops_agg AS (
+    SELECT
+      s.event_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'stop_order',   s.stop_order,
+          'place_id',     COALESCE(s.place_id, s.id::text),
+          'place_name',   s.place_name,
+          'address',      s.address,
+          'image_urls',   to_jsonb(s.image_urls),
+          'ai_description', s.ai_description,
+          'lat',          s.lat,
+          'lng',          s.lng,
+          'price_cents',  s.price_cents
+        )
+        ORDER BY s.stop_order ASC
+      ) AS stops
+    FROM public.experience_stops s
+    WHERE s.event_id IN (SELECT id FROM eligible)
+    GROUP BY s.event_id
+  ),
+  -- ORCH-1072: the next ≤12 future occurrences per experience, each carrying the
+  -- event-level capacity / sold / remaining of the ONE sellable ticket. The
+  -- Book sheet renders this as the date picker (one-off → single element →
+  -- auto-select; sold-out [remaining = 0] → disabled row).
+  occurrences_agg AS (
+    SELECT
+      occ.event_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'event_date_id', occ.id,
+          'start_at',      occ.start_at,
+          'end_at',        occ.end_at,
+          'capacity',      occ.ticket_capacity,
+          'sold',          occ.ticket_sold,
+          'remaining',     occ.ticket_remaining
+        )
+        ORDER BY occ.start_at ASC
+      ) AS upcoming_occurrences
+    FROM (
+      SELECT
+        ed.event_id,
+        ed.id,
+        ed.start_at,
+        ed.end_at,
+        el.ticket_capacity,
+        el.ticket_sold,
+        el.ticket_remaining,
+        ROW_NUMBER() OVER (PARTITION BY ed.event_id ORDER BY ed.start_at ASC) AS rn
+      FROM public.event_dates ed
+      JOIN eligible el ON el.id = ed.event_id
+      WHERE ed.end_at > p_now
+    ) occ
+    WHERE occ.rn <= 12
+    GROUP BY occ.event_id
+  )
+  SELECT
+    el.id                                   AS event_id,
+    el.slug                                 AS event_slug,
+    el.title,
+    el.experience_intents,
+    el.tagline,
+    el.description,
+    el.cover_media_url,
+    el.cover_media_type,
+    el.currency,
+    COALESCE(el.timezone, 'UTC')            AS timezone,
+    el.brand_id,
+    b.name                                  AS brand_name,
+    b.slug                                  AS brand_slug,
+    b.profile_photo_url                     AS brand_logo_url,
+    el.next_start_at                        AS master_date_utc,
+    el.next_end_at                          AS master_end_at_utc,
+    -- prefer the all-in display price; fall back to the raw ticket price:
+    COALESCE(el.display_price_cents, el.ticket_price_cents, 0) AS total_price_cents,
+    COALESCE(sa.stops, '[]'::jsonb)         AS stops,
+    COALESCE(oa.upcoming_occurrences, '[]'::jsonb) AS upcoming_occurrences
+  FROM eligible el
+  JOIN public.brands b ON b.id = el.brand_id
+  LEFT JOIN stops_agg sa ON sa.event_id = el.id
+  LEFT JOIN occurrences_agg oa ON oa.event_id = el.id
+  WHERE b.deleted_at IS NULL
+  ORDER BY el.next_start_at ASC NULLS LAST, el.published_at DESC
+  LIMIT LEAST(GREATEST(p_limit, 0), 30);
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.pg_eligible_experiences_for_deck(double precision, double precision, double precision, text[], timestamptz, uuid[], integer) TO service_role;


### PR DESCRIPTION
## ORCH-1072 — experience detail: cover, description, Book Experience, availability

Brand experiences now render + book properly on the consumer app:
- **Card:** real experience COVER (image/video via shared EventCoverMedia) as hero + stop strip below + brand badge + Book.
- **Detail sheet (ExpandedBusinessEventSheet):** real cover (video/image) + real description + multi-stop itinerary + a "Book Experience" buy action (no Save/Schedule). Save/Schedule tag-loss bug fixed (decoder recovers cardType:'experience' structurally).
- **Availability:** supply returns upcoming occurrences with remaining capacity; the Book sheet shows a date picker (sold-out disabled), one-off skips to quantity; `ticket-checkout-create` extended with an OPTIONAL `event_date_id` occurrence param (omitted = byte-identical to today; events/trips unchanged — COMMS-0014/0016).

Supply: `pg_eligible_experiences_for_deck` widened (DROP+CREATE) with cover_media_url/type, description, upcoming_occurrences; threaded through discover-cards + generate-curated-experiences identically. Migration `20260908000000` applied; 3 edge fns deployed. ORCH_1072 C7 allowlist same-commit (COMMS-0002); Stripe/Supabase docs cited (COMMS-0003); no place_pool (COMMS-0018).

Verified against live data: Raleigh crawl returns a real .mp4 video cover, real description, occurrence capacity 20/remaining 20. 11 new regression tests (fails-on-revert: cover-not-fabricated, date-occurrence checkout, sold-out rejection) + ORCH-1065 suite (25) pass; deno/tsc/C7 green.

[deploy] — app-mobile client + backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)