### PR TITLE
ORCH-1099 [deploy]: web-gate ticket scanner — clean 'scan in the app' fallback, no dead camera screen

### DIFF
--- a/mingla-business/app/event/[id]/scanner/index.web.tsx
+++ b/mingla-business/app/event/[id]/scanner/index.web.tsx
@@ -1,0 +1,154 @@
+/**
+ * /event/[id]/scanner — WEB override (ORCH-1099 [scanner-camera-web-behavior]).
+ *
+ * The native scanner (./index.tsx) statically imports `expo-camera`
+ * (`CameraView`, `useCameraPermissions`) + `expo-haptics`. `expo-camera`'s
+ * `CameraView` has no working barcode-scan path on web — `onBarcodeScanned`
+ * is native-only — so on a phone browser the route either dead-ends on a
+ * camera-permission gate that leads nowhere, or ships native camera refs
+ * into the web bundle. Metro resolves THIS `.web.tsx` for the web export,
+ * so the native `expo-camera`/`expo-haptics` imports never land in the web
+ * bundle at all (same hygiene as coverPickerVideoTrimEditor.web.ts and the
+ * connect-* .web.tsx route splits).
+ *
+ * Rather than strand a web operator on a dead camera screen, the web path is
+ * an explicit, coherent end state: scanning happens in the Mingla Business
+ * app. We keep the same chrome (close + title), reuse the kind-aware copy
+ * lens, honor the replacement-event redirect, and offer a clear way forward
+ * (back to the event dashboard). No camera, no permission prompt, no crash.
+ *
+ * The native iOS/Android scanner (./index.tsx) is intentionally left
+ * byte-unchanged — it is the primary scan surface.
+ */
+
+import React, { useCallback, useEffect } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  spacing,
+  text as textTokens,
+} from "../../../../src/constants/designSystem";
+import { useManagedEventRoute } from "../../../../src/hooks/useManagedEventRoute";
+import {
+  capitalizeNoun,
+  offeringKindConfig,
+  offeringKindFromEventType,
+} from "../../../../src/components/offering/offeringKind";
+
+import { Button } from "../../../../src/components/ui/Button";
+import { EmptyState } from "../../../../src/components/ui/EmptyState";
+import { Icon } from "../../../../src/components/ui/Icon";
+import { IconChrome } from "../../../../src/components/ui/IconChrome";
+
+export default function ScannerCameraWebRoute(): React.ReactElement {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const eventId = Array.isArray(params.id) ? params.id[0] : params.id;
+
+  const routeEvent = useManagedEventRoute(
+    typeof eventId === "string" ? eventId : null,
+  );
+  const event = routeEvent.event;
+  const kindCfg = offeringKindConfig(
+    offeringKindFromEventType(event?.event_type),
+  );
+
+  // Honor the same replacement-event redirect the native route uses, so a
+  // rescheduled/replaced event resolves to its live id on web too.
+  useEffect(() => {
+    if (routeEvent.replacementEventId !== null) {
+      router.replace(`/event/${routeEvent.replacementEventId}/scanner` as never);
+    }
+  }, [routeEvent.replacementEventId, router]);
+
+  const handleBack = useCallback((): void => {
+    if (router.canGoBack()) {
+      router.back();
+    } else if (typeof eventId === "string") {
+      router.replace(`/event/${eventId}` as never);
+    }
+  }, [router, eventId]);
+
+  const handleOpenDashboard = useCallback((): void => {
+    if (typeof eventId === "string") {
+      router.replace(`/event/${eventId}` as never);
+    } else {
+      handleBack();
+    }
+  }, [router, eventId, handleBack]);
+
+  return (
+    <View style={[styles.host, { paddingTop: insets.top }]}>
+      <View style={styles.chromeRow}>
+        <IconChrome
+          icon="close"
+          size={36}
+          onPress={handleBack}
+          accessibilityLabel="Back"
+        />
+        <Text style={styles.chromeTitle}>Scan tickets</Text>
+        <View style={styles.chromeRightSlot} />
+      </View>
+
+      <View style={styles.body}>
+        <EmptyState
+          illustration={<Icon name="qr" size={48} color={textTokens.primary} />}
+          title="Scan tickets in the app"
+          description={`Door scanning uses your phone camera, which works in the Mingla Business app. Open the app on your phone to scan tickets for this ${kindCfg.noun}. You can manage everything else for this ${kindCfg.noun} here on the web.`}
+        />
+        <View style={styles.actions}>
+          <Button
+            label={`Back to ${capitalizeNoun(kindCfg.noun)}`}
+            onPress={handleOpenDashboard}
+            variant="primary"
+            size="lg"
+            fullWidth
+            accessibilityLabel={`Back to the ${kindCfg.noun} dashboard`}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+    backgroundColor: "#000000",
+  },
+  chromeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.sm,
+    gap: spacing.sm,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  chromeTitle: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#ffffff",
+    letterSpacing: -0.2,
+    textAlign: "center",
+  },
+  chromeRightSlot: {
+    width: 36,
+  },
+  body: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.xl,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: spacing.lg,
+  },
+  actions: {
+    alignSelf: "stretch",
+    paddingHorizontal: spacing.lg,
+  },
+});

