### PR TITLE
[deploy] META-ORCH-1073 Sub-A4: fix search→Stripe tax/account routes + onboard cold-start error

### DIFF
--- a/mingla-business/src/hooks/useBrandStripeStatus.ts
+++ b/mingla-business/src/hooks/useBrandStripeStatus.ts
@@ -103,6 +103,13 @@ export function useBrandStripeStatus(
     enabled,
     staleTime: STALE_TIME_MS,
     refetchInterval: STALE_TIME_MS, // 30s poll fallback per D-B2-11
+    // META-ORCH-1073 Sub-A4: ride out the `brand-stripe-refresh-status`
+    // edge-function cold-start on first load. The global retry:2 (~3s window)
+    // is too short, so a cold start surfaced a false "Couldn't reach Stripe"
+    // on the onboarding shell until a manual retry hit the now-warm function.
+    // 4 retries with backoff (~1+2+4+8 = 15s) absorbs the cold start.
+    retry: 4,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
     queryFn: async (): Promise<RefreshStatusResult> => {
       if (brandId === null) {
         throw new Error("useBrandStripeStatus: brandId is null but enabled");

--- a/mingla-business/src/lib/search/registry.ts
+++ b/mingla-business/src/lib/search/registry.ts
@@ -260,7 +260,11 @@ export const FEATURE_REGISTRY: readonly SearchRegistryItem[] = [
     type: "setting",
     title: "Tax registrations",
     subtitle: "VAT, sales tax and tax IDs",
-    route: "/connect-tax-registrations",
+    // The embedded /connect-tax-registrations page needs a Stripe account
+    // session token generated server-side (useBrandStripeTaxAccountSession);
+    // visiting it directly shows "Invalid tax tools link". Route to the brand
+    // payments hub, which launches the tax tools with a valid token.
+    route: `/brand/${BRAND_ID_TOKEN}/payments`,
     group: "settings",
     minRank: 50,
     synonyms: ["vat", "sales tax", "tax settings", "tax id"],
@@ -337,7 +341,10 @@ export const FEATURE_REGISTRY: readonly SearchRegistryItem[] = [
     type: "setting",
     title: "Manage payout account",
     subtitle: "Update bank in the Stripe dashboard",
-    route: "/connect-account-management",
+    // The embedded /connect-account-management page needs a Stripe account
+    // session token (shows "Invalid management link" without one). Route to
+    // the brand payments hub, which launches it with a valid token.
+    route: `/brand/${BRAND_ID_TOKEN}/payments`,
     group: "settings",
     minRank: 30,
     synonyms: ["stripe dashboard", "update bank", "manage account"],


### PR DESCRIPTION
Operator-reported: two search 'Jump to' rows led to Stripe error pages on web.

**1. Tax registrations + Manage payout account → 'Invalid link'.** Both rows routed straight to the embedded Stripe pages `/connect-tax-registrations` and `/connect-account-management`, which require a server-generated Stripe **account session token** (via `useBrandStripeTaxAccountSession`); visited directly they show 'Invalid tax/management link — try again from the app'. Repointed both registry routes to `/brand/{id}/payments`, the hub that launches these embedded pages with a valid token.

**2. Onboarding 'Couldn't reach Stripe' (retry worked).** Root cause: the `brand-stripe-refresh-status` edge function **cold-start** on first load exceeds the global `retry:2` (~3s) window, so `useBrandStripeStatus` surfaces a false error until a manual retry hits the now-warm function. Hardened that query's retry to 4 attempts (~15s backoff) so the cold start auto-recovers. (If it ever recurs under heavier cold-starts, an edge-fn keep-warm cron is the robust infra follow-up.)

Scoped: search registry routes + one query's retry config. eslint clean, search suite 55/55. COMMS-0002/0003 N/A (no backend files, no new external-API surface). Builds on Sub-A/A2/A3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)