### PR TITLE
[deploy] ORCH-1090 business web mobile chunk auth recovery

### DIFF
--- a/mingla-business/public/home.html
+++ b/mingla-business/public/home.html
@@ -421,7 +421,7 @@
           <img class="brand-mark" src="/brand/mingla-business-logo.png" alt="Mingla Business" />
           <div class="brand-copy">
             <p class="brand-name">Mingla Business</p>
-            <p class="session" id="session-label">Signed in</p>
+            <p class="session" id="session-label">Signed out</p>
           </div>
         </div>
         <a class="chip" href="#account" data-tab-link="account">Account</a>
@@ -753,8 +753,8 @@
           if (raw) {
             var session = JSON.parse(raw);
             var email = session && session.user && session.user.email;
-            if (email) {
-              document.getElementById("session-label").textContent = email;
+            if (session && session.access_token) {
+              document.getElementById("session-label").textContent = email || "Signed in";
             }
           }
         } catch (_error) {}

--- a/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
+++ b/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
@@ -56,6 +56,12 @@ const home = read("public/home.html");
 if (!home.includes("Business Home") || !home.includes("Run your next drop.")) {
   fail("public/home.html must render a branded mobile Business Home shell");
 }
+if (!home.includes('id="session-label">Signed out</p>')) {
+  fail("public/home.html must not claim Signed in without a real browser session");
+}
+if (!home.includes('session.access_token') || !home.includes('email || "Signed in"')) {
+  fail("public/home.html must switch the session label only after reading a usable auth session");
+}
 for (const tab of ["Home", "Hub", "Ari", "Blast", "Account"]) {
   if (!home.includes(`>${tab}<`)) {
     fail(`public/home.html must render the ${tab} tab`);
@@ -99,6 +105,14 @@ if (
 ) {
   fail("post-export injection must include the signed-in mobile / -> /home preboot redirect");
 }
+if (
+  !injectScript.includes("mingla-mobile-web-chunk-recovery") ||
+  !injectScript.includes("/_expo/static/js/web/") ||
+  !injectScript.includes("location.reload()") ||
+  !injectScript.includes("/home?recovered=chunk")
+) {
+  fail("post-export injection must include stale async chunk recovery before Expo app boot");
+}
 
 if (existsSync(join(WEB_BUILD, "index.html"))) {
   const indexHtml = read(join(WEB_BUILD, "index.html"));
@@ -127,6 +141,9 @@ if (existsSync(join("dist", "index.html"))) {
   const distIndex = read(join("dist", "index.html"));
   if (!distIndex.includes("mingla-mobile-web-home-preboot")) {
     fail("dist/index.html must contain the mobile signed-in preboot redirect");
+  }
+  if (!distIndex.includes("mingla-mobile-web-chunk-recovery")) {
+    fail("dist/index.html must contain stale async chunk recovery");
   }
   if (!distIndex.includes("mingla-mobile-web-no-blur")) {
     fail("dist/index.html must contain the mobile no-blur style");

--- a/mingla-business/scripts/inject-mobile-blur-css.mjs
+++ b/mingla-business/scripts/inject-mobile-blur-css.mjs
@@ -17,10 +17,12 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 const HTML_PATH = "dist/index.html";
 const MARKER = "mingla-mobile-web-no-blur";
 const PREBOOT_MARKER = "mingla-mobile-web-home-preboot";
+const CHUNK_RECOVERY_MARKER = "mingla-mobile-web-chunk-recovery";
 const STYLE_TAG =
   `<style id="${MARKER}">@media (max-width:767px){*,*::before,*::after{` +
   `-webkit-backdrop-filter:none !important;backdrop-filter:none !important}}</style>`;
 const PREBOOT_SCRIPT = `<script id="${PREBOOT_MARKER}">(function(){try{var p=location.pathname;if(p!=="/"&&p!=="/index.html")return;var isPhone=matchMedia&&matchMedia("(max-width: 767px)").matches;if(!isPhone)return;var raw=localStorage.getItem("sb-gqnoajqerqhnvulmnyvv-auth-token");if(!raw)return;var session=JSON.parse(raw);if(session&&session.access_token){location.replace("/home");}}catch(_e){}})();</script>`;
+const CHUNK_RECOVERY_SCRIPT = `<script id="${CHUNK_RECOVERY_MARKER}">(function(){function isChunkUrl(value){return typeof value==="string"&&value.indexOf("/_expo/static/js/web/")!==-1&&/\\.js(?:$|[?#])/.test(value)}function recover(reason){try{var key="mingla-mobile-web-chunk-recovery";var last=sessionStorage.getItem(key);var now=String(Date.now());if(last){console.warn("[mobile-web] chunk recovery already attempted",reason);location.replace("/home?recovered=chunk");return}sessionStorage.setItem(key,now);console.warn("[mobile-web] stale chunk detected; reloading",reason);location.reload()}catch(_e){location.replace("/home?recovered=chunk")}}window.addEventListener("error",function(event){var target=event&&event.target;var src=target&&(target.src||target.href);if(isChunkUrl(src)){recover(src)}} ,true);window.addEventListener("unhandledrejection",function(event){var reason=event&&event.reason;var text=String(reason&&((reason.message||reason.name)||reason)||"");if(/Loading chunk|loadBundleAsync|ChunkLoadError|Importing a module script failed|Failed to fetch dynamically imported module/i.test(text)){recover(text)}});})();</script>`;
 
 try {
   if (!existsSync(HTML_PATH)) {
@@ -28,7 +30,7 @@ try {
     process.exit(0);
   }
   let html = readFileSync(HTML_PATH, "utf8");
-  if (html.includes(MARKER) && html.includes(PREBOOT_MARKER)) {
+  if (html.includes(MARKER) && html.includes(PREBOOT_MARKER) && html.includes(CHUNK_RECOVERY_MARKER)) {
     console.log("[mobile-blur-fix] already present — skipping.");
     process.exit(0);
   }
@@ -36,10 +38,10 @@ try {
     console.warn("[mobile-blur-fix] no </head> in dist/index.html — skipping.");
     process.exit(0);
   }
-  const headInsert = `${html.includes(PREBOOT_MARKER) ? "" : PREBOOT_SCRIPT}${html.includes(MARKER) ? "" : STYLE_TAG}`;
+  const headInsert = `${html.includes(CHUNK_RECOVERY_MARKER) ? "" : CHUNK_RECOVERY_SCRIPT}${html.includes(PREBOOT_MARKER) ? "" : PREBOOT_SCRIPT}${html.includes(MARKER) ? "" : STYLE_TAG}`;
   html = html.replace("</head>", `${headInsert}</head>`);
   writeFileSync(HTML_PATH, html);
-  console.log("[mobile-blur-fix] injected mobile preboot + blur-kill into dist/index.html <head>.");
+  console.log("[mobile-blur-fix] injected mobile chunk recovery + preboot + blur-kill into dist/index.html <head>.");
 } catch (err) {
   console.warn(`[mobile-blur-fix] failed (non-fatal): ${err?.message ?? err}`);
 }

--- a/mingla-business/src/utils/__tests__/orch_1090_mobile_web_chunk_auth_recovery.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1090_mobile_web_chunk_auth_recovery.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+
+const repoFile = (relativePath: string): string =>
+  readFileSync(join(REPO_ROOT, "mingla-business", relativePath), "utf8");
+
+describe("ORCH-1090 mobile web chunk/auth recovery", () => {
+  test("static Home does not claim signed-in state without a real session", () => {
+    const source = repoFile("public/home.html");
+
+    expect(source).toContain('id="session-label">Signed out</p>');
+    expect(source).toContain("session && session.access_token");
+    expect(source).toContain('email || "Signed in"');
+    expect(source).not.toContain('id="session-label">Signed in</p>');
+  });
+
+  test("post-export HTML injection recovers stale async route chunks before app boot", () => {
+    const source = repoFile("scripts/inject-mobile-blur-css.mjs");
+
+    expect(source).toContain("mingla-mobile-web-chunk-recovery");
+    expect(source).toContain("/_expo/static/js/web/");
+    expect(source).toContain("location.reload()");
+    expect(source).toContain("/home?recovered=chunk");
+    expect(source).toContain("unhandledrejection");
+    expect(source).toContain("ChunkLoadError");
+  });
+
+  test("mobile-web CI guard pins the Home auth label and chunk recovery contracts", () => {
+    const source = repoFile("scripts/ci/orch-1085-mobile-web-signin-home.mjs");
+
+    expect(source).toContain("must not claim Signed in without a real browser session");
+    expect(source).toContain("must include stale async chunk recovery before Expo app boot");
+    expect(source).toContain("dist/index.html must contain stale async chunk recovery");
+  });
+});


### PR DESCRIPTION
## Summary\n- Adds a pre-Expo mobile web chunk recovery hook to reload once when a stale async route chunk fails after deploy.\n- Stops static Home from claiming Signed in unless a usable Supabase browser session exists.\n- Pins both contracts in ORCH-1085 and ORCH-1090 regression guards.\n\n## Verification\n- npx jest src/utils/__tests__/orch_1090_mobile_web_chunk_auth_recovery.test.ts --runInBand\n- npm run test:orch-1089\n- rm -rf dist && npx expo export -p web --output-dir dist && node scripts/inject-mobile-blur-css.mjs && node scripts/ci/orch-1085-mobile-web-signin-home.mjs\n- Android Chrome via adb reverse: http://127.0.0.1:8090/home.html?orch1090=1 shows Signed out + tabs; http://127.0.0.1:8090/event/create?orch1090=1 shows Sign in to create an event recovery instead of hanging