### PR TITLE
[deploy] ORCH-1091 ensure web JS cache header wins

### DIFF
--- a/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
+++ b/mingla-business/scripts/ci/orch-1085-mobile-web-signin-home.mjs
@@ -100,11 +100,20 @@ if (homeRewriteIndex < 0 || catchAllIndex < 0 || homeRewriteIndex > catchAllInde
 const webJsHeader = (vercel.headers ?? []).find(
   (header) => header.source === "/_expo/static/js/web/(.*)",
 );
+const broadExpoStaticHeaderIndex = (vercel.headers ?? []).findIndex(
+  (header) => header.source === "/_expo/static/(.*)",
+);
+const webJsHeaderIndex = (vercel.headers ?? []).findIndex(
+  (header) => header.source === "/_expo/static/js/web/(.*)",
+);
 if (
   !webJsHeader ||
   !JSON.stringify(webJsHeader.headers ?? []).includes("max-age=0, must-revalidate")
 ) {
   fail("web JS bundles must not be served immutable because async route manifests can stale across deploys");
+}
+if (broadExpoStaticHeaderIndex < 0 || webJsHeaderIndex < broadExpoStaticHeaderIndex) {
+  fail("web JS cache header must appear after the broad Expo static immutable header so Vercel applies must-revalidate");
 }
 
 const injectScript = read("scripts/inject-mobile-blur-css.mjs");

--- a/mingla-business/src/utils/__tests__/orch_1091_mobile_web_js_cache_invalidation.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1091_mobile_web_js_cache_invalidation.test.ts
@@ -19,6 +19,19 @@ describe("ORCH-1091 mobile web JS cache invalidation", () => {
     );
   });
 
+  test("Vercel web JS header overrides the broad immutable static header", () => {
+    const vercel = JSON.parse(repoFile("vercel.json"));
+    const broadStaticIndex = vercel.headers.findIndex(
+      (header: { source?: string }) => header.source === "/_expo/static/(.*)",
+    );
+    const webJsIndex = vercel.headers.findIndex(
+      (header: { source?: string }) => header.source === "/_expo/static/js/web/(.*)",
+    );
+
+    expect(broadStaticIndex).toBeGreaterThanOrEqual(0);
+    expect(webJsIndex).toBeGreaterThan(broadStaticIndex);
+  });
+
   test("post-export injection cache-busts eager Expo JS script URLs", () => {
     const source = repoFile("scripts/inject-mobile-blur-css.mjs");
 

--- a/mingla-business/vercel.json
+++ b/mingla-business/vercel.json
@@ -50,15 +50,15 @@
   ],
   "headers": [
     {
-      "source": "/_expo/static/js/web/(.*)",
-      "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
-      ]
-    },
-    {
       "source": "/_expo/static/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/_expo/static/js/web/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
       ]
     },
     {


### PR DESCRIPTION
## What changed

Production verification of PR #395 proved the HTML cache-bust shipped, but Vercel still served `/_expo/static/js/web/index...js?v=orch1091` with the broad immutable header. The specific web-JS header was present but placed before the broad `_expo/static` rule, so the broad rule won.

This follow-up moves the web-JS `public, max-age=0, must-revalidate` header after the broad immutable static header and pins that ordering in both the mobile-web CI guard and the ORCH-1091 Jest test.

## Verification

- `npx jest src/utils/__tests__/orch_1091_mobile_web_js_cache_invalidation.test.ts --runInBand`
- `node scripts/ci/orch-1085-mobile-web-signin-home.mjs`
- `rm -rf dist && npx expo export -p web --output-dir dist && node scripts/inject-mobile-blur-css.mjs && node scripts/ci/orch-1085-mobile-web-signin-home.mjs`

## Deploy note

Business web surface. Production proof must be from merged `main` per COMMS-0015/0018; do not deploy this worktree directly.