### PR TITLE
Close ORCH-1107: companion-stops + picnic-grocery off Google onto scored place_pool

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1581,6 +1581,7 @@ function checkNoNewBackendFiles() {
     "supabase/functions/get-companion-stops/index.ts",
     "supabase/functions/get-picnic-grocery/index.ts",
     "supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts",
+    "supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts",
   ];
   // Issue #426 [Production-readiness foundation] PR #427. C7 is scoped to
   // ORCH-0863 marketing; structuredLog.ts is #426 observability scaffolding

--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -1572,6 +1572,16 @@ function checkNoNewBackendFiles() {
     "supabase/functions/agent-chat/index.ts",
     "supabase/functions/agent-confirm-action/index.ts",
   ];
+  // ORCH-1107 [De-Google companion-stops + picnic-grocery onto the scored
+  // place_pool]. C7 is scoped to ORCH-0863 marketing; these are the two
+  // EXISTING companion/picnic edge functions re-sourced from live Google
+  // Places to the `query_servable_places_by_signal` RPC, plus the happy-path
+  // Deno regression test. No new edge function, no migration. Per COMMS-0002.
+  const ORCH_1107_BACKEND_ALLOWLIST = [
+    "supabase/functions/get-companion-stops/index.ts",
+    "supabase/functions/get-picnic-grocery/index.ts",
+    "supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts",
+  ];
   // Issue #426 [Production-readiness foundation] PR #427. C7 is scoped to
   // ORCH-0863 marketing; structuredLog.ts is #426 observability scaffolding
   // (not yet wired into edge functions), not marketing scope.
