### PR TITLE
[deploy] Fix business web auth callback crash

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1086_BUSINESS_WEB_AUTH_CALLBACK.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1086_BUSINESS_WEB_AUTH_CALLBACK.md
@@ -1,0 +1,74 @@
+# ORCH-1086 — Business Web Auth Callback Static Cut
+
+Date: 2026-06-05
+Branch: `ORCH-1086-business-web-auth-callback`
+Worktree: `~/Desktop/mingla-orchs/ORCH-1086-[business-web-auth-callback]/`
+
+## User-Visible Problem
+
+On iPhone Safari, `business.usemingla.com` reached the welcome screen, but after OAuth sign-in Safari repeatedly crashed on:
+
+`https://business.usemingla.com/auth/callback`
+
+The screenshot showed Safari's native "A problem repeatedly occurred" page, which means the browser process repeatedly failed while loading that callback URL.
+
+## Root Cause
+
+`/auth/callback` was handled by the Expo Router SPA route `mingla-business/app/auth/callback.tsx`. That route imports the business app auth context and therefore asks mobile Safari to load the same large Expo web bundle at the most fragile point in the OAuth flow.
+
+Supabase's local `@supabase/auth-js` implementation confirms the implicit OAuth callback extracts `access_token`, `refresh_token`, expiry metadata, fetches `/auth/v1/user`, and saves a JSON session to the storage key derived by `@supabase/supabase-js`: `sb-gqnoajqerqhnvulmnyvv-auth-token`.
+
+## Fix
+
+Added `mingla-business/public/auth/callback.html`, a tiny static callback page that:
+
+- Parses the OAuth hash/search parameters without mounting the Expo app.
+- Fetches the Supabase user via `https://gqnoajqerqhnvulmnyvv.supabase.co/auth/v1/user`.
+- Falls back to JWT payload decoding if the user lookup is transiently unavailable.
+- Saves the session to `localStorage` using Supabase's existing storage key and JSON session shape.
+- Clears tokens from the visible URL and redirects to `/`.
+- Shows a small retry message if the callback contains an OAuth error or no session tokens.
+
+Updated `mingla-business/vercel.json` so Vercel serves `/auth/callback` from `/auth/callback.html` before the existing catch-all SPA fallback.
+
+## Regression Test
+
+Added `mingla-business/__tests__/authCallbackStatic.test.ts`:
+
+- Verifies `/auth/callback` rewrite precedes `/(.*)`.
+- Verifies the callback file stores the Supabase session and redirects home without Expo bundle markers.
+- Verifies error and missing-session branches stay inside the static page.
+
+## Verification
+
+Commands run from `mingla-business`:
+
+```sh
+npm run test:orch-1086
+npx jest __tests__/authCallbackStatic.test.ts --runInBand
+npx expo export -p web --clear
+node scripts/inject-mobile-blur-css.mjs
+test -f dist/auth/callback.html
+grep -q 'sb-gqnoajqerqhnvulmnyvv-auth-token' dist/auth/callback.html
+```
+
+Results:
+
+- Jest: PASS, 3/3.
+- Expo export: PASS.
+- Mobile blur post-export injection: PASS.
+- `dist/auth/callback.html`: present and contains the expected Supabase storage key.
+
+Additional WebKit smoke against the exported static file:
+
+- Started a local static server from `mingla-business/dist`.
+- Opened `http://127.0.0.1:8126/auth/callback.html#access_token=...&refresh_token=...&expires_in=3600&token_type=bearer` in Playwright WebKit with an iPhone-size viewport.
+- Confirmed the page redirected to `/`.
+- Confirmed `localStorage["sb-gqnoajqerqhnvulmnyvv-auth-token"]` contained the access token, refresh token, and user id.
+- Confirmed zero page errors.
+
+## Scope Notes
+
+This is the deterministic emergency cut for the observed Safari callback crash. It does not change `web.output`, async routes, Supabase settings, Google settings, native app links, or auth provider configuration.
+
+The broader business-web boot problem still needs ORCH-1085 architectural code-splitting/static-output work. Domain/app-link ownership should also be cleaned up separately because Android currently claims the business host broadly, but that was not the direct cause of the iPhone Safari `/auth/callback` crash shown in the screenshot.

