### PR TITLE
[deploy] META-ORCH-1073 Sub-A5: fix Stripe onboarding 401 (stale-token auth header)

### DIFF
--- a/mingla-business/src/hooks/useBrandStripeBalances.ts
+++ b/mingla-business/src/hooks/useBrandStripeBalances.ts
@@ -66,7 +66,7 @@ export function useBrandStripeBalances(
       if (brandId === null) {
         throw new Error("useBrandStripeBalances: brandId is null but enabled");
       }
-      return fetchBrandStripeBalances(brandId, session?.access_token ?? null);
+      return fetchBrandStripeBalances(brandId);
     },
   });
 }

--- a/mingla-business/src/hooks/useBrandStripeStatus.ts
+++ b/mingla-business/src/hooks/useBrandStripeStatus.ts
@@ -103,18 +103,13 @@ export function useBrandStripeStatus(
     enabled,
     staleTime: STALE_TIME_MS,
     refetchInterval: STALE_TIME_MS, // 30s poll fallback per D-B2-11
-    // META-ORCH-1073 Sub-A4: ride out the `brand-stripe-refresh-status`
-    // edge-function cold-start on first load. The global retry:2 (~3s window)
-    // is too short, so a cold start surfaced a false "Couldn't reach Stripe"
-    // on the onboarding shell until a manual retry hit the now-warm function.
-    // 4 retries with backoff (~1+2+4+8 = 15s) absorbs the cold start.
-    retry: 4,
-    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
+    // (Sub-A4's retry:4 cold-start band-aid removed — the real cause was a
+    //  stale token, fixed in refreshBrandStripeStatus; global retry:2 is fine.)
     queryFn: async (): Promise<RefreshStatusResult> => {
       if (brandId === null) {
         throw new Error("useBrandStripeStatus: brandId is null but enabled");
       }
-      return refreshBrandStripeStatus(brandId, session?.access_token ?? null);
+      return refreshBrandStripeStatus(brandId);
     },
   });
 }

--- a/mingla-business/src/services/__tests__/brandStripeBalancesService.test.ts
+++ b/mingla-business/src/services/__tests__/brandStripeBalancesService.test.ts
@@ -39,7 +39,11 @@ describe("brandStripeBalancesService", () => {
     ).toThrow("malformed payload");
   });
 
-  test("passes explicit bearer token to the balances edge function", async () => {
+  // [TEST-MOD-APPROVED META-ORCH-1073-Sub-A5] — the function no longer passes a
+  // custom Authorization header (that sent a stale useAuth() token → 401). It
+  // now relies on supabase.functions.invoke's own auto-refreshed session token,
+  // so the invoke must be called with NO custom headers.
+  test("invokes the balances edge fn without a custom auth header (uses client session)", async () => {
     const invoke = supabase.functions.invoke as jest.MockedFunction<
       typeof supabase.functions.invoke
     >;
@@ -54,11 +58,10 @@ describe("brandStripeBalancesService", () => {
     });
 
     await expect(
-      fetchBrandStripeBalances("brand-1", "access-token-1"),
+      fetchBrandStripeBalances("brand-1"),
     ).resolves.toMatchObject({ currency: "USD" });
     expect(invoke).toHaveBeenCalledWith("brand-stripe-balances", {
       body: { brand_id: "brand-1" },
-      headers: { Authorization: "Bearer access-token-1" },
     });
   });
 });

--- a/mingla-business/src/services/brandStripeBalancesService.ts
+++ b/mingla-business/src/services/brandStripeBalancesService.ts
@@ -56,16 +56,15 @@ export function parseBrandStripeBalancesResponse(
 
 export async function fetchBrandStripeBalances(
   brandId: string,
-  accessToken?: string | null,
 ): Promise<BrandStripeBalancesResult> {
+  // No custom Authorization header: let supabase.functions.invoke use the
+  // client's CURRENT (auto-refreshed) session token. META-ORCH-1073 Sub-A5:
+  // passing useAuth()'s `session.access_token` sent a STALE token rejected by
+  // the edge fn's auth.getUser with 401 (same bug as refreshBrandStripeStatus).
   const { data, error } = await supabase.functions.invoke<RawBalancesResponse>(
     "brand-stripe-balances",
     {
       body: { brand_id: brandId },
-      headers:
-        typeof accessToken === "string" && accessToken.length > 0
-          ? { Authorization: `Bearer ${accessToken}` }
-          : undefined,
     },
   );
   if (error) throw error;

--- a/mingla-business/src/services/brandStripeService.ts
+++ b/mingla-business/src/services/brandStripeService.ts
@@ -192,15 +192,17 @@ export async function startBrandStripeOnboarding(
  */
 export async function refreshBrandStripeStatus(
   brandId: string,
-  accessToken?: string | null,
 ): Promise<RefreshStatusResult> {
+  // No custom Authorization header: let supabase.functions.invoke use the
+  // client's CURRENT (auto-refreshed) session token. META-ORCH-1073 Sub-A5:
+  // passing useAuth()'s `session.access_token` here sent a STALE token (the
+  // Supabase client refreshes silently but the React session snapshot lags),
+  // which the edge fn's `auth.getUser` rejected with 401 — surfacing as
+  // "Couldn't reach Stripe" on the onboarding shell's first load.
   const { data, error } = await supabase.functions.invoke<RefreshStatusResult>(
     "brand-stripe-refresh-status",
     {
       body: { brand_id: brandId },
-      headers: typeof accessToken === "string" && accessToken.length > 0
-        ? { Authorization: `Bearer ${accessToken}` }
-        : undefined,
     },
   );
   if (error) {


### PR DESCRIPTION
**Real root cause of 'Couldn't reach Stripe'** (my Sub-A4 cold-start theory was wrong; reverted that band-aid).

Live edge-function logs showed `brand-stripe-refresh-status` (and `brand-stripe-balances`) returning **401 on every call**, ~150ms each — i.e. the function *ran* and its own `auth.getUser(token)` rejected the token (a gateway/cold-start reject would be ~10ms).

The client passed `useAuth()`'s `session.access_token` as a **custom `Authorization` header**, overriding `supabase.functions.invoke`'s default. That React session snapshot **lags the Supabase client's silently-refreshed token**, so a stale/expired token reached the edge fn → 401. (`startBrandStripeOnboarding`, which passes no custom header, never 401'd — that's the working pattern.) 'Try again worked' only because the snapshot had refreshed by then.

**Fix:** drop the custom header in both services so invoke uses the client's current auto-refreshed token. Revert Sub-A4's retry:4 (pointless against a 401). 4 files + 1 test updated ([TEST-MOD-APPROVED]). Client-only — no edge fn/migration. eslint clean, balances suite 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)