### PR TITLE
ORCH-1108 close docs: prod secret manifest + investigations + COMMS-0023 (1108 collision)

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1108_DELETE_DEAD_FUNCTIONS.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1108_DELETE_DEAD_FUNCTIONS.md
@@ -1,0 +1,160 @@
+# IMPLEMENTATION — ORCH-1108 [delete 3 confirmed-dead AI edge functions]
+
+**Branch:** `ORCH-1108-delete-dead-ai-functions`
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1108-[delete-dead-ai-functions]/`
+**Commit:** `7103b2826`
+**Status:** implemented and verified. Backend-only deletion. NOT deployed / merged / closed — routes back to orchestrator for REVIEW (orchestrator undeploys the 3 functions at close).
+
+---
+
+## 1. Summary
+
+Deleted three dead AI edge-function directories that forensics proved have ZERO invokers anywhere (no client `functions.invoke`, no edge-to-edge call, no cron). Removed the single matching `[functions.ai-reason]` block from `supabase/config.toml`. Kept the shared helper `photoAestheticEnums.ts` — it is NOT orphaned (still imported by a live function). Added a Deno regression test (green, fails-on-revert proven). Touched nothing else; no functional code in other functions was rewritten.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| # | Criterion | Result | Evidence (commit `7103b2826`) |
+|---|-----------|--------|-------------------------------|
+| SC-1 | `generate-ai-summary/`, `ai-reason/`, `score-place-photo-aesthetics/` dirs deleted entirely | ✓ | `ls supabase/functions/ \| grep -E '...'` → empty; `git diff origin/main...HEAD` shows the 3 `index.ts` as `D` |
+| SC-2 | `[functions.ai-reason]` block removed from `config.toml`; no `generate-ai-summary` / `score-place-photo-aesthetics` blocks existed | ✓ | Only `[functions.ai-reason]` was present (lines 6–7); removed. `grep -nE 'functions\.(generate-ai-summary\|ai-reason\|score-place-photo-aesthetics)' supabase/config.toml` → NONE |
+| SC-3 | `photoAestheticEnums.ts` handled correctly (delete-if-orphaned / keep-with-reason) | ✓ | KEPT — `run-place-intelligence-trial/index.ts:25` still imports `computeCostUsdGemini` + `MINGLA_SIGNAL_IDS` from it. See §3 verdict. |
+| SC-4 | No functional code in other functions rewritten; historical comments left intact | ✓ | Only deletions + config block + new test staged. Comments in `admin-seed-places`, `run-place-intelligence-trial`, migration COMMENTs untouched. |
+| SC-5 | Regression test green with fails-on-revert proof | ✓ | 3/3 pass; fails-on-revert verified at `7103b2826` (see §6) |
+| SC-6 | Nothing else touched | ✓ | `git diff origin/main...HEAD --name-status` = exactly 5 paths (1 M config, 1 A test, 3 D index.ts) |
+
+---
+
+## 3. `photoAestheticEnums.ts` verdict: **KEEP** (NOT orphaned)
+
+`grep -rnE "photoAestheticEnums" app-mobile mingla-business mingla-admin supabase` returned three hits:
+
+1. `supabase/functions/score-place-photo-aesthetics/index.ts:29` — `import { ... } from "../_shared/photoAestheticEnums.ts"` → **this is the deleted file**.
+2. `supabase/functions/run-place-intelligence-trial/index.ts:25` — `import { computeCostUsdGemini, MINGLA_SIGNAL_IDS } from "../_shared/photoAestheticEnums.ts"` → **a REMAINING, live function actively importing it**.
+3. `mingla-admin/src/constants/placeIntelligenceTrial.js:4` — a code COMMENT referencing the path (`// supabase/functions/_shared/photoAestheticEnums.ts::MINGLA_SIGNAL_IDS`), not an import.
+
+Because `run-place-intelligence-trial` still statically imports two symbols from it, the helper is NOT orphaned. Deleting it would break a live function. **Verdict: KEEP `photoAestheticEnums.ts`.**
+
+---
+
+## 4. Data-model changes applied
+
+None. Backend-only deletion; no migration, no schema/RLS change.
+
+---
+
+## 5. Edge functions touched
+
+| Function | Change | `verify_jwt` to preserve |
+|----------|--------|--------------------------|
+| `generate-ai-summary` | **DELETED** | n/a (was unconfigured in config.toml; default applied) |
+| `ai-reason` | **DELETED** + config block removed | n/a (deleted) |
+| `score-place-photo-aesthetics` | **DELETED** | n/a (was unconfigured in config.toml; default applied) |
+
+**Orchestrator/operator action at close:** undeploy the 3 functions from the live project (the implementor does NOT deploy/undeploy). No remaining function's `verify_jwt` changed.
+
+`ANTHROPIC_API_KEY`: the only active consumer was `score-place-photo-aesthetics`; deleting it removes the live ref. The remaining hit (`run-place-intelligence-trial/index.ts:652`) is a comment noting the key is no longer required.
+
+---
+
+## 6. Regression tests added
+
+**Path:** `supabase/functions/__tests__/orch_1108_dead_functions_removed.test.ts`
+**Cases (3):**
+- (a) the 3 function directories do NOT exist on disk;
+- (b) grep across `app-mobile` / `mingla-business` / `mingla-admin` / `supabase/functions` finds ZERO `functions.invoke("<name>")` (quote-flavor agnostic) and ZERO fetch/URL to `/functions/v1/<name>`;
+- (c) guard: `config.toml` declares no `[functions.<dead>]` block.
+
+Historical comments that merely mention the names are explicitly NOT matched (only `.invoke("<name>")` / `/functions/v1/<name>` patterns).
+
+**Passing run (committed state, `7103b2826`):**
+```
+ORCH-1108 (a): the 3 dead function directories are deleted ... ok (0ms)
+ORCH-1108 (b): zero invoke/fetch callers across the four roots ... ok (236ms)
+ORCH-1108 (c): config.toml has no block for any deleted function ... ok (0ms)
+ok | 3 passed | 0 failed (240ms)
+```
+
+**fails-on-revert verified at `7103b2826`:** restored one deleted dir via
+`git checkout origin/main -- supabase/functions/ai-reason`, re-ran →
+```
+ORCH-1108 (a): ... FAILED
+AssertionError: Dead function dir still exists: supabase/functions/ai-reason
+FAILED | 2 passed | 1 failed
+```
+Then `git rm -r supabase/functions/ai-reason` and re-ran → 3 passed / 0 failed (green restored). This is a true file restoration (not a comment-out), so the proof is real.
+
+Test command:
+```
+/Users/sethogieva/.deno/bin/deno test --allow-read --allow-env \
+  supabase/functions/__tests__/orch_1108_dead_functions_removed.test.ts
+```
+
+---
+
+## 7. Old → New receipts
+
+### supabase/functions/generate-ai-summary/index.ts (DELETED)
+**Before:** dead edge function (zero invokers). **Now:** removed. **Why:** SC-1, forensics-confirmed dead. **Lines:** whole dir removed.
+
+### supabase/functions/ai-reason/index.ts (DELETED)
+**Before:** dead edge function (zero invokers). **Now:** removed. **Why:** SC-1. **Lines:** whole dir removed.
+
+### supabase/functions/score-place-photo-aesthetics/index.ts (DELETED)
+**Before:** dead edge function, superseded by the Gemini intelligence-trial; sole live consumer of `ANTHROPIC_API_KEY`. **Now:** removed. **Why:** SC-1. **Lines:** whole dir removed.
+
+### supabase/config.toml (MODIFIED)
+**Before:** declared `[functions.ai-reason] verify_jwt = true` (lines 6–7). **Now:** that block removed; rest of the file intact. **Why:** SC-2 (config for a deleted function). **Lines:** −4 (block + surrounding blank line).
+
+### supabase/functions/__tests__/orch_1108_dead_functions_removed.test.ts (ADDED)
+**Before:** n/a. **Now:** Deno regression test (3 cases). **Why:** SC-5, implementor-owned happy-path regression. **Lines:** +~210.
+
+---
+
+## 8. Cross-surface impact table
+
+| Surface | Affected? | Reason |
+|---------|-----------|--------|
+| Consumer iOS | No | The 3 functions had zero callers in `app-mobile`. |
+| Consumer Android | No | Same shared RN codebase; zero callers. |
+| Buyer/anonymous Web | No | No invoke/fetch refs in `mingla-business`. |
+| Business iOS | No | No invoke/fetch refs in `mingla-business`. |
+| Business Android | No | Same. |
+| Admin Web (adjacent) | No | `mingla-admin` has only a path COMMENT, no import/caller. |
+| Business Web preview (adjacent) | No | Same `mingla-business` codebase; zero callers. |
+
+Pure backend deletion of unused functions — no end-user surface changes. Parity is automatic (nothing rendered).
+
+---
+
+## 9. Smoke result
+
+No sim/device smoke — backend-only, no user-touchable change. Verification was via Deno test + greps:
+- `ls supabase/functions/ | grep -E 'generate-ai-summary|ai-reason|score-place-photo-aesthetics'` → empty.
+- `grep -rnE "generate-ai-summary|ai-reason|score-place-photo-aesthetics" app-mobile mingla-business mingla-admin supabase/functions | grep -iE "invoke|functions/v1|fetch"` → NONE.
+- `grep -rlE "generate-ai-summary|ai-reason|score-place-photo-aesthetics" .github/` → NONE (no CI gate/workflow references them; deletion won't break CI).
+- Relevant strict-grep gates run green: `regression-test-backfill-warning.mjs` (no in-scope source modified), `i-ai-signal-scores-column-sole-owner.mjs` (OK, 1494 files), `i-consumer-reads-ai-signal-scores-not-trial-table.mjs` (OK).
+- `deno check` on the new test → clean.
+
+---
+
+## 10. Known issues / deferred
+
+None. No `[TRANSITIONAL]` code introduced.
+
+---
+
+## 11. Operator action required
+
+- **No migration** (none written).
+- **Undeploy (orchestrator/operator, from MERGED main at close):** `generate-ai-summary`, `ai-reason`, `score-place-photo-aesthetics`. The implementor does not deploy/undeploy.
+- **Do NOT remove `ANTHROPIC_API_KEY` blindly here** — out of ORCH-1108 scope; the live consumer is now gone, but key teardown (if desired) is a separate decision. Flagged only for awareness.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- `ANTHROPIC_API_KEY` now has zero active consumers in `supabase/functions/` (only a comment remains in `run-place-intelligence-trial/index.ts:652`). If the orchestrator wants the secret removed from the project env, that's a separate small task — NOT done here (out of scope).
+- `mingla-admin/src/constants/placeIntelligenceTrial.js:4` carries a doc-comment path reference to `_shared/photoAestheticEnums.ts`; harmless, left intact.
+- Comms ledger: no OPEN BLOCK/WARN entry addressed to `implementor`, `ORCH-1108`, or `ALL` required action this turn. No new COMMS entry written (no cross-ORCH discovery).

--- a/Mingla_Artifacts/reports/INVESTIGATE_OPENAI_ANTHROPIC_DEPRECATION_AND_LOGO.md
+++ b/Mingla_Artifacts/reports/INVESTIGATE_OPENAI_ANTHROPIC_DEPRECATION_AND_LOGO.md
@@ -1,0 +1,94 @@
+# INVESTIGATE — OpenAI/Anthropic edge-function deprecation safety + real email-logo URL
+
+**Mode:** INVESTIGATE (read-only, zero code changes). **Date:** 2026-06-10.
+**Working tree:** `/Users/sethogieva/Desktop/mingla-main` @ `main` (clean).
+**Method:** real repo greps (app-mobile + mingla-business + mingla-admin + supabase/functions + supabase/migrations), Supabase Storage SQL via MCP (project `gqnoajqerqhnvulmnyvv`), live `curl -sI`.
+
+---
+
+## ═══ HEADLINE ═══
+
+**Investigation 1 — DO NOT delete the OpenAI/Anthropic keys or 3 of the 6 functions.** Earlier analysis assumed all 6 are dead because they only "read the key." That is **wrong**: 3 of the 6 are on **live, invoked, user-facing paths** AND still call OpenAI at runtime (graceful fallback, but the key is consumed when present). Only **3** are truly orphaned.
+
+- **DELETE-SAFE (zero invokers): `generate-ai-summary`, `ai-reason`, `score-place-photo-aesthetics`.**
+- **MUST KEEP (live callers + active OpenAI use): `moderate-content`, `generate-curated-experiences`, `generate-holiday-categories`.**
+- **`OPENAI_API_KEY` is NOT safe to delete** — 3 live functions read+use it. `ANTHROPIC_API_KEY` **is** safe to delete (its only consumer, `score-place-photo-aesthetics`, is orphaned; the live intelligence-trial replacement uses Gemini, not Anthropic).
+
+**Investigation 2 — the real email logo is in Supabase Storage, not usemingla.com.**
+`MINGLA_LOGO_URL` on dev points at **`https://gqnoajqerqhnvulmnyvv.supabase.co/storage/v1/object/public/App%20Stuff/mingla_official_logo.png`** — verified **HTTP 200, image/png, 29,762 bytes, last-modified 2026-05-11** (the day ORCH-0785 email branding shipped). The code's hardcoded fallback `https://usemingla.com/email-assets/mingla-logo.png` returns **404** (confirms operator: it was never published there).
+
+---
+
+## ═══ INVESTIGATION 1: OpenAI/Anthropic edge functions — LIVE vs DEAD ═══
+
+### Per-function verdict table
+
+| # | Function | Provider | Invoked by (file:line) | OpenAI/Anthropic use today | Verdict |
+|---|----------|----------|------------------------|----------------------------|---------|
+| 1 | `moderate-content` | OPENAI | `app-mobile/src/services/moderationService.ts:42` `supabase.functions.invoke('moderate-content')` → called from `useMessages.ts:286` (DM moderation), `authService.ts:286` (profile-bio moderation), `boardMessageService.ts:226` (board-message moderation) | **YES** — OpenAI Moderations endpoint at `index.ts:52` (`api.openai.com/v1/moderations`), **fail-open** if key missing (`index.ts:44-47`) | **KEEP — LIVE** |
+| 2 | `generate-ai-summary` | OPENAI | **NONE.** Zero `invoke`/`functions/v1` callers in app-mobile, mingla-business, mingla-admin, or any edge fn. Only doc/report mentions in `Mingla_Artifacts/`. | OpenAI at `index.ts:189` (only reached if invoked — it isn't) | **DELETE-SAFE — DEAD/ORPHANED** |
+| 3 | `ai-reason` | OPENAI | **NONE.** Zero code refs anywhere. (The migration hits for `ai_reason`/`ai_reasoning` are **DB columns** in `place_pool`/RPC return types — unrelated to this edge fn.) | OpenAI at `index.ts:17` (unreachable) | **DELETE-SAFE — DEAD/ORPHANED** |
+| 4 | `generate-curated-experiences` | OPENAI | **MANY (live).** Consumer service `app-mobile/src/services/curatedExperiencesService.ts:53,70` (`trackedInvoke`); edge→edge `supabase/functions/discover-cards/index.ts:894` (`fetch …/functions/v1/generate-curated-experiences`, the curated/picnic deck path); `supabase/functions/_shared/personHeroCards.ts:657` (`fetch …/v1/generate-curated-experiences`); kept hot in `supabase/functions/keep-warm/index.ts:13` | **YES (partial)** — Gemini Q2 reasoning slice (META-ORCH-1009 Sub-B, `index.ts:807`) **plus** OpenAI for picnic shopping-list + descriptions at `index.ts:1453/1512/1546` (`api.openai.com/v1/chat/completions`); falls back to `PICNIC_STATIC_SHOPPING_LIST` / static when no key (`index.ts:1436/1496/1530`) | **KEEP — LIVE** |
+| 5 | `generate-holiday-categories` | OPENAI | `app-mobile/src/services/holidayCategoryService.ts:24` (`fetch …/functions/v1/generate-holiday-categories`) → `useHolidayCategories.ts:64,108` → `PersonHolidayView.tsx:593,678` (holiday category sections in the app) | **YES** — OpenAI at `index.ts:102` (`api.openai.com/v1/chat/completions`); fallback categories if no key (`index.ts:72-74`) | **KEEP — LIVE** |
+| 6 | `score-place-photo-aesthetics` | ANTHROPIC | **NONE.** Only **comment** mentions (`admin-seed-places/index.ts:1043,1491`; `_shared/photoAestheticEnums.ts:4`; `run-place-intelligence-trial/index.ts:229`). No `invoke`, no `functions/v1`, no cron, no pg_net. | n/a (unreachable) | **DELETE-SAFE — DEAD/ORPHANED** |
+
+### What replaced the dead Anthropic photo-scorer
+
+Photo-aesthetic scoring is now owned by **`run-place-intelligence-trial`** on **Gemini 2.5 Flash** (DEC-101 / ORCH-0733). Evidence in `supabase/functions/run-place-intelligence-trial/index.ts`:
+- `GEMINI_MODEL_ID = "gemini-2.5-flash"` (line 69); `GEMINI_API_URL = …generativelanguage.googleapis.com…` (line 71-72).
+- Lines 58-59, 95: *"vs Anthropic baseline … Gemini 2.5 Flash matched quality at −71% cost … Gemini-only locked"*, *"Gemini 2.5 Flash is now the sole provider per DEC-101."*
+- This function (and `run-signal-scorer`) are the only AI-scoring edge fns invoked from migrations/cron: `grep` of `supabase/migrations/` for `functions/v1/*` yields `run-place-intelligence-trial` + `run-signal-scorer` (plus install/thumb/notify/marketing crons) — **none of the 6 audited functions appear in any migration/cron.**
+
+### Cron / dispatcher / keep-warm cross-check
+- **keep-warm** (`supabase/functions/keep-warm/index.ts`) lists `discover-cards`, `generate-curated-experiences`, `get-person-hero-cards` only. Its own header comment (line 10) says *"generate-curated-experiences are the surviving hot paths."* None of the 3 dead fns are warmed.
+- **No `_shared` dispatcher** routes to any of the 6.
+- **No pg_cron / pg_net** migration invokes any of the 6 (verified by `functions/v1/` extraction over `supabase/migrations/`).
+
+### Verdict — safe to delete vs must keep
+
+**SAFE TO DELETE (code + their effect on secrets):**
+1. `supabase/functions/generate-ai-summary/` — zero invokers.
+2. `supabase/functions/ai-reason/` — zero invokers.
+3. `supabase/functions/score-place-photo-aesthetics/` — zero invokers; superseded by Gemini `run-place-intelligence-trial`.
+
+**MUST KEEP (live, invoked, user-facing — deleting breaks features):**
+4. `moderate-content` — UGC safety on DMs / profile bios / board messages (3 live call sites). Deleting silently disables moderation.
+5. `generate-curated-experiences` — curated/picnic deck (consumer + discover-cards + person-hero + keep-warm).
+6. `generate-holiday-categories` — holiday category sections in `PersonHolidayView`.
+
+**Secrets verdict:**
+- **`ANTHROPIC_API_KEY` — DELETE-SAFE.** Sole consumer `score-place-photo-aesthetics` is orphaned; the live replacement uses Gemini (`GOOGLE_AI`/Gemini key), not Anthropic.
+- **`OPENAI_API_KEY` — DO NOT DELETE.** Three LIVE functions read+use it: `moderate-content` (OpenAI Moderations), `generate-curated-experiences` (picnic list + descriptions), `generate-holiday-categories` (category generation). All three degrade gracefully (fail-open / static fallback) if the key is removed, but removing it **silently disables real OpenAI behavior** on shipped paths — that is a functional regression, not dead-code cleanup. If the intent is to migrate these 3 off OpenAI onto the Gemini pipeline, that is a separate ORCH (code change), not a key-deletion.
+
+> ⚠️ Caveat: the operator's premise ("OpenAI/Anthropic are deprecated, replaced by the intelligence trial") is **only true for the Anthropic photo-scorer**. The intelligence-trial/Gemini pipeline replaced **photo-aesthetic + signal scoring** — it did **not** replace UGC moderation, curated-experience descriptions/picnic lists, or holiday categories. Those still ride OpenAI.
+
+---
+
+## ═══ INVESTIGATION 2: real published URL of the email logo ═══
+
+### Answer (ranked)
+
+| Rank | Candidate URL | curl -sI result | Evidence it's the real one |
+|------|---------------|-----------------|----------------------------|
+| **1 ✅** | `https://gqnoajqerqhnvulmnyvv.supabase.co/storage/v1/object/public/App%20Stuff/mingla_official_logo.png` | **HTTP 200**, `content-type: image/png`, `content-length: 29762`, `last-modified: Mon, 11 May 2026 18:16:44 GMT`, `etag "75a9f8a984dc58e2132796e424d8223f"` | Real PNG in the **public `App Stuff` bucket** (`storage.buckets.public = true`). Object `mingla_official_logo.png`, uploaded **2026-05-11** — the exact day ORCH-0785 email branding shipped + the logo-publish launch op was filed. Same filename ships in-repo as `app-mobile/assets/mingla_official_logo.png` + `mingla-business/assets/mingla_official_logo.png`. The render-image endpoint also serves it 200. This is the only logo asset in any public Storage bucket. |
+| 2 ❌ | `https://usemingla.com/email-assets/mingla-logo.png` (code's hardcoded fallback) | **HTTP 404** (Vercel 404 page) | This is the *test/default* fallback baked into `_shared/email/index.ts:57`, `_shared/marketingEmailRender.ts:188`, `_shared/email/tripConfirmationEmail.ts:138`, `invite-brand-member/index.ts:196`. ORCH-0785 listed "publish logo at usemingla.com/email-assets/" as an **operator launch op that was never done** → 404. Confirms operator's claim. |
+| 3 ❌ | Cloudinary `res.cloudinary.com/dhza7d54o/image/upload/{mingla-logo,mingla_official_logo,logo}.png` | **HTTP 404** (all variants) | No logo asset in the `dhza7d54o` Cloudinary cloud. Cloudinary here is used only for **event cover video** (`event-cover-video-upload-intent`), not the email logo. |
+
+### How the live render resolves to #1
+- `MINGLA_LOGO_URL` is read in: `_shared/email/index.ts:55` (required in prod, throws `email_env_missing:MINGLA_LOGO_URL` if unset), `_shared/marketingEmailRender.ts:187`, `ticket-confirmation-dispatch/index.ts:62/929`, `ticket-pdf-fetch/index.ts:24/139`, `invite-brand-member/index.ts:580`, `_shared/email/tripConfirmationEmail.ts:136`.
+- The hardcoded `usemingla.com` string is **only the no-env fallback** (and only used under `DENO_TESTING=1` in `_shared/email/index.ts`). Since emails currently render the logo, the dev **`MINGLA_LOGO_URL` secret is set to the Storage URL in #1** (hashed in the secrets API, but its target is the only live logo image that exists).
+- Git history has no committed `MINGLA_LOGO_URL=<value>`; only the doc/runbook references to the (never-published) usemingla.com path. The truth lives in the Supabase function secret, pointing at Storage.
+
+### Recommended action for the logo
+- **If keeping the current behavior:** nothing to do — `MINGLA_LOGO_URL` already points at the live Storage PNG (#1). Treat **#1 as canonical** and update any doc/runbook still claiming `usemingla.com/email-assets/`.
+- **Optional hardening:** change the code fallback in the 4 files above from the dead `usemingla.com/email-assets/mingla-logo.png` to the live Storage URL #1, so a missing secret degrades to a working image instead of a 404. (Code change — out of scope for this read-only investigation; flag as a follow-up.)
+- Note: bucket name `App Stuff` contains a space → URL **must** encode it as `App%20Stuff`. A path written with a literal space will 404.
+
+---
+
+## Evidence appendix (commands run)
+- Invocation sweep: `grep -rn '<fn>'` across `app-mobile mingla-business mingla-admin supabase/functions` (excluding each fn's own dir + `node_modules` + `Mingla_Artifacts` docs) for all 6 names + camel/snake variants + `functions/v1/<fn>`.
+- Migration/cron sweep: `grep -roE 'functions/v1/[a-z-]+' supabase/migrations/` → only install/thumb/notify/marketing/booking/installment + `run-place-intelligence-trial` + `run-signal-scorer`. None of the 6.
+- Provider-in-fn checks: `grep -niE 'OPENAI|gemini|anthropic'` inside each fn's `index.ts`.
+- Storage: MCP `execute_sql` on `storage.objects`/`storage.buckets` (project `gqnoajqerqhnvulmnyvv`).
+- Live checks: `curl -sI` on all 3 logo candidates (#1 → 200; #2,#3 → 404).

--- a/Mingla_Artifacts/reports/INVESTIGATE_PROD_CONFIG_VARS.md
+++ b/Mingla_Artifacts/reports/INVESTIGATE_PROD_CONFIG_VARS.md
@@ -1,0 +1,135 @@
+# INVESTIGATE — Prod Supabase CONFIG Env Vars (23) + Key-Deletion Scope
+
+**Date:** 2026-06-10
+**Mode:** mingla-forensics INVESTIGATE (read-only, no code changes)
+**Goal:** For each of ~23 CONFIG env vars, trace actual code to determine purpose, read-sites, in-code default, format, and recommended prod value. Plus confirm deletion scope for OPENAI / ANTHROPIC (keep) vs LOVABLE / GOOGLE_GEOLOCATION (delete).
+**Method:** Exhaustive `grep` of `Deno.env.get("VAR")` / `process.env.VAR` across `supabase/functions`, `app-mobile`, `mingla-business`, `mingla-admin`, `scripts` (node_modules + .git excluded), then verbatim read of every read-site file.
+**Prod project:** `gupxgpmukdwhozqfmzgd` ("Mingla-prod"). Domains in code defaults: `mingla.app`, `business.usemingla.com`, `usemingla.com`.
+
+> **HEADLINE SURPRISE:** All 9 `PLACES_*` vars and `MINGLA_LOGO_URL_2X` have **ZERO read-sites in code** — they are NOT consumed anywhere. The standup runbook lists `PLACES_*` as "derivable config" but no code reads them. They are safe to **skip entirely** on prod (set nothing). Details in Section C.
+
+---
+
+## A. The 23-Var Master Table
+
+Legend for "Recommended prod value": a value in `code` font is the exact in-code default (set it verbatim or leave unset to inherit it); **operator must supply** means no code default exists and the var is required or behavior-affecting.
+
+| # | Var | Purpose (what it powers) | Reads at file:line | Code default / fallback | Recommended prod value |
+|---|-----|--------------------------|--------------------|-------------------------|------------------------|
+| 1 | `MINGLA_PUBLIC_APP_ORIGIN` | Base origin for **consumer-app links inside marketing emails** (unsubscribe/app deep-links built by marketing-send). | `supabase/functions/marketing-send/index.ts:772` | `?? "https://mingla.app"` | `https://mingla.app` (code default; leave unset OR set explicitly to the production consumer-app origin if different) |
+| 2 | `MINGLA_PUBLIC_WEB_BASE_URL` | **Buyer-web Stripe Checkout success/cancel URLs** (`/checkout/{id}/confirm`, `/payment`). **Required for web checkout** — 500 `web_base_url_missing` if unset/invalid. | `supabase/functions/ticket-checkout-create/index.ts:975` (also client mirror `EXPO_PUBLIC_MINGLA_PUBLIC_WEB_BASE_URL` in `mingla-business/src/hooks/useBrandStripeTaxAccountSession.ts:10`) | **none — hard 500 if unset; must match `^https://...$`** | **operator must supply: the production buyer-web origin** (the Vercel domain that serves `mingla-business` web `/checkout/...`, e.g. `https://business.usemingla.com`). Must be `https://`. |
+| 3 | `MINGLA_BUSINESS_WEB_URL` | Base origin for **business-web links in emails** (brand-member invite accept, scanner invite accept, ticket-confirmation organiser links, claim-approved). Edge-side. | `supabase/functions/invite-brand-member/index.ts:520`; `invite-scanner/index.ts:382`; `ticket-confirmation-dispatch/index.ts:231`; `_shared/email/claimApprovedEmail.ts:24` | `?? "https://business.usemingla.com"` (all four sites) | `https://business.usemingla.com` (code default; leave unset OR set verbatim) |
+| 4 | `BUSINESS_WEB_ORIGIN` | **Stripe Connect embedded onboarding/account-session return + refresh URLs** for brand & partner payout onboarding. **Fail-closed**: edge fns throw at module load if unset. | `partner-stripe-onboard/index.ts:55`; `brand-stripe-account-session/index.ts:29`; `brand-stripe-onboard/index.ts:47` | **none — throws `BUSINESS_WEB_ORIGIN env var is not set` at import** | **operator must supply: the production business-web origin** (same Vercel domain, e.g. `https://business.usemingla.com`). Hard-required for any brand payout onboarding. |
+| 5 | `RESEND_ADMIN_FROM` | Sender identity for **admin/hello transactional email** ("Mingla <hello@…>"). | `supabase/functions/_shared/email/senders.ts:26` | `?? {name:"Mingla", address:"hello@usemingla.com"}` | `Mingla <hello@usemingla.com>` (code default; leave unset OR set verbatim — requires Resend DKIM on `hello@usemingla.com`) |
+| 6 | `RESEND_SYSTEM_FROM` | Sender identity for **system/notification email** ("Mingla <notifications@…>"). | `supabase/functions/_shared/email/senders.ts:27` | `?? {name:"Mingla", address:"notifications@usemingla.com"}` | `Mingla <notifications@usemingla.com>` (code default — requires Resend DKIM on `notifications@usemingla.com`) |
+| 7 | `RESEND_TICKET_FROM` | Sender identity for **buyer ticket-confirmation email** ("Mingla <tickets@…>"). | `supabase/functions/_shared/email/senders.ts:25` | `?? {name:"Mingla", address:"tickets@usemingla.com"}` | `Mingla <tickets@usemingla.com>` (code default — requires Resend DKIM on `tickets@usemingla.com`) |
+| 8 | `STRIPE_DISPUTE_ALERT_EMAILS` | **Comma-separated** recipient list for **Stripe dispute alert emails**. If empty, dispute is persisted but no operator notification (warns to log). | `supabase/functions/_shared/stripeDisputeHandlers.ts:97` | `?? ""` (parsed `split(",").map(trim).filter(Boolean)`) | **operator must supply: the ops alert recipient(s)**, comma-separated (e.g. `seth@usemingla.com` or `ops@usemingla.com,seth@usemingla.com`). |
+| 9 | `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` | **Comma-separated** recipients for **Stripe webhook signature-failure alerts** (security/ops). Empty ⇒ no alert sent. | `supabase/functions/stripe-webhook/index.ts:38` | `?? ""` (same CSV parse) | **operator must supply: the ops alert recipient(s)**, comma-separated (same address(es) as #8 is fine). |
+| 10 | `MINGLA_FOOTER_ADDRESS` | **Footer "from" address line in all transactional + marketing emails.** **Required in production** — email render throws `email_env_missing:MINGLA_FOOTER_ADDRESS` if unset (test-only default exists). | `_shared/email/index.ts:61` (required); `invite-brand-member/index.ts:582`; `_shared/marketingEmailRender.ts:189` (defaulted); `_shared/email/tripConfirmationEmail.ts:142` | required in `_shared/email/index.ts` (no default unless `DENO_TESTING=1` → `"Mingla, hello@usemingla.com"`); marketing render defaults `?? "Mingla, hello@usemingla.com"` | `Mingla, hello@usemingla.com` (the canonical test-default; set verbatim, or operator's real mailing address if a physical address is desired for CAN-SPAM). **Must be set in prod or transactional email render throws.** |
+| 11 | `MINGLA_LOGO_URL` | **Logo image URL in the email brand shell + ticket PDF.** **Required in production** — render throws `email_env_missing:MINGLA_LOGO_URL` if unset (test-only default). | `_shared/email/index.ts:55` (required); `invite-brand-member/index.ts`; `ticket-confirmation-dispatch`; `_shared/marketingEmailRender.ts:187`; `_shared/email/tripConfirmationEmail.ts:136`; `ticket-pdf-fetch/index.ts:24` | required in `_shared/email/index.ts` (no default unless `DENO_TESTING=1` → `"https://usemingla.com/email-assets/mingla-logo.png"`); marketing render + pdf default to that same URL | `https://usemingla.com/email-assets/mingla-logo.png` (canonical default; set verbatim). **Operator must publish the logo at that URL** (or set this var to wherever the prod logo actually lives). Required or email render throws. |
+| 12 | `MINGLA_LOGO_URL_2X` | **UNUSED.** Retina `@2x` logo variant — was reserved in ORCH-0785 but **never wired into any renderer**. Zero functional read-sites. | (none — only docs/specs in `Mingla_Artifacts/`) | n/a | **Skip — do not set.** No code reads it. (Optional: set `https://usemingla.com/email-assets/mingla-logo@2x.png` for forward-compat, but it has no effect today.) |
+| 13 | `EVENT_COVER_VIDEO_PROVIDER` | Selects the **event-cover-video provider**. The ONLY value that enables the feature is `"cloudinary"`; any other value disables provider (`providerConfigured()` returns false). | `supabase/functions/_shared/eventCoverVideo.ts:249` | `?? "cloudinary"` | `cloudinary` (code default; leave unset OR set verbatim). Note: provider also needs `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` set or the feature is off regardless. |
+| 14 | `NATIVE_PAID_ALLOWED_REGIONS` | **DECOMMISSIONED (ORCH-0955).** Region allowlist gate was deleted; native paid is now universal. No active code reads it; tests assert it is **absent** from `ticket-checkout-create`. | (none in active `index.ts`; only `__tests__/` assertions that it must NOT appear) | n/a | **Skip — do NOT set.** Setting it has no effect; re-introducing the gate would violate the ORCH-0955 invariant. |
+| 15 | `PLACES_BUDGET_USD` | **UNUSED in code.** Intended places-seeding budget cap. Zero read-sites anywhere. | (none) | n/a — `admin-seed-places` uses hardcoded constants, not this env var | **Skip — do not set.** No code consumes it. (See Section C.) |
+| 16 | `PLACES_DEFAULT_RADIUS_M` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 17 | `PLACES_MAX_CALLS_PER_BATCH` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 18 | `PLACES_MAX_RADIUS_M` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 19 | `PLACES_PAGES_MAX` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 20 | `PLACES_PRICE_DETAILS_PER_1K` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 21 | `PLACES_PRICE_NEARBY_PER_1K` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 22 | `PLACES_PRICE_PHOTOS_PER_1K` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+| 23 | `PLACES_PRICE_TEXT_PER_1K` | **UNUSED in code.** Zero read-sites. | (none) | n/a | **Skip — do not set.** |
+
+### Quick "must-supply" shortlist (the only ones with no usable code default)
+
+| Var | Why it needs a real value |
+|-----|---------------------------|
+| `MINGLA_PUBLIC_WEB_BASE_URL` | Hard 500 on buyer-web checkout if unset/non-https. |
+| `BUSINESS_WEB_ORIGIN` | Edge fns throw at load; brand payout onboarding dead without it. |
+| `STRIPE_DISPUTE_ALERT_EMAILS` | Empty ⇒ no dispute alert ever fires (silent). |
+| `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS` | Empty ⇒ no webhook-tamper alert ever fires (silent). |
+| `MINGLA_FOOTER_ADDRESS` | Transactional email render THROWS in prod if unset. |
+| `MINGLA_LOGO_URL` | Transactional email render THROWS in prod if unset; logo asset must exist at the URL. |
+
+Everything else either has a correct code default (`MINGLA_PUBLIC_APP_ORIGIN`, `MINGLA_BUSINESS_WEB_URL`, `RESEND_*_FROM`, `EVENT_COVER_VIDEO_PROVIDER`) or is dead/unused (skip).
+
+---
+
+## B. Deletion Verdict
+
+### KEEP + SET (actively used)
+
+#### `OPENAI_API_KEY` — KEEP, ACTIVELY USED (5 consuming functions)
+
+| Consuming function | Read at | Fail-mode without key |
+|--------------------|---------|------------------------|
+| `moderate-content` | `index.ts:44` | **Fails OPEN** — `OPENAI_API_KEY missing — failing open`, returns `{flagged:false}` (does not block users). |
+| `generate-ai-summary` | `index.ts:189` | **Degrades** — returns hardcoded fallback summary, HTTP 200. |
+| `generate-curated-experiences` | `index.ts:40` (+ reads at 1436/1457/1496/1514/1530/1548/1564/1581/1819/1824) | **Degrades** — `?? ''`; returns static shopping list / skips AI enrichment, no hard error. |
+| `generate-holiday-categories` | `index.ts:72` | **Degrades** — `No OPENAI_API_KEY — returning fallback`, returns `FALLBACK_CATEGORIES`, HTTP 200. |
+| `ai-reason` | `index.ts:17` | **HARD-ERRORS** — returns HTTP **500** `{error:'OpenAI API key not configured'}`. |
+| (script) `scripts/verify-places-pipeline.mjs` | `:34`, asserted required `:41`, used `:1042` | Verification script aborts if missing — not a runtime function. |
+
+**Verdict:** KEEP and SET on prod. Without it, four functions silently degrade and **`ai-reason` hard-500s** (weather-aware experience recommendations break).
+
+#### `ANTHROPIC_API_KEY` — KEEP, ACTIVELY USED (1 active consuming function)
+
+| Consuming function | Read at | Fail-mode without key |
+|--------------------|---------|------------------------|
+| `score-place-photo-aesthetics` | `index.ts:82` | **HARD-ERRORS** — returns HTTP **500** `{error:"ANTHROPIC_API_KEY not configured"}`. |
+| `run-place-intelligence-trial` | `index.ts:652` | **NOT a real read — COMMENT ONLY.** `// ANTHROPIC_API_KEY env var no longer required` (dropped per DEC-101 / ORCH-0733; Gemini is sole provider). |
+
+**Verdict:** KEEP and SET on prod. Exactly **one** active consumer (`score-place-photo-aesthetics`), and it **hard-500s** without the key. The runbook's premise is correct.
+
+### DELETE-SAFE (zero functional code references)
+
+#### `LOVABLE_API_KEY` — SAFE TO DELETE
+
+- **Functional refs across `supabase` / `app-mobile` / `mingla-business` / `mingla-admin` / `scripts`: ZERO.**
+- **Not in `supabase/config.toml`.**
+- **Only reference in the entire repo:** `Mingla_Artifacts/reports/PROD_SUPABASE_STANDUP_RUNBOOK_2026-06-10.md:32` (lists it in the "GAP — need values" bucket). That is a planning doc, not code.
+- **Verdict:** No code reads it. Do NOT set it on prod; remove from any dev secrets cleanup. The runbook line at :32 should drop it from the "need values" list.
+
+#### `GOOGLE_GEOLOCATION_API_KEY` — SAFE TO DELETE
+
+- **Functional refs across all code dirs: ZERO.**
+- **Not in `supabase/config.toml`.**
+- **Only reference in the entire repo:** `Mingla_Artifacts/reports/PROD_SUPABASE_STANDUP_RUNBOOK_2026-06-10.md:32` (same "GAP — need values" bucket). Planning doc only.
+- **Note:** Distinct from `GOOGLE_MAPS_API_KEY`, which IS used (`admin-seed-places/index.ts:32`, seeding + companion/picnic stops per memory). Do not confuse the two.
+- **Verdict:** No code reads it. Do NOT set it on prod. Drop from the runbook :32 list.
+
+---
+
+## C. Surprises (where "reputation" ≠ code reality)
+
+1. **All 9 `PLACES_*` vars are NOT read by any code.** The standup runbook (`PROD_SUPABASE_STANDUP_RUNBOOK_2026-06-10.md:30`) lists `PLACES_*` budgets under "Derivable config" implying code reads them — it does not. `admin-seed-places/index.ts` uses **hardcoded constants** (`EXPECTED_UNIQUE_PLACES_PER_TILE = 10`, `PHOTOS_PER_PLACE`, `COST_PER_PHOTO`, etc. at lines 125/549/671), not env vars. `scripts/verify-places-pipeline.mjs` reads only `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `SERPER_API_KEY`. **There is no in-code default to "derive" for these because there is no read-site.** → **Skip all 9.** (If they exist on the dev project, they are orphaned secrets set but never consumed.)
+
+2. **`MINGLA_LOGO_URL_2X` is read by NOTHING.** ORCH-0785 reserved it but never wired it into the `<img srcset>` (documented as a low-pri follow-up in the QA + implementation reports). Zero functional read-sites. → Skip.
+
+3. **`NATIVE_PAID_ALLOWED_REGIONS` is decommissioned, not just unused.** ORCH-0955 deleted the region gate entirely; tests now assert the string must NOT appear in `ticket-checkout-create`. Setting it does nothing; re-introducing the gate would break the ORCH-0955 invariant. → Skip (and the runbook should drop it from `EVENT_COVER_VIDEO_PROVIDER`'s neighbor list of "derivable config").
+
+4. **`run-place-intelligence-trial` does NOT consume `ANTHROPIC_API_KEY`** despite the grep hit — that line is a historical comment (DEC-101 moved the trial to Gemini). So ANTHROPIC has exactly **one** live consumer, not two. The key is still required (for `score-place-photo-aesthetics`), so the KEEP verdict stands, but the consumer count is 1.
+
+5. **Six vars are "required/fail-closed", not merely defaulted** — and three of those (`MINGLA_PUBLIC_WEB_BASE_URL`, `BUSINESS_WEB_ORIGIN`, plus `MINGLA_LOGO_URL`/`MINGLA_FOOTER_ADDRESS` in prod) will **break a user-facing flow at runtime** (web checkout 500 / payout onboarding throw / email render throw) if left unset on the fresh prod project. These are the real launch-blockers in the 23, not the PLACES budgets.
+
+6. **`EVENT_COVER_VIDEO_PROVIDER` accepts only `"cloudinary"`.** There is no `"pexels"`/`"mux"` branch — any non-`"cloudinary"` value silently disables the provider. The default `"cloudinary"` is correct; the var only matters as a kill-switch.
+
+---
+
+## Evidence appendix (read-sites, verbatim anchors)
+
+- `marketing-send/index.ts:772` — `return Deno.env.get("MINGLA_PUBLIC_APP_ORIGIN") ?? "https://mingla.app";`
+- `ticket-checkout-create/index.ts:975` — `const baseUrl = Deno.env.get("MINGLA_PUBLIC_WEB_BASE_URL");` → `:976` `if (!baseUrl || !/^https:\/\/[^\s]+$/.test(baseUrl))` → 500 `web_base_url_missing`.
+- `invite-brand-member/index.ts:520`, `invite-scanner/index.ts:382`, `ticket-confirmation-dispatch/index.ts:231`, `_shared/email/claimApprovedEmail.ts:24` — all `?? "https://business.usemingla.com"`.
+- `partner-stripe-onboard/index.ts:55-58`, `brand-stripe-account-session/index.ts:29-32`, `brand-stripe-onboard/index.ts:47-50` — `if (!BUSINESS_WEB_ORIGIN) throw … "BUSINESS_WEB_ORIGIN env var is not set."` (fail-closed at module load; adversarial test `brand-stripe-onboard/__tests__/embeddedOnboarding.adversarial.test.ts` enforces).
+- `_shared/email/senders.ts:25-27` — `resolveSender("RESEND_TICKET_FROM","Mingla","tickets@usemingla.com")` etc.
+- `_shared/stripeDisputeHandlers.ts:97` — `Deno.env.get("STRIPE_DISPUTE_ALERT_EMAILS") ?? ""` then `.split(",").map(trim).filter(Boolean)`.
+- `stripe-webhook/index.ts:38` — `Deno.env.get("STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS") ?? ""` (same CSV parse; empty ⇒ `return 0`, no alert).
+- `_shared/email/index.ts:54-65` — `requireEnv("MINGLA_LOGO_URL", DENO_TESTING===1 ? "…/mingla-logo.png" : undefined)` and `requireEnv("MINGLA_FOOTER_ADDRESS", DENO_TESTING===1 ? "Mingla, hello@usemingla.com" : undefined)`; `requireEnv` throws `email_env_missing:${key}` when unset and no fallback.
+- `_shared/marketingEmailRender.ts:187/189` — `?? "https://usemingla.com/email-assets/mingla-logo.png"` / `?? "Mingla, hello@usemingla.com"`.
+- `_shared/eventCoverVideo.ts:249` — `(Deno.env.get("EVENT_COVER_VIDEO_PROVIDER") ?? "cloudinary") === "cloudinary"`.
+- OPENAI: `moderate-content:44`, `generate-ai-summary:189`, `generate-curated-experiences:40`, `generate-holiday-categories:72`, `ai-reason:17`.
+- ANTHROPIC: `score-place-photo-aesthetics:82` (active, 500 on miss); `run-place-intelligence-trial:652` (comment only).
+- LOVABLE / GOOGLE_GEOLOCATION: zero refs in `supabase|app-mobile|mingla-business|mingla-admin|scripts`; sole hit `PROD_SUPABASE_STANDUP_RUNBOOK_2026-06-10.md:32`.
+
+**Confidence:** proven (static-config trace; every read-site read verbatim). No simulator repro applicable — this is a backend config-audit, exempt from the live-fire directive.

--- a/Mingla_Artifacts/reports/PROD_SECRET_MANIFEST_2026-06-10.md
+++ b/Mingla_Artifacts/reports/PROD_SECRET_MANIFEST_2026-06-10.md
@@ -1,0 +1,50 @@
+# Mingla-prod Secret Manifest
+
+**Project:** `gupxgpmukdwhozqfmzgd` (Mingla-prod) · **Date:** 2026-06-10
+**State:** 75 secrets set · Stripe **TEST** mode · marketing **OFF** · functionally complete except the 2 launch webhook secrets.
+**Source of truth for values:** `~/Desktop/Key Details For Mingla/MINGLA_MASTER_KEYS.md` (consolidated 2026-06-10).
+
+This manifest is the canonical record of what is/isn't set on prod and why. Values are NOT recorded here (see master keys doc).
+
+## SET on prod (75)
+
+| Category | Vars |
+|---|---|
+| Stripe — money layer | `STRIPE_SECRET_KEY`, `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY`, 8 RAKs × {base, `_LIVE`, `_TEST`}, `STRIPE_RAK_TAX_DASHBOARD_TEST` |
+| Stripe — mode/config | `MINGLA_STRIPE_MODE`=**test**, `ENVIRONMENT`=production |
+| Twilio | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_MESSAGING_SERVICE_SID`, `TWILIO_VERIFY_SERVICE_SID` (from Twilio API), `TWILIO_STATUS_CALLBACK_SECRET` (generated) |
+| OneSignal | consumer `ONESIGNAL_APP_ID` + `ONESIGNAL_REST_API_KEY`; business `ONESIGNAL_BUSINESS_APP_ID` + `ONESIGNAL_BUSINESS_REST_API_KEY` |
+| Resend | `RESEND_API_KEY`, `RESEND_ADMIN_FROM`, `RESEND_SYSTEM_FROM`, `RESEND_TICKET_FROM` |
+| AI | `GEMINI_API_KEY`, `GEMINI_API_KEY_ARI`, `OPENAI_API_KEY` (still live: moderate-content, curated-experiences, holiday-categories) |
+| Maps & Places | `GOOGLE_MAPS_API_KEY` = `GOOGLE_PLACES_API_KEY` (one key), `MAPBOX_ACCESS_TOKEN` |
+| Media | `CLOUDINARY_CLOUD_NAME/API_KEY/API_SECRET/URL`, `PEXELS_API_KEY`, `EVENT_COVER_VIDEO_PROVIDER`=cloudinary |
+| Attribution | `APPSFLYER_DEV_KEY`, `APPSFLYER_BUSINESS_DEV_KEY` (same), `APPSFLYER_BUSINESS_ANDROID_APP_ID`, `APPSFLYER_BUSINESS_IOS_APP_ID` |
+| Other ext. | `TICKETMASTER_API_KEY`, `PAYSTACK_SECRET_KEY_TEST`, `SERPER_API_KEY`, `OPENWEATHER_API_KEY` |
+| Generated | `UNSUBSCRIBE_TOKEN_SECRET`, `app.qr_token_pepper` |
+| Config (URLs) | `MINGLA_PUBLIC_APP_ORIGIN`=https://usemingla.com · `MINGLA_PUBLIC_WEB_BASE_URL` / `BUSINESS_WEB_ORIGIN` / `MINGLA_BUSINESS_WEB_URL`=https://business.usemingla.com |
+| Config (email) | `MINGLA_FOOTER_ADDRESS`, `MINGLA_LOGO_URL`=Supabase Storage `App Stuff/mingla_official_logo.png` (verified 200), `STRIPE_DISPUTE_ALERT_EMAILS` / `STRIPE_WEBHOOK_FAILURE_ALERT_EMAILS`=seth@usemingla.com |
+
+Auto-injected by the platform (not counted/managed): `SUPABASE_URL/ANON_KEY/SERVICE_ROLE_KEY/DB_URL/JWKS/PUBLISHABLE_KEYS/SECRET_KEYS`.
+
+## LAUNCH-PENDING (2) — created at webhook repoint (runbook step C)
+- `STRIPE_WEBHOOK_SECRET`, `STRIPE_WEBHOOK_SECRET_PLATFORM` — generated NEW when the live Stripe webhook endpoints are repointed from dev → prod. Do NOT copy dev's.
+
+## SKIPPED — intentionally NOT set (with reason)
+- `STRIPE_RAK_TAX_DASHBOARD_LINK` — live mode doesn't use it (ORCH-0953 §3.1).
+- `STRIPE_WEBHOOK_SECRET_PREVIOUS` — empty rotation slot.
+- All 9 `PLACES_*` — **dead** (admin-seed-places uses hardcoded constants, not env). Also deleted from dev.
+- `MINGLA_LOGO_URL_2X` — reserved, never wired. Deleted from dev.
+- `NATIVE_PAID_ALLOWED_REGIONS` — **decommissioned** (ORCH-0955); tests assert absence. Deleted from dev.
+- `GOOGLE_GEOLOCATION_API_KEY`, `LOVABLE_API_KEY` — **0 code refs**. Deleted from dev.
+- `ANTHROPIC_API_KEY` — only the orphaned `score-place-photo-aesthetics` used it (replaced by Gemini intelligence-trial). Deleted from dev.
+
+## Mode & posture
+- `MINGLA_STRIPE_MODE`=**test** for Taofeek's load/readiness testing (flip to **live** at real launch).
+- `MARKETING_SEND_LIVE_ENABLED`=**false** (no real email/SMS sends).
+
+## Pending code cleanup (ORCH-1108)
+Delete 3 confirmed-dead functions from the repo + undeploy: `generate-ai-summary`, `ai-reason`, `score-place-photo-aesthetics`. Evidence: `INVESTIGATE_OPENAI_ANTHROPIC_DEPRECATION_AND_LOGO.md`.
+
+## Follow-ups
+- Logo currently points at **dev** storage (works); copy to prod storage + fix the dead `usemingla.com/email-assets` code fallback at launch.
+- Optional: migrate moderate-content / generate-curated-experiences / generate-holiday-categories off OpenAI onto Gemini to fully drop the OpenAI runtime dependency.

--- a/Mingla_Artifacts/reports/QA_ORCH-1108_REPORT.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1108_REPORT.md
@@ -1,0 +1,188 @@
+# QA — ORCH-1108 [delete 3 dead AI edge functions]
+
+**Mode:** TARGETED (backend-only, source-exempt from sim gate)
+**Branch:** `ORCH-1108-delete-dead-ai-functions`
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1108-[delete-dead-ai-functions]/`
+**Commit under test:** `7103b2826` (implementor) → tester adversarial test added at `5bee87700`
+**origin/main base:** verified via `git fetch origin` before diffing.
+
+---
+
+## 1. Verdict
+
+**PASS** — 0 P0 · 0 P1 · 0 P2 · 0 P3 · 2 P4 (informational).
+
+A pure backend deletion of three forensics-confirmed-dead AI edge functions plus their one config block. Independently re-derived: the 3 dirs are gone, the config blocks are gone, the diff is exactly the expected set, no migration is touched, and — adversarially — there is no dangling import into the deleted dirs, no raw fetch/URL call path, and no migration/cron/net.http executable reference to the dead names. The KEEP verdict on `photoAestheticEnums.ts` is correct (a live function still imports it). Both regression tests run green with independently-proven fails-on-revert.
+
+**Sim gate:** EXEMPT — backend-only / edge-function deletion / config-only, zero UI/runtime surface. No `app-mobile`, `mingla-business`, or `mingla-admin` code touched; nothing renders. Exemption stated per Phase 0.A.
+
+**Routing:** → CLOSE (orchestrator). One operator action remains at close: undeploy the 3 still-ACTIVE live functions (see P4-1).
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Result | Independent evidence |
+|----|-----------|--------|----------------------|
+| SC-1 | `generate-ai-summary/`, `ai-reason/`, `score-place-photo-aesthetics/` dirs deleted entirely | **PASS** | `ls supabase/functions/ \| grep -E '...'` → NONE; `git diff --name-status origin/main...HEAD` shows all 3 `index.ts` as `D` (−87 / −274 / −1040 lines) |
+| SC-2 | `[functions.ai-reason]` block removed from `config.toml`; the other 2 never had blocks | **PASS** | `grep -nE 'functions\.(generate-ai-summary\|ai-reason\|score-place-photo-aesthetics)' supabase/config.toml` → NONE. config.toml diff = exactly `-[functions.ai-reason]` + its `verify_jwt=true` + blank line (−3); nothing else in the file changed |
+| SC-3 | `photoAestheticEnums.ts` handled correctly (KEEP, not orphaned) | **PASS** | Helper still exists on disk; sole importer = LIVE `run-place-intelligence-trial/index.ts:25` `from "../_shared/photoAestheticEnums.ts"`. Deleting it would have orphan-broken a live fn. See §3 + adversarial (d). |
+| SC-4 | No functional code in other functions rewritten; comments intact | **PASS** | Diff touches only the 3 deleted dirs + config + 2 test files. Remaining textual refs are inert: SQL `COMMENT ON` strings (migration baseline) + source comments in `admin-seed-places`, `run-place-intelligence-trial`. None executable. |
+| SC-5 | Regression test green with fails-on-revert | **PASS** | Implementor test re-run 3/0 on clean HEAD; fails-on-revert independently re-proven (§4). Tester adversarial test 4/0 with its own fails-on-revert (§5). |
+| SC-6 | Nothing else touched | **PASS** | `git diff --name-status origin/main...HEAD` = exactly 6 paths (1 M config, 2 A tests, 3 D index.ts). NO migration in diff. |
+
+---
+
+## 3. KEEP verdict on `photoAestheticEnums.ts` — CONFIRMED CORRECT
+
+```
+$ ls -la supabase/functions/_shared/photoAestheticEnums.ts   → exists (7110 bytes)
+$ grep -rnE 'from .*photoAestheticEnums' <code roots>
+  supabase/functions/run-place-intelligence-trial/index.ts:25:} from "../_shared/photoAestheticEnums.ts";   ← LIVE, surviving fn
+```
+
+Only ONE importer remains, and it is a function that was NOT deleted. The other historical importer was the now-deleted `score-place-photo-aesthetics`. Had the implementor deleted the helper, `run-place-intelligence-trial` would fail to bundle. **KEEP is correct.** (`mingla-admin/src/constants/placeIntelligenceTrial.js:4` carries only a path COMMENT, not an import.)
+
+---
+
+## 4. Step 0.5 — independent re-run of the IMPLEMENTOR's fails-on-revert proof
+
+Re-ran on a clean checkout at HEAD `7103b2826` with `/Users/sethogieva/.deno/bin/deno` (deno 2.7.14).
+
+**Clean HEAD (`7103b2826`):**
+```
+ORCH-1108 (a): the 3 dead function directories are deleted ... ok
+ORCH-1108 (b): zero invoke/fetch callers across the four roots ... ok
+ORCH-1108 (c): config.toml has no block for any deleted function ... ok
+ok | 3 passed | 0 failed
+```
+
+**Revert (`git checkout origin/main -- supabase/functions/ai-reason` → dir restored):**
+```
+ORCH-1108 (a): the 3 dead function directories are deleted ... FAILED
+  AssertionError: ... (assertEquals at test:59) Dead function dir still exists
+FAILED | 2 passed | 1 failed
+```
+
+**Restore (force-removed the restored dir):**
+```
+ok | 3 passed | 0 failed   (green restored)
+```
+
+Implementor's fails-on-revert proof **independently re-verified at `7103b2826`** — true file restoration, real failing assertion (case a, line 59), green on re-deletion. Worktree returned clean (HEAD unchanged).
+
+---
+
+## 5. Tester adversarial test added (different angle: no-dangling-refs / orphan-break)
+
+**Path:** `supabase/functions/__tests__/orch_1108_no_dangling_refs.test.ts`
+**Commit (append-only, in-diff):** `5bee87700`
+**Angle vs implementor:** implementor checked *dirs absent + `.invoke`/`/functions/v1` callers absent + config block absent*. This test attacks the **orphan-break surface the implementor did not cover**:
+
+- **(a)** no source file anywhere `import`s/`require`s FROM a deleted directory (a dangling import = build break) — implementor never checked imports.
+- **(b)** no `supabase/migrations` `.sql` names a dead function in an EXECUTABLE position (`cron.schedule` / `pg_cron` / `net.http` / `http_post`); inert `COMMENT ON` strings explicitly allowed — implementor only grepped config.toml, not migrations.
+- **(c)** no non-`.invoke` programmatic path remains (`/functions/v1/<dead>` URL or `fetch(".../<dead>")`).
+- **(d)** POSITIVE guard: the KEPT helper `photoAestheticEnums.ts` still exists AND `run-place-intelligence-trial` still imports it (proves the KEEP verdict).
+
+**Clean HEAD run:** `4 passed | 0 failed`; `deno check` clean.
+
+**fails-on-revert verified at `5bee87700`** (each case proven hermetically, then restored):
+- (d): removed `photoAestheticEnums.ts` from disk → `(d) FAILED (0 passed/1 failed)`; restored → green. (Simulates the wrong KEEP verdict.)
+- (a): injected `run-place-intelligence-trial/__dangling_probe.ts` importing `"../ai-reason/index.ts"` → `(a) FAILED`; removed → green.
+- (b): injected `migrations/__orch1108_probe.sql` with `cron.schedule(... net.http_post('.../functions/v1/ai-reason'))` → `(b) FAILED`; removed → green.
+
+**Both test files appear in the closing diff** (`git diff --name-status origin/main...HEAD`):
+```
+A supabase/functions/__tests__/orch_1108_dead_functions_removed.test.ts   (implementor happy-path)
+A supabase/functions/__tests__/orch_1108_no_dangling_refs.test.ts          (tester adversarial)
+```
+Final joint run: **7 passed | 0 failed.**
+
+---
+
+## 6. Dangling-ref / migration / cron sweep — CLEAN
+
+| Check | Command (re-derived) | Result |
+|-------|----------------------|--------|
+| Raw fetch/URL to `/functions/v1/<dead>` | grep across app-mobile/business/admin/supabase | **NONE** |
+| `.invoke("<dead>")` (re-derived implementor angle) | grep across 4 roots | **NONE** |
+| Import FROM a deleted dir | `from "…/<dead>/…"` across all roots | **NONE** (no dangling import) |
+| Cross-dead import (deleted dir → another deleted dir) | `git show origin/main:<dir>/index.ts` | **NONE** (each imported only `_shared`) |
+| Migration executable ref (cron/pg_cron/net.http) | grep `supabase/migrations` | **NONE** |
+| Migration textual refs | grep `supabase/migrations` | 2 hits — both `COMMENT ON COLUMN/TABLE` strings (baseline squash, ORCH-0708 doc). Inert. |
+| Remaining textual refs (broad repo, ex-artifacts) | grep whole repo | source COMMENTS only (`admin-seed-places`, `run-place-intelligence-trial`, `photoAestheticEnums.ts` header). No call path. |
+| Migration in the diff | `git diff --name-only \| grep migrations` | **NONE** — no migration touched (confirmed). |
+
+---
+
+## 7. Constitution 14-rule matrix (independently re-checked against the diff)
+
+| # | Rule | Result | Evidence |
+|---|------|--------|----------|
+| 1 | No dead taps | N/A | No UI surface. |
+| 2 | One owner per truth | **PASS** | Deletion removes the only writer of `photo_aesthetic_data`/`photo_aesthetic_runs` invocation; no new writer introduced. The `I-PHOTO-AESTHETIC-DATA-SOLE-OWNER` COMMENT now documents a fn that no longer exists — harmless doc-drift, not an ownership conflict (P4-2). |
+| 3 | No silent failures | N/A | No error path added; code only removed. |
+| 4 | One query key per entity | N/A | No client query keys touched. |
+| 5 | Server state stays server-side | N/A | No Zustand/state touched. |
+| 6 | Logout clears everything | N/A | No auth/session code. |
+| 7 | Label `[TRANSITIONAL]` + exit | **PASS** | None introduced. |
+| 8 | Subtract before adding | **PASS** | This ORCH IS subtraction — dead code removed, nothing re-added. |
+| 9 | No fabricated data | N/A | No data paths. |
+| 10 | Currency-aware | N/A | No money code. |
+| 11 | One auth instance | N/A | No auth client touched. |
+| 12 | Validate at right time | N/A | No validation logic. |
+| 13 | Exclusion consistency | N/A | No filter logic. |
+| 14 | Persisted-state startup gate | N/A | No hydration code. |
+
+No violation. No automatic-P0 trigger fired.
+
+---
+
+## 8. Device / parity matrix
+
+| Surface | Status | Reason |
+|---------|--------|--------|
+| Consumer iOS | N/A (skip) | Zero callers in `app-mobile`; nothing renders. |
+| Consumer Android | N/A (skip) | Same RN codebase; zero callers. |
+| Buyer/anonymous Web | N/A (skip) | No invoke/fetch/import refs in `mingla-business`. |
+| Business iOS | N/A (skip) | No refs in `mingla-business`. |
+| Business Android | N/A (skip) | Same. |
+| Admin Web (adjacent) | N/A (skip) | `mingla-admin` carries only a path COMMENT; no import/caller. |
+| Business Web preview (adjacent) | N/A (skip) | Same `mingla-business`; zero callers. |
+| Edge-fn live deploy state | **NOTE** | All 3 functions still **ACTIVE** in the live project (generate-ai-summary v280, ai-reason v418, score-place-photo-aesthetics v182) — EXPECTED; the implementor does not undeploy. Orchestrator/operator must undeploy at close (P4-1). |
+
+Backend-only source deletion → no end-user surface changes → parity is automatic.
+
+---
+
+## 9. Findings (P-numbered)
+
+**P4-1 (NOTE) — 3 deleted functions are still deployed-ACTIVE live; undeploy is owed at close.**
+- Evidence: `mcp__supabase__list_edge_functions` shows `generate-ai-summary` (v280), `ai-reason` (v418), `score-place-photo-aesthetics` (v182) all `status:"ACTIVE"`.
+- Impact: none functional (they have zero callers); but the live project still hosts dead functions until torn down. This is the documented hand-off (impl report §11), NOT a defect.
+- Required action (orchestrator/operator, NOT implementor): undeploy the 3 functions from MERGED main at close.
+- Retest: re-run `list_edge_functions`; confirm the 3 slugs are absent post-close.
+
+**P4-2 (NOTE) — doc-drift: a migration COMMENT + a few source comments still name the deleted functions.**
+- Evidence: `20260505000000_baseline_squash_orch_0729.sql:7248,8834` (`COMMENT ON ... 'Owned EXCLUSIVELY by score-place-photo-aesthetics'`); comments in `admin-seed-places/index.ts:1043,1491`, `run-place-intelligence-trial/index.ts:229,652`, `photoAestheticEnums.ts:4`, `mingla-admin/.../placeIntelligenceTrial.js:4`.
+- Impact: zero runtime effect (comments / SQL doc-strings only). Left intact per SC-4 (do not rewrite other functions). Worth a future doc-sweep but out of ORCH-1108 scope.
+- Required action: none for this ORCH. Optional orchestrator cleanup later.
+- Retest: n/a.
+
+No P0 / P1 / P2 / P3.
+
+---
+
+## 10. Discoveries for Orchestrator
+
+- `ANTHROPIC_API_KEY` now has zero active edge-fn consumers (sole consumer `score-place-photo-aesthetics` deleted; only a comment remains in `run-place-intelligence-trial/index.ts:652`). Secret teardown is a separate operator decision — correctly NOT done here.
+- At close: (1) undeploy the 3 ACTIVE functions from merged main; (2) optionally sweep the doc-drift comments in P4-2; (3) optionally remove `ANTHROPIC_API_KEY`.
+- Comms ledger: no OPEN BLOCK/WARN entry addressed to `tester`, `ORCH-1108`, or `ALL` required action this turn. No new COMMS entry written (no cross-ORCH discovery).
+
+---
+
+## 11. Test environment
+
+- deno 2.7.14 (`/Users/sethogieva/.deno/bin/deno`), `--allow-all`.
+- Repo-only hermetic tests (filesystem walks of repo roots + migrations; no network, no live project).
+- HEAD verified `7103b2826` (impl) then `5bee87700` (after appending the adversarial test). Worktree left clean (only the untracked IMPLEMENTATION report remains, which is the implementor's working copy — not committed by QA).


### PR DESCRIPTION
Docs only — no product code. Persists the prod stand-up artifacts + ORCH-1108 impl/QA reports, and logs COMMS-0023 flagging the ORCH-1108 ID collision (shipped-first keeps 1108; the parallel partner-invite-surface-and-ari-gate session renumbers to 1110+). The other session's untracked artifacts are left untouched.