--- a/mingla-business/__tests__/authCallbackStatic.test.ts
+++ b/mingla-business/__tests__/authCallbackStatic.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const businessRoot = path.resolve(__dirname, "..");
+const vercelPath = path.join(businessRoot, "vercel.json");
+const callbackPath = path.join(businessRoot, "public/auth/callback.html");
+
+describe("ORCH-1086 static web auth callback", () => {
+  it("routes /auth/callback to the static handler before the SPA fallback", () => {
+    const vercel = JSON.parse(fs.readFileSync(vercelPath, "utf8")) as {
+      rewrites: Array<{ source: string; destination: string }>;
+    };
+
+    const callbackIndex = vercel.rewrites.findIndex(
+      (rewrite) => rewrite.source === "/auth/callback",
+    );
+    const fallbackIndex = vercel.rewrites.findIndex(
+      (rewrite) => rewrite.source === "/(.*)",
+    );
+
+    expect(callbackIndex).toBeGreaterThanOrEqual(0);
+    expect(fallbackIndex).toBeGreaterThanOrEqual(0);
+    expect(callbackIndex).toBeLessThan(fallbackIndex);
+    expect(vercel.rewrites[callbackIndex]).toEqual({
+      source: "/auth/callback",
+      destination: "/auth/callback.html",
+    });
+  });
+
+  it("keeps the callback handler independent of the Expo web bundle", () => {
+    const html = fs.readFileSync(callbackPath, "utf8");
+
+    expect(html).toContain("sb-gqnoajqerqhnvulmnyvv-auth-token");
+    expect(html).toContain("/auth/v1/user");
+    expect(html).toContain("normalized.padEnd");
+    expect(html).toContain("window.localStorage.setItem");
+    expect(html).toContain("JSON.stringify(session)");
+    expect(html).toContain('window.location.replace("/")');
+    expect(html).not.toContain("__expo");
+    expect(html).not.toContain("expo-router");
+    expect(html).not.toContain("id=\"root\"");
+  });
+
+  it("handles OAuth error and missing-session branches without entering the SPA", () => {
+    const html = fs.readFileSync(callbackPath, "utf8");
+
+    expect(html).toContain("params.error");
+    expect(html).toContain("No sign-in session was returned.");
+    expect(html).toContain("Sign-in needs another try");
+    expect(html).toContain('window.history.replaceState(null, "", "/auth/callback")');
+  });
+});

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -47,7 +47,8 @@
     "test:orch-0892": "node ../.github/scripts/strict-grep/orch-0892-no-bespoke-keyboard-plumbing.mjs && npx jest src/wrappers/__tests__/KeyboardRoot.test.tsx",
     "test:orch-1001": "node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs --self-test && node ../.github/scripts/strict-grep/orch-1001-no-native-turbomodule-in-web-bundle.mjs && npx jest orch1001CoverPickerWebSplit orch1001NativeTurbomoduleGate",
     "test:orch-1004": "node ../.github/scripts/strict-grep/orch-1004-auth-scoped-query-readiness.mjs --self-test && node ../.github/scripts/strict-grep/orch-1004-auth-scoped-query-readiness.mjs && npx jest authScopedQueryReadiness orch1004AuthScopedQueryGate",
