### PR TITLE
#426 PR5: Checkout Grade A evidence harness

### DIFF
--- a/.github/workflows/production-readiness-audit.yml
+++ b/.github/workflows/production-readiness-audit.yml
@@ -35,6 +35,8 @@ jobs:
         run: node scripts/audit/run-all.mjs
       - name: DB perf contract (#426 PR4)
         run: node scripts/audit/orch-429-db-perf-contract.mjs
+      - name: Checkout Grade A contract (#426 PR5)
+        run: node scripts/audit/checkout-grade-a-contract.mjs
       - name: Validate k6 script structure
         run: node scripts/load/validate-k6-scripts.mjs
 

--- a/docs/LAUNCH_GATES.md
+++ b/docs/LAUNCH_GATES.md
@@ -23,6 +23,7 @@ Completed via repo/CI:
 - Feature flags / kill switches (`mingla-business/src/config/featureFlags.ts`)
 - Incident runbooks + cost model template
 - Structured logging helper for edge functions
+- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md) — CI `checkout-grade-a-contract.mjs`
 
 ## Related
 

--- a/docs/evidence/grade-a-checkout.md
+++ b/docs/evidence/grade-a-checkout.md
@@ -1,0 +1,66 @@
+# Grade A evidence — Buyer checkout (#426 PR5)
+
+**Domain:** Buyer anon checkout funnel (`/checkout/{eventId}` → buyer → payment → confirm)  
+**Apps:** mingla-business (web + native buyer surfaces)  
+**Status:** Engineering evidence baseline — runtime device proof remains operator smoke.
+
+## Why checkout first
+
+Checkout is on the **100k load profile** critical path (`ticket-checkout-create`, `ticket-checkout-status`) and directly affects revenue. This doc links code, tests, and load harness to Workstream E “all states everywhere.”
+
+## Funnel routes
+
+| Step | Route | File | States covered |
+|------|-------|------|----------------|
+| 1 — Tickets | `/checkout/{eventId}` | `app/checkout/[eventId]/index.tsx` | Loading, not found, past/cancelled, empty cart, populated |
+| 2 — Buyer | `/checkout/{eventId}/buyer` | `app/checkout/[eventId]/buyer.tsx` | Validation errors, empty-cart guard, free vs paid branch |
+| 3 — Payment | `/checkout/{eventId}/payment` | `app/checkout/[eventId]/payment.tsx` | Stripe/web payment errors, cart guards |
+| 4 — Confirm | `/checkout/{eventId}/confirm` | `app/checkout/[eventId]/confirm.tsx` | Polling, realtime pending, confirm errors |
+
+## Regression tests (repo-running)
+
+| Test | What it proves |
+|------|----------------|
+| `orch_0911_confirm_loading_state.test.tsx` | Confirm screen loading / pending states |
+| `isPastGate.test.ts` | Past-event gate blocks purchase (ORCH-0850) |
+| `orch-0852-bulletproof-confirm.test.ts` | `ticket-checkout-confirm` client contract |
+| `ticketCheckoutService` / `publicEventsService` tests | Server mapping + checkout create path |
+| `npm run test:orch-430` | PR5 Grade A contract (routes + state markers) |
+
+## Load harness (#426)
+
+| Script | Path |
+|--------|------|
+| Checkout create | `scripts/load/ticket-checkout-create.js` |
+| Checkout status | `scripts/load/ticket-checkout-status.js` |
+| Combined smoke | `scripts/load/smoke.js` |
+
+Fixtures: [load-test-fixtures.md](../load-test-fixtures.md)
+
+## Backend hot paths
+
+| Edge function | Observability | DB indexes |
+|---------------|---------------|------------|
+| `ticket-checkout-create` | Structured log (#428) | `idx_event_dates_event_id_end_at` (#430) |
+| `ticket-checkout-status` | Structured log (#428) | `idx_tickets_order_id_created_at` (#430) |
+| `ticket-checkout-confirm` | — | — |
+| `stripe-webhook` | Structured log (#428) | — |
+
+See [db-hot-queries.md](../db-hot-queries.md).
+
+## Manual smoke gate (operator)
+
+After deploy, on staging:
+
+1. Open a published event → Get tickets → complete free checkout.
+2. Repeat paid checkout (Stripe test card) on web.
+3. Confirm page shows tickets / QR without silent spinner hang.
+4. Optional: run `k6 run scripts/load/ticket-checkout-create.js` with `LOAD_TEST_EVENT_ID`.
+
+Attach screenshots or load output to epic #426 when closing Workstream E checkout box.
+
+## Out of scope (follow-up PRs)
+
+- Trip checkout (`/checkout-trip/…`)
+- Hub organiser surfaces
+- Full Maestro matrix expansion

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -55,7 +55,8 @@
     "test:orch-426": "node ../scripts/audit/run-all.mjs --self-test && node ../scripts/load/validate-k6-scripts.mjs && npx jest src/config/__tests__/featureFlags.test.ts --runInBand",
     "test:orch-427": "npx jest src/diagnostics/__tests__/reportNonFatal.test.ts --runInBand",
     "test:orch-428": "node ../scripts/load/validate-k6-scripts.mjs && node ../scripts/load/orch-428-load-harness-contract.mjs",
-    "test:orch-429": "node ../scripts/audit/rls-perf-heuristic.mjs --self-test && node ../scripts/audit/orch-429-db-perf-contract.mjs"
+    "test:orch-429": "node ../scripts/audit/rls-perf-heuristic.mjs --self-test && node ../scripts/audit/orch-429-db-perf-contract.mjs",
+    "test:orch-430": "node ../scripts/audit/checkout-grade-a-contract.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/scripts/audit/checkout-grade-a-contract.mjs
+++ b/scripts/audit/checkout-grade-a-contract.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * #426 PR5 — Grade A contract for buyer checkout funnel.
+ * Fails if critical routes lose loading / empty / error state handling.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const CHECKOUT = join(ROOT, "mingla-business/app/checkout/[eventId]");
+
+const ROUTES = [
+  {
+    file: "index.tsx",
+    mustInclude: ["isLoading", "EmptyState", "Loading tickets"],
+    label: "tickets",
+  },
+  {
+    file: "buyer.tsx",
+    mustInclude: ["errorText", "lines.length === 0", "createTicketCheckout"],
+    label: "buyer",
+  },
+  {
+    file: "payment.tsx",
+    mustInclude: ["paymentError", "confirmTicketCheckout", "thrown_error"],
+    label: "payment",
+  },
+  {
+    file: "confirm.tsx",
+    mustInclude: ["checkoutSessionId", "buyerStatusToken"],
+    label: "confirm",
+  },
+];
+
+const REQUIRED_EXTERNAL = [
+  "docs/evidence/grade-a-checkout.md",
+  "scripts/load/ticket-checkout-create.js",
+  "scripts/load/ticket-checkout-status.js",
+  "mingla-business/src/services/ticketCheckoutService.ts",
+];
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+for (const rel of REQUIRED_EXTERNAL) {
+  if (!existsSync(join(ROOT, rel))) fail(`missing ${rel}`);
+}
+
+for (const route of ROUTES) {
+  const path = join(CHECKOUT, route.file);
+  if (!existsSync(path)) fail(`missing checkout route ${route.file}`);
+  const text = readFileSync(path, "utf8");
+  for (const snippet of route.mustInclude) {
+    if (!text.includes(snippet)) {
+      fail(`${route.label} (${route.file}) missing required marker: ${snippet}`);
+    }
+  }
+}
+
+const evidence = readFileSync(
+  join(ROOT, "docs/evidence/grade-a-checkout.md"),
+  "utf8",
+);
+if (!evidence.includes("ticket-checkout-create") || !evidence.includes("test:orch-430")) {
+  fail("grade-a-checkout.md must reference load scripts and test:orch-430");
+}
+
+console.log("PASS: checkout Grade A contract (4 routes + evidence)");
+process.exit(0);


### PR DESCRIPTION
## Summary

First Workstream E domain sweep for epic #426 — **buyer checkout funnel**.

- `docs/evidence/grade-a-checkout.md` — links routes, regression tests, k6 scripts, DB/observability
- `scripts/audit/checkout-grade-a-contract.mjs` — CI enforces loading/empty/error markers on all 4 checkout routes
- `test:orch-430` regression
- `LAUNCH_GATES.md` updated with Grade A evidence table entry

Part of #426 Tier 1. Follows merged #427–#430.

**Note:** Epic checkbox for "all states everywhere" stays unchecked until operator runtime smoke is attached.

## Test plan

- [x] `cd mingla-business && npm run test:orch-430`
- [ ] CI production-readiness-audit (checkout contract job)
- [ ] Operator: staging free + paid checkout smoke; attach to #426