### PR TITLE
#426 PR6: Hub Grade A evidence harness

### DIFF
--- a/.github/workflows/production-readiness-audit.yml
+++ b/.github/workflows/production-readiness-audit.yml
@@ -37,6 +37,8 @@ jobs:
         run: node scripts/audit/orch-429-db-perf-contract.mjs
       - name: Checkout Grade A contract (#426 PR5)
         run: node scripts/audit/checkout-grade-a-contract.mjs
+      - name: Hub Grade A contract (#426 PR6)
+        run: node scripts/audit/hub-grade-a-contract.mjs
       - name: Validate k6 script structure
         run: node scripts/load/validate-k6-scripts.mjs
 

--- a/docs/LAUNCH_GATES.md
+++ b/docs/LAUNCH_GATES.md
@@ -23,7 +23,7 @@ Completed via repo/CI:
 - Feature flags / kill switches (`mingla-business/src/config/featureFlags.ts`)
 - Incident runbooks + cost model template
 - Structured logging helper for edge functions
-- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md) — CI `checkout-grade-a-contract.mjs`
+- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md), [hub](./evidence/grade-a-hub.md) — CI contracts in `scripts/audit/`
 
 ## Related
 

--- a/docs/evidence/grade-a-hub.md
+++ b/docs/evidence/grade-a-hub.md
@@ -1,0 +1,56 @@
+# Grade A evidence — Organizer Hub (#426 PR6)
+
+**Domain:** Hub sub-nav (Events, Trips, Experiences) in mingla-business  
+**Routes:** `/(tabs)/hub/events`, `/(tabs)/hub/trips`, `/(tabs)/hub/experiences`  
+**Status:** Engineering evidence baseline — device/runtime smoke remains operator gate.
+
+## Why Hub second
+
+Hub is the organizer's primary pipeline surface (events, trips, experiences). It sits on the business critical path for activation and ties to discover/read load (`discover-merged-events` serves published events created here).
+
+## Surfaces
+
+| Tab | Route | File | States covered |
+|-----|-------|------|----------------|
+| Events | `/hub/events` | `app/(tabs)/hub/events.tsx` | Universal empty, filter empty, draft delete errors, manage actions |
+| Trips | `/hub/trips` | `app/(tabs)/hub/trips.tsx` | Brand missing, loading, error, populated list |
+| Experiences | `/hub/experiences` | `app/(tabs)/hub/experiences.tsx` | Loading, empty list + CTA, parse errors via toast |
+| Layout | `/hub/*` | `app/(tabs)/hub/_layout.tsx` | Sub-nav loading, smart to-do toggle |
+
+`getstarted.tsx` is decommissioned (redirect only per ORCH-1038).
+
+## Regression tests (repo-running)
+
+| Test / guard | What it proves |
+|--------------|----------------|
+| `hub/__tests__/events.pastTab.test.tsx` | Past-tab filtering contract |
+| `eventType.filter.audit.test.ts` | Trips excluded from events list (ORCH-0859) |
+| `maestro/tr2-events-tab-no-trip-leak.yaml` | No trip rows in events tab |
+| `experiencesService.test.ts` | Hub list card column selection |
+| `npm run test:orch-431` | PR6 Hub Grade A contract |
+
+## Load / read path (#426)
+
+Published events from Hub feed the consumer discover merge:
+
+| Script | Path |
+|--------|------|
+| Discover merge | `scripts/load/discover-merged-events.js` |
+
+See [load-profile.md](../load-profile.md) and [db-hot-queries.md](../db-hot-queries.md).
+
+## Known gaps (honest)
+
+| Gap | Follow-up |
+|-----|-----------|
+| Events tab has no dedicated loading spinner (relies on query hydration + empty states) | Optional UX polish ORCH |
+| Hub Experiences web phone route was blocked in ORCH-1093 — desktop/native primary | Web parity wave |
+| Runtime device proof not attached | Operator smoke on staging |
+
+## Manual smoke gate (operator)
+
+1. Sign in as organizer with a brand.
+2. Hub → Events: verify pills, empty state, create flow entry.
+3. Hub → Trips: verify loading resolves, error copy if offline.
+4. Hub → Experiences: verify empty CTA and list cards.
+5. Attach screenshots to epic #426 when closing Hub Workstream E box.

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -56,7 +56,8 @@
     "test:orch-427": "npx jest src/diagnostics/__tests__/reportNonFatal.test.ts --runInBand",
     "test:orch-428": "node ../scripts/load/validate-k6-scripts.mjs && node ../scripts/load/orch-428-load-harness-contract.mjs",
     "test:orch-429": "node ../scripts/audit/rls-perf-heuristic.mjs --self-test && node ../scripts/audit/orch-429-db-perf-contract.mjs",
