### PR TITLE
chore: persist session artifacts (ORCH-1107 close + recovery docs)

### DIFF
--- a/Mingla_Artifacts/CLOSE_NOTE_ORCH-1107.md
+++ b/Mingla_Artifacts/CLOSE_NOTE_ORCH-1107.md
@@ -1,0 +1,32 @@
+# CLOSE NOTE — ORCH-1107
+
+**Title:** De-Google companion-stops + picnic-grocery onto the scored place_pool
+**Closed:** 2026-06-10 · **Verdict:** PASS (functional) · **Merge:** PR #434 squash `53584e0d3`
+**Affected Surfaces:** iOS-consumer + Android-consumer (Take-a-Stroll / Picnic-Dates card expand) + backend (2 edge functions). NOT business/admin/buyer-web.
+
+## What changed (plain English)
+Take-a-Stroll and Picnic-Dates companion stops no longer call Google Places live. Both edge functions (`get-companion-stops`, `get-picnic-grocery`) now read the scored, servable `place_pool` via the `query_servable_places_by_signal` RPC — the same path the consumer deck uses. This removes the **only consumer-runtime Google dependency**, kills the hardcoded Unsplash placeholder (real photo or honest null), and returns a graceful-empty body (no Google fallback, no crash) when no scored spot is nearby. Client contract unchanged.
+
+## Pipeline (first full run of the rebuilt skills)
+- INVESTIGATE/SPEC: corrected the RPC (original `fetch_local_signal_ranked` returns ~0 rows for launch cities; `query_servable_places_by_signal` is the live deck path). SPEC AMENDMENT 1.
+- IMPLEMENT → REVIEW: **NEEDS WORK** — orchestrator's independent test run caught a non-hermetic test (`supabaseUrl is required` on clean env) that the implementor's ambient-env run hid. Fixed (hermetic test).
+- TEST → REVIEW: **FAIL** — tester wrote an adversarial RPC-error test, live-probed the populated path (real Raleigh restaurants/groceries with photos via the RPC), and caught a C7 allowlist gap. One-line fix.
+- Final REVIEW: APPROVED — 5-file diff, C7 "All checks PASS", both regression tests 19/0 on clean env, zero Google.
+
+## Evidence
+- Merge: PR #434 `53584e0d3`; origin/main verified de-Googled (RPC present, no `GOOGLE_MAPS_API_KEY`) for both functions.
+- Step 0.5 regression gate: implementor happy-path `orch_1107_companion_picnic_place_pool.test.ts` (fails-on-revert verified at `7eda94e2`) + tester adversarial `orch_1107_rpc_error_adversarial.test.ts` (different angle = RPC-error tolerance; fails-on-revert verified at `f8a79bac7`). Both append-only, in-diff, 19 passed | 0 failed clean-env.
+- Deploy: `get-companion-stops` + `get-picnic-grocery` deployed from MERGED main to project `gqnoajqerqhnvulmnyvv`, `verify_jwt` preserved. No migration. No EAS OTA (app-mobile untouched). No `[deploy]` tag (no Vercel surface).
+- Worktree reaped: `~/Desktop/mingla-orchs/ORCH-1107-[companion-picnic-place-pool]/` + branch `ORCH-1107-companion-picnic-place-pool` (local + remote) + `/tmp/orch-1107` scratch.
+
+## Comms ledger
+COMMS-0002 (C7 no-new-backend-files gate) — honored: `ORCH_1107_BACKEND_ALLOWLIST` added with both test files. COMMS-0018 (place_scores population) — factored: populated companion/picnic render is data-gated on `run-signal-scorer` per city (operator-owned), NOT a 1107 code defect; unscored cities correctly return graceful-empty.
+
+## Operational follow-on (NOT a code defect)
+Companion/picnic stops return graceful-empty in a city until `place_scores` is populated there via `run-signal-scorer` (the deterministic+AI blend). Tester proved the populated path works via live RPC probe. Running the scorer per launch city is Seth's operational task.
+
+## Discovery for follow-up
+`_shared/placesCache.ts` (`batchSearchPlaces`) is now orphaned (no remaining edge-function importer) — candidate for a future dead-code ORCH.
+
+## Artifact-sync note
+Full World Map / tracker sync + committing this close note and the recovery-session docs to `main` are folded into the pending repo-state cleanup pass (anchor currently on `retrigger-3` from the iCloud-recovery; flagged, not force-switched, per the Step 1.9 ownership-scoped rule).

--- a/Mingla_Artifacts/INVARIANT_REGISTRY.md
+++ b/Mingla_Artifacts/INVARIANT_REGISTRY.md
@@ -7,6 +7,18 @@
 
 ---
 
+## DRAFT (pending close)
+
+### I-ENV-HYGIENE-OWNERSHIP-SCOPED (DRAFT — flips ACTIVE on the close that ships the orchestrator Environment Hygiene Sweep)
+
+- **Rule:** The orchestrator's environment hygiene sweep (CLOSE Step 1.9 / SWEEP-HYGIENE mode) deletes only artifacts the closing ORCH provably owns; all unowned items (other sessions' worktrees, shared `/tmp`/`~/Downloads`/screenshots, an off-main anchor, iCloud residue) are FLAGGED, never deleted. No blanket surface deletion. No destructive anchor ops (`reset --hard` / `checkout -- .` / `add -A` / `clean -fd`). No global `pkill` / port-range kill.
+- **Rationale:** Mingla runs MULTIPLE concurrent chat sessions sharing the anchor, the `~/Desktop/mingla-orchs/` worktree root, `/tmp`, `~/Downloads`, and screenshot surfaces. A surface-wide cleanup by one session destroys another session's in-flight work. Ownership-scoped deletion + flag-the-rest is the only cross-session-safe cleanup. Extends the Step 1.8 anchor-cleanup discipline to five more surfaces.
+- **Enforcement:** Skill definition `.claude/skills/mingla-orchestrator/SKILL.md` CLOSE Step 1.9 + SWEEP-HYGIENE mode + Working-Branch Discipline forward convention (ORCH-namespaced scratch: `/tmp/orch-<ID>/`, `Mingla_Artifacts/evidence/<ORCH>/`, ORCH-ID-tagged downloads); detailed per-surface rules in `references/review-close-protocol.md` Step 1.9 and `references/operating-system.md` § Cleanup. A CI gate may be added in a follow-up.
+- **Test that catches a regression:** any orchestrator cleanup path that deletes a shared-surface item without proving closing-ORCH ownership, or that runs a destructive anchor op / global `pkill`, violates this invariant (caught at REVIEW by inspecting the cited `Hygiene: <N owned removed>, <M unowned flagged>, anchor on <branch>` banner against the actual deletions).
+- **Established:** registered DRAFT 2026-06-10 by the Environment Hygiene Sweep addition to mingla-orchestrator.
+
+---
+
 ## ACTIVE (post ORCH-1103 [Ari smart brand CRUD + in-chat media] IMPLEMENT 2026-06-08)
 
 ### I-ARI-BRAND-DELETE-GUARD