@@ -1968,6 +1978,7 @@ function checkNoNewBackendFiles() {
     ...ORCH_1073_BACKEND_ALLOWLIST,
     ...ORCH_1079_BACKEND_ALLOWLIST,
     ...ORCH_1103_BACKEND_ALLOWLIST,
+    ...ORCH_1107_BACKEND_ALLOWLIST,
     ...ORCH_426_BACKEND_ALLOWLIST,
     // Schedule-edit buyer protection + "Refund all & proceed" (separate PR;
     // shares the ORCH-1047 work id used in code). New migration recording the

--- a/supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts
+++ b/supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts
@@ -1,0 +1,211 @@
+// ORCH-1107 — companion-stops + picnic-grocery off live Google Places onto the
+// scored, servable place_pool via the `query_servable_places_by_signal` RPC.
+//
+// Happy-path regression (implementor-owned). The tester adds the adversarial
+// angle separately. These assertions FAIL ON REVERT of the core change:
+//   * the RPC params are built correctly (signal id + filter_min + radius from
+//     maxDistance + lat/lng) — proves the new RPC source, not Google;
+//   * a returned row maps to the existing client response shape with imageUrl
+//     drawn from stored_photo_urls[0] (the Unsplash placeholder is gone);
+//   * NEITHER edge function references Google (no googleapis.com call, no
+//     GOOGLE_MAPS_API_KEY read, no Unsplash placeholder), and the ONLY data
+//     source is query_servable_places_by_signal.
+//
+// The handler-level helpers (buildRpcParams, mapServableRow…, handleRequest) are
+// EXPORTED from each function module and exercised directly. The module reads env
+// + may call serve() at load, so we set dummy env first and DYNAMICALLY import it
+// (see HERMETIC SETUP below) rather than statically — keeping the suite runnable
+// with zero ambient env.
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// HERMETIC SETUP (ORCH-1107 rework). Both edge modules read SUPABASE_URL /
+// SUPABASE_SERVICE_ROLE_KEY and call createClient() at module load — createClient
+// THROWS "supabaseUrl is required" when SUPABASE_URL is unset. Static ES imports
+// are hoisted above any in-body code, so we cannot set env before a static import
+// runs. Instead we set the dummy creds FIRST, then DYNAMICALLY import the SUT
+// modules so construction happens after the env exists. The dummy creds only
+// satisfy createClient() construction — no network call is made (the tests
+// exercise the exported pure helpers + the 400 validation branch only). This
+// makes the test pass on a clean `deno test --allow-all <path>` with ZERO ambient
+// env (no shell exports required).
+Deno.env.set("SUPABASE_URL", "http://localhost:54321");
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+// Suppress the listening socket each module starts at load (both guard serve()
+// behind this flag); without it the dynamic import would bind a server and leave
+// a dangling resource, failing the runner on a clean no-env invocation.
+Deno.env.set("ORCH_TEST_NO_SERVE", "1");
+
+const {
+  buildCompanionRpcParams,
+  handleRequest: handleCompanion,
+  mapServableRowToCompanionStop,
+} = await import("../get-companion-stops/index.ts");
+const {
+  buildGroceryRpcParams,
+  handleRequest: handleGrocery,
+  mapServableRowToGroceryStore,
+} = await import("../get-picnic-grocery/index.ts");
+
+// Let any construction-time timer the Supabase client schedules during the
+// dynamic imports above settle BEFORE the first test registers; otherwise Deno's
+// leak sanitizer attributes that timer's completion to the first test and fails
+// it. A short real-timer wait drains it deterministically.
+await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+// A representative servable place_pool row, shaped like the RPC return.
+const SERVABLE_ROW = {
+  place_id: "11111111-1111-1111-1111-111111111111",
+  google_place_id: "ChIJ_companion_abc",
+  name: "Corner Bakery",
+  address: "12 Stroll Lane",
+  lat: 40.7128,
+  lng: -74.006,
+  rating: 4.6,
+  review_count: 233,
+  price_level: 1,
+  opening_hours: null,
+  website: "https://corner.example",
+  stored_photo_urls: [
+    "https://cdn.example/real-photo-1.jpg",
+    "https://cdn.example/real-photo-2.jpg",
+  ],
+  types: ["bakery", "cafe"],
+  primary_type: "bakery",
+  signal_score: 187,
+};
+
+const ANCHOR = { lat: 40.713, lng: -74.0061 };
+
+// ── Companion RPC params ─────────────────────────────────────────────────────
+Deno.test("CP-01 companion RPC params: casual_food signal, filter_min 120, radius from maxDistance", () => {
+  const params = buildCompanionRpcParams(ANCHOR, 500);
+  assertEquals(params.p_signal_id, "casual_food");
+  assertEquals(params.p_filter_min, 120);
+  assertEquals(params.p_radius_m, 500);
+  assertEquals(params.p_lat, ANCHOR.lat);
+  assertEquals(params.p_lng, ANCHOR.lng);
+  assert(params.p_limit >= 1, "limit must over-fetch (we pick top 1)");
+});
+
+Deno.test("CP-02 companion RPC radius tracks a non-default maxDistance", () => {
+  const params = buildCompanionRpcParams(ANCHOR, 900);
+  assertEquals(params.p_radius_m, 900);
+});
+
+// ── Companion row → response shape ───────────────────────────────────────────
+Deno.test("CP-03 companion row maps to client shape with imageUrl from stored_photo_urls[0]", () => {
+  const stop = mapServableRowToCompanionStop(SERVABLE_ROW, ANCHOR);
+  assertEquals(stop.id, SERVABLE_ROW.place_id);
+  assertEquals(stop.name, "Corner Bakery");
+  assertEquals(stop.location, { lat: 40.7128, lng: -74.006 });
+  assertEquals(stop.address, "12 Stroll Lane");
+  assertEquals(stop.rating, 4.6);
+  assertEquals(stop.reviewCount, 233);
+  assertEquals(stop.placeId, "ChIJ_companion_abc");
+  assertEquals(stop.type, "bakery");
+  // The load-bearing assertion: real photo, NOT the killed Unsplash placeholder.
+  assertEquals(stop.imageUrl, "https://cdn.example/real-photo-1.jpg");
+  assert(
+    !String(stop.imageUrl).includes("unsplash"),
+    "imageUrl must NOT be an Unsplash placeholder",
+  );
+});
+
+Deno.test("CP-04 companion row with no stored photos yields null imageUrl (no fabricated placeholder)", () => {
+  const stop = mapServableRowToCompanionStop(
+    { ...SERVABLE_ROW, stored_photo_urls: [] },
+    ANCHOR,
+  );
+  assertEquals(stop.imageUrl, null);
+});
+
+// ── Grocery RPC params ───────────────────────────────────────────────────────
+Deno.test("GR-01 grocery RPC params: groceries signal, filter_min 120, radius from maxDistance", () => {
+  const params = buildGroceryRpcParams(ANCHOR, 2000);
+  assertEquals(params.p_signal_id, "groceries");
+  assertEquals(params.p_filter_min, 120);
+  assertEquals(params.p_radius_m, 2000);
+  assertEquals(params.p_lat, ANCHOR.lat);
+  assertEquals(params.p_lng, ANCHOR.lng);
+  assert(params.p_limit >= 1, "limit must over-fetch");
+});
+
+// ── Grocery row → response shape ─────────────────────────────────────────────
+Deno.test("GR-02 grocery row maps to client shape with imageUrl from stored_photo_urls[0] + distance", () => {
+  const store = mapServableRowToGroceryStore(SERVABLE_ROW, ANCHOR);
+  assertEquals(store.id, SERVABLE_ROW.place_id);
+  assertEquals(store.name, "Corner Bakery");
+  assertEquals(store.address, "12 Stroll Lane");
+  assertEquals(store.placeId, "ChIJ_companion_abc");
+  assertEquals(store.type, "bakery");
+  assertEquals(store.imageUrl, "https://cdn.example/real-photo-1.jpg");
+  assert(
+    !String(store.imageUrl).includes("unsplash"),
+    "imageUrl must NOT be an Unsplash placeholder",
+  );
+  // picnic response shape preserves types[] + a numeric distance.
+  assertEquals(store.types, ["bakery", "cafe"]);
+  assert(typeof store.distance === "number" && store.distance >= 0);
+});
+
+// ── Handler wiring (no RPC / no Google needed) ───────────────────────────────
+Deno.test("HW-01 companion handler rejects a missing anchor location with 400", async () => {
+  const res = await handleCompanion(
+    new Request("http://x", { method: "POST", body: JSON.stringify({}) }),
+  );
+  assertEquals(res.status, 400);
+  const json = await res.json();
+  assertEquals(json.error, "Anchor location is required");
+});
+
+Deno.test("HW-02 picnic handler rejects a missing picnic location with 400", async () => {
+  const res = await handleGrocery(
+    new Request("http://x", { method: "POST", body: JSON.stringify({}) }),
+  );
+  assertEquals(res.status, 400);
+  const json = await res.json();
+  assertEquals(json.error, "Picnic location is required");
+});
+
+// ── No-Google + graceful-empty source guards (fail-on-revert anchor) ─────────
+const COMPANION_SRC = await Deno.readTextFile(
+  "supabase/functions/get-companion-stops/index.ts",
+);
+const GROCERY_SRC = await Deno.readTextFile(
+  "supabase/functions/get-picnic-grocery/index.ts",
+);
+
+for (const [name, src] of [
+  ["companion-stops", COMPANION_SRC],
+  ["picnic-grocery", GROCERY_SRC],
+] as const) {
+  Deno.test(`NG-01 ${name} has ZERO Google references`, () => {
+    assert(!src.includes("GOOGLE_MAPS_API_KEY"), `${name} must not read GOOGLE_MAPS_API_KEY`);
+    assert(!src.includes("googleapis"), `${name} must not call googleapis`);
+    assert(!src.includes("batchSearchPlaces"), `${name} must not import batchSearchPlaces`);
+    assert(!src.includes("unsplash"), `${name} must not embed an Unsplash placeholder`);
+    assert(
+      !/Google Maps API key is not configured/.test(src),
+      `${name} must not retain the Google API-key 500 guard`,
+    );
+  });
+
+  Deno.test(`NG-02 ${name} sources only query_servable_places_by_signal`, () => {
+    assert(
+      src.includes("query_servable_places_by_signal"),
+      `${name} must call query_servable_places_by_signal`,
+    );
+  });
+
+  Deno.test(`NG-03 ${name} returns a graceful-empty body when the RPC yields no rows`, () => {
+    const emptyKey = name === "companion-stops" ? "strollData: null" : "picnicData: null";
+    assert(
+      src.includes(emptyKey),
+      `${name} must return ${emptyKey} (graceful empty, no Google fallback)`,
+    );
+  });
+}

--- a/supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts
+++ b/supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts
@@ -1,0 +1,162 @@
+// ORCH-1107 — TESTER ADVERSARIAL regression (RPC-ERROR path).
+//
+// DIFFERENT ANGLE than the implementor happy-path test (which covered RPC
+// param-building, row→shape mapping, and 0-row source-grep). This attacks the
+// FAILURE path the implementor's suite never exercises at runtime: what happens
+// when `query_servable_places_by_signal` REJECTS — i.e. the supabase-js client
+// returns `{ data: null, error: {...} }` (PostgREST 4xx/5xx) OR throws.
+//
+// Contract under attack (SPEC AMENDMENT 1 + SC-9): on an RPC error the handler
+// MUST
+//   (1) NOT crash / NOT surface a 500 — it returns the graceful-empty body;
+//   (2) NOT fall back to Google (no googleapis.com request leaves the process);
+//   (3) return the canonical empty body — companion `strollData: null`,
+//       picnic `picnicData: null`.
+//
+// HOW THE ERROR IS INJECTED (real, not a re-implementation): we stand up a local
+// HTTP server and point SUPABASE_URL at it BEFORE the SUT modules load. The real
+// @supabase/supabase-js client (constructed at module load) issues its RPC POST
+// to /rest/v1/rpc/query_servable_places_by_signal against our server, which
+// replies with a PostgREST-shaped 500 error body. supabase-js then resolves the
+// `.rpc()` call to `{ data: null, error: {...} }` — exercising the REAL
+// `if (error) { ...; return []/null }` branch in each edge function, end to end
+// through the exported `handleRequest`. We also record EVERY request path the
+// process tries to reach so we can prove no Google fallback request fires.
+//
+// This is NOT a copy of the implementor's test: it imports the SUT, drives the
+// exported handler over a real (mocked) network round-trip on the error path,
+// and asserts runtime graceful-empty + no-Google + no-throw — none of which the
+// implementor's pure-helper/source-grep suite touches.
+
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// ── HERMETIC SETUP ───────────────────────────────────────────────────────────
+// Point the supabase client at a LOCAL mock so its RPC POST hits us and we can
+// force an error reply. Set env + the no-serve seam BEFORE the dynamic import so
+// createClient() constructs against our URL and neither module binds its own
+// edge-function socket.
+const MOCK_PORT = 54399;
+const MOCK_URL = `http://127.0.0.1:${MOCK_PORT}`;
+Deno.env.set("SUPABASE_URL", MOCK_URL);
+Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key");
+Deno.env.set("ORCH_TEST_NO_SERVE", "1");
+
+// Records every request path the SUT makes to the mock (proves the only network
+// the handler performs is the single RPC call — no Google fallback).
+const seenPaths: string[] = [];
+
+const ac = new AbortController();
+const server = Deno.serve(
+  { port: MOCK_PORT, signal: ac.signal, onListen() {} },
+  (req) => {
+    const url = new URL(req.url);
+    seenPaths.push(url.pathname);
+    // PostgREST error shape that supabase-js maps to `error` (non-2xx) →
+    // `.rpc()` resolves `{ data:null, error:{...} }`, the exact failure the
+    // handler's `if (error) { return []/null }` branch must absorb.
+    return new Response(
+      JSON.stringify({
+        code: "P0001",
+        message: "query_servable_places_by_signal boom (adversarial)",
+        details: null,
+        hint: null,
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  },
+);
+
+const { handleRequest: handleCompanion } = await import(
+  "../get-companion-stops/index.ts"
+);
+const { handleRequest: handleGrocery } = await import(
+  "../get-picnic-grocery/index.ts"
+);
+
+// Drain the supabase client's construction-time timer before the first test so
+// the leak sanitizer doesn't attribute it to test #1 (same drain the
+// implementor's suite uses).
+await new Promise<void>((r) => setTimeout(r, 50));
+
+const ANCHOR_BODY = JSON.stringify({
+  anchor: { name: "Riverside Park", location: { lat: 40.78, lng: -73.97 } },
+  maxDistance: 500,
+});
+const PICNIC_BODY = JSON.stringify({
+  picnic: { name: "Riverside Park", location: { lat: 40.78, lng: -73.97 } },
+  maxDistance: 2000,
+});
+
+function newReq(body: string): Request {
+  return new Request("http://edge.local", { method: "POST", body });
+}
+
+// ── RPC returns { data:null, error } ─────────────────────────────────────────
+Deno.test("ADV-01 companion: RPC error → graceful strollData:null, status 200, no throw", async () => {
+  seenPaths.length = 0;
+  const res = await handleCompanion(newReq(ANCHOR_BODY));
+  // (1) no crash: the handler resolved with a Response, and it is NOT the 500
+  // catch-path (a thrown RPC would have produced status 500 with {error}).
+  assertEquals(res.status, 200, "RPC error must be swallowed into graceful 200, not a 500");
+  const json = await res.json();
+  // (3) canonical empty body.
+  assertEquals(json.strollData, null, "companion must return strollData:null on RPC error");
+  // (2) no Google fallback: the only request the SUT made was the single RPC.
+  const googleish = seenPaths.filter((p) => /googleapis|maps|searchNearby/i.test(p));
+  assertEquals(googleish.length, 0, "no Google fallback request may be made");
+  assert(
+    seenPaths.some((p) => p.includes("query_servable_places_by_signal")),
+    "handler must have attempted the RPC (proves the error path was actually hit)",
+  );
+});
+
+Deno.test("ADV-02 picnic: RPC error → graceful picnicData:null, status 200, no throw", async () => {
+  seenPaths.length = 0;
+  const res = await handleGrocery(newReq(PICNIC_BODY));
+  assertEquals(res.status, 200, "RPC error must be swallowed into graceful 200, not a 500");
+  const json = await res.json();
+  assertEquals(json.picnicData, null, "picnic must return picnicData:null on RPC error");
+  const googleish = seenPaths.filter((p) => /googleapis|maps|searchNearby/i.test(p));
+  assertEquals(googleish.length, 0, "no Google fallback request may be made");
+  assert(
+    seenPaths.some((p) => p.includes("query_servable_places_by_signal")),
+    "handler must have attempted the RPC",
+  );
+});
+
+// ── RPC body returns the empty/error JSON; assert no fabricated content ───────
+Deno.test("ADV-03 companion: error-path body carries the empty marker, no fabricated stop", async () => {
+  seenPaths.length = 0;
+  const res = await handleCompanion(newReq(ANCHOR_BODY));
+  const text = await res.text();
+  assertStringIncludes(text, "strollData");
+  assert(!/unsplash/i.test(text), "no Unsplash placeholder may leak on the error path");
+  assert(!/googleapis/i.test(text), "no Google artifact may leak on the error path");
+});
+
+Deno.test("ADV-04 picnic: error-path body carries the empty marker, no fabricated store", async () => {
+  seenPaths.length = 0;
+  const res = await handleGrocery(newReq(PICNIC_BODY));
+  const text = await res.text();
+  assertStringIncludes(text, "picnicData");
+  assert(!/unsplash/i.test(text), "no Unsplash placeholder may leak on the error path");
+  assert(!/googleapis/i.test(text), "no Google artifact may leak on the error path");
+});
+
+// Teardown runs as the LAST registered test (top-level code executes at
+// registration time, before any test body, so it cannot tear down here). The
+// mock server is a top-level resource intentionally torn down here, so the
+// per-test op/resource sanitizers are disabled for THIS step only (they would
+// otherwise flag the cross-test cleanup of a resource they didn't see created).
+Deno.test({
+  name: "ADV-99 teardown: stop the mock server",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    await server.shutdown().catch(() => {});
+  },
+});

--- a/supabase/functions/get-companion-stops/index.ts
+++ b/supabase/functions/get-companion-stops/index.ts
@@ -1,7 +1,6 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { batchSearchPlaces } from '../_shared/placesCache.ts';
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -9,12 +8,80 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-const GOOGLE_API_KEY = Deno.env.get("GOOGLE_MAPS_API_KEY");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const supabaseAdmin = createClient(SUPABASE_URL ?? '', SUPABASE_SERVICE_ROLE_KEY ?? '');
 
-serve(async (req) => {
+// ORCH-1107 — companion stops now come from the scored, servable place_pool via
+// the live solo-deck RPC `query_servable_places_by_signal` (the same RPC
+// discover-cards uses), NOT live Google Places. The RPC enforces is_servable +
+// is_active + place_scores.score >= p_filter_min + real stored_photo_urls + a
+// haversine radius, so the three serving gates come for free.
+const COMPANION_SIGNAL_ID = "casual_food";
+const COMPANION_FILTER_MIN = 120;
+const COMPANION_RPC_LIMIT = 10;
+
+// Build the RPC params for a companion-stop lookup around the stroll anchor.
+// Exported for the regression test (ORCH-1107).
+export function buildCompanionRpcParams(
+  anchorLocation: { lat: number; lng: number },
+  maxDistance: number,
+): {
+  p_signal_id: string;
+  p_filter_min: number;
+  p_lat: number;
+  p_lng: number;
+  p_radius_m: number;
+  p_limit: number;
+} {
+  return {
+    p_signal_id: COMPANION_SIGNAL_ID,
+    p_filter_min: COMPANION_FILTER_MIN,
+    p_lat: anchorLocation.lat,
+    p_lng: anchorLocation.lng,
+    p_radius_m: maxDistance,
+    p_limit: COMPANION_RPC_LIMIT,
+  };
+}
+
+// Map a query_servable_places_by_signal row → the companion-stop shape the
+// client (stopReplacementService / ExpandedCardModal / CompanionStopsSection)
+// already expects. imageUrl is the first real stored photo — NO Unsplash
+// placeholder (ORCH-1107 killed it). Exported for the regression test.
+export function mapServableRowToCompanionStop(
+  row: any,
+  anchorLocation: { lat: number; lng: number },
+): {
+  id: any;
+  name: string;
+  location: { lat: number; lng: number };
+  address: string;
+  rating: number;
+  reviewCount: number;
+  imageUrl: string | null;
+  placeId: any;
+  type: string;
+} {
+  const storedPhotos = Array.isArray(row.stored_photo_urls)
+    ? row.stored_photo_urls
+    : [];
+  return {
+    id: row.place_id,
+    name: row.name || "Unknown Place",
+    location: {
+      lat: typeof row.lat === "number" ? row.lat : anchorLocation.lat,
+      lng: typeof row.lng === "number" ? row.lng : anchorLocation.lng,
+    },
+    address: row.address || "",
+    rating: row.rating ?? 0,
+    reviewCount: row.review_count ?? 0,
+    imageUrl: storedPhotos[0] ?? null,
+    placeId: row.google_place_id ?? row.place_id,
+    type: row.primary_type || COMPANION_SIGNAL_ID,
+  };
+}
+
+export async function handleRequest(req: Request): Promise<Response> {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -36,20 +103,7 @@ serve(async (req) => {
       );
     }
 
-    if (!GOOGLE_API_KEY) {
-      console.warn("⚠️ Google API key not available for companion stops");
-      return new Response(
-        JSON.stringify({
-          error: "Google Maps API key is not configured",
-        }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Fetch companion stops in parallel and keep only the top result
+    // Fetch companion stops from the scored place_pool and keep only the top result
     const companionStops = await findCompanionStops(
       anchor.location,
       maxDistance
@@ -98,77 +152,45 @@ serve(async (req) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
-});
+}
 
-// Find companion stops (café/bakery/ice cream/food truck) near a stroll anchor
+// Only bind the HTTP server when running as an edge function — NOT when this
+// module is imported by the ORCH-1107 regression test (which exercises the
+// exported pure helpers without a listening socket).
+if (!Deno.env.get("ORCH_TEST_NO_SERVE")) {
+  serve(handleRequest);
+}
+
+// Find companion stops near a stroll anchor from the scored, servable place_pool.
+// Sorted by signal_score desc; returns the top 1. Graceful empty (no Google
+// fallback, no throw) when the RPC returns 0 rows.
 async function findCompanionStops(
   anchorLocation: { lat: number; lng: number },
   maxDistance: number = 500 // meters
 ): Promise<any[]> {
-  const companionTypes = [
-    "supermarket",
-    "food_store",
-    "convenience_store",
-    "store",
-    "grocery_store",
-    "meal_takeaway",
-    "ice_cream_shop",
-    "bakery",
-    "deli",
-  ];
-
   try {
-    const { results: typeResults } = await batchSearchPlaces(
-      supabaseAdmin,
-      GOOGLE_API_KEY!,
-      companionTypes,
-      anchorLocation.lat,
-      anchorLocation.lng,
-      maxDistance,
-      { maxResultsPerType: 5, ttlHours: 24 }
+    const { data, error } = await supabaseAdmin.rpc(
+      "query_servable_places_by_signal",
+      buildCompanionRpcParams(anchorLocation, maxDistance)
     );
 
-    // Merge all results
-    const allRawPlaces: any[] = [];
-    for (const places of Object.values(typeResults)) {
-      allRawPlaces.push(...places);
-    }
-
-    if (allRawPlaces.length === 0) {
+    if (error) {
+      console.error("Error fetching companion stops:", error.message);
       return [];
     }
 
-    // Map places to our format
-    const allCompanions = allRawPlaces.map((place: any) => {
-      // Extract photo reference from new API format
-      const primaryPhoto = place.photos?.[0];
-      const imageUrl = 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=800&q=80';
+    const rows: any[] = Array.isArray(data) ? data : [];
+    if (rows.length === 0) {
+      return [];
+    }
 
-      // Determine the type by matching place types with companion types
-      const placeTypes = place.types || [];
-      const matchedType =
-        companionTypes.find((type) => placeTypes.includes(type)) ||
-        companionTypes[0]; // Fallback to first type if no match
+    const sorted = [...rows].sort(
+      (a, b) => Number(b.signal_score ?? 0) - Number(a.signal_score ?? 0)
+    );
 
-      return {
-        id: place.id,
-        name: place.displayName?.text || "Unknown Place",
-        location: {
-          lat: place.location?.latitude || anchorLocation.lat,
-          lng: place.location?.longitude || anchorLocation.lng,
-        },
-        address: place.formattedAddress || "",
-        rating: place.rating || 0,
-        reviewCount: place.userRatingCount || 0,
-        imageUrl: imageUrl,
-        placeId: place.id, // In new API, place.id is the identifier
-        type: matchedType,
-      };
-    });
-
-    return allCompanions
-      .sort((a, b) => (b.rating || 0) - (a.rating || 0))
-      .slice(0, 1);
+    return sorted
+      .slice(0, 1)
+      .map((row) => mapServableRowToCompanionStop(row, anchorLocation));
   } catch (error) {
     console.error(`Error fetching companion stops:`, error);
     return [];

--- a/supabase/functions/get-picnic-grocery/index.ts
+++ b/supabase/functions/get-picnic-grocery/index.ts
@@ -1,7 +1,6 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { batchSearchPlaces } from '../_shared/placesCache.ts';
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -9,12 +8,89 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-const GOOGLE_API_KEY = Deno.env.get("GOOGLE_MAPS_API_KEY");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const supabaseAdmin = createClient(SUPABASE_URL ?? '', SUPABASE_SERVICE_ROLE_KEY ?? '');
 
-serve(async (req) => {
+// ORCH-1107 — picnic grocery stops now come from the scored, servable
+// place_pool via the live solo-deck RPC `query_servable_places_by_signal` (the
+// same RPC discover-cards uses), NOT live Google Places. The RPC enforces
+// is_servable + is_active + place_scores.score >= p_filter_min + real
+// stored_photo_urls + a haversine radius, so the three serving gates come free.
+const GROCERY_SIGNAL_ID = "groceries";
+const GROCERY_FILTER_MIN = 120;
+const GROCERY_RPC_LIMIT = 10;
+
+// Build the RPC params for a grocery lookup around the picnic location.
+// Exported for the regression test (ORCH-1107).
+export function buildGroceryRpcParams(
+  picnicLocation: { lat: number; lng: number },
+  maxDistance: number,
+): {
+  p_signal_id: string;
+  p_filter_min: number;
+  p_lat: number;
+  p_lng: number;
+  p_radius_m: number;
+  p_limit: number;
+} {
+  return {
+    p_signal_id: GROCERY_SIGNAL_ID,
+    p_filter_min: GROCERY_FILTER_MIN,
+    p_lat: picnicLocation.lat,
+    p_lng: picnicLocation.lng,
+    p_radius_m: maxDistance,
+    p_limit: GROCERY_RPC_LIMIT,
+  };
+}
+
+// Map a query_servable_places_by_signal row → the grocery-store shape the
+// client (stopReplacementService / ExpandedCardModal / picnic timeline) already
+// expects. imageUrl is the first real stored photo — NO Unsplash placeholder
+// (ORCH-1107 killed it). Exported for the regression test.
+export function mapServableRowToGroceryStore(
+  row: any,
+  picnicLocation: { lat: number; lng: number },
+): {
+  id: any;
+  name: string;
+  location: { lat: number; lng: number };
+  address: string;
+  rating: number;
+  reviewCount: number;
+  imageUrl: string | null;
+  placeId: any;
+  type: string;
+  types: string[];
+  distance: number;
+} {
+  const storedPhotos = Array.isArray(row.stored_photo_urls)
+    ? row.stored_photo_urls
+    : [];
+  const lat = typeof row.lat === "number" ? row.lat : picnicLocation.lat;
+  const lng = typeof row.lng === "number" ? row.lng : picnicLocation.lng;
+  const distance = calculateDistance(
+    picnicLocation.lat,
+    picnicLocation.lng,
+    lat,
+    lng
+  );
+  return {
+    id: row.place_id,
+    name: row.name || "Unknown Store",
+    location: { lat, lng },
+    address: row.address || "",
+    rating: row.rating ?? 0,
+    reviewCount: row.review_count ?? 0,
+    imageUrl: storedPhotos[0] ?? null,
+    placeId: row.google_place_id ?? row.place_id,
+    type: row.primary_type || GROCERY_SIGNAL_ID,
+    types: Array.isArray(row.types) ? row.types : [],
+    distance,
+  };
+}
+
+export async function handleRequest(req: Request): Promise<Response> {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -39,20 +115,7 @@ serve(async (req) => {
       );
     }
 
-    if (!GOOGLE_API_KEY) {
-      console.warn("⚠️ Google API key not available for picnic grocery search");
-      return new Response(
-        JSON.stringify({
-          error: "Google Maps API key is not configured",
-        }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // Find grocery stores and markets near the picnic location
+    // Find a grocery store near the picnic location from the scored place_pool
     const groceryStore = await findGroceryStore(picnicLocation, maxDistance);
 
     if (!groceryStore) {
@@ -107,157 +170,51 @@ serve(async (req) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
-});
+}
 
-// Find grocery stores and markets near a picnic location
+// Only bind the HTTP server when running as an edge function — NOT when this
+// module is imported by the ORCH-1107 regression test (which exercises the
+// exported pure helpers without a listening socket).
+if (!Deno.env.get("ORCH_TEST_NO_SERVE")) {
+  serve(handleRequest);
+}
+
+// Find a grocery store near a picnic location from the scored, servable
+// place_pool. The RPC ranks by signal_score; among the returned servable rows
+// we prefer the closest (then higher rating), matching prior UX. Graceful empty
+// (no Google fallback, no throw) when the RPC returns 0 rows.
 async function findGroceryStore(
   picnicLocation: { lat: number; lng: number },
   maxDistance: number = 2000 // meters
 ): Promise<any | null> {
-  const groceryTypes = [
-    "supermarket",
-    "food_store",
-    "convenience_store",
-    "store",
-    "grocery_store",
-    "meal_takeaway",
-    "ice_cream_shop",
-    "bakery",
-    "deli",
-  ];
-
   try {
-    const { results: typeResults } = await batchSearchPlaces(
-      supabaseAdmin,
-      GOOGLE_API_KEY!,
-      groceryTypes,
-      picnicLocation.lat,
-      picnicLocation.lng,
-      maxDistance,
-      { maxResultsPerType: 5, ttlHours: 24 }
+    const { data, error } = await supabaseAdmin.rpc(
+      "query_servable_places_by_signal",
+      buildGroceryRpcParams(picnicLocation, maxDistance)
     );
 
-    // Merge all results
-    const allRawPlaces: any[] = [];
-    for (const places of Object.values(typeResults)) {
-      allRawPlaces.push(...places);
-    }
-
-    if (allRawPlaces.length === 0) {
+    if (error) {
+      console.error("Error fetching grocery stores:", error.message);
       return null;
     }
 
-    // Filter and map places to grocery stores
-    // When "store" type is used, filter to only include grocery-related stores
-    const groceryRelatedKeywords = [
-      "grocery",
-      "supermarket",
-      "market",
-      "food",
-      "convenience",
-      "deli",
-      "butcher",
-      "bakery",
-      "produce",
-    ];
-
-    const allGroceryStores = allRawPlaces
-      .filter((place: any) => {
-        // If place has explicit grocery types, include it
-        const hasGroceryType = place.types?.some((type: string) =>
-          [
-            "grocery_store",
-            "supermarket",
-            "food_store",
-            "convenience_store",
-          ].includes(type)
-        );
-        if (hasGroceryType) return true;
-
-        // If place only has "store" type, check if it's grocery-related
-        const isOnlyStore =
-          place.types?.includes("store") &&
-          !place.types?.some((type: string) =>
-            [
-              "grocery_store",
-              "supermarket",
-              "food_store",
-              "convenience_store",
-            ].includes(type)
-          );
-
-        if (isOnlyStore) {
-          // Check if name or types suggest it's a grocery store
-          const name = (place.displayName?.text || "").toLowerCase();
-          const typesString = (place.types || []).join(" ").toLowerCase();
-          return groceryRelatedKeywords.some(
-            (keyword) => name.includes(keyword) || typesString.includes(keyword)
-          );
-        }
-
-        return true; // Include other explicitly requested types
-      })
-      .map((place: any) => {
-        // Extract photo reference from new API format
-        const primaryPhoto = place.photos?.[0];
-        const imageUrl = 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=800&q=80';
-
-        // Calculate distance from picnic location
-        const distance = calculateDistance(
-          picnicLocation.lat,
-          picnicLocation.lng,
-          place.location?.latitude || picnicLocation.lat,
-          place.location?.longitude || picnicLocation.lng
-        );
-
-        // Determine the primary type from the place's types array
-        const primaryType =
-          place.types?.find((type: string) =>
-            [
-              "grocery_store",
-              "supermarket",
-              "food_store",
-              "convenience_store",
-            ].includes(type)
-          ) ||
-          place.types?.find((type: string) => groceryTypes.includes(type)) ||
-          place.types?.[0] ||
-          "grocery_store";
-
-        return {
-          id: place.id,
-          name: place.displayName?.text || "Unknown Store",
-          location: {
-            lat: place.location?.latitude || picnicLocation.lat,
-            lng: place.location?.longitude || picnicLocation.lng,
-          },
-          address: place.formattedAddress || "",
-          rating: place.rating || 0,
-          reviewCount: place.userRatingCount || 0,
-          imageUrl: imageUrl,
-          placeId: place.id,
-          type: primaryType,
-          types: place.types || [],
-          distance: distance, // distance in meters
-        };
-      });
-
-    if (allGroceryStores.length === 0) {
+    const rows: any[] = Array.isArray(data) ? data : [];
+    if (rows.length === 0) {
       return null;
     }
 
-    // Sort by distance (closest first), then by rating
-    const sortedStores = allGroceryStores.sort((a, b) => {
-      // First prioritize by distance
+    const stores = rows.map((row) =>
+      mapServableRowToGroceryStore(row, picnicLocation)
+    );
+
+    // Prefer the closest store; if distances are within 100m, prefer higher rating.
+    const sortedStores = stores.sort((a, b) => {
       if (Math.abs(a.distance - b.distance) > 100) {
-        // If distance difference is more than 100m, prefer closer one
         return a.distance - b.distance;
       }
-      // If distances are similar, prefer higher rating
       return (b.rating || 0) - (a.rating || 0);
     });
 
-    // Return the closest grocery store
     return sortedStores[0];
   } catch (error) {
     console.error("Error fetching grocery stores:", error);


### PR DESCRIPTION
ORCH-1107 [de-Google companion-stops + picnic-grocery onto the scored place_pool].

**What changed (plain English):** Take-a-Stroll and Picnic-Dates companion stops no longer call Google Places live — both edge functions now read the scored, servable place_pool via the `query_servable_places_by_signal` RPC (the same path the deck uses). Removes the only consumer-runtime Google dependency; kills the hardcoded Unsplash placeholder; graceful-empty (no Google fallback) when no scored spot is nearby. Client contract unchanged.

**Scope:** 2 edge functions (get-companion-stops, get-picnic-grocery) + 2 regression tests + C7 allowlist. No migration. No product-app code.

**QA verdict:** PASS (functional) — happy-path + adversarial RPC-error regression tests, both fails-on-revert; live RPC probe proved the populated path (real Raleigh restaurants/groceries with photos). Populated device-render is data-gated on run-signal-scorer populating place_scores per city (operator-owned, COMMS-0018) — not a code defect; unscored cities correctly return graceful-empty.

**Deploy notes:** after merge, deploy get-companion-stops + get-picnic-grocery from MERGED main (verify_jwt preserved). No EAS OTA (app-mobile untouched). No [deploy] tag (no Vercel surface).