### PR TITLE
[deploy] META-ORCH-1073 Sub-A2: global search sheet edge padding

### DIFF
--- a/mingla-business/src/components/ui/GlobalSearchSheet.tsx
+++ b/mingla-business/src/components/ui/GlobalSearchSheet.tsx
@@ -340,6 +340,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingTop: spacing.sm,
+    // Edge gutter so the search input, group headings ("JUMP TO") and rows
+    // are not flush to the sheet edge (META-ORCH-1073 Sub-A2 QA). Matches the
+    // standard sheet content inset used across mingla-business UI.
+    paddingHorizontal: spacing.md,
   },
   divider: {
     height: 1,


### PR DESCRIPTION
QA polish on the shipped Sub-A search sheet: the "JUMP TO" group heading, row icons and rows were flush to the screen edge with no horizontal inset (operator-reported on web). Adds `paddingHorizontal: spacing.md` (16px, the standard sheet gutter) to the sheet content container — insets the search input, group headings and all rows uniformly. Pure styling; jest 55/55, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)