--- a/mingla-business/src/utils/__tests__/orch_1099_scanner_web_camera_gate.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1099_scanner_web_camera_gate.test.ts
@@ -1,0 +1,70 @@
+/**
+ * ORCH-1099 [scanner-camera-web-behavior] regression test.
+ *
+ * Asserts the door-scanner web path is camera-gated:
+ *   1. A web override exists at app/event/[id]/scanner/index.web.tsx so Metro
+ *      resolves it for the web export (keeps expo-camera out of the web bundle).
+ *   2. The web override does NOT import expo-camera / CameraView /
+ *      useCameraPermissions / expo-haptics (no native camera refs ship to web,
+ *      no dead camera-permission gate).
+ *   3. The web override renders the coherent non-dead-end fallback (a clear
+ *      "scan in the app" message + a way forward), not a camera viewport.
+ *   4. The NATIVE scanner (index.tsx) is byte-unchanged: it still statically
+ *      imports expo-camera + CameraView + useCameraPermissions (the primary
+ *      scan surface must not regress).
+ *
+ * Fails-on-revert: deleting index.web.tsx makes assertion 1 throw; stripping
+ * the camera-gate guard re-adds expo-camera and fails assertion 2.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+
+const bizFile = (relativePath: string): string =>
+  readFileSync(join(REPO_ROOT, "mingla-business", relativePath), "utf8");
+
+const bizPath = (relativePath: string): string =>
+  join(REPO_ROOT, "mingla-business", relativePath);
+
+const stripCommentLines = (source: string): string =>
+  source
+    .split("\n")
+    .filter((line) => !/^\s*(\/\*|\*|\/\/)/.test(line))
+    .join("\n");
+
+const WEB_ROUTE = "app/event/[id]/scanner/index.web.tsx";
+const NATIVE_ROUTE = "app/event/[id]/scanner/index.tsx";
+
+describe("ORCH-1099 scanner web camera gate", () => {
+  test("web override file exists (Metro resolves it for web export)", () => {
+    expect(existsSync(bizPath(WEB_ROUTE))).toBe(true);
+  });
+
+  test("web override does NOT import expo-camera / camera permission / haptics", () => {
+    const code = stripCommentLines(bizFile(WEB_ROUTE));
+    expect(code).not.toMatch(/from\s+["']expo-camera["']/);
+    expect(code).not.toContain("CameraView");
+    expect(code).not.toContain("useCameraPermissions");
+    expect(code).not.toMatch(/from\s+["']expo-haptics["']/);
+    expect(code).not.toContain("onBarcodeScanned");
+  });
+
+  test("web override renders the coherent in-app fallback, not a camera", () => {
+    const code = stripCommentLines(bizFile(WEB_ROUTE));
+    // A clear non-dead-end message pointing at the app + a way forward.
+    expect(code).toContain("Scan tickets in the app");
+    expect(code).toContain("EmptyState");
+    expect(code).toContain("Button");
+  });
+
+  test("native scanner is unchanged — still the primary camera scan surface", () => {
+    const code = stripCommentLines(bizFile(NATIVE_ROUTE));
+    expect(code).toMatch(/from\s+["']expo-camera["']/);
+    expect(code).toContain("CameraView");
+    expect(code).toContain("useCameraPermissions");
+    expect(code).toContain("onBarcodeScanned");
+  });
+});


### PR DESCRIPTION
The business-web ticket scanner imported the native camera with no web guard → on a phone browser it stranded operators on a camera-permission screen that can never scan (Expo camera has no working web scan path; no web QR-decode lib in the app). Fix: a web override (`scanner/index.web.tsx`) shows a branded 'Scan tickets in the app' message + 'Back to Event' instead of a dead camera; expo-camera is fully web-gated (native ScannerCameraRoute has 0 refs in the web bundle). Native iOS/Android scanner byte-unchanged (not in diff). Device-proven on the Samsung (signed-in, real event → fallback renders, no crash/stuck-permission). Test 4/4, fails-on-revert at `9e33fb4dc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)