### PR TITLE
[deploy] ORCH-1085 mobile web Home CI hardening

### DIFF
--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -59,6 +59,7 @@ on:
 #   - I-PROPOSED-M (i-proposed-m-persist-key-whitelist.mjs) — persist-key whitelist sync (META-ORCH-0744)
 #   - I-PROPOSED-N (i-proposed-n-transitional-exit-condition.mjs) — TRANSITIONAL exit-condition lint (META-ORCH-0744)
 #   - I-PROPOSED-X (i-proposed-x-web-deprecation.mjs) — web-export deprecation parser (META-ORCH-0744)
+#   - ORCH-1085 (mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs) — mobile browser sign-in lands on static /home before Expo boot
 #   - ORCH-0785-A (orch-0785-resend-attachment-aware.mjs) — Resend POST must declare attachments or opt out (ORCH-0785)
 #   - ORCH-0785-B (orch-0785-no-resend-sandbox-fallback.mjs) — no onboarding@resend.dev fallback in source (ORCH-0785)
 #   - ORCH-0785-C (orch-0785-buyer-string-escape.mjs) — buyer/event/order strings must flow through escapeHtml (ORCH-0785)
@@ -737,6 +738,18 @@ jobs:
         run: npx expo export -p web 2>/tmp/expo-export-web.stderr || true
       - name: Run I-PROPOSED-X parser
         run: node .github/scripts/strict-grep/i-proposed-x-web-deprecation.mjs /tmp/expo-export-web.stderr
+
+  orch-1085-mobile-web-signin-home:
+    name: "ORCH-1085: mobile web sign-in Home guard"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1085 mobile web sign-in Home guard
+        working-directory: mingla-business
+        run: npm run test:orch-1085
 
   orch-0776d-cancelled-at-schema:
     name: "ORCH-0776D: event cover video cancelled_at schema/code parity"

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_REWORK_ORCH-1085_MOBILE_WEB_HOME_CI_HARDENING.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_REWORK_ORCH-1085_MOBILE_WEB_HOME_CI_HARDENING.md
@@ -1,0 +1,61 @@
+# IMPLEMENTATION REWORK ORCH-1085 - Mobile Web Home CI Hardening
+
+Date: 2026-06-05
+Worktree: `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1085-[phase2-close-sync]`
+Branch: `ORCH-1085-phase2-close-sync`
+Base: `origin/main` at `58ba51ad80cadce4dbc7863f110622ae586796e7`
+Status: implemented and locally verified
+
+## Outcome
+
+This rework closes the tester's remaining Phase 2 hardening findings after PR #387:
+
+- The static mobile-web Home regression guard is now wired into GitHub Actions.
+- The static Account tab no longer uses provider-specific "Stripe account" copy.
+- The ORCH-1085 guard now fails if `public/home.html` regresses to placeholder copy, loads the Expo bundle, or reintroduces the provider-specific static copy.
+
+This does not claim the full Expo/RN web app is complete. It hardens the crash-stop signed-in browser landing page that Seth can use today while Phase 3 inventories and optimizes the full web app route-by-route.
+
+## Files Changed
+
+- `.github/workflows/strict-grep-mingla-business.yml`
+  - Adds `orch-1085-mobile-web-signin-home`.
+  - Runs `npm run test:orch-1085` from `mingla-business`.
+  - Registers the gate in the workflow comment registry.
+- `mingla-business/public/home.html`
+  - Changes Account tab action title from `Stripe account` to `Payout account`.
+- `mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs`
+  - Adds a negative assertion against `Stripe account` in the static Home shell.
+
+## Verification
+
+Local command:
+
+```bash
+cd /Users/sethogieva/Desktop/mingla-orchs/ORCH-1085-[phase2-close-sync]/mingla-business
+npm run test:orch-1085
+```
+
+Result:
+
+```text
+ORCH-1085 mobile-web sign-in PASS.
+```
+
+Prior production proof from this close lane:
+
+- `https://business.usemingla.com/home` served the branded tabbed static Home shell.
+- Physical Android Chrome loaded production `/home`.
+- Physical Android Chrome `/auth/callback#access_token=...&refresh_token=...` redirected to `/home`.
+- Fatal/OOM/renderer-death grep returned zero lines at `/tmp/orch1085-prod-callback-fatal-only.txt`.
+- Screenshot: `/tmp/orch1085-prod-tabbed-home.png`.
+
+## Deploy Notes
+
+This touches `mingla-business/public/home.html`, so the PR title/commit must include `[deploy]` for Vercel. Deploy/verification must happen from merged `main`, per COMMS-0015 and COMMS-0018.
+
+No native OTA is needed for this rework.
+
+## Residual Work
+
+Phase 3 remains open: full business-web functionality needs route-by-route forensic inventory and optimization, including heavy surfaces such as cover picker/media upload, marketing composer, Stripe Connect, Ari, Hub, creator wizards, sheets/modals, date/time pickers, Mapbox/location, QR/share, auth/session restore, OG/deep-link rewrites, analytics/native SDK shims, and all Expo/RN-web parity assumptions.

--- a/mingla-business/public/home.html
+++ b/mingla-business/public/home.html
@@ -525,7 +525,7 @@
           </a>
           <a class="action" href="/connect-account-management">
             <span>
-              <strong>Stripe account</strong>
+              <strong>Payout account</strong>
               <span>Manage payouts and verification</span>
             </span>
             <span class="arrow">›</span>

--- a/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
+++ b/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
@@ -72,9 +72,10 @@ if (
 if (
   home.includes("Fast mobile home") ||
   home.includes("Browser mode") ||
-  home.includes("heavy app boot")
+  home.includes("heavy app boot") ||
+  home.includes("Stripe account")
 ) {
-  fail("public/home.html must not regress to the placeholder stabilization copy");
+  fail("public/home.html must not regress to placeholder or provider-specific copy");
 }
 if (home.includes("/_expo/static/js/") || home.includes("expo-metro-runtime")) {
   fail("public/home.html must not load the Expo/RN web bundle");


### PR DESCRIPTION
## Summary
- Wire the ORCH-1085 mobile browser sign-in Home guard into GitHub Actions.
- Change the static Account tab copy from provider-specific "Stripe account" to "Payout account".
- Extend the ORCH-1085 guard so provider-specific static Home copy fails the regression check.

## Verification
- cd mingla-business && npm run test:orch-1085

## Deploy
- Vercel deploy required because this touches mingla-business/public/home.html.
- No native OTA required.