### PR TITLE
ORCH-1114: public trip + experience Share → web-aware ShareModal (fix dead-tap) [deploy]

### DIFF
--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1114_PUBLIC_TRIP_SHARE.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1114_PUBLIC_TRIP_SHARE.md
@@ -1,0 +1,231 @@
+# INVESTIGATE — ORCH-1114 [public trip page Share button does not share the link]
+
+- **Mode:** INVESTIGATE (forensics)
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1114-[trip-share-link]/` · branch `ORCH-1114-trip-share-link` (rebased on origin/main; anchor at `a7cc767e3`)
+- **Date:** 2026-06-11
+- **Confidence:** ROOT CAUSE PROVEN (runtime-grade — proven against the installed react-native-web `Share` source, the exact code executed in the browser). No live browser session required because the executed module is read verbatim and is deterministic.
+
+---
+
+## Symptom summary (expected vs actual)
+
+On the PUBLIC trip page (`/t/{brandSlug}/{tripSlug}`, served as Expo Web at `business.usemingla.com`), tapping the Share icon (top-right IconChrome) does nothing observable — no share sheet, no copy-link, no toast, no feedback.
+
+- **Expected:** tapping Share offers the buyer a way to share the page link (native share sheet where supported; otherwise a usable fallback such as copy-link).
+- **Actual:** dead tap. On a desktop browser the share promise rejects and the empty `catch {}` swallows it silently. On a mobile browser with the Web Share API it may pop the OS sheet, but there is no fallback and no copy path, so the control is unreliable and frequently a no-op.
+
+---
+
+## Investigation manifest (every file read, in trace order)
+
+| # | File | Layer | Why |
+|---|------|-------|-----|
+| 1 | `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` | Code (route) | Primary suspect — `handleShare` + `Share.share` + empty `catch {}` |
+| 2 | `mingla-business/app/e/[brandSlug]/[eventSlug].tsx` | Code (route) | Cluster check — public event page |
+| 3 | `mingla-business/src/components/event/PublicEventPage.tsx` | Code (component) | Where event-page share actually lives |
+| 4 | `mingla-business/src/components/ui/ShareModal.tsx` | Code (kit) | The web-aware share primitive used by event/brand |
+| 5 | `mingla-business/src/utils/sharePublicUrl.ts` | Code (util) | The web-aware share/copy implementation |
+| 6 | `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` | Code (route) | Cluster check — public experience page |
+| 7 | `mingla-business/app/b/[brandSlug]/index.tsx` + `src/components/brand/PublicBrandPage.tsx` | Code (route+component) | Cluster check — public brand page |
+| 8 | `node_modules/react-native-web/dist/exports/Share/index.js` | **Runtime** | The exact `Share.share` code executed in the browser |
+| 9 | `mingla-business/src/constants/publicUrls.ts` | Code (helper) | Canonical public-URL helper (`tripPublicUrl`) |
+| 10 | `app.json` (web.output) | Config | Confirms `/t/` is served as web (`output: "single"`) |
+| 11 | `app/(tabs)/hub/trips.tsx`, `hub/experiences.tsx` | Code | Authenticated share path (uses ShareModal — correct) |
+| 12 | `mingla-business/app/t/__tests__/public-trip-page.test.ts` | Test | What the existing test asserts about share (nothing) |
+
+---
+
+## Q-scorecard
+
+**Q1 — Is the public trip page Share button a dead tap, and why?**
+Verdict: YES — PROVEN. `handleShare` calls react-native-web `Share.share`, which rejects when `window.navigator.share` is undefined; the route's empty `catch {}` swallows the rejection with no fallback. (F-1, F-2)
+
+**Q2 — Does the bug affect native business iOS/Android, or only web?**
+Verdict: WEB-SPECIFIC for the dead-tap. On native iOS/Android `Share.share` is the real OS share sheet and works. But the public `/t/` route's primary real-world traffic is WEB (buyer arrives via share link in a browser). (F-3)
+
+**Q3 — Do the sibling public pages (event `/e/`, brand `/b/`) share this defect?**
+Verdict: NO — REFUTED for event + brand. Both route share to `ShareModal` → `sharePublicUrl`, which is web-aware (uses `navigator.share` when present, and ALWAYS offers copy-link / QR / platform deep-links as fallback). (F-4)
+
+**Q4 — Is there a sibling that DOES share the defect (true causal cluster)?**
+Verdict: YES — the public EXPERIENCE page `/exp/{brandSlug}/{experienceSlug}` has the IDENTICAL inline `Share.share` + empty `catch {}` bug. It was authored as a copy of the trip page. (F-5)
+
+**Q5 — Is the share URL constructed correctly, and is there a canonical helper to reuse?**
+Verdict: URL value is correct (`https://business.usemingla.com/t/{brandSlug}/{tripSlug}`) but it is HARDCODED. A canonical helper `tripPublicUrl({brandSlug, tripSlug})` already exists in `src/constants/publicUrls.ts` and should be reused. (F-6)
+
+**Q6 — What does the existing test assert about share?**
+Verdict: NOTHING. `public-trip-page.test.ts` covers anon-tolerance, mounting, and state handling only. The share control is entirely untested. (F-7)
+
+---
+
+## Findings (six-field evidence)
+
+### F-1 — `Share.share` on react-native-web rejects when `navigator.share` is absent — CONFIRMED ROOT CAUSE
+1. **Symptom:** Tapping Share on the public trip page in a browser does nothing.
+2. **Layer:** Runtime (the executed react-native-web module).
+3. **Probe:** `cat mingla-business/node_modules/react-native-web/dist/exports/Share/index.js`
+4. **Evidence (verbatim):**
+```js
+class Share {
+  static share(content, options) {
+    ...
+    if (window.navigator.share !== undefined) {
+      return window.navigator.share({ title: content.title, text: content.message, url: content.url });
+    } else {
+      return Promise.reject(new Error('Share is not supported in this browser'));
+    }
+  }
+}
+```
+5. **Mechanism:** On web, `Share.share` is NOT the native OS sheet. When `window.navigator.share` is `undefined` (all desktop Chrome/Firefox, Safari macOS in most configs, and any browser without the Web Share API) it returns a REJECTED promise. The trip page is served as web (`app.json` → `web.output: "single"`), so this is the code that actually runs for buyers.
+6. **Severity:** CONFIRMED ROOT CAUSE.
+
+### F-2 — Empty `catch {}` swallows the rejection with NO fallback — CONFIRMED ROOT CAUSE
+1. **Symptom:** No share sheet, no error, no copy-link, no toast — a pure dead tap.
+2. **Layer:** Code (route).
+3. **Probe:** Read `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` lines 81-95.
+4. **Evidence (verbatim):**
+```js
+const handleShare = useCallback(async (): Promise<void> => {
+  if (typeof brandSlug !== "string" || typeof tripSlug !== "string") return;
+  const url = `https://business.usemingla.com/t/${brandSlug}/${tripSlug}`;
+  const title = query.data?.trip.title ?? "Mingla trip";
+  try {
+    await Share.share(
+      Platform.OS === "ios"
+        ? { url, message: title }
+        : { message: `${title} ${url}`, title },
+    );
+  } catch {
+    // Native Share rejection (user cancels) is non-actionable;
+    // do not surface a toast. Constitution #3 exempts user-cancelled flows.
+  }
+}, [brandSlug, tripSlug, query.data?.trip.title]);
+```
+5. **Mechanism:** The branch is `Platform.OS === "ios"` vs else — there is NO `Platform.OS === "web"` branch. On web, `Share.share` rejects (F-1), control falls into the empty `catch {}`, which assumes the only rejection cause is "user cancelled native sheet." On web the rejection means "share is impossible," yet the code provides no copy-link or toast fallback → the user sees nothing. The protective comment is WRONG for the web surface (it reasons only about native user-cancel).
+6. **Severity:** CONFIRMED ROOT CAUSE (F-1 + F-2 together are the complete cause).
+
+### F-3 — Native iOS/Android business app: share WORKS; web is the broken surface — RULED OUT (native) / CONFIRMED (web)
+1. **Symptom:** N/A on native; dead tap on web.
+2. **Layer:** Runtime (platform branch).
+3. **Probe:** Read the `Platform.OS === "ios"` branch + RN native Share semantics.
+4. **Evidence:** On native, `Share` resolves to React Native's native module — `Share.share` opens the real OS share sheet. The iOS branch passes `{ url, message }`; the else (Android-native) branch passes `{ message, title }`. Both are valid native payloads.
+5. **Mechanism:** The bug is exclusively a web-platform-branch omission. Native iOS/Android share works. But the public `/t/` route's real audience is browsers reached via a share link, so the broken surface is the one that matters most.
+6. **Severity:** RULED OUT for native; the web surface is the CONFIRMED defect.
+
+### F-4 — Event + Brand public pages do NOT have this bug (use web-aware ShareModal) — RULED OUT
+1. **Symptom:** Event/brand share works on web.
+2. **Layer:** Code.
+3. **Probe:** Grep `Share.share|ShareModal|onShare` across event/brand components.
+4. **Evidence:** `PublicEventPage.tsx:264` → `handleShare = () => setShareModalVisible(true)`; `PublicBrandPage.tsx:315` → `onShare: () => setShareModalVisible(true)` + `<ShareModal …>`. `ShareModal` → `sharePublicUrl` (`src/utils/sharePublicUrl.ts`), which has an explicit `Platform.OS === "web"` branch using `navigator.share` AND always offers **copy-link** (`copyPublicUrl` → `navigator.clipboard.writeText`), a **QR code**, and **platform deep-links** as fallbacks, with toasts (`"Native share not supported on this browser."`).
+5. **Mechanism:** Event + brand pages were built on the correct ShareModal primitive; the trip + experience pages were built with a one-off inline `Share.share` that bypasses it.
+6. **Severity:** RULED OUT (event/brand are correct — they are the reference fix shape).
+
+### F-5 — Public EXPERIENCE page `/exp/` has the IDENTICAL bug — SECONDARY ROOT CAUSE (causal cluster)
+1. **Symptom:** Share on the public experience page is the same dead tap on web.
+2. **Layer:** Code (route).
+3. **Probe:** Read `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` lines 79-94.
+4. **Evidence (verbatim):**
+```js
+const handleShare = useCallback(async (): Promise<void> => {
+  ...
+  const url = `https://business.usemingla.com/exp/${brandSlug}/${experienceSlug}`;
+  const title = query.data?.experience.title ?? "Mingla experience";
+  try {
+    await Share.share(
+      Platform.OS === "ios" ? { url, message: title } : { message: `${title} ${url}`, title },
+    );
+  } catch {
+    // User-cancelled native Share is non-actionable; Constitution #3 exempts.
+  }
+}, [brandSlug, experienceSlug, query.data?.experience.title]);
+```
+File header confirms: "Mirrors /t/[brandSlug]/[tripSlug] exactly." It inherited the exact defect.
+5. **Mechanism:** Same as F-1+F-2 — no web branch, empty `catch {}`, no fallback.
+6. **Severity:** SECONDARY ROOT CAUSE — same defect, must be fixed in the same pass to fix the cluster not the symptom.
+
+### F-6 — Share URL is hardcoded; canonical `tripPublicUrl` helper exists and should be reused — SUSPECTED CONTRIBUTOR (maintenance)
+1. **Symptom:** URL string duplicated across files (drift risk if the domain ever changes).
+2. **Layer:** Code.
+3. **Probe:** Read `src/constants/publicUrls.ts`.
+4. **Evidence:** `export const tripPublicUrl = (input: { brandSlug; tripSlug }) => \`${BUSINESS_PUBLIC_ORIGIN}${tripPublicPath(input)}\`` already exists (also `eventPublicUrl`, `brandPublicUrl`, `checkoutPublicUrl`). The trip page instead hardcodes `https://business.usemingla.com/t/${brandSlug}/${tripSlug}`. There is NO `experiencePublicUrl` helper yet (the `/exp/` page hardcodes too). Note: the authenticated Hub share paths (`hub/trips.tsx:324`, `hub/experiences.tsx:353`) ALSO hardcode the same strings but route through `<ShareModal>`, so they WORK on web despite the hardcoded URL.
+5. **Mechanism:** The URL VALUE is correct today, so this is not the cause of the dead tap — but the fix should reuse `tripPublicUrl` (and add `experiencePublicUrl`) so the corrected share path stays in sync with the canonical origin.
+6. **Severity:** SUSPECTED CONTRIBUTOR (maintenance / correctness hygiene, not the live cause).
+
+### F-7 — No test covers the share control — SUSPECTED CONTRIBUTOR (regression gap)
+1. **Symptom:** The dead tap shipped and persisted because nothing guards share behavior.
+2. **Layer:** Test.
+3. **Probe:** Read `mingla-business/app/t/__tests__/public-trip-page.test.ts`.
+4. **Evidence:** The 8 tests (`A-PUBLIC-1..8`) assert anon-tolerance (no `useAuth`), no sign-in redirect, mounting of `TripPreview`/`TripCheckoutFlow`, hook usage, and state handling. ZERO assertions about `handleShare`, `Share`, `ShareModal`, web fallback, or copy-link.
+5. **Mechanism:** No fails-on-revert guard exists for the web share path, so the regression was invisible to CI.
+6. **Severity:** SUSPECTED CONTRIBUTOR — the SPEC must add a fails-on-revert test asserting the corrected share path (web-aware) on both trip and experience pages.
+
+---
+
+## Five-Truth-Layer reconciliation
+
+| Layer | Finding | Contradiction? |
+|-------|---------|----------------|
+| **Docs** | File header (line 80) claims "share → native share sheet with the public trip URL." JSDoc assumes native. | YES — doc assumes native; the page is served as WEB where the native sheet does not exist. The doc never accounts for the web surface. |
+| **Schema** | N/A — no DB/RLS involved (frontend-only). | — |
+| **Code** | `handleShare` branches `ios` vs else only; empty `catch {}`; bypasses the web-aware `ShareModal`/`sharePublicUrl`. | YES — code diverges from the sibling event/brand convention (ShareModal). |
+| **Runtime** | Installed react-native-web `Share.share` rejects when `navigator.share` is undefined (verbatim source). | This is the truth-holding layer: the web rejection + empty catch = dead tap. |
+| **Data** | N/A. | — |
+
+The gap between the **Docs/Code** assumption ("native share works") and the **Runtime** reality ("web rejects, no fallback") IS the bug.
+
+---
+
+## Repro evidence
+
+- **Runtime-grade proof without a live session:** the executed module `react-native-web/dist/exports/Share/index.js` is read verbatim (F-1). Its behavior is deterministic: `navigator.share === undefined` → rejected promise → empty `catch {}` (F-2) → no UI. This is the exact code path the browser runs.
+- **Web surface confirmed:** `app.json` → `web.output: "single"` confirms `/t/` and `/exp/` are served as Expo Web at `business.usemingla.com`.
+- **No iOS simulator run performed:** the defect is a web-platform-branch omission proven from the executed web bundle's source, not a native gesture/animation/keyboard bug; the live-fire directive's exemption for "the executed code path is read verbatim and deterministic" applies. If SPEC/TEST wants belt-and-suspenders, a browser repro on a desktop Chrome session (`navigator.share === undefined`) will show the dead tap; a mobile-Chrome session may pop the OS sheet (illustrating the inconsistency), and neither offers any copy-link fallback.
+
+---
+
+## Blast radius / cross-surface map
+
+| Surface | Affected? | Behavior |
+|---------|-----------|----------|
+| Buyer/anon Web — `/t/{brandSlug}/{tripSlug}` | **BROKEN (in scope)** | Dead tap on desktop browsers; unreliable on mobile; no fallback. |
+| Buyer/anon Web — `/exp/{brandSlug}/{experienceSlug}` | **BROKEN (in scope — cluster)** | Identical dead-tap defect (F-5). |
+| Buyer/anon Web — `/e/{brandSlug}/{eventSlug}` | Working | Uses ShareModal (web-aware). Out of scope. |
+| Buyer/anon Web — `/b/{brandSlug}` | Working | Uses ShareModal (web-aware). Out of scope. |
+| Business iOS/Android (native, public routes) | Working | Native `Share.share` opens the OS sheet. |
+| Business app authenticated Hub share (`hub/trips.tsx`, `hub/experiences.tsx`) | Working | Already route through `<ShareModal>`. Out of scope. |
+| Consumer app (`app-mobile/`) | N/A | These routes do not exist there. |
+| Admin web (`mingla-admin/`) | N/A | — |
+
+**In-scope surfaces to fix:** public trip page `/t/` and public experience page `/exp/`. **Out-of-scope:** event, brand, Hub, and native-only behavior (already correct).
+
+---
+
+## Invariant impact
+
+- No existing `INVARIANT_REGISTRY.md` entry is violated by the defect itself.
+- **Constitution #1 (dead-tap / interactive-elements-must-fire):** the Share control claims to share but does nothing at runtime on web — a textbook dead tap. Memory rule `feedback_interactive_elements_must_fire_runtime_proof.md` applies; the fix must be proven to FIRE at runtime on web.
+- The protective comment in `handleShare` ("Constitution #3 exempts user-cancelled flows") is MISAPPLIED on web: the rejection there is "share impossible," not "user cancelled."
+- SPEC should consider proposing `I-PROPOSED-PUBLIC-SHARE-VIA-SHAREMODAL` (DRAFT): all buyer-anon public detail pages share via the web-aware `ShareModal`/`sharePublicUrl` primitive, never a bare inline `Share.share` with a swallow-only catch.
+
+## Discoveries for Orchestrator
+
+- **D-1 (cluster):** `/exp/` carries the identical bug (F-5) — fix in the same ORCH.
+- **D-2 (helper gap):** No `experiencePublicUrl` helper exists in `publicUrls.ts`; adding one alongside reusing `tripPublicUrl` keeps both fixed pages on the canonical origin (F-6).
+- **D-3 (hardcoded-but-working):** Authenticated Hub share paths hardcode the same URL strings but work (they use ShareModal). Not a bug; flagged for the helper-consolidation note only.
+- **D-4 (test gap):** No share test exists on the trip page; SPEC must add a fails-on-revert guard for both pages (F-7).
+- **No COMMS-ledger BLOCK/WARN entry targets this ORCH or forensics.** COMMS-0002 (backend allowlist) and COMMS-0018 (deploy-from-merged-main) are N/A — this is frontend-only, no edge deploy, no migration. COMMS-0003 (external-API docs) is N/A — no external provider integration.
+
+---
+
+## Confidence
+
+**ROOT CAUSE PROVEN.** F-1 (verbatim executed react-native-web `Share` source) + F-2 (empty `catch {}`, no web branch, no fallback) fully explain the dead tap with runtime-grade evidence. The cluster (F-5) is proven by verbatim source. The fix shape is established by the working sibling reference (F-4).
+
+## Recommended next phase + scope (direction only — NOT a fix)
+
+- **Next phase:** SPEC (forensics SPEC mode) → then implementor.
+- **Recommended scope (direction, not a contract):** make the public trip page AND the public experience page share via the existing web-aware path used by event/brand — i.e. the `ShareModal`/`sharePublicUrl` primitive (which already has the web `navigator.share` branch plus copy-link/QR/platform-deep-link fallbacks and toasts) — instead of the bare inline `Share.share` + empty `catch {}`. Reuse the canonical `tripPublicUrl` helper (and add an `experiencePublicUrl` helper) so the share URL stays on `BUSINESS_PUBLIC_ORIGIN`. Add a fails-on-revert test on both pages asserting the share control routes through the web-aware primitive (not bare `Share.share`). Keep scope to the two broken public pages; do not touch event/brand/Hub/native.
+
+---
+
+*Artifact: `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1114_PUBLIC_TRIP_SHARE.md`*

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md
@@ -1,0 +1,159 @@
+# IMPLEMENTATION — ORCH-1114 [public trip + experience Share button is a dead tap on web]
+
+- **Mode:** IMPLEMENT (mingla-implementor) — executes the binding SPEC verbatim.
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1114-[trip-share-link]/` · branch `ORCH-1114-trip-share-link`
+- **Date:** 2026-06-11
+- **Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md`
+- **Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1114_PUBLIC_TRIP_SHARE.md`
+- **Single commit:** `e8c45511dd069f209b6ebde6070d5a2a3603b84d`
+- **Status:** implemented and verified (web routing via source-guard tests + typecheck; native parity preserved by construction — runtime device proof is the tester's gate per spec §11).
+
+---
+
+## 1. Summary
+
+The public buyer-anon **trip** page (`/t/{brandSlug}/{tripSlug}`) and **experience** page (`/exp/{brandSlug}/{experienceSlug}`) previously called react-native `Share.share` with an empty `catch {}`. On `react-native-web` (all desktop browsers, where `navigator.share` is undefined) that call rejects and the empty catch swallowed it — a dead tap with no share sheet, no copy-link, no toast.
+
+Both pages now open the existing web-aware `ShareModal` (the same primitive the event `/e/` and brand `/b/` pages already use), which offers Copy link, Share via…, QR, and platform deep-links with success/failure toasts on every browser. A net-new `experiencePublicUrl` (+ `experiencePublicPath`) helper was added to `publicUrls.ts`, mirroring the existing trip helpers; the trip page reuses the existing `tripPublicUrl`. Frontend-only — no DB, edge, migration, or deploy.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+All criteria satisfied by commit `e8c45511`.
+
+| SC | Criterion | How verified | Result |
+|----|-----------|--------------|--------|
+| SC-1-Web (trip) | Tap Share on `/t/…` opens ShareModal (Copy link / Share via… / URL / QR) | Source-guard A-PUBLIC-9 (`<ShareModal` + `setShareModalVisible` + `tripPublicUrl(`); ShareModal already renders all elements (DO-NOT-TOUCH, verified verbatim) | ✓ (runtime browser proof = tester gate) |
+| SC-2-Web (trip copy) | Copy link → "Link copied" toast | Delivered by reused `ShareModal` (unmodified) | ✓ (tester gate) |
+| SC-3-Web (trip native-share fallback) | Share via… without `navigator.share` → "Native share not supported" toast | Reused `ShareModal` (unmodified) | ✓ (tester gate) |
+| SC-4-Web (experience) | Same as SC-1 for `/exp/…` | Source-guard A-EXP-9 (`<ShareModal` + `experiencePublicUrl(`) | ✓ (tester gate) |
+| SC-5-iOS (native parity) | Business iOS Share opens ShareModal; Share via… → OS sheet | `ShareModal`→`sharePublicUrl` native branch unchanged; no web-only guard added | ✓ preserved by construction (tester device gate) |
+| SC-6-Android (native parity) | Same via Android `sharePublicUrl` branch | same | ✓ preserved by construction (tester device gate) |
+| SC-7 (helper) | `experiencePublicUrl({brandSlug:"acme",experienceSlug:"sunset-sail"})` → `https://business.usemingla.com/exp/acme/sunset-sail`; throws `PublicUrlError` on empty segment; `tripPublicUrl` unchanged | jest T-1/T-2/T-3/T-4/T-5 PASS | ✓ |
+| SC-8 (no bare Share.share) | Neither route imports/calls `Share`; both reference `ShareModal` | jest A-PUBLIC-9 / A-EXP-9 (`.not.toMatch(/Share\.share/)` + no `Share` import) PASS | ✓ |
+| SC-9 (no silent catch) | No empty `catch {}` around share path | empty-catch handler deleted from both routes (source) | ✓ |
+
+---
+
+## 3. Files changed
+
+| File | Status | Δ (approx) |
+|------|--------|-----------|
+| `mingla-business/src/constants/publicUrls.ts` | M | +16 |
+| `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` | M | +10 / −20 |
+| `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` | M | +12 / −19 |
+| `mingla-business/src/constants/__tests__/publicUrls.test.ts` | M | +27 |
+| `mingla-business/app/t/__tests__/public-trip-page.test.ts` | M | +18 |
+| `mingla-business/app/exp/__tests__/public-experience-page.test.ts` | A (new) | +81 |
+
+Only the 6 spec-allowlist files were touched. No DO-NOT-TOUCH file modified.
+
+---
+
+## 4. Data-model changes applied
+
+None. Frontend-only ORCH (no migration, table, constraint, index, or RLS change).
+
+---
+
+## 5. Edge functions touched
+
+None.
+
+---
+
+## 6. Regression tests added
+
+- `mingla-business/src/constants/__tests__/publicUrls.test.ts` — T-1/T-2 (canonical trip + experience URLs), T-3 (segment encoding), T-4/T-5 (empty/whitespace segment → `PublicUrlError`). +3 tests.
+- `mingla-business/app/t/__tests__/public-trip-page.test.ts` — A-PUBLIC-9 (trip share routes through `ShareModal`, no bare `Share.share`, no `Share` import). +1 test.
+- `mingla-business/app/exp/__tests__/public-experience-page.test.ts` — NEW. A-EXP-1..7 (anon-tolerance + mounts mirror) + A-EXP-9 (experience share routes through `ShareModal` + `experiencePublicUrl`, no bare `Share.share`). +8 tests.
+
+**Test run (fix in place):**
+```
+PASS app/exp/__tests__/public-experience-page.test.ts
+PASS src/constants/__tests__/publicUrls.test.ts
+PASS app/t/__tests__/public-trip-page.test.ts
+Test Suites: 3 passed, 3 total
+Tests:       23 passed, 23 total
+```
+
+**fails-on-revert verified at `e8c45511dd069f209b6ebde6070d5a2a3603b84d`** (true line-deletion, not comment-out):
+- Reverted `app/t/[brandSlug]/[tripSlug].tsx` ShareModal mount → `Share.share` call, AND `experiencePublicUrl` → hand-rolled concat without `requireSegment`. Result:
+```
+FAIL app/t/__tests__/public-trip-page.test.ts
+  ● A-PUBLIC-9: trip share routes through ShareModal, not bare Share.share
+FAIL src/constants/__tests__/publicUrls.test.ts
+  ● T-4/T-5: experience helper rejects empty/whitespace segments (fails-on-revert)
+Tests:       2 failed, 13 passed, 15 total
+```
+- Restored via `git checkout` → all 23 PASS again (shown above). The tests exercise the actual regression.
+
+---
+
+## 7. Old → New receipts
+
+### `src/constants/publicUrls.ts`
+- **Before:** had `tripPublicPath`/`tripPublicUrl` but NO experience helper.
+- **Now:** adds `experiencePublicPath` + `experiencePublicUrl` after the trip helpers, using shared `requireSegment` + `BUSINESS_PUBLIC_ORIGIN` (mirror of trip pair). `tripPublicUrl` and all other exports unchanged.
+- **Why:** SC-7; the experience page needs a canonical, guard-checked share URL (none existed).
+- **Lines:** +16.
+
+### `app/t/[brandSlug]/[tripSlug].tsx`
+- **Before:** `handleShare` async called `Share.share` (Platform-branched) with empty `catch {}`; share `IconChrome` `onPress` wrapped `void handleShare()`. Imported `Share` + `Platform`.
+- **Now:** `handleShare` is a synchronous 1-liner `setShareModalVisible(true)`; share `IconChrome` `onPress={handleShare}`; added `useState` + `<ShareModal url={tripPublicUrl({brandSlug,tripSlug})} title={payload.trip.title} description={payload.trip.description?.slice(0,200)} />` gated on `typeof brandSlug/tripSlug === "string"`. Removed `Share`, `Platform` imports.
+- **Why:** SC-1/SC-8/SC-9 — kill the dead-tap + silent catch; route through web-aware modal.
+- **Lines:** +10 / −20.
+
+### `app/exp/[brandSlug]/[experienceSlug].tsx`
+- **Before:** identical `Share.share` + empty-catch dead-tap pattern with `void handleShare()` wrapper; imported `Share` + `Platform`.
+- **Now:** same swap as trip, with `<ShareModal url={experiencePublicUrl({brandSlug,experienceSlug})} title={experience.title} description={experience.description?.slice(0,200) ?? undefined} />` gated on string slugs. Removed `Share`, `Platform` imports.
+- **Why:** SC-4/SC-8/SC-9.
+- **Lines:** +12 / −19.
+
+---
+
+## 8. Cross-surface impact table
+
+| # | Surface | Affected | What changes | Parity |
+|---|---------|----------|--------------|--------|
+| 1 | Consumer iOS (`app-mobile/`) | NO | routes don't exist there | — |
+| 2 | Consumer Android (`app-mobile/`) | NO | routes absent | — |
+| 3 | Buyer/anon Web (`mingla-business/` `/t/`, `/exp/`) | YES (primary) | Share opens ShareModal (copy/QR/share-via/toasts) — no dead tap | Automatic (shared ShareModal) |
+| 4 | Business iOS (native) | YES (parity-preserve) | Share opens ShareModal; Share via… → OS sheet via `sharePublicUrl` native branch | Automatic |
+| 5 | Business Android (native) | YES (parity-preserve) | same via Android branch | Automatic |
+| 6 | Admin Web (`mingla-admin/`) | NO | no such routes | — |
+| 7 | Business Web preview (adjacent) | NO | public buyer routes, not in-app preview | — |
+
+Parity is automatic across all affected surfaces — the shared `ShareModal` (DO-NOT-TOUCH, unmodified) already branches native internally. No web-only guard was added that could suppress the modal on native (spec §3 native-parity note honored).
+
+---
+
+## 9. Smoke result
+
+- jest (the 3 touched specs): 23/23 PASS.
+- `tsc --noEmit` (business `typecheck`): ZERO errors in any touched file (the 4 source files + 2 test files). The 303 pre-existing tsc errors are all in unrelated files (`packages/*`, marketing ComposerV2, checkout flows) — the known business-app baseline, not introduced here.
+- Runtime browser/device verification (desktop Chrome modal open + Copy-link/Share-via toasts + native OS-sheet parity) is the tester's gate per spec §11 (Constitution #1 demands real-browser proof, not source-only). Labeled: web routing structurally verified; runtime behavior delivered by the unmodified, already-shipped `ShareModal`.
+
+---
+
+## 10. Known issues / deferred
+
+- Pre-existing unused import `glass` in `app/t/[brandSlug]/[tripSlug].tsx` (line 31) — present before this ORCH, NOT in the spec allowlist scope, left untouched (no scope creep). Not introduced by this change.
+- No `[TRANSITIONAL]` markers added.
+
+---
+
+## 11. Operator action required
+
+- **Migration `db push`:** none (frontend-only).
+- **Edge-function deploy:** none.
+- **OTA:** per spec §11 + `feedback_eas_ota_publish_per_platform.md`, this is pure-JS (business-app + buyer-web) — no native rebuild needed. OTA is orchestrator/operator-owned at CLOSE (per-platform: `eas update --platform ios` then `--platform android`). The implementor does NOT deploy/merge/OTA.
+- **Next:** route to `mingla-tester` for the device/runtime gate, then `mingla-orchestrator` CLOSE (flip `I-PROPOSED-PUBLIC-SHARE-VIA-SHAREMODAL` DRAFT → ACTIVE).
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- The route-guard regression tests are intentionally worded to avoid the literal string `Share.share` in the protective comments (the comment now says "the bare react-native share API"), because A-PUBLIC-9/A-EXP-9 assert `.not.toMatch(/Share\.share/)` over the whole source file — a comment containing `Share.share` would (correctly) fail the test. Future edits to these route files must keep the literal `Share.share` out of comments to satisfy the guard.
+- COMMS_LEDGER: scanned on entry. The OPEN entries addressed to `ALL` are WARN-level only (COMMS-0003 external-API docs, COMMS-0021 Stripe seller-surface copy, COMMS-0022 business-web phone-browser routes) — all N/A to this frontend-only share-button change (no external API, no Stripe copy, no BottomNav/route-shell touch). Factored, no acks written (no BLOCK to action; no cross-ORCH discovery to register).

--- a/Mingla_Artifacts/reports/QA_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md
@@ -1,0 +1,133 @@
+# QA — ORCH-1114 [public trip + experience Share button is a dead tap on web]
+
+- **Mode:** TARGETED (tester) — brutal gatekeeper, runtime-proof required (Constitution #1).
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1114-[trip-share-link]/` · branch `ORCH-1114-trip-share-link`
+- **Code commit under test:** `e8c45511d`
+- **Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md`
+- **Implementation report:** `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md`
+- **Date:** 2026-06-11
+
+---
+
+## 1. Verdict
+
+**PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 1 (pre-existing, not introduced) · P4: 2.
+
+Runtime evidence is `proven`-level for the buyer-anon **Web** surface (real Chromium, `navigator.share` undefined, real exported RNW bundle, real ShareModal). Native iOS/Android parity is `suspected`-but-strong (share primitive byte-identical to origin/main; no web-only guard) — no device run, stated explicitly; it does not gate PASS because the only behavior that *changed* on native is "tap opens the same ShareModal event/brand already use," and the share dispatch path is unmodified.
+
+Regression gate satisfied: implementor happy-path tests present + fails-on-revert independently reproduced; tester adversarial **runtime** spec added on-branch, in-diff, with its own fails-on-revert proven.
+
+---
+
+## 2. Success-criteria matrix
+
+| SC | Criterion | Verdict | Evidence (runtime / live-fire) |
+|----|-----------|---------|--------------------------------|
+| SC-1-Web (trip) | `/t/` Share tap opens ShareModal (Copy link / Share via… / URL / QR), no dead tap | **PASS (proven)** | Playwright real Chromium: tap aria-"Share" → "Copy link" + "Share via…" + URL row + QR all visible. Screenshot `/tmp/orch1114-modal.png` shows the full sheet. Test 1 PASS. |
+| SC-2-Web (trip copy) | Copy link → "Link copied" toast + URL copied | **PASS (proven)** | Test 2 PASS: "Link copied" toast visible; captured copied value = `https://business.usemingla.com/t/acme-co/bali-escape`. |
+| SC-3-Web (trip native-share fallback) | Share via… (no `navigator.share`) → "Native share not supported on this browser." toast, no silent swallow | **PASS (proven)** | Test 3 PASS: `navigator.share` asserted undefined; tap → exact toast text. |
+| SC-4-Web (experience) | Same as SC-1 for `/exp/` with `/exp/…` URL | **PASS (proven)** | Tests 4–6 PASS: modal opens; copied value = `https://business.usemingla.com/exp/acme-co/sunset-sail`; "not supported" toast fires. |
+| SC-5-iOS (native parity) | Business iOS Share opens ShareModal; Share via… → OS sheet | **PASS (suspected — no device)** | `sharePublicUrl.ts` + `ShareModal.tsx` byte-identical to origin/main (`git diff --stat` empty); modal mount gated only on `typeof slug==="string"`, NO `Platform.OS==="web"` guard → native branch reachable. Not device-run; stated. |
+| SC-6-Android (native parity) | Same via Android `sharePublicUrl` branch | **PASS (suspected — no device)** | Same as SC-5; Android branch (`Share.share({title,message})`) unmodified. |
+| SC-7 (helper) | `experiencePublicUrl(...)` → canonical URL; throws `PublicUrlError` on empty; `tripPublicUrl` unchanged | **PASS (proven)** | jest T-1…T-5 PASS; AND the production URL `https://business.usemingla.com/exp/...` was rendered+copied at RUNTIME (not only unit-asserted). |
+| SC-8 (no bare Share.share) | Neither route imports/calls RN `Share`; both reference `ShareModal` | **PASS (proven)** | `grep` finds zero `Share`/`Platform`/`Share.share` refs in both routes; runtime fails-on-revert: reverting to `Share.share` made all 3 `/t/` runtime tests FAIL (dead tap reproduced). |
+| SC-9 (no silent catch) | No empty `catch {}` around share path | **PASS (proven)** | Empty-catch deleted from both routes (diff); the only share error handling is ShareModal's toast (SC-3 proves it surfaces). |
+
+---
+
+## 3. Findings
+
+### P3-1 — pre-existing unused `glass` import in the trip route (NOT introduced)
+- **Evidence:** `app/t/[brandSlug]/[tripSlug].tsx:33` imports `glass`; present on `origin/main` (`git show origin/main:… | grep glass` → line 33). Implementor flagged it in report §10.
+- **Impact:** none functional; a lint nit that predates ORCH-1114.
+- **Required fix:** none in this ORCH (out of allowlist scope). Orchestrator may sweep separately.
+- **Retest:** n/a.
+
+### P4-1 — clean, spec-faithful pattern reuse (praise)
+Both routes reuse the already-shipped `ShareModal`/`sharePublicUrl`/`tripPublicUrl` primitives verbatim; the new `experiencePublicUrl` mirrors `tripPublicUrl` exactly (shared `requireSegment` guard, `BUSINESS_PUBLIC_ORIGIN`). No new share UI, no duplicated logic (Constitution #8). DO-NOT-TOUCH files byte-identical.
+
+### P4-2 — protective comments prevent silent regression
+The one-line `handleShare` comment in both routes explicitly forbids reverting to the bare RN share API and cites the SPEC; the route-guard tests assert `.not.toMatch(/Share\.share/)` over the whole file (so even a comment containing `Share.share` would fail) — a durable guard.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Reproduced on commit `e8c45511d` (the worktree HEAD code commit), file-level true reverts (not comment-out), then `git checkout`-restore:
+
+1. **Trip route → `origin/main` (`Share.share` dead-tap):** ran `jest public-trip-page.test.ts publicUrls.test.ts` →
+   `FAIL app/t/__tests__/public-trip-page.test.ts ● A-PUBLIC-9: trip share routes through ShareModal, not bare Share.share` (1 failed, 14 passed). Matches implementor claim.
+2. **`experiencePublicUrl` helper → hand-rolled concat (drop `requireSegment`):** ran `jest publicUrls.test.ts` →
+   `FAIL … ✕ T-3: experience helper encodes path segments` AND `✕ T-4/T-5: experience helper rejects empty/whitespace segments (fails-on-revert)` (2 failed, 4 passed). Matches (and is stronger than) the implementor claim.
+3. **Restored both** (`cp` from pre-revert backups) → all 23 implementor tests PASS again; `git status` clean (byte-identical to commit).
+
+Implementor's fails-on-revert is independently verified at `e8c45511d`.
+
+---
+
+## 5. Adversarial test added (tester-owned, DIFFERENT ANGLE)
+
+- **Path:** `mingla-business/playwright/orch-1114-share-modal-runtime.spec.ts` (NEW, append-only) + dedicated `mingla-business/playwright.orch1114.config.ts`.
+- **Angle vs implementor:** the implementor's tests are **static source-grep guards** (`readFileSync` + `toMatch`) — which cap at "suspected" for a dead-tap (Constitution #1). This spec is a **behavioral RUNTIME** gate: it builds the real Expo Web export, serves it, and drives **real Chromium** (where `navigator.share` is genuinely undefined — the exact original dead-tap condition), navigates the REAL public route component, taps the REAL Share IconChrome, and asserts the REAL ShareModal mounts + the REAL copy/share-via toasts fire. It attacks the failure mode the source guards cannot: "wired in source but dead at runtime."
+- **Result:** 6/6 PASS (3 trip + 3 experience): modal opens on tap; "Link copied" toast + exact production URL captured; "Native share not supported on this browser." toast on `navigator.share`-undefined. Console-clean, deterministic (10.9s).
+- **Fidelity:** HIGH. Real headless Chromium, real exported `react-native-web` JS bundle, real `ShareModal` + `sharePublicUrl` + `copyPublicUrl`, real `Toast`. The route is driven to its render body by route-mocking the public-trip/experience Supabase REST chain (the test Supabase project is a stub) + seeding a localStorage session to clear the route-agnostic ORCH-1102 auth gate; clipboard `writeText` is stubbed in-page because headless Chromium has no OS clipboard. Everything in the share UI under test is real and unmodified.
+- **fails-on-revert verified at `e8c45511d`:** with the trip route reverted to `origin/main`'s `Share.share` and the web bundle re-exported, all 3 `/t/` runtime tests FAILED ("Copy link"/"Share via…" never appear — a genuine dead tap), while the 3 `/exp/` tests still PASSED (proving the spec is specific, not flaky). Restored → 6/6 PASS.
+- **In closing diff:** YES — `git diff --name-only origin/main...HEAD` will include the spec + config after commit. Implementor's happy-path tests are already in-diff (publicUrls.test.ts, public-trip-page.test.ts, public-experience-page.test.ts).
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | **PASS** | The whole fix. Runtime-proven: Share tap opens ShareModal on real web (6/6); fails-on-revert reproduces the dead tap. |
+| 2 | One owner per truth | PASS | Share URL owned by `tripPublicUrl`/`experiencePublicUrl` (single helper file). |
+| 3 | No silent failures | **PASS** | Empty `catch {}` removed; ShareModal toasts on copy-fail and share-unsupported (SC-3 runtime-proven). |
+| 4 | One query key per entity | N/A | No query keys touched. |
+| 5 | Server state server-side | N/A | No Zustand/server-state change. |
+| 6 | Logout clears everything | N/A | No auth/session writes. |
+| 7 | `[TRANSITIONAL]` labeled | N/A | None added. |
+| 8 | Subtract before adding | PASS | Reuses ShareModal; deletes the inline Share.share + catch; no duplicated share UI. |
+| 9 | No fabricated data | PASS | URL built from real slugs via guarded helper; no faked values. |
+| 10 | Currency-aware | N/A | No money surface. |
+| 11 | One auth instance | PASS | Routes remain anon-tolerant; no `useAuth` added (anon-tolerance preserved). |
+| 12 | Validate at the right time | N/A | No datetime validation. |
+| 13 | Exclusion consistency | N/A | No list/exclusion logic. |
+| 14 | Persisted-state startup | N/A | No persisted-state gate. |
+
+No violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Evidence |
+|---------|---------|----------|
+| Consumer iOS | N/A (skip) | Routes do not exist in `app-mobile/`. |
+| Consumer Android | N/A (skip) | Same. |
+| **Buyer/anon Web** (primary) | **PASS (proven)** | 6/6 Playwright real-Chromium runtime tests; screenshots `/tmp/orch1114-modal.png` (modal open), `/tmp/orch1114-trip4.png` (route renders w/ Share icon). |
+| Business iOS (native) | PASS (suspected) | Share primitive byte-identical to origin/main; no web-only guard. No device run (stated). |
+| Business Android (native) | PASS (suspected) | Same. |
+| Admin Web (adjacent) | N/A (skip) | No such routes. |
+| Business Web preview (adjacent) | N/A (skip) | Public buyer routes, not in-app preview. |
+
+**Physical iPhone HITL:** not requested for this turn; native parity is preserved-by-construction (unmodified shared primitive). If Seth wants device confirmation of the OS share sheet on business iOS/Android before CLOSE, that is the only `suspected`→`proven` upgrade available; it does not gate PASS because the native share dispatch is unchanged.
+
+**Edge-function live deploy state:** N/A — frontend-only ORCH, no edge functions, no migration.
+
+---
+
+## 8. Discoveries for Orchestrator (not fixed here)
+
+- **D-1 (process/infra, MEDIUM):** the static Expo Web export (`expo export -p web`) runs the app in **SPA mode** and the **route-agnostic ORCH-1102 auth gate redirects EVERY no-user web route to `/` (sign-in)** after the 7s ceiling — including the buyer-anon public routes `/t/`, `/exp/`, `/e/`, `/b/`. To render a public route in a local export I had to seed a localStorage session under BOTH `sb-orch1114-auth-token` (runtime ref) AND the **hardcoded** `sb-gqnoajqerqhnvulmnyvv-auth-token` (production ref in `AuthContext.WEB_AUTH_STORAGE_KEY`). This raises a question worth an orchestrator note: how do genuinely-anonymous buyers reach `/t/`,`/e/`,`/b/`,`/exp/` on `business.usemingla.com` in production? Either the Vercel deploy serves these routes via SSG (bypassing the SPA gate) or the gate would bounce real anon buyers. NOT investigated here (out of ORCH-1114 scope) — flag for forensics if buyer-funnel anon access is unverified. The ORCH-1114 fix itself is correct regardless; this is about the surrounding harness/funnel.
+- **D-2 (test-infra, LOW):** the exported bundle bakes `MINGLA_BUSINESS_WEB_URL` from `app.config.ts`'s `extra` default (production origin), ignoring the `expo export` env override — so the ShareModal renders the real `https://business.usemingla.com/...` URL at runtime (a positive: SC-7's production output is runtime-proven, not just unit-asserted).
+
+---
+
+## 9. Routing
+
+**PASS → CLOSE (orchestrator).** Flip `I-PROPOSED-PUBLIC-SHARE-VIA-SHAREMODAL` DRAFT → ACTIVE. OTA per `feedback_eas_ota_publish_per_platform.md` (pure-JS business-app + buyer-web; per-platform `eas update --platform ios` then `--platform android`; no native rebuild). Optional pre-CLOSE upgrade: a single business iOS/Android device tap to lift SC-5/SC-6 from `suspected`→`proven` (the OS share sheet) — not required for PASS.
+
+---
+
+*Artifact: `Mingla_Artifacts/reports/QA_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md`*

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md
@@ -1,0 +1,252 @@
+# SPEC — ORCH-1114 [public trip + experience page Share button does not share the link]
+
+- **Mode:** SPEC (forensics) — binding build contract. No code; illustrative fragments ≤3 lines only.
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1114-[trip-share-link]/` · branch `ORCH-1114-trip-share-link`
+- **Date:** 2026-06-11
+- **Source investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1114_PUBLIC_TRIP_SHARE.md` (ROOT CAUSE PROVEN)
+- **Confidence carried in:** ROOT CAUSE PROVEN (F-1 + F-2 fully explain the dead tap; F-5 is the proven cluster sibling).
+
+---
+
+## 1. Executive summary
+
+On the public buyer-anon **trip** page (`/t/{brandSlug}/{tripSlug}`) and the public **experience** page (`/exp/{brandSlug}/{experienceSlug}`) — both served as Expo Web at `business.usemingla.com` — tapping the top-right Share icon does nothing on a desktop browser. The pages call React-Native `Share.share`, which on `react-native-web` returns a **rejected promise** whenever `navigator.share` is undefined (all desktop browsers and most macOS Safari configs). The route's empty `catch {}` swallows that rejection with no fallback, so the buyer gets a dead tap: no share sheet, no copy-link, no toast.
+
+The sibling public **event** (`/e/`) and **brand** (`/b/`) pages already solved this: they open the web-aware `ShareModal` (`src/components/ui/ShareModal.tsx`), which uses `navigator.share` when present AND always offers copy-link, a QR code, and platform deep-links with success/failure toasts — working in any browser. This ORCH replicates that exact, already-shipped pattern on the two broken pages. No new share UI is built; the existing primitive is reused.
+
+The fix:
+1. Replace the inline `handleShare`/`Share.share`/empty-`catch` on both pages with `ShareModal` state (`shareModalVisible`) + a `<ShareModal>` mount, exactly as `PublicEventPage.tsx` wires it.
+2. Reuse the canonical `tripPublicUrl` helper for the trip page; add a net-new `experiencePublicUrl` (+ `experiencePublicPath`) helper to `publicUrls.ts` for the experience page (no such helper exists today — confirmed below).
+3. Add fails-on-revert regression tests asserting the share control routes through `ShareModal`, not bare `Share.share`.
+
+---
+
+## 2. Scope & non-goals
+
+### In scope (exactly two pages + one helper + tests)
+- `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` — swap inline `Share.share` for `ShareModal`.
+- `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` — same swap.
+- `mingla-business/src/constants/publicUrls.ts` — add `experiencePublicPath` + `experiencePublicUrl` (mirror `tripPublicPath`/`tripPublicUrl`). Reuse existing `tripPublicUrl`.
+- `mingla-business/src/constants/__tests__/publicUrls.test.ts` — add canonical + empty-segment-rejection assertions for trip + experience builders.
+- New tests guarding the two route source files route through `ShareModal` (locations in §7/§9).
+
+### Non-goals (do NOT touch — HARD)
+- Event page (`/e/`), brand page (`/b/`), `PublicEventPage.tsx`, `PublicBrandPage.tsx` — already correct; reference only.
+- The `ShareModal` component itself, `sharePublicUrl.ts`, `shareIntents.ts`, `copyPublicUrl` — reused verbatim, NOT modified.
+- Authenticated Hub share paths (`app/(tabs)/hub/trips.tsx`, `hub/experiences.tsx`) — already route through `ShareModal` and work; out of scope (they hardcode URLs but are NOT broken — D-3).
+- Native iOS/Android share behavior — already works via `ShareModal`'s internal `sharePublicUrl` native branch; must NOT regress (see §3).
+- No new share UI, no design change, no new share surface, no DB/edge/RLS/migration work (frontend-only).
+- The `IconChrome` share-button placement, `accessibilityLabel="Share"`, size, overlay positioning, and the X-close button — UNCHANGED. Only the `onPress` target changes.
+
+### Assumptions (verified against source)
+- `tripPublicUrl({ brandSlug, tripSlug })` EXISTS in `publicUrls.ts` (line 80) → reuse it.
+- `experiencePublicUrl` / `experiencePublicPath` DO **NOT** exist (grep confirmed: `publicUrls.ts` has only `eventPublicUrl`, `brandPublicUrl`, `checkoutPublicUrl`, `tripCheckoutUrl`, `tripPublicUrl`, OG-image helpers) → must be ADDED.
+- The public experience route path segment is `/exp/{brandSlug}/{experienceSlug}` (the route file is `app/exp/[brandSlug]/[experienceSlug].tsx`; existing hardcoded URL used `/exp/`).
+- `ShareModal` props are `{ visible, onClose, url, title, description? }` (verified). `description` is optional.
+- Trip exposes `payload.trip.title` (string) + `payload.trip.description` (string, may be empty). Experience exposes `payload.experience.title` (string) + `payload.experience.description` (string | null).
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY per-surface table)
+
+| # | Surface | Covered? | User-visible behavior demanded | Files touched here | Parity |
+|---|---------|----------|--------------------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile/`) | NOT covered | n/a — these routes do not exist in the consumer app | none | — |
+| 2 | Consumer Android (`app-mobile/`) | NOT covered | n/a — routes absent | none | — |
+| 3 | **Buyer/anon Web** (`mingla-business/` `/t/…`, `/exp/…`) | **COVERED (primary)** | Tapping Share opens the `ShareModal` sheet: Copy link (→ "Link copied" toast), Share via… (→ `navigator.share` when present, else "Native share not supported on this browser." toast), QR, platform deep-links, tappable URL row. NO dead tap, NO silent failure. | `app/t/[brandSlug]/[tripSlug].tsx`, `app/exp/[brandSlug]/[experienceSlug].tsx`, `src/constants/publicUrls.ts` | Automatic (shared `ShareModal`) |
+| 4 | **Business iOS** (native) | COVERED (parity-preserve) | Tapping Share opens the same `ShareModal`; "Share via…" routes through `sharePublicUrl`'s native iOS branch → real OS share sheet. Copy link uses `expo-clipboard`. Must match event/brand native behavior. | same two route files | Automatic (shared `ShareModal`) |
+| 5 | **Business Android** (native) | COVERED (parity-preserve) | Same `ShareModal`; "Share via…" → `sharePublicUrl` Android branch (RN `Share.share` with message). | same two route files | Automatic (shared `ShareModal`) |
+| 6 | Admin Web (`mingla-admin/`) | NOT covered | n/a — no such routes | none | — |
+| 7 | Business Web preview (adjacent) | NOT covered | n/a — public buyer routes, not the in-app preview surface | none | — |
+
+**Native parity note (Constitution / non-regression):** today the inline `Share.share` already works on native iOS/Android (F-3). After the swap, native share runs through `ShareModal` → `sharePublicUrl`, whose native branches (`Platform.OS === "android"` and the iOS/else branch) call RN `Share.share` with the correct `{ title, message, url }` payload — this is the SAME primitive event/brand pages already use on native. Parity is therefore preserved by construction, NOT regressed. The implementor MUST NOT add a web-only guard that would suppress the modal on native.
+
+---
+
+## 4. Layered specification
+
+Frontend-only. No Database / Edge / Service / Hook / Realtime layers are touched. Two layers apply: **Constant/helper** and **Component (route)**.
+
+### 4.1 Constant/helper layer — `src/constants/publicUrls.ts`
+
+Add two exports, mirroring the existing `tripPublicPath` / `tripPublicUrl` pair (lines 70–83) exactly in shape, ordering, and the `requireSegment(...)` guard:
+
+- `experiencePublicPath(input: { brandSlug: string; experienceSlug: string }): string`
+  → returns `/exp/${requireSegment(input.brandSlug,"brandSlug")}/${requireSegment(input.experienceSlug,"experienceSlug")}`.
+- `experiencePublicUrl(input: { brandSlug: string; experienceSlug: string }): string`
+  → returns `${BUSINESS_PUBLIC_ORIGIN}${experiencePublicPath(input)}`.
+
+Contract requirements (inherited from the sibling helpers — do NOT deviate):
+- Use the shared `requireSegment` (which `encodeURIComponent`s and throws `PublicUrlError` on empty/whitespace segments). Do NOT hand-roll encoding.
+- Place the two new exports adjacent to the trip helpers (after line 83), with a one-line comment referencing ORCH-1114 and "mirror of tripPublicPath/tripPublicUrl".
+- Do NOT modify `tripPublicPath`/`tripPublicUrl` or any other export.
+
+### 4.2 Component layer — `app/t/[brandSlug]/[tripSlug].tsx`
+
+**Imports**
+- ADD `useState` to the `react` import (currently only `useCallback`).
+- ADD `import { ShareModal } from "../../../src/components/ui/ShareModal";`
+- ADD `import { tripPublicUrl } from "../../../src/constants/publicUrls";` (reuse).
+- REMOVE `Share` from the `react-native` import list.
+- REMOVE `Platform` from the `react-native` import **only if** it becomes unused after the swap (verify; if still referenced elsewhere keep it — current file uses `Platform` only inside `handleShare`, so it should be removed).
+
+**State (modal visibility)**
+- ADD `const [shareModalVisible, setShareModalVisible] = useState<boolean>(false);` alongside the other top-of-component hooks (mirror `PublicEventPage.tsx:206`).
+
+**Handler (replaces the inline `Share.share`)**
+- REPLACE the entire `handleShare` `useCallback` (current lines 80–95, the `Share.share` + empty `catch {}` block, incl. its ORCH-0874 comment) with a 1-line opener:
+  `const handleShare = useCallback((): void => { setShareModalVisible(true); }, []);`
+  (mirror `PublicEventPage.tsx:263–265`; note: now synchronous `void`, NOT `async`.)
+- The `IconChrome` share button's `onPress` MUST become `onPress={handleShare}` directly (remove the `() => { void handleShare(); }` async wrapper at lines 236–238, since `handleShare` is now synchronous). Everything else on that `IconChrome` (`icon="share"`, `size={36}`, `accessibilityLabel="Share"`) and its `shareOverlay` wrapper position is UNCHANGED.
+
+**Modal mount**
+- ADD `<ShareModal …>` as the LAST sibling inside the top-level `<View style={styles.host}>` return block (after the two overlay `<View>`s, before the closing `</View>`), mirroring `PublicEventPage.tsx:421–427`:
+  - `visible={shareModalVisible}`
+  - `onClose={() => setShareModalVisible(false)}`
+  - `url={tripPublicUrl({ brandSlug, tripSlug })}` — at this point in the render both are confirmed strings (the early `payload` guards have returned for non-string/missing data; the render body only runs after the loading/error/not-found returns). The implementor MUST confirm `brandSlug`/`tripSlug` are narrowed to `string` at the mount site; if TypeScript cannot narrow, guard with the existing `typeof … === "string"` pattern and pass a stable value (do NOT mount the modal with a malformed URL — `tripPublicUrl` throws `PublicUrlError` on empty segments, which is acceptable fail-closed but must not crash render; gate the mount on valid slugs if needed).
+  - `title={payload.trip.title}`
+  - `description={payload.trip.description?.slice(0, 200)}` (optional; matches the event page's `.slice(0,200)` convention; `description` may be empty string — passing it is harmless).
+
+**Removed protective comment:** the ORCH-0874 `handleShare` JSDoc ("share → native share sheet with the public trip URL", lines 80) is superseded; replace with a one-line note referencing ORCH-1114 ("share → web-aware ShareModal (copy-link/QR/native-share-via); see SPEC_ORCH-1114").
+
+### 4.3 Component layer — `app/exp/[brandSlug]/[experienceSlug].tsx`
+
+Identical transformation, with the experience helper:
+- ADD `useState`; ADD `import { ShareModal } from "../../../src/components/ui/ShareModal";`; ADD `import { experiencePublicUrl } from "../../../src/constants/publicUrls";`.
+- REMOVE `Share` from the `react-native` import; REMOVE `Platform` if it becomes unused (current file uses `Platform` only in `handleShare` — verify and remove).
+- ADD `const [shareModalVisible, setShareModalVisible] = useState<boolean>(false);`.
+- REPLACE the `handleShare` `useCallback` (current lines 79–94) with `const handleShare = useCallback((): void => { setShareModalVisible(true); }, []);`.
+- Change the share `IconChrome` `onPress` from the `() => { void handleShare(); }` wrapper (lines 216–218) to `onPress={handleShare}`. Placement, `icon="share"`, `size={36}`, `accessibilityLabel="Share"`, `shareOverlay` UNCHANGED.
+- ADD `<ShareModal>` as the last sibling inside the top-level `<View style={styles.host}>` (after the two overlay views):
+  - `visible={shareModalVisible}` / `onClose={() => setShareModalVisible(false)}`
+  - `url={experiencePublicUrl({ brandSlug, experienceSlug })}` (with the same slug-narrowing guard as the trip page)
+  - `title={experience.title}` (the render body already binds `const experience = payload.experience;` at line 136)
+  - `description={experience.description?.slice(0, 200) ?? undefined}` (experience `description` is `string | null`; coalesce null to undefined so the optional prop stays optional).
+
+### 4.4 States (every state of the share interaction — all delivered by the reused `ShareModal`, none re-implemented)
+
+| State | Trigger | UI / behavior | Owner |
+|-------|---------|---------------|-------|
+| Closed (default) | initial render | `shareModalVisible=false`; modal not shown; Share icon idle | route |
+| Open | tap Share icon | `setShareModalVisible(true)` → `ShareModal` Sheet animates up | route → ShareModal |
+| Copy success | tap "Copy link" | `copyPublicUrl` resolves → "Link copied" toast | ShareModal |
+| Copy failure | clipboard unavailable | "Copy failed. Try Share via instead." toast | ShareModal |
+| Native-share success | tap "Share via…" (web w/ `navigator.share`, or native) | OS/Web share sheet opens | ShareModal → sharePublicUrl |
+| Native-share unsupported | tap "Share via…" (web, no `navigator.share`) | "Native share not supported on this browser." toast (NO silent failure) | ShareModal |
+| QR | always visible when open | QR encodes `url` | ShareModal |
+| Platform deep-link | tap Twitter/WhatsApp/Email/SMS | opens intent or "Couldn't open {label}." toast | ShareModal |
+| Close | tap X / backdrop | `onClose` → `setShareModalVisible(false)` | route → ShareModal |
+
+The route owns ONLY `visible` + `onClose` + the three props (`url`, `title`, `description`). All copy/toast/QR/deep-link/native-share states are the `ShareModal`'s existing responsibility and are NOT re-implemented in the route.
+
+---
+
+## 5. Success criteria (numbered, observable, testable)
+
+- **SC-1-Web (trip):** On desktop Chrome (where `navigator.share` is undefined), opening `/t/{brandSlug}/{tripSlug}` and tapping the Share icon opens the `ShareModal` sheet showing "Copy link", "Share via…", the URL `https://business.usemingla.com/t/{brandSlug}/{tripSlug}`, and a QR. NO dead tap.
+- **SC-2-Web (trip copy):** Tapping "Copy link" copies the trip URL and shows the "Link copied" toast.
+- **SC-3-Web (trip native-share fallback):** Tapping "Share via…" on a browser without `navigator.share` shows the "Native share not supported on this browser." toast (no silent swallow).
+- **SC-4-Web (experience):** Same as SC-1 for `/exp/{brandSlug}/{experienceSlug}` with the `/exp/…` URL.
+- **SC-5-iOS (native parity):** On business iOS, tapping Share opens `ShareModal`; "Share via…" opens the native OS share sheet with the trip/experience URL. Behavior matches the event page.
+- **SC-6-Android (native parity):** On business Android, same as SC-5 via the Android `sharePublicUrl` branch.
+- **SC-7 (helper):** `experiencePublicUrl({ brandSlug: "acme", experienceSlug: "sunset-sail" })` returns `https://business.usemingla.com/exp/acme/sunset-sail`; it throws `PublicUrlError` on an empty `brandSlug` or `experienceSlug`. `tripPublicUrl` continues to return `…/t/{brandSlug}/{tripSlug}`.
+- **SC-8 (no bare Share.share):** Neither route file imports or calls react-native `Share` after the change; both reference `ShareModal`. (Fails-on-revert guard — §9.)
+- **SC-9 (no silent catch):** Neither route file contains an empty `catch {}` around a share path. The only error handling for share is inside `ShareModal` (which toasts).
+
+---
+
+## 6. Invariants
+
+**Preserved:**
+- **Anon-tolerance** (`feedback_anon_buyer_routes.md`): neither route gains `useAuth` or a sign-in redirect. `ShareModal`, `tripPublicUrl`, `experiencePublicUrl` are all auth-free. Verified by existing `public-trip-page.test.ts` A-PUBLIC-1/2 (still pass).
+- **Constitution #1 (no dead taps / `feedback_interactive_elements_must_fire_runtime_proof.md`):** the whole point — the Share control now fires (opens the modal) at runtime on web. Tester must prove it FIRES on a real browser (not source-only).
+- **Constitution #3 (no silent failures):** the empty `catch {}` (the violation) is removed; `ShareModal` surfaces success/failure via toasts.
+- **Canonical-origin helpers (`publicUrls.ts`):** new `experiencePublicUrl` uses `BUSINESS_PUBLIC_ORIGIN` + `requireSegment`, matching siblings — no new hardcoded origin string.
+
+**Proposed NEW (DRAFT — orchestrator flips ACTIVE at CLOSE):**
+- **`I-PROPOSED-PUBLIC-SHARE-VIA-SHAREMODAL` (DRAFT):** every buyer-anon public detail page (`/e/`, `/b/`, `/t/`, `/exp/`) shares via the web-aware `ShareModal`/`sharePublicUrl` primitive — never a bare inline `Share.share` with a swallow-only `catch`. Verified by the §9 fails-on-revert tests on the trip + experience routes (and the pre-existing correctness of event/brand).
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-1 | helper happy path (trip) | `tripPublicUrl({brandSlug:"acme",tripSlug:"bali"})` | `https://business.usemingla.com/t/acme/bali` | helper unit |
+| T-2 | helper happy path (experience) | `experiencePublicUrl({brandSlug:"acme",experienceSlug:"sunset-sail"})` | `https://business.usemingla.com/exp/acme/sunset-sail` | helper unit |
+| T-3 | helper encodes segments | `experiencePublicPath({brandSlug:"my brand",experienceSlug:"sail one"})` | `/exp/my%20brand/sail%20one` | helper unit |
+| T-4 | helper rejects empty segment (fails-on-revert) | `experiencePublicUrl({brandSlug:"",experienceSlug:"x"})` | throws `PublicUrlError` | helper unit |
+| T-5 | helper rejects empty experienceSlug | `experiencePublicUrl({brandSlug:"a",experienceSlug:"  "})` | throws `PublicUrlError` | helper unit |
+| T-6 | trip route routes share through ShareModal (happy/structural) | read `app/t/[brandSlug]/[tripSlug].tsx` | source matches `<ShareModal` AND `setShareModalVisible` AND `tripPublicUrl(` | route source guard |
+| T-7 | trip route has NO bare Share.share (error-path/fails-on-revert) | read trip route source | source does NOT match `Share.share` AND does NOT import `Share` from react-native | route source guard |
+| T-8 | experience route routes share through ShareModal | read `app/exp/[brandSlug]/[experienceSlug].tsx` | source matches `<ShareModal` AND `experiencePublicUrl(` | route source guard |
+| T-9 | experience route has NO bare Share.share | read experience route source | source does NOT match `Share.share` AND no `Share` import | route source guard |
+| T-10 | anon-tolerance preserved (edge) | existing `public-trip-page.test.ts` A-PUBLIC-1/2 | still pass (no `useAuth`, no auth redirect) | route source guard |
+
+---
+
+## 8. Implementation order
+
+1. **Helper** — `src/constants/publicUrls.ts`: add `experiencePublicPath` + `experiencePublicUrl` (§4.1).
+2. **Helper tests** — `src/constants/__tests__/publicUrls.test.ts`: add T-1…T-5 (import the new + existing trip builders; assert canonical output + `PublicUrlError` on empty segments).
+3. **Trip route** — `app/t/[brandSlug]/[tripSlug].tsx`: imports, `useState`, replace `handleShare`, `onPress={handleShare}`, mount `<ShareModal>` (§4.2).
+4. **Experience route** — `app/exp/[brandSlug]/[experienceSlug].tsx`: same (§4.3).
+5. **Route guard tests** — add T-6…T-9 (see §9 for exact file locations).
+6. **Run gates** — `npm test` for the touched specs; `tsc --noEmit` (the worktree's typecheck); confirm `public-trip-page.test.ts` (A-PUBLIC-1…8) still passes. Prove fails-on-revert per §9.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+**Structural safeguard:** source-grep route-contract tests (the same mechanism `public-trip-page.test.ts` already uses — `readFileSync` the route file + `expect(source).toMatch/.not.toMatch`).
+
+**Implementor happy-path test (REQUIRED at CLOSE):**
+- Extend `mingla-business/app/t/__tests__/public-trip-page.test.ts` with **A-PUBLIC-9** (and a sibling for experience):
+  - A-PUBLIC-9 (trip): asserts the trip route source `toMatch(/<ShareModal/)` AND `toMatch(/setShareModalVisible/)` AND `toMatch(/tripPublicUrl\(/)` AND `**not**.toMatch(/\bShare\.share\b/)` AND `**not**.toMatch(/^import[\s\S]*\bShare\b[\s\S]*from ["']react-native["']/m)`.
+  - Create `mingla-business/app/exp/__tests__/public-experience-page.test.ts` (new dir — does not exist yet) mirroring `public-trip-page.test.ts` for the experience route, INCLUDING the same `<ShareModal>` / `experiencePublicUrl(` / no-`Share.share` assertions.
+- This is the test that asserts the share control **routes through the web-aware `ShareModal`/`sharePublicUrl`, NOT bare `Share.share`.** It FAILS the instant the route is reverted to `Share.share` (the `.not.toMatch(/Share\.share/)` flips) and PASSES when restored. ✅ fails-on-revert.
+
+**Helper fails-on-revert:** T-4/T-5 fail if `experiencePublicUrl` is ever changed to skip `requireSegment` (e.g. hand-rolled string concat without the empty-segment guard).
+
+**Protective comments:** in both route files, the swapped-in one-line `handleShare` comment must read e.g. `// ORCH-1114: share → web-aware ShareModal (copy-link/QR/native-share-via). NEVER revert to bare Share.share — it dead-taps on react-native-web (navigator.share undefined). See SPEC_ORCH-1114.` In `publicUrls.ts`, the new helpers carry a `// ORCH-1114: experience public-URL helper, mirror of tripPublicUrl.` comment.
+
+---
+
+## 10. Open questions
+
+- **None blocking.** Two confirmations the implementor must satisfy in-pass (not design questions, just narrowing):
+  1. Confirm `Platform` is unused after the swap in each route before removing it from the `react-native` import (avoid an unused-import lint error OR a missing-import error). Current source uses `Platform` ONLY inside `handleShare`, so removal is expected — but verify.
+  2. Confirm the `url` prop's slug values are TypeScript-narrowed to `string` at the `<ShareModal>` mount site (the render body runs after the not-found/error early returns). If the compiler still sees `string | undefined`, gate the modal mount on `typeof brandSlug === "string" && typeof tripSlug === "string"` (resp. `experienceSlug`) so `tripPublicUrl`/`experiencePublicUrl` never receive an empty segment and throw mid-render.
+
+---
+
+## 11. Downstream routing
+
+**Next = `mingla-implementor`.** Build exactly §4 (helper + two routes) + §7/§9 tests, in the §8 order. Run `npm test` on the touched specs + `tsc --noEmit`; prove the §9 fails-on-revert (revert one route to `Share.share`, watch A-PUBLIC-9 / experience test fail, restore). Frontend-only: NO migration, NO edge deploy, NO `db push`. Then → `mingla-tester` for the device/runtime gate (Constitution #1 demands a REAL browser proof: load `/t/` and `/exp/` on desktop Chrome where `navigator.share` is undefined, tap Share, see the modal + "Copy link" → "Link copied" toast + the "Native share not supported on this browser." toast on "Share via…"; plus native iOS/Android parity that "Share via…" opens the OS sheet). Then → `mingla-orchestrator` CLOSE (flip `I-PROPOSED-PUBLIC-SHARE-VIA-SHAREMODAL` → ACTIVE; OTA per `feedback_eas_ota_publish_per_platform.md` since this is pure-JS business-app + buyer-web — no native rebuild needed).
+
+**Working tree:** `~/Desktop/mingla-orchs/ORCH-1114-[trip-share-link]/` on branch `ORCH-1114-trip-share-link`.
+
+---
+
+## Allowlist + DO-NOT-TOUCH
+
+**Allowlist (implementor may modify ONLY these):**
+- `mingla-business/app/t/[brandSlug]/[tripSlug].tsx`
+- `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx`
+- `mingla-business/src/constants/publicUrls.ts`
+- `mingla-business/src/constants/__tests__/publicUrls.test.ts`
+- `mingla-business/app/t/__tests__/public-trip-page.test.ts` (extend with A-PUBLIC-9)
+- `mingla-business/app/exp/__tests__/public-experience-page.test.ts` (CREATE)
+
+**DO-NOT-TOUCH (stop-and-amend before any edit):**
+- `src/components/ui/ShareModal.tsx`, `src/utils/sharePublicUrl.ts`, `src/utils/shareIntents.ts`
+- `src/components/event/PublicEventPage.tsx`, `src/components/brand/PublicBrandPage.tsx`, `app/e/**`, `app/b/**`
+- `app/(tabs)/hub/trips.tsx`, `app/(tabs)/hub/experiences.tsx`
+- `src/components/ui/IconChrome.tsx`, the route `styles`/overlay layout, the X-close handler
+- any DB / edge / migration / RLS file (none are in scope)
+
+Amendments append in-file or land as `SPEC_AMENDMENT_ORCH-1114_*.md` — never silently widen.
+
+---
+
+*Artifact: `Mingla_Artifacts/specs/SPEC_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md`*

--- a/mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx
+++ b/mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx
@@ -14,12 +14,10 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed cover on the public experience share-link page (mirrors /t/{brandSlug}/{tripSlug}); the buyer-facing banner aesthetic is intentional. ExperiencePreview renders the cover full-bleed to the screen edge by design; the X-close + share overlays absolute-position over the cover but do not introduce SafeScreen wrapping. Per META-ORCH-1059 Sub-C (mirror of ORCH-0859/0874 trip public page).
 
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import {
   ActivityIndicator,
-  Platform,
   ScrollView,
-  Share,
   StyleSheet,
   Text,
   View,
@@ -35,6 +33,8 @@ import {
 } from "../../../src/constants/designSystem";
 import { GlassCard } from "../../../src/components/ui/GlassCard";
 import { IconChrome } from "../../../src/components/ui/IconChrome";
+import { ShareModal } from "../../../src/components/ui/ShareModal";
+import { experiencePublicUrl } from "../../../src/constants/publicUrls";
 import { usePublicExperienceBySlug } from "../../../src/hooks/usePublicExperience";
 import { ExperiencePreview } from "../../../src/components/experience/ExperiencePreview";
 import { ExperienceCheckoutFlow } from "../../../src/components/experience/ExperienceCheckoutFlow";
@@ -61,6 +61,8 @@ export default function PublicExperienceRoute(): React.ReactElement {
     ? params.experienceSlug[0]
     : params.experienceSlug;
 
+  const [shareModalVisible, setShareModalVisible] = useState<boolean>(false);
+
   const query = usePublicExperienceBySlug(
     typeof brandSlug === "string" ? brandSlug : null,
     typeof experienceSlug === "string" ? experienceSlug : null,
@@ -76,22 +78,12 @@ export default function PublicExperienceRoute(): React.ReactElement {
     }
   }, [router, brandSlug]);
 
-  const handleShare = useCallback(async (): Promise<void> => {
-    if (typeof brandSlug !== "string" || typeof experienceSlug !== "string") {
-      return;
-    }
-    const url = `https://business.usemingla.com/exp/${brandSlug}/${experienceSlug}`;
-    const title = query.data?.experience.title ?? "Mingla experience";
-    try {
-      await Share.share(
-        Platform.OS === "ios"
-          ? { url, message: title }
-          : { message: `${title} ${url}`, title },
-      );
-    } catch {
-      // User-cancelled native Share is non-actionable; Constitution #3 exempts.
-    }
-  }, [brandSlug, experienceSlug, query.data?.experience.title]);
+  // ORCH-1114: share → web-aware ShareModal (copy-link/QR/native-share-via).
+  // NEVER revert to the bare react-native share API — it dead-taps on
+  // react-native-web (navigator.share undefined). See SPEC_ORCH-1114.
+  const handleShare = useCallback((): void => {
+    setShareModalVisible(true);
+  }, []);
 
   if (query.isLoading || query.isFetching) {
     return (
@@ -213,12 +205,20 @@ export default function PublicExperienceRoute(): React.ReactElement {
         <IconChrome
           icon="share"
           size={36}
-          onPress={() => {
-            void handleShare();
-          }}
+          onPress={handleShare}
           accessibilityLabel="Share"
         />
       </View>
+
+      {typeof brandSlug === "string" && typeof experienceSlug === "string" && (
+        <ShareModal
+          visible={shareModalVisible}
+          onClose={() => setShareModalVisible(false)}
+          url={experiencePublicUrl({ brandSlug, experienceSlug })}
+          title={experience.title}
+          description={experience.description?.slice(0, 200) ?? undefined}
+        />
+      )}
     </View>
   );
 }

--- a/mingla-business/app/exp/__tests__/public-experience-page.test.ts
+++ b/mingla-business/app/exp/__tests__/public-experience-page.test.ts
@@ -1,0 +1,76 @@
+/**
+ * ORCH-1114 [public trip + experience Share button is a dead tap on web] —
+ * public anon experience page contract (mirror of public-trip-page.test.ts).
+ *
+ * Asserts the /exp/[brandSlug]/[experienceSlug] route is anon-tolerant per
+ * feedback_anon_buyer_routes.md (no useAuth, no sign-in redirect) AND that the
+ * Share control routes through the web-aware ShareModal, NOT bare react-native
+ * Share.share (which dead-taps on react-native-web when navigator.share is
+ * undefined).
+ *
+ * Fails-on-revert: reverting the share control to Share.share flips both the
+ * .toMatch(<ShareModal) and the .not.toMatch(Share.share) assertions in
+ * A-EXP-9.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const publicRouteSource = readFileSync(
+  join(__dirname, "..", "[brandSlug]", "[experienceSlug].tsx"),
+  "utf-8",
+);
+const publicHookSource = readFileSync(
+  join(__dirname, "..", "..", "..", "src", "hooks", "usePublicExperience.ts"),
+  "utf-8",
+);
+
+describe("ORCH-1114 — /exp/{brandSlug}/{experienceSlug} public anon route contract", () => {
+  test("A-EXP-1: route does NOT import or call useAuth (anon-tolerant)", () => {
+    expect(publicRouteSource).not.toMatch(/^import[\s\S]*\buseAuth\b[\s\S]*from/m);
+    expect(publicRouteSource).not.toMatch(/\buseAuth\s*\(/);
+  });
+
+  test("A-EXP-2: route does NOT redirect to sign-in / (auth)", () => {
+    expect(publicRouteSource).not.toMatch(/router\.replace.*\(auth\)/);
+    expect(publicRouteSource).not.toMatch(/router\.push.*\(auth\)/);
+    expect(publicRouteSource).not.toMatch(/router\.replace.*sign-in/);
+  });
+
+  test("A-EXP-3: route mounts ExperiencePreview", () => {
+    expect(publicRouteSource).toMatch(/<ExperiencePreview/);
+  });
+
+  test("A-EXP-4: route mounts ExperienceCheckoutFlow", () => {
+    expect(publicRouteSource).toMatch(/<ExperienceCheckoutFlow/);
+  });
+
+  test("A-EXP-5: route uses usePublicExperienceBySlug hook", () => {
+    expect(publicRouteSource).toMatch(/usePublicExperienceBySlug/);
+  });
+
+  test("A-EXP-6: route handles loading, error, and not-found states", () => {
+    expect(publicRouteSource).toMatch(/isLoading/);
+    expect(publicRouteSource).toMatch(/isError/);
+    expect(publicRouteSource).toMatch(/Experience not found|null|undefined/);
+  });
+
+  test("A-EXP-7: usePublicExperience hook does NOT import or call useAuth", () => {
+    expect(publicHookSource).not.toMatch(/^import[\s\S]*\buseAuth\b[\s\S]*from/m);
+    expect(publicHookSource).not.toMatch(/\buseAuth\s*\(/);
+  });
+
+  // ORCH-1114 — the Share control must route through the web-aware ShareModal,
+  // NOT bare react-native Share.share. Fails-on-revert: reverting to Share.share
+  // flips both the .toMatch(<ShareModal) and the .not.toMatch(Share.share).
+  test("A-EXP-9: experience share routes through ShareModal, not bare Share.share", () => {
+    expect(publicRouteSource).toMatch(/<ShareModal/);
+    expect(publicRouteSource).toMatch(/setShareModalVisible/);
+    expect(publicRouteSource).toMatch(/experiencePublicUrl\(/);
+    expect(publicRouteSource).not.toMatch(/\bShare\.share\b/);
+    expect(publicRouteSource).not.toMatch(
+      /^import[\s\S]*\bShare\b[\s\S]*from ["']react-native["']/m,
+    );
+  });
+});

--- a/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
+++ b/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
@@ -15,12 +15,10 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed cover on the public trip share-link page (mirrors /e/{brandSlug}/{eventSlug}); the buyer-facing banner aesthetic is intentional. TripPreview renders the cover full-bleed to the screen edge by design; status-bar overlap is the chosen look. Per ORCH-0859 [Tr2 Minimum Viable Trip] REWORK 5b operator design ruling 2026-05-17 (QA report §1, pattern parity with screenshot 17-PUBLIC-EVENT-PAGE.png). ORCH-0874 preserves this; X-close + share overlays absolute-position over the cover but do not introduce SafeScreen wrapping.
 
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import {
   ActivityIndicator,
-  Platform,
   ScrollView,
-  Share,
   StyleSheet,
   Text,
   View,
@@ -39,6 +37,8 @@ import {
 } from "../../../src/constants/designSystem";
 import { GlassCard } from "../../../src/components/ui/GlassCard";
 import { IconChrome } from "../../../src/components/ui/IconChrome";
+import { ShareModal } from "../../../src/components/ui/ShareModal";
+import { tripPublicUrl } from "../../../src/constants/publicUrls";
 import { usePublicTripBySlug } from "../../../src/hooks/usePublicTripBySlug";
 import { TripPreview } from "../../../src/components/trip/TripPreview";
 import { TripCheckoutFlow } from "../../../src/components/trip/TripCheckoutFlow";
@@ -60,6 +60,8 @@ export default function PublicTripRoute(): React.ReactElement {
     ? params.tripSlug[0]
     : params.tripSlug;
 
+  const [shareModalVisible, setShareModalVisible] = useState<boolean>(false);
+
   const query = usePublicTripBySlug(
     typeof brandSlug === "string" ? brandSlug : null,
     typeof tripSlug === "string" ? tripSlug : null,
@@ -77,22 +79,12 @@ export default function PublicTripRoute(): React.ReactElement {
     }
   }, [router, brandSlug]);
 
-  // ORCH-0874: share → native share sheet with the public trip URL.
-  const handleShare = useCallback(async (): Promise<void> => {
-    if (typeof brandSlug !== "string" || typeof tripSlug !== "string") return;
-    const url = `https://business.usemingla.com/t/${brandSlug}/${tripSlug}`;
-    const title = query.data?.trip.title ?? "Mingla trip";
-    try {
-      await Share.share(
-        Platform.OS === "ios"
-          ? { url, message: title }
-          : { message: `${title} ${url}`, title },
-      );
-    } catch {
-      // Native Share rejection (user cancels) is non-actionable;
-      // do not surface a toast. Constitution #3 exempts user-cancelled flows.
-    }
-  }, [brandSlug, tripSlug, query.data?.trip.title]);
+  // ORCH-1114: share → web-aware ShareModal (copy-link/QR/native-share-via).
+  // NEVER revert to the bare react-native share API — it dead-taps on
+  // react-native-web (navigator.share undefined). See SPEC_ORCH-1114.
+  const handleShare = useCallback((): void => {
+    setShareModalVisible(true);
+  }, []);
 
   if (query.isLoading || query.isFetching) {
     return (
@@ -233,12 +225,20 @@ export default function PublicTripRoute(): React.ReactElement {
         <IconChrome
           icon="share"
           size={36}
-          onPress={() => {
-            void handleShare();
-          }}
+          onPress={handleShare}
           accessibilityLabel="Share"
         />
       </View>
+
+      {typeof brandSlug === "string" && typeof tripSlug === "string" && (
+        <ShareModal
+          visible={shareModalVisible}
+          onClose={() => setShareModalVisible(false)}
+          url={tripPublicUrl({ brandSlug, tripSlug })}
+          title={payload.trip.title}
+          description={payload.trip.description?.slice(0, 200)}
+        />
+      )}
     </View>
   );
 }

--- a/mingla-business/app/t/__tests__/public-trip-page.test.ts
+++ b/mingla-business/app/t/__tests__/public-trip-page.test.ts
@@ -71,4 +71,18 @@ describe("ORCH-0859 — /t/{brandSlug}/{tripSlug} public anon route contract", (
       /\.in\(\s*"status"\s*,\s*\[\s*"scheduled"\s*,\s*"live"\s*\]/,
     );
   });
+
+  // ORCH-1114 — the Share control must route through the web-aware ShareModal,
+  // NOT bare react-native Share.share (which dead-taps on react-native-web when
+  // navigator.share is undefined). Fails-on-revert: reverting to Share.share
+  // flips both the .toMatch(<ShareModal) and the .not.toMatch(Share.share).
+  test("A-PUBLIC-9: trip share routes through ShareModal, not bare Share.share", () => {
+    expect(publicRouteSource).toMatch(/<ShareModal/);
+    expect(publicRouteSource).toMatch(/setShareModalVisible/);
+    expect(publicRouteSource).toMatch(/tripPublicUrl\(/);
+    expect(publicRouteSource).not.toMatch(/\bShare\.share\b/);
+    expect(publicRouteSource).not.toMatch(
+      /^import[\s\S]*\bShare\b[\s\S]*from ["']react-native["']/m,
+    );
+  });
 });

--- a/mingla-business/playwright.orch1114.config.ts
+++ b/mingla-business/playwright.orch1114.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// ORCH-1114 tester runtime gate — dedicated config. The spec self-hosts its
+// static server (beforeAll spawns meta-orch-0952-static-server.mjs on
+// web-build-orch1114), so NO webServer block here. Real Desktop Chrome →
+// navigator.share is undefined, reproducing the original dead-tap condition.
+export default defineConfig({
+  testDir: "./playwright",
+  testMatch: /orch-1114-share-modal-runtime\.spec\.ts$/,
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"]],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/mingla-business/playwright/orch-1114-share-modal-runtime.spec.ts
+++ b/mingla-business/playwright/orch-1114-share-modal-runtime.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * ORCH-1114 [public trip + experience Share button dead-tap on web] — TESTER
+ * adversarial RUNTIME gate (Playwright, real Chromium, navigator.share UNDEFINED).
+ *
+ * Constitution #1 (no dead taps) demands runtime FIRING proof, not source wiring.
+ * The implementor's tests are source-grep guards (readFileSync + toMatch) which
+ * cap at "suspected". This spec proves, in a real desktop-Chrome RNW bundle where
+ * the Web Share API does not exist, that tapping the public-page Share control
+ * ACTUALLY opens the web-aware ShareModal and that the share paths surface toasts
+ * (no silent swallow) instead of dead-tapping.
+ *
+ * Different angle than the implementor's source guards: this is a behavioral,
+ * runtime, render-and-tap assertion on the live exported bundle, driving the
+ * REAL route component (Supabase REST chain route-mocked so the cover render body
+ * — and therefore the Share IconChrome — mounts), then tapping through the modal.
+ *
+ * Fidelity: HIGH. Real Chromium (Playwright Desktop Chrome has NO navigator.share),
+ * real exported RNW JS bundle, real ShareModal + sharePublicUrl + copyPublicUrl,
+ * real toasts. Supabase payloads are route-mocked because the test Supabase project
+ * is a stub; the share UI under test is fully real.
+ *
+ * Serves web-build-orch1114 (exported with EXPO_PUBLIC_MINGLA_BUSINESS_WEB_URL=
+ * http://127.0.0.1:43114) on its own static server. Self-contained — does NOT use
+ * the repo playwright.config.ts webServer (which targets meta_orch_0952).
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { resolve } from "node:path";
+import { chromium, expect, test, type Browser, type Page, type Route } from "@playwright/test";
+
+const PORT = 43114;
+const BASE = `http://127.0.0.1:${PORT}`;
+// The exported bundle bakes MINGLA_BUSINESS_WEB_URL from app.config.ts's `extra`
+// default (the production canonical origin), NOT the export-time env override —
+// so the ShareModal renders the REAL production URL. We assert exactly that, which
+// also proves SC-7's production-origin output at runtime (not just in the unit test).
+const ORIGIN = "https://business.usemingla.com";
+
+const WEB_BUILD = resolve(__dirname, "..", "web-build-orch1114");
+const STATIC_SERVER = resolve(__dirname, "meta-orch-0952-static-server.mjs");
+
+const BRAND_SLUG = "acme-co";
+const TRIP_SLUG = "bali-escape";
+const EXP_SLUG = "sunset-sail";
+
+const BRAND_ID = "11111111-1111-1111-1111-111111111111";
+const TRIP_EVENT_ID = "22222222-2222-2222-2222-222222222222";
+const EXP_EVENT_ID = "33333333-3333-3333-3333-333333333333";
+
+const jsonHeaders = {
+  "content-type": "application/json",
+  "access-control-allow-origin": "*",
+};
+
+let server: ChildProcess;
+let browser: Browser;
+
+test.beforeAll(async () => {
+  server = spawn("node", [STATIC_SERVER, WEB_BUILD, String(PORT)], {
+    stdio: "ignore",
+  });
+  // give the static server a moment to bind
+  await new Promise((r) => setTimeout(r, 1200));
+  browser = await chromium.launch();
+});
+
+test.afterAll(async () => {
+  await browser?.close();
+  server?.kill("SIGTERM");
+});
+
+/**
+ * Route-mock the public-trip / public-experience Supabase REST chain so the
+ * route reaches its render body (the cover hero with the Share IconChrome).
+ * Keyed by PostgREST table path. Anything else under /rest/v1 returns [].
+ */
+async function installPublicDataMocks(
+  page: Page,
+  kind: "trip" | "experience",
+): Promise<void> {
+  const eventId = kind === "trip" ? TRIP_EVENT_ID : EXP_EVENT_ID;
+  const slug = kind === "trip" ? TRIP_SLUG : EXP_SLUG;
+  const eventType = kind === "trip" ? "trip" : "experience";
+  const title = kind === "trip" ? "Bali Escape" : "Sunset Sail";
+
+  const brandRow = {
+    id: BRAND_ID,
+    slug: BRAND_SLUG,
+    name: "Acme Co",
+    description: "Acme adventures",
+    cover_media_url: null,
+  };
+  const eventRow = {
+    id: eventId,
+    brand_id: BRAND_ID,
+    slug,
+    title,
+    description: "An unforgettable day on the water.",
+    status: "scheduled",
+    visibility: "public",
+    published_at: "2026-01-01T00:00:00Z",
+    timezone: "UTC",
+    event_type: eventType,
+    cover_media_url: null,
+    cover_media_type: null,
+    currency: "usd",
+    departure_text: null,
+    theme: {},
+  };
+
+  await page.route("**/rest/v1/**", (route: Route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+    const table = path.split("/rest/v1/")[1]?.split("?")[0] ?? "";
+    let body: unknown = [];
+    if (table === "brands") {
+      body = brandRow; // maybeSingle → object
+    } else if (table === "events") {
+      body = eventRow; // maybeSingle → object
+    } else if (table === "experiences" || table === "experience_intents") {
+      body = kind === "experience" ? [] : [];
+    } else {
+      // trip_days, trip_pricing_tiers, trip_inclusions, ticket_types,
+      // experience_stops, etc. → empty arrays (page renders with no sidecar data)
+      body = [];
+    }
+    route.fulfill({ status: 200, headers: jsonHeaders, body: JSON.stringify(body) });
+  });
+}
+
+/** Assert navigator.share is genuinely undefined in this Chromium context. */
+async function assertNoWebShare(page: Page): Promise<void> {
+  const hasShare = await page.evaluate(
+    () => typeof (navigator as { share?: unknown }).share !== "undefined",
+  );
+  expect(hasShare, "navigator.share must be UNDEFINED for this dead-tap repro").toBe(false);
+}
+
+/**
+ * Seed a non-expired Supabase web session into localStorage BEFORE the app
+ * bundle runs, so the route-agnostic ORCH-1102 auth gate (logged-out web users
+ * are redirected to `/`) does not bounce us off the public route. The bundle was
+ * exported with EXPO_PUBLIC_SUPABASE_URL=https://orch1114.supabase.co → project
+ * ref "orch1114" → storageKey "sb-orch1114-auth-token". The AsyncStorage web shim
+ * persists under the raw key; seed both raw + "@RNAsyncStorage:"-prefixed forms
+ * for resilience. /auth/v1/user is also route-mocked so getUser() resolves.
+ *
+ * NOTE: the Share fix under test is auth-INDEPENDENT (the IconChrome + ShareModal
+ * are identical for authed and anon viewers). Seeding a session only gets the
+ * route to mount its render body; it does not alter the share behavior proven.
+ */
+async function seedSession(page: Page): Promise<void> {
+  const FUTURE = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // +24h
+  const session = {
+    access_token: "orch1114-fake-access-token",
+    token_type: "bearer",
+    expires_in: 86_400,
+    expires_at: FUTURE,
+    refresh_token: "orch1114-fake-refresh-token",
+    user: {
+      id: "99999999-9999-9999-9999-999999999999",
+      aud: "authenticated",
+      role: "authenticated",
+      email: "qa-orch1114@usemingla.test",
+      app_metadata: { provider: "email", providers: ["email"] },
+      user_metadata: {},
+      identities: [],
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  };
+  const value = JSON.stringify(session);
+  // Two keys are required: supabase-js reads under the RUNTIME project ref
+  // ("sb-orch1114-auth-token", from the export's EXPO_PUBLIC_SUPABASE_URL), while
+  // AuthContext.readStoredWebSession() (the 3s-bootstrap-timeout fallback) reads a
+  // HARDCODED production ref "sb-gqnoajqerqhnvulmnyvv-auth-token". Seed both so the
+  // route mounts (user resolves) instead of hitting the ORCH-1102 7s-ceiling
+  // redirect-to-sign-in. The /auth/v1/user mock keeps the ORCH-1106 getUser()
+  // staleness probe from signing the seeded session out.
+  await page.addInitScript(
+    ([v]) => {
+      try {
+        window.localStorage.setItem("sb-orch1114-auth-token", v);
+        window.localStorage.setItem("sb-gqnoajqerqhnvulmnyvv-auth-token", v);
+      } catch {
+        /* storage unavailable — ignore */
+      }
+    },
+    [value],
+  );
+  // getUser() / token refresh fallbacks → resolve to the seeded user.
+  await page.route("**/auth/v1/**", (route: Route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/user")) {
+      route.fulfill({ status: 200, headers: jsonHeaders, body: JSON.stringify(session.user) });
+    } else {
+      route.fulfill({ status: 200, headers: jsonHeaders, body: JSON.stringify(session) });
+    }
+  });
+}
+
+/**
+ * Headless Chromium blocks navigator.clipboard.writeText even with the
+ * clipboard-write permission (no real OS clipboard). Install a deterministic
+ * writeText that records the copied value into window.__orch1114Copied so the
+ * REAL ShareModal copy path (copyPublicUrl → writeText → "Link copied" toast)
+ * resolves and we can assert the EXACT value the modal copied. navigator.share
+ * is deliberately left UNDEFINED (the dead-tap condition under test).
+ */
+async function installClipboardCapture(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const w = window as unknown as { __orch1114Copied?: string };
+    const nav = navigator as unknown as {
+      clipboard?: { writeText?: (v: string) => Promise<void> };
+    };
+    const stub = {
+      writeText: (v: string): Promise<void> => {
+        w.__orch1114Copied = v;
+        return Promise.resolve();
+      },
+      readText: (): Promise<string> => Promise.resolve(w.__orch1114Copied ?? ""),
+    };
+    try {
+      Object.defineProperty(navigator, "clipboard", { value: stub, configurable: true });
+    } catch {
+      if (nav.clipboard) nav.clipboard.writeText = stub.writeText;
+    }
+  });
+}
+
+async function openPage(page: Page, kind: "trip" | "experience"): Promise<void> {
+  await seedSession(page);
+  await installClipboardCapture(page);
+  await installPublicDataMocks(page, kind);
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+  const route =
+    kind === "trip"
+      ? `${BASE}/t/${BRAND_SLUG}/${TRIP_SLUG}`
+      : `${BASE}/exp/${BRAND_SLUG}/${EXP_SLUG}`;
+  await page.goto(route, { waitUntil: "networkidle" });
+  await assertNoWebShare(page);
+  // The Share IconChrome renders aria-label="Share" in the cover overlay.
+  await expect(page.getByLabel("Share").first()).toBeVisible({ timeout: 25_000 });
+}
+
+for (const kind of ["trip", "experience"] as const) {
+  const pathLabel = kind === "trip" ? "/t/" : "/exp/";
+  const expectedUrl =
+    kind === "trip"
+      ? `${ORIGIN}/t/${BRAND_SLUG}/${TRIP_SLUG}`
+      : `${ORIGIN}/exp/${BRAND_SLUG}/${EXP_SLUG}`;
+
+  test.describe(`ORCH-1114 ${pathLabel} runtime share gate`, () => {
+    test(`${pathLabel} Share tap OPENS ShareModal (not a dead tap)`, async () => {
+      const page = await browser.newPage();
+      try {
+        await openPage(page, kind);
+
+        // Before tap: the ShareModal title bar "Share" sheet must NOT be present.
+        // (The IconChrome aria-label is also "Share"; the modal exposes the
+        // "Copy link" + "Share via…" buttons, which are the unambiguous markers.)
+        await expect(page.getByText("Copy link", { exact: true })).toHaveCount(0);
+
+        await page.getByLabel("Share").first().click();
+
+        // RUNTIME FIRING PROOF: the modal mounted on tap.
+        await expect(page.getByText("Copy link", { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+        await expect(page.getByText("Share via…", { exact: true })).toBeVisible();
+        // The URL row shows the canonical public URL for this surface.
+        await expect(page.getByText(expectedUrl, { exact: false })).toBeVisible();
+      } finally {
+        await page.close();
+      }
+    });
+
+    test(`${pathLabel} Copy link → "Link copied" toast + clipboard has the URL`, async () => {
+      const page = await browser.newPage();
+      try {
+        await openPage(page, kind);
+        await page.getByLabel("Share").first().click();
+        await expect(page.getByText("Copy link", { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+
+        await page.getByText("Copy link", { exact: true }).click();
+
+        await expect(page.getByText("Link copied", { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+        const clip = await page.evaluate(
+          () => (window as unknown as { __orch1114Copied?: string }).__orch1114Copied,
+        );
+        expect(clip).toBe(expectedUrl);
+      } finally {
+        await page.close();
+      }
+    });
+
+    test(`${pathLabel} Share via… → graceful "not supported" toast (no silent swallow)`, async () => {
+      const page = await browser.newPage();
+      try {
+        await openPage(page, kind);
+        await page.getByLabel("Share").first().click();
+        await expect(page.getByText("Share via…", { exact: true })).toBeVisible({
+          timeout: 10_000,
+        });
+
+        await page.getByText("Share via…", { exact: true }).click();
+
+        // navigator.share is undefined → sharePublicUrl throws → ShareModal toasts.
+        await expect(
+          page.getByText("Native share not supported on this browser.", { exact: true }),
+        ).toBeVisible({ timeout: 10_000 });
+      } finally {
+        await page.close();
+      }
+    });
+  });
+}

--- a/mingla-business/src/constants/__tests__/publicUrls.test.ts
+++ b/mingla-business/src/constants/__tests__/publicUrls.test.ts
@@ -22,6 +22,9 @@ import {
   eventOgImageUrl,
   eventPublicPath,
   eventPublicUrl,
+  experiencePublicPath,
+  experiencePublicUrl,
+  tripPublicUrl,
 } from "../publicUrls";
 
 describe("public business URL builders", () => {
@@ -49,6 +52,31 @@ describe("public business URL builders", () => {
     ).toThrow(PublicUrlError);
     expect(() => brandPublicUrl("   ")).toThrow(PublicUrlError);
     expect(() => checkoutPublicUrl("")).toThrow(PublicUrlError);
+  });
+
+  // ORCH-1114 — trip + experience public share-link URL builders.
+  test("T-1/T-2: builds canonical public trip and experience URLs", () => {
+    expect(tripPublicUrl({ brandSlug: "acme", tripSlug: "bali" })).toBe(
+      "https://business.usemingla.com/t/acme/bali",
+    );
+    expect(
+      experiencePublicUrl({ brandSlug: "acme", experienceSlug: "sunset-sail" }),
+    ).toBe("https://business.usemingla.com/exp/acme/sunset-sail");
+  });
+
+  test("T-3: experience helper encodes path segments", () => {
+    expect(
+      experiencePublicPath({ brandSlug: "my brand", experienceSlug: "sail one" }),
+    ).toBe("/exp/my%20brand/sail%20one");
+  });
+
+  test("T-4/T-5: experience helper rejects empty/whitespace segments (fails-on-revert)", () => {
+    expect(() =>
+      experiencePublicUrl({ brandSlug: "", experienceSlug: "x" }),
+    ).toThrow(PublicUrlError);
+    expect(() =>
+      experiencePublicUrl({ brandSlug: "a", experienceSlug: "  " }),
+    ).toThrow(PublicUrlError);
   });
 
   test("uses public absolute media when present and canonical fallbacks otherwise", () => {

--- a/mingla-business/src/constants/publicUrls.ts
+++ b/mingla-business/src/constants/publicUrls.ts
@@ -82,6 +82,21 @@ export const tripPublicUrl = (input: {
   tripSlug: string;
 }): string => `${BUSINESS_PUBLIC_ORIGIN}${tripPublicPath(input)}`;
 
+// ORCH-1114: experience public-URL helper, mirror of tripPublicPath/tripPublicUrl.
+export const experiencePublicPath = (input: {
+  brandSlug: string;
+  experienceSlug: string;
+}): string =>
+  `/exp/${requireSegment(input.brandSlug, "brandSlug")}/${requireSegment(
+    input.experienceSlug,
+    "experienceSlug",
+  )}`;
+
+export const experiencePublicUrl = (input: {
+  brandSlug: string;
+  experienceSlug: string;
+}): string => `${BUSINESS_PUBLIC_ORIGIN}${experiencePublicPath(input)}`;
+
 export const eventOgImageUrl = (input: {
   eventId: string;
   coverMediaUrl?: string | null;


### PR DESCRIPTION
## ORCH-1114 — public trip + experience Share button is a dead tap on web

**Symptom (Seth):** The public trip page Share button and link do not actually share the link to the page.

**Root cause (forensics-proven, runtime):** The public trip page (\`/t/{brandSlug}/{tripSlug}\`) and public experience page (\`/exp/{brandSlug}/{experienceSlug}\`) called React-Native \`Share.share\`, which is a no-op/throws on \`react-native-web\` (the buyer-web runtime where \`navigator.share\` is undefined). An empty \`catch {}\` silently swallowed the rejection → true dead tap, no copy-link, no toast. Causal cluster: \`/exp/\` had the identical copy-pasted bug. The public **event** and **brand** pages were already correct (they use the web-aware \`ShareModal\`) — that was the reference fix.

**Fix:** Both pages now route through the existing web-aware \`ShareModal\` (Copy link + QR + Share via… + toasts), identical to event/brand. Reuses \`tripPublicUrl\`; adds \`experiencePublicPath\`/\`experiencePublicUrl\` to \`publicUrls.ts\`. Native iOS/Android share-via parity preserved (ShareModal's native branch untouched; no web-only guard).

**Scope:** 2 route files + \`publicUrls.ts\` + tests only. ShareModal/sharePublicUrl/event/brand/Hub/IconChrome untouched.

## Evidence
- Investigation: \`Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1114_PUBLIC_TRIP_SHARE.md\`
- Spec: \`Mingla_Artifacts/specs/SPEC_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md\`
- Implementation: \`Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md\`
- QA: \`Mingla_Artifacts/reports/QA_ORCH-1114_PUBLIC_TRIP_EXPERIENCE_SHARE.md\` — **PASS**, real Chromium runtime proof (navigator.share undefined), 6/6, fails-on-revert verified.

## Regression tests (Step-0.5 gate)
- Implementor happy-path: route-source guard (asserts \`<ShareModal>\` present, bare \`Share.share\` absent) + \`publicUrls\` empty-segment guards — fails-on-revert at \`e8c45511d\`.
- Tester adversarial (different angle): Playwright runtime spec in real browser — \`mingla-business/playwright/orch-1114-share-modal-runtime.spec.ts\`.

QA verdict: PASS. Frontend-only — no migration, no edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)