### PR TITLE
[deploy] ORCH-1091 business web JS cache invalidation

### DIFF
--- a/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
+++ b/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
@@ -97,6 +97,15 @@ const catchAllIndex = (vercel.rewrites ?? []).findIndex((r) => r.source === "/(.
 if (homeRewriteIndex < 0 || catchAllIndex < 0 || homeRewriteIndex > catchAllIndex) {
   fail("/home rewrite must appear before the SPA catch-all rewrite");
 }
+const webJsHeader = (vercel.headers ?? []).find(
+  (header) => header.source === "/_expo/static/js/web/(.*)",
+);
+if (
+  !webJsHeader ||
+  !JSON.stringify(webJsHeader.headers ?? []).includes("max-age=0, must-revalidate")
+) {
+  fail("web JS bundles must not be served immutable because async route manifests can stale across deploys");
+}
 
 const injectScript = read("scripts/inject-mobile-blur-css.mjs");
 if (
@@ -112,6 +121,13 @@ if (
   !injectScript.includes("/home?recovered=chunk")
 ) {
   fail("post-export injection must include stale async chunk recovery before Expo app boot");
+}
+if (
+  !injectScript.includes("orch1091-js-cache-bust") ||
+  !injectScript.includes("?v=${JS_CACHE_BUST_PARAM}") ||
+  !injectScript.includes("/_expo/static/js/web/")
+) {
+  fail("post-export injection must cache-bust eager Expo JS script URLs");
 }
 
 if (existsSync(join(WEB_BUILD, "index.html"))) {
@@ -144,6 +160,9 @@ if (existsSync(join("dist", "index.html"))) {
   }
   if (!distIndex.includes("mingla-mobile-web-chunk-recovery")) {
     fail("dist/index.html must contain stale async chunk recovery");
+  }
+  if (!distIndex.includes("orch1091-js-cache-bust") || !distIndex.includes("?v=orch1091")) {
+    fail("dist/index.html must cache-bust eager Expo JS script URLs");
   }
   if (!distIndex.includes("mingla-mobile-web-no-blur")) {
     fail("dist/index.html must contain the mobile no-blur style");

--- a/mingla-business/scripts/inject-mobile-blur-css.mjs
+++ b/mingla-business/scripts/inject-mobile-blur-css.mjs
@@ -18,6 +18,8 @@ const HTML_PATH = "dist/index.html";
 const MARKER = "mingla-mobile-web-no-blur";
 const PREBOOT_MARKER = "mingla-mobile-web-home-preboot";
 const CHUNK_RECOVERY_MARKER = "mingla-mobile-web-chunk-recovery";
+const JS_CACHE_BUST_MARKER = "orch1091-js-cache-bust";
+const JS_CACHE_BUST_PARAM = "orch1091";
 const STYLE_TAG =
   `<style id="${MARKER}">@media (max-width:767px){*,*::before,*::after{` +
   `-webkit-backdrop-filter:none !important;backdrop-filter:none !important}}</style>`;
@@ -39,6 +41,12 @@ try {
     process.exit(0);
   }
   const headInsert = `${html.includes(CHUNK_RECOVERY_MARKER) ? "" : CHUNK_RECOVERY_SCRIPT}${html.includes(PREBOOT_MARKER) ? "" : PREBOOT_SCRIPT}${html.includes(MARKER) ? "" : STYLE_TAG}`;
+  if (!html.includes(JS_CACHE_BUST_MARKER)) {
+    html = html.replace(
+      /src="(\/_expo\/static\/js\/web\/[^"?]+\.js)"/g,
+      `src="$1?v=${JS_CACHE_BUST_PARAM}" data-${JS_CACHE_BUST_MARKER}="true"`,
+    );
+  }
   html = html.replace("</head>", `${headInsert}</head>`);
   writeFileSync(HTML_PATH, html);
   console.log("[mobile-blur-fix] injected mobile chunk recovery + preboot + blur-kill into dist/index.html <head>.");

--- a/mingla-business/src/utils/__tests__/orch_1091_mobile_web_js_cache_invalidation.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1091_mobile_web_js_cache_invalidation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+
+const repoFile = (relativePath: string): string =>
+  readFileSync(join(REPO_ROOT, "mingla-business", relativePath), "utf8");
+
+describe("ORCH-1091 mobile web JS cache invalidation", () => {
+  test("Vercel does not serve async web JS manifests as immutable", () => {
+    const vercel = JSON.parse(repoFile("vercel.json"));
+    const webJsHeader = vercel.headers.find(
+      (header: { source?: string }) => header.source === "/_expo/static/js/web/(.*)",
+    );
+
+    expect(JSON.stringify(webJsHeader?.headers ?? [])).toContain(
+      "max-age=0, must-revalidate",
+    );
+  });
+
+  test("post-export injection cache-busts eager Expo JS script URLs", () => {
+    const source = repoFile("scripts/inject-mobile-blur-css.mjs");
+
+    expect(source).toContain("orch1091-js-cache-bust");
+    expect(source).toContain("JS_CACHE_BUST_PARAM");
+    expect(source).toContain("/_expo/static/js/web/");
+    expect(source).toContain("?v=${JS_CACHE_BUST_PARAM}");
+  });
+
+  test("mobile-web CI guard pins the JS cache invalidation contract", () => {
+    const source = repoFile("scripts/ci/orch-1085-mobile-web-signin-home.mjs");
+
+    expect(source).toContain("web JS bundles must not be served immutable");
+    expect(source).toContain("post-export injection must cache-bust eager Expo JS script URLs");
+    expect(source).toContain("dist/index.html must cache-bust eager Expo JS script URLs");
+  });
+});

--- a/mingla-business/vercel.json
+++ b/mingla-business/vercel.json
@@ -50,6 +50,12 @@
   ],
   "headers": [
     {
+      "source": "/_expo/static/js/web/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
       "source": "/_expo/static/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## What changed

Fixes the remaining mobile-browser web failure where phones kept using a stale Expo web entry bundle after deploy. The old entry bundle still pointed at deleted async route chunks, so Android Chrome could hang on /event/create even after the latest code shipped.

This PR makes the deploy deterministic by:

- serving Expo web JS with `public, max-age=0, must-revalidate` instead of immutable caching
- adding a post-export cache-busting query to eager Expo web scripts in `dist/index.html`
- pinning the contract with Jest and CI guard coverage

## Verification

- `npx jest src/utils/__tests__/orch_1091_mobile_web_js_cache_invalidation.test.ts --runInBand`
- `npm run test:orch-1085`
- `rm -rf dist && npx expo export -p web --output-dir dist && node scripts/inject-mobile-blur-css.mjs && node scripts/ci/orch-1085-mobile-web-signin-home.mjs`
- Android Chrome local export smoke: `http://127.0.0.1:8091/event/create?orch1091=1` loaded `index-673...js?v=orch1091`, loaded current `create-c6d99...js`, and rendered the sign-in-needed state instead of hanging.

## Deploy note

This is business web surface work. Per COMMS-0015/0018, production verification/deploy happens only after this branch is merged to `main`; no OTA or deploy is run from the worktree.