-    "test:orch-430": "node ../scripts/audit/checkout-grade-a-contract.mjs"
+    "test:orch-430": "node ../scripts/audit/checkout-grade-a-contract.mjs",
+    "test:orch-431": "node ../scripts/audit/hub-grade-a-contract.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/scripts/audit/hub-grade-a-contract.mjs
+++ b/scripts/audit/hub-grade-a-contract.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * #426 PR6 — Grade A contract for organizer Hub surfaces.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const HUB = join(ROOT, "mingla-business/app/(tabs)/hub");
+
+const ROUTES = [
+  {
+    file: "events.tsx",
+    mustInclude: [
+      "useBusinessEventsForBrand",
+      "Nothing created yet",
+      "emptyTitle",
+      "errorMessage={deleteDraftError}",
+    ],
+    label: "events",
+  },
+  {
+    file: "trips.tsx",
+    mustInclude: ["tripsQuery.isLoading", "tripsQuery.isError", "ActivityIndicator"],
+    label: "trips",
+  },
+  {
+    file: "experiences.tsx",
+    mustInclude: [
+      "experiencesQuery.isLoading",
+      "emptyListHint",
+      "ActivityIndicator",
+    ],
+    label: "experiences",
+  },
+  {
+    file: "_layout.tsx",
+    mustInclude: ["visibleTabs.isLoading", "HubSubNav"],
+    label: "layout",
+  },
+];
+
+const REQUIRED_EXTERNAL = [
+  "docs/evidence/grade-a-hub.md",
+  "mingla-business/app/(tabs)/hub/__tests__/events.pastTab.test.tsx",
+  "mingla-business/maestro/tr2-events-tab-no-trip-leak.yaml",
+  "scripts/load/discover-merged-events.js",
+];
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+for (const rel of REQUIRED_EXTERNAL) {
+  if (!existsSync(join(ROOT, rel))) fail(`missing ${rel}`);
+}
+
+for (const route of ROUTES) {
+  const path = join(HUB, route.file);
+  if (!existsSync(path)) fail(`missing hub route ${route.file}`);
+  const text = readFileSync(path, "utf8");
+  for (const snippet of route.mustInclude) {
+    if (!text.includes(snippet)) {
+      fail(`${route.label} (${route.file}) missing required marker: ${snippet}`);
+    }
+  }
+}
+
+const evidence = readFileSync(join(ROOT, "docs/evidence/grade-a-hub.md"), "utf8");
+if (!evidence.includes("discover-merged-events") || !evidence.includes("test:orch-431")) {
+  fail("grade-a-hub.md must reference discover load script and test:orch-431");
+}
+
+console.log("PASS: hub Grade A contract (4 hub routes + evidence)");
+process.exit(0);


### PR DESCRIPTION
## Summary

Second Workstream E domain sweep for epic #426 — **organizer Hub** (Events / Trips / Experiences).

- `docs/evidence/grade-a-hub.md` — routes, regression tests, discover load link, known gaps
- `scripts/audit/hub-grade-a-contract.mjs` — CI enforces state markers on hub routes + layout
- `test:orch-431` regression

Part of #426 Tier 1. Follows merged #427–#431.

## Test plan

- [x] `cd mingla-business && npm run test:orch-431`
- [ ] CI production-readiness-audit (hub contract job)
- [ ] Operator: hub tabs smoke on staging; attach to #426