--- a/Mingla_Artifacts/reports/AUDIT_PRODUCTION_READINESS_2026-06-10.md
+++ b/Mingla_Artifacts/reports/AUDIT_PRODUCTION_READINESS_2026-06-10.md
@@ -1,0 +1,99 @@
+# Production-Readiness Forensic Audit — Mingla
+
+**Date:** 2026-06-10
+**Author:** Claude `mingla-orchestrator` (direct audit; forensics skill unavailable — lost in iCloud incident)
+**Method:** Live probes against Supabase Management API + Postgres (read-only), repo config, security advisors. Facts only; no inference where a probe was possible.
+**Project ref:** `gqnoajqerqhnvulmnyvv`
+
+---
+
+## 1. Payments / Stripe — the headline correction
+
+| Fact | Evidence |
+|---|---|
+| `MINGLA_STRIPE_MODE` = **`test`** | Management API secret digest = `9f86d081…0a08` = SHA-256("test") |
+| **Both** test AND live restricted keys are loaded | All 8 `STRIPE_RAK_*_TEST` and `STRIPE_RAK_*_LIVE` secrets present in Supabase |
+| Mode switch is code-wired (ORCH-1056) | `_shared/stripeMode.ts` `resolveStripeKey(role)` routes on `MINGLA_STRIPE_MODE` |
+| Build fail-close honored | `mingla-business/app.config.ts:151` requires `pk_live_` only when mode=live; default = `pk_test_51TTnt1…` sandbox |
+| Brand money state | 59 brands · 20 with test Stripe Connect · **7 charges_enabled + 7 payouts_enabled** · 0 Paystack · 0 null currency · 5 currencies |
+
+**Conclusion:** Going live is **flipping one flag** (`MINGLA_STRIPE_MODE` → `live`, swap the Vercel `pk` to `pk_live_`) + business/legal verification. The live keys are already in Supabase. My earlier "4–8 hour from-scratch" framing was wrong — it cited the superseded B2 checklist.
+
+## 2. Service configuration — 98 secrets, platform fully wired
+
+Configured & loaded (Supabase secrets): Stripe (test+live), OneSignal (app+business), Resend (4), Twilio (5), Cloudinary, Gemini (+Ari), OpenAI, Anthropic, Google (Places/Maps/Geo), Mapbox, Pexels, Ticketmaster, AppsFlyer, OpenWeather, Serper, Paystack (**TEST only**), feature flags (`MARKETING_SEND_LIVE_ENABLED`, `EVENT_COVER_VIDEO_PROVIDER`).
+
+**Sentry:** wired for the apps, NOT for edge functions.
+- Consumer: `Sentry.init` DSN hardcoded in `app-mobile/app/_layout.tsx:29` (live).
+- Business: production EAS profile sets `SENTRY_DISABLE_AUTO_UPLOAD: false` (source-map upload on); DSN in Key Details.
+- **Gap:** no `SENTRY_*` secret in Supabase → edge-function errors are NOT sent to Sentry (Taofeek's `reportNonFatal` is native-only). Minor, optional.
+
+**Stale leftover:** `NATIVE_PAID_ALLOWED_REGIONS` secret still present though the region gate was decommissioned (ORCH-0955). Harmless (no code reads it); delete for hygiene.
+
+## 3. Scale reality — pre-launch dataset
+
+Approx live rows: tickets 174 · events 138 · orders 64 · brands 59 · profiles 39 · agent_messages 29 · event_dates 22 · marketing_campaigns 19 · support_tickets 1 · stripe_disputes 0.
+
+**Conclusion:** No real production traffic yet. The #430 hot-path indexes (applied 2026-06-10) and the 100k load test are **future-capacity** work, not fixes for a current problem. No money has been charged for real (mode=test).
+
+## 4. Security posture — Supabase advisors (667 findings, classified by REAL risk)
+
+| Level | Lint | Count | Real risk assessment |
+|---|---|---|---|
+| ERROR | `rls_disabled_in_public` | 12 | **LOW** — 10 are stale `_backup_*`/`_archive_*`/`_deprecated_*` tables; verified **no `anon`/`authenticated` grants** → NOT API-reachable. 1 = `spatial_ref_sys` (PostGIS system table, false positive). `seed_map_presence`/`used_trial_phones` = review. Action: **drop the dead backup tables** (hygiene + removes the lint). |
+| ERROR | `security_definer_view` | 3 | **REVIEW** — `claimed_venues_public_view`, `business_public_events_view`, `business_public_brands_view`. Intentional public views for public pages; confirm they expose only public columns. |
+| WARN | `*_security_definer_function_executable` (anon+auth) | 515 | **BY DESIGN** — heavy-RPC architecture; each SECURITY DEFINER RPC must validate auth internally. Surface is large but expected. |
+| WARN | `function_search_path_mutable` | 120 | **HARDENING** — pin `search_path` on these functions (search-path-injection defense). Real debt, not urgent. |
+| WARN | `public_bucket_allows_listing` | 7 | **LOW** — avatars/covers/photos/marketing buckets; public by design, listing enumeration is a minor info-leak. Optional: disable listing. |
+| WARN | `rls_policy_always_true` | 1 | `ticketmaster_events_cache` — public cache data; acceptable. |
+| WARN | `materialized_view_in_api` | 1 | `admin_place_pool_mv` — confirm it's not anon-readable (admin data). |
+| WARN | `extension_in_public` | 2 | cosmetic. |
+| INFO | `rls_enabled_no_policy` | 6 | deny-all by default; fine. |
+
+**Conclusion:** No active public data-exposure hole found. The scary "15 ERRORS" decompose into stale-table cleanup + a PostGIS false positive + 3 intentional public views to spot-check. Genuine pre-launch security work = drop dead backup tables, pin function search_paths, review the 3 SD views + `used_trial_phones` RLS.
+
+## 5. Migrations / deploy
+
+- 202 local migration files; `#430` hot-path index migration applied + recorded (`20260923000000`) on 2026-06-10.
+- 4 hot-path edge functions (`ticket-checkout-create/-status`, `stripe-webhook`, `agent-chat`) redeployed 2026-06-10 with #428 structured logging (verified versions v202/v198/v173/v142).
+
+## 6. The 7 launch gates — evidence-based status (corrects 2026-06-10 first pass)
+
+| Gate | Status by fact |
+|---|---|
+| G3 Sentry live | **DONE for apps** (consumer DSN hardcoded; business prod EAS upload on). Optional gap: edge-fn Sentry not wired. |
+| G6 Stripe TEST→LIVE | **Technically one flag** — live keys already in Supabase; needs business/legal verification + the flip decision. |
+| G7 App Store / Play | **Credentials ready** (Apple Issuer ID + AuthKey `.p8`); needs the actual submission. |
+| G2 Staging/prod Supabase project | **STILL THE KEYSTONE** — single project runs everything; this is why prod can't run alongside test. Real, unblocks G1 + safe G6. |
+| G1 100k load test | Real future-capacity exercise; scripts exist (#427/#429/#433). No current load. |
+| G4 DR restore drill | Real activity; not performed. |
+| G5 Incident/alert drill | Real activity; Sentry (alerting half) already live. |
+
+## 7. Verification pass (2026-06-10, live probes)
+
+**RLS policy bodies on live money/user tables — VERIFIED SOLID.**
+- `orders`, `tickets`: **no `anon` access**; all reads/writes gated by `biz_can_read_order_for_caller` / `biz_*_rank` role functions or buyer's own order. Anon buyers reach these only via service-role edge functions.
+- `brands`, `events`, `event_dates`: anon SELECT limited to non-deleted + `visibility='public'` + published rows; writes gated by `biz_is_brand_admin_plus` / `biz_brand_effective_rank >= event_manager`.
+- `profiles`: scoped by `auth.uid()=id`, `visibility_mode='public'`, friends, and blocked checks.
+- `agent_messages`: owner-only (`user_id = auth.uid()`). **No exposure gaps.**
+
+**Live-mode Stripe — VERIFIED, account is launch-ready.**
+- Live platform account `acct_1TU23…`: `charges_enabled=true`, `details_submitted=true`, `payouts_enabled=true`, country US → **fully verified & active**.
+- **2 live webhook endpoints** enabled, both → prod `…supabase.co/functions/v1/stripe-webhook` (18 events Connect + 10 events Platform — the ORCH-0953 dual-endpoint design).
+- **0 live connected accounts** (expected — brands onboard to live after the flip).
+
+**Vercel production Stripe key — PARTIALLY VERIFIED (good security finding).**
+- `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY` and `MINGLA_STRIPE_MODE` are stored as Vercel **Sensitive (write-only)** vars — unreadable via API or `vercel env pull` (returns empty). This is correct hygiene.
+- Indirect proof of consistency: `app.config.ts` build **fail-closes** on any pk/mode mismatch; business.usemingla.com deploys successfully (HTTP 200); backend mode=test; 0 live connected accounts ⇒ the web serves **`pk_test`** consistently. Direct confirmation would require triggering the lazy checkout chunk on a live checkout URL.
+- All 3 web surfaces live: business.usemingla.com, usemingla.com, admin.usemingla.com → HTTP 200.
+
+**Still not probed:** EAS *remote* env secret values (only `eas.json` static config read); the deeply-lazy checkout-chunk pk on the live site (needs a real checkout URL).
+
+## 8. Recommended order of work (fact-driven)
+
+1. **G2 — separate prod Supabase project.** Keystone; unblocks live Stripe co-existence + safe load testing.
+2. **Security cleanup** (cheap, pre-launch): drop dead `_backup_*`/`_archive_*` tables; review `used_trial_phones`/`seed_map_presence` RLS; spot-check the 3 SD public views; delete stale `NATIVE_PAID_ALLOWED_REGIONS` secret.
+3. **G1 load test** against the new staging project.
+4. **G4/G5 drills.**
+5. **G6 Stripe flip + G7 store submit** — short, credential-ready.
+6. Optional hardening: pin `search_path` on 120 functions; wire edge-fn Sentry.

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE.md
@@ -1,0 +1,189 @@
+# IMPLEMENTATION — ORCH-1107: Companion-stops + Picnic-grocery off Google onto scored place_pool
+
+**Date:** 2026-06-10 · **Skill:** mingla-implementor (Claude) · **Branch:** `ORCH-1107-companion-picnic-place-pool` · **Worktree:** `~/Desktop/mingla-orchs/ORCH-1107-[companion-picnic-place-pool]/` · **Commit:** `7eda94e2521c20f977c9180a31fcb7f299f488c7` (amended in REWORK to carry the hermetic test) · **Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE_ONTO_PLACE_POOL.md` (binding, with SPEC AMENDMENT 1).
+
+> **REWORK (orchestrator REVIEW = NEEDS WORK, 2026-06-10).** The single defect was a NON-HERMETIC regression test: on a clean `deno test --allow-all <path>` with NO ambient env, the static SUT imports ran `createClient(SUPABASE_URL ?? '', …)` at module load and threw `supabaseUrl is required` before any test ran (the prior "14/0 green" only held because the shell had ambient Supabase env). FIX (option A): the test now sets dummy `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `ORCH_TEST_NO_SERVE` BEFORE the SUT modules load and DYNAMICALLY `await import(...)`s them (static imports hoist, so they had to become dynamic). The two approved edge functions and the C7 allowlist are UNCHANGED; only the test file was updated and the commit re-amended. Test now passes deterministically with ZERO ambient env (verified under `env -i`).
+
+---
+
+## 1. Summary
+
+Take-a-Stroll (companion stops) and Picnic-Dates (grocery stop) were the only consumer-runtime Google dependency: both edge functions called `batchSearchPlaces` → live Google Places `places.googleapis.com/v1/places:searchNearby`, read `GOOGLE_MAPS_API_KEY`, did no `place_pool` read, and returned raw Google results with a hardcoded Unsplash placeholder image.
+
+Both functions now source from the scored, servable `place_pool` via the `query_servable_places_by_signal` RPC — the same RPC `discover-cards` uses (per SPEC Amendment 1, which superseded the original `fetch_local_signal_ranked` choice). The RPC enforces `is_servable` + `is_active` + `place_scores.score >= p_filter_min` + real `stored_photo_urls` + a haversine radius, so the three serving gates come for free. The Google API-key read, the 500 "not configured" guard, the `batchSearchPlaces` import, and the Unsplash placeholder are all deleted. The client contract is unchanged — same response shape, new source. When the RPC returns 0 rows, the existing graceful-empty body is returned (`strollData: null` / `picnicData: null`) — no Google fallback, no throw.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+All satisfied at commit `7eda94e2`.
+
+| SC | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| SC-1 | `grep GOOGLE_MAPS_API_KEY` over both functions → zero | ✓ | grep exit 1 (no match) — §“Grep proofs” below |
+| SC-2 | No `googleapis.com` reference in either function | ✓ | grep exit 1 (no match) |
+| SC-3 | Both functions call `query_servable_places_by_signal` | ✓ | grep shows the RPC call in each `index.ts` |
+| SC-4 | companion: `p_signal_id='casual_food'`, `p_filter_min=120`, `p_radius_m=maxDistance` (default 500), `p_limit=10`, sort by `signal_score` desc, top 1 | ✓ | `buildCompanionRpcParams` + `findCompanionStops`; test CP-01/CP-02 |
+| SC-5 | picnic: `p_signal_id='groceries'`, same geo/limit pattern | ✓ | `buildGroceryRpcParams` + `findGroceryStore`; test GR-01 |
+| SC-6 | Row → existing client shape (id, name, location, address, rating, reviewCount, imageUrl, placeId, type) | ✓ | `mapServableRowToCompanionStop` / `mapServableRowToGroceryStore`; test CP-03/GR-02 |
+| SC-7 | `imageUrl = stored_photo_urls[0]`; Unsplash placeholder deleted | ✓ | test CP-03/CP-04/GR-02; grep `unsplash.com` exit 1 |
+| SC-8 | Removed `GOOGLE_MAPS_API_KEY` read + 500 guard + unused `batchSearchPlaces` import from both | ✓ | grep; test NG-01 |
+| SC-9 | Graceful empty on 0 rows (`strollData:null` / `picnicData:null`), no Google fallback, no throw | ✓ | handler branch retained; test NG-03 |
+| SC-10 | Client untouched (`stopReplacementService`, `ExpandedCardModal`, `CompanionStopsSection`) | ✓ | diff is backend-only (4 files, all under `supabase/functions/` + the gate) |
+| SC-11 | Happy-path regression test green + fails-on-revert (HERMETIC) | ✓ | 14/14 pass with ZERO ambient env (`env -i`); revert → CP-04/NG-01 FAIL; restore → pass |
+| SC-12 | `deno check` clean on both files | ✓ | §Gates |
+| SC-13 | C7 no-new-backend-files gate passes (allowlist added same commit, COMMS-0002) | ✓ | gate `# All checks PASS` (4 files changed) |
+
+---
+
+## 3. Files changed
+
+| File | Type | ~Lines |
+|------|------|--------|
+| `supabase/functions/get-companion-stops/index.ts` | modify | ~ +95 / −75 (net ~ +20; Google path removed, RPC path + 2 exported helpers + serve-seam added) |
+| `supabase/functions/get-picnic-grocery/index.ts` | modify | ~ +90 / −95 (net ~ −5; Google search/filter block removed, RPC path + 2 exported helpers + serve-seam added) |
+| `supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts` | new (hermetic in REWORK) | +210 |
+| `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` | modify | +12 (ORCH_1107_BACKEND_ALLOWLIST const + union spread) |
+
+`git diff --name-only origin/main...HEAD` returns exactly these four. The untracked SPEC file under `Mingla_Artifacts/specs/` is orchestrator-owned and intentionally NOT staged.
+
+---
+
+## 4. Data-model changes applied
+
+None. No migration, no schema/RLS/index change. The `query_servable_places_by_signal` RPC already exists and is in production use by `discover-cards`.
+
+---
+
+## 5. Edge functions touched
+
+| Function | Change | `verify_jwt` to preserve |
+|----------|--------|--------------------------|
+| `get-companion-stops` | Google→RPC re-source | No `config.toml` `[functions.*]` override present → default (`verify_jwt = true`). Unchanged by this ORCH — code path untouched; only the data source changed. |
+| `get-picnic-grocery` | Google→RPC re-source | Same — default, unchanged. |
+
+Note: these functions read no auth header in their bodies and use the service-role client for the RPC (matching the prior `supabaseAdmin` usage), so the JWT posture is identical pre/post. Edge deploy is orchestrator/operator-owned from MERGED main — see §11.
+
+---
+
+## 6. Regression tests added
+
+**Path:** `supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts` (14 Deno tests).
+
+Coverage: companion RPC params (CP-01/02), companion row→shape + imageUrl-from-`stored_photo_urls[0]` + null-on-no-photos (CP-03/04), grocery RPC params (GR-01), grocery row→shape + distance + types (GR-02), handler 400 validation wiring (HW-01/02), and per-function source guards — zero Google references / sources only the RPC / graceful-empty branch present (NG-01/02/03 × 2 functions).
+
+**Run command (HERMETIC — no env exports required).** The test is now self-contained: it sets dummy `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `ORCH_TEST_NO_SERVE` at the very top, THEN dynamically `await import(...)`s the two SUT modules so `createClient()` constructs after the env exists (static ES imports hoist above body code, so the imports had to become dynamic). It passes on a clean invocation with zero ambient Supabase env:
+
+```bash
+cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1107-[companion-picnic-place-pool]"
+~/.deno/bin/deno test --allow-all \
+  supabase/functions/__tests__/orch_1107_companion_picnic_place_pool.test.ts
+```
+
+Passing output on a NO-ambient-env shell (`env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY …`) AND under a fully cleared environment (`env -i HOME=$HOME …`): `ok | 14 passed | 0 failed`.
+
+Defect this REWORK fixed: previously the test STATICALLY imported the two `index.ts` modules. With no ambient env, the module-load `createClient(SUPABASE_URL ?? '', …)` at `get-companion-stops/index.ts:13:23` threw `error: (in promise) Error: supabaseUrl is required.` as an UNCAUGHT error before any test ran — so the orchestrator's independent clean run failed (`0 passed | 1 failed`), even though a shell with ambient Supabase env reported `14/0`. The fix is the dummy-env-then-dynamic-import pattern; a 50 ms `setTimeout` drain after the imports settles the Supabase client's construction-time timer so Deno's leak sanitizer does not attribute it to the first test.
+
+**fails-on-revert verified at `7eda94e2521c20f977c9180a31fcb7f299f488c7`.** True line-edit of the core fix line in `get-companion-stops/index.ts` — `imageUrl: storedPhotos[0] ?? null` reverted to the old `imageUrl: storedPhotos[0] ?? "https://images.unsplash.com/photo-placeholder"` — caused **CP-04 and NG-01 to FAIL** (CP-04 = "no-stored-photos yields null imageUrl, no fabricated placeholder"; NG-01 = "ZERO Google/Unsplash references in source"); result `12 passed | 2 failed`. Restoring the fix returned the suite to `14 passed | 0 failed` under `env -i`. The test exercises the actual exported handler-helper logic, not a parallel re-implementation. (CP-03 passes in both states because its row carries photos, so the `?? unsplash` fallback branch is never reached — CP-04 + NG-01 are the load-bearing fails-on-revert cases.)
+
+A test seam (`ORCH_TEST_NO_SERVE`) is present in both modules: `if (!Deno.env.get("ORCH_TEST_NO_SERVE")) serve(handleRequest);`. The test now SETS this flag itself (no longer requires it on the command line) so the dynamic import does not bind a listening socket. It does NOT alter edge-function runtime behavior (the env var is never set in production). The handler body is exported as `handleRequest(req)` so the 400-validation path is directly testable.
+
+---
+
+## 7. Old → New receipts
+
+### get-companion-stops/index.ts
+**What it did before:** Read `GOOGLE_MAPS_API_KEY`; on missing key returned 500 "Google Maps API key is not configured"; `findCompanionStops` called `batchSearchPlaces(... GOOGLE_API_KEY ...)` → live Google `searchNearby` across 9 companion types, merged raw results, hardcoded `imageUrl` to an Unsplash URL, sorted by rating, returned top 1 in the stroll-timeline shape.
+**What it does now:** No Google key/guard/import. `findCompanionStops` calls `supabaseAdmin.rpc('query_servable_places_by_signal', { p_signal_id:'casual_food', p_filter_min:120, p_lat, p_lng, p_radius_m:maxDistance, p_limit:10 })`, sorts the returned servable rows by `signal_score` desc, maps the top 1 via `mapServableRowToCompanionStop` (`imageUrl = stored_photo_urls[0] ?? null`), and returns the identical stroll-timeline shape. 0 rows / RPC error → `[]` → existing `strollData:null` body. Handler extracted to exported `handleRequest`; `serve()` gated behind `ORCH_TEST_NO_SERVE`.
+**Why:** SC-1..SC-9 — remove the only consumer-runtime Google dependency; serve from the scored, servable place_pool with real photos.
+**Lines changed:** ~ +95 / −75.
+
+### get-picnic-grocery/index.ts
+**What it did before:** Read `GOOGLE_MAPS_API_KEY`; 500 guard on missing key; `findGroceryStore` called `batchSearchPlaces(... Google ...)`, filtered raw results to grocery-related types/keywords, hardcoded the Unsplash `imageUrl`, computed haversine distance, sorted by distance-then-rating, returned the closest in the picnic shape.
+**What it does now:** No Google key/guard/import. `findGroceryStore` calls the RPC with `p_signal_id='groceries'` (same geo/limit pattern), maps rows via `mapServableRowToGroceryStore` (`imageUrl = stored_photo_urls[0] ?? null`; preserves the `types[]` + numeric `distance` fields the picnic shape carries), and keeps the prior closest-then-rating preference among the already-gated servable rows. 0 rows / RPC error → `null` → existing `picnicData:null` body. Handler extracted to exported `handleRequest`; `serve()` gated behind `ORCH_TEST_NO_SERVE`. The haversine `calculateDistance` helper is retained (now used by the mapper for the response `distance` field).
+**Why:** SC-1..SC-9 — same de-Google + scored-pool re-source for Picnic Dates.
+**Lines changed:** ~ +90 / −95.
+
+### .github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+**What it did before:** C7 `no-new-backend-files` flagged any `supabase/functions/**` or `supabase/migrations/**` file in the `origin/main...HEAD` diff not present in the union ALLOWLIST.
+**What it does now:** Adds `ORCH_1107_BACKEND_ALLOWLIST` (the 2 edge fns + the 1 test) and spreads it into the union. C7 now PASSES on this ORCH's diff.
+**Why:** SC-13 / COMMS-0002 — editing existing backend files still trips C7 (it flags modified, not just new); the spec directs adding this allowlist in the SAME commit.
+**Lines changed:** +12.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Detail / reason |
+|---------|----------|-----------------|
+| Consumer iOS | YES | Take-a-Stroll / Picnic card expand now shows a servable, scored, real-photo place_pool spot instead of a raw Google result with an Unsplash placeholder. Shared backend — automatic parity. |
+| Consumer Android | YES | Same as iOS — automatic parity (shared edge functions, client untouched). |
+| Buyer / anonymous Web | NO | These edge functions serve the consumer deck-expand path only; not a buyer-web route. |
+| Business iOS | NO | Not a business-app surface. |
+| Business Android | NO | Not a business-app surface. |
+| Admin Web (adjacent) | NO | No admin code touched. |
+| Business Web preview (adjacent) | NO | No business code touched. |
+
+Parity is automatic (single shared backend; no client changes).
+
+---
+
+## 9. Smoke result
+
+- `deno check` clean on the test file (and on `get-companion-stops/index.ts`, `get-picnic-grocery/index.ts`, unchanged).
+- Regression suite (HERMETIC): `14 passed | 0 failed` on a NO-ambient-env shell and under `env -i HOME=$HOME` (fully cleared environment) — no uncaught error.
+- fails-on-revert at `7eda94e2`: reverting the companion `imageUrl` fix → `12 passed | 2 failed` (CP-04 + NG-01); restore → `14 passed | 0 failed`.
+- C7 strict-grep gate: `# All checks PASS` (4 files changed, all allowlisted) — re-run after the REWORK amend.
+- **Not run:** live device sim (iOS/Android) of the Take-a-Stroll / Picnic expand — this is backend-only and (per SPEC Amendment 1 operational note) will only return rows in a city once `run-signal-scorer` has populated `place_scores` there. Runtime device verification of the expand-card render is the tester's TEST phase (and depends on scorer-populated data, a separate operational task overlapping COMMS-0018 / META-ORCH-1062). Source + contract + RPC params are verified; the device render is **implemented, unverified** pending tester device-fire + scorer data.
+
+### Grep proofs (from the worktree, post-commit)
+
+```
+$ grep -rn "GOOGLE_MAPS_API_KEY\|googleapis" supabase/functions/get-companion-stops supabase/functions/get-picnic-grocery
+# (no output) exit=1   ← ZERO
+
+$ grep -rni "images.unsplash.com\|unsplash.com" supabase/functions/get-companion-stops supabase/functions/get-picnic-grocery
+# (no output) exit=1   ← placeholder URL gone
+
+$ grep -rn "batchSearchPlaces" supabase/functions/get-companion-stops supabase/functions/get-picnic-grocery
+# (no output) exit=1   ← import removed from both
+
+$ grep -rn "query_servable_places_by_signal" supabase/functions/get-companion-stops supabase/functions/get-picnic-grocery
+supabase/functions/get-companion-stops/index.ts:173:      "query_servable_places_by_signal",
+supabase/functions/get-picnic-grocery/index.ts:192:      "query_servable_places_by_signal",
+# present in BOTH
+```
+
+---
+
+## 10. Known issues / deferred
+
+- **`_shared/placesCache.ts` (`batchSearchPlaces`) is now orphaned.** After this change, no edge function imports it (only the helper definition + this test's negative-assertion string reference it). The SPEC explicitly says do NOT delete the shared helper. Left untouched. Flagged for the orchestrator as a possible future cleanup once confirmed truly dead.
+- **Data dependency (NOT a code defect, per SPEC Amendment 1):** companion/picnic will return rows in a city only after `run-signal-scorer` has populated `place_scores` for that city. ORCH-1107 ships the correct code; data population is Seth's operational task (overlaps COMMS-0018 / META-ORCH-1062 scorer-invoke fix).
+- **Test env requirement: NONE (fixed in REWORK).** The regression test is now hermetic — it sets the dummy env itself and dynamic-imports the SUT, so `deno test --allow-all <path>` passes with zero ambient env. No command-line env exports are required (this was the orchestrator's NEEDS-WORK defect).
+- No `[TRANSITIONAL]` code. The `ORCH_TEST_NO_SERVE` seam is a permanent, production-inert test affordance, not transitional debt.
+
+---
+
+## 11. Operator action required
+
+- **No migration.** Nothing to `db push`.
+- **Edge-function deploy (orchestrator/operator-owned, from MERGED main — after REVIEW + TEST + merge):**
+  - `get-companion-stops` (`verify_jwt` = default/true — preserve)
+  - `get-picnic-grocery` (`verify_jwt` = default/true — preserve)
+  - Deploy from merged `main`, NOT a worktree (clobber risk per memory rule).
+- **Data:** run `run-signal-scorer` for the target launch cities so `place_scores` is populated, or companion/picnic will correctly return graceful-empty there.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **`_shared/placesCache.ts` is now an orphan** (no remaining edge-function importer). Candidate for a future dead-code removal ORCH once confirmed unused program-wide. Not removed here (out of ORCH-1107 scope; SPEC said keep the shared helper).
+2. **C7 flags MODIFIED backend files, not just new ones** — confirmed by reading the gate. Any ORCH that edits an existing `supabase/functions/**` file needs an allowlist entry, not only ORCHs that add new files. (Already handled here via `ORCH_1107_BACKEND_ALLOWLIST`; noting for general awareness.)
+3. **No new COMMS entry written** — no cross-ORCH discovery beyond what COMMS-0002 (no-new-backend-files gate) and COMMS-0018 (scorer population) already cover, both of which were factored.
+
+---
+
+## Handoff
+
+Route back to **mingla-orchestrator** for REVIEW, then **mingla-tester** dispatch. Working tree: `~/Desktop/mingla-orchs/ORCH-1107-[companion-picnic-place-pool]/` on branch `ORCH-1107-companion-picnic-place-pool`, commit `7eda94e2` (amended in REWORK; the regression test is now hermetic). Do NOT deploy/merge/close. The tester adds the adversarial test (e.g. RPC-error tolerance / 0-row graceful-empty through the live RPC mock, and device-fire of the expand-card render against scorer-populated data).

--- a/Mingla_Artifacts/reports/PROD_SUPABASE_STANDUP_RUNBOOK_2026-06-10.md
+++ b/Mingla_Artifacts/reports/PROD_SUPABASE_STANDUP_RUNBOOK_2026-06-10.md
@@ -1,0 +1,66 @@
+# Mingla-prod Supabase Stand-Up — Runbook & Status
+
+**Date:** 2026-06-10
+**Owner:** Claude `mingla-orchestrator` (direct execution)
+**Decision basis:** Operator authorized "stand up a separate PROD Supabase project." Choices locked: Pro org, **straight-to-LIVE Stripe**, region us-east-2 (match dev), name "Mingla-prod".
+
+## Identity
+
+| | Value |
+|---|---|
+| Prod project ref | `gupxgpmukdwhozqfmzgd` |
+| Prod DB host | `db.gupxgpmukdwhozqfmzgd.supabase.co` |
+| Prod URL | `https://gupxgpmukdwhozqfmzgd.supabase.co` |
+| Region / org | us-east-2 / Mingla (`mrcqqkovdchaltvquggd`) |
+| DB password | in Key Details → `mingla-prod-supabase-db-password.md` |
+| Dev project (unchanged) | `gqnoajqerqhnvulmnyvv` ("Mingla-dev") |
+
+## DONE ✅
+
+1. **Project created** — Pro, us-east-2, ACTIVE_HEALTHY.
+2. **Schema applied** — all **202 migrations** pushed (`supabase db push --linked`); verified **195 public tables, 1,078 functions, 202 migrations recorded**. Exit 0.
+3. **Storage** — all **9 buckets** present (6 migration-created + `avatars`/`marketing-assets`/`place-photos` replicated from dev with matching public flag, size limits, mime types).
+
+## REMAINING (gated — see blockers)
+
+### A. Secrets (98) — BLOCKED on values
+Supabase Management API returns secret **values as hashes**, so dev's values cannot be copied programmatically. Source map:
+- **Have (Key Details):** Stripe LIVE (pk/sk + 8 RAKs), Twilio (5), OneSignal (4), Mapbox, Google Places, Pexels, Paystack (test), Resend key, Gemini-Ari, Ticketmaster, AppsFlyer.
+- **Auto (Supabase sets per-project):** `SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY/DB_URL/JWKS/PUBLISHABLE_KEYS/SECRET_KEYS` → use prod's own.
+- **Derivable config:** `ENVIRONMENT=production`, `MINGLA_PUBLIC_*` URLs, `RESEND_*_FROM`, `*_ALERT_EMAILS`, `PLACES_*` budgets, `MARKETING_SEND_LIVE_ENABLED`, `EVENT_COVER_VIDEO_PROVIDER`, `BUSINESS_WEB_ORIGIN`.
+- **Generate fresh (no data yet):** `UNSUBSCRIBE_TOKEN_SECRET`, `app.qr_token_pepper`.
+- **GAP — need values (≈9):** `CLOUDINARY_API_KEY/SECRET/CLOUD_NAME/URL`, `OPENAI_API_KEY`, `GEMINI_API_KEY` (main), `ANTHROPIC_API_KEY`, `SERPER_API_KEY`, `OPENWEATHER_API_KEY`, `GOOGLE_MAPS_API_KEY`, `GOOGLE_GEOLOCATION_API_KEY`, `LOVABLE_API_KEY`.
+  - **Best single source:** the dev project's `.env` / a `supabase` secrets file inside the OLD `mingla-main` (recoverable from iCloud — same folder that holds the lost skills). Otherwise pull each from its service dashboard.
+- **Also:** `MINGLA_STRIPE_MODE=live` on prod (straight-to-live per operator); load `STRIPE_RAK_*_LIVE` + `STRIPE_SECRET_KEY` (live) + `STRIPE_WEBHOOK_SECRET*` (NEW — see C).
+
+### B. Edge functions (~72) — mechanical, do after secrets
+```bash
+cd ~/Desktop/mingla-main
+# (CLI is already linked to prod ref gupxgpmukdwhozqfmzgd)
+supabase functions deploy --project-ref gupxgpmukdwhozqfmzgd   # or per-function
+```
+Preserve `verify_jwt` per function (CLI reads config.toml). Webhook fns stay `verify_jwt:false`.
+
+### C. Stripe LIVE webhooks — repoint to prod
+Live webhooks currently point at the **dev** ref (`gqnoajqerqhnvulmnyvv`). For prod-live, create 2 live webhook endpoints on `https://gupxgpmukdwhozqfmzgd.supabase.co/functions/v1/stripe-webhook` (Connect: 18 events, Platform: 10 events), then load their NEW signing secrets into prod (`STRIPE_WEBHOOK_SECRET`, `STRIPE_WEBHOOK_SECRET_PLATFORM`).
+
+### D. Auth config — set on prod
+Redirect/allow URLs, SMTP sender, external providers, JWT/site URL → mirror dev's GoTrue config.
+
+### E. App cutover — DELIBERATE LAUNCH STEP (affects live users)
+Point production builds at prod:
+- **Vercel** (mingla-business, marketing, admin): set `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_ANON_KEY` → prod; `MINGLA_STRIPE_MODE=live`; `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_*`. Redeploy.
+- **EAS** (app-mobile, mingla-business): production channel env → prod URL/anon key + pk_live. New build or OTA as appropriate.
+- Do this only after A–D verified on prod; this is the real "go-live" switch.
+
+## Verification checklist (before cutover)
+- [ ] All 98 secrets set on prod (0 gaps).
+- [ ] All edge functions deployed; versions bumped; `verify_jwt` preserved.
+- [ ] Live Stripe webhooks point at prod + signing secrets loaded; test event delivered.
+- [ ] Auth redirect URLs correct.
+- [ ] Smoke: anon checkout (live test card), Ari chat, push, media upload, email.
+- [ ] Security: re-run `get_advisors` on prod; drop dead backup tables there too (they won't exist on a fresh prod — clean by default).
+
+## Notes
+- Dev (`gqnoajqerqhnvulmnyvv`) is **untouched** and remains the test/dev project. CLI is currently linked to prod — relink to dev (`supabase link --project-ref gqnoajqerqhnvulmnyvv`) when returning to dev work.
+- Prod starts with **zero data** (correct for production). No test brands/accounts carried over.

--- a/Mingla_Artifacts/reports/QA_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE_REPORT.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE_REPORT.md
@@ -1,0 +1,292 @@
+# QA — ORCH-1107: Companion-stops + Picnic-grocery off Google onto scored place_pool
+
+**Date:** 2026-06-10 · **Skill:** mingla-tester (Claude) · **Mode:** TARGETED + SPEC-COMPLIANCE
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1107-[companion-picnic-place-pool]/` · **Branch:** `ORCH-1107-companion-picnic-place-pool`
+**Implementor commit under test:** `7eda94e2521c20f977c9180a31fcb7f299f488c7`
+**Tester adversarial-test commit:** `f8a79bac7` (appended on-branch)
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE_ONTO_PLACE_POOL.md` (binding, with SPEC AMENDMENT 1)
+
+---
+
+## 1. Verdict
+
+# FAIL — P0: 0 · P1: 1 · P2: 0 · P3: 1 · P4: 2
+
+The product code change is **correct and complete** — every functional success criterion (de-Google,
+RPC re-source, `imageUrl=stored_photo_urls[0]`, kill Unsplash, graceful-empty on 0-rows AND on
+RPC-error, client untouched) is independently proven, including live RPC-probe runtime evidence and an
+adversarial RPC-error-path test that fails-on-revert. **The single blocker is a CI-gate completeness
+defect (P1):** the implementor's `ORCH_1107_BACKEND_ALLOWLIST` (added at `7eda94e2`) allowlisted only
+its own happy-path test, NOT the tester's mandatory adversarial test under `supabase/functions/__tests__/`.
+As required by the pipeline, that adversarial test is now committed on-branch and in-diff — and the C7
+`no-new-backend-files` gate therefore goes **RED** on the closing diff (gate exit 1, offender =
+`orch_1107_rpc_error_adversarial.test.ts`). The tester cannot edit the gate (it is config/product code,
+append-only applies to test files only). This is a one-line REWORK for the implementor.
+
+Routing: **FAIL → REWORK (implementor)**. Single required fix in §3 (P1). Re-test is mechanical
+(re-run the C7 gate → expect exit 0).
+
+---
+
+## 2. SC-by-SC matrix
+
+SC numbering follows the implementation report's table (which tracks SPEC §"Success criteria" + AMENDMENT 1).
+
+| SC | Criterion | Status | Independent evidence |
+|----|-----------|--------|----------------------|
+| SC-1 | `grep GOOGLE_MAPS_API_KEY` over both fns → zero | **PASS** | Read full diff `git show 7eda94e25` — `const GOOGLE_API_KEY = …` line DELETED from both; no `GOOGLE_MAPS_API_KEY` anywhere in either `index.ts`. |
+| SC-2 | No `googleapis.com` ref in either fn | **PASS** | `batchSearchPlaces` import (the only googleapis path) removed from both; no `googleapis` token in either file. |
+| SC-3 | Both call `query_servable_places_by_signal` | **PASS** | companion `index.ts:172`, picnic `index.ts` `findGroceryStore` — both `supabaseAdmin.rpc("query_servable_places_by_signal", …)`. RPC signature verified live (§5). |
+| SC-4 | companion: `casual_food`, filter 120, radius=maxDistance(500), limit 10, sort signal_score desc, top 1 | **PASS** | `COMPANION_SIGNAL_ID="casual_food"`, `COMPANION_FILTER_MIN=120`, `COMPANION_RPC_LIMIT=10`, `p_radius_m:maxDistance`; sort `Number(b.signal_score)-Number(a.signal_score)` then `.slice(0,1)`. Test CP-01/02; my read of the diff. |
+| SC-5 | picnic: `groceries`, same geo/limit pattern | **PASS** | `GROCERY_SIGNAL_ID="groceries"`, filter 120, limit 10, `p_radius_m:maxDistance`; closest-then-rating preference among already-gated rows. Test GR-01. |
+| SC-6 | Row → existing client shape (id,name,location,address,rating,reviewCount,imageUrl,placeId,type[,types,distance]) | **PASS** | `mapServableRowToCompanionStop` / `mapServableRowToGroceryStore` read in full; field-by-field correct. Test CP-03/GR-02. |
+| SC-7 | `imageUrl = stored_photo_urls[0]`; Unsplash placeholder deleted | **PASS** | `imageUrl: storedPhotos[0] ?? null` in both mappers; no `unsplash` token in either file. fails-on-revert proven (§4). |
+| SC-8 | Removed key read + 500 guard + `batchSearchPlaces` import from both | **PASS** | The `if (!GOOGLE_API_KEY) … 500 "Google Maps API key is not configured"` block DELETED from both; import line gone. |
+| SC-9 | Graceful empty on 0 rows (`strollData:null`/`picnicData:null`), no Google fallback, no throw | **PASS (proven)** | Source: `if (error){return []/null}` + outer `try/catch{return []/null}` + handler `if(!len){strollData:null}` / `if(!store){picnicData:null}`. Runtime: my adversarial test ADV-01..04 drives the RPC-error path end-to-end → graceful 200 + null body + zero Google request (§4). 0-row data condition proven live (§5: unscored-ocean probe → 0 rows). |
+| SC-10 | Client untouched (`stopReplacementService`, `ExpandedCardModal`, `CompanionStopsSection`) | **PASS** | `git diff --name-only origin/main...HEAD` = backend-only; zero `app-mobile/` files. |
+| SC-11 | Happy-path test green + fails-on-revert (hermetic) | **PASS (independently re-run)** | `14 passed \| 0 failed`, zero uncaught, on a clean `env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ANON_KEY` shell. fails-on-revert re-proven by me (§4). |
+| SC-12 | `deno check` clean | **PASS** | `deno check` clean on the adversarial test; implementor reported clean on both `index.ts` (consistent — `deno test` compiled both with no type error). |
+| SC-13 | C7 no-new-backend-files gate passes (allowlist same commit) | **FAIL** | At `7eda94e2` (4 files) the gate passes. But the pipeline REQUIRES the tester adversarial test in-diff; once it is committed (mandatory), C7 goes RED — the allowlist omits it. Gate exit 1, offender `orch_1107_rpc_error_adversarial.test.ts`. See P1 finding §3. |
+
+**Parity note (SC-1..SC-10 apply to Consumer iOS + Consumer Android):** both surfaces consume the SAME two
+edge functions with the client untouched → parity is automatic. Device render of the expand card is
+**operator/data-gated** (requires `place_scores` for the test city via `run-signal-scorer`), correctly
+attributed below as NOT an ORCH-1107 code defect. The data PATH is runtime-proven via the live RPC probe (§5).
+
+---
+
+## 3. Findings
+
+### P1-1 — C7 gate omits the tester's mandatory adversarial test → closing PR CI goes RED
+
+- **Evidence:** `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` `ORCH_1107_BACKEND_ALLOWLIST`
+  (added by the implementor at `7eda94e2`, lines ~1577-1583) lists exactly:
+  `get-companion-stops/index.ts`, `get-picnic-grocery/index.ts`,
+  `__tests__/orch_1107_companion_picnic_place_pool.test.ts`. It does NOT include the tester's adversarial
+  test. The gate computes offenders via `git diff --name-only origin/main...HEAD` (script line ~222).
+  After the required tester test is committed (`f8a79bac7`), running the gate:
+  ```
+  FAIL [C7: no-new-backend-files] … offenders:
+    supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts
+  # 1 failure(s)
+  ```
+  gate exit = 1. The workflow `strict-grep-mingla-business.yml` triggers on `supabase/functions/**`
+  (verified `on.pull_request.paths`) and runs `orch-0863-marketing-hub-phase-b` (verified job, line 1684),
+  so this is a RED required check on the closing PR, not a local-only artifact.
+- **Why the tester cannot self-fix:** the gate is config/product code. The tester's append-only license
+  covers NEW test files only; editing the allowlist is implementor/product work, and the dispatch's HARD
+  GUARD is "if you find a defect, write a P0/P1 finding and return for REWORK — do not fix product code."
+- **Impact:** the merge is blocked by a RED required CI check. The functional change is correct; this is a
+  gate-completeness gap the implementor left when it allowlisted only its own test and not the
+  pipeline-mandatory tester test.
+- **Required fix (implementor, REWORK):** add
+  `"supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts"` to `ORCH_1107_BACKEND_ALLOWLIST`
+  in `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` (same const, one line). Per
+  COMMS-0002 this lands in the backend change set.
+- **Retest:** `node .github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` → exit 0,
+  `# All checks PASS` over the 5-file diff.
+
+### P3-1 — `_shared/placesCache.ts` (`batchSearchPlaces`) is now orphaned
+
+- **Evidence:** after this change no edge function imports `batchSearchPlaces`; only its own definition +
+  the implementor test's negative-grep string reference it.
+- **Impact:** dead shared code (no runtime cost). The SPEC explicitly says do NOT delete the shared helper,
+  so leaving it is correct for this ORCH.
+- **Required fix:** none in 1107. Candidate for a future dead-code-removal ORCH once confirmed
+  program-wide-dead. (Implementor already flagged this in Discoveries — agreed.)
+- **Retest:** n/a.
+
+### P4-1 (praise) — Error tolerance is genuinely two-layered and correct
+
+The de-Google re-source keeps BOTH an `if (error) return []/null` guard AND an outer `try/catch` returning
+the empty value — so neither a PostgREST `{error}` nor a thrown fetch can surface a 500 or trigger a Google
+fallback. My adversarial RPC-error test proves this end-to-end. Clean.
+
+### P4-2 (praise) — Constitution Rule 9 win
+
+The hardcoded Unsplash placeholder (fabricated imagery) is fully removed; `imageUrl` is now a real
+`stored_photo_urls[0]` or honest `null`. This is exactly the "missing is hidden, never faked" principle.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof (hashes cited)
+
+**Checked out / ran on:** worktree HEAD `7eda94e2521c20f977c9180a31fcb7f299f488c7` (product files), test file
+`orch_1107_companion_picnic_place_pool.test.ts` at that commit.
+
+1. **Baseline (clean env), implementor happy-path test, re-run by me:**
+   `env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ANON_KEY deno test --allow-all <happy-path>`
+   → **`ok | 14 passed | 0 failed (8ms)`**, ZERO uncaught. (The REWORK hermeticity fix holds — no
+   `supabaseUrl is required` throw.)
+2. **Revert applied by me** (true line-edit, product file): in `get-companion-stops/index.ts`
+   `mapServableRowToCompanionStop`, `imageUrl: storedPhotos[0] ?? null` → `…?? "https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=800&q=80"`.
+   Re-run → **`FAILED | 12 passed | 2 failed`**: **CP-04** ("no-stored-photos yields null imageUrl, no
+   fabricated placeholder") and **NG-01** ("companion-stops has ZERO Google references" — the source-grep
+   catches the `unsplash` token) FAIL. Matches the implementor's claim exactly.
+3. **Restored** from backup → `git diff --quiet` confirms byte-identical to HEAD → re-run → **`14 passed | 0 failed`**.
+
+Implementor fails-on-revert: **independently confirmed at `7eda94e2`.**
+
+---
+
+## 5. Adversarial test added (tester-owned, RPC-ERROR angle)
+
+- **Path:** `supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts`
+- **Commit:** `f8a79bac7` (appended on `ORCH-1107-companion-picnic-place-pool`; in
+  `git diff --name-only origin/main...HEAD`).
+- **Different angle (vs implementor's param-building + row-mapping + 0-row source-grep):** the **RPC-ERROR
+  path**. It stands up a local HTTP mock, points `SUPABASE_URL` at it BEFORE the SUT dynamic-imports, and
+  replies with a PostgREST-shaped HTTP 500 so the REAL `@supabase/supabase-js` client resolves
+  `.rpc()` to `{ data: null, error: {...} }`. The exported `handleRequest` is then driven with a valid
+  anchor/picnic, exercising each edge function's `if (error)` branch **end-to-end over a real (mocked)
+  network round-trip** — not a re-implementation. It records every request path the SUT makes to prove no
+  Google fallback fires.
+- **Assertions (5 tests, all green — `5 passed | 0 failed`, also `19 passed | 0 failed` combined with the
+  implementor suite, clean env):**
+  - ADV-01/02: companion/picnic RPC-error → HTTP **200** (NOT a thrown 500), body `strollData:null` /
+    `picnicData:null`, **zero** `googleapis|maps|searchNearby` request, and the RPC WAS attempted.
+  - ADV-03/04: error-path body carries the empty marker and leaks no `unsplash` / `googleapis` artifact.
+- **Hermetic:** sets its own dummy `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`/`ORCH_TEST_NO_SERVE` and
+  dynamic-imports; passes under `env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ANON_KEY`.
+  `deno check` clean. NOT a renamed copy of the implementor's test.
+- **fails-on-revert verified at `7eda94e2` product base:** I removed the companion error-tolerance (replaced
+  `if (error){…return []}` with `throw new Error(error.message)` and the outer catch's `return []` with
+  `throw error`). Re-run → **`FAILED | 3 passed | 2 failed`**: **ADV-01** (now gets a 500, not graceful 200)
+  and **ADV-03** FAIL. Restored → `git diff --quiet` clean → **`5 passed | 0 failed`**. The test is
+  load-bearing on the exact error-tolerance contract.
+
+**Both regression tests appear in the closing diff** (`git diff --name-only origin/main...HEAD`):
+`…/orch_1107_companion_picnic_place_pool.test.ts` AND `…/orch_1107_rpc_error_adversarial.test.ts`.
+
+---
+
+## 6. Live RPC-probe runtime evidence (populated data path) + graceful-empty proof
+
+Read-only via `mcp__supabase__execute_sql` against prod `gqnoajqerqhnvulmnyvv`.
+
+**RPC signature (verified, matches SPEC AMENDMENT 1):**
+`query_servable_places_by_signal(p_signal_id text, p_filter_min numeric, p_lat double precision, p_lng double precision, p_radius_m double precision, p_exclude_place_ids uuid[], p_limit integer)`.
+
+**Coverage of scored, servable, photo'd rows (`score>=120`, `is_servable`, `is_active`, photos>0):**
+- `casual_food`: **5,245** rows (21,099 scored total) — far more than the dispatch's "~32"; densest tile
+  Raleigh NC (35.78,-78.64) = 31, matching the dispatch reference.
+- `groceries`: **240** rows (16,307 scored total) — present but much sparser.
+
+**Companion path probe** — `query_servable_places_by_signal('casual_food', 120, 35.7777, -78.6396, 1500, '{}', 10)`
+→ **10 rows**, ALL with non-empty real `stored_photo_urls` (5 each, `…/storage/v1/object/public/place-photos/…`,
+NOT Unsplash), sorted by `signal_score` desc (top: Sam Jones BBQ 194 / A Place at the Table 194 / Benchwarmers Bagels 194).
+→ proves `findCompanionStops` returns mappable rows; `mapServableRowToCompanionStop(row[0])` →
+`{name:"Sam Jones BBQ", imageUrl:"https://gqnoajqerqhnvulmnyvv.supabase.co/.../0.jpg", rating:4.4, …}`.
+
+**Picnic path probe** — `query_servable_places_by_signal('groceries', 120, 35.7365, -78.7803, 5000, '{}', 10)`
+→ **10 rows** (Trader Joe's 194, Whole Foods 194, Harris Teeter ×5, Walmart, Grand Asia Market, Lowes Foods),
+ALL with non-empty real `stored_photo_urls` (5 each), `signal_score`-ordered. → proves
+`mapServableRowToGroceryStore` returns the picnic shape with real `imageUrl` + numeric distance.
+
+**Graceful-empty data condition proven live** — same RPC at an unscored coordinate (0.0, -30.0 mid-ocean):
+`casual_food` → **0 rows**, `groceries` → **0 rows**. → in an unscored city the RPC returns 0 → companion
+`return []` → `strollData:null`; picnic `return null` → `picnicData:null`. **Graceful-empty path is sound.**
+
+**Populated DEVICE render — correctly attributed to operator data population, NOT a 1107 code defect.**
+A populated Take-a-Stroll / Picnic expand-card RENDER on a real device requires `place_scores` populated for
+the test city via `run-signal-scorer` (operator / COMMS-0018-owned; overlaps META-ORCH-1062's scorer-invoke
+fix). In unscored cities the CORRECT behavior is graceful-empty (proven above). I did NOT fake a populated
+render; the data PATH is runtime-proven by the two live probes (real rows with real photos exist and the
+mappers consume them correctly). Per SPEC AMENDMENT 1 operational note, 1107 ships correct code; data
+population is separate.
+
+---
+
+## 7. Constitution 14-rule matrix (re-checked against the diff independently)
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | N/A | No UI change; client untouched (SC-10). |
+| 2 | One owner per truth | PASS | place_pool/place_scores remain the single source; these fns are read-only consumers of the RPC. |
+| 3 | No silent failures | PASS | RPC error logs `console.error` and returns the DELIBERATE graceful-empty product contract (SC-9) — not a swallowed error masquerading as user success; the contract IS "no stop available → null body", a designed UX, not a hidden failure. |
+| 4 | One query key per entity | N/A | Backend edge fns; no React Query keys. |
+| 5 | Server state stays server-side | PASS | No Zustand/client-state touched. |
+| 6 | Logout clears everything | N/A | No auth/session state. |
+| 7 | Label `[TRANSITIONAL]` + exit | PASS | No transitional code. `ORCH_TEST_NO_SERVE` is a permanent, production-inert test seam (never set in prod), not transitional debt. |
+| 8 | Subtract before adding | PASS | Google path fully removed (key/guard/import/Unsplash) as part of the change, not layered on top. |
+| 9 | No fabricated data | PASS (headline) | Unsplash placeholder DELETED; `imageUrl = stored_photo_urls[0] ?? null` — real photo or honest null. fails-on-revert enforces it. |
+| 10 | Currency-aware | N/A | No price/currency rendering added (grep `+.*GBP/currency/priceGbp` → none). |
+| 11 | One auth instance | PASS | Reuses the single module-level `supabaseAdmin` service-role client; no new auth instance; `verify_jwt` posture unchanged (deployed v290/v288 both `verify_jwt=true`). |
+| 12 | Validate at the right time | N/A | No datetime logic. |
+| 13 | Exclusion consistency | PASS | RPC's `p_exclude_place_ids` defaulted `'{}'`; gating (is_servable/score/photos/radius) is enforced uniformly inside the RPC, identical to discover-cards. |
+| 14 | Persisted-state startup gate | N/A | No persisted client state. |
+
+No constitutional violation. (The C7 gate failure in §3 is a CI-completeness defect, not one of the 14
+engineering principles.)
+
+---
+
+## 8. Device / parity matrix
+
+| Surface | Status | Detail |
+|---------|--------|--------|
+| Consumer iOS | PASS (code+data-path proven; device render data-gated) | Shared edge fns; client untouched. Data path runtime-proven via live RPC probe (§6). Populated on-device render requires scorer-populated city (operator-owned) — correctly out of 1107 code scope. |
+| Consumer Android | PASS (automatic parity) | Same shared backend, client untouched. No platform-specific code. |
+| Buyer/anonymous Web | N/A | Consumer deck-expand path only; not a buyer-web route. |
+| Business iOS | N/A | Not a business surface. |
+| Business Android | N/A | Not a business surface. |
+| Admin Web (adjacent) | N/A | No admin code touched. |
+| Business Web preview (adjacent) | N/A | No business code touched. |
+
+**Physical-iPhone HITL:** not requested for this backend-only re-source; a populated expand-card render is
+data-gated on `run-signal-scorer` for the test city (operator-owned), so a HITL render now would correctly
+show graceful-empty in an unscored city and would not exercise the new mapping. Deferred to post-merge +
+post-scorer; not a blocker for this code change.
+
+**Live deploy state (read-only):** `get-companion-stops` v290, `get-picnic-grocery` v288 — both ACTIVE,
+`verify_jwt=true`. These are the PRE-merge Google-era versions; the new RPC code is NOT yet deployed
+(correct — deploy is operator-owned from MERGED main post-merge, per impl report §11 + COMMS-0018).
+
+---
+
+## 9. Comms ledger (read on entry)
+
+Read `COMMS_LEDGER.md`. Relevant rows are both **WARN** (not BLOCK), factored:
+- **COMMS-0002** (C7 `no-new-backend-files` gate blocks backend PRs unless allowlisted) — directly
+  materialized here as **P1-1**: the gate fails on the new test file. Factored.
+- **COMMS-0018** (place_scores population / scorer-invoke is operator/data-owned; deploy only from merged
+  main) — confirms the graceful-empty-in-unscored-cities framing and that the populated device render is a
+  data-population task, NOT a 1107 code defect. Factored.
+
+No new cross-ORCH discovery beyond what COMMS-0002/0018 already cover → no new COMMS entry written.
+
+---
+
+## 10. Discoveries for Orchestrator
+
+1. **C7 allowlist must include the tester's adversarial test** (the P1). General pattern: when an ORCH that
+   touches `supabase/functions/**` will receive a tester adversarial test under `__tests__/`, the
+   `*_BACKEND_ALLOWLIST` must anticipate BOTH the implementor test AND the tester test — otherwise the
+   tester's mandatory, in-diff test predictably RED-lights C7. Recommend the implementor add the tester
+   test path proactively, or the orchestrator pre-allowlists the known tester filename at spec time.
+2. **`_shared/placesCache.ts` is now orphaned** (no edge-function importer). Candidate for a future
+   dead-code-removal ORCH (impl flagged it too; SPEC said keep the shared helper, so untouched here).
+3. **Scorer coverage is far broader than the spec assumed** — `casual_food` has 5,245 servable/scored/photo'd
+   rows (densest in Raleigh NC, not NYC), `groceries` 240. So Take-a-Stroll will already return real stops in
+   well-scored metros (Raleigh, etc.) on first deploy; Picnic will be sparser. Informational for the
+   operator's post-merge `run-signal-scorer` planning.
+
+---
+
+## 11. Accepted conditions
+
+None (verdict is FAIL, not CONDITIONAL PASS). The single P1 is a mechanical, well-understood REWORK; the
+functional change is otherwise fully verified.
+
+---
+
+## Handoff
+
+Route to **mingla-orchestrator** → **REWORK (implementor)** for the single P1: add
+`"supabase/functions/__tests__/orch_1107_rpc_error_adversarial.test.ts"` to `ORCH_1107_BACKEND_ALLOWLIST` in
+`.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` (one line, COMMS-0002), then re-run the C7
+gate (expect exit 0). All functional success criteria, both regression tests (with independent
+fails-on-revert), the live RPC populated-path probe, and the graceful-empty path are already PROVEN — the
+re-test after the allowlist fix is purely the gate. Working tree:
+`~/Desktop/mingla-orchs/ORCH-1107-[companion-picnic-place-pool]/` on branch
+`ORCH-1107-companion-picnic-place-pool` (tester test at `f8a79bac7`, product code at `7eda94e2`).

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE_ONTO_PLACE_POOL.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1107_COMPANION_PICNIC_OFF_GOOGLE_ONTO_PLACE_POOL.md
@@ -1,0 +1,50 @@
+# SPEC — ORCH-1107: Companion-stops + Picnic-grocery off Google onto scored place_pool
+
+**Date:** 2026-06-10 · **Owner:** Claude `mingla-orchestrator` · **Operator directive:** "remove it. Nothing must use Google… companion stops should use the scored pipeline we already have and every other curated intent uses." (Scope confirmed = Bucket A only.)
+
+## Problem (proven)
+`get-companion-stops` (Take a Stroll) and `get-picnic-grocery` (Picnic Dates) both call `batchSearchPlaces` (`_shared/placesCache.ts`) → **live Google Places `searchNearby`** (`places.googleapis.com/v1/places:searchNearby`), reading `GOOGLE_MAPS_API_KEY`. They make ~1 call per companion type (≈9 per expansion), do **no** `place_pool` read (the "cache" is vestigial: `cacheHits` hardcoded 0, `ttlHours` unused), and return raw Google results (companion-stops even hardcodes an Unsplash placeholder image). This bypasses the scored intelligence pipeline and is the only consumer-runtime Google dependency.
+
+## Target pattern (already exists)
+Every other curated intent serves stops via `fetchSinglesForSignalRank` (`_shared/signalRankFetch.ts`) → RPC **`fetch_local_signal_ranked`**, which enforces the three serving gates: G1 `is_servable=true`, G2 `signal score >= filter_min`, G3 real `stored_photo_urls`. Params: `{ filterSignal, filterMin, rankSignal, centerLat, centerLng, radiusMeters, limit, requiredTypes }`. `replace-curated-stop` already uses this path.
+
+## Change (both edge functions)
+1. Replace `batchSearchPlaces(...Google...)` with `fetchSinglesForSignalRank(supabaseAdmin, {...})`:
+   - `centerLat/centerLng` = anchor location; `radiusMeters` = `maxDistance` (companion default 500m; picnic per its current value).
+   - `requiredTypes` = companion types (`bakery, cafe, ice_cream_shop, meal_takeaway, deli, grocery_store, convenience_store, supermarket, food_store`) for companion; picnic = its grocery/park set.
+   - `rankSignal` / `filterSignal` = the signal these intents already map to in `signalRankFetch` (Take-a-Stroll → `scenic`; Picnic → `picnic_friendly`) — choose the companion-appropriate one (likely a casual/food signal; confirm against the rank-signal allowlist).
+   - `limit` small (companion returns top 1; fetch ~5 and pick best).
+2. Map `SignalRankResult` → the existing response shape (id, name, location, address, rating, reviewCount, imageUrl from real `stored_photo_urls[0]` — **kill the Unsplash placeholder**).
+3. **Remove** `GOOGLE_MAPS_API_KEY` read + the 500 "Google Maps API key not configured" guard from both functions.
+4. Leave the client (`stopReplacementService`, `ExpandedCardModal.fetchStrollData/fetchPicnicData`, `CompanionStopsSection`) unchanged — same contract, new source.
+
+## Success criteria
+- `grep GOOGLE_MAPS_API_KEY supabase/functions/get-companion-stops supabase/functions/get-picnic-grocery` → **zero**.
+- Both functions call `fetch_local_signal_ranked` (directly or via `fetchSinglesForSignalRank`); no `googleapis.com` reference remains in either.
+- Take-a-Stroll + Picnic cards still render a companion/grocery spot on expand (device-verified iOS + Android), now sourced from servable, scored, real-photo place_pool rows.
+- Regression test: happy-path (companion returned from place_pool for an anchor with nearby servable food places) + adversarial (anchor with no nearby servable companion → graceful empty, no Google fallback, no crash).
+
+## Out of scope
+Buckets B (seeding pipeline), C (Gemini/Ari), D (Google login / Firebase push / map links) — operator deferred. Seeding pipeline remains the legitimate Google→place_pool ingestion.
+
+---
+
+## SPEC AMENDMENT 1 (2026-06-10, orchestrator — SUPERSEDES §8-9 RPC choice)
+
+**Investigated correction.** §8 named `fetch_local_signal_ranked` / `fetchSinglesForSignalRank`. Live probing proved that RPC returns ~0 rows for the launch cities (it gates on `place_scores`, which is the canonical deterministic+AI **blend** written by `run-signal-scorer`, currently sparse for NY/Paris/etc. because the scorer hasn't been run there). The **live solo-deck RPC** `query_servable_places_by_signal` is the correct, simpler path and is what `discover-cards` itself uses. USE IT.
+
+**RPC contract (verified signature):**
+`query_servable_places_by_signal(p_signal_id text, p_filter_min numeric, p_lat double precision, p_lng double precision, p_radius_m double precision, p_exclude_place_ids uuid[] DEFAULT '{}', p_limit integer DEFAULT 20)` → returns `place_id, google_place_id, name, address, lat, lng, rating, review_count, price_level, price_range_start_cents, price_range_end_cents, opening_hours, website, photos, stored_photo_urls, types, primary_type, signal_score, …`. It already enforces G1 `is_servable` + `is_active`, G2 `place_scores.score >= p_filter_min`, G3 real `stored_photo_urls`, and a haversine radius — so the three serving gates come for free.
+
+**Per-function call:**
+- `get-companion-stops`: `p_signal_id='casual_food'`, `p_lat/p_lng` = anchor, `p_radius_m` = `maxDistance` (default 500), `p_filter_min=120`, `p_limit=10`; sort by `signal_score` desc, take top 1.
+- `get-picnic-grocery`: `p_signal_id='groceries'`, same geo/limit pattern.
+Map the returned row → the existing response shape; `imageUrl = stored_photo_urls[0]` (KILL the Unsplash placeholder). Graceful empty (`strollData:null` / no grocery) when the RPC returns 0 rows — NO Google fallback, no throw.
+
+**Operational note (NOT a code defect, NOT in 1107 scope):** companion/picnic will return results in a city only AFTER `run-signal-scorer` has populated `place_scores` for that city. That is Seth's operational task (and overlaps META-ORCH-1062 / COMMS-0018's scorer-invoke fix). 1107 ships the correct code; data population is separate.
+
+**Success-criteria update:** replace "calls `fetch_local_signal_ranked`" with "calls `query_servable_places_by_signal`"; the zero-`GOOGLE_MAPS_API_KEY` / zero-`googleapis.com` criteria stand.
+
+**COMMS-0002 factor:** ORCH-1107 edits EXISTING edge functions (no NEW backend files, no migration), so the ORCH-0863 C7 `no-new-backend-files` gate should not trip — but if CI flags it, add an `ORCH_1107_BACKEND_ALLOWLIST` entry in `.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs` in the SAME commit.
+
+**Affected Surfaces:** iOS-consumer + Android-consumer (Take-a-Stroll / Picnic-Dates card expand), backend (2 edge functions). NOT business app, admin, or buyer-web.

--- a/Mingla_Roadmap/living/MINGLA_CANONICAL_VOICE_AND_SCRIPTS.md
+++ b/Mingla_Roadmap/living/MINGLA_CANONICAL_VOICE_AND_SCRIPTS.md
@@ -1,0 +1,119 @@
+# Mingla — Canonical Voice & What Mingla Does (VERBATIM, DO NOT EDIT)
+
+**Status:** Canonical tone reference + canonical "what Mingla does." Operator-provided, saved verbatim 2026-06-10.
+**Owners/anchors:** `mingla-product` (marketing copywriting + positioning), `mingla-designer` (copy-as-personality layer). Any external-facing copy, positioning, App Store/Play text, release notes, push, or brand voice MUST anchor to the tone and the "what Mingla does" framing below. **Do not paraphrase or rewrite these scripts** — they are the source of truth for voice.
+
+**One-line positioning:** Mingla is the vibe-to-plan decision engine for consumers + the AI growth OS for venues and experience brands. Consumer tagline: *"Find the plan that fits the vibe."* Brand close: *"Find the plan. Feel the city. Show up."*
+
+---
+
+## 1. Mingla Consumer App Script
+“Less Planning. More Living.”
+Tone: warm, cinematic, intimate
+Audience: explorers, couples, friend groups, people who want to go out but hate deciding
+Length: about 75 seconds
+SCRIPT
+There are so many beautiful places around us.
+Little restaurants people walk past every day.
+Hidden cafés.
+Rooftops with the perfect view.
+Bars where the music feels just right.
+Events you would have loved… if only you had known they existed.
+But somehow, finding something to do has become exhausting.
+We scroll.
+We search.
+We ask the group chat.
+We send links back and forth.
+We say, “I’m down for whatever,” even though nobody really knows what “whatever” means.
+And before you know it, the plan dies before it ever becomes a memory.
+That’s why we built Mingla.
+Mingla helps you find places, events, date ideas, and city gems that actually fit the vibe — whether it’s a first date, a night out with friends, a solo reset, or just one of those days where you want to feel more connected to the world around you.
+Because we believe life gets better when people spend less time figuring out what to do…
+…and more time showing up.
+Showing up for the person across the table.
+Showing up for your friends.
+Showing up for your city.
+Showing up for the little moments that become stories later.
+Mingla is not just about finding a place.
+It’s about making it easier to say yes to real life.
+Less searching.
+Less overthinking.
+Less “what are we doing tonight?”
+More discovery.
+More connection.
+More reasons to go.
+Mingla.
+Find the plan that fits the vibe.
+
+## 2. Mingla Business Script
+“Your Place Deserves to Be Found.”
+Tone: empathetic, founder-led, pro-local-business
+Audience: restaurants, bars, venues, cafés, activity spaces, event organizers
+Length: about 75–90 seconds
+SCRIPT
+Every local business has something that makes it special.
+Maybe it’s the dish people keep coming back for.
+The cocktail only your bartender knows how to make.
+The room that feels perfect on a Friday night.
+The owner who remembers everyone’s name.
+The events, the atmosphere, the little details that make your place more than just a location on a map.
+But too often, the businesses with the most soul are the hardest for people to discover.
+Not because they aren’t special.
+Not because people wouldn’t love them.
+But because attention is scattered, algorithms are crowded, and running a business already takes everything you have.
+You shouldn’t need to become a full-time marketer just to help your community understand why your place matters.
+That’s why we built Mingla Business.
+Mingla gives restaurants, bars, venues, cafés, creators, and local experience brands the tools to showcase what makes them different — their events, menus, offers, parties, atmosphere, and story.
+And then we help connect that story with people nearby who are actually looking for a place like yours.
+People planning dates.
+Friend groups looking for somewhere to go.
+Locals searching for something new.
+Communities wanting to gather in real life again.
+Because we believe local businesses are not just businesses.
+They are where birthdays happen.
+Where first dates turn into relationships.
+Where friendships get stronger.
+Where neighborhoods become neighborhoods.
+Mingla Business exists to help more people find those places — and help those places grow.
+Your business has a vibe.
+Your community is looking for it.
+Mingla helps them find you.
+
+## 3. Mingla Brand Manifesto Script
+“Real Life Is Still the Point.”
+Tone: emotional, mission-driven, best for launch/founder video
+Audience: consumers, businesses, investors, community
+Length: about 90 seconds
+SCRIPT
+At Mingla, we believe real life is still the point.
+Not the endless scrolling.
+Not the group chat that goes nowhere.
+Not the hours spent comparing reviews, saving videos, checking maps, and trying to figure out what everyone might like.
+The point is the dinner.
+The walk after.
+The laugh you didn’t expect.
+The friend you finally made time for.
+The local spot you never would have found on your own.
+The business owner watching new people walk through the door and realize, “This place is special.”
+We built Mingla because planning should not be the thing that gets in the way of connection.
+People should not have to work so hard just to spend time with the people they love.
+And local businesses should not have to fight so hard to be seen by the communities they serve.
+So Mingla brings both sides together.
+For explorers, Mingla helps you find date ideas, restaurants, bars, events, activities, and city gems that match your vibe — so you can stop overthinking and start going.
+For businesses, Mingla gives you tools to showcase what makes you special — your space, your menu, your events, your story — so the right people can discover you, support you, and come back.
+Because when people go out more, relationships get stronger.
+When local gems get discovered, neighborhoods get better.
+When planning becomes easier, showing up becomes natural.
+And when we show up — for our friends, our partners, our cities, and the people building something in them — the world feels a little less disconnected.
+That is what drives us.
+Not just more clicks.
+Not just more listings.
+Not just another app.
+More real plans.
+More local discovery.
+More people around tables.
+More businesses with full rooms.
+More moments that remind us we are human.
+Mingla exists to make real life easier to find.
+Mingla.
+Find the plan. Feel the city. Show up.


### PR DESCRIPTION
Docs-only. Persists the ORCH-1107 close note + spec + impl/QA reports, the production-readiness audit, the prod-Supabase runbook, the canonical voice/scripts doc, and an INVARIANT_REGISTRY update that were living only in the local working tree after the iCloud-recovery session. No product code, no migration, no Vercel surface.