### PR TITLE
#426 PR4: Hot-path DB indexes + perf audit tooling

### DIFF
--- a/.github/workflows/production-readiness-audit.yml
+++ b/.github/workflows/production-readiness-audit.yml
@@ -1,7 +1,7 @@
 name: Production Readiness Audit (#426)
 
 # Tier 1 engineering gates: RLS coverage, secrets scan, swallowed errors,
-# N+1 heuristic (informational). No platform secrets required.
+# N+1 heuristic (informational), RLS perf heuristic (warn-only). No secrets.
 
 on:
   push:
@@ -33,6 +33,8 @@ jobs:
         run: node scripts/audit/run-all.mjs --self-test
       - name: Run production readiness audits
         run: node scripts/audit/run-all.mjs
+      - name: DB perf contract (#426 PR4)
+        run: node scripts/audit/orch-429-db-perf-contract.mjs
       - name: Validate k6 script structure
         run: node scripts/load/validate-k6-scripts.mjs
 

--- a/docs/db-hot-queries.md
+++ b/docs/db-hot-queries.md
@@ -1,0 +1,70 @@
+# Database hot queries (#426 PR4)
+
+Maps **load-profile critical paths** to Postgres access patterns, supporting indexes, and staging verification steps.
+
+Full 100k proof still requires staging `EXPLAIN ANALYZE` — see [scripts/db/explain-hot-queries.sql](../scripts/db/explain-hot-queries.sql).
+
+## Critical paths (from load profile)
+
+| Path | Edge / RPC | Tables | Migration indexes |
+|------|------------|--------|-------------------|
+| Discover merge | `discover-merged-events` | `events`, `brands`, `event_dates`, `ticket_types` | `idx_events_city_published` (ORCH-0824) |
+| Checkout create | `ticket-checkout-create` | `event_dates`, `ticket_types`, `events` | `idx_event_dates_event_id_end_at` (ORCH-426) |
+| Checkout status | `ticket-checkout-status` | `ticket_checkout_sessions`, `tickets`, `orders` | `idx_tickets_order_id_created_at` (ORCH-426) |
+| Ari chat | `agent-chat` | `agent_conversations`, `agent_messages`, `agent_pending_actions` | `idx_agent_messages_user_role_created` (ORCH-426) |
+
+## Query patterns
+
+### Checkout create — future dates gate
+
+```sql
+SELECT count(*) FROM event_dates
+WHERE event_id = $1 AND end_at > now();
+```
+
+**Index:** `(event_id, end_at)` — `idx_event_dates_event_id_end_at`
+
+### Checkout status — tickets for order
+
+```sql
+SELECT * FROM tickets
+WHERE order_id = $1
+ORDER BY created_at ASC;
+```
+
+**Index:** `(order_id, created_at)` — `idx_tickets_order_id_created_at` (supplements `idx_tickets_order_id`)
+
+### Agent chat — daily turn rate limit
+
+```sql
+SELECT count(*) FROM agent_messages
+WHERE user_id = $1 AND role = 'user' AND created_at >= $2;
+```
+
+**Index:** partial `(user_id, created_at DESC) WHERE role = 'user'` — `idx_agent_messages_user_role_created`
+
+### Discover — public events by city
+
+Service-role read with explicit visibility filter. Partial index on published public events:
+
+**Index:** `idx_events_city_published` — `(city) WHERE deleted_at IS NULL AND visibility = 'public' AND status IN ('scheduled','live')`
+
+## RLS performance
+
+High-traffic owner-scoped tables (`agent_*`, checkout) use `user_id = auth.uid()` in policies. Supabase recommends `(select auth.uid())` for initplan caching on large scans.
+
+- Audit: `node scripts/audit/rls-perf-heuristic.mjs` (warn-only in CI)
+- Fix pattern: replace `auth.uid()` with `(select auth.uid())` in policy predicates when EXPLAIN shows per-row initplan cost
+
+## Staging verification
+
+1. Set `DATABASE_URL` to staging (read-only role OK for EXPLAIN).
+2. Run `scripts/db/explain-hot-queries.sql` in psql or Supabase SQL editor.
+3. Confirm **Index Scan** or **Bitmap Index Scan** — not Seq Scan on large tables.
+4. Attach output to epic #426 before checking Workstream B boxes.
+
+## Open items (post-PR4)
+
+- Top-20 query list from `pg_stat_statements` on staging (operator)
+- RLS policy rewrites where audit + EXPLAIN justify it
+- Connection pool sizing (Supavisor) — operator doc in `docs/LAUNCH_GATES.md`

--- a/docs/load-profile.md
+++ b/docs/load-profile.md
@@ -47,5 +47,6 @@ Adjust these with real Mixpanel/Supabase metrics before launch.
 
 - Scripts: `scripts/load/`
 - Fixtures: [load-test-fixtures.md](./load-test-fixtures.md)
+- DB hot queries: [db-hot-queries.md](./db-hot-queries.md)
 - Validation: `node scripts/load/validate-k6-scripts.mjs`
 - Workflow: `.github/workflows/load-smoke.yml`

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -54,7 +54,8 @@
     "test:orch-1105": "node ../.github/scripts/strict-grep/orch-1105-no-route-stub-gates.mjs --self-test && node ../.github/scripts/strict-grep/orch-1105-no-route-stub-gates.mjs && node ../.github/scripts/strict-grep/orch-1105-layout-no-self-redirect.mjs --self-test && node ../.github/scripts/strict-grep/orch-1105-layout-no-self-redirect.mjs && node ../.github/scripts/strict-grep/orch-1105-web-glass-opaque-fallback.mjs --self-test && node ../.github/scripts/strict-grep/orch-1105-web-glass-opaque-fallback.mjs && node ../.github/scripts/strict-grep/orch-1105-web-gesture-safe.mjs --self-test && node ../.github/scripts/strict-grep/orch-1105-web-gesture-safe.mjs && npx jest src/utils/__tests__/navTabGate.test.ts --runInBand",
     "test:orch-426": "node ../scripts/audit/run-all.mjs --self-test && node ../scripts/load/validate-k6-scripts.mjs && npx jest src/config/__tests__/featureFlags.test.ts --runInBand",
     "test:orch-427": "npx jest src/diagnostics/__tests__/reportNonFatal.test.ts --runInBand",
-    "test:orch-428": "node ../scripts/load/validate-k6-scripts.mjs && node ../scripts/load/orch-428-load-harness-contract.mjs"
+    "test:orch-428": "node ../scripts/load/validate-k6-scripts.mjs && node ../scripts/load/orch-428-load-harness-contract.mjs",
+    "test:orch-429": "node ../scripts/audit/rls-perf-heuristic.mjs --self-test && node ../scripts/audit/orch-429-db-perf-contract.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/scripts/audit/orch-429-db-perf-contract.mjs
+++ b/scripts/audit/orch-429-db-perf-contract.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * #426 PR4 — Regression contract for DB perf tooling + hot-path migration.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const REQUIRED = [
+  "supabase/migrations/20260923000000_orch_426_scale_hot_path_indexes.sql",
+  "docs/db-hot-queries.md",
+  "scripts/db/explain-hot-queries.sql",
+  "scripts/audit/rls-perf-heuristic.mjs",
+];
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+for (const rel of REQUIRED) {
+  if (!existsSync(join(ROOT, rel))) fail(`missing ${rel}`);
+}
+
+const mig = readFileSync(
+  join(ROOT, "supabase/migrations/20260923000000_orch_426_scale_hot_path_indexes.sql"),
+  "utf8",
+);
+for (const idx of [
+  "idx_event_dates_event_id_end_at",
+  "idx_tickets_order_id_created_at",
+  "idx_agent_messages_user_role_created",
+]) {
+  if (!mig.includes(idx)) fail(`migration missing ${idx}`);
+}
+
+console.log("PASS: orch-429 db perf contract");
+process.exit(0);

--- a/scripts/audit/rls-perf-heuristic.mjs
+++ b/scripts/audit/rls-perf-heuristic.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * #426 PR4 — RLS performance heuristic.
+ *
+ * Flags bare auth.uid() in CREATE POLICY statements. Supabase recommends
+ * (select auth.uid()) for initplan caching on high-traffic tables.
+ *
+ * Default: warn-only (exit 0). Use --strict to fail CI.
+ *
+ * Usage:
+ *   node scripts/audit/rls-perf-heuristic.mjs
+ *   node scripts/audit/rls-perf-heuristic.mjs --self-test
+ */
+
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  EXIT,
+  listMigrationSqlFiles,
+  parseArgs,
+  reportViolations,
+} from "./_shared.mjs";
+
+/** Load-profile hot tables — strict mode fails only on these. */
+const HOT_TABLES = new Set([
+  "agent_conversations",
+  "agent_messages",
+  "agent_pending_actions",
+  "ticket_checkout_sessions",
+  "orders",
+  "tickets",
+  "events",
+  "event_dates",
+]);
+
+const POLICY_LINE_RE =
+  /CREATE\s+POLICY|^\s+ON\s+public\."([^"]+)"|^\s+ON\s+public\.(\w+)/i;
+const BARE_AUTH_UID_RE = /(?<!\(select\s)auth\.uid\(\)/i;
+const CACHED_AUTH_UID_RE = /\(select\s+auth\.uid\(\)\)/i;
+
+function scanMigrations(files) {
+  const findings = [];
+
+  for (const file of files) {
+    const sql = readFileSync(file, "utf8");
+    const lines = sql.split("\n");
+    let currentTable = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const onMatch = line.match(/^\s+ON\s+public\."([^"]+)"/i)
+        ?? line.match(/^\s+ON\s+public\.(\w+)/i);
+      if (onMatch) {
+        currentTable = onMatch[1] ?? onMatch[2];
+      }
+      if (/CREATE\s+POLICY/i.test(line)) {
+        currentTable = null;
+      }
+      if (!BARE_AUTH_UID_RE.test(line)) continue;
+      if (CACHED_AUTH_UID_RE.test(line)) continue;
+
+      const table = currentTable ?? "unknown";
+      findings.push({
+        file,
+        line: i + 1,
+        table,
+        hot: HOT_TABLES.has(table),
+        text: line.trim(),
+      });
+    }
+  }
+  return findings;
+}
+
+function runAudit(files, { strict, hotOnly }) {
+  const findings = scanMigrations(files);
+  const filtered = hotOnly
+    ? findings.filter((f) => f.hot)
+    : findings;
+
+  if (filtered.length === 0) {
+    console.log("PASS: no bare auth.uid() in RLS policies");
+    return EXIT.OK;
+  }
+
+  console.warn(`WARN: ${filtered.length} bare auth.uid() in RLS policy line(s)`);
+  for (const f of filtered.slice(0, 30)) {
+    const tag = f.hot ? "[hot]" : "";
+    console.warn(`  ${tag} ${f.file.split("/").pop()}:${f.line} (${f.table})`);
+  }
+  if (filtered.length > 30) {
+    console.warn(`  … and ${filtered.length - 30} more`);
+  }
+  console.warn("Fix: use (select auth.uid()) — see docs/db-hot-queries.md");
+
+  if (strict) {
+    return reportViolations(
+      "bare auth.uid() in RLS policies (--strict)",
+      filtered.map((f) => `${f.file}:${f.line}`),
+    );
+  }
+  return EXIT.OK;
+}
+
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), "rls-perf-"));
+  const migDir = join(dir, "supabase", "migrations");
+  mkdirSync(migDir, { recursive: true });
+
+  writeFileSync(
+    join(migDir, "001_test.sql"),
+    `
+CREATE POLICY "bad" ON public.agent_messages FOR SELECT
+  USING (user_id = auth.uid());
+CREATE POLICY "good" ON public.agent_messages FOR SELECT
+  USING (user_id = (select auth.uid()));
+`,
+  );
+
+  const files = [join(migDir, "001_test.sql")];
+  const findings = scanMigrations(files);
+  const bad = findings.filter((f) => f.text.includes("user_id = auth.uid()"));
+  const good = findings.filter((f) => f.text.includes("(select auth.uid())"));
+  rmSync(dir, { recursive: true, force: true });
+
+  if (bad.length !== 1 || good.length !== 0) {
+    console.error("FAIL: self-test expected 1 bare auth.uid() finding");
+    process.exit(EXIT.ERROR);
+  }
+  console.log("PASS: rls-perf-heuristic self-test");
+  process.exit(EXIT.OK);
+}
+
+function main() {
+  const { selfTest: isSelfTest } = parseArgs(process.argv);
+  if (isSelfTest) selfTest();
+
+  const strict = process.argv.includes("--strict");
+  const hotOnly = process.argv.includes("--hot-only");
+  const files = listMigrationSqlFiles();
+  const code = runAudit(files, { strict, hotOnly });
+  process.exit(code);
+}
+
+main();

