### PR TITLE
[deploy] META-ORCH-1073 Sub-A3: search input focus + top-anchor polish

### DIFF
--- a/mingla-business/src/components/ui/GlobalSearchSheet.tsx
+++ b/mingla-business/src/components/ui/GlobalSearchSheet.tsx
@@ -181,7 +181,13 @@ export const GlobalSearchSheet: React.FC = () => {
   );
 
   return (
-    <Sheet visible={isOpen} onClose={close} snapPoint="full" testID="global-search-sheet">
+    <Sheet
+      visible={isOpen}
+      onClose={close}
+      snapPoint="full"
+      verticalAlign="top"
+      testID="global-search-sheet"
+    >
       <View style={styles.container}>
         <Input
           variant="search"

--- a/mingla-business/src/components/ui/Input.tsx
+++ b/mingla-business/src/components/ui/Input.tsx
@@ -31,6 +31,7 @@ import { Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } fr
 import type {
   StyleProp,
   TextInputProps,
+  TextStyle,
   ViewStyle,
 } from "react-native";
 
@@ -633,6 +634,17 @@ export const Input: React.FC<InputProps> = ({
             },
             Platform.OS === "android"
               ? styles.inputAndroid
+              : null,
+            // Search variant on web (META-ORCH-1073 Sub-A3): drop the browser's
+            // default blue focus outline (the design's accent.warm border is the
+            // focus indicator) and give the blinking caret the accent colour so
+            // typing is clearly indicated.
+            variant === "search" && Platform.OS === "web"
+              ? ({
+                  outlineWidth: 0,
+                  outlineStyle: "none",
+                  caretColor: accent.warm,
+                } as unknown as TextStyle)
               : null,
           ]}
           {...behaviour}

--- a/mingla-business/src/components/ui/Sheet.web.tsx
+++ b/mingla-business/src/components/ui/Sheet.web.tsx
@@ -115,6 +115,7 @@ const DesktopCenteredCard: React.FC<SheetProps> = ({
   onClose,
   children,
   dismissOnScrimTap = true,
+  verticalAlign = "center",
   testID,
   style,
 }) => {
@@ -230,7 +231,20 @@ const DesktopCenteredCard: React.FC<SheetProps> = ({
             inner Animated.View carries the fade + scale-in. Sub-sheets
             MUST live inside `children` here — never as Fragment siblings
             of this <Sheet> (I-SUB-SHEET-INSIDE-PARENT). */}
-        <View style={styles.cardWrap} pointerEvents="box-none">
+        <View
+          style={[
+            styles.cardWrap,
+            verticalAlign === "top"
+              ? {
+                  justifyContent: "flex-start",
+                  // Anchor near the top (~12vh) so the card grows/shrinks with
+                  // content without the whole sheet re-centring as you type.
+                  paddingTop: Math.max(viewportHeight * 0.12, 48),
+                }
+              : null,
+          ]}
+          pointerEvents="box-none"
+        >
           <Animated.View
             style={[
               styles.card,

--- a/mingla-business/src/components/ui/SheetMobile.tsx
+++ b/mingla-business/src/components/ui/SheetMobile.tsx
@@ -124,6 +124,14 @@ export interface SheetProps {
   snapPoint?: SheetSnapValue;
   /** Tap on scrim closes sheet. Default `true`. */
   dismissOnScrimTap?: boolean;
+  /**
+   * Wide-desktop web only: vertical placement of the centred card.
+   * `"center"` (default) vertically centres it; `"top"` anchors it near the
+   * top so the card can grow/shrink with content without the whole sheet
+   * re-centring (e.g. a search palette whose result count changes as you type).
+   * Ignored by the mobile bottom sheet, which is always bottom-anchored.
+   */
+  verticalAlign?: "center" | "top";
   testID?: string;
   style?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
Three operator-reported polish fixes on the global search sheet (web):

1. **No more shift on type** — the wide-desktop sheet was vertically *centred*, so as the result count changed (full list → 'no matches') the whole card re-centred and the input jumped. Added an opt-in `verticalAlign="top"` to the shared Sheet (default stays `center`; mobile bottom sheet unaffected) and the search sheet now top-anchors (~12vh), so the input stays put and only the list below grows/shrinks.
2. **Blue focus ring removed** — dropped the browser's default focus outline on the search input (web); the design's `accent.warm` border is the focus indicator.
3. **Blinking caret indicator** — gave the search caret the accent colour so typing is clearly indicated.

Scoped: Input change applies only to `variant="search"` on web; Sheet change is opt-in via the new prop (no other sheet affected). Styling-only (no logic branches); eslint clean, search suite 55/55. Builds on Sub-A/A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)