### PR TITLE
META-ORCH-1074: wire OneSignal App ID into EAS build env (notifications-ready builds)

### DIFF
--- a/mingla-business/eas.json
+++ b/mingla-business/eas.json
@@ -15,7 +15,8 @@
         "buildConfiguration": "Debug"
       },
       "env": {
-        "SENTRY_DISABLE_AUTO_UPLOAD": "true"
+        "SENTRY_DISABLE_AUTO_UPLOAD": "true",
+        "EXPO_PUBLIC_ONESIGNAL_APP_ID": "4505e476-6b2a-424d-906f-d751614980bf"
       }
     },
     "development-sim": {
@@ -37,7 +38,8 @@
       "distribution": "internal",
       "channel": "production",
       "env": {
-        "SENTRY_DISABLE_AUTO_UPLOAD": "true"
+        "SENTRY_DISABLE_AUTO_UPLOAD": "true",
+        "EXPO_PUBLIC_ONESIGNAL_APP_ID": "4505e476-6b2a-424d-906f-d751614980bf"
       }
     },
     "preview-sim": {
@@ -54,7 +56,8 @@
       "autoIncrement": true,
       "channel": "production",
       "env": {
-        "SENTRY_DISABLE_AUTO_UPLOAD": "false"
+        "SENTRY_DISABLE_AUTO_UPLOAD": "false",
+        "EXPO_PUBLIC_ONESIGNAL_APP_ID": "4505e476-6b2a-424d-906f-d751614980bf"
       }
     },
     "production-apk": {
@@ -64,7 +67,8 @@
         "buildType": "apk"
       },
       "env": {
-        "SENTRY_DISABLE_AUTO_UPLOAD": "false"
+        "SENTRY_DISABLE_AUTO_UPLOAD": "false",
+        "EXPO_PUBLIC_ONESIGNAL_APP_ID": "4505e476-6b2a-424d-906f-d751614980bf"
       }
     }
   },


### PR DESCRIPTION
Adds `EXPO_PUBLIC_ONESIGNAL_APP_ID` (public client ID for the Mingla Business OneSignal app) to the development/preview/production/production-apk EAS build profiles. Without it, `app.config.ts` filters out the OneSignal plugin and the SDK no-ops — so a fresh App Store / Play Store build would ship with notifications dead. This makes the next build notification-ready. Backend REST key is already a Supabase secret; iOS APNs + Android FCM already configured in OneSignal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)