-    "test:orch-1005": "node scripts/ci/orch-1005-dead-code-removed.mjs --self-test && node scripts/ci/orch-1005-dead-code-removed.mjs"
+    "test:orch-1005": "node scripts/ci/orch-1005-dead-code-removed.mjs --self-test && node scripts/ci/orch-1005-dead-code-removed.mjs",
+    "test:orch-1086": "npx jest __tests__/authCallbackStatic.test.ts --runInBand"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/mingla-business/public/auth/callback.html
+++ b/mingla-business/public/auth/callback.html
@@ -1,0 +1,236 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Signing in | Mingla Business</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        background: #f7f1ea;
+        color: #201814;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+        margin: 0;
+        min-height: 100vh;
+        padding: 24px;
+      }
+
+      main {
+        max-width: 360px;
+        text-align: center;
+      }
+
+      img {
+        height: 56px;
+        margin-bottom: 28px;
+        width: auto;
+      }
+
+      h1 {
+        font-size: 22px;
+        line-height: 1.2;
+        margin: 0 0 10px;
+      }
+
+      p {
+        color: #695e57;
+        font-size: 15px;
+        line-height: 1.45;
+        margin: 0;
+      }
+
+      a {
+        color: #b4542d;
+        font-weight: 700;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          background: #130f0c;
+          color: #f7f1ea;
+        }
+
+        p {
+          color: #c7bbb2;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <img src="/brand/mingla-business-logo.png" alt="Mingla Business" />
+      <h1 id="title">Signing you in</h1>
+      <p id="message">Finishing the secure handoff.</p>
+    </main>
+    <script>
+      (function () {
+        "use strict";
+
+        var SUPABASE_URL = "https://gqnoajqerqhnvulmnyvv.supabase.co";
+        var SUPABASE_ANON_KEY =
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdxbm9hanFlcnFobnZ1bG1ueXZ2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc1MDUyNzIsImV4cCI6MjA3MzA4MTI3Mn0.p4yi9yD2RWfJ2HN4DD-dgrvXnyzhJi3g2YCouSK-hbo";
+        var STORAGE_KEY = "sb-gqnoajqerqhnvulmnyvv-auth-token";
+
+        var title = document.getElementById("title");
+        var message = document.getElementById("message");
+
+        function setStatus(nextTitle, nextMessage) {
+          if (title) title.textContent = nextTitle;
+          if (message) message.textContent = nextMessage;
+        }
+
+        function parseParams(value) {
+          var trimmed = value.replace(/^[?#]/, "");
+          var params = new URLSearchParams(trimmed);
+          var out = {};
+          params.forEach(function (paramValue, key) {
+            out[key] = paramValue;
+          });
+          return out;
+        }
+
+        function readCallbackParams() {
+          return Object.assign(
+            {},
+            parseParams(window.location.search),
+            parseParams(window.location.hash),
+          );
+        }
+
+        function secondsNow() {
+          return Math.round(Date.now() / 1000);
+        }
+
+        function buildUserFromJwt(accessToken) {
+          try {
+            var payload = accessToken.split(".")[1];
+            var normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+            var padded = normalized.padEnd(
+              normalized.length + ((4 - (normalized.length % 4)) % 4),
+              "=",
+            );
+            var decoded = JSON.parse(
+              decodeURIComponent(
+                Array.prototype.map
+                  .call(atob(padded), function (char) {
+                    return "%" + ("00" + char.charCodeAt(0).toString(16)).slice(-2);
+                  })
+                  .join(""),
+              ),
+            );
+
+            return {
+              id: decoded.sub,
+              aud: decoded.aud,
+              role: decoded.role,
+              email: decoded.email,
+              app_metadata: decoded.app_metadata || {},
+              user_metadata: decoded.user_metadata || {},
+              created_at: decoded.created_at || new Date().toISOString(),
+            };
+          } catch (_error) {
+            return null;
+          }
+        }
+
+        async function fetchSupabaseUser(accessToken) {
+          var response = await fetch(SUPABASE_URL + "/auth/v1/user", {
+            headers: {
+              apikey: SUPABASE_ANON_KEY,
+              Authorization: "Bearer " + accessToken,
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error("Supabase user lookup failed: " + response.status);
+          }
+
+          return await response.json();
+        }
+
+        function persistSession(session) {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+          window.localStorage.removeItem(STORAGE_KEY + "-code-verifier");
+
+          try {
+            var channel = new BroadcastChannel(STORAGE_KEY);
+            channel.postMessage({ event: "SIGNED_IN", session: session });
+            channel.close();
+          } catch (_error) {
+            // BroadcastChannel is optional; the redirect reloads the app.
+          }
+        }
+
+        async function run() {
+          var params = readCallbackParams();
+
+          if (params.error || params.error_description || params.error_code) {
+            throw new Error(
+              params.error_description || params.error || "The sign-in was cancelled.",
+            );
+          }
+
+          var accessToken = params.access_token;
+          var refreshToken = params.refresh_token;
+          var tokenType = params.token_type || "bearer";
+          var expiresIn = Number(params.expires_in || 3600);
+          var expiresAt = Number(params.expires_at || secondsNow() + expiresIn);
+
+          if (!accessToken || !refreshToken) {
+            throw new Error("No sign-in session was returned.");
+          }
+
+          var user;
+          try {
+            user = await fetchSupabaseUser(accessToken);
+          } catch (_error) {
+            user = buildUserFromJwt(accessToken);
+          }
+
+          if (!user || !user.id) {
+            throw new Error("The sign-in session could not be verified.");
+          }
+
+          persistSession({
+            provider_token: params.provider_token,
+            provider_refresh_token: params.provider_refresh_token,
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            expires_in: expiresIn,
+            expires_at: expiresAt,
+            token_type: tokenType,
+            user: user,
+          });
+
+          window.history.replaceState(null, "", "/auth/callback");
+          window.location.replace("/");
+        }
+
+        run().catch(function (error) {
+          window.history.replaceState(null, "", "/auth/callback");
+          setStatus(
+            "Sign-in needs another try",
+            (error && error.message ? error.message : "Something went wrong.") +
+              " Refresh, then sign in again.",
+          );
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/mingla-business/vercel.json
+++ b/mingla-business/vercel.json
@@ -44,6 +44,7 @@
       "destination": "/api/public-brand?brandSlug=:brandSlug"
     },
     { "source": "/stripe-onboarding-return", "destination": "/stripe-onboarding-return.html" },
+    { "source": "/auth/callback", "destination": "/auth/callback.html" },
     { "source": "/(.*)", "destination": "/" }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- serve /auth/callback from a tiny static handler before the SPA fallback
- persist Supabase OAuth sessions without loading the heavy Expo web bundle on mobile Safari
- add ORCH-1086 regression coverage and implementation evidence

## Verification
- npm run test:orch-1086
- npx expo export -p web --clear
- node scripts/inject-mobile-blur-css.mjs
- WebKit exported callback smoke: fake OAuth fragment persisted session + redirected home with zero page errors

## Notes
- No Supabase, Google, native app-link, asyncRoutes, or web.output changes in this emergency cut.
- ORCH-1085 still owns the broader business-web code-splitting cure.