### PR TITLE
#426 PR7: Tier 1 completion bundle (Marketing + Trip checkout + marketing-send k6)

### DIFF
--- a/.github/workflows/production-readiness-audit.yml
+++ b/.github/workflows/production-readiness-audit.yml
@@ -39,6 +39,8 @@ jobs:
         run: node scripts/audit/checkout-grade-a-contract.mjs
       - name: Hub Grade A contract (#426 PR6)
         run: node scripts/audit/hub-grade-a-contract.mjs
+      - name: Marketing Grade A contract (#426 PR7)
+        run: node scripts/audit/marketing-grade-a-contract.mjs
       - name: Validate k6 script structure
         run: node scripts/load/validate-k6-scripts.mjs
 

--- a/.github/workflows/production-readiness-audit.yml
+++ b/.github/workflows/production-readiness-audit.yml
@@ -41,6 +41,8 @@ jobs:
         run: node scripts/audit/hub-grade-a-contract.mjs
       - name: Marketing Grade A contract (#426 PR7)
         run: node scripts/audit/marketing-grade-a-contract.mjs
+      - name: Trip checkout Grade A contract (#426 PR7 bundle)
+        run: node scripts/audit/trip-checkout-grade-a-contract.mjs
       - name: Validate k6 script structure
         run: node scripts/load/validate-k6-scripts.mjs
 

--- a/docs/LAUNCH_GATES.md
+++ b/docs/LAUNCH_GATES.md
@@ -23,7 +23,7 @@ Completed via repo/CI:
 - Feature flags / kill switches (`mingla-business/src/config/featureFlags.ts`)
 - Incident runbooks + cost model template
 - Structured logging helper for edge functions
-- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md), [hub](./evidence/grade-a-hub.md) — CI contracts in `scripts/audit/`
+- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md), [hub](./evidence/grade-a-hub.md), [marketing](./evidence/grade-a-marketing.md) — CI contracts in `scripts/audit/`
 
 ## Related
 

--- a/docs/LAUNCH_GATES.md
+++ b/docs/LAUNCH_GATES.md
@@ -23,7 +23,8 @@ Completed via repo/CI:
 - Feature flags / kill switches (`mingla-business/src/config/featureFlags.ts`)
 - Incident runbooks + cost model template
 - Structured logging helper for edge functions
-- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md), [hub](./evidence/grade-a-hub.md), [marketing](./evidence/grade-a-marketing.md) — CI contracts in `scripts/audit/`
+- Grade A evidence (per domain): [checkout](./evidence/grade-a-checkout.md), [hub](./evidence/grade-a-hub.md), [marketing](./evidence/grade-a-marketing.md), [trip checkout](./evidence/grade-a-trip-checkout.md) — CI contracts in `scripts/audit/`
+- Load harness: 6 k6 scripts including `marketing-send.js` — `node scripts/load/validate-k6-scripts.mjs`
 
 ## Related
 

--- a/docs/evidence/grade-a-checkout.md
+++ b/docs/evidence/grade-a-checkout.md
@@ -59,8 +59,11 @@ After deploy, on staging:
 
 Attach screenshots or load output to epic #426 when closing Workstream E checkout box.
 
-## Out of scope (follow-up PRs)
+## Related funnels
 
-- Trip checkout (`/checkout-trip/…`)
-- Hub organiser surfaces
+- Trip checkout: [grade-a-trip-checkout.md](./grade-a-trip-checkout.md)
+- Hub organiser surfaces: [grade-a-hub.md](./grade-a-hub.md)
+
+## Out of scope (follow-up)
+
 - Full Maestro matrix expansion

--- a/docs/evidence/grade-a-marketing.md
+++ b/docs/evidence/grade-a-marketing.md
@@ -1,0 +1,61 @@
+# Grade A evidence — Organizer Marketing (#426 PR7)
+
+**Domain:** Marketing tab (Overview, Audiences, Campaigns, Templates) in mingla-business  
+**Routes:** `/(tabs)/marketing/*`  
+**Status:** Engineering evidence baseline — device/runtime smoke and `marketing-send` load harness remain operator/follow-up gates.
+
+## Why marketing third
+
+Marketing is on the **100k load profile** burst path (`marketing-send`: 10 sustained / 500 burst RPS) and ties to buyer audiences created by checkout. Organizer blast is a revenue-retention surface; disabled-query loading bugs (ORCH-0889) previously showed false empty states during auth bootstrap.
+
+## Surfaces
+
+| Tab | Route | File | States covered |
+|-----|-------|------|----------------|
+| Overview | `/marketing` | `app/(tabs)/marketing/index.tsx` | `hasResolved` skeleton, error empty, populated metrics + recent campaigns |
+| Audiences | `/marketing/audiences` | `app/(tabs)/marketing/audiences/index.tsx` | Skeleton, error, empty buyers, virtual-row materialize + error toast |
+| Campaigns | `/marketing/campaigns` | `app/(tabs)/marketing/campaigns/index.tsx` | Spinner, error, filter empty, populated list + cancel/delete alerts |
+| Templates | `/marketing/templates` | `app/(tabs)/marketing/templates/index.tsx` | Starter loading/error, user-template inline error |
+| Layout | `/marketing/*` | `app/(tabs)/marketing/_layout.tsx` | `MarketingSubNav`, composer hides universal "+" |
+
+Composer (`/marketing/campaigns/compose`) and campaign report (`/marketing/campaigns/[id]`) are covered by strict-grep + composer regression tests; full composer Grade A is a follow-up wave.
+
+## Regression tests (repo-running)
+
+| Test / guard | What it proves |
+|--------------|----------------|
+| `marketing/__tests__/MarketingOverview.disabled-query.test.ts` | Overview does not show error during auth-bootstrap (`I-DISABLED-QUERY-IS-LOADING`) |
+| `marketing/__tests__/MarketingAudiences.disabled-query.adversarial.test.ts` | Audiences skeleton during disabled query |
+| `marketingOverviewService.test.ts` | Overview funnel snapshot mapping |
+| `orch-0863-marketing-hub-phase-b.mjs` | Phase B constitution (no currency literal, funnel labels) |
+| `orch-0815-b-composer-and-send.mjs` | Composer + `marketing-send` wiring |
+| `supabase/functions/marketing-send/index.test.ts` | Send edge function contract |
+| `npm run test:orch-432` | PR7 Marketing Grade A contract |
+
+## Load / send path (#426)
+
+| Item | Path / note |
+|------|-------------|
+| Load profile row | `docs/load-profile.md` — `marketing-send` JWT, future harness |
+| Edge function | `supabase/functions/marketing-send/index.ts` |
+| Checkout → audiences | Buyers from ticket checkout feed `marketing_audiences` |
+
+k6 script for `marketing-send` is **not yet shipped** (Tier 1 gap — queue/rate-limit burst proof is Tier 2).
+
+## Known gaps (honest)
+
+| Gap | Follow-up |
+|-----|-----------|
+| No k6 `marketing-send` harness yet | PR after queue semantics locked |
+| Composer full state matrix (draft save errors, schedule failures) | Separate composer Grade A ORCH |
+| Marketing send API kill switch not wired in `featureFlags.ts` | Workstream F |
+| Runtime device proof not attached | Operator smoke on staging |
+
+## Manual smoke gate (operator)
+
+1. Sign in as organizer with a brand that has ticket buyers.
+2. Marketing → Overview: skeleton resolves, metrics or empty caption.
+3. Marketing → Audiences: list or "No buyers yet"; tap virtual row.
+4. Marketing → Campaigns: filter pills, empty vs list, open composer via FAB.
+5. Marketing → Templates: starter pack loads; duplicate flow.
+6. Attach screenshots to epic #426 when closing Marketing Workstream E box.

--- a/docs/evidence/grade-a-marketing.md
+++ b/docs/evidence/grade-a-marketing.md
@@ -36,17 +36,18 @@ Composer (`/marketing/campaigns/compose`) and campaign report (`/marketing/campa
 
 | Item | Path / note |
 |------|-------------|
-| Load profile row | `docs/load-profile.md` — `marketing-send` JWT, future harness |
+| Load profile row | `docs/load-profile.md` — `marketing-send` JWT |
+| Load script | `scripts/load/marketing-send.js` |
 | Edge function | `supabase/functions/marketing-send/index.ts` |
 | Checkout → audiences | Buyers from ticket checkout feed `marketing_audiences` |
 
-k6 script for `marketing-send` is **not yet shipped** (Tier 1 gap — queue/rate-limit burst proof is Tier 2).
+k6 script: `scripts/load/marketing-send.js` (CI structural validation; burst proof at 500 RPS is Tier 2).
 
 ## Known gaps (honest)
 
 | Gap | Follow-up |
 |-----|-----------|
-| No k6 `marketing-send` harness yet | PR after queue semantics locked |
+| Burst load proof (500 RPS) not run on staging | Tier 2 operator gate |
 | Composer full state matrix (draft save errors, schedule failures) | Separate composer Grade A ORCH |
 | Marketing send API kill switch not wired in `featureFlags.ts` | Workstream F |
 | Runtime device proof not attached | Operator smoke on staging |

--- a/docs/evidence/grade-a-trip-checkout.md
+++ b/docs/evidence/grade-a-trip-checkout.md
@@ -1,0 +1,51 @@
+# Grade A evidence — Trip buyer checkout (#426 PR7 bundle)
+
+**Domain:** Buyer trip checkout funnel (`/checkout-trip/{tripEventId}` → intake? → buyer → payment → confirm)  
+**Apps:** mingla-business (web + native buyer surfaces)  
+**Status:** Engineering evidence baseline — runtime device proof remains operator gate.
+
+## Why trip checkout
+
+Trip checkout mirrors event ticket checkout on the **same** `biz_ticket_checkout_create_session` RPC (Tr3 branches on `event_type='trip'`). It is a separate public funnel with installment + intake steps and must not regress independently of event checkout ([#431](https://github.com/Mingla-LLC/mingla-main/pull/431)).
+
+## Funnel routes
+
+| Step | Route | File | States covered |
+|------|-------|------|----------------|
+| 1 — Spots | `/checkout-trip/{tripEventId}` | `app/checkout-trip/[tripEventId]/index.tsx` | Loading, not found, past/cancelled, empty cart, populated |
+| 1b — Intake | `/checkout-trip/{tripEventId}/intake` | `app/checkout-trip/[tripEventId]/intake.tsx` | Schema loading, validation errors, empty-cart guard |
+| 2 — Buyer | `/checkout-trip/{tripEventId}/buyer` | `app/checkout-trip/[tripEventId]/buyer.tsx` | Field validation, empty-cart guard, free vs paid branch |
+| 3 — Payment | `/checkout-trip/{tripEventId}/payment` | `app/checkout-trip/[tripEventId]/payment.tsx` | Stripe/web payment errors, cart guards |
+| 4 — Confirm | `/checkout-trip/{tripEventId}/confirm` | `app/checkout-trip/[tripEventId]/confirm.tsx` | Polling, realtime pending, URL fragment recovery |
+
+## Regression tests (repo-running)
+
+| Test | What it proves |
+|------|----------------|
+| `orch_0911_trip_confirm_loading_state.test.tsx` | Trip confirm loading / pending states |
+| `orch_0928_url_fragment_recovery.test.tsx` | `#csi` / `#bst` fragment recovery on confirm |
+| `orch_0915_pay_in_full_choice.test.ts` | Pay-in-full vs installment choice |
+| `ticketCheckoutService` tests | Shared create/confirm client contract |
+| `npm run test:orch-433` | PR7 trip checkout Grade A contract |
+
+## Load harness (#426)
+
+| Script | Path |
+|--------|------|
+| Checkout create (shared RPC) | `scripts/load/ticket-checkout-create.js` |
+| Checkout status | `scripts/load/ticket-checkout-status.js` |
+
+Trip-specific load IDs (`LOAD_TEST_TRIP_EVENT_ID`) are a follow-up fixture doc row — event checkout fixtures exercise the same RPC path today.
+
+## Manual smoke gate (operator)
+
+1. Open a published trip → Reserve my spot → complete free checkout.
+2. Repeat paid checkout (Stripe test card) on web.
+3. If intake tiers exist, complete intake step before buyer.
+4. Confirm page shows tickets / QR without silent spinner hang.
+5. Attach screenshots to epic #426 when closing trip checkout Workstream E box.
+
+## Out of scope (Tier 2 / follow-up)
+
+- Staging load proof at scale
+- Full Maestro matrix for trip funnel

--- a/docs/load-profile.md
+++ b/docs/load-profile.md
@@ -24,7 +24,7 @@ Adjust these with real Mixpanel/Supabase metrics before launch.
 | Buyer checkout status | `ticket-checkout-status` | Anon token | `scripts/load/ticket-checkout-status.js` |
 | Checkout create | `ticket-checkout-create` | Anon / mixed | `scripts/load/ticket-checkout-create.js` |
 | Ari chat | `agent-chat` | JWT | `scripts/load/agent-chat.js` |
-| Marketing send | `marketing-send` | JWT | Future (rate-limited; queue) |
+| Marketing send | `marketing-send` | JWT | `scripts/load/marketing-send.js` |
 | Stripe webhooks | `stripe-webhook` | Signature | Stripe load tests only |
 
 ## SLO targets (staging / production)

--- a/docs/load-test-fixtures.md
+++ b/docs/load-test-fixtures.md
@@ -51,6 +51,17 @@ Or sign in via mingla-business staging, then copy the access token from browser 
 
 **JWT expiry:** Tokens expire (~1h). Re-run `fetch-test-jwt.mjs` before long load runs.
 
+## Optional — marketing-send (direct dispatch path)
+
+| Variable | Purpose |
+|----------|---------|
+| `LOAD_TEST_USER_JWT` | Organizer access token (same as agent-chat) |
+| `LOAD_TEST_CAMPAIGN_ID` | Draft or scheduled campaign UUID owned by that user |
+
+Without JWT, `marketing-send.js` validates the **403 auth gate** (CI-safe, no Resend calls).
+
+With JWT but a synthetic `LOAD_TEST_CAMPAIGN_ID`, expect **403** (not owned) or **2xx** with `preview_skipped` when `MARKETING_SEND_LIVE_ENABLED=false` on staging.
+
 ### GitHub Actions (optional)
 
 Add repo secrets for full agent-chat smoke:

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -57,7 +57,8 @@
     "test:orch-428": "node ../scripts/load/validate-k6-scripts.mjs && node ../scripts/load/orch-428-load-harness-contract.mjs",
     "test:orch-429": "node ../scripts/audit/rls-perf-heuristic.mjs --self-test && node ../scripts/audit/orch-429-db-perf-contract.mjs",
     "test:orch-430": "node ../scripts/audit/checkout-grade-a-contract.mjs",
-    "test:orch-431": "node ../scripts/audit/hub-grade-a-contract.mjs"
+    "test:orch-431": "node ../scripts/audit/hub-grade-a-contract.mjs",
+    "test:orch-432": "node ../scripts/audit/marketing-grade-a-contract.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -58,7 +58,8 @@
     "test:orch-429": "node ../scripts/audit/rls-perf-heuristic.mjs --self-test && node ../scripts/audit/orch-429-db-perf-contract.mjs",
     "test:orch-430": "node ../scripts/audit/checkout-grade-a-contract.mjs",
     "test:orch-431": "node ../scripts/audit/hub-grade-a-contract.mjs",
-    "test:orch-432": "node ../scripts/audit/marketing-grade-a-contract.mjs"
+    "test:orch-432": "node ../scripts/audit/marketing-grade-a-contract.mjs",
+    "test:orch-433": "node ../scripts/audit/trip-checkout-grade-a-contract.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/scripts/audit/marketing-grade-a-contract.mjs
+++ b/scripts/audit/marketing-grade-a-contract.mjs
@@ -93,8 +93,11 @@ const evidence = readFileSync(
   join(ROOT, "docs/evidence/grade-a-marketing.md"),
   "utf8",
 );
-if (!evidence.includes("marketing-send") || !evidence.includes("test:orch-432")) {
-  fail("grade-a-marketing.md must reference marketing-send and test:orch-432");
+if (
+  !evidence.includes("marketing-send.js") ||
+  !evidence.includes("test:orch-432")
+) {
+  fail("grade-a-marketing.md must reference marketing-send.js and test:orch-432");
 }
 
 console.log("PASS: marketing Grade A contract (5 marketing routes + evidence)");

--- a/scripts/audit/marketing-grade-a-contract.mjs
+++ b/scripts/audit/marketing-grade-a-contract.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * #426 PR7 — Grade A contract for organizer Marketing surfaces.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const MARKETING = join(ROOT, "mingla-business/app/(tabs)/marketing");
+
+const ROUTES = [
+  {
+    file: "index.tsx",
+    mustInclude: [
+      "useMarketingOverview",
+      "hasResolved",
+      "Couldn't load metrics",
+      "overview-skeleton",
+    ],
+    label: "overview",
+  },
+  {
+    file: "audiences/index.tsx",
+    mustInclude: [
+      "useAudienceList",
+      "hasResolved",
+      "Couldn't load audiences",
+      "No buyers yet",
+      "errorToast",
+    ],
+    label: "audiences",
+  },
+  {
+    file: "campaigns/index.tsx",
+    mustInclude: [
+      "useCampaigns",
+      "hasResolved",
+      "Couldn't load campaigns",
+      "campaigns-spinner",
+      "Your first campaign starts here",
+    ],
+    label: "campaigns",
+  },
+  {
+    file: "templates/index.tsx",
+    mustInclude: [
+      "useStarterTemplates",
+      "Couldn't load templates",
+      "ActivityIndicator",
+    ],
+    label: "templates",
+  },
+  {
+    file: "_layout.tsx",
+    mustInclude: ["MarketingSubNav", "hideUniversalPlus"],
+    label: "layout",
+  },
+];
+
+const REQUIRED_EXTERNAL = [
+  "docs/evidence/grade-a-marketing.md",
+  "docs/load-profile.md",
+  "mingla-business/app/(tabs)/marketing/__tests__/MarketingOverview.disabled-query.test.ts",
+  "mingla-business/app/(tabs)/marketing/__tests__/MarketingAudiences.disabled-query.adversarial.test.ts",
+  "mingla-business/src/services/marketing/__tests__/marketingOverviewService.test.ts",
+  "supabase/functions/marketing-send/index.test.ts",
+  ".github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs",
+];
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+for (const rel of REQUIRED_EXTERNAL) {
+  if (!existsSync(join(ROOT, rel))) fail(`missing ${rel}`);
+}
+
+for (const route of ROUTES) {
+  const path = join(MARKETING, route.file);
+  if (!existsSync(path)) fail(`missing marketing route ${route.file}`);
+  const text = readFileSync(path, "utf8");
+  for (const snippet of route.mustInclude) {
+    if (!text.includes(snippet)) {
+      fail(`${route.label} (${route.file}) missing required marker: ${snippet}`);
+    }
+  }
+}
+
+const evidence = readFileSync(
+  join(ROOT, "docs/evidence/grade-a-marketing.md"),
+  "utf8",
+);
+if (!evidence.includes("marketing-send") || !evidence.includes("test:orch-432")) {
+  fail("grade-a-marketing.md must reference marketing-send and test:orch-432");
+}
+
+console.log("PASS: marketing Grade A contract (5 marketing routes + evidence)");
+process.exit(0);

--- a/scripts/audit/trip-checkout-grade-a-contract.mjs
+++ b/scripts/audit/trip-checkout-grade-a-contract.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * #426 PR7 bundle — Grade A contract for trip buyer checkout funnel.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const TRIP_CHECKOUT = join(ROOT, "mingla-business/app/checkout-trip/[tripEventId]");
+
+const ROUTES = [
+  {
+    file: "index.tsx",
+    mustInclude: ["usePublicTripById", "isLoading", "EmptyState", "Loading trip"],
+    label: "spots",
+  },
+  {
+    file: "intake.tsx",
+    mustInclude: ["schemasQuery.isLoading", "lines.length === 0", "createTicketCheckout"],
+    label: "intake",
+  },
+  {
+    file: "buyer.tsx",
+    mustInclude: ["createTicketCheckout", "lines.length === 0", "errorText"],
+    label: "buyer",
+  },
+  {
+    file: "payment.tsx",
+    mustInclude: ["paymentError", "confirmTicketCheckout", "thrown_error"],
+    label: "payment",
+  },
+  {
+    file: "confirm.tsx",
+    mustInclude: ["checkoutSessionId", "buyerStatusToken"],
+    label: "confirm",
+  },
+];
+
+const REQUIRED_EXTERNAL = [
+  "docs/evidence/grade-a-trip-checkout.md",
+  "scripts/load/ticket-checkout-create.js",
+  "scripts/load/ticket-checkout-status.js",
+  "mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_0911_trip_confirm_loading_state.test.tsx",
+  "mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_0928_url_fragment_recovery.test.tsx",
+];
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+for (const rel of REQUIRED_EXTERNAL) {
+  if (!existsSync(join(ROOT, rel))) fail(`missing ${rel}`);
+}
+
+for (const route of ROUTES) {
+  const path = join(TRIP_CHECKOUT, route.file);
+  if (!existsSync(path)) fail(`missing trip checkout route ${route.file}`);
+  const text = readFileSync(path, "utf8");
+  for (const snippet of route.mustInclude) {
+    if (!text.includes(snippet)) {
+      fail(`${route.label} (${route.file}) missing required marker: ${snippet}`);
+    }
+  }
+}
+
+const evidence = readFileSync(
+  join(ROOT, "docs/evidence/grade-a-trip-checkout.md"),
+  "utf8",
+);
+if (!evidence.includes("ticket-checkout-create") || !evidence.includes("test:orch-433")) {
+  fail("grade-a-trip-checkout.md must reference load scripts and test:orch-433");
+}
+
+console.log("PASS: trip checkout Grade A contract (5 routes + evidence)");
+process.exit(0);

--- a/scripts/load/marketing-send.js
+++ b/scripts/load/marketing-send.js
@@ -1,0 +1,58 @@
+/**
+ * #426 PR7 bundle — Load: marketing-send (JWT required for direct path).
+ *
+ * Without LOAD_TEST_USER_JWT: exercises auth gate (expects 403 — campaign_id
+ * required + ownership check).
+ * With JWT + LOAD_TEST_CAMPAIGN_ID: full dispatch path (2xx preview_skipped or
+ * 403 if campaign not owned).
+ *
+ * Run:
+ *   LOAD_BASE_URL=... SUPABASE_ANON_KEY=... \
+ *   LOAD_TEST_USER_JWT=<access_token> \
+ *   LOAD_TEST_CAMPAIGN_ID=<draft_or_scheduled_campaign_uuid> \
+ *   k6 run scripts/load/marketing-send.js
+ */
+
+import { check, sleep } from "k6";
+import { optionalEnv, postJson, postJsonAuthed, checkNot5xx } from "./lib/supabase-edge.js";
+
+export const options = {
+  scenarios: {
+    marketing_send: {
+      executor: "constant-vus",
+      vus: Number(__ENV.LOAD_VUS || 2),
+      duration: __ENV.LOAD_DURATION || "20s",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    http_req_duration: ["p(95)<5000"],
+  },
+};
+
+export default function marketingSend() {
+  const jwt = optionalEnv("LOAD_TEST_USER_JWT");
+  const campaignId = optionalEnv(
+    "LOAD_TEST_CAMPAIGN_ID",
+    "00000000-0000-4000-8000-000000000099",
+  );
+  const body = { campaign_id: campaignId };
+
+  const res = jwt
+    ? postJsonAuthed("marketing-send", body, jwt)
+    : postJson("marketing-send", body);
+
+  if (jwt) {
+    check(res, {
+      ...checkNot5xx("marketing-send"),
+      "marketing-send authed (2xx or 403)": (r) =>
+        (r.status >= 200 && r.status < 300) || r.status === 403,
+    });
+  } else {
+    check(res, {
+      "marketing-send auth gate (403)": (r) => r.status === 403,
+    });
+  }
+
+  sleep(1);
+}

--- a/scripts/load/smoke.js
+++ b/scripts/load/smoke.js
@@ -87,5 +87,20 @@ export default function smoke() {
     check(agent, { "agent-chat auth gate": (r) => r.status === 401 });
   }
 
+  const marketingBody = {
+    campaign_id: optionalEnv(
+      "LOAD_TEST_CAMPAIGN_ID",
+      "00000000-0000-4000-8000-000000000099",
+    ),
+  };
+  const marketing = jwt
+    ? postJsonAuthed("marketing-send", marketingBody, jwt)
+    : postJson("marketing-send", marketingBody);
+  if (jwt) {
+    check(marketing, checkNot5xx("marketing-send"));
+  } else {
+    check(marketing, { "marketing-send auth gate": (r) => r.status === 403 });
+  }
+
   sleep(0.5);
 }

--- a/scripts/load/validate-k6-scripts.mjs
+++ b/scripts/load/validate-k6-scripts.mjs
@@ -19,6 +19,7 @@ const REQUIRED_SCRIPT_NAMES = [
   "ticket-checkout-status.js",
   "ticket-checkout-create.js",
   "agent-chat.js",
+  "marketing-send.js",
 ];
 
 const LIB_EXPORTS = ["postJsonAuthed", "edgeHeadersWithJwt", "checkNot5xx"];


### PR DESCRIPTION
## Summary

**Final Tier 1 engineering bundle** for epic #426 — consolidates the remaining domain sweeps and load harness gap into one PR.

### Grade A evidence + CI contracts
| Domain | Evidence | Contract | Test |
|--------|----------|----------|------|
| Marketing | `docs/evidence/grade-a-marketing.md` | `marketing-grade-a-contract.mjs` | `test:orch-432` |
| Trip checkout | `docs/evidence/grade-a-trip-checkout.md` | `trip-checkout-grade-a-contract.mjs` | `test:orch-433` |

(Checkout + Hub landed in #431–#432.)

### Load harness
- `scripts/load/marketing-send.js` — JWT path + 403 auth-gate smoke
- `validate-k6-scripts.mjs` now requires 6 scripts
- `smoke.js` includes marketing-send gate
- `docs/load-test-fixtures.md` — campaign ID fixtures

Part of #426 Tier 1. After merge, **only Tier 2 operator gates remain** (`docs/LAUNCH_GATES.md`).

## Test plan

- [x] `cd mingla-business && npm run test:orch-432`
- [x] `cd mingla-business && npm run test:orch-433`
- [x] `node scripts/load/validate-k6-scripts.mjs`
- [ ] CI production-readiness-audit
- [ ] Operator: marketing + trip checkout smoke on staging