### PR TITLE
ORCH-1081: Partner workflow polish — 7 surfaces

### DIFF
--- a/mingla-business/app/(tabs)/account.tsx
+++ b/mingla-business/app/(tabs)/account.tsx
@@ -43,6 +43,9 @@ import { useBrandListState } from "../../src/hooks/useBrandListShim";
 // refetches on window focus + mount so the flip becomes visible within
 // seconds of the next Account-tab open (no manual reload needed).
 import { usePartnerStripeStatus } from "../../src/hooks/usePartnerStripe";
+// ORCH-1081 — partner_brand_links count drives the "Partner brands" row meta
+// (active + pending). Read-only; staleTime 30s.
+import { usePartnerBrandLinks } from "../../src/hooks/usePartnerBrandLinks";
 import {
   useCurrentBrandStore,
   type Brand,
@@ -117,6 +120,21 @@ export default function AccountTab(): React.ReactElement {
   }, [router]);
   const partnerStatus = usePartnerStripeStatus();
   const isPartner = partnerStatus.data?.partner_enabled === true;
+  // ORCH-1081 — partner brand portfolio entry-row meta. Skipped (no fetch) when
+  // the user isn't a partner — `enabled` is implicit through React Query's
+  // staleTime + we just don't read .data when isPartner=false.
+  const partnerLinksQuery = usePartnerBrandLinks();
+  const partnerActiveCount = isPartner
+    ? (partnerLinksQuery.data ?? []).filter((r) => r.status === "active").length
+    : 0;
+  const partnerPendingCount = isPartner
+    ? (partnerLinksQuery.data ?? []).filter(
+        (r) => r.status === "awaiting_owner" || r.status === "awaiting_stripe",
+      ).length
+    : 0;
+  const handlePartnerBrands = useCallback((): void => {
+    router.push("/partner/brands" as never);
+  }, [router]);
 
   const handleOpenSwitcher = useCallback((): void => {
     setSheetVisible(true);
@@ -264,6 +282,18 @@ export default function AccountTab(): React.ReactElement {
                 icon="trending-up"
                 label="Partner earnings"
                 onPress={handlePartnerEarnings}
+              />
+              {/* ORCH-1081 — Partner brands row. Meta count rendered inline.
+                  Shows on every partner's account; the empty-list-state
+                  inside the screen handles the no-brands case. */}
+              <SettingsNavRow
+                icon="tag"
+                label={
+                  partnerActiveCount === 0 && partnerPendingCount === 0
+                    ? "Partner brands"
+                    : `Partner brands · ${partnerActiveCount} active · ${partnerPendingCount} pending`
+                }
+                onPress={handlePartnerBrands}
               />
             </View>
           </GlassCard>

--- a/mingla-business/app/accept-brand-invitation.tsx
+++ b/mingla-business/app/accept-brand-invitation.tsx
@@ -91,6 +91,26 @@ export default function AcceptBrandInvitationRoute(): React.ReactElement {
     router.replace(`/brand/${phase.result.brandId}/team` as never);
   }, [phase, router]);
 
+  // ORCH-1081 — once accept succeeds AND the brand was a partner setup, route
+  // immediately to the celebration screen instead of staying on the inline
+  // success card. This is the path most new owners take (link from email →
+  // sign in → accept → celebration). For non-partner-setup accepts, we keep
+  // the existing inline success card.
+  useEffect(() => {
+    if (phase.kind !== "success") return;
+    if (!phase.result.partnerSetup) return;
+    if (!phase.result.transferred) return;
+    const params = new URLSearchParams();
+    params.set("brand_id", phase.result.brandId);
+    if (phase.result.brandSlug) params.set("brand", phase.result.brandSlug);
+    if (phase.result.newOwnerFirstName) {
+      params.set("owner_name", phase.result.newOwnerFirstName);
+    }
+    router.replace(
+      `/accept-brand-invitation/success?${params.toString()}` as never,
+    );
+  }, [phase, router]);
+
   const handleGoHome = useCallback((): void => {
     router.replace("/(tabs)/home" as never);
   }, [router]);

--- a/mingla-business/app/accept-brand-invitation/success.tsx
+++ b/mingla-business/app/accept-brand-invitation/success.tsx
@@ -1,0 +1,225 @@
+/**
+ * /accept-brand-invitation/success — post-accept celebration screen.
+ * ORCH-1081.
+ *
+ * Mounted from /accept-brand-invitation after a partner-setup invite is
+ * accepted (transferred=true AND partner_setup=true). Renders:
+ *   - 🎉 hero
+ *   - "Welcome to {BrandName}" + partner attribution line
+ *   - Primary: "Set up {BrandName} on the web →" → /brand/{id}/payments
+ *   - Secondary: App Store + Play Store CTA pair (HARDCODED URLs per spec)
+ *   - Footer: "Or come back to your email anytime."
+ *
+ * Query params (all optional except brand_id):
+ *   - brand_id      — UUID of the now-owned brand. Required.
+ *   - brand         — brand slug (used in copy when name lookup fails).
+ *   - owner_name    — new owner first name (used in body copy).
+ *
+ * We re-fetch the brand row by id when present so we surface the canonical
+ * display name; the slug param is a fallback for the loading state. RLS on
+ * brands allows the new owner (via brands.account_id = auth.uid()) to read
+ * their own brand.
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+import { Button } from "../../src/components/ui/Button";
+import {
+  accent,
+  canvas,
+  glass,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../src/constants/designSystem";
+import { supabase } from "../../src/services/supabase";
+
+// HARDCODED per spec — App Store records exist; URLs 404 pre-launch but
+// become live the moment Mingla Business ships. NO feature flag.
+const IOS_STORE_URL = "https://apps.apple.com/app/id6768737367";
+const ANDROID_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.sethogieva.minglabusiness";
+
+export default function AcceptBrandInvitationSuccess(): React.ReactElement {
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    brand_id?: string | string[];
+    brand?: string | string[];
+    owner_name?: string | string[];
+  }>();
+  const brandId = pickFirst(params.brand_id);
+  const brandSlug = pickFirst(params.brand);
+  const ownerName = pickFirst(params.owner_name);
+
+  const [brandName, setBrandName] = useState<string | null>(
+    brandSlug ? toTitleFromSlug(brandSlug) : null,
+  );
+  const [loading, setLoading] = useState<boolean>(brandId !== null);
+
+  useEffect(() => {
+    if (brandId === null) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { data } = await supabase
+          .from("brands")
+          .select("name")
+          .eq("id", brandId)
+          .maybeSingle();
+        if (cancelled) return;
+        const name = (data?.name as string | null) ?? null;
+        if (name && name.trim().length > 0) {
+          setBrandName(name.trim());
+        }
+      } catch {
+        // Fall through to slug-derived fallback.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [brandId]);
+
+  const handleOpenPayments = (): void => {
+    if (brandId === null) {
+      router.replace("/(tabs)/home" as never);
+      return;
+    }
+    router.replace(`/brand/${brandId}/payments` as never);
+  };
+
+  const handleOpenStore = (url: string): void => {
+    if (Platform.OS === "web") {
+      if (typeof window !== "undefined") window.location.href = url;
+      return;
+    }
+    void Linking.openURL(url).catch(() => undefined);
+  };
+
+  const displayName = brandName ?? brandSlug ?? "your brand";
+  const partnerLine = ownerName
+    ? `Hey ${ownerName} — Mingla has built it out for you.`
+    : "Mingla has built it out for you.";
+
+  return (
+    <View style={styles.host}>
+      <View style={styles.card}>
+        <Text style={styles.hero}>🎉</Text>
+        <Text style={styles.title} accessibilityRole="header">
+          {loading ? "Welcome…" : `Welcome to ${displayName}`}
+        </Text>
+        <Text style={styles.body}>
+          {partnerLine}
+          {" "}
+          The next step is connecting your bank so customers can buy tickets.
+        </Text>
+        {loading ? (
+          <ActivityIndicator color={accent.warm} style={{ marginTop: 8 }} />
+        ) : null}
+        <Button
+          label={`Set up ${displayName} on the web →`}
+          onPress={handleOpenPayments}
+          variant="primary"
+          size="lg"
+          fullWidth
+        />
+        <View style={styles.storeRow}>
+          <Button
+            label="Download for iOS"
+            onPress={() => handleOpenStore(IOS_STORE_URL)}
+            variant="secondary"
+            size="md"
+            style={styles.storeButton}
+          />
+          <Button
+            label="Download for Android"
+            onPress={() => handleOpenStore(ANDROID_STORE_URL)}
+            variant="secondary"
+            size="md"
+            style={styles.storeButton}
+          />
+        </View>
+        <Text style={styles.footnote}>
+          Or come back to your email anytime.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function pickFirst(v: string | string[] | undefined): string | null {
+  if (Array.isArray(v)) return v[0] ?? null;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function toTitleFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter((p) => p.length > 0)
+    .map((p) => p[0].toUpperCase() + p.slice(1))
+    .join(" ");
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+    backgroundColor: canvas.discover,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: spacing.xl,
+  },
+  card: {
+    maxWidth: 480,
+    width: "100%",
+    backgroundColor: glass.tint.profileBase,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    borderRadius: radiusTokens.lg,
+    padding: spacing.xl,
+    gap: spacing.md,
+  },
+  hero: {
+    fontSize: 56,
+    textAlign: "center",
+    marginBottom: 4,
+  },
+  title: {
+    ...typography.h1,
+    color: textTokens.primary,
+    textAlign: "center",
+  },
+  body: {
+    ...typography.body,
+    color: textTokens.secondary,
+    textAlign: "center",
+  },
+  storeRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  storeButton: {
+    flex: 1,
+  },
+  footnote: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+    textAlign: "center",
+    marginTop: spacing.sm,
+  },
+});

--- a/mingla-business/app/partner/brands.tsx
+++ b/mingla-business/app/partner/brands.tsx
@@ -1,0 +1,414 @@
+/**
+ * /partner/brands — Mingla partner brand portfolio list. ORCH-1081.
+ *
+ * Visible only to flagged Mingla partners (creator_accounts.partner_enabled
+ * = true). Reads partner_brand_links via the usePartnerBrandLinks hook
+ * (RLS gates: partner_account_id = auth.uid()) and surfaces:
+ *   - rows in priority order (awaiting_owner → awaiting_stripe → active)
+ *   - status chip + subtext per row
+ *   - tap-through → /brand/{id} dashboard
+ *   - empty state CTA → /brand/new?partner_mode=client (BrandCreationFlow
+ *     reads partner_mode and lands on step 1 with mode='client').
+ *
+ * Mirrors earnings.tsx structure (modal-style with X close header, scroll
+ * content, dark canvas, GlassCard rows).
+ */
+
+import React, { useCallback, useMemo } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Stack, useRouter } from "expo-router";
+
+import { usePartnerBrandLinks } from "../../src/hooks/usePartnerBrandLinks";
+import type {
+  PartnerBrandLinkStatus,
+  PartnerBrandLinkWithStatus,
+} from "../../src/services/partnerBrandLinksService";
+import {
+  accent,
+  canvas,
+  glass,
+  radius,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../src/constants/designSystem";
+import { GlassCard } from "../../src/components/ui/GlassCard";
+import { IconChrome } from "../../src/components/ui/IconChrome";
+
+const STATUS_RANK: Record<PartnerBrandLinkStatus, number> = {
+  awaiting_owner: 0,
+  awaiting_stripe: 1,
+  active: 2,
+  cancelled: 3,
+};
+
+export default function PartnerBrandsScreen(): React.ReactElement {
+  const router = useRouter();
+  const linksQuery = usePartnerBrandLinks();
+
+  const handleClose = useCallback((): void => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/account" as never);
+    }
+  }, [router]);
+
+  const handleOpenBrand = useCallback(
+    (brandId: string): void => {
+      router.push(`/brand/${brandId}` as never);
+    },
+    [router],
+  );
+
+  const handleSetUpFirst = useCallback((): void => {
+    router.push("/brand/new?partner_mode=client" as never);
+  }, [router]);
+
+  const sortedRows = useMemo<PartnerBrandLinkWithStatus[]>(() => {
+    const rows = linksQuery.data ?? [];
+    return [...rows].sort((a, b) => {
+      const rankDiff = STATUS_RANK[a.status] - STATUS_RANK[b.status];
+      if (rankDiff !== 0) return rankDiff;
+      // Within active: sort by first_split_at desc (most recent earnings first).
+      if (a.status === "active" && b.status === "active") {
+        const aTime = a.first_split_at
+          ? new Date(a.first_split_at).getTime()
+          : 0;
+        const bTime = b.first_split_at
+          ? new Date(b.first_split_at).getTime()
+          : 0;
+        return bTime - aTime;
+      }
+      // Within any other state: newest invite first.
+      const aTime = new Date(a.invited_at).getTime();
+      const bTime = new Date(b.invited_at).getTime();
+      return bTime - aTime;
+    });
+  }, [linksQuery.data]);
+
+  const activeCount = sortedRows.filter((r) => r.status === "active").length;
+  const pendingCount = sortedRows.filter(
+    (r) => r.status === "awaiting_owner" || r.status === "awaiting_stripe",
+  ).length;
+
+  return (
+    <SafeAreaView style={styles.safe} edges={["top", "bottom"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.header}>
+        <View style={styles.headerTextCol}>
+          <Text style={styles.eyebrow}>MINGLA PARTNER</Text>
+          <Text style={styles.h1}>Brands</Text>
+          {(activeCount > 0 || pendingCount > 0) ? (
+            <Text style={styles.headerMeta}>
+              {activeCount} active · {pendingCount} pending
+            </Text>
+          ) : null}
+        </View>
+        <IconChrome
+          icon="x"
+          size={36}
+          onPress={handleClose}
+          accessibilityLabel="Close partner brands"
+          testID="partner-brands-close-button"
+        />
+      </View>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {linksQuery.isLoading ? (
+          <View style={styles.center}>
+            <ActivityIndicator color={accent.warm} />
+          </View>
+        ) : linksQuery.error ? (
+          <GlassCard variant="elevated" padding={spacing.lg}>
+            <Text style={styles.cardTitle}>Couldn't load your brands</Text>
+            <Text style={styles.cardBody}>{linksQuery.error.message}</Text>
+            <Pressable
+              accessibilityLabel="Retry"
+              style={styles.secondaryBtn}
+              onPress={() => linksQuery.refetch()}
+            >
+              <Text style={styles.secondaryBtnText}>Retry</Text>
+            </Pressable>
+          </GlassCard>
+        ) : sortedRows.length === 0 ? (
+          <GlassCard variant="elevated" padding={spacing.lg}>
+            <Text style={styles.cardTitle}>No partner brands yet</Text>
+            <Text style={styles.cardBody}>
+              Brands you set up for clients show up here. You'll see them go
+              from invite-sent to live to earning.
+            </Text>
+            <Pressable
+              accessibilityLabel="Set up your first partner brand"
+              style={styles.primaryBtn}
+              onPress={handleSetUpFirst}
+            >
+              <Text style={styles.primaryBtnText}>
+                Set up your first partner brand →
+              </Text>
+            </Pressable>
+          </GlassCard>
+        ) : (
+          sortedRows.map((row) => (
+            <BrandLinkRow
+              key={row.id}
+              row={row}
+              onPress={() => handleOpenBrand(row.brand_id)}
+            />
+          ))
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function BrandLinkRow(props: {
+  row: PartnerBrandLinkWithStatus;
+  onPress: () => void;
+}): React.ReactElement {
+  const { row, onPress } = props;
+  const brand = row.brand ?? null;
+  const brandName = brand?.name ?? "Brand";
+  const coverUrl = brand?.cover_media_url ?? null;
+  const coverType = brand?.cover_media_type ?? null;
+  // Stills only for the round thumbnail; skip videos.
+  const hasStillCover = coverUrl !== null &&
+    coverUrl.length > 0 &&
+    coverType !== "video";
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${brandName}`}
+      onPress={onPress}
+    >
+      <GlassCard variant="elevated" padding={spacing.md}>
+        <View style={styles.rowOuter}>
+          <View style={styles.thumbWrap}>
+            {hasStillCover ? (
+              <Image
+                source={{ uri: coverUrl as string }}
+                style={styles.thumb}
+                accessibilityIgnoresInvertColors
+              />
+            ) : (
+              <View style={[styles.thumb, styles.thumbFallback]}>
+                <Text style={styles.thumbFallbackText}>
+                  {brandName.slice(0, 1).toUpperCase()}
+                </Text>
+              </View>
+            )}
+          </View>
+          <View style={styles.rowBody}>
+            <Text style={styles.brandName} numberOfLines={1}>
+              {brandName}
+            </Text>
+            <View style={styles.statusRow}>
+              <StatusDot status={row.status} />
+              <Text style={styles.statusLabel}>{statusLabel(row.status)}</Text>
+            </View>
+            <Text style={styles.subText} numberOfLines={1}>
+              {subTextFor(row)}
+            </Text>
+          </View>
+        </View>
+      </GlassCard>
+    </Pressable>
+  );
+}
+
+function StatusDot({ status }: { status: PartnerBrandLinkStatus }): React.ReactElement {
+  const color = status === "active"
+    ? semantic.success
+    : status === "awaiting_stripe"
+    ? semantic.warning
+    : status === "awaiting_owner"
+    ? accent.warm
+    : textTokens.tertiary;
+  return <View style={[styles.dot, { backgroundColor: color }]} />;
+}
+
+function statusLabel(status: PartnerBrandLinkStatus): string {
+  switch (status) {
+    case "awaiting_owner":
+      return "Awaiting Owner";
+    case "awaiting_stripe":
+      return "Awaiting Stripe";
+    case "active":
+      return "Active";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return status;
+  }
+}
+
+function subTextFor(row: PartnerBrandLinkWithStatus): string {
+  switch (row.status) {
+    case "awaiting_owner":
+      return `Invite sent ${timeAgo(row.invited_at)}`;
+    case "awaiting_stripe":
+      return row.accepted_at !== null
+        ? `Owner accepted ${timeAgo(row.accepted_at)}`
+        : "Owner accepted";
+    case "active":
+      return row.first_split_at !== null
+        ? `First split ${timeAgo(row.first_split_at)}`
+        : "Stripe connected";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "";
+  }
+}
+
+function timeAgo(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  const wk = Math.floor(day / 7);
+  if (wk < 4) return `${wk}w ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  const yr = Math.floor(day / 365);
+  return `${yr}y ago`;
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: canvas.profile },
+  scroll: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xxl,
+    gap: spacing.sm,
+  },
+  center: { paddingVertical: spacing.xxl, alignItems: "center" },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+  },
+  headerTextCol: { flex: 1, gap: 2 },
+  eyebrow: {
+    ...typography.labelCap,
+    color: accent.warm,
+  },
+  h1: {
+    ...typography.h1,
+    color: textTokens.primary,
+  },
+  headerMeta: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+    marginTop: 2,
+  },
+  cardTitle: {
+    ...typography.h3,
+    color: textTokens.primary,
+    marginTop: spacing.xs,
+  },
+  cardBody: {
+    ...typography.body,
+    color: textTokens.secondary,
+    marginTop: spacing.xs,
+  },
+  primaryBtn: {
+    backgroundColor: accent.warm,
+    paddingVertical: spacing.sm + 4,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radius.md,
+    alignItems: "center",
+    marginTop: spacing.md,
+  },
+  primaryBtnText: {
+    ...typography.buttonMd,
+    color: textTokens.inverse,
+  },
+  secondaryBtn: {
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    borderRadius: radius.md,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: glass.border.profileElevated,
+    marginTop: spacing.md,
+    backgroundColor: glass.tint.profileBase,
+  },
+  secondaryBtnText: {
+    ...typography.buttonMd,
+    color: textTokens.primary,
+  },
+  rowOuter: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  thumbWrap: {
+    width: 60,
+    height: 60,
+  },
+  thumb: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    overflow: "hidden",
+  },
+  thumbFallback: {
+    backgroundColor: accent.warm,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  thumbFallbackText: {
+    fontSize: 22,
+    fontWeight: "800",
+    color: "#FFFFFF",
+  },
+  rowBody: {
+    flex: 1,
+    gap: 2,
+  },
+  brandName: {
+    ...typography.bodyLg,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 2,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  statusLabel: {
+    ...typography.micro,
+    fontWeight: "700",
+    color: textTokens.secondary,
+    letterSpacing: 0.5,
+  },
+  subText: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+  },
+});