--- a/scripts/audit/run-all.mjs
+++ b/scripts/audit/run-all.mjs
@@ -18,6 +18,7 @@ const AUDITS = [
   "secrets-scan.mjs",
   "swallowed-errors.mjs",
   "n-plus-one-heuristic.mjs",
+  "rls-perf-heuristic.mjs",
 ];
 
 function run(script, extraArgs = []) {

--- a/scripts/db/explain-hot-queries.sql
+++ b/scripts/db/explain-hot-queries.sql
@@ -1,0 +1,45 @@
+-- #426 PR4 — EXPLAIN ANALYZE templates for load-profile hot paths.
+-- Run on STAGING with representative UUIDs / city names. Do not run on production
+-- under load without operator approval.
+--
+-- Usage:
+--   psql "$DATABASE_URL" -v event_id='...' -v order_id='...' -v user_id='...' \
+--     -v city='London' -f scripts/db/explain-hot-queries.sql
+
+\timing on
+\echo '=== ORCH-426 hot path EXPLAIN (staging) ==='
+
+\echo '--- 1. event_dates future count (ticket-checkout-create) ---'
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT count(*)::int
+FROM public.event_dates
+WHERE event_id = :'event_id'::uuid
+  AND end_at > now();
+
+\echo '--- 2. tickets by order (ticket-checkout-status) ---'
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT id, ticket_type_id, qr_code, status, created_at
+FROM public.tickets
+WHERE order_id = :'order_id'::uuid
+ORDER BY created_at ASC;
+
+\echo '--- 3. agent_messages 24h user turns (agent-chat rate limit) ---'
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT count(*)::int
+FROM public.agent_messages
+WHERE user_id = :'user_id'::uuid
+  AND role = 'user'
+  AND created_at >= now() - interval '24 hours';
+
+\echo '--- 4. discover public events by city (discover-merged-events) ---'
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT e.id, e.title, e.city, e.status
+FROM public.events e
+WHERE e.deleted_at IS NULL
+  AND e.visibility = 'public'
+  AND e.event_type = 'event'
+  AND e.status IN ('scheduled', 'live')
+  AND e.city = :'city'
+LIMIT 20;
+
+\echo '=== done ==='

--- a/supabase/migrations/20260923000000_orch_426_scale_hot_path_indexes.sql
+++ b/supabase/migrations/20260923000000_orch_426_scale_hot_path_indexes.sql
@@ -1,0 +1,53 @@
+-- ===========================================================================
+-- ORCH-426 (#426 PR4) — Hot-path indexes for 100k load-profile critical paths
+-- ===========================================================================
+--
+-- Evidence: code-path analysis (not yet staging EXPLAIN — run
+-- scripts/db/explain-hot-queries.sql on staging and attach output to #426).
+--
+-- Paths covered:
+--   ticket-checkout-create — count future event_dates per event
+--   ticket-checkout-status — list tickets for order (ordered)
+--   agent-chat             — 24h user-message rate limit count
+--
+-- PostgreSQL CREATE INDEX:
+--   https://www.postgresql.org/docs/current/sql-createindex.html
+--
+BEGIN;
+
+-- ticket-checkout-create: .eq("event_id", …).gt("end_at", now) count/lookup
+CREATE INDEX IF NOT EXISTS idx_event_dates_event_id_end_at
+  ON public.event_dates (event_id, end_at);
+
+-- ticket-checkout-status: tickets by order_id ORDER BY created_at
+CREATE INDEX IF NOT EXISTS idx_tickets_order_id_created_at
+  ON public.tickets (order_id, created_at ASC);
+
+-- agent-chat rate limit: user_id + role=user + created_at window
+CREATE INDEX IF NOT EXISTS idx_agent_messages_user_role_created
+  ON public.agent_messages (user_id, created_at DESC)
+  WHERE role = 'user';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public' AND indexname = 'idx_event_dates_event_id_end_at'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-426 self-verify: idx_event_dates_event_id_end_at missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public' AND indexname = 'idx_tickets_order_id_created_at'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-426 self-verify: idx_tickets_order_id_created_at missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public' AND indexname = 'idx_agent_messages_user_role_created'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-426 self-verify: idx_agent_messages_user_role_created missing';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Migration `20260923000000_orch_426_scale_hot_path_indexes.sql` — indexes for load-profile hot paths:
  - `event_dates (event_id, end_at)` — checkout create future-date gate
  - `tickets (order_id, created_at)` — checkout status ticket list
  - `agent_messages (user_id, created_at) WHERE role='user'` — Ari rate limit
- `docs/db-hot-queries.md` — maps critical paths → queries → indexes
- `scripts/db/explain-hot-queries.sql` — staging EXPLAIN ANALYZE templates
- `scripts/audit/rls-perf-heuristic.mjs` — warn-only bare `auth.uid()` detector
- Regression: `npm run test:orch-429`

Part of #426 Tier 1. Follows merged #427–#429.

**Note:** Full Workstream B proof still needs operator to run EXPLAIN on staging and attach output to #426.

## Test plan

- [x] `cd mingla-business && npm run test:orch-429`
- [x] `node scripts/audit/run-all.mjs --self-test`
- [ ] CI production-readiness-audit
- [ ] Apply migration on staging; run `explain-hot-queries.sql` with real UUIDs

## Post-merge

- [ ] `supabase db push` / deploy migration to staging
- [ ] Operator: attach EXPLAIN output to epic #426