### PR TITLE
ORCH-1073: admin suspend/delete venue listing + owner messaging

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1475,7 +1475,11 @@ function checkNoNewBackendFiles() {
   // ORCH_1071), so only the migration + the two new test files need listing.
   // C7 is scoped to ORCH-0863 marketing; these are consumer-deck backend
   // touches. Per COMMS-0002 — lands in the SAME commit as the migration.
-  const ORCH_1072_BACKEND_ALLOWLIST = [
+  // NOTE (ORCH-1073): this entry collided with the brand-experiences ORCH-1072
+  // below — two `const ORCH_1072_BACKEND_ALLOWLIST` in one scope crashed the gate
+  // (SyntaxError) on main. Renamed to a unique identifier to unbreak CI; the
+  // migration file retains its on-disk orch_1072 name (renumber was incomplete).
+  const ORCH_1072_EXPERIENCE_DETAIL_BACKEND_ALLOWLIST = [
     "supabase/migrations/20260908000000_orch_1072_experience_detail_cover_availability.sql",
     "supabase/functions/discover-cards/__tests__/orch_1072_experience_detail_supply.test.ts",
     "supabase/functions/ticket-checkout-create/__tests__/orch1072_experience_occurrence_checkout.test.ts",
@@ -1516,6 +1520,15 @@ function checkNoNewBackendFiles() {
   // (ORCH-1071 was already allocated to a separate effort; this work is 1072.)
   const ORCH_1072_BACKEND_ALLOWLIST = [
     "supabase/migrations/20260906000000_orch_1072_brand_experiences_for_place.sql",
+  ];
+  // ORCH-1073 [admin suspend/delete venue listing + owner messaging]: one
+  // additive migration (soft-delete cols + invariant trigger + claim_status &
+  // action_type CHECK widen + admin_suspend/soft_delete/restore RPCs + the
+  // biz_resubmit_venue_claim patch to accept a suspended brand). No new edge
+  // function source. C7 is scoped to ORCH-0863 marketing; this is an admin/
+  // venue-listing backend touch. Per COMMS-0002 — same commit as the migration.
+  const ORCH_1073_BACKEND_ALLOWLIST = [
+    "supabase/migrations/20260909000000_orch_1073_admin_suspend_delete_listing.sql",
   ];
   // ORCH-1032 [Intelligence pipeline concurrency cap + chunked enqueue]:
   // adds the additive 'queued'-status migration (status CHECK widen + per-city
@@ -1747,10 +1760,11 @@ function checkNoNewBackendFiles() {
     ...ORCH_1062_BACKEND_ALLOWLIST,
     ...ORCH_1065_BACKEND_ALLOWLIST,
     ...ORCH_1071_BACKEND_ALLOWLIST,
-    ...ORCH_1072_BACKEND_ALLOWLIST,
+    ...ORCH_1072_EXPERIENCE_DETAIL_BACKEND_ALLOWLIST,
     ...ORCH_1064_BACKEND_ALLOWLIST,
     ...ORCH_1067_BACKEND_ALLOWLIST,
     ...ORCH_1072_BACKEND_ALLOWLIST,
+    ...ORCH_1073_BACKEND_ALLOWLIST,
     // Schedule-edit buyer protection + "Refund all & proceed" (separate PR;
     // shares the ORCH-1047 work id used in code). New migration recording the
     // already-live business_patch_event_when change — not ORCH-0863 marketing

--- a/mingla-admin/src/pages/PlacePoolManagementPage.jsx
+++ b/mingla-admin/src/pages/PlacePoolManagementPage.jsx
@@ -375,8 +375,23 @@ function PlaceDetailModal({ place, open, onClose, onSave }) {
   // disables the button + shows spinner; error surfaces inline + via toast.
   const [reeval, setReeval] = useState({ pending: false, error: null });
 
+  // ORCH-1073 — admin listing actions (suspend with owner message + structured
+  // to-do list / soft-delete from the pool / restore). Calls admin_suspend_listing,
+  // admin_soft_delete_listing, admin_restore_listing.
+  const [actionView, setActionView] = useState(null); // 'suspend' | 'delete' | null
+  const [actionBusy, setActionBusy] = useState(false);
+  const [suspendMsg, setSuspendMsg] = useState("");
+  const [suspendReason, setSuspendReason] = useState("");
+  const [todoItems, setTodoItems] = useState([]); // [{ category, note }]
+  const [deleteMsg, setDeleteMsg] = useState("");
+  const [deleteReason, setDeleteReason] = useState("");
+
   useEffect(() => {
     if (!open || !place) return;
+    // reset action UI whenever a new place opens
+    setActionView(null); setActionBusy(false);
+    setSuspendMsg(""); setSuspendReason(""); setTodoItems([]);
+    setDeleteMsg(""); setDeleteReason("");
     setEditForm({
       name: place.name || "",
       price_tiers: place.price_tiers?.length ? place.price_tiers : (place.price_tier ? [place.price_tier] : []),
@@ -458,6 +473,53 @@ function PlaceDetailModal({ place, open, onClose, onSave }) {
       addToast({ variant: "error", title: "Re-evaluation failed", description: msg });
       setReeval({ pending: false, error: msg });
     }
+  };
+
+  // ORCH-1073 — feedback categories mirror the DB enum in admin_suspend_listing.
+  const FEEDBACK_CATEGORIES = ["photos", "address", "hours", "category", "description", "quality", "other"];
+
+  const handleSuspend = async () => {
+    setActionBusy(true);
+    const items = todoItems
+      .filter((i) => i.note && i.note.trim())
+      .map((i) => ({ category: i.category, note: i.note.trim() }));
+    const { data, error } = await supabase.rpc("admin_suspend_listing", {
+      p_place_id: place.id,
+      p_overall_message: suspendMsg.trim() || null,
+      p_items: items,
+      p_reason: suspendReason.trim() || null,
+    });
+    if (error) { addToast({ variant: "error", title: "Suspend failed", description: error.message }); setActionBusy(false); return; }
+    addToast({
+      variant: "success", title: "Listing suspended",
+      description: data?.brand_id
+        ? `Owner notified (${data.notified}); ${data.todo_items} to-do item(s) sent.`
+        : "Taken off the deck (no claimed owner to notify).",
+    });
+    setActionBusy(false); onClose(); if (onSave) onSave();
+  };
+
+  const handleDelete = async () => {
+    setActionBusy(true);
+    const { data, error } = await supabase.rpc("admin_soft_delete_listing", {
+      p_place_id: place.id,
+      p_reason: deleteReason.trim() || null,
+      p_message: deleteMsg.trim() || null,
+    });
+    if (error) { addToast({ variant: "error", title: "Delete failed", description: error.message }); setActionBusy(false); return; }
+    addToast({
+      variant: "success", title: "Listing removed",
+      description: data?.brand_id ? `Claim revoked; owner notified (${data.notified}).` : "Removed from the pool.",
+    });
+    setActionBusy(false); onClose(); if (onSave) onSave();
+  };
+
+  const handleRestore = async () => {
+    setActionBusy(true);
+    const { error } = await supabase.rpc("admin_restore_listing", { p_place_id: place.id });
+    if (error) { addToast({ variant: "error", title: "Restore failed", description: error.message }); setActionBusy(false); return; }
+    addToast({ variant: "success", title: "Listing restored" });
+    setActionBusy(false); onClose(); if (onSave) onSave();
   };
 
   // META-ORCH-1009 Sub-D — extract the most-recent AI evaluated_at across
@@ -669,6 +731,89 @@ function PlaceDetailModal({ place, open, onClose, onSave }) {
               </div>
               <Toggle label="Active" checked={editForm.is_active} onChange={(val) => setEditForm((f) => ({ ...f, is_active: val }))} />
             </div>
+          </div>
+
+          {/* ORCH-1073 — Listing actions: suspend (off the deck + notify the owner
+              with a custom message + structured to-do list), soft-delete (remove
+              from the pool + revoke claim + notify), or restore (admin undo). */}
+          <div className="border-t border-[var(--gray-200)] pt-4">
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider">Listing Actions</h4>
+              {place.deleted_at
+                ? <Badge variant="error">Removed</Badge>
+                : !place.is_active
+                  ? <Badge variant="warning">Off deck</Badge>
+                  : <Badge variant="success">Live</Badge>}
+            </div>
+
+            {place.deleted_at ? (
+              <div className="space-y-2">
+                <p className="text-xs text-[var(--color-text-secondary)]">
+                  Removed{place.deleted_reason ? ` — "${place.deleted_reason}"` : ""}. Restoring brings it back as active and re-verifies any claim.
+                </p>
+                <Button variant="secondary" loading={actionBusy} onClick={handleRestore}>Restore listing</Button>
+              </div>
+            ) : actionView === "suspend" ? (
+              <div className="space-y-2">
+                <textarea
+                  className="block w-full rounded border border-[var(--gray-300)] bg-[var(--color-background-primary)] px-2 py-1.5 text-sm"
+                  rows={2} value={suspendMsg}
+                  onChange={(e) => setSuspendMsg(e.target.value)}
+                  placeholder="Message to the owner — why it was suspended / what to fix (shows in their listing banner + notification)" />
+                <div className="space-y-1.5">
+                  {todoItems.map((it, idx) => (
+                    <div className="flex gap-2 items-center" key={idx}>
+                      <select
+                        className="rounded border border-[var(--gray-300)] bg-[var(--color-background-primary)] px-2 py-1.5 text-xs"
+                        value={it.category}
+                        onChange={(e) => setTodoItems((arr) => arr.map((x, i) => i === idx ? { ...x, category: e.target.value } : x))}>
+                        {FEEDBACK_CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                      </select>
+                      <input
+                        className="flex-1 rounded border border-[var(--gray-300)] bg-[var(--color-background-primary)] px-2 py-1.5 text-sm"
+                        value={it.note}
+                        onChange={(e) => setTodoItems((arr) => arr.map((x, i) => i === idx ? { ...x, note: e.target.value } : x))}
+                        placeholder="What needs fixing (becomes a to-do item)" />
+                      <button type="button" className="text-[var(--color-text-tertiary)] hover:text-[var(--color-error-700)] px-1"
+                        onClick={() => setTodoItems((arr) => arr.filter((_, i) => i !== idx))}>×</button>
+                    </div>
+                  ))}
+                  <button type="button" className="text-xs text-[var(--color-brand-600)] hover:underline"
+                    onClick={() => setTodoItems((arr) => [...arr, { category: "photos", note: "" }])}>+ Add to-do item</button>
+                </div>
+                <input
+                  className="block w-full rounded border border-[var(--gray-300)] bg-[var(--color-background-primary)] px-2 py-1.5 text-xs"
+                  value={suspendReason} onChange={(e) => setSuspendReason(e.target.value)}
+                  placeholder="Internal reason (audit log, not shown to owner)" />
+                <div className="flex gap-2 justify-end">
+                  <Button variant="ghost" onClick={() => setActionView(null)} disabled={actionBusy}>Cancel</Button>
+                  <Button variant="primary" loading={actionBusy} onClick={handleSuspend}>Suspend &amp; notify owner</Button>
+                </div>
+              </div>
+            ) : actionView === "delete" ? (
+              <div className="space-y-2">
+                <p className="text-xs text-[var(--color-error-700)]">
+                  Removes the venue from the pool and revokes any claim. Reversible by an admin (Restore).
+                </p>
+                <textarea
+                  className="block w-full rounded border border-[var(--gray-300)] bg-[var(--color-background-primary)] px-2 py-1.5 text-sm"
+                  rows={2} value={deleteMsg} onChange={(e) => setDeleteMsg(e.target.value)}
+                  placeholder="Message to the owner (optional)" />
+                <input
+                  className="block w-full rounded border border-[var(--gray-300)] bg-[var(--color-background-primary)] px-2 py-1.5 text-xs"
+                  value={deleteReason} onChange={(e) => setDeleteReason(e.target.value)}
+                  placeholder="Internal reason (audit log)" />
+                <div className="flex gap-2 justify-end">
+                  <Button variant="ghost" onClick={() => setActionView(null)} disabled={actionBusy}>Cancel</Button>
+                  <Button variant="danger" loading={actionBusy} onClick={handleDelete}>Delete from pool</Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <Button variant="secondary" onClick={() => setActionView("suspend")}>Suspend…</Button>
+                <Button variant="danger" onClick={() => setActionView("delete")}>Delete…</Button>
+              </div>
+            )}
           </div>
 
           {/* ORCH-0646: "AI Classification Override" block removed per D-3.
@@ -1157,7 +1302,7 @@ function MapTab({ scope, registeredCity, tiles, seedingOps }) {
     if (!selectedCity) { setPlaces([]); return; }
     setMapLoading(true);
     let q = supabase.from("place_pool")
-      .select("id, name, lat, lng, rating, ai_categories, seeding_category, is_active, stored_photo_urls, is_servable")
+      .select("id, name, lat, lng, rating, ai_categories, seeding_category, is_active, stored_photo_urls, is_servable, deleted_at, deleted_reason")
       .eq("is_active", true)
       .eq("is_servable", true)
       .eq("city_id", selectedCity);

--- a/mingla-business/app/brand/[id]/listing.tsx
+++ b/mingla-business/app/brand/[id]/listing.tsx
@@ -91,8 +91,11 @@ export default function BrandListingRoute(): React.ReactElement {
   // mount). openCount drives the tile badge; the sheet + a single Toast host are
   // mounted at the bottom of this screen.
   const followUpAt = brand?.claimFollowUpAt ?? null;
+  // ORCH-1073 — a `suspended` listing also carries a follow-up stamp + to-do
+  // round; surface the same interactive banner + feedback sheet + resubmit loop.
   const hasFollowUp =
-    brand?.claimStatus === "pending_review" && Boolean(followUpAt);
+    (brand?.claimStatus === "pending_review" ||
+      brand?.claimStatus === "suspended") && Boolean(followUpAt);
   const openFeedbackCount = useVenueClaimOpenCount(brandId, followUpAt);
   const [feedbackVisible, setFeedbackVisible] = useState<boolean>(false);
   const [toast, setToast] = useState<{

--- a/mingla-business/src/components/brand/VenueClaimStatusBanner.tsx
+++ b/mingla-business/src/components/brand/VenueClaimStatusBanner.tsx
@@ -68,8 +68,9 @@ export function VenueClaimStatusBanner({
   const copy = venueClaimBannerCopy(variant, brand.rejectionReason);
   if (copy === null) return null;
 
-  // ── ORCH-1064 — interactive follow_up tile ─────────────────────────────────
-  if (variant === "follow_up") {
+  // ── ORCH-1064 — interactive follow_up tile (ORCH-1073: `suspended` shares it
+  //    — same to-do checklist + resubmit loop, just suspension copy) ───────────
+  if (variant === "follow_up" || variant === "suspended") {
     const allFixed = openCount === 0;
     // DESIGN §2.4 — openCount===0 (all addressed, not yet re-submitted) swaps to
     // the "Ready" success badge + check icon + the re-submit nudge body.
@@ -117,9 +118,9 @@ export function VenueClaimStatusBanner({
     );
   }
 
-  // ── unchanged static variants (byte-identical to pre-ORCH-1064) ────────────
+  // ── static variants. ORCH-1073: `revoked` (removed) shares the error tone. ──
   const toneStyle =
-    variant === "rejected"
+    variant === "rejected" || variant === "revoked"
       ? styles.toneError
       : styles.toneInfo;
 

--- a/mingla-business/src/services/__tests__/venueClaimBannerLogic.orch1073.test.ts
+++ b/mingla-business/src/services/__tests__/venueClaimBannerLogic.orch1073.test.ts
@@ -1,0 +1,69 @@
+/**
+ * ORCH-1073 — admin suspend/delete adds two claim states to the business
+ * banner: `suspended` (interactive — same to-do/resubmit loop as follow_up,
+ * distinct copy) and `revoked` (static "removed" notice).
+ */
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  venueClaimBannerVariant,
+  venueClaimBannerCopy,
+} from "../venueClaimBannerLogic";
+
+describe("venueClaimBannerVariant — ORCH-1073 states", () => {
+  test("suspended → 'suspended' variant (interactive)", () => {
+    expect(
+      venueClaimBannerVariant({
+        claim_status: "suspended",
+        rejection_reason: null,
+        claim_follow_up_at: "2026-06-04T00:00:00Z",
+      }),
+    ).toBe("suspended");
+  });
+
+  test("suspended with no follow-up stamp still resolves to 'suspended'", () => {
+    expect(
+      venueClaimBannerVariant({
+        claim_status: "suspended",
+        rejection_reason: null,
+        claim_follow_up_at: null,
+      }),
+    ).toBe("suspended");
+  });
+
+  test("revoked → 'revoked' variant (static removed notice)", () => {
+    expect(
+      venueClaimBannerVariant({
+        claim_status: "revoked",
+        rejection_reason: null,
+        claim_follow_up_at: null,
+      }),
+    ).toBe("revoked");
+  });
+
+  test("verified is unaffected (regression guard)", () => {
+    expect(
+      venueClaimBannerVariant({
+        claim_status: "verified",
+        rejection_reason: null,
+        claim_follow_up_at: null,
+      }),
+    ).toBe("verified");
+  });
+});
+
+describe("venueClaimBannerCopy — ORCH-1073 states", () => {
+  test("suspended copy is distinct from follow_up and mentions resubmit", () => {
+    const suspended = venueClaimBannerCopy("suspended");
+    const followUp = venueClaimBannerCopy("follow_up");
+    expect(suspended?.title).toBe("Listing suspended");
+    expect(suspended?.body.toLowerCase()).toContain("resubmit");
+    expect(suspended?.title).not.toBe(followUp?.title);
+  });
+
+  test("revoked copy reads as removed", () => {
+    const revoked = venueClaimBannerCopy("revoked");
+    expect(revoked?.title).toBe("Listing removed");
+    expect(revoked?.body.toLowerCase()).toContain("removed");
+  });
+});

--- a/mingla-business/src/services/venueClaimBannerLogic.ts
+++ b/mingla-business/src/services/venueClaimBannerLogic.ts
@@ -15,6 +15,10 @@ export type VenueClaimBannerVariant =
   | "follow_up"
   | "rejected"
   | "verified"
+  // ORCH-1073 — admin suspend/delete. `suspended` is INTERACTIVE (same to-do
+  // sheet + resubmit loop as `follow_up`); `revoked` is a static "removed" notice.
+  | "suspended"
+  | "revoked"
   | null;
 
 export function venueClaimBannerVariant(
@@ -23,6 +27,10 @@ export function venueClaimBannerVariant(
   if (row === null || row === undefined) return null;
   if (row.claim_status === "verified") return "verified";
   if (row.claim_status === "rejected") return "rejected";
+  if (row.claim_status === "revoked") return "revoked";
+  // ORCH-1073 — a suspended listing always carries a follow-up stamp + a to-do
+  // round (admin_suspend_listing), so it routes through the interactive tile.
+  if (row.claim_status === "suspended") return "suspended";
   if (row.claim_status === "pending_review") {
     if (row.claim_follow_up_at) return "follow_up";
     return "pending_review";
@@ -58,6 +66,18 @@ export function venueClaimBannerCopy(
       return {
         title: "Verified location",
         body: "Verified location ✓ — your brand has the Verified badge on your public page.",
+      };
+    case "suspended":
+      // ORCH-1073 — distinct from follow_up: an admin took the live listing down.
+      return {
+        title: "Listing suspended",
+        body:
+          "An admin suspended your listing. Tap to see what to fix, then resubmit to go back live.",
+      };
+    case "revoked":
+      return {
+        title: "Listing removed",
+        body: "Your listing was removed from Mingla. Reach out to support if you think this was a mistake.",
       };
     default:
       return null;

--- a/mingla-business/src/types/brand.ts
+++ b/mingla-business/src/types/brand.ts
@@ -324,12 +324,16 @@ export type Brand = {
   hasPhysicalLocation?: boolean;
 };
 
-/** Ve1 — `brands.claim_status` + optional UI-only states. */
+/** Ve1 — `brands.claim_status` + optional UI-only states.
+ *  ORCH-1073 added `suspended` (admin took a live listing off the deck; fixable
+ *  + resubmittable) and `revoked` (admin removed the listing from the pool). */
 export type BrandClaimStatus =
   | "none"
   | "pending_review"
   | "verified"
-  | "rejected";
+  | "rejected"
+  | "suspended"
+  | "revoked";
 
 export type VenueCategory = "restaurant" | "play" | "creative_and_arts";
 

--- a/mingla-business/src/utils/listingStatus.ts
+++ b/mingla-business/src/utils/listingStatus.ts
@@ -36,6 +36,21 @@ export function listingStatusView(input: {
       hint: "Make the requested changes and resubmit to go live.",
     };
   }
+  // ORCH-1073 — admin took a live listing down.
+  if (input.claimStatus === "suspended") {
+    return {
+      label: "Suspended",
+      tone: "warning",
+      hint: "An admin suspended your listing. Open it to see what to fix, then resubmit to go live again.",
+    };
+  }
+  if (input.claimStatus === "revoked") {
+    return {
+      label: "Removed",
+      tone: "warning",
+      hint: "Your listing was removed from Mingla. Reach out to support if you think this was a mistake.",
+    };
+  }
   if (input.claimStatus === "verified") {
     return {
       label: "Live on Mingla",

--- a/supabase/migrations/20260909000000_orch_1073_admin_suspend_delete_listing.sql
+++ b/supabase/migrations/20260909000000_orch_1073_admin_suspend_delete_listing.sql
@@ -1,0 +1,312 @@
+-- ORCH-1073 [admin suspend/delete venue listing + owner messaging]
+-- ============================================================================
+-- Adds admin controls to take a LIVE venue listing off the consumer deck:
+--   • SUSPEND   — flips the place off the deck (is_active=false), suspends a
+--                 claimed brand, drops the admin's custom message + to-do items
+--                 into the ORCH-1064 structured to-do list, and notifies the
+--                 brand owner(s) (push + in-app). Business fixes the to-dos and
+--                 resubmits (existing biz_resubmit_venue_claim) → admin approves
+--                 → re-bounce → back on the deck.
+--   • DELETE    — soft-deletes the place_pool row (deleted_at), revokes the
+--                 claim, notifies the owner. Reversible by an admin.
+--   • RESTORE   — admin undo for suspend/delete.
+--
+-- Soft-delete invariant I-1073-DELETED-PLACE-NEVER-SERVABLE is enforced by ONE
+-- row-level trigger (below): a row with deleted_at set is force-held at
+-- is_servable=false AND is_active=false, so NO fetch/bouncer/scorer path can
+-- resurrect it and the deck (which gates on is_servable=true AND is_active=true)
+-- excludes it everywhere. No per-query filter threading required.
+-- ============================================================================
+
+-- 1) Soft-delete markers on place_pool ---------------------------------------
+alter table public.place_pool add column if not exists deleted_at timestamptz;
+alter table public.place_pool add column if not exists deleted_reason text;
+
+-- 2) Invariant trigger: deleted ⇒ never servable/active ----------------------
+create or replace function public._orch1073_enforce_deleted_unservable()
+returns trigger
+language plpgsql
+as $$
+begin
+  if NEW.deleted_at is not null then
+    NEW.is_servable := false;
+    NEW.is_active := false;
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists trg_orch1073_deleted_unservable on public.place_pool;
+create trigger trg_orch1073_deleted_unservable
+  before insert or update on public.place_pool
+  for each row execute function public._orch1073_enforce_deleted_unservable();
+
+-- 3) Brand claim lifecycle: add 'suspended' + 'revoked' ----------------------
+alter table public.brands drop constraint if exists brands_claim_status_check;
+alter table public.brands add constraint brands_claim_status_check
+  check (claim_status = any (array[
+    'none','pending_review','verified','rejected','suspended','revoked'
+  ]));
+
+-- 4) Admin action audit: allow the new action types --------------------------
+alter table public.place_admin_actions drop constraint if exists place_admin_actions_action_type_check;
+alter table public.place_admin_actions add constraint place_admin_actions_action_type_check
+  check (action_type = any (array[
+    'deactivate','reactivate','refresh','bulk_deactivate','bulk_reactivate','bulk_refresh',
+    'suspend','soft_delete','restore'
+  ]));
+
+-- 5a) SUSPEND ----------------------------------------------------------------
+create or replace function public.admin_suspend_listing(
+  p_place_id        uuid,
+  p_overall_message text default null,
+  p_items           jsonb default '[]'::jsonb,
+  p_reason          text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public','pg_temp'
+as $$
+declare
+  v_brand    public.brands%rowtype;
+  v_round    integer;
+  v_item     jsonb;
+  v_cat      text;
+  v_note     text;
+  v_first    boolean := true;
+  v_count    integer := 0;
+  v_uid      uuid;
+  v_notified integer := 0;
+  v_msg      text := nullif(trim(coalesce(p_overall_message,'')),'');
+begin
+  if auth.uid() is null then raise exception 'not_authenticated'; end if;
+  if not public.is_admin_user() then raise exception 'forbidden'; end if;
+
+  -- Take it off the deck (is_active gate). deleted rows cannot be suspended.
+  update public.place_pool set is_active = false
+   where id = p_place_id and deleted_at is null;
+  if not found then raise exception 'place_not_found_or_deleted'; end if;
+
+  -- Claimed (verified) brand → suspend it + drive the business banner/to-do list.
+  select * into v_brand
+    from public.brands
+   where place_pool_id = p_place_id and deleted_at is null and claim_status = 'verified'
+   limit 1;
+
+  if found then
+    update public.brands
+       set claim_status = 'suspended', claim_follow_up_at = now()
+     where id = v_brand.id;
+
+    -- Structured to-do round (mirrors ORCH-1064 admin_add_venue_claim_feedback).
+    if p_items is not null and jsonb_typeof(p_items) = 'array' and jsonb_array_length(p_items) > 0 then
+      select coalesce(max(round),0)+1 into v_round
+        from public.venue_claim_feedback where brand_id = v_brand.id;
+      for v_item in select * from jsonb_array_elements(p_items) loop
+        v_cat  := nullif(trim(v_item->>'category'),'');
+        v_note := nullif(trim(v_item->>'note'),'');
+        if v_cat is null or v_cat not in
+           ('photos','address','hours','category','description','quality','other') then
+          raise exception 'invalid_category';
+        end if;
+        if v_note is null then raise exception 'note_required'; end if;
+        insert into public.venue_claim_feedback
+          (brand_id, place_pool_id, round, category, note, overall_message, created_by)
+        values
+          (v_brand.id, p_place_id, v_round, v_cat, v_note,
+           case when v_first then v_msg else null end, auth.uid());
+        v_first := false;
+        v_count := v_count + 1;
+      end loop;
+    elsif v_msg is not null then
+      -- Message but no explicit items → one 'other' to-do carrying the message.
+      select coalesce(max(round),0)+1 into v_round
+        from public.venue_claim_feedback where brand_id = v_brand.id;
+      insert into public.venue_claim_feedback
+        (brand_id, place_pool_id, round, category, note, overall_message, created_by)
+      values (v_brand.id, p_place_id, v_round, 'other', v_msg, v_msg, auth.uid());
+      v_count := 1;
+    end if;
+
+    -- Notify active brand members (in-app + push pipeline picks it up).
+    for v_uid in
+      select user_id from public.brand_team_members
+       where brand_id = v_brand.id and removed_at is null and accepted_at is not null
+    loop
+      insert into public.notifications
+        (user_id, type, title, body, brand_id, related_id, related_type, deep_link, data)
+      values
+        (v_uid, 'listing_suspended', 'Your listing was suspended',
+         coalesce(v_msg, 'An admin suspended your venue listing. Open it to see what to fix.'),
+         v_brand.id, p_place_id::text, 'place_pool',
+         '/brand/' || v_brand.id::text || '/listing',
+         jsonb_build_object('place_id', p_place_id, 'brand_id', v_brand.id, 'reason', p_reason));
+      v_notified := v_notified + 1;
+    end loop;
+  end if;
+
+  insert into public.place_admin_actions (place_id, action_type, acted_by, reason, metadata)
+  values (p_place_id, 'suspend', auth.uid(), p_reason,
+          jsonb_build_object('brand_id', v_brand.id, 'todo_items', v_count, 'notified', v_notified));
+
+  return jsonb_build_object('ok', true, 'suspended', true,
+                            'brand_id', v_brand.id, 'todo_items', v_count, 'notified', v_notified);
+end;
+$$;
+
+-- 5b) SOFT-DELETE ------------------------------------------------------------
+create or replace function public.admin_soft_delete_listing(
+  p_place_id uuid,
+  p_reason   text default null,
+  p_message  text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public','pg_temp'
+as $$
+declare
+  v_brand    public.brands%rowtype;
+  v_uid      uuid;
+  v_notified integer := 0;
+  v_msg      text := nullif(trim(coalesce(p_message,'')),'');
+begin
+  if auth.uid() is null then raise exception 'not_authenticated'; end if;
+  if not public.is_admin_user() then raise exception 'forbidden'; end if;
+
+  -- Soft-delete; the trigger forces is_servable=false + is_active=false.
+  update public.place_pool
+     set deleted_at = now(), deleted_reason = p_reason
+   where id = p_place_id and deleted_at is null;
+  if not found then raise exception 'place_not_found_or_already_deleted'; end if;
+
+  -- Revoke a claimed brand. Keep place_pool_id intact so RESTORE can re-link.
+  select * into v_brand
+    from public.brands
+   where place_pool_id = p_place_id and deleted_at is null
+     and claim_status in ('verified','suspended','pending_review')
+   limit 1;
+  if found then
+    update public.brands
+       set claim_status = 'revoked', claim_follow_up_at = now()
+     where id = v_brand.id;
+    for v_uid in
+      select user_id from public.brand_team_members
+       where brand_id = v_brand.id and removed_at is null and accepted_at is not null
+    loop
+      insert into public.notifications
+        (user_id, type, title, body, brand_id, related_id, related_type, deep_link, data)
+      values
+        (v_uid, 'listing_removed', 'Your listing was removed',
+         coalesce(v_msg, 'An admin removed your venue listing from Mingla.'),
+         v_brand.id, p_place_id::text, 'place_pool',
+         '/brand/' || v_brand.id::text || '/listing',
+         jsonb_build_object('place_id', p_place_id, 'reason', p_reason));
+      v_notified := v_notified + 1;
+    end loop;
+  end if;
+
+  insert into public.place_admin_actions (place_id, action_type, acted_by, reason, metadata)
+  values (p_place_id, 'soft_delete', auth.uid(), p_reason,
+          jsonb_build_object('brand_id', v_brand.id, 'notified', v_notified));
+
+  return jsonb_build_object('ok', true, 'deleted', true,
+                            'brand_id', v_brand.id, 'notified', v_notified);
+end;
+$$;
+
+-- 5c) RESTORE (admin undo) ---------------------------------------------------
+create or replace function public.admin_restore_listing(p_place_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public','pg_temp'
+as $$
+declare
+  v_was_deleted boolean;
+  v_brand_id    uuid;
+begin
+  if auth.uid() is null then raise exception 'not_authenticated'; end if;
+  if not public.is_admin_user() then raise exception 'forbidden'; end if;
+
+  select (deleted_at is not null) into v_was_deleted
+    from public.place_pool where id = p_place_id;
+  if v_was_deleted is null then raise exception 'place_not_found'; end if;
+
+  -- Clear soft-delete + bring it back as active. is_servable is left to the
+  -- bouncer/scorer to re-establish (a restore should not fabricate servability).
+  update public.place_pool
+     set deleted_at = null, deleted_reason = null, is_active = true
+   where id = p_place_id;
+
+  -- Re-verify a brand we suspended/revoked for this place.
+  update public.brands
+     set claim_status = 'verified', claim_follow_up_at = null
+   where place_pool_id = p_place_id and claim_status in ('suspended','revoked')
+  returning id into v_brand_id;
+
+  insert into public.place_admin_actions (place_id, action_type, acted_by, reason, metadata)
+  values (p_place_id, 'restore', auth.uid(), null,
+          jsonb_build_object('was_deleted', v_was_deleted, 'brand_id', v_brand_id));
+
+  return jsonb_build_object('ok', true, 'restored', true,
+                            'was_deleted', v_was_deleted, 'brand_id', v_brand_id);
+end;
+$$;
+
+grant execute on function public.admin_suspend_listing(uuid,text,jsonb,text)  to authenticated, service_role;
+grant execute on function public.admin_soft_delete_listing(uuid,text,text)    to authenticated, service_role;
+grant execute on function public.admin_restore_listing(uuid)                  to authenticated, service_role;
+
+-- 6) Extend the ORCH-1064 resubmit loop to accept a SUSPENDED brand ----------
+-- A suspended listing (claim_status='suspended', follow-up stamp set by
+-- admin_suspend_listing) is a corrective state: the business fixes the to-do
+-- items and resubmits, flipping back to pending_review for admin re-approval
+-- (runApproveGoLive then re-bounces → is_servable=true + is_active=true → live).
+create or replace function public.biz_resubmit_venue_claim(p_brand_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public','pg_temp'
+as $function$
+declare
+  v_brand        public.brands%rowtype;
+  v_active_round integer;
+begin
+  if auth.uid() is null then raise exception 'not_authenticated'; end if;
+
+  select * into v_brand from public.brands b
+   where b.id = p_brand_id and b.deleted_at is null;
+  if not found then raise exception 'brand_not_found'; end if;
+
+  if public.biz_brand_effective_rank_for_caller(p_brand_id)
+       < public.biz_role_rank('brand_owner') then
+    raise exception 'forbidden';
+  end if;
+
+  -- Awaiting business action = need-more-info (pending_review + stamp) OR suspended.
+  if v_brand.claim_status not in ('pending_review','suspended')
+     or v_brand.claim_follow_up_at is null then
+    raise exception 'not_awaiting_resubmit';
+  end if;
+
+  select max(round) into v_active_round
+    from public.venue_claim_feedback where brand_id = p_brand_id;
+  if v_active_round is null then
+    raise exception 'no_feedback_to_resubmit';
+  end if;
+
+  -- Back to a clean pending_review for re-review (history preserved).
+  update public.brands
+     set claim_status = 'pending_review', claim_follow_up_at = null
+   where id = p_brand_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'brand_id', p_brand_id,
+    'resubmitted_round', v_active_round,
+    'claim_status', 'pending_review'
+  );
+end;
+$function$;


### PR DESCRIPTION
## What

Admins can take a **live venue listing** off the consumer deck from the **Place Pool Management** modal, with the business owner kept in the loop.

- **Suspend** — off the deck (`is_active=false`), suspends a claimed brand, drops the admin's **custom message + structured to-do items** into the ORCH-1064 to-do list, and **notifies the owner** (push + in-app). The business fixes the to-dos and **resubmits** → admin approves → `runApproveGoLive` re-bounces → back on the deck.
- **Delete** — soft-deletes the `place_pool` row (`deleted_at`), **revokes the claim**, notifies the owner. **Reversible** by an admin (Restore).

## How

**Backend** (`20260909000000_orch_1073…`, applied live + end-to-end smoke-tested — suspend/restore/delete/trigger all pass):
- `place_pool.deleted_at`/`deleted_reason` + **one invariant trigger** `I-1073-DELETED-PLACE-NEVER-SERVABLE`: a deleted row is force-held at `is_servable=false`/`is_active=false`, so no fetch/bouncer/scorer path can resurrect it and the deck excludes it — no per-query filter threading.
- `claim_status` += `suspended`/`revoked`; `place_admin_actions.action_type` += `suspend`/`soft_delete`/`restore`.
- `admin_suspend_listing` / `admin_soft_delete_listing` / `admin_restore_listing` (`SECURITY DEFINER`, `is_admin_user()`-gated); `biz_resubmit_venue_claim` patched to accept a suspended brand.

**Admin UI:** Suspend (message + to-do builder + reason) / Delete (confirm) / Restore + Live/Off-deck/Removed badges in `PlacePoolManagementPage`.

**Business app:** `suspended` reuses the interactive to-do banner + resubmit loop (distinct copy); `revoked` → static "removed" notice; listing badge + `BrandClaimStatus` extended. tsc clean; **16 jest tests pass**.

## Also: unbreaks CI
A cross-session merge left **two `const ORCH_1072_BACKEND_ALLOWLIST`** in one scope of the ORCH-0863 gate (`SyntaxError` crashed it on **every** PR). Renamed the experience-detail entry to a unique identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)