--- a/mingla-business/app/partner/earnings.tsx
+++ b/mingla-business/app/partner/earnings.tsx
@@ -28,6 +28,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
+// ORCH-1081 — AsyncStorage for the one-time welcome-to-portfolio toast.
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import {
   useDetachPartnerStripe,
@@ -39,6 +41,9 @@ import {
   usePartnerEarningsSummary,
   usePartnerSplits,
 } from "../../src/hooks/usePartnerSplits";
+// ORCH-1081 — partner_brand_links drives the "Ready to earn" nudge + the
+// smarter splits empty-state copy.
+import { usePartnerBrandLinks } from "../../src/hooks/usePartnerBrandLinks";
 import type {
   PartnerSplitRow,
   PartnerSplitStatus,
@@ -202,6 +207,11 @@ export default function PartnerEarningsScreen(): React.ReactElement {
         />
       </View>
 
+      {/* ORCH-1081 — welcome-to-portfolio toast: fires once per (partner,
+          brand_id) pair when the link first goes accepted. Tracks dismissal
+          via AsyncStorage so it never replays. */}
+      <PortfolioWelcomeToast />
+
       <ScrollView contentContainerStyle={styles.scroll}>
         {statusQuery.isLoading ? (
           <View style={styles.center}>
@@ -253,11 +263,135 @@ export default function PartnerEarningsScreen(): React.ReactElement {
               onDisconnect={handleDisconnectStripe}
               disconnecting={detachStripe.isPending}
             />
+            {/* ORCH-1081 — Ready-to-earn nudge. Visible only when the partner is
+                connected (status=active) AND has zero partner_brand_links. */}
+            {statusQuery.data?.status === "active" ? <ReadyToEarnNudge /> : null}
             <PartnerSplitsSection />
           </>
         )}
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+/**
+ * ORCH-1081 — Ready-to-earn nudge card. Renders only when the active partner
+ * has ZERO partner_brand_links. CTA drives them to the brand-creation wizard
+ * with partner_mode=client so step 1 lands with mode='client' already set.
+ */
+function ReadyToEarnNudge(): React.ReactElement | null {
+  const router = useRouter();
+  const linksQuery = usePartnerBrandLinks();
+  if (linksQuery.isLoading) return null;
+  const links = linksQuery.data ?? [];
+  if (links.length > 0) return null;
+  return (
+    <GlassCard variant="elevated" padding={spacing.lg}>
+      <Text style={styles.nudgeEyebrow}>✨ READY TO START EARNING?</Text>
+      <Text style={styles.cardTitle}>Set up your first partner brand</Text>
+      <Text style={styles.cardBody}>
+        Partners earn 0.15% of every ticket sold on brands you help set up.
+      </Text>
+      <Text style={styles.nudgeStep}>① Create a brand for a venue you know</Text>
+      <Text style={styles.nudgeStep}>② Build it out (events, cover, etc.)</Text>
+      <Text style={styles.nudgeStep}>③ Invite the real owner</Text>
+      <Pressable
+        accessibilityLabel="Set up your first partner brand"
+        style={styles.primaryBtn}
+        onPress={() => router.push("/brand/new?partner_mode=client" as never)}
+      >
+        <Text style={styles.primaryBtnText}>
+          Set up your first partner brand →
+        </Text>
+      </Pressable>
+    </GlassCard>
+  );
+}
+
+/**
+ * ORCH-1081 — Welcome-to-portfolio toast. On first /partner/earnings open
+ * AFTER a partner_brand_links row went accepted, we surface a celebratory
+ * dismissable toast. Dismissal is persisted per (link.id) so it never
+ * replays — we treat each accepted link as a one-shot.
+ */
+const WELCOME_DISMISSED_KEY = "mingla-business:partner:portfolio:welcomeDismissed:v1";
+
+function PortfolioWelcomeToast(): React.ReactElement | null {
+  const linksQuery = usePartnerBrandLinks();
+  const [showLink, setShowLink] = useState<{ id: string; brand: string } | null>(
+    null,
+  );
+  const [dismissedIds, setDismissedIds] = useState<Set<string> | null>(null);
+
+  // Load dismissed ids once.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(WELCOME_DISMISSED_KEY);
+        if (cancelled) return;
+        if (raw === null) {
+          setDismissedIds(new Set());
+          return;
+        }
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          setDismissedIds(new Set(parsed.filter((v): v is string => typeof v === "string")));
+        } else {
+          setDismissedIds(new Set());
+        }
+      } catch {
+        if (!cancelled) setDismissedIds(new Set());
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Pick the first un-dismissed accepted link.
+  useEffect(() => {
+    if (dismissedIds === null) return;
+    const links = linksQuery.data ?? [];
+    const accepted = links.find(
+      (r) => r.accepted_at !== null && !dismissedIds.has(r.id),
+    );
+    if (accepted) {
+      setShowLink({
+        id: accepted.id,
+        brand: accepted.brand?.name ?? "your brand",
+      });
+    }
+  }, [linksQuery.data, dismissedIds]);
+
+  const handleDismiss = useCallback((): void => {
+    if (showLink === null || dismissedIds === null) return;
+    const next = new Set(dismissedIds);
+    next.add(showLink.id);
+    setDismissedIds(next);
+    setShowLink(null);
+    void AsyncStorage.setItem(
+      WELCOME_DISMISSED_KEY,
+      JSON.stringify(Array.from(next)),
+    ).catch(() => undefined);
+  }, [showLink, dismissedIds]);
+
+  if (showLink === null) return null;
+  return (
+    <View style={styles.welcomeToastWrap}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss welcome message"
+        onPress={handleDismiss}
+        style={styles.welcomeToast}
+      >
+        <Text style={styles.welcomeToastText}>
+          🎉 Welcome aboard, partner of {showLink.brand}. You'll see splits
+          here once they connect Stripe and sell their first ticket.
+        </Text>
+        <Text style={styles.welcomeToastClose}>Tap to dismiss</Text>
+      </Pressable>
+    </View>
   );
 }
 
@@ -277,6 +411,9 @@ function PartnerSplitsSection(): React.ReactElement {
   const splitsQuery = usePartnerSplits(
     currencyFilter ? { currency: currencyFilter } : {},
   );
+  // ORCH-1081 — varies the empty-state copy depending on whether the partner
+  // already has brands in flight.
+  const linksQuery = usePartnerBrandLinks();
 
   const availableCurrencies = useMemo(() => {
     const set = new Set<string>();
@@ -312,13 +449,19 @@ function PartnerSplitsSection(): React.ReactElement {
   const splits = splitsQuery.data ?? [];
 
   if (totals.length === 0) {
+    // ORCH-1081 — copy varies based on partner_brand_links state.
+    const links = linksQuery.data ?? [];
+    const hasLinks = links.length > 0;
+    const firstBrandName = hasLinks
+      ? (links[0].brand?.name ?? "your brand")
+      : null;
+    const copy = hasLinks
+      ? `Almost there. You've set up ${firstBrandName}. You'll see your first split as soon as their Stripe is connected and tickets sell.`
+      : "You'll see your first split as soon as a brand you set up makes a sale.";
     return (
       <GlassCard variant="elevated" padding={spacing.lg}>
         <Text style={styles.cardTitle}>Splits</Text>
-        <Text style={styles.cardBody}>
-          No splits yet. As soon as a partnered event sells tickets, your
-          share lands here automatically.
-        </Text>
+        <Text style={styles.cardBody}>{copy}</Text>
       </GlassCard>
     );
   }
@@ -853,5 +996,37 @@ const styles = StyleSheet.create({
   },
   badgeText: {
     ...typography.micro,
+  },
+  // ORCH-1081 — Ready-to-earn nudge typography.
+  nudgeEyebrow: {
+    ...typography.labelCap,
+    color: accent.warm,
+    marginBottom: spacing.xs,
+  },
+  nudgeStep: {
+    ...typography.body,
+    color: textTokens.secondary,
+    marginTop: 4,
+  },
+  welcomeToastWrap: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+  },
+  welcomeToast: {
+    backgroundColor: accent.tint,
+    borderRadius: radius.md,
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    borderWidth: 1,
+    borderColor: accent.border,
+  },
+  welcomeToastText: {
+    ...typography.body,
+    color: textTokens.primary,
+  },
+  welcomeToastClose: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+    marginTop: 4,
   },
 });

--- a/mingla-business/src/components/brand/BrandCreationFlow.tsx
+++ b/mingla-business/src/components/brand/BrandCreationFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 // orch-strict-grep-allow orch-0892 — META-ORCH-0972 Sub-B BrandCreationFlow is a 4-step universal brand creation flow; keyboard-input fields (brand name, bio, address) sit at top of viewport and are not scroll-occluded by the on-screen keyboard. SmartScrollView migration deferred to a dedicated keyboard-hygiene follow-up ORCH.
 import {
   Pressable,
@@ -8,7 +8,12 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
+// ORCH-1081 — partner mode (Step 0 + Step 5 "Invite the owner"). The toggle
+// is gated on creator_accounts.partner_enabled via usePartnerStripeStatus,
+// the same flag the rest of the partner surface keys off.
+import { usePartnerStripeStatus } from "../../hooks/usePartnerStripe";
+import { inviteBrandMember } from "../../services/brandInvitationsService";
 
 import {
   accent,
@@ -56,7 +61,13 @@ export interface BrandCreationFlowProps {
   onCancel?: () => void;
 }
 
-export type BrandCreationStep = 1 | 2 | 3 | 4;
+// ORCH-1081 — step 0 = partner-mode picker (only visible to flagged partners),
+// step 5 = "Invite the owner" appended when partner-mode "client" is picked.
+// Step ids stay numeric for back-compat with the existing reducer + stepper
+// integers; the new steps are 0 and 5.
+export type BrandCreationStep = 0 | 1 | 2 | 3 | 4 | 5;
+
+export type PartnerMode = "self" | "client";
 
 export interface BrandCreationState {
   step: BrandCreationStep;
@@ -64,12 +75,16 @@ export interface BrandCreationState {
   bio: string;
   address: string | null;
   brandId: string | null;
+  // ORCH-1081 — partner-mode state. When the user is NOT a flagged partner
+  // mode stays 'self' forever and step 0 is skipped (initial step = 1).
+  mode: PartnerMode;
 }
 
 export type BrandCreationAction =
   | { type: "setIdentity"; name: string; bio: string }
   | { type: "brandCreated"; brandId: string }
   | { type: "setAddress"; address: string | null }
+  | { type: "setMode"; mode: PartnerMode }
   | { type: "next" }
   | { type: "back" };
 
@@ -79,15 +94,33 @@ export const BRAND_CREATION_INITIAL_STATE: BrandCreationState = {
   bio: "",
   address: null,
   brandId: null,
+  mode: "self",
 };
 
 export const BRAND_CREATION_COPY = {
+  step0: {
+    title: "Who's this brand for?",
+    subtitle:
+      "You can set up a brand for yourself or for a client venue you're helping onboard.",
+    selfTitle: "It's mine",
+    selfBody: "Standard brand setup — you'll be the brand owner.",
+    clientTitle: "I'm setting it up for a client",
+    clientBody:
+      "Build out the brand, then invite the real owner. You earn 0.15% on every ticket they sell.",
+    cta: "Continue",
+  },
   step1: {
     title: "Create brand",
+    titleClient: "Create the client's brand",
     nameLabel: "Brand name",
+    nameLabelClient: "What's their venue called?",
     namePlaceholder: "e.g. Wandering Soul Retreats",
+    namePlaceholderClient: "e.g. The Vibe Bar",
     bioLabel: "Short bio (optional)",
+    bioLabelClient: "Describe the brand the way the owner would",
     bioPlaceholder: "Tell people what you're about — 200 characters.",
+    bioPlaceholderClient:
+      "Tell people what this brand is about — 200 characters.",
     cta: "Continue",
   },
   step2: {
@@ -107,6 +140,21 @@ export const BRAND_CREATION_COPY = {
     headline: "What do you want to make first?",
     subhead: "Mix and match anytime.",
   },
+  step5: {
+    title: "Invite the owner",
+    subtitle:
+      "Send them an invite to take ownership. They'll connect their bank to start selling.",
+    emailLabel: "Owner email",
+    emailPlaceholder: "owner@example.com",
+    noteLabel: "Personal message (optional)",
+    notePlaceholder:
+      "e.g. Hey — I set up your Mingla brand. Accept to take over.",
+    ctaDefault: "Save & invite the owner",
+    ctaWithName: (first: string): string => `Save & invite ${first}`,
+    successToast: (brand: string, email: string): string =>
+      `${brand} saved. We sent the invite to ${email}.`,
+    inviteErrorToast: "Couldn't send the invite. Tap to retry.",
+  },
   createErrorToast: "Couldn't create brand. Tap to retry.",
 } as const;
 
@@ -121,20 +169,45 @@ export const brandCreationReducer = (
       return { ...state, brandId: action.brandId, step: 2 };
     case "setAddress":
       return { ...state, address: action.address, step: 3 };
-    case "next":
-      return { ...state, step: Math.min(4, state.step + 1) as BrandCreationStep };
-    case "back":
-      return { ...state, step: Math.max(1, state.step - 1) as BrandCreationStep };
+    case "setMode":
+      return { ...state, mode: action.mode };
+    case "next": {
+      // ORCH-1081 — in client mode, after step 3 (cover) we go to step 5
+      // (Invite the owner) instead of step 4 (offering chooser). The client
+      // path's terminal step is the invite.
+      const max = state.mode === "client" ? 5 : 4;
+      const nextStep = state.mode === "client" && state.step === 3
+        ? 5
+        : Math.min(max, (state.step as number) + 1);
+      return { ...state, step: nextStep as BrandCreationStep };
+    }
+    case "back": {
+      // Min back-step honors partner-mode visibility: only flagged partners
+      // can step back to 0. For everyone else, 1 is the floor.
+      const min = 0;
+      // Mirror the next-step jump backwards: from step 5 → step 3.
+      const prevStep = state.step === 5 ? 3 : Math.max(min, (state.step as number) - 1);
+      return { ...state, step: prevStep as BrandCreationStep };
+    }
     default:
       return state;
   }
 };
 
-const STEPS = [
+const STEPS_SELF = [
   { id: "identity", label: "Identity" },
   { id: "address", label: "Address" },
   { id: "cover", label: "Cover" },
   { id: "welcome", label: "Welcome" },
+];
+
+// ORCH-1081 — partner client-mode stepper. Replaces "Welcome" with "Invite".
+const STEPS_CLIENT = [
+  { id: "mode", label: "Mode" },
+  { id: "identity", label: "Identity" },
+  { id: "address", label: "Address" },
+  { id: "cover", label: "Cover" },
+  { id: "invite", label: "Invite" },
 ];
 
 const slugify = (value: string): string =>
@@ -154,9 +227,55 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
   const updateBrandMutation = useUpdateBrand();
   const updateCreatorAccountMutation = useUpdateCreatorAccount();
 
-  const [state, setState] = useState<BrandCreationState>(
-    BRAND_CREATION_INITIAL_STATE,
-  );
+  // ORCH-1081 — gate Step 0 on creator_accounts.partner_enabled. Read via the
+  // existing usePartnerStripeStatus hook so the flag is consistent app-wide.
+  const partnerStatus = usePartnerStripeStatus();
+  const isPartner = partnerStatus.data?.partner_enabled === true;
+
+  // ORCH-1081 — `partner_mode=client` query param pre-flags client mode (used
+  // by the /partner/brands empty-state CTA + the earnings nudge card).
+  const params = useLocalSearchParams<{ partner_mode?: string | string[] }>();
+  const partnerModeParam = Array.isArray(params.partner_mode)
+    ? params.partner_mode[0]
+    : params.partner_mode;
+
+  const initialState: BrandCreationState = (() => {
+    // For flagged partners, step 0 is the entry point. Non-partners start at 1.
+    // Pre-flagged client-mode (via deep-link) lands the user on step 1 with
+    // mode='client' already set.
+    if (isPartner && partnerModeParam === "client") {
+      return { ...BRAND_CREATION_INITIAL_STATE, mode: "client", step: 1 };
+    }
+    if (isPartner) {
+      return { ...BRAND_CREATION_INITIAL_STATE, step: 0 };
+    }
+    return BRAND_CREATION_INITIAL_STATE;
+  })();
+
+  const [state, setState] = useState<BrandCreationState>(initialState);
+
+  // If partner status arrives AFTER initial mount (network race), promote the
+  // user to step 0 IF they haven't started the wizard yet (still on step 1
+  // with no name typed). Never demote.
+  useEffect(() => {
+    if (
+      isPartner &&
+      state.step === 1 &&
+      state.name === "" &&
+      state.bio === "" &&
+      state.mode === "self" &&
+      partnerModeParam !== "client"
+    ) {
+      setState((prev) => ({ ...prev, step: 0 }));
+    }
+  }, [
+    isPartner,
+    state.step,
+    state.name,
+    state.bio,
+    state.mode,
+    partnerModeParam,
+  ]);
   const [brand, setBrand] = useState<Brand | null>(null);
   const [name, setName] = useState("");
   const [bio, setBio] = useState("");
@@ -173,6 +292,10 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
   }>({ lat: null, lng: null, city: null, countryCode: null, googlePlaceId: null });
   const [toast, setToast] = useState<string | null>(null);
   const [coverPickerVisible, setCoverPickerVisible] = useState(false);
+  // ORCH-1081 — partner-mode Step 5 form state.
+  const [inviteeEmail, setInviteeEmail] = useState("");
+  const [inviteeNote, setInviteeNote] = useState("");
+  const [invitePending, setInvitePending] = useState(false);
 
   const addressValidated =
     address.trim().length > 0 && addrMeta.lat !== null && addrMeta.lng !== null;
@@ -205,6 +328,8 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
         address: null,
         coverHue: 25,
         bio: bio.trim().length > 0 ? bio.trim() : undefined,
+        // ORCH-1081 — partner client mode flags brand at insert.
+        partnerSetup: state.mode === "client",
       });
       setBrand(newBrand);
       commitDefaultBrand(newBrand);
@@ -285,21 +410,93 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
     [brand, onComplete, router],
   );
 
+  // ORCH-1081 — Step 5: invite the owner. Uses inviteBrandMember with
+  // role=brand_owner + partner_setup=true. Same edge fn the team-invite UI
+  // calls, so we inherit auth/permission gating.
+  const trimmedInviteeEmail = inviteeEmail.trim().toLowerCase();
+  const inviteeEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+    trimmedInviteeEmail,
+  );
+
+  const handleInviteOwner = useCallback(async (): Promise<void> => {
+    if (brand === null) return;
+    if (!inviteeEmailValid) return;
+    setInvitePending(true);
+    try {
+      // The edge fn requires a non-empty invitee_name; derive a sensible default
+      // from the email local-part. The owner can edit their display_name later.
+      const localPart = trimmedInviteeEmail.split("@")[0] ?? "owner";
+      const inviteeName = localPart.length > 0 ? localPart : "owner";
+      await inviteBrandMember({
+        brandId: brand.id,
+        inviteeEmail: trimmedInviteeEmail,
+        inviteeName,
+        role: "brand_owner",
+        personalNote: inviteeNote.trim().length > 0
+          ? inviteeNote.trim()
+          : undefined,
+        partnerSetup: true,
+      });
+      // Brand row already inserted (with partner_setup=true) at step 1. We
+      // commit the optimistic complete + surface the success toast on the
+      // landing surface. The post-create caller renders its own success UX.
+      setToast(
+        BRAND_CREATION_COPY.step5.successToast(
+          brand.displayName,
+          trimmedInviteeEmail,
+        ),
+      );
+      onComplete(brand.id);
+    } catch (err) {
+      console.error("[BrandCreationFlow] partner invite failed", err);
+      setToast(BRAND_CREATION_COPY.step5.inviteErrorToast);
+    } finally {
+      setInvitePending(false);
+    }
+  }, [
+    brand,
+    inviteeEmailValid,
+    inviteeNote,
+    onComplete,
+    trimmedInviteeEmail,
+  ]);
+
+  // CTA label varies with whether email-local-part is fillable.
+  const inviteCtaLabel = trimmedInviteeEmail.length > 0
+    ? BRAND_CREATION_COPY.step5.ctaWithName(
+      capitalize(trimmedInviteeEmail.split("@")[0] ?? "the owner"),
+    )
+    : BRAND_CREATION_COPY.step5.ctaDefault;
+
+  // ORCH-1081 — pick the stepper variant + compute the active-index based on
+  // partner mode. The 'self' path uses the legacy 4-step stepper; the 'client'
+  // path uses a 5-step stepper that re-labels the welcome stop as 'Invite'.
+  const stepperVariant = state.mode === "client" ? STEPS_CLIENT : STEPS_SELF;
+  const currentIndex = state.mode === "client"
+    ? (state.step === 0 ? 0
+      : state.step === 1 ? 1
+      : state.step === 2 ? 2
+      : state.step === 3 ? 3
+      : state.step === 5 ? 4 : 0)
+    : Math.max(0, (state.step as number) - 1);
+
+  const isAtEntry = state.step === 0 || (state.step === 1 && !isPartner);
+
   return (
     <View style={styles.host}>
       <View style={styles.header}>
         <Pressable
           onPress={() => {
-            if (state.step === 1) onCancel?.();
+            if (isAtEntry) onCancel?.();
             else updateState({ type: "back" });
           }}
           accessibilityRole="button"
-          accessibilityLabel={state.step === 1 ? "Cancel brand creation" : "Back"}
+          accessibilityLabel={isAtEntry ? "Cancel brand creation" : "Back"}
           style={styles.backTouch}
         >
-          <Icon name={state.step === 1 ? "close" : "chevL"} size={18} color={textTokens.secondary} />
+          <Icon name={isAtEntry ? "close" : "chevL"} size={18} color={textTokens.secondary} />
         </Pressable>
-        <Stepper steps={STEPS} currentIndex={state.step - 1} />
+        <Stepper steps={stepperVariant} currentIndex={currentIndex} />
       </View>
 
       <ScrollView
@@ -307,23 +504,119 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
+        {state.step === 0 ? (
+          <View style={styles.stepBody}>
+            <Text style={styles.title}>{BRAND_CREATION_COPY.step0.title}</Text>
+            <Text style={styles.body}>
+              {BRAND_CREATION_COPY.step0.subtitle}
+            </Text>
+            <Pressable
+              accessibilityRole="radio"
+              accessibilityState={{ selected: state.mode === "self" }}
+              accessibilityLabel={BRAND_CREATION_COPY.step0.selfTitle}
+              onPress={() => updateState({ type: "setMode", mode: "self" })}
+              style={styles.modeCardWrap}
+            >
+              <GlassCard
+                variant="elevated"
+                padding={spacing.lg}
+                style={state.mode === "self" ? styles.modeCardActive : undefined}
+              >
+                <View style={styles.modeCardRow}>
+                  <View style={styles.modeCardCol}>
+                    <Text style={styles.modeCardTitle}>
+                      {BRAND_CREATION_COPY.step0.selfTitle}
+                    </Text>
+                    <Text style={styles.modeCardBody}>
+                      {BRAND_CREATION_COPY.step0.selfBody}
+                    </Text>
+                  </View>
+                  <View
+                    style={[
+                      styles.radioDot,
+                      state.mode === "self" && styles.radioDotActive,
+                    ]}
+                  />
+                </View>
+              </GlassCard>
+            </Pressable>
+            <Pressable
+              accessibilityRole="radio"
+              accessibilityState={{ selected: state.mode === "client" }}
+              accessibilityLabel={BRAND_CREATION_COPY.step0.clientTitle}
+              onPress={() => updateState({ type: "setMode", mode: "client" })}
+              style={styles.modeCardWrap}
+            >
+              <GlassCard
+                variant="elevated"
+                padding={spacing.lg}
+                style={
+                  state.mode === "client" ? styles.modeCardActive : undefined
+                }
+              >
+                <View style={styles.modeCardRow}>
+                  <View style={styles.modeCardCol}>
+                    <Text style={styles.modeCardTitle}>
+                      🤝 {BRAND_CREATION_COPY.step0.clientTitle}
+                    </Text>
+                    <Text style={styles.modeCardBody}>
+                      {BRAND_CREATION_COPY.step0.clientBody}
+                    </Text>
+                  </View>
+                  <View
+                    style={[
+                      styles.radioDot,
+                      state.mode === "client" && styles.radioDotActive,
+                    ]}
+                  />
+                </View>
+              </GlassCard>
+            </Pressable>
+          </View>
+        ) : null}
+
         {state.step === 1 ? (
           <View style={styles.stepBody}>
-            <Text style={styles.title}>{BRAND_CREATION_COPY.step1.title}</Text>
-            <Text style={styles.label}>{BRAND_CREATION_COPY.step1.nameLabel}</Text>
+            <View style={styles.titleRow}>
+              <Text style={styles.title}>
+                {state.mode === "client"
+                  ? BRAND_CREATION_COPY.step1.titleClient
+                  : BRAND_CREATION_COPY.step1.title}
+              </Text>
+              {state.mode === "client" ? (
+                <Text style={styles.partnerChip}>🤝 Client setup</Text>
+              ) : null}
+            </View>
+            <Text style={styles.label}>
+              {state.mode === "client"
+                ? BRAND_CREATION_COPY.step1.nameLabelClient
+                : BRAND_CREATION_COPY.step1.nameLabel}
+            </Text>
             <Input
               variant="text"
               value={name}
               onChangeText={setName}
-              placeholder={BRAND_CREATION_COPY.step1.namePlaceholder}
+              placeholder={
+                state.mode === "client"
+                  ? BRAND_CREATION_COPY.step1.namePlaceholderClient
+                  : BRAND_CREATION_COPY.step1.namePlaceholder
+              }
               accessibilityLabel={BRAND_CREATION_COPY.step1.nameLabel}
               clearable
             />
-            <Text style={styles.label}>{BRAND_CREATION_COPY.step1.bioLabel}</Text>
+            <Text style={styles.label}>
+              {state.mode === "client"
+                ? BRAND_CREATION_COPY.step1.bioLabelClient
+                : BRAND_CREATION_COPY.step1.bioLabel}
+            </Text>
             <TextInput
               value={bio}
               onChangeText={(value) => setBio(value.slice(0, 200))}
-              placeholder={BRAND_CREATION_COPY.step1.bioPlaceholder}
+              placeholder={
+                state.mode === "client"
+                  ? BRAND_CREATION_COPY.step1.bioPlaceholderClient
+                  : BRAND_CREATION_COPY.step1.bioPlaceholder
+              }
               placeholderTextColor={textTokens.quaternary}
               accessibilityLabel={BRAND_CREATION_COPY.step1.bioLabel}
               multiline
@@ -426,9 +719,93 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
             onSelect={handleOfferingSelect}
           />
         ) : null}
+
+        {state.step === 5 ? (
+          <View style={styles.stepBody}>
+            <View style={styles.titleRow}>
+              <Text style={styles.title}>
+                {BRAND_CREATION_COPY.step5.title}
+              </Text>
+              <Text style={styles.partnerChip}>🤝 Client setup</Text>
+            </View>
+            <Text style={styles.body}>
+              {BRAND_CREATION_COPY.step5.subtitle}
+            </Text>
+            <Text style={styles.label}>
+              {BRAND_CREATION_COPY.step5.emailLabel}
+            </Text>
+            <Input
+              variant="text"
+              value={inviteeEmail}
+              onChangeText={setInviteeEmail}
+              placeholder={BRAND_CREATION_COPY.step5.emailPlaceholder}
+              accessibilityLabel={BRAND_CREATION_COPY.step5.emailLabel}
+              clearable
+            />
+            <Text style={styles.label}>
+              {BRAND_CREATION_COPY.step5.noteLabel}
+            </Text>
+            <TextInput
+              value={inviteeNote}
+              onChangeText={(v) => setInviteeNote(v.slice(0, 280))}
+              placeholder={BRAND_CREATION_COPY.step5.notePlaceholder}
+              placeholderTextColor={textTokens.quaternary}
+              accessibilityLabel={BRAND_CREATION_COPY.step5.noteLabel}
+              multiline
+              style={styles.textArea}
+            />
+            {/* Preview card — minimal hero/title/CTA mirror of the email. */}
+            <GlassCard variant="elevated" padding={spacing.lg}>
+              <Text style={styles.previewEyebrow}>EMAIL PREVIEW</Text>
+              {brand?.coverMediaUrl != null ? (
+                <View style={styles.coverPreview}>
+                  <EventCoverMedia
+                    hue={25}
+                    mediaUrl={brand.coverMediaUrl}
+                    mediaType={brand.coverMediaType ?? "image"}
+                    radius={radius.md}
+                    label="Brand cover preview"
+                    height={120}
+                    muted
+                  />
+                </View>
+              ) : (
+                <View style={styles.previewHeroFallback}>
+                  <Text style={styles.previewHeroFallbackText}>
+                    {(brand?.displayName ?? name).slice(0, 1).toUpperCase()}
+                  </Text>
+                </View>
+              )}
+              <Text style={styles.previewAttribution}>
+                🤝 Set up for you on Mingla
+              </Text>
+              <Text style={styles.previewTitle}>
+                {brand?.displayName ?? name}
+              </Text>
+              <Text style={styles.previewBody}>
+                Built out for you — events, cover, description. Accept to
+                become the owner.
+              </Text>
+              <View style={styles.previewCta}>
+                <Text style={styles.previewCtaText}>
+                  Accept &amp; set up{" "}
+                  {brand?.displayName ?? name}
+                </Text>
+              </View>
+            </GlassCard>
+          </View>
+        ) : null}
       </ScrollView>
 
       <View style={styles.footer}>
+        {state.step === 0 ? (
+          <Button
+            label={BRAND_CREATION_COPY.step0.cta}
+            onPress={() => updateState({ type: "next" })}
+            variant="primary"
+            size="lg"
+          />
+        ) : null}
         {state.step === 1 ? (
           <Button
             label={BRAND_CREATION_COPY.step1.cta}
@@ -476,6 +853,16 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
               style={styles.footerButton}
             />
           </View>
+        ) : null}
+        {state.step === 5 ? (
+          <Button
+            label={inviteCtaLabel}
+            onPress={() => void handleInviteOwner()}
+            variant="primary"
+            size="lg"
+            disabled={!inviteeEmailValid || invitePending}
+            loading={invitePending}
+          />
         ) : null}
       </View>
 
@@ -536,6 +923,12 @@ export const BrandCreationFlow: React.FC<BrandCreationFlowProps> = ({
     </View>
   );
 };
+
+// ORCH-1081 — utility used by step-5 CTA copy ("Save & invite Sarah").
+function capitalize(s: string): string {
+  if (s.length === 0) return s;
+  return s.slice(0, 1).toUpperCase() + s.slice(1);
+}
 
 const styles = StyleSheet.create({
   host: {
@@ -616,6 +1009,117 @@ const styles = StyleSheet.create({
   },
   footerButton: {
     flex: 1,
+  },
+  // ORCH-1081 — Step 0 + Step 5 + partner chip styles.
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.sm,
+  },
+  partnerChip: {
+    fontSize: typography.caption.fontSize,
+    fontWeight: "600",
+    color: accent.warm,
+    backgroundColor: glass.tint.profileBase,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    borderRadius: radius.full,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: 4,
+  },
+  modeCardWrap: {
+    // Pressable wrapping a GlassCard so the entire surface is tappable.
+  },
+  modeCardActive: {
+    borderColor: accent.warm,
+    borderWidth: 2,
+  },
+  modeCardRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  modeCardCol: {
+    flex: 1,
+    gap: 4,
+  },
+  modeCardTitle: {
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  modeCardBody: {
+    fontSize: typography.bodySm.fontSize,
+    lineHeight: typography.bodySm.lineHeight,
+    color: textTokens.secondary,
+  },
+  radioDot: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: glass.border.profileBase,
+    backgroundColor: "transparent",
+  },
+  radioDotActive: {
+    borderColor: accent.warm,
+    backgroundColor: accent.warm,
+  },
+  previewEyebrow: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 1.2,
+    color: textTokens.tertiary,
+    marginBottom: spacing.sm,
+  },
+  previewHeroFallback: {
+    width: "100%",
+    height: 120,
+    borderRadius: radius.md,
+    backgroundColor: accent.warm,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: spacing.sm,
+  },
+  previewHeroFallbackText: {
+    fontSize: 36,
+    fontWeight: "800",
+    color: "#FFFFFF",
+  },
+  previewAttribution: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+    color: accent.warm,
+    marginTop: spacing.sm,
+    marginBottom: 4,
+  },
+  previewTitle: {
+    fontSize: typography.h3.fontSize,
+    lineHeight: typography.h3.lineHeight,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  previewBody: {
+    fontSize: typography.bodySm.fontSize,
+    lineHeight: typography.bodySm.lineHeight,
+    color: textTokens.secondary,
+    marginTop: 4,
+  },
+  previewCta: {
+    marginTop: spacing.sm + 2,
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    backgroundColor: accent.warm,
+    borderRadius: radius.md,
+    alignItems: "center",
+  },
+  previewCtaText: {
+    color: "#FFFFFF",
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "700",
   },
 });
 

--- a/mingla-business/src/hooks/usePartnerBrandLinks.ts
+++ b/mingla-business/src/hooks/usePartnerBrandLinks.ts
@@ -1,0 +1,24 @@
+/**
+ * usePartnerBrandLinks — ORCH-1081 React Query hook for the partner's
+ * partner_brand_links list. Read-only.
+ */
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import {
+  listPartnerBrandLinks,
+  partnerBrandLinksKeys,
+  type PartnerBrandLinkWithStatus,
+} from "../services/partnerBrandLinksService";
+
+export function usePartnerBrandLinks(): UseQueryResult<
+  PartnerBrandLinkWithStatus[],
+  Error
+> {
+  return useQuery<PartnerBrandLinkWithStatus[], Error>({
+    queryKey: partnerBrandLinksKeys.list(),
+    queryFn: listPartnerBrandLinks,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/mingla-business/src/services/brandInvitationsService.ts
+++ b/mingla-business/src/services/brandInvitationsService.ts
@@ -58,6 +58,10 @@ export interface InviteBrandMemberInput {
   inviteeEmail: string;
   inviteeName: string;
   role: BrandRole;
+  // ORCH-1081 — partner-mode extensions. Both optional; either or both can
+  // accompany a non-partner invite as well (the edge fn just renders the note).
+  personalNote?: string;
+  partnerSetup?: boolean;
 }
 
 export interface InviteBrandMemberResult {
@@ -70,6 +74,10 @@ export interface AcceptBrandInvitationResult {
   transferred: boolean;
   previousOwnerAccountId: string | null;
   newOwnerAccountId: string | null;
+  // ORCH-1081 — surfaced for the celebration screen.
+  brandSlug: string | null;
+  newOwnerFirstName: string | null;
+  partnerSetup: boolean;
 }
 
 export class BrandInvitationServiceError extends Error {
@@ -106,6 +114,11 @@ export const brandTeamMemberKeys = {
 export async function inviteBrandMember(
   input: InviteBrandMemberInput,
 ): Promise<InviteBrandMemberResult> {
+  // ORCH-1081 — personal_note + partner_setup flow through to the edge fn
+  // which renders them in the Mingla brand-shell-wrapped email.
+  const note = typeof input.personalNote === "string"
+    ? input.personalNote.trim()
+    : "";
   const { data, error } = await supabase.functions.invoke(
     "invite-brand-member",
     {
@@ -114,6 +127,8 @@ export async function inviteBrandMember(
         invitee_email: input.inviteeEmail.trim().toLowerCase(),
         invitee_name: input.inviteeName.trim(),
         role: input.role,
+        ...(note.length > 0 ? { personal_note: note } : {}),
+        ...(input.partnerSetup === true ? { partner_setup: true } : {}),
       },
     },
   );
@@ -157,6 +172,10 @@ export async function acceptBrandInvitation(
       typeof d.new_owner_account_id === "string"
         ? d.new_owner_account_id
         : null,
+    brandSlug: typeof d.brand_slug === "string" ? d.brand_slug : null,
+    newOwnerFirstName:
+      typeof d.new_owner_first_name === "string" ? d.new_owner_first_name : null,
+    partnerSetup: d.partner_setup === true,
   };
 }
 

--- a/mingla-business/src/services/brandsService.ts
+++ b/mingla-business/src/services/brandsService.ts
@@ -229,6 +229,10 @@ export interface CreateBrandInput {
   tagline?: string;
   contact?: { email?: string; phone?: string };
   links?: Brand["links"];
+  // ORCH-1081 — when true, brands.partner_setup is set at insert time so the
+  // brand is permanently flagged as a partner-initiated setup. Flag is one-way
+  // (set at create; never edited).
+  partnerSetup?: boolean;
 }
 
 export interface SoftDeleteRejection {
@@ -273,6 +277,14 @@ export async function createBrand(
       links: input.links,
     },
   });
+  // ORCH-1081 — partner_setup flag is column-direct (not on the Brand UI type)
+  // so we set it on the raw insert payload rather than threading it through
+  // mapUiToBrandInsert / Brand. Column added in migration 20260920000000.
+  if (input.partnerSetup === true) {
+    // The DB column default is false; only stamp when true so the insert payload
+    // shape stays minimal.
+    (insertPayload as Record<string, unknown>).partner_setup = true;
+  }
 
   const { data, error } = await supabase
     .from("brands")

--- a/mingla-business/src/services/partnerBrandLinksService.ts
+++ b/mingla-business/src/services/partnerBrandLinksService.ts
@@ -1,0 +1,91 @@
+/**
+ * partnerBrandLinksService — ORCH-1081 frontend reader for partner_brand_links.
+ *
+ * RLS allows partner self-read (partner_account_id = auth.uid()). No writes
+ * exposed; the link is INSERTed by the invite-brand-member edge fn and
+ * status columns are stamped by DB triggers + the accept RPC.
+ *
+ * Derived status is computed client-side from the raw timestamp columns
+ * (mirrors public.partner_brand_link_status). We don't rely on the
+ * column-function form here because Supabase JS doesn't surface derived
+ * column-funcs without a view; computing locally keeps the read path
+ * simple and lossless.
+ */
+
+import { supabase } from "./supabase";
+
+export type PartnerBrandLinkStatus =
+  | "awaiting_owner"
+  | "awaiting_stripe"
+  | "active"
+  | "cancelled";
+
+export interface PartnerBrandLinkRow {
+  id: string;
+  partner_account_id: string;
+  brand_id: string;
+  invited_owner_email: string;
+  personal_note: string | null;
+  invited_at: string;
+  accepted_at: string | null;
+  owner_stripe_connected_at: string | null;
+  first_split_at: string | null;
+  cancelled_at: string | null;
+  // Joined brand metadata (PostgREST embedded select). Optional so the type
+  // is reusable without the join.
+  brand?: {
+    id: string;
+    name: string;
+    slug: string;
+    cover_media_url: string | null;
+    cover_media_type: string | null;
+    default_currency: string | null;
+  } | null;
+}
+
+export interface PartnerBrandLinkWithStatus extends PartnerBrandLinkRow {
+  status: PartnerBrandLinkStatus;
+}
+
+export const partnerBrandLinksKeys = {
+  all: ["partnerBrandLinks"] as const,
+  list: () => [...partnerBrandLinksKeys.all, "list"] as const,
+};
+
+export function deriveLinkStatus(
+  row: PartnerBrandLinkRow,
+): PartnerBrandLinkStatus {
+  if (row.cancelled_at !== null) return "cancelled";
+  if (row.first_split_at !== null) return "active";
+  if (row.owner_stripe_connected_at !== null) return "active";
+  if (row.accepted_at !== null) return "awaiting_stripe";
+  return "awaiting_owner";
+}
+
+/**
+ * Read the caller's partner_brand_links rows. Excludes cancelled rows by
+ * default. Embeds the brand row for the list UI (name / cover / currency).
+ */
+export async function listPartnerBrandLinks(): Promise<
+  PartnerBrandLinkWithStatus[]
+> {
+  const { data: userResult } = await supabase.auth.getUser();
+  if (!userResult.user) {
+    throw new Error("not_authenticated");
+  }
+  const userId = userResult.user.id;
+
+  const { data, error } = await supabase
+    .from("partner_brand_links")
+    .select(
+      "id, partner_account_id, brand_id, invited_owner_email, personal_note, invited_at, accepted_at, owner_stripe_connected_at, first_split_at, cancelled_at, brand:brands(id, name, slug, cover_media_url, cover_media_type, default_currency)",
+    )
+    .eq("partner_account_id", userId)
+    .is("cancelled_at", null)
+    .order("invited_at", { ascending: false });
+
+  if (error) throw new Error(error.message);
+
+  const rows = (data ?? []) as unknown as PartnerBrandLinkRow[];
+  return rows.map((row) => ({ ...row, status: deriveLinkStatus(row) }));
+}

--- a/supabase/functions/_shared/partnerSplits.ts
+++ b/supabase/functions/_shared/partnerSplits.ts
@@ -32,6 +32,11 @@
 // @ts-ignore — Deno ESM
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import type { StripeClient } from "./stripe.ts";
+// ORCH-1081 — partner first-split push: fires once when a partner's first
+// transferred split lands for a brand. The trigger on partner_splits ALREADY
+// stamps partner_brand_links.first_split_at; here we additionally surface a
+// push so the partner sees the win in real time.
+import { dispatchNotification, formatMoneyCents } from "./stripeEdgeAuth.ts";
 
 // 10% of the 1.5% application fee = 0.15% of GMV.
 // MINGLA_APPLICATION_FEE_RATE = 0.015 lives in installments/createInstallmentPI.ts
@@ -342,6 +347,88 @@ export async function handleChargeSucceeded(
       p_application_fee_id: applicationFeeId,
       p_transfer_id: transferId,
     });
+
+    // ORCH-1081 — fire business.partner_first_split when this transfer is the
+    // FIRST one for the (partner, brand). Best-effort + idempotent: the
+    // notify-dispatch idempotencyKey collapses webhook replays to one push.
+    // We detect "first" by checking whether partner_brand_links.first_split_at
+    // was previously NULL — the partner_splits trigger sets it in the same
+    // transaction, so by the time we get here it's set. The race-safe rule:
+    // fire when transferred_at == first_split_at (∆ < 5s) which is true for
+    // the first transferred row only.
+    try {
+      const { data: linkRow } = await supabase
+        .from("partner_brand_links")
+        .select("first_split_at, accepted_at")
+        .eq("partner_account_id", partnerAccountId)
+        .eq("brand_id", brandId)
+        .is("cancelled_at", null)
+        .maybeSingle();
+      const firstSplitAt = (linkRow?.first_split_at as string | null) ?? null;
+      // Only fire when first_split_at is freshly stamped (within 30s of now).
+      // For webhook replays the trigger is a no-op (COALESCE preserves the
+      // earliest timestamp), so this comparison stays true ONLY on first.
+      const stampedRecently = firstSplitAt !== null &&
+        Date.now() - new Date(firstSplitAt).getTime() < 30_000;
+      if (stampedRecently) {
+        // Resolve brand name + event title for nicer copy. Best-effort.
+        const { data: brandRow } = await supabase
+          .from("brands")
+          .select("name")
+          .eq("id", brandId)
+          .maybeSingle();
+        const brandName = (brandRow?.name as string | null) ?? "your brand";
+
+        let eventTitle: string | null = null;
+        const { data: orderRow } = await supabase
+          .from("orders")
+          .select("event_id")
+          .eq("id", orderId)
+          .maybeSingle();
+        const eventId = (orderRow?.event_id as string | null) ?? null;
+        if (eventId) {
+          const { data: eventRow } = await supabase
+            .from("events")
+            .select("title")
+            .eq("id", eventId)
+            .maybeSingle();
+          eventTitle = (eventRow?.title as string | null) ?? null;
+        }
+
+        const amount = formatMoneyCents(partnerShareCents, currency);
+        const bodySuffix = eventTitle
+          ? ` from ${eventTitle}. Tap to see your ledger.`
+          : ". Tap to see your ledger.";
+        await dispatchNotification({
+          userId: partnerAccountId,
+          brandId,
+          type: "business.partner_first_split",
+          title: `Your first split from ${brandName}!`,
+          body: `${amount}${bodySuffix}`,
+          data: {
+            brandName,
+            eventTitle: eventTitle ?? undefined,
+            amountCents: partnerShareCents,
+            currency,
+            applicationFeeId,
+          },
+          relatedId: brandId,
+          relatedType: "brand",
+          idempotencyKey:
+            `business.partner_first_split:${partnerAccountId}:${brandId}`,
+          deepLink: `mingla-business://partner/earnings`,
+        });
+      }
+    } catch (firstSplitErr) {
+      // Best-effort — never fail the transfer flow on a notify error.
+      console.warn(
+        "[partner-splits] partner_first_split notify threw (non-fatal):",
+        firstSplitErr instanceof Error
+          ? firstSplitErr.message
+          : String(firstSplitErr),
+      );
+    }
+
     return { brandId, status: "transferred" };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/supabase/functions/accept-brand-invitation/index.ts
+++ b/supabase/functions/accept-brand-invitation/index.ts
@@ -253,6 +253,13 @@ export async function handler(req: Request): Promise<Response> {
     // owner + admins (EXCLUDING the member who just joined). Idempotent on
     // brandId:memberUserId. Best-effort: a notify failure never fails the
     // accept (the invitation is already committed by the RPC above).
+    //
+    // ORCH-1081 — surface brand_slug + new_owner_first_name to the client so
+    // the post-accept celebration page can render the right copy. Also fire
+    // business.partner_transfer_completed to the partner who set up the brand
+    // (when partner_brand_links has a matching row).
+    let resolvedBrandSlug: string | null = null;
+    let resolvedNewOwnerFirstName: string | null = null;
     try {
       const result = (rpcResult ?? {}) as Record<string, unknown>;
       const brandId = typeof result.brand_id === "string" ? result.brand_id : null;
@@ -269,12 +276,19 @@ export async function handler(req: Request): Promise<Response> {
         memberName = (nameRow?.display_name as string | null) ??
           (nameRow?.business_name as string | null) ?? null;
 
+        // ORCH-1081 — also pull slug + partner_setup so the celebration
+        // screen redirect can use the slug and we know whether to fire the
+        // partner-transfer notification.
         const { data: brandRow } = await service
           .from("brands")
-          .select("name")
+          .select("name, slug, partner_setup")
           .eq("id", brandId)
           .maybeSingle();
         const brandName = (brandRow?.name as string | null) ?? "your brand";
+        resolvedBrandSlug = (brandRow?.slug as string | null) ?? null;
+        resolvedNewOwnerFirstName = memberName
+          ? memberName.split(/\s+/)[0]
+          : null;
         const roleLabel = humanizeRole(memberRole);
 
         const recipients = await getBrandTeamUserIdsByRoles(
@@ -310,6 +324,67 @@ export async function handler(req: Request): Promise<Response> {
         }
         // namePart kept for parity with Sub-D fallback copy intent.
         void namePart;
+
+        // ORCH-1081 — business.partner_transfer_completed: notify the partner
+        // who set up the brand. Idempotent on brandId:partner_account_id.
+        // We resolve the partner from partner_brand_links (matched by brand_id
+        // + invitee email = invitation.email). The accept-RPC already stamped
+        // accepted_at; the partner row exists.
+        try {
+          // The invitation's email is the canonical match key. Pull it off
+          // brand_invitations via the rpc payload's brand_id + accepted_by
+          // chain, but the simpler path: read the most recent accepted partner
+          // link for this brand whose invited_owner_email matches the joining
+          // member's email.
+          const { data: memberEmailRow } = await service
+            .from("creator_accounts")
+            .select("id")
+            .eq("id", account.id)
+            .maybeSingle();
+          // Auth-user email lookup is needed because creator_accounts doesn't
+          // carry email; the JWT does. We already have it via userResult.
+          const memberEmail = (userResult.user.email ?? "").toLowerCase();
+          if (memberEmail.length > 0) {
+            const { data: linkRow } = await service
+              .from("partner_brand_links")
+              .select("partner_account_id, accepted_at, cancelled_at")
+              .eq("brand_id", brandId)
+              .eq("invited_owner_email", memberEmail)
+              .is("cancelled_at", null)
+              .maybeSingle();
+            const partnerAccountId = (linkRow?.partner_account_id as string | null) ??
+              null;
+            if (partnerAccountId && partnerAccountId !== account.id) {
+              const newOwnerLabel = memberName ?? "The owner";
+              await dispatchNotification({
+                userId: partnerAccountId,
+                brandId,
+                type: "business.partner_transfer_completed",
+                title: `${brandName} accepted your invite`,
+                body:
+                  `${newOwnerLabel} is now the owner. Keep creating events — you'll earn 0.15% on every ticket sold.`,
+                data: {
+                  brandName,
+                  newOwnerUserId: account.id,
+                  newOwnerName: memberName ?? undefined,
+                },
+                relatedId: brandId,
+                relatedType: "brand",
+                idempotencyKey:
+                  `business.partner_transfer_completed:${brandId}:${partnerAccountId}`,
+                deepLink: `mingla-business://partner/brands`,
+              });
+            }
+          }
+          void memberEmailRow;
+        } catch (partnerNotifyErr) {
+          console.warn(
+            "[accept-brand-invitation] partner_transfer_completed notify threw (non-fatal):",
+            partnerNotifyErr instanceof Error
+              ? partnerNotifyErr.message
+              : String(partnerNotifyErr),
+          );
+        }
       }
     } catch (teamNotifyErr) {
       console.warn(
@@ -320,7 +395,15 @@ export async function handler(req: Request): Promise<Response> {
       );
     }
 
-    return json(rpcResult ?? {}, 200);
+    // ORCH-1081 — extend response with the slug + first name so the celebration
+    // page can render without an extra round-trip. partner_setup already flows
+    // back from the RPC (added in the migration); we pass it through.
+    const responseBody = {
+      ...(rpcResult as Record<string, unknown> | null ?? {}),
+      brand_slug: resolvedBrandSlug,
+      new_owner_first_name: resolvedNewOwnerFirstName,
+    };
+    return json(responseBody, 200);
   } catch (err) {
     console.error(
       "[accept-brand-invitation] unexpected error",

--- a/supabase/functions/invite-brand-member/index.ts
+++ b/supabase/functions/invite-brand-member/index.ts
@@ -31,12 +31,21 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+// ORCH-1081 — wrap the invite email through the Mingla brand shell
+// (header/hero/footer). renderShell handles the outer wrapper; we provide the
+// inner bodyHtml. escapeHtml is the canonical escape; reuse it here so any
+// caller-provided string (brand name, inviter name, personal note) is
+// rendered safely.
+import { renderShell } from "../_shared/email/shell.ts";
+import { escapeHtml as sharedEscapeHtml } from "../_shared/email/escape.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
+
+const PERSONAL_NOTE_MAX = 280;
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -68,6 +77,11 @@ export interface InvitePayload {
   invitee_email: string;
   invitee_name: string;
   role: string;
+  // ORCH-1081 — optional partner-attribution payload. personal_note appears in
+  // the email body when present. partner_setup tells the renderer to switch
+  // to the "Set up for you by X" attribution + "Accept & set up X" CTA.
+  personal_note?: string;
+  partner_setup?: boolean;
 }
 
 export type ValidationOutcome =
@@ -97,6 +111,12 @@ export function validateInvite(raw: unknown): ValidationOutcome {
   }
   if (!VALID_ROLES.has(role)) fields.push("role");
 
+  // ORCH-1081 — optional personal_note (≤280 chars) + partner_setup flag.
+  const rawNote = typeof body.personal_note === "string" ? body.personal_note : "";
+  const personalNote = rawNote.trim();
+  if (personalNote.length > PERSONAL_NOTE_MAX) fields.push("personal_note");
+  const partnerSetup = body.partner_setup === true;
+
   if (fields.length > 0) return { ok: false, fields };
   return {
     ok: true,
@@ -105,6 +125,8 @@ export function validateInvite(raw: unknown): ValidationOutcome {
       invitee_email: inviteeEmail,
       invitee_name: inviteeName,
       role,
+      personal_note: personalNote.length > 0 ? personalNote : undefined,
+      partner_setup: partnerSetup,
     },
   };
 }
@@ -129,13 +151,25 @@ export async function sha256Hex(input: string): Promise<string> {
 }
 
 function escHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+  // Local alias kept in case existing tests reference it. Delegates to the
+  // canonical shared escapeHtml so we don't ship two implementations.
+  return sharedEscapeHtml(s);
 }
 
+/**
+ * ORCH-1081 — Build the invite email, wrapped through the shared Mingla
+ * email shell (renderShell). When `partnerSetup=true`, the layout swaps to
+ * partner-attribution copy and the brand cover image renders as the email
+ * hero banner. Falls back to the standard Mingla logo header when no cover.
+ *
+ * Inputs added beyond the ORCH-1050 shape:
+ *   - brandCoverUrl       — direct URL to the brand's cover (image only, no
+ *                            video — shell hero won't render a video tag).
+ *   - personalNote        — optional message from the inviter (≤280 chars).
+ *   - partnerSetup        — when true, partner-mode body + CTA copy.
+ *   - logoUrl/supportEmail/footerAddress — shell config; sourced from
+ *                            env in the caller and threaded through here.
+ */
 export function buildInviteEmail(input: {
   inviteeName: string;
   inviteeEmail: string;
@@ -144,28 +178,140 @@ export function buildInviteEmail(input: {
   role: string;
   acceptUrl: string;
   from: string;
+  brandCoverUrl?: string | null;
+  brandCoverMediaType?: string | null;
+  personalNote?: string | null;
+  partnerSetup?: boolean;
+  logoUrl?: string;
+  supportEmail?: string;
+  footerAddress?: string;
 }): { from: string; to: string[]; subject: string; html: string; text: string } {
   const roleLabel = roleDisplay(input.role);
-  const subject = `${input.brandName} invited you to join their team on Mingla`;
-  const html = `<div style="font-family:system-ui,-apple-system,sans-serif;font-size:15px;color:#0e0e10;max-width:560px;">
-  <p>Hi ${escHtml(input.inviteeName)},</p>
-  <p><strong>${escHtml(input.inviterName)}</strong> invited you to join
-  <strong>${escHtml(input.brandName)}</strong> on Mingla as
-  <strong>${escHtml(roleLabel)}</strong>.</p>
-  <p style="margin:24px 0;">
-    <a href="${escHtml(input.acceptUrl)}"
-       style="background:#EB7825;color:#fff;text-decoration:none;padding:12px 20px;border-radius:8px;font-weight:600;display:inline-block;">
-      Accept invitation
-    </a>
-  </p>
-  <p style="color:#6b7280;font-size:13px;">This link expires in ${EXPIRY_DAYS} days.
-  If the button doesn't work, copy and paste this URL into your browser:</p>
-  <p style="word-break:break-all;font-size:12px;color:#6b7280;">${escHtml(input.acceptUrl)}</p>
-</div>`;
-  const text =
-    `Hi ${input.inviteeName},\n\n${input.inviterName} invited you to join ` +
-    `${input.brandName} on Mingla as ${roleLabel}.\n\nAccept: ${input.acceptUrl}\n\n` +
-    `This link expires in ${EXPIRY_DAYS} days.`;
+  const partnerSetup = input.partnerSetup === true;
+
+  // Shell config — fall back to defaults that match the rest of the codebase.
+  // Production paths inject MINGLA_LOGO_URL / MINGLA_FOOTER_ADDRESS from env;
+  // tests can override.
+  const logoUrl = input.logoUrl ??
+    "https://usemingla.com/email-assets/mingla-logo.png";
+  const supportEmail = input.supportEmail ?? "support@usemingla.com";
+  const footerAddress = input.footerAddress ?? "Mingla, hello@usemingla.com";
+
+  // Only use the brand cover as the email hero when it's a still image.
+  // Skip video covers (and gifs are okay — most mail clients render them).
+  const useBrandHero = typeof input.brandCoverUrl === "string" &&
+    input.brandCoverUrl.length > 0 &&
+    input.brandCoverMediaType !== "video";
+
+  const subject = partnerSetup
+    ? `${input.brandName} — your Mingla brand is ready to claim`
+    : `${input.brandName} invited you to join their team on Mingla`;
+
+  const preheader = partnerSetup
+    ? `${input.inviterName} built ${input.brandName} for you on Mingla. Accept to become the owner.`
+    : `${input.inviterName} invited you to ${input.brandName} as ${roleLabel}.`;
+
+  // Body content — paragraph + CTA + optional personal note + fine print.
+  // Every interpolation flows through sharedEscapeHtml so the ORCH-0785-C
+  // buyer-string-escape gate sees an escapeHtml(...) form at every call site.
+  const ctaLabel = partnerSetup
+    ? `Accept & set up ${input.brandName}`
+    : "Accept invitation";
+
+  const attributionChip = partnerSetup
+    ? `<p style="margin:0 0 16px 0;">
+        <span style="display:inline-block;padding:6px 12px;border-radius:999px;background:#FFF6F1;color:#FF6B2C;font-size:12px;font-weight:600;letter-spacing:0.3px;text-transform:uppercase;">
+          Set up for you by ${sharedEscapeHtml(input.inviterName)}
+        </span>
+      </p>`
+    : "";
+
+  const bodyParagraph = partnerSetup
+    ? `<p style="margin:0 0 16px 0;font-size:15px;line-height:1.55;color:#0F1115;">
+        ${sharedEscapeHtml(input.inviterName)} has built
+        <strong>${sharedEscapeHtml(input.brandName)}</strong>
+        for you on Mingla — events, cover photos, description. Accept to become
+        the owner and connect your bank so customers can buy tickets and you can
+        get paid.
+      </p>`
+    : `<p style="margin:0 0 16px 0;font-size:15px;line-height:1.55;color:#0F1115;">
+        <strong>${sharedEscapeHtml(input.inviterName)}</strong> invited you to join
+        <strong>${sharedEscapeHtml(input.brandName)}</strong> on Mingla as
+        <strong>${sharedEscapeHtml(roleLabel)}</strong>.
+      </p>`;
+
+  const personalNoteBlock =
+    typeof input.personalNote === "string" && input.personalNote.length > 0
+      ? `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width:100%;margin:0 0 16px 0;">
+          <tr>
+            <td style="padding:14px 16px;background:#FFF6F1;border-left:3px solid #FF6B2C;border-radius:6px;">
+              <p style="margin:0;font-size:14px;line-height:1.5;color:#0F1115;font-style:italic;">
+                "${sharedEscapeHtml(input.personalNote)}"
+              </p>
+              <p style="margin:6px 0 0 0;font-size:12px;color:#5B6172;">
+                — ${sharedEscapeHtml(input.inviterName)}
+              </p>
+            </td>
+          </tr>
+        </table>`
+      : "";
+
+  // CTA button — table-based for client compatibility.
+  const cta = `<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0;">
+    <tr>
+      <td style="background:#FF6B2C;border-radius:8px;">
+        <a href="${sharedEscapeHtml(input.acceptUrl)}"
+           style="display:inline-block;padding:14px 24px;color:#FFFFFF;text-decoration:none;font-weight:600;font-size:15px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+          ${sharedEscapeHtml(ctaLabel)}
+        </a>
+      </td>
+    </tr>
+  </table>`;
+
+  const finePrint = `<p style="margin:16px 0 0 0;font-size:13px;line-height:1.5;color:#5B6172;">
+      This link expires in ${EXPIRY_DAYS} days. If the button doesn't work, copy
+      and paste this URL into your browser:
+    </p>
+    <p style="margin:6px 0 0 0;word-break:break-all;font-size:12px;color:#5B6172;">
+      ${sharedEscapeHtml(input.acceptUrl)}
+    </p>
+    <p style="margin:18px 0 0 0;font-size:12px;color:#5B6172;">
+      Your bank details go directly to Stripe — Mingla never sees them.
+    </p>`;
+
+  // Hi line — render only when we don't lean on the hero (the hero is itself
+  // a brand-name overlay equivalent).
+  const greeting = `<p style="margin:0 0 12px 0;font-size:15px;line-height:1.55;color:#0F1115;">
+      Hi ${sharedEscapeHtml(input.inviteeName)},
+    </p>`;
+
+  const bodyHtml = `${greeting}
+    ${attributionChip}
+    ${bodyParagraph}
+    ${personalNoteBlock}
+    ${cta}
+    ${finePrint}`;
+
+  const html = renderShell({
+    preheader,
+    bodyHtml,
+    supportEmail,
+    logoUrl,
+    footerAddress,
+    brandHeaderImageUrl: useBrandHero ? (input.brandCoverUrl ?? null) : null,
+  });
+
+  // Plain-text fallback — keep it short, mirror the body copy.
+  const textBody = partnerSetup
+    ? `Hi ${input.inviteeName},\n\n${input.inviterName} has built ${input.brandName} for you on Mingla. ` +
+      `Accept to become the owner and connect your bank so customers can buy tickets.\n\n`
+    : `Hi ${input.inviteeName},\n\n${input.inviterName} invited you to join ${input.brandName} on Mingla as ${roleLabel}.\n\n`;
+  const noteLine =
+    typeof input.personalNote === "string" && input.personalNote.length > 0
+      ? `Note: "${input.personalNote}"\n\n`
+      : "";
+  const text = `${textBody}${noteLine}Accept: ${input.acceptUrl}\n\nThis link expires in ${EXPIRY_DAYS} days.`;
+
   return {
     from: input.from,
     to: [input.inviteeEmail],
@@ -299,9 +445,13 @@ export async function handler(req: Request): Promise<Response> {
     }
 
     // Brand lookup for the email template + 404 surface.
+    // ORCH-1081 — also pull cover_media_url + cover_media_type so the email
+    // shell can render the brand cover as a hero banner; and partner_setup so
+    // we know which copy variant the email should use even if the caller
+    // forgot the partner_setup flag in the request body.
     const { data: brandRow, error: brandErr } = await service
       .from("brands")
-      .select("id, display_name")
+      .select("id, name, cover_media_url, cover_media_type, partner_setup")
       .eq("id", payload.brand_id)
       .is("deleted_at", null)
       .maybeSingle();
@@ -373,8 +523,32 @@ export async function handler(req: Request): Promise<Response> {
       businessOrigin.replace(/\/+$/, "")
     }/accept-brand-invitation?token=${encodeURIComponent(token)}`;
 
-    const inviterDisplay = inviterEmail || "A teammate";
-    const brandDisplay = brandRow.display_name as string ?? "your brand";
+    // ORCH-1081 — inviter display: pull the inviter's display_name from
+    // creator_accounts when available so the email reads "Seth invited you"
+    // rather than "seth@example.com invited you". Falls back to email.
+    let inviterDisplay = inviterEmail || "A teammate";
+    try {
+      const { data: inviterRow } = await service
+        .from("creator_accounts")
+        .select("display_name, business_name")
+        .eq("id", userId)
+        .maybeSingle();
+      const name = (inviterRow?.display_name as string | null) ??
+        (inviterRow?.business_name as string | null) ?? null;
+      if (name && name.trim().length > 0) inviterDisplay = name.trim();
+    } catch {
+      /* fall back to email */
+    }
+
+    const brandDisplay = brandRow.name as string ?? "your brand";
+    const brandCoverUrl = (brandRow.cover_media_url as string | null) ?? null;
+    const brandCoverMediaType = (brandRow.cover_media_type as string | null) ??
+      null;
+    // Effective partner_setup: client flag wins, but if brand has partner_setup
+    // already persisted we respect that too (covers the case where an admin
+    // toggles flag client-side without the wizard).
+    const effectivePartnerSetup = payload.partner_setup === true ||
+      brandRow.partner_setup === true;
 
     const resendKey = Deno.env.get("RESEND_API_KEY") ?? "";
     if (!resendKey) {
@@ -397,6 +571,15 @@ export async function handler(req: Request): Promise<Response> {
       role: payload.role,
       acceptUrl,
       from,
+      brandCoverUrl,
+      brandCoverMediaType,
+      personalNote: payload.personal_note ?? null,
+      partnerSetup: effectivePartnerSetup,
+      // ORCH-0785 shell env — share the same env keys the rest of the
+      // transactional email pipeline uses.
+      logoUrl: Deno.env.get("MINGLA_LOGO_URL") ?? undefined,
+      supportEmail: Deno.env.get("SUPPORT_EMAIL") ?? undefined,
+      footerAddress: Deno.env.get("MINGLA_FOOTER_ADDRESS") ?? undefined,
     });
 
     const sent = await sendInviteEmail(resendKey, emailPayload);
@@ -417,10 +600,39 @@ export async function handler(req: Request): Promise<Response> {
         after: {
           role: payload.role,
           invitee_email: payload.invitee_email,
+          partner_setup: effectivePartnerSetup,
         },
       });
     } catch {
       /* ignore audit failures */
+    }
+
+    // ORCH-1081 — partner_brand_links insert. Only when this is an OWNERSHIP
+    // invite (role=brand_owner) for a partner-setup brand. ON CONFLICT
+    // DO NOTHING handles re-invite-after-cancel races (the unique index is
+    // partial WHERE cancelled_at IS NULL, so two cancelled rows coexist).
+    if (effectivePartnerSetup && payload.role === "brand_owner") {
+      try {
+        const { error: linkErr } = await service
+          .from("partner_brand_links")
+          .insert({
+            partner_account_id: userId,
+            brand_id: payload.brand_id,
+            invited_owner_email: payload.invitee_email,
+            personal_note: payload.personal_note ?? null,
+          });
+        if (linkErr && linkErr.code !== PG_UNIQUE_VIOLATION) {
+          console.warn(
+            "[invite-brand-member] partner_brand_links insert non-fatal failure",
+            linkErr.message,
+          );
+        }
+      } catch (linkThrow) {
+        console.warn(
+          "[invite-brand-member] partner_brand_links insert threw (non-fatal)",
+          linkThrow instanceof Error ? linkThrow.message : String(linkThrow),
+        );
+      }
     }
 
     return json({ invitation_id: inserted.id }, 201);

--- a/supabase/migrations/20260920000000_orch_1081_partner_brand_links.sql
+++ b/supabase/migrations/20260920000000_orch_1081_partner_brand_links.sql
@@ -1,0 +1,417 @@
+-- ORCH-1081 [Partner workflow polish] — partner_brand_links + brands.partner_setup.
+--
+-- Adds:
+--   1. brands.partner_setup boolean (default false) — flag set when a brand is
+--      created in "client mode" by a Mingla partner (see BrandCreationFlow
+--      Step 0). Persisted at insert; never changes after.
+--   2. public.partner_brand_links — link rows recording every partner-initiated
+--      brand setup + invite. Tracks the lifecycle from invite-sent →
+--      owner-accepted → owner-stripe-connected → first-split. Drives the new
+--      /partner/brands list screen + the empty-state in /partner/earnings.
+--   3. public.partner_brand_link_status(row) — derived status accessor so
+--      clients can SELECT status without re-implementing the case tree.
+--   4. Trigger after partner_splits status='transferred' to set
+--      first_split_at on the matching partner_brand_links row (idempotent).
+--   5. Trigger after stripe_connect_accounts.charges_enabled flips to true to
+--      set owner_stripe_connected_at on matching partner_brand_links rows.
+--
+-- Note on accept-flow: the accepted_at column is set by an extension of the
+-- accept_invite_and_transfer_brand_ownership RPC (see CREATE OR REPLACE
+-- below). Keeping the column-set logic in the RPC keeps it in the same
+-- transaction as the invite acceptance.
+--
+-- Backfill: NONE (clean-slate; ORCH-1081 launches this surface).
+--
+-- Invariants:
+--   - Inline EXISTS / direct equality in every RLS predicate
+--     ([[feedback-rls-returning-owner-gap]]).
+--   - Triggers are SECURITY DEFINER, search_path locked.
+--   - Idempotent: re-runnable end-to-end without side effects.
+
+BEGIN;
+
+-- =============================================================
+-- 1. brands.partner_setup
+-- =============================================================
+ALTER TABLE public.brands
+  ADD COLUMN IF NOT EXISTS partner_setup boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.brands.partner_setup IS
+  'ORCH-1081: true when this brand was created by a Mingla partner setting it up for an external owner. Flipped at brand insert; not editable after.';
+
+-- =============================================================
+-- 2. partner_brand_links
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.partner_brand_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_account_id uuid NOT NULL
+    REFERENCES public.creator_accounts(id) ON DELETE CASCADE,
+  brand_id uuid NOT NULL
+    REFERENCES public.brands(id) ON DELETE CASCADE,
+  invited_owner_email text NOT NULL,
+  personal_note text,
+  invited_at timestamptz NOT NULL DEFAULT now(),
+  accepted_at timestamptz,
+  owner_stripe_connected_at timestamptz,
+  first_split_at timestamptz,
+  cancelled_at timestamptz
+);
+
+-- One ACTIVE link per (partner, brand). Cancelled rows aren't subject to the
+-- uniqueness so a partner can cancel and re-link the same brand if needed.
+CREATE UNIQUE INDEX IF NOT EXISTS partner_brand_links_partner_brand_active_idx
+  ON public.partner_brand_links (partner_account_id, brand_id)
+  WHERE cancelled_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS partner_brand_links_partner_idx
+  ON public.partner_brand_links (partner_account_id, invited_at DESC);
+
+CREATE INDEX IF NOT EXISTS partner_brand_links_brand_idx
+  ON public.partner_brand_links (brand_id);
+
+CREATE INDEX IF NOT EXISTS partner_brand_links_email_idx
+  ON public.partner_brand_links (lower(invited_owner_email));
+
+COMMENT ON TABLE public.partner_brand_links IS
+  'ORCH-1081: per-brand link recording a partner-initiated setup + invite. Drives /partner/brands list + earnings nudge.';
+
+-- =============================================================
+-- 3. RLS — partner reads own; service role writes.
+-- =============================================================
+ALTER TABLE public.partner_brand_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS partner_brand_links_self_select ON public.partner_brand_links;
+CREATE POLICY partner_brand_links_self_select
+  ON public.partner_brand_links
+  FOR SELECT
+  TO authenticated
+  USING (partner_account_id = auth.uid());
+
+-- No INSERT/UPDATE/DELETE policies → service role only.
+
+-- =============================================================
+-- 4. partner_brand_link_status — derived status column-function.
+-- =============================================================
+CREATE OR REPLACE FUNCTION public.partner_brand_link_status(
+  row public.partner_brand_links
+)
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $function$
+  SELECT CASE
+    WHEN row.cancelled_at IS NOT NULL THEN 'cancelled'
+    WHEN row.first_split_at IS NOT NULL THEN 'active'
+    WHEN row.owner_stripe_connected_at IS NOT NULL THEN 'active'
+    WHEN row.accepted_at IS NOT NULL THEN 'awaiting_stripe'
+    ELSE 'awaiting_owner'
+  END;
+$function$;
+
+COMMENT ON FUNCTION public.partner_brand_link_status(public.partner_brand_links) IS
+  'ORCH-1081: derived link status. Clients select via partner_brand_links.partner_brand_link_status (column-syntax). Pure case tree, no IO.';
+
+-- =============================================================
+-- 5. Trigger — first_split_at on partner_splits status flip to transferred.
+-- =============================================================
+CREATE OR REPLACE FUNCTION public.partner_brand_links_mark_first_split()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  -- Only fire when a row moves into 'transferred'. Idempotent: COALESCE keeps
+  -- the earliest first_split_at if multiple transferred rows land later.
+  IF NEW.status = 'transferred'
+     AND (OLD.status IS DISTINCT FROM 'transferred')
+  THEN
+    UPDATE public.partner_brand_links
+       SET first_split_at = COALESCE(first_split_at, now())
+     WHERE partner_account_id = NEW.partner_account_id
+       AND brand_id           = NEW.brand_id
+       AND cancelled_at IS NULL;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS partner_brand_links_first_split_trigger
+  ON public.partner_splits;
+CREATE TRIGGER partner_brand_links_first_split_trigger
+  AFTER UPDATE OF status ON public.partner_splits
+  FOR EACH ROW
+  EXECUTE FUNCTION public.partner_brand_links_mark_first_split();
+
+-- Also fire on INSERT in case the very first row is created already at
+-- 'transferred' (defensive — current flow inserts 'pending', but webhook
+-- replay or schema-future-proofing). NEW.status check covers it.
+CREATE OR REPLACE FUNCTION public.partner_brand_links_mark_first_split_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NEW.status = 'transferred' THEN
+    UPDATE public.partner_brand_links
+       SET first_split_at = COALESCE(first_split_at, now())
+     WHERE partner_account_id = NEW.partner_account_id
+       AND brand_id           = NEW.brand_id
+       AND cancelled_at IS NULL;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS partner_brand_links_first_split_insert_trigger
+  ON public.partner_splits;
+CREATE TRIGGER partner_brand_links_first_split_insert_trigger
+  AFTER INSERT ON public.partner_splits
+  FOR EACH ROW
+  EXECUTE FUNCTION public.partner_brand_links_mark_first_split_insert();
+
+-- =============================================================
+-- 6. Trigger — owner_stripe_connected_at on brand stripe_connect_accounts
+--    charges_enabled flip to true.
+--
+--    The brand's Stripe Connect mirror table is public.stripe_connect_accounts
+--    (per the baseline). When charges_enabled becomes true AND the matching
+--    brand has an active partner_brand_links row, stamp owner_stripe_connected_at.
+-- =============================================================
+CREATE OR REPLACE FUNCTION public.partner_brand_links_mark_stripe_connected()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NEW.charges_enabled = true
+     AND (OLD.charges_enabled IS DISTINCT FROM true)
+     AND NEW.brand_id IS NOT NULL
+  THEN
+    UPDATE public.partner_brand_links
+       SET owner_stripe_connected_at = COALESCE(owner_stripe_connected_at, now())
+     WHERE brand_id = NEW.brand_id
+       AND cancelled_at IS NULL;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS partner_brand_links_stripe_connected_trigger
+  ON public.stripe_connect_accounts;
+CREATE TRIGGER partner_brand_links_stripe_connected_trigger
+  AFTER UPDATE OF charges_enabled ON public.stripe_connect_accounts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.partner_brand_links_mark_stripe_connected();
+
+-- =============================================================
+-- 7. accept_invite_and_transfer_brand_ownership — extend to stamp
+--    partner_brand_links.accepted_at when a matching row exists.
+--
+--    Re-create the function adding a single UPDATE at the end of the SUCCESS
+--    branch (before COMMIT). Everything else is byte-for-byte equivalent to
+--    the ORCH-1050 definition; we keep the original docs/invariants.
+-- =============================================================
+CREATE OR REPLACE FUNCTION public.accept_invite_and_transfer_brand_ownership(
+  p_token_hash text,
+  p_accepting_account_id uuid
+)
+  RETURNS jsonb
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_invitation record;
+  v_acceptor_email text;
+  v_acceptor_user_id uuid;
+  v_prior_owner_account_id uuid;
+  v_brand_record record;
+  v_transferred boolean := false;
+BEGIN
+  SELECT a.id INTO v_acceptor_user_id
+  FROM public.creator_accounts a
+  WHERE a.id = p_accepting_account_id;
+
+  IF v_acceptor_user_id IS NULL THEN
+    RAISE EXCEPTION 'invite_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT u.email INTO v_acceptor_email
+  FROM auth.users u
+  WHERE u.id = v_acceptor_user_id;
+
+  SELECT * INTO v_invitation
+  FROM public.brand_invitations
+  WHERE token_hash = p_token_hash
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'invite_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_invitation.status = 'accepted' THEN
+    RAISE EXCEPTION 'invite_already_used' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_invitation.status = 'revoked' THEN
+    RAISE EXCEPTION 'invite_revoked' USING ERRCODE = 'P0005';
+  END IF;
+
+  IF v_invitation.expires_at <= now() THEN
+    RAISE EXCEPTION 'invite_expired' USING ERRCODE = 'P0003';
+  END IF;
+
+  IF v_acceptor_email IS NULL
+     OR lower(v_acceptor_email) <> lower(v_invitation.email) THEN
+    RAISE EXCEPTION 'invite_email_mismatch' USING ERRCODE = 'P0004';
+  END IF;
+
+  IF v_invitation.role = 'brand_owner' THEN
+    SELECT * INTO v_brand_record
+    FROM public.brands
+    WHERE id = v_invitation.brand_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'invite_not_found' USING ERRCODE = 'P0001';
+    END IF;
+
+    v_prior_owner_account_id := v_brand_record.account_id;
+
+    UPDATE public.brand_team_members
+    SET role = 'brand_admin'
+    WHERE brand_id = v_invitation.brand_id
+      AND role = 'brand_owner'
+      AND removed_at IS NULL;
+
+    UPDATE public.brands
+    SET account_id = p_accepting_account_id
+    WHERE id = v_invitation.brand_id;
+
+    INSERT INTO public.brand_team_members
+      (brand_id, user_id, role, invited_at, accepted_at, removed_at)
+    VALUES
+      (v_invitation.brand_id, v_acceptor_user_id, 'brand_owner',
+       v_invitation.expires_at - interval '7 days', now(), NULL)
+    ON CONFLICT DO NOTHING;
+
+    UPDATE public.brand_team_members
+    SET role = 'brand_owner',
+        accepted_at = now(),
+        removed_at = NULL
+    WHERE brand_id = v_invitation.brand_id
+      AND user_id = v_acceptor_user_id
+      AND role <> 'brand_owner';
+
+    v_transferred := true;
+  ELSE
+    IF EXISTS (
+      SELECT 1 FROM public.brand_team_members
+      WHERE brand_id = v_invitation.brand_id
+        AND user_id = v_acceptor_user_id
+    ) THEN
+      UPDATE public.brand_team_members
+      SET role = v_invitation.role,
+          accepted_at = now(),
+          removed_at = NULL
+      WHERE brand_id = v_invitation.brand_id
+        AND user_id = v_acceptor_user_id;
+    ELSE
+      INSERT INTO public.brand_team_members
+        (brand_id, user_id, role, invited_at, accepted_at, removed_at)
+      VALUES
+        (v_invitation.brand_id, v_acceptor_user_id, v_invitation.role,
+         v_invitation.expires_at - interval '7 days', now(), NULL);
+    END IF;
+  END IF;
+
+  UPDATE public.brand_invitations
+  SET status = 'accepted',
+      accepted_at = now(),
+      accepted_by_account_id = p_accepting_account_id
+  WHERE id = v_invitation.id;
+
+  -- ORCH-1081: stamp accepted_at on the matching partner_brand_links row
+  -- (matched by brand_id + invitee email). Best-effort same-tx update.
+  UPDATE public.partner_brand_links
+     SET accepted_at = COALESCE(accepted_at, now())
+   WHERE brand_id = v_invitation.brand_id
+     AND lower(invited_owner_email) = lower(v_invitation.email)
+     AND cancelled_at IS NULL;
+
+  BEGIN
+    INSERT INTO public.audit_log
+      (user_id, brand_id, action, target_type, target_id, after)
+    VALUES (
+      v_acceptor_user_id,
+      v_invitation.brand_id,
+      CASE WHEN v_transferred
+        THEN 'brand_ownership_transferred'
+        ELSE 'brand_team_invitation_accepted'
+      END,
+      'brand_invitation',
+      v_invitation.id::text,
+      jsonb_build_object(
+        'role', v_invitation.role,
+        'transferred', v_transferred,
+        'previous_owner_account_id', v_prior_owner_account_id,
+        'new_owner_account_id', p_accepting_account_id,
+        'invitation_email', v_invitation.email
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    NULL;
+  END;
+
+  RETURN jsonb_build_object(
+    'brand_id', v_invitation.brand_id,
+    'role', v_invitation.role,
+    'transferred', v_transferred,
+    'previous_owner_account_id', v_prior_owner_account_id,
+    'new_owner_account_id',
+      CASE WHEN v_transferred THEN p_accepting_account_id ELSE NULL END,
+    -- ORCH-1081: surface partner attribution to the accept-flow client so the
+    -- celebration screen can render the "Seth has built it out for you" copy.
+    'partner_setup', (SELECT b.partner_setup FROM public.brands b WHERE b.id = v_invitation.brand_id)
+  );
+END;
+$function$;
+
+ALTER FUNCTION public.accept_invite_and_transfer_brand_ownership(text, uuid)
+  OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.accept_invite_and_transfer_brand_ownership(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.accept_invite_and_transfer_brand_ownership(text, uuid)
+  TO service_role;
+
+-- =============================================================
+-- 8. Probes — verify schema landed.
+-- =============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='brands'
+      AND column_name='partner_setup'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-1081 probe failed: brands.partner_setup missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='partner_brand_links'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-1081 probe failed: partner_brand_links table missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname='public' AND p.proname='partner_brand_link_status'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-1081 probe failed: partner_brand_link_status fn missing';
+  END IF;
+END$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes the UX gap left by META-ORCH-1048. Today partners use identical flows to brand owners — they connect their own Stripe but nothing in the app acknowledges they're a partner or guides them through setting up brands for clients. ORCH-1081 turns the working plumbing into a legible workflow.

## What ships (7 surfaces)

1. **Brand-creation Step 0 toggle** — Mine / Client picker visible only when `partner_enabled=true`. Client mode flips `brands.partner_setup=true`, adds 🤝 chip + reframed copy throughout wizard.
2. **"Invite the owner" final wizard step** — email + optional note + email preview card.
3. **`partner_brand_links` table** — lifecycle tracking with derived status function + triggers on `partner_splits` + `stripe_connect_accounts.charges_enabled`.
4. **`/partner/brands` list screen** — Awaiting Owner 🟠 / Awaiting Stripe 🟡 / Active 🟢 with inline Resend + Cancel pills.
5. **"Ready to earn" nudge** in `/partner/earnings` + rewritten splits empty states.
6. **Three notifications** — transfer-complete + first-split + one-time portfolio welcome toast.
7. **Branded invite email + post-accept celebration screen** — wraps invite through existing `_shared/email/shell.ts` (brand cover hero, partner attribution chip, partner-mode copy); new screen at `/accept-brand-invitation/success` with hardcoded App Store URLs.

## Migration
`supabase/migrations/20260920000000_orch_1081_partner_brand_links.sql` — 417 lines, idempotent, RLS lock-down (service-role writes), search_path-locked SECURITY DEFINER triggers.

## Tests
- BrandCreationFlow Jest: 3/3 pass
- invite-brand-member Deno: 9/9
- accept-brand-invitation Deno: 19/19
- partnerSplits (ORCH-1054) Deno: 16/16
- migration-guard: 30 tests pass
- Deno check clean; tsc no new errors

## Operator pre-merge steps

1. Apply migration via Supabase Management API
2. Redeploy edge fns: `invite-brand-member`, `accept-brand-invitation`, plus anything that imports `_shared/partnerSplits.ts`
3. Vercel auto-deploys both mingla-business + mingla-admin

App Store URLs are intentionally hardcoded (operator-approved; App Store records exist, URLs 404 pre-launch, become live the moment Mingla Business ships to either store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)