### PR TITLE
ORCH-1115: restore anon-buyer web funnel — public buyer routes must not redirect to sign-in (P0) [deploy]

### DIFF
--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1115_ANON_BUYER_TRIP_EXPERIENCE_ACCESS.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1115_ANON_BUYER_TRIP_EXPERIENCE_ACCESS.md
@@ -1,0 +1,196 @@
+# INVESTIGATE — ORCH-1115 [can anonymous buyers reach AND purchase trips/experiences like events?]
+
+- **Mode:** INVESTIGATE (forensics) — production runtime proof mandatory.
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1115-[anon-buyer-access]/` · branch `ORCH-1115-anon-buyer-access` (HEAD `a7cc767e3`, even with origin/main).
+- **Date:** 2026-06-11
+- **Origin:** ORCH-1114 QA report Discovery D-1 — the ORCH-1102 route-agnostic auth gate redirected EVERY no-user web route (incl. public `/t/ /e/ /b/ /exp/`) to sign-in in a LOCAL web export. ORCH-1115 asks whether this holds on PRODUCTION.
+- **Seth's exact question:** "So anonymous buyers can't buy trips and experiences like events?"
+
+---
+
+## 1. Headline answer (direct, per surface)
+
+| Surface | Anon VIEW (web) | Anon BUY (web) |
+|---------|-----------------|----------------|
+| **EVENT** (`/e/…`) | **NO** — redirects to sign-in | **NO** — `/checkout/…` redirects to sign-in |
+| **TRIP** (`/t/…`) | **NO** — redirects to sign-in | **NO** — `/checkout-trip/…` redirects to sign-in |
+| **EXPERIENCE** (`/exp/…`) | **NO** — redirects to sign-in | **NO** — checkout route redirects to sign-in |
+| **BRAND** (`/b/…`) | **NO** — redirects to sign-in | n/a |
+
+**The premise of the question is the surprise: there is NO event-vs-trip asymmetry.** A fully logged-out web buyer cannot view OR buy ANY of the three — events are broken in exactly the same way as trips and experiences. The *entire* anonymous share-link → checkout funnel on `business.usemingla.com` is currently collapsed for logged-out users. So the honest answer to Seth is: "Right now, anonymous buyers can't buy trips and experiences on web — but they can't buy events on web either. It's not that trips/experiences are special; the whole anon web funnel is down."
+
+**Severity: P0 — LAUNCH BLOCKER.** Every share link sent to a guest (IG bio, WhatsApp, text) bounces the guest to a business sign-up screen instead of the purchase page. This is the primary money funnel.
+
+**Scope note:** native consumer app (`app-mobile/`) is a SEPARATE surface and is NOT affected — these `/t/ /e/ /b/ /exp/` routes exist only in `mingla-business/` web. The collapse is web-only.
+
+---
+
+## 2. Investigation manifest (files read, in trace order)
+
+| # | File / artifact | Layer | Why |
+|---|-----------------|-------|-----|
+| 1 | `COMMS_LEDGER.md` | docs | entry guard; no BLOCK/OPEN targeting ORCH-1115/forensics/ALL (only WARN/FYI). |
+| 2 | ORCH-1114 `QA_…_PUBLIC_TRIP_EXPERIENCE_SHARE.md` (D-1) | docs | the exact reproduction + workaround that spawned this ORCH. |
+| 3 | `feedback_anon_buyer_routes.md` | docs | the long-standing anon-tolerant route contract this gate violates. |
+| 4 | `mingla-business/app/_layout.tsx` | code | the ORCH-1102 ROOT-layout auth gate; governs every route. |
+| 5 | `mingla-business/src/utils/coldLoadAuthGates.ts` | code | the `shouldRedirectToSignInFromRoute` predicate — no public-route allowlist. |
+| 6 | `app/t/`, `app/e/`, `app/exp/`, `app/b/` (`_layout` absence + page heads) | code | confirm no nested layout overrides the root gate; page comments still claim "anon-tolerant, no redirect". |
+| 7 | `app/checkout/`, `app/checkout-trip/`, `app/checkout-experience/` `_layout.tsx` | code | confirm checkout layouts are anon-tolerant but still nested under the gated root. |
+| 8 | `git log app/_layout.tsx` | data | dates ORCH-1102 (#414) `[deploy]` ship to 2026-06-08 — a 3-day-old regression. |
+| 9 | Production browser drive (Playwright/Chromium, anon) | runtime | the decisive proof — see §5. |
+| 10 | Anon REST reads (anon key) of events + sidecar tables | data/schema | RLS is NOT the gap — anon reads everything needed. |
+
+---
+
+## 3. Q-scorecard
+
+**Q1. On production, can a logged-out buyer VIEW a trip / experience page the way they can an event?**
+Verdict: **NO for all three (events, trips, experiences) — `proven` (production Chromium).** None render; all redirect to the business sign-in welcome screen. No asymmetry.
+
+**Q2. On production, can a logged-out buyer reach CHECKOUT and pay, per surface?**
+Verdict: **NO for all three — `proven` (production Chromium).** `/checkout/…` and `/checkout-trip/…` both redirect to sign-in before the checkout screen (or PaymentSheet) can mount. The redirect fires at the root layout, above the route, so the CTA and payment step are unreachable.
+
+**Q3. What is the root cause, and is it a route-allowlist gap, an RLS gap, or both?**
+Verdict: **Route-allowlist gap ONLY — `proven`.** The ORCH-1102 root-layout gate (`shouldRedirectToSignInFromRoute`) redirects every web route except `/` for a logged-out user; it has NO allowlist exempting the public buyer routes. RLS is fully permissive to anon for the events row AND the sidecar tables (`trip_days`, `trip_pricing_tiers`, `event_dates`, `experience_stops`) — proven by direct anon-key reads. The fix is purely at the route-gate layer.
+
+**Q4. Is the production redirect a real bug, a dev-only artifact, or a recent regression?**
+Verdict: **Real, live, recent regression — `proven`.** ORCH-1102 (PR #414, commit `7c86708c2`, `[deploy]`-tagged) shipped 2026-06-08 and moved the auth gate from a `(tabs)`-scoped / route-list gate to the route-AGNOSTIC ROOT layout. Curl confirms Vercel serves HTTP 200 SPA shell for the public routes (no edge redirect); the redirect is purely client-side, executed after hydration. The tester's local-export observation reproduces on production.
+
+---
+
+## 4. Findings (six-field evidence)
+
+### F-1 — CONFIRMED ROOT CAUSE: the ORCH-1102 root-layout auth gate redirects every public buyer web route to sign-in; no allowlist for `/t/ /e/ /b/ /exp/ /checkout*`.
+
+1. **Symptom.** A logged-out browser loading any of `/e/…`, `/t/…`, `/exp/…`, `/b/…`, `/checkout/…`, `/checkout-trip/…` on `business.usemingla.com` lands on the business sign-in welcome screen ("Continue with Apple / Google / Email"), not the buyer page.
+2. **Layer.** Code (client route guard) — confirmed against Runtime.
+3. **Probe.**
+   - `mingla-business/app/_layout.tsx` read verbatim.
+   - `mingla-business/src/utils/coldLoadAuthGates.ts` read verbatim.
+   - `grep -nE "/t/|/e/|/b/|/exp/|checkout|public|buyer|allowlist|isPublic" src/utils/coldLoadAuthGates.ts` → no matches.
+4. **Evidence.**
+   - `coldLoadAuthGates.ts:124-138` —
+     ```ts
+     export const shouldRedirectToSignInFromRoute = ({...pathname}) =>
+       shouldRedirectToSignIn({ isWeb, loading, hasUser, hasStoredWebSession }) &&
+       !isSignInRoute(pathname);
+     ```
+     and `:66-76` `shouldRedirectToSignIn = isWeb && !loading && !hasUser && !hasStoredWebSession`. The ONLY pathname check is `isSignInRoute`, which (`:102-112`) matches only `/`. There is **no public-route allowlist**.
+   - `app/_layout.tsx:307-313` computes `redirectToSignIn` from that predicate and `:568-574` returns `<Redirect href="/" />` for any logged-out web user on any non-`/` route.
+   - `app/_layout.tsx` is the ROOT layout — it wraps every route in the Expo Router tree. `app/t/`, `app/e/`, `app/exp/`, `app/b/` have **no own `_layout.tsx`** (`ls` confirms only `[brandSlug]/` + `__tests__/`), so nothing overrides the root gate.
+5. **Mechanism.** For a genuinely logged-out user `loading` resolves quickly and `hasStoredWebSession()` is false → `redirectToSignIn` is true on every non-`/` route → the root layout returns `<Redirect href="/" />` before the buyer page or checkout screen ever mounts → the guest sees the business sign-in screen.
+6. **Severity.** **CONFIRMED ROOT CAUSE.**
+
+### F-2 — CONFIRMED (rules out RLS): anon RLS reads every table the buyer pages need; the gap is NOT data-layer.
+
+1. **Symptom.** N/A (this finding RULES OUT an alternative cause).
+2. **Layer.** Schema (RLS) / Data.
+3. **Probe.** Anon-key (`role=anon`) REST reads against `https://gqnoajqerqhnvulmnyvv.supabase.co/rest/v1/…` for the three published rows and their sidecar tables.
+4. **Evidence.** Anon returned the rows:
+   - `events` (trip `the-dc-adventure`, experience `raleigh-wine-and-dine-crawl`, event `the-reckoning`) — all readable.
+   - `trip_days` (event_id = the-dc-adventure) → "Day 1 - Arrival" row returned.
+   - `trip_pricing_tiers` (event_id = the-dc-adventure) → "Standard" tier returned.
+   - `event_dates` (event_id = the-dc-adventure) → 2026-08-17 master date returned.
+   - `experience_stops` (event_id = raleigh-wine-and-dine-crawl) → stop row returned.
+5. **Mechanism.** Because anon can read the offering + sidecar data for all three kinds, the page would render fully and checkout could price — IF the route gate let the page mount. The blocker is exclusively the client route guard (F-1), not RLS.
+6. **Severity.** **RULED OUT** (RLS as a cause) — and it confirms the fix is purely route-gate-shaped.
+
+### F-3 — SECONDARY (regression timing + Docs↔Code contradiction): ORCH-1102 silently broke the anon-buyer contract.
+
+1. **Symptom.** Page-head comments on `/t/` and `/exp/` still read "Anon-tolerant per feedback_anon_buyer_routes.md: no useAuth, no sign-in redirect. Anyone with the share link sees this page." — yet the share link redirects to sign-in.
+2. **Layer.** Docs vs Code contradiction; regression dating.
+3. **Probe.** `git show -s 7c86708c2`; head-comment greps of the public routes; `feedback_anon_buyer_routes.md` read.
+4. **Evidence.** ORCH-1102 (#414) shipped `2026-06-08 12:24` `[deploy]`. `feedback_anon_buyer_routes.md` says these routes "MUST NOT … redirect to sign-in" and were kept OUT of `(tabs)` precisely so the (then `(tabs)`-scoped) auth gate would not apply. ORCH-1102 relocated the gate to the ROOT layout — which sits ABOVE both `(tabs)` and the public routes — so the "live outside `(tabs)`" defense no longer protects them. The page comments are now false.
+5. **Mechanism.** The anon-tolerance design assumed a tab-group-scoped gate; ORCH-1102's route-agnostic root gate invalidated that assumption without updating the contract or adding a public-route carve-out.
+6. **Severity.** **SECONDARY ROOT CAUSE** (the contract regression that the fix must restore).
+
+---
+
+## 5. Production runtime repro (the decisive evidence)
+
+**Method & fidelity.** Real headless Chromium via Playwright (binary `chromium-1223` present in the worktree's `node_modules`), driven against the LIVE `https://business.usemingla.com`. Each surface used a **fresh browser context** (no cookies, no localStorage) = a genuinely anonymous buyer. Each load waited past the ORCH-1102 7s auth-resolution ceiling (11s) so any redirect settled. **Fidelity: HIGH** — production origin, production Vercel SPA bundle, real client auth gate, real logged-out state. This is the exact condition a guest clicking a share link hits.
+
+**VIEW test — all four surfaces redirected:**
+
+```
+SURFACE: EVENT       requested /e/leggothis/the-reckoning            → final https://business.usemingla.com/  VERDICT REDIRECTED_TO_SIGNIN
+SURFACE: TRIP        requested /t/travelbrand/the-dc-adventure       → final https://business.usemingla.com/  VERDICT REDIRECTED_TO_SIGNIN
+SURFACE: EXPERIENCE  requested /exp/lanternvine/raleigh-wine-and-dine-crawl → final …/  VERDICT REDIRECTED_TO_SIGNIN
+SURFACE: BRAND       requested /b/leggothis                          → final https://business.usemingla.com/  VERDICT REDIRECTED_TO_SIGNIN
+```
+Body of the final page on all four: *"List experiences, reach guests, and grow — simply. Continue with Apple / Continue with Google / Continue with Email …"* (the BusinessWelcomeScreen). Screenshots: `/tmp/orch1115-event.png`, `/tmp/orch1115-trip.png`, `/tmp/orch1115-experience.png`, `/tmp/orch1115-brand.png`.
+
+**Timeline (trip URL, anon) — redirect is near-instant, content never shows:**
+```
+t=0.9s … t=16.3s : state=SIGNIN every sample; trip content never rendered at any point.
+```
+(For a logged-out user `loading` resolves fast and there is no stored session, so the redirect fires immediately — the 7s ceiling only applies to a *warming* session, which a guest never has.)
+
+**CHECKOUT test — both redirected:**
+```
+EVENT /checkout       → final / verdict REDIRECTED_TO_SIGNIN
+TRIP  /checkout-trip  → final / verdict REDIRECTED_TO_SIGNIN
+```
+The Reserve/Book CTA and Stripe PaymentSheet are unreachable for an anon user because the redirect fires at the root layout before the checkout route mounts.
+
+**Edge-vs-client confirmation (rules out Vercel rewrite as the cause):**
+```
+curl -s -o /dev/null -w "%{http_code} %{url_effective}" -L <each public URL>
+  → 200 https://business.usemingla.com/e/leggothis/the-reckoning   (URL unchanged)
+  → 200 https://business.usemingla.com/t/travelbrand/the-dc-adventure
+  → 200 https://business.usemingla.com/exp/lanternvine/raleigh-wine-and-dine-crawl
+served HTML: <title>Business</title> + #root  (SPA shell)
+```
+Vercel serves a 200 SPA shell and does NOT change the URL at the edge → the bounce to `/` is purely the client-side ORCH-1102 gate after hydration. This pinpoints the cause to F-1 and excludes any server/CDN routing explanation.
+
+---
+
+## 6. Five-Truth-Layer reconciliation
+
+| Layer | Truth | Contradiction |
+|-------|-------|---------------|
+| **Docs** | `feedback_anon_buyer_routes.md` + page-head comments: public buyer routes MUST be anon-tolerant, never redirect to sign-in; "Anyone with the share link sees this page." | **Contradicts Code & Runtime.** Docs describe the intended (pre-ORCH-1102) behavior; reality diverged 2026-06-08. |
+| **Schema (RLS)** | Anon can read `events` + `trip_days` + `trip_pricing_tiers` + `event_dates` + `experience_stops`. The data layer fully supports anon view+price. | **No contradiction** — RLS is correct; it is NOT the bug. Confirms the fix is route-gate-only. |
+| **Code** | `app/_layout.tsx` (root) runs `shouldRedirectToSignInFromRoute`, which redirects every logged-out web route except `/`. No public-route allowlist. Public routes have no overriding `_layout`. | **Holds the truth** for current behavior. Contradicts Docs. |
+| **Runtime** | Production Chromium (anon): all of `/e/ /t/ /exp/ /b/ /checkout /checkout-trip` redirect to the sign-in welcome screen. | **Holds the truth.** Confirms Code, refutes Docs, refutes the "asymmetry" hypothesis (events break identically). |
+| **Data** | The three rows + sidecars exist, are published/scheduled, public, and anon-readable. | Consistent with RLS; proves data is not the blocker. |
+
+The decisive gap is **Docs (and the page comments) ↔ Code/Runtime**: the ORCH-1102 root gate broke the anon-buyer contract that Docs still assert. Code/Runtime hold the truth.
+
+---
+
+## 7. Blast radius / cross-surface map
+
+| Surface | Affected? | Detail |
+|---------|-----------|--------|
+| Buyer/anon **Web** (`mingla-business` `/e/ /t/ /exp/ /b/ /checkout* `) | **YES — P0** | All public buyer routes + all checkout routes redirect anon users to sign-in. The whole anon funnel. |
+| Business iOS / Android (native) | NO | Native never reaches the web `redirectToSignIn` branch (`isWeb` guard); business users are authenticated anyway. |
+| Consumer iOS / Android (`app-mobile/`) | NO | These routes do not exist in `app-mobile/`; consumer checkout is native PaymentSheet, separate path. |
+| Admin Web | NO | No public buyer routes. |
+| Logged-IN business users on web | NO | They have a session, so `redirectToSignIn` is false — they can open `/t/ /e/ /exp/` normally (which is why this slipped past until a true logged-out test). |
+
+**Invariant impact:** violates the anon-buyer-route contract in `feedback_anon_buyer_routes.md` ("public buyer surfaces MUST NOT redirect to sign-in"). The ORCH-1102 design goal ("no dead-ends; an unauth user on any route → sign-in") is correct *for authed-only routes* but was applied too broadly — it swept the intentionally-public buyer routes into the gate.
+
+---
+
+## 8. Discoveries for Orchestrator (side issues)
+
+- **D-1 (process, MEDIUM):** ORCH-1102's SPEC/QA appears not to have included a true logged-out test of the public buyer routes — the gate's blast radius onto `/t/ /e/ /b/ /exp/ /checkout*` was missed. Any future auth-routing ORCH on `mingla-business` MUST include a fresh-context (no-session) load of every public buyer route as a gate. Worth an `I-PROPOSED` invariant.
+- **D-2 (docs, LOW):** the page-head comments on `/t/` and `/exp/` ("no sign-in redirect; anyone with the share link sees this page") are now FALSE and should be corrected (or, better, made true again by the fix). Same for `feedback_anon_buyer_routes.md`'s "live OUTSIDE `(tabs)` so the gate doesn't fire" — that defense no longer holds against a root-level gate.
+
+---
+
+## 9. Confidence
+
+**`proven` (production runtime).** Source analysis pinpointed a no-allowlist root-layout gate; production Chromium against the live site confirmed all four public surfaces + both checkout routes redirect a genuinely-anonymous user to sign-in; curl confirmed the redirect is client-side (not edge); anon-key reads confirmed RLS is not the cause; git dated it to the ORCH-1102 `[deploy]` of 2026-06-08. All Five Truth Layers reconciled, with the Docs↔Code/Runtime contradiction flagged.
+
+---
+
+## 10. Recommended next phase + scope (direction only — NOT a fix design)
+
+**Next phase: SPEC → IMPLEMENT, P0 launch-blocker priority.** Recommended scope (shape only): re-establish an anon-tolerant carve-out so the root-layout gate does NOT redirect the public buyer route prefixes (`/t/`, `/e/`, `/b/`, `/exp/`, `/checkout`, `/checkout-trip`, `/checkout-experience`) — i.e., restore the anon-buyer contract for exactly those prefixes while preserving ORCH-1102's no-dead-end behavior for genuinely authed-only routes, and ORCH-1103/1106's loop-safety. The fix lives entirely in the route-gate layer (`coldLoadAuthGates.ts` predicate + its use in `app/_layout.tsx`); no RLS, schema, or edge-function change is needed (F-2). A fails-on-revert regression test must drive a logged-out load of each public prefix and assert NO redirect to `/`. Severity is launch-blocker: until fixed, every guest share link funnels to a business sign-up wall instead of checkout — for events, trips, AND experiences.
+
+---
+
+*Artifact: `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1115_ANON_BUYER_TRIP_EXPERIENCE_ACCESS.md`*
+*Probe scripts were removed from the worktree post-run (worktree clean). Screenshots retained at `/tmp/orch1115-{event,trip,experience,brand}.png`.*

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md
@@ -1,0 +1,173 @@
+# IMPLEMENTATION — ORCH-1115 [anon-buyer web funnel restored — public buyer routes must not redirect logged-out users to sign-in]
+
+- **Mode:** IMPLEMENT (mingla-implementor). Executes the binding SPEC verbatim.
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1115-[anon-buyer-access]/` · branch `ORCH-1115-anon-buyer-access` (HEAD even with `origin/main` at start; rebase was a no-op — branch up to date).
+- **SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md`
+- **Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1115_ANON_BUYER_TRIP_EXPERIENCE_ACCESS.md`
+- **Date:** 2026-06-11
+- **Fix commit:** `551f1749ec9a88f8b477b3e61caedb5864d1dd14`
+- **Status:** implemented and verified (source/unit layer). Runtime web drive (T-A1/T-A2) is the tester's gate per SPEC §11.
+
+---
+
+## 1. Summary (plain English)
+
+ORCH-1102 moved the logged-out "send them to sign-in" redirect to the root layout that wraps **every** page, with no carve-out for the intentionally-public buyer pages. So a logged-out person opening a share link (`/e/ /t/ /b/ /exp/`), a guest checkout (`/checkout* /checkout-trip/ /checkout-experience/`), or a post-purchase receipt / emailed cancel link (`/o/ /booking/`) got bounced to the business sign-in wall instead of seeing the page.
+
+This change adds a single source-of-truth allowlist (`PUBLIC_BUYER_ROUTE_PREFIXES`) plus a segment-safe matcher (`isPublicBuyerRoute`) to `coldLoadAuthGates.ts`, and ANDs `!isPublicBuyerRoute(pathname)` into **both** the web redirect decision (`shouldRedirectToSignInFromRoute`) and the native redirect path (`nativeRedirectToSignIn` in `app/_layout.tsx`). The new clause can only ever turn a redirect **OFF** on a public route — it never creates a redirect that did not already fire, so every authed-only route still bounces a logged-out user exactly as before. Frontend route-gate layer only; no RLS / schema / edge / Vercel change.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence / commit |
+|----|-----------|--------|-------------------|
+| SC-1-Web | Public share pages (`/e/ /t/ /b/ /exp/`) render for logged-out guest; URL stays the route | ✓ predicate-verified (unit) | T-1 in test, fix `551f1749`. Runtime render = tester T-A1. |
+| SC-2-Web | Guest checkout (`/checkout/ /checkout-trip/ /checkout-experience/`) reachable logged-out | ✓ predicate-verified (unit) | T-1 (incl. `/checkout/abc/payment`, `/checkout-trip/.../buyer`), `551f1749`. Runtime = tester T-A1. |
+| SC-3-Web | Receipt `/o/` + cancel `/booking/` render logged-out (OQ-1 INCLUDED per orchestrator) | ✓ predicate-verified (unit) | T-1 (`/o/order-77`, `/booking/order-77/cancel`), `551f1749`. |
+| SC-4-Web | Authed-only route (`/account`, `/(tabs)/…`, `/brand/…`, +12 more) STILL redirects logged-out | ✓ verified (unit) | T-2 (15 authed routes → `true`), `551f1749`. |
+| SC-5-Web | Logged-IN user on a public route still renders (unchanged) | ✓ verified (unit) | T-6, `551f1749`. |
+| SC-6-Web | No hydration flash — warming session shows spinner, not flash-redirect (Constitution #14) | ✓ verified (unit) + code-preserved | T-7; `authResolving` spinner branch + ceiling untouched (diff shows no edit to those branches). |
+| SC-7 | `shouldRedirectToSignInFromRoute` false on every public prefix, true on authed; `isPublicBuyerRoute` segment-safe (`/checkouter` ≠ `/checkout/`) | ✓ verified (unit) | T-1/T-2/T-3/T-4/T-5, `551f1749`. |
+| SC-8 | Single source of truth — one exported constant; web + native both consult `isPublicBuyerRoute`; no second hardcoded list | ✓ verified (unit + structural grep) | T-9 (constant defined exactly once; `_layout.tsx` references `isPublicBuyerRoute`), `551f1749`. |
+
+All criteria with a runtime dimension (SC-1/2/3 render) are unit-proven at the predicate layer here; the SPEC routes the fresh-context browser render proof (T-A1/T-A2) to the tester (§11). Source-only is labelled "predicate-verified", not "render-proven", per the cap-at-suspected rule for runtime-routing.
+
+---
+
+## 3. Files changed (diff vs `origin/main`, 5 files, +378 / −13)
+
+| File | Δ | Nature |
+|------|---|--------|
+| `mingla-business/src/utils/coldLoadAuthGates.ts` | +93/−2 | NEW `PUBLIC_BUYER_ROUTE_PREFIXES` constant + `isPublicBuyerRoute` helper + JSDoc; AND-clause into `shouldRedirectToSignInFromRoute` + its JSDoc. |
+| `mingla-business/app/_layout.tsx` | +23/−2 | import `isPublicBuyerRoute`; AND it into `nativeRedirectToSignIn`; ORCH-1102 comment block notes the ORCH-1115 allowlist. No web call-site edit (already passes `pathname`). |
+| `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` | +8/−1 | head-comment correction ONLY (Discovery D-2). |
+| `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` | +8/−2 | head-comment correction ONLY (Discovery D-2). |
+| `mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts` | +256 (new) | T-1..T-9 regression suite. |
+
+Diff vs `origin/main` is EXACTLY these 5 files — no out-of-scope residue. All committed in `551f1749` on branch `ORCH-1115-anon-buyer-access`.
+
+---
+
+## 4. Data-model changes applied
+
+**NONE.** No migration, no table/column/constraint/index/RLS change. SPEC §2 + F-2 proved anon RLS already reads every offering + sidecar table. `supabase/` untouched.
+
+---
+
+## 5. Edge functions touched
+
+**NONE.** No edge function or `_shared/` change. No `verify_jwt` value altered. (This ORCH is a pure client route-gate fix.)
+
+---
+
+## 6. Regression tests added
+
+- **Path:** `mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts`
+- **Count:** 85 test cases across T-1..T-9 (16 public-route samples × happy, 15 authed-route guards, segment-safety, trailing-slash, null/empty, logged-in, warming, `/` loop guard, single-source structural).
+- **Result with fix present:** `Test Suites: 1 passed, 1 total · Tests: 85 passed, 85 total`.
+
+### Fails-on-revert proof (true line deletion, NOT comment-out)
+
+Deleted the `&& !isPublicBuyerRoute(pathname)` line from `shouldRedirectToSignInFromRoute` in `coldLoadAuthGates.ts` and re-ran:
+
+```
+FAIL src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts
+  ORCH-1115 T-1 (happy) — logged-out guest on a PUBLIC buyer route is NOT redirected
+    ✕ /e/travelbrand → shouldRedirectToSignInFromRoute === false
+    ✕ /t/travelbrand/the-dc-adventure → ...
+    ✕ /checkout/abc123/payment → ...
+    ✕ /o/order-77 → ...
+    ✕ /booking/order-77/cancel → ...   (all 16 public samples flip true → FAIL)
+  ORCH-1115 T-2 (guard)
+    ✕ the web predicate ANDs in the public-route exemption (structural grep)
+  ORCH-1115 T-2 (guard) — AUTHED-only route STILL redirects
+    ✓ /account → true   (all 15 authed routes STAY passing)
+Tests:       17 failed, 68 passed, 85 total
+```
+
+T-1 (public) FAILS, T-2 behavioral (authed) STAYS PASSING — exactly as SPEC §9 predicts, proving the allowlist is what suppresses the redirect, not a blanket behavior change. Fix restored; re-ran → `85 passed, 85 total`.
+
+**fails-on-revert verified at `551f1749ec9a88f8b477b3e61caedb5864d1dd14`.**
+
+### Existing-suite non-regression
+
+`orch_1103_signout_redirect_loop.test.ts` + `orch1100ColdLoadAuthGates.test.ts` re-run alongside the new file: `Test Suites: 3 passed · Tests: 122 passed`. ORCH-1102/1103/1106 contracts intact.
+
+---
+
+## 7. Old → New receipts
+
+### `mingla-business/src/utils/coldLoadAuthGates.ts`
+- **Before:** `shouldRedirectToSignInFromRoute = shouldRedirectToSignIn({...}) && !isSignInRoute(pathname)`. No concept of a public buyer route; every non-`/` web route redirected a logged-out user.
+- **Now:** adds `PUBLIC_BUYER_ROUTE_PREFIXES` (9 prefixes, single source of truth) + `isPublicBuyerRoute` (pure, RN-import-free, segment-safe via `base + "/"` boundary). Predicate is now `… && !isSignInRoute(pathname) && !isPublicBuyerRoute(pathname)` — public routes are exempted.
+- **Why:** SC-1/2/3/7/8; restores `feedback_anon_buyer_routes.md` contract. The new clause only flips `true`→`false` on a public route (SC-4 preserved).
+- **Lines:** +91 / −2.
+
+### `mingla-business/app/_layout.tsx`
+- **Before:** `nativeRedirectToSignIn = !isWeb && !loading && user === null && !isSignInRoute(pathname)`. Web path already calls `shouldRedirectToSignInFromRoute({...pathname})` (no edit needed there).
+- **Now:** imports `isPublicBuyerRoute`; `nativeRedirectToSignIn` also ANDs `&& !isPublicBuyerRoute(pathname)` so the exemption lives in ONE shared helper (SC-8). The web call site is unchanged — `shouldRedirectToSignInFromRoute` now returns `false` on public routes so the deferred `<Redirect href="/" />` no longer fires for a guest there. ORCH-1102 comment block annotated with the ORCH-1115 exception.
+- **Why:** SC-1/2/3 (web render via existing call site) + SC-8 (single source of truth, native consults it too). NO-OP on native today (business native serves none of these routes) — pinned by T-9/T-2.
+- **Lines:** +21 / −2. `authResolving` spinner branch, `authResolutionExpired` ceiling, module-level deadline anchor, `atSignInRoute` guards — all UNEDITED (Constitution #14 + ORCH-1106 preserved).
+
+### `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` + `app/exp/[brandSlug]/[experienceSlug].tsx`
+- **Before:** head comment claimed "no useAuth, no sign-in redirect … anyone with the share link sees this page" + "Lives OUTSIDE app/(tabs)/" as the defense — which became FALSE once ORCH-1102 moved the redirect to the root layout (Discovery D-2).
+- **Now:** comment states the no-sign-in-redirect guarantee is enforced at the root layout by `PUBLIC_BUYER_ROUTE_PREFIXES` (ORCH-1115), and that living outside `(tabs)` is no longer sufficient on its own.
+- **Why:** SPEC §4.3 (doc-only; zero behavior change). The `orch-strict-grep-allow safearea-on-fullscreen-routes` comment + all code preserved verbatim.
+- **Lines:** +8/−1 (trip), +8/−2 (exp). Doc-only.
+
+---
+
+## 8. Cross-surface impact
+
+| # | Surface | Affected | User-visible change | Parity |
+|---|---------|----------|---------------------|--------|
+| 1 | Consumer iOS | NO | routes don't exist in `app-mobile/` | — |
+| 2 | Consumer Android | NO | same | — |
+| 3 | **Buyer / anonymous Web** | **YES (P0)** | logged-out guest on a public buyer route renders the page; URL stays the route, not `/` | automatic (shared gate) |
+| 4 | Business iOS | NO (no-op refactor) | native redirect helper now consults `isPublicBuyerRoute`; no native public route exists → zero behavior change (T-2/T-9 pin it) | automatic (shared helper) |
+| 5 | Business Android | NO (no-op refactor) | same as #4 | automatic |
+| 6 | Admin Web | NO | separate app, no public buyer routes | — |
+| 7 | Business Web preview | YES (same bundle) | identical to #3 | automatic |
+
+Only surface with a user-visible behavior change: **Buyer/anonymous Web (#3)**.
+
+---
+
+## 9. Smoke / gate result
+
+- **Jest (touched + related):** `3 passed, 122 passed` (`orch_1115_*`, `orch_1103_signout_redirect_loop`, `orch1100ColdLoadAuthGates`).
+- **Jest (new file alone):** `85 passed, 85 total`.
+- **Fails-on-revert:** verified by true line deletion → `17 failed`; restored → `85 passed`. At `551f1749`.
+- **tsc --noEmit:** ZERO errors in any of the 5 touched files. Remaining tsc errors all pre-existing and unrelated (`packages/phone-input/*`, `app/checkout/[eventId]/buyer.tsx`, `app/checkout-trip/.../buyer.tsx` — none in my branch diff vs origin/main).
+- **strict-grep gates run:** `orch-1105-layout-no-self-redirect.mjs` PASS (loop guard intact), `orch-1105-no-route-stub-gates.mjs` PASS, `i-proposed-tr2-safearea-on-fullscreen-routes.mjs` exit 0 (my two route files NOT flagged; pre-existing `support/[ticketId].tsx` etc. violations are unrelated). `i-proposed-n-transitional-exit-condition` N/A (no `[TRANSITIONAL]` added).
+- **Runtime web drive (T-A1/T-A2):** NOT run here — owned by the tester per SPEC §11 (fresh-context Playwright load of `/t/ /e/ /exp/ /checkout-trip/` render + URL-not-sign-in, and `/account` must-still-redirect, against the MERGED build).
+
+---
+
+## 10. Known issues / deferred
+
+- No `[TRANSITIONAL]` code introduced.
+- Runtime render proof (the page actually mounts content for a logged-out browser) is deferred to the tester per SPEC §11 — the predicate truth is proven here; source-only render is capped at "suspected" for a runtime-routing bug, so I do not claim render-proven.
+- OQ-2 (`/auth*`) and OQ-3 (`usePathname` shape) are out of scope per SPEC §10; not touched.
+
+---
+
+## 11. Operator action required
+
+- **Migration `db push`:** NONE (no migration).
+- **Edge-fn deploy:** NONE (no edge function touched).
+- **Deploy:** web-only (Vercel) on merge — no OTA, no edge, no migration, per SPEC §11.
+- **Next phase:** route to mingla-tester for T-A1/T-A2 (fresh-context Playwright drive against the merged build), then orchestrator CLOSE (flip I-PROPOSED-1115 ACTIVE; retire the stale `feedback_anon_buyer_routes.md` "lives outside (tabs)" defense note per D-2).
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **D-pre-existing-1 (tsc):** `mingla-business` has pre-existing strict-mode tsc errors unrelated to this ORCH — implicit-`any` parameters in `app/checkout/[eventId]/buyer.tsx`, `app/checkout-trip/[tripEventId]/buyer.tsx`, and missing-`react`-module errors in `packages/phone-input/*`. Not in my lane (my branch diff vs origin/main is exactly the 5 SPEC files). Flag for a typecheck-hygiene ORCH if desired.
+- **D-pre-existing-2 (strict-grep TR2):** `i-proposed-tr2-safearea-on-fullscreen-routes.mjs` reports 12 pre-existing safearea violations (e.g. `app/support/[ticketId].tsx`) — none mine, gate exits 0. Flag if the orchestrator wants the soft-warnings cleaned.
+- **Comms ledger:** read on entry; no OPEN BLOCK row targets ORCH-1115 / implementor / ALL. The OPEN rows are WARN-level backend/external-API entries addressed to other ORCHs — N/A to this frontend route-gate change (acked as factored per dispatch). No new cross-ORCH discovery written this turn.
+
+---
+
+*Artifact: `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md`*

--- a/Mingla_Artifacts/reports/TEST_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md
@@ -1,0 +1,183 @@
+# TEST — ORCH-1115 [anon-buyer web funnel restored — public buyer routes must not redirect logged-out users to sign-in]
+
+- **Mode:** TARGETED (mingla-tester). Brutal gatekeeper — assumed broken until proven.
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1115-[anon-buyer-access]/` · branch `ORCH-1115-anon-buyer-access`
+- **Fix commit under test:** `551f1749ec9a88f8b477b3e61caedb5864d1dd14`
+- **Tester adversarial commit:** `cdc5d6595b7d1608373df6ba4c0a11f189c68ad1`
+- **Date:** 2026-06-11
+- **SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md`
+- **Comms ledger:** read on entry. No genuinely-OPEN row targets ORCH-1115, `tester`, or `ALL` (verified by parsing the status column, not substring matches). Nothing to ack.
+
+---
+
+## 1. Verdict
+
+# PASS — P0: 0 · P1: 0 · P2: 0 · P3: 0 · P4: 2
+
+The anon-buyer web funnel is **restored and runtime-proven**. A genuinely logged-out browser renders every public buyer route (share links, guest checkout, receipt, cancel) with the requested URL preserved and NO sign-in wall; every authed-only route still redirects to `/` and shows the BusinessWelcomeScreen. The allowlist did not over-widen. Adversarial path-confusion / segment-safety attacks (including dot-segment traversal, encoded authed routes, double-slash, and authed-route-with-public-tail) all correctly stay gated, proven both at the unit layer and at runtime in a headless browser.
+
+`proven`-level live-fire evidence obtained (headless Chromium against the branch web export served with a production-faithful SPA fallback). Regression gate satisfied (implementor happy-path fails-on-revert independently re-run + tester adversarial different-angle test, both on-branch, both in the closing diff).
+
+---
+
+## 2. Build + serve method and fidelity
+
+**Build.** From `mingla-business/`: `EXPO_ROUTER_APP_ROOT="$PWD/app" EXPO_PUBLIC_SUPABASE_URL=… EXPO_PUBLIC_SUPABASE_ANON_KEY=… npx expo export -p web --clear` (output `dist/`, `web.output: "single"` per `app.json`). Supabase URL + legacy anon key (read-only, public-by-design) were baked so the buyer pages fetch REAL data and render real content vs an error stub.
+
+- **First export FAILED faithfully-and-loud, then was fixed.** The initial `npx expo export -p web` produced a ROUTELESS bundle (`[PAGEERROR] No routes found` at every path, including `/`; `document.body.innerText.length === 0`; grep of the bundle showed zero route markers). Root cause: this worktree has **no `babel.config.js`** (none exists in git for `mingla-business` — only `app-mobile/` has one) and `node_modules` is a **symlink to the anchor** (`/Users/sethogieva/Desktop/mingla-main/mingla-business/node_modules`), so Expo Router's `require.context` over `app/` did not resolve and `EXPO_ROUTER_APP_ROOT` was unset. Setting `EXPO_ROUTER_APP_ROOT="$PWD/app"` + `--clear` produced a correct route-split export (per-route chunks: `account-*.js`, `[eventSlug]-*.js`, `[tripSlug]-*.js`, `home-*.js`, `[orderId]-*.js`, …). The app then hydrated cleanly with zero page errors. **This is a build-environment workaround for the local headless export; production Vercel builds already render correctly (the investigation proved the bug on prod), so this does not indicate a product defect** — flagged as P4 note D-pre-1.
+
+**Serve.** A tiny Node static server (`/tmp/orch1115_harness/spa-server.mjs`) that (a) serves a real file from `dist/` when one exists (the JS bundle, assets, favicon) and (b) falls back ALL other non-bot paths to `dist/index.html`. This replicates `vercel.json`'s final rewrite `{ "source": "/(.*)", "destination": "/" }` exactly. Verified: deep route `/exp/lanternvine/raleigh-wine-and-dine-crawl` returns the same 1.4KB `index.html` (SPA fallback), the 984KB bundle serves 200, and `expo serve` (Expo's own static server) returns 404 on deep paths — confirming the export emits only `/index.html` and the SPA fallback is the correct production replica.
+
+**Driver.** Playwright 1.60.0 (local in `node_modules`), Chromium headless. Each route loaded in a **fresh `browser.newContext()` with no cookies, no localStorage, no service worker** — a genuinely logged-out guest. 9s settle per route to clear the ORCH-1102 auth-resolution ceiling + hydration before reading the final URL and `document.body.innerText`.
+
+**Fidelity vs production.** HIGH.
+- Same bundle output (`expo export -p web`, the exact `vercel.json buildCommand`), same `output: "single"` SPA, same SPA fallback rewrite, real Supabase anon reads (real brand/event/trip/experience content rendered).
+- Sign-in-wall detection uses production copy from `BusinessWelcomeScreen.tsx` ("Continue with Apple" / "Continue with Google").
+- **Not replicated (does not affect this gate):** Vercel `cleanUrls`/edge bot-rewrites (only fire for crawler UAs; an anonymous human UA hits the SPA fallback — exactly what was driven), the `inject-mobile-blur-css.mjs` post-step (CSS only). The redirect decision is data-independent and runs identically.
+- The investigation's original repro was production Chromium against `business.usemingla.com`; this is the same method against the FIXED branch build.
+
+---
+
+## 3. SC-by-SC matrix (runtime evidence)
+
+| SC | Criterion | Verdict | Evidence |
+|----|-----------|---------|----------|
+| SC-1-Web | Public share pages render logged-out; URL stays | **PASS** | `/e/leggothis/big-party` → body "Big Party PRESENTED BY Leggo This", finalPath `=/e/leggothis/big-party`, signinWall=false. `/t/travelbrand/the-dc-adventure` → "The DC Adventure by Travel Brand … DAY BY DAY", URL stayed. `/exp/lanternvine/raleigh-wine-and-dine-crawl` → "Raleigh Wine and Dine Crawl by Lantern & Vine … THE ITINERARY", URL stayed. `/b/leggothis` → "Leggo This We are a brand that throws parties", URL stayed. |
+| SC-2-Web | Guest checkout reachable logged-out | **PASS** | `/checkout/{eventId}` → "Get tickets 1 OF 3 …", URL stayed, no wall. `/checkout-trip/{id}` → "Reserve your spot 1 OF 3 …", URL stayed. `/checkout-experience/{id}` → "Get your spot 1 OF 3 …", URL stayed. |
+| SC-3-Web | Receipt `/o/` + cancel `/booking/` render logged-out (OQ-1 INCLUDED) | **PASS** | `/o/test-order-id` → "Order … Order not found" receipt screen (its own content, not the wall), URL stayed. `/booking/{id}/cancel?token=abc` → "This cancel link isn't valid …" cancel screen, finalPath `=/booking/{id}/cancel` (query preserved), no wall. |
+| SC-4-Web | Authed-only route STILL redirects logged-out | **PASS** | `/account` → finalPath `=/`, signinWall=TRUE ("Continue with Apple/Google"). `/home` (`(tabs)`) → `/`, wall. `/brand/some-brand-id` → `/`, wall. Allowlist did NOT over-widen. |
+| SC-5-Web | Logged-IN on public route unchanged | **PASS** (unit) | T-6: `hasUser:true` on all 16 public samples → predicate `false` (renders). No regression to logged-in behavior; the public clause only matters for the no-user case. |
+| SC-6-Web | No hydration flash (Constitution #14) | **PASS** (unit + code-preserved) | T-7 (warming session → predicate false on public AND authed; spinner branch owns the gate). Diff shows `authResolving` spinner branch, `authResolutionExpired` ceiling, module-level deadline anchor all UNEDITED. `orch1100ColdLoadAuthGates` + `orch1100FirewallHydration` + `orch1102Wave2LoadingTimeout` suites green. |
+| SC-7 | Predicate unit truth + segment-safe | **PASS** | implementor T-1/T-2/T-3/T-4/T-5 (85 cases) + tester adversarial (45 cases) green; `/checkouter` ≠ `/checkout/` proven; runtime confirms. |
+| SC-8 | Single source of truth | **PASS** | T-9: `PUBLIC_BUYER_ROUTE_PREFIXES` defined exactly once; `_layout.tsx` native path consults `isPublicBuyerRoute`; grep finds no second hardcoded list. |
+
+**Runtime drive raw result** (fresh logged-out context, all 9 prefixes + 3 authed):
+- PUBLIC (URL stayed, NO wall): `/e/…`, `/t/…`, `/exp/…`, `/b/…`, `/checkout/…`, `/checkout-trip/…`, `/checkout-experience/…`, `/o/…`, `/booking/…/cancel?token=…` — **9/9 render content.**
+- AUTHED (redirect to `/`, wall shown): `/account`, `/home`, `/brand/{id}` — **3/3 still gated.**
+- console errors: 0 on every route.
+
+---
+
+## 4. Findings
+
+**No P0/P1/P2/P3.** Two P4 notes:
+
+- **P4-1 (build-env, not a product defect):** the local headless `expo export -p web` needs `EXPO_ROUTER_APP_ROOT="$PWD/app"` to bake the route tree, because this worktree has no `babel.config.js` and a symlinked `node_modules`. Production Vercel builds are unaffected (render proven on prod by the investigation). Documented so a future tester reproducing this gate doesn't burn time on the "No routes found" blank-render.
+- **P4-2 (praise):** the fix is minimal, segment-safe by construction (`base + "/"` boundary), single-source-of-truth, and the implementor's protective comment + the "add new public routes HERE and to the test" rule make the invariant self-documenting. The clause is composed to only ever flip a redirect TRUE→FALSE, which bounds the blast radius to public routes — exactly as a security-sensitive gate change should be written.
+
+---
+
+## 5. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out the fix at `551f1749`, then performed a **true line deletion** of `&& !isPublicBuyerRoute(pathname)` from `shouldRedirectToSignInFromRoute` in `coldLoadAuthGates.ts` (not a comment-out) and re-ran `orch_1115_anon_buyer_route_allowlist.test.ts`:
+
+```
+Tests: 17 failed, 68 passed, 85 total
+  ✕ T-1 (happy) — all 16 PUBLIC samples flip true → FAIL
+    /e/travelbrand, /t/travelbrand/the-dc-adventure, /checkout/abc123/payment,
+    /o/order-77, /booking/order-77/cancel, … (16 cases)
+  ✕ T-2 structural grep "the web predicate ANDs in the public-route exemption"
+  ✓ T-2 behavioral — all 15 AUTHED routes STAY passing (/account → true, etc.)
+```
+
+Restored the clause → `85 passed, 85 total`. The pattern matches the implementor's report exactly: T-1 (public) flips to FAIL, T-2 (authed) stays PASS, proving the allowlist is what suppresses the redirect — not a blanket behavior change. **Implementor fails-on-revert independently confirmed at `551f1749`.**
+
+---
+
+## 6. Adversarial test added (tester-owned, different angle)
+
+- **Path:** `mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_path_confusion.adversarial.test.ts`
+- **Commit:** `cdc5d6595` (on-branch; appears in `git diff origin/main...HEAD --name-only` alongside the implementor's `orch_1115_anon_buyer_route_allowlist.test.ts`).
+- **Angle (different from the implementor's happy-path allowlist suite):** the **security false-positive** failure mode — can a crafted path that is REALLY an authed route (or junk) wrongly MATCH the allowlist and LEAK an authed surface to a logged-out guest? 45 cases:
+  - **ADV-1/ADV-2** — authed-first-segment with a public tail (`/account/e/x`, `/account/checkout/x`, `/brand/123/e/x`, `/(tabs)/home/checkout/x`, `/notifications/o/1`), segment-boundary lookalikes (`/echo`, `/blog`, `/orders`, `/experience`, `/experiences`, `/checkout-experiences`, `/bookings`, `/tickets`), double-slash junk (`//account`, `//e/x`), whitespace-padded authed route (`  /account  `) → all `isPublicBuyerRoute === false` AND composed `shouldRedirectToSignInFromRoute === true`.
+  - **ADV-3 (encoding)** — URL-encoded authed routes the gate CAN see (`/%61ccount`, `/account%2Fe`, `/e%2F..%2Faccount`, `/checkout%00/x`) → not exempted, still redirect.
+  - **ADV-4 (positive control)** — genuine deep public subpaths DO match (proves the suite is not vacuously passing).
+- **Teeth proven:** weakening the matcher to a naive `normalized.includes(base)` made **14 of the 45 cases FAIL** (`/account/e/x`, `/echo`, `/blog`, `/orders`, `//e/x`, … would leak) — the implementor's suite caught the simple `/checkouter`/`/exposed` trailing-junk class but NOT the authed-route-with-public-tail leak; this suite does. Matcher restored cleanly (no residual diff).
+- **Result on the fix:** `45 passed, 45 total`.
+
+### Dot-segment traversal — runtime-proven non-issue (not asserted on a raw input the gate never sees)
+
+The adversarial suite originally asserted `isPublicBuyerRoute("/e/../account") === false`. That FAILED — the textual matcher treats `/e/../account` as a `/e/` subpath (it `startsWith("/e/")`). Rather than hand-wave, I **drove it in a real browser**: `/e/../account`, `/checkout/../account`, `/exp/../../brand/x`, `/booking/../../account`, and the encoded `/e/%2e%2e/account` were each loaded logged-out. **All five resolved to `/` and showed the sign-in wall** — because the browser normalizes `..` segments per RFC-3986 / WHATWG-URL BEFORE the request leaves the client, so `usePathname()` (and the gate) only ever receives the collapsed `/account`. The raw dotted form is unreachable in production. I therefore corrected those assertions OUT of `MUST_NOT_MATCH` and documented the runtime proof in the test header — asserting the proven reality, not an idealized input the gate cannot receive.
+
+---
+
+## 7. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps / share link reaches a live page | **PASS (RESTORED)** | runtime: every share/checkout link renders its page instead of the sign-in wall. |
+| 2 | One owner per truth | **PASS** | redirect decision owned solely by `shouldRedirectToSignInFromRoute`/`nativeRedirectToSignIn`; allowlist is one exported constant (SC-8/T-9). |
+| 3 | No silent failures | **PASS** | pure total predicate, returns boolean, never throws; no swallowed errors. |
+| 4 | One query key per entity | **N/A** | no query layer touched. |
+| 5 | Server state server-side | **N/A** | no Zustand/server-state change. |
+| 6 | Logout clears everything | **N/A** | unaffected (only the no-user redirect exemption changed). |
+| 7 | Label `[TRANSITIONAL]` | **N/A** | none introduced. |
+| 8 | Subtract before adding | **PASS** | additive AND-clause; no parallel gate added; native routes through the same shared helper. |
+| 9 | No fabricated data | **PASS** | pages render real Supabase content or their own honest not-found/closed states (observed). |
+| 10 | Currency-aware | **N/A** | no pricing logic. |
+| 11 | One auth instance | **PASS** | buyer pages still call no `useAuth`; gate reads the single root auth state. |
+| 12 | Validate at the right time | **N/A** | no datetime validation. |
+| 13 | Exclusion consistency | **PASS** | the exemption is the same single helper on web + native; no divergent route lists. |
+| 14 | Persisted-state startup (hydration gate before redirect) | **PASS** | `authResolving` spinner branch + ceiling + deadline anchor UNEDITED; T-7 warming-session test green; no flash-redirect before resolution. |
+
+No violations → no automatic P0.
+
+---
+
+## 8. Device / parity matrix
+
+| # | Surface | Verdict | Evidence / reason |
+|---|---------|---------|-------------------|
+| 1 | Consumer iOS | **N/A (skip)** | routes do not exist in `app-mobile/`. |
+| 2 | Consumer Android | **N/A (skip)** | same. |
+| 3 | **Buyer / anonymous Web** | **PASS (proven)** | headless Chromium fresh-context drive of all 9 public prefixes (render + URL) + 3 authed routes (redirect). The only surface with a behavior change. |
+| 4 | Business iOS | **PASS (no-op)** | native `nativeRedirectToSignIn` now ANDs `isPublicBuyerRoute`, a no-op (no native public route); T-2/T-9 pin no authed-route native redirect changed. Native render not driven (no behavior change; the helper is the same pure function proven on web). |
+| 5 | Business Android | **PASS (no-op)** | same as #4. |
+| 6 | Admin Web | **N/A (skip)** | separate app, no public buyer routes. |
+| 7 | Business Web preview | **PASS** | identical bundle to #3. |
+
+**Physical iPhone (HITL):** not required — the only behavior change is buyer WEB, proven in a real browser; no iOS/Android runtime behavior changed (native path is a no-op refactor). No physical-device step was deferred or stubbed.
+
+**Live deploy state:** no edge function / migration / `vercel.json` in the diff (verified). Deploy is web-only (Vercel) on merge — no OTA, no edge deploy, no `db push`. Nothing to verify against a live edge version.
+
+---
+
+## 9. Scope confirmation
+
+`git diff origin/main...HEAD` product files = exactly the SPEC's allowlist:
+- `mingla-business/src/utils/coldLoadAuthGates.ts` (+91/−2) — constant + helper + AND-clause. **Logic change.**
+- `mingla-business/app/_layout.tsx` (+21/−2) — import + AND-in `nativeRedirectToSignIn` + comments. **Logic change (native no-op).**
+- `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` (+8/−1) — **doc-comment-only** (verified: the diff is entirely inside the leading `/** */` block; no code line changed).
+- `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` (+8/−2) — **doc-comment-only** (verified same).
+- 2 test files (implementor allowlist + tester adversarial).
+- impl report (docs).
+
+**RLS / schema / migration / edge function / `vercel.json` — UNTOUCHED** (grep confirmed CLEAN). The runtime drive rendering real anon content independently confirms anon RLS reads were already live (investigation F-2).
+
+---
+
+## 10. Regression / unit results
+
+- `orch_1115_anon_buyer_route_allowlist.test.ts` (implementor) — **85 passed.** Fails-on-revert independently re-confirmed (§5).
+- `orch_1115_anon_buyer_route_path_confusion.adversarial.test.ts` (tester) — **45 passed.** Teeth proven via weakened-matcher (14 fail).
+- Loop-guard / cold-load / no-dead-ends / hydration / ceiling / boot-probe suites — `orch_1103_signout_redirect_loop`, `orch1100ColdLoadAuthGates`, `orch1100FirewallHydration`, `orch1102AuthRoutingNoDeadEnds`, `orch1102Wave2LoadingTimeout`, `bootSessionProbe.orch_1106` — **all green.**
+- **Consolidated:** `Test Suites: 8 passed · Tests: 231 passed.`
+- ESLint on the new file: 0 errors. `tsc --noEmit`: 0 errors attributable to the new file (pre-existing unrelated strict-mode errors in `checkout/buyer.tsx`, `phone-input/*` noted by implementor D-pre-1, not in this lane).
+
+---
+
+## 11. Discoveries for Orchestrator
+
+- **D-1 (build-env P4-1):** local `expo export -p web` for `mingla-business` needs `EXPO_ROUTER_APP_ROOT="$PWD/app"` (+`--clear`) to bake the route tree in a worktree with no `babel.config.js` and a symlinked `node_modules`; without it the bundle is routeless ("No routes found", blank render). Production Vercel is unaffected. Worth recording in the sim/web test reference so the next anon-web gate test doesn't lose time.
+- **D-2 (carried, pre-existing):** `mingla-business` has pre-existing strict-mode `tsc` errors (`app/checkout/[eventId]/buyer.tsx`, `app/checkout-trip/.../buyer.tsx`, `packages/phone-input/*`) and TR2 safearea soft-warnings — none introduced here; flagged for a typecheck-hygiene ORCH if desired (matches implementor D-pre-1/2).
+- **CLOSE actions (from SPEC §11):** flip `I-PROPOSED-1115-PUBLIC-BUYER-ROUTE-ALLOWLIST` ACTIVE; retire the stale `feedback_anon_buyer_routes.md` "lives outside (tabs)" defense note (D-2 in investigation); web-only Vercel deploy, no OTA/edge/migration.
+
+---
+
+## 12. Routing
+
+**PASS → CLOSE (orchestrator).** No rework. No accepted conditions (zero P1/P2). Web-only deploy on merge.
+
+---
+
+*Artifact: `Mingla_Artifacts/reports/TEST_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md`*

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md
@@ -1,0 +1,246 @@
+# SPEC — ORCH-1115 [anon-buyer web funnel restored — public buyer routes must not redirect logged-out users to sign-in]
+
+- **Mode:** SPEC (forensics). Binding contract for the implementor.
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1115-[anon-buyer-access]/` · branch `ORCH-1115-anon-buyer-access` (HEAD even with `origin/main`).
+- **Date:** 2026-06-11
+- **Source investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1115_ANON_BUYER_TRIP_EXPERIENCE_ACCESS.md` (`proven`, production Chromium).
+- **Priority:** P0 — LAUNCH BLOCKER. The entire anonymous share-link → checkout funnel on `business.usemingla.com` bounces guests to a business sign-in wall.
+- **Comms ledger:** read on entry; no `BLOCK`/`OPEN` row targets ORCH-1115, forensics, or `ALL`. No new cross-ORCH discovery written this turn.
+
+---
+
+## 1. Executive summary
+
+ORCH-1102 (shipped 2026-06-08, PR #414) moved the unauthenticated "no dead-end" sign-in redirect from a route-list / `(tabs)`-scoped gate to the **root layout** (`mingla-business/app/_layout.tsx`), which wraps EVERY route. The redirect decision (`shouldRedirectToSignInFromRoute` in `coldLoadAuthGates.ts`) has **no allowlist** for the intentionally-public buyer routes. Result, proven on production with a fresh logged-out browser: `/e/…`, `/t/…`, `/b/…`, `/exp/…`, `/checkout/…`, `/checkout-trip/…`, `/checkout-experience/…` all redirect a guest to the business welcome/sign-in screen; the buyer page and checkout never render. RLS is fully permissive to anon (proven) — this is **purely a client route-gate bug**.
+
+This SPEC restores the anon-buyer contract (`feedback_anon_buyer_routes.md`) by adding a **single-source-of-truth public-buyer-route allowlist** to `coldLoadAuthGates.ts` and ANDing it into the redirect predicate, so a logged-out user on a public buyer route is NOT redirected and the page renders — while EVERY authed-only route still redirects (ORCH-1102 preserved) and the `/` self-redirect loop guard (ORCH-1103) and the deadlock ceiling (ORCH-1106) remain intact. **Frontend-only, route-gate layer only. No RLS / schema / edge-function change.**
+
+---
+
+## 2. Scope & non-goals
+
+### In scope
+1. Add an exported, single-source-of-truth public-buyer-route prefix list + matcher helper to `mingla-business/src/utils/coldLoadAuthGates.ts`.
+2. Modify the existing `shouldRedirectToSignInFromRoute` predicate so it returns `false` (no redirect) when the current pathname matches a public-buyer prefix — for the WEB redirect path only.
+3. Apply the same allowlist exemption to the **native** unauthenticated redirect computed inline in `app/_layout.tsx` (`nativeRedirectToSignIn`) so the helper is the one place public-route exemption is decided (defensive — native does not serve these routes today, but the exemption must not be web-only-duplicated logic; see §4 Component layer).
+4. Add a fails-on-revert regression test extending the existing `coldLoadAuthGates` unit-test pattern.
+5. Correct the now-false page-head comments on the public routes that assert "no sign-in redirect" (Discovery D-2), to point at the restored guarantee (documentation-only edit, no behavior change).
+
+### Out of scope (explicit non-goals)
+- **NO RLS / schema / migration / edge-function change.** Investigation F-2 proved anon RLS already reads every offering + sidecar table; the data layer is correct. DO NOT touch it.
+- **NO widening the gate for authed-only routes.** The allowlist is PUBLIC-BUYER-ONLY. `/(tabs)/*` (home/hub), `/account*`, `/brand/*`, `/event/*`, `/trip/*`, `/experience/*`, `/venue/*`, `/partner/*`, `/ari*`, `/support*`, `/notifications`, `/connect-*`, `/accept-*`, `/stripe-onboarding-return` MUST continue to redirect a logged-out user. (See §2-table below.)
+- **NO change to the `/` self-redirect loop guard (ORCH-1103) or the auth-resolution ceiling / deadlock backstop (ORCH-1102 Wave 2 / ORCH-1106).** Those branches are preserved verbatim; the allowlist composes BEFORE them in the predicate, not around them.
+- **NO change to `/auth*` (OAuth callback) gating in this ORCH.** `/auth/callback` is the sign-in completion flow, not a buyer route. The investigation did not scope it. (Flagged as Open Question OQ-2 — do not silently include it.)
+- **NO native-app code path change in behavior** beyond routing the public-route exemption through the shared helper (`app-mobile/` untouched; business native does not serve these routes).
+- **NO Vercel / `vercel.json` / OG / `.well-known` change.** Those assets (`/og/*`, `/.well-known/*`, `/auth/callback.html`, `/stripe-onboarding-return.html`) are served by Vercel statically/serverless and **never route through the client SPA gate** — they are already exempt at the edge (verified in `vercel.json`). No allowlist entry is needed for them; adding one would be dead code.
+
+### Assumptions
+- Expo Router `usePathname()` returns a leading-slash, decoded pathname WITHOUT query string (e.g. `/t/travelbrand/the-dc-adventure`, `/checkout/abc123`). The matcher operates on this shape (prefix match on the pathname only). `cleanUrls: true` + `trailingSlash: false` in `vercel.json` means no trailing slash in production; the matcher tolerates a single trailing slash defensively anyway (mirrors `isSignInRoute`).
+- A genuinely logged-out guest has no stored web session → `loading` resolves fast, `authResolving` is false, and the redirect branch is the one that fires today. The allowlist must short-circuit that branch.
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY)
+
+| # | Surface | Covered? | User-visible behavior demanded | Files touched here | Parity |
+|---|---------|----------|-------------------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile/` iOS) | **NOT covered** | n/a — these routes do not exist in `app-mobile/`; consumer checkout is native PaymentSheet. | none | — |
+| 2 | Consumer Android (`app-mobile/` Android) | **NOT covered** | same reason as #1. | none | — |
+| 3 | **Buyer / anonymous Web** (`mingla-business/` `/e/ /t/ /b/ /exp/ /checkout* /o/ /booking/*`) | **YES — P0** | A logged-out browser on any public buyer route renders the page (and can proceed through checkout); the URL does NOT become the sign-in route. | `src/utils/coldLoadAuthGates.ts`, `app/_layout.tsx`, public-route head comments, new test file | automatic (shared gate) |
+| 4 | Business iOS | **NOT covered (no behavior change)** | Business native never reaches the web redirect branch (`isWeb` guard); the native redirect helper change is a no-op (these routes are not served on native). | `app/_layout.tsx` (helper routing only) | automatic (shared helper) |
+| 5 | Business Android | **NOT covered (no behavior change)** | same as #4. | (shared) | automatic |
+| 6 | Admin Web (`mingla-admin/`, adjacent) | **NOT covered** | no public buyer routes; separate app. | none | — |
+| 7 | Business Web preview (adjacent) | **YES (same bundle)** | identical to #3 — same `mingla-business` web bundle. | (shared) | automatic |
+
+**HARD GATE:** the ONLY surface with a user-visible behavior change is **Buyer/anonymous Web (#3)**. Native business apps (#4/#5) get a no-op refactor of WHERE the public-route exemption is decided, with zero behavior change (proven by the native test in §7).
+
+---
+
+## 4. Layered specification
+
+This change touches exactly TWO code layers: a pure predicate utility, and the root layout that consumes it. No DB, edge, service, hook, or realtime layer is involved.
+
+### 4.1 Utility layer — `mingla-business/src/utils/coldLoadAuthGates.ts`
+
+**4.1.1 NEW exported constant — `PUBLIC_BUYER_ROUTE_PREFIXES`.**
+
+A single, exported, readonly array of pathname prefixes that are anon-tolerant public buyer routes. This is the **single source of truth** (Dispatch requirement #3). Future public routes are added here and ONLY here.
+
+The prefix set (each is matched as a path-segment prefix — see 4.1.2):
+
+| Prefix | Route | Why public |
+|--------|-------|-----------|
+| `/e/` | `/e/[brandSlug]/[eventSlug]` public event page | share link |
+| `/t/` | `/t/[brandSlug]/[tripSlug]` public trip page | share link |
+| `/b/` | `/b/[brandSlug]` public brand page | share link |
+| `/exp/` | `/exp/[brandSlug]/[experienceSlug]` public experience page | share link |
+| `/checkout/` | `/checkout/[eventId]/…` event checkout | guest purchase |
+| `/checkout-trip/` | `/checkout-trip/[tripEventId]/…` trip checkout | guest purchase |
+| `/checkout-experience/` | `/checkout-experience/[experienceEventId]/…` experience checkout | guest purchase |
+| `/o/` | `/o/[orderId]` buyer order receipt (post-purchase) | shareable receipt; explicitly anon-tolerant per its own head comment + I-21 |
+| `/booking/` | `/booking/[orderId]/cancel` buyer cancel-from-email | anon-buyer-tolerant per `feedback_anon_buyer_routes.md` |
+
+> **Why `/o/` and `/booking/` are included** (reconciliation requirement, Dispatch #1): both are part of the SAME anon-buyer-route class the investigation identified — their own source head comments declare them "ANON-TOLERANT … MUST NOT call useAuth or redirect to sign-in" (`/o/[orderId].tsx` per I-21) and "Anon-buyer-tolerant per feedback_anon_buyer_routes.md. NO useAuth, NO sign-in redirect" (`/booking/[orderId]/cancel.tsx`). They are ALSO swept into the ORCH-1102 root gate today and would redirect a logged-out buyer arriving at a receipt or an emailed cancel link weeks post-purchase. Including them is completing the identified contract class, not widening scope. **This decision is surfaced for ratification in OQ-1; if the orchestrator rules them out, drop only those two rows — the matcher and everything else stay.**
+
+**4.1.2 NEW exported helper — `isPublicBuyerRoute(pathname: string | null | undefined): boolean`.**
+
+Pure, RN-import-free (same discipline as the rest of the file so it is node-jest-unit-testable and fails-on-revert).
+
+Matching logic (prefix match on pathname, segment-safe):
+- `null` / `undefined` / empty / whitespace-only → `false` (a missing pathname is NOT a public route; it falls through to the existing `isSignInRoute`-driven behavior, which treats empty as `/`).
+- Trim; strip a single trailing slash for `length > 1` (mirror `isSignInRoute` normalization) so `/checkout/` and `/checkout` both behave; do not strip the root `/`.
+- Return `true` iff the normalized pathname **equals a prefix with the trailing slash removed** (e.g. `/checkout`) OR **starts with the full prefix** (e.g. `/checkout/abc`). This MUST be segment-safe: `/checkout/x` matches `/checkout/` but a hypothetical `/checkouter` MUST NOT match (guard by requiring the char after the prefix-minus-slash to be `/` or end-of-string). Equivalent phrasing: for each prefix `P` (e.g. `/checkout/`), let `base = P` without its trailing slash (`/checkout`); match when `normalized === base` OR `normalized.startsWith(base + "/")`.
+- This makes the matcher robust to the `[brandSlug]/[slug]` and `[eventId]/buyer|payment|confirm` sub-paths under each checkout route.
+
+> Illustrative shape only (≤3 lines, NOT an implementation):
+> ```ts
+> export const PUBLIC_BUYER_ROUTE_PREFIXES = ["/e/","/t/","/b/","/exp/","/checkout/","/checkout-trip/","/checkout-experience/","/o/","/booking/"] as const;
+> // isPublicBuyerRoute: normalize pathname, then for each prefix P with base=P.slice(0,-1): return normalized===base || normalized.startsWith(base + "/")
+> ```
+
+**4.1.3 MODIFY `shouldRedirectToSignInFromRoute`.**
+
+Add the public-route exemption as an ADDITIONAL AND-clause, composed BEFORE the existing decision so the existing ORCH-1102 + ORCH-1103 logic is untouched:
+
+`shouldRedirectToSignInFromRoute = shouldRedirectToSignIn({...}) && !isSignInRoute(pathname) && !isPublicBuyerRoute(pathname)`
+
+- The new clause ONLY ever flips a `true` to `false` (suppresses a redirect on a public route). It can NEVER cause a redirect that did not already fire. This bounds the blast radius: no authed-only route's behavior can change.
+- `isSignInRoute` and `shouldRedirectToSignIn` are NOT modified.
+- Update the JSDoc above the function to name ORCH-1115 and the allowlist (cite `PUBLIC_BUYER_ROUTE_PREFIXES`).
+
+**Error contract:** pure function, total over its inputs, returns `boolean`, never throws. No change to the `isWeb`/`loading`/`hasUser`/`hasStoredWebSession`/`pathname` parameter shape (additive logic only — preserves all existing callers and tests).
+
+### 4.2 Layout layer — `mingla-business/app/_layout.tsx`
+
+**4.2.1 WEB redirect path — `redirectToSignIn` (line ~307–313).** No change required at the call site: it already calls `shouldRedirectToSignInFromRoute({ ..., pathname })`, which now returns `false` on public routes. The deferred `if (redirectToSignIn) return <Redirect href="/" />` (line ~568) therefore no longer fires for a logged-out guest on a public buyer route → the Stack mounts and the page renders. **VERIFY at IMPLEMENT** the call site still passes `pathname` (it does today, line ~312).
+
+**4.2.2 NATIVE redirect path — `nativeRedirectToSignIn` (line ~329–330).** Today this is computed inline as `!isWeb && !loading && user === null && !isSignInRoute(pathname)`. To keep the public-route exemption in ONE place (Dispatch #3 single-source-of-truth) and to harden against a future native public-route, AND-in the same helper: `… && !isSignInRoute(pathname) && !isPublicBuyerRoute(pathname)`. This is a **no-op today** (business native serves none of these routes) — the native test in §7 pins that no native authed route's redirect changes. Import `isPublicBuyerRoute` alongside the existing `coldLoadAuthGates` imports (line ~76–82).
+
+**4.2.3 Preserve verbatim:** `authResolving` spinner branch (line ~565), `authResolutionExpired` ceiling redirect (line ~557), the module-level deadline anchor (ORCH-1102 Wave 2), and the `atSignInRoute` guards. The allowlist composes inside the predicate, ABOVE these branches; none of them are edited.
+
+**4.2.4 States (all enumerated):**
+- **Logged-out + public route** (guest, no session, on `/t/…` etc.): `redirectToSignIn=false`, `authResolving=false` → falls through to `<Stack>` → page renders. ✅ (the fix)
+- **Logged-out + authed route** (guest on `/account`): `redirectToSignIn=true` (allowlist miss) → `<Redirect href="/" />`. ✅ (ORCH-1102 preserved)
+- **Logged-in + public route** (business owner opens own `/t/…`): `redirectToSignIn=false` (no-user check already false) → renders. ✅ (no change)
+- **Logged-in + authed route**: unchanged. ✅
+- **Cold-load hydration race** (stored web session warming, no user yet, on a public OR authed route): `authResolving=true` → `<AuthResolvingScreen/>` spinner; the allowlist does NOT pre-empt the spinner (the spinner branch is checked independently of `redirectToSignIn`). A warming session NEVER flash-redirects before hydration completes — Constitution #14 honored, identical to today. On a public route, once warming resolves to "no user", the allowlist then suppresses the redirect and the page renders. ✅
+- **On `/`** (root): `isSignInRoute('/')=true` → no redirect (ORCH-1103 loop guard), renders BusinessWelcomeScreen. The allowlist does not list `/` and does not interfere. ✅
+
+### 4.3 Documentation layer — public-route head comments (Discovery D-2)
+
+Correct the now-false head comments that assert "no sign-in redirect" on:
+- `app/t/[brandSlug]/[tripSlug].tsx`
+- `app/exp/[brandSlug]/[experienceSlug].tsx`
+
+Change the wording to reflect that anon-tolerance is now guaranteed by the root-layout allowlist (`PUBLIC_BUYER_ROUTE_PREFIXES` in `coldLoadAuthGates.ts`), not merely by living outside `(tabs)`. Documentation-only; no behavior change. (`/e/` and `/b/` head comments do not currently make the false claim and may be left as-is, or optionally annotated.) **Do NOT edit any other line in these route files.**
+
+---
+
+## 5. Success criteria (numbered, observable, testable)
+
+All criteria are **Web-only** (the only surface with a behavior change); native parity is "no-op", verified separately.
+
+- **SC-1-Web (render public, logged out).** A genuinely logged-out browser (no cookies, no localStorage) loading each of `/e/{brandSlug}/{eventSlug}`, `/t/{brandSlug}/{tripSlug}`, `/b/{brandSlug}`, `/exp/{brandSlug}/{experienceSlug}` on `business.usemingla.com` renders the buyer page content (not the BusinessWelcomeScreen), and the final URL is the requested route — NOT `/`.
+- **SC-2-Web (reach checkout, logged out).** A logged-out browser loading `/checkout/{eventId}`, `/checkout-trip/{tripEventId}`, `/checkout-experience/{experienceEventId}` renders the checkout screen (does not redirect to `/`); the Reserve/Book CTA and the buyer→payment chain are reachable.
+- **SC-3-Web (receipt + cancel, logged out).** A logged-out browser loading `/o/{orderId}` and `/booking/{orderId}/cancel?token=…` renders (subject to OQ-1 ratification).
+- **SC-4-Web (authed route STILL redirects).** A logged-out browser loading a representative authed-only route (e.g. `/account`, `/(tabs)/…`, `/brand/{id}`) STILL redirects to `/` and shows the business sign-in welcome screen. The allowlist did NOT over-widen.
+- **SC-5-Web (logged-in unchanged).** A logged-IN business user opening any public buyer route renders it (unchanged from today).
+- **SC-6-Web (no hydration flash).** On a warming/cold-load of a public route with a stored session, the user sees the loading spinner (not a flash-redirect to `/`) until auth resolves, then the page renders. No flash-redirect before `_hasHydrated`-equivalent resolution (Constitution #14).
+- **SC-7 (predicate unit truth).** `shouldRedirectToSignInFromRoute` returns `false` for a logged-out user on every prefix in `PUBLIC_BUYER_ROUTE_PREFIXES` (and representative sub-paths), and `true` for a logged-out user on a representative authed route; `isPublicBuyerRoute` is segment-safe (`/checkouter` does NOT match `/checkout/`).
+- **SC-8 (single source of truth).** The allowlist exists as exactly ONE exported constant; the web predicate and the native redirect both consult it (grep finds no second hardcoded prefix list).
+
+---
+
+## 6. Invariants
+
+| Invariant | Preserve / Establish | How | Verified by |
+|-----------|---------------------|-----|-------------|
+| Anon-buyer-route contract (`feedback_anon_buyer_routes.md`) | **RESTORE** | Public buyer routes no longer redirect anon users to sign-in. | SC-1/2/3-Web, §7 happy-path + adversarial |
+| ORCH-1102 no-dead-end redirect | **PRESERVE** | The redirect still fires for every authed-only route (allowlist only suppresses public prefixes; the existing AND-clauses are unchanged). | SC-4-Web, §7 T-2/T-7 |
+| ORCH-1103 `/`→`/` loop guard (React #185) | **PRESERVE** | `isSignInRoute` AND-clause untouched; the new clause composes alongside it; `/` is not in the allowlist. | existing `orch_1103_signout_redirect_loop.test.ts` must still pass; §7 T-8 |
+| ORCH-1102 Wave 2 / ORCH-1106 ceiling + deadlock backstop | **PRESERVE** | `authResolutionExpired`, the module-level anchor, and `authResolving` branches are not edited. | manual code-diff review; existing `orch1100ColdLoadAuthGates.test.ts` passes |
+| Constitution #14 (hydration gate before redirect) | **PRESERVE** | The `authResolving` spinner branch still runs before any redirect; the allowlist never pre-empts the spinner. | SC-6-Web |
+| Constitution #1 (no dead taps / share link reaches a live page) | **RESTORE** | Share links now reach the live buyer page instead of a sign-in wall. | SC-1/2-Web adversarial drive |
+| **NEW — I-PROPOSED-1115-PUBLIC-BUYER-ROUTE-ALLOWLIST (DRAFT)** | **ESTABLISH** | The root-layout unauthenticated redirect MUST exempt every prefix in `PUBLIC_BUYER_ROUTE_PREFIXES`; the list is the single source of truth and any new public buyer route MUST be added to it (and to the regression test). Flips ACTIVE on CLOSE (orchestrator owns the flip). | §7 fails-on-revert test |
+
+---
+
+## 7. Test cases
+
+Unit tests extend the existing `coldLoadAuthGates` jest pattern (node env, pure predicate); the adversarial web test is a fresh-context Playwright drive (tester-owned, different angle).
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-1 (happy) | logged-out on each public prefix | `{isWeb:true,loading:false,hasUser:false,hasStoredWebSession:false, pathname}` for each of the 9 prefixes + a representative sub-path (e.g. `/checkout/abc/payment`, `/t/brand/slug`) | `shouldRedirectToSignInFromRoute === false` for all | unit |
+| T-2 (error/guard) | logged-out on authed route | same inputs, `pathname: "/account"`, `/(tabs)/home`, `/brand/123` | `shouldRedirectToSignInFromRoute === true` | unit |
+| T-3 (edge) | segment-safety | `isPublicBuyerRoute("/checkouter")`, `"/exposed"`, `"/booking-x"` | `false` (must not match `/checkout/`, `/exp/`, `/booking/`) | unit |
+| T-4 (edge) | trailing slash + bare | `isPublicBuyerRoute("/checkout")`, `"/checkout/")`, `"/t/")` | `true` | unit |
+| T-5 (edge) | null/empty pathname | `isPublicBuyerRoute(null \| undefined \| "" \| " ")` | `false` | unit |
+| T-6 (regression) | logged-IN on public route still renders | `hasUser:true`, public pathname | `false` (already false via no-user clause; pins it stays so) | unit |
+| T-7 (regression) | warming session never redirects | `hasUser:false, hasStoredWebSession:true`, public + authed pathname | `false` for both (spinner branch owns this; predicate stays false) | unit |
+| T-8 (regression) | `/` loop guard intact | `pathname:"/"`, logged out | `false` (ORCH-1103) — re-asserted | unit |
+| T-9 (single-source) | one allowlist | grep | exactly one `PUBLIC_BUYER_ROUTE_PREFIXES` definition; native + web both reference `isPublicBuyerRoute` | structural |
+| T-A1 (adversarial — TESTER) | fresh-context production-shaped browser load | Playwright, NO cookies/localStorage, load `/t/…`, `/e/…`, `/exp/…` (and `/checkout-trip/…`), wait past auth ceiling | page content renders; final URL == requested route, NOT the sign-in route; NOT BusinessWelcomeScreen body | runtime/web |
+| T-A2 (adversarial — TESTER) | fresh-context load of an authed route | Playwright, no session, load `/account` | redirects to `/`, BusinessWelcomeScreen shown (proves no over-widening at runtime) | runtime/web |
+
+> T-A1/T-A2 are the **tester's** different-angle proof: source unit truth (T-1..T-9) is capped at "suspected" for a runtime-routing bug; the fresh-context browser drive is the "proven" gate (matches the investigation's production repro method). They MUST be run against the merged build per the edge-deploy/bundle-refresh hazards.
+
+---
+
+## 8. Implementation order
+
+1. **`src/utils/coldLoadAuthGates.ts`** — add `PUBLIC_BUYER_ROUTE_PREFIXES` constant + `isPublicBuyerRoute` helper (pure, RN-import-free, JSDoc'd); AND `!isPublicBuyerRoute(pathname)` into `shouldRedirectToSignInFromRoute`; update its JSDoc to cite ORCH-1115.
+2. **`src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts`** — NEW test file (T-1..T-9). Confirm it FAILS when the AND-clause is reverted and PASSES when restored (§9).
+3. **`app/_layout.tsx`** — import `isPublicBuyerRoute`; AND it into `nativeRedirectToSignIn` (§4.2.2); verify the web call site already passes `pathname` (no edit expected there). Update the ORCH-1102 comment block to note the ORCH-1115 allowlist.
+4. **`app/t/[brandSlug]/[tripSlug].tsx` + `app/exp/[brandSlug]/[experienceSlug].tsx`** — correct the false "no sign-in redirect" head comments (doc-only).
+5. Run gates: `npm test` (the new file + existing `orch_1103_*` + `orch1100ColdLoadAuthGates` + `brandStripeStatusAuthGate` must all pass), typecheck, lint, any `orch-strict-grep` gate. Then hand to tester for T-A1/T-A2.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+- **Structural safeguard:** the public-route exemption lives in a single exported constant + pure helper, consumed by the redirect predicate. Reverting the `&& !isPublicBuyerRoute(pathname)` clause (or deleting the constant) re-breaks the funnel.
+- **The fails-on-revert test:** `orch_1115_anon_buyer_route_allowlist.test.ts` → **T-1** asserts `shouldRedirectToSignInFromRoute` returns `false` for a logged-out user on every public prefix, and **T-2** asserts it returns `true` on a representative authed route. If the AND-clause is removed, T-1 flips to `true` and FAILS; T-2 stays `true` and PASSES — so the pair proves the allowlist is what suppresses the redirect (not a blanket behavior change). If the constant is deleted, the test file fails to compile/import — also a fail-on-revert.
+- **Protective comment:** above the AND-clause and the constant, a comment naming ORCH-1115, the P0 symptom (anon share link → sign-in wall), and the rule "any new public buyer route is added HERE and to the regression test" (carries I-PROPOSED-1115).
+- **Process safeguard (Discovery D-1):** the tester MUST include a fresh-context (no-session) load of every public buyer prefix as a runtime gate (T-A1) — the exact blast-radius check ORCH-1102's QA missed.
+
+---
+
+## 10. Open questions
+
+- **OQ-1 (scope ratification — `/o/` + `/booking/`):** the investigation's named prefix list was `/t /e /b /exp /checkout /checkout-trip /checkout-experience`. This SPEC ALSO allowlists `/o/` (buyer receipt) and `/booking/` (cancel-from-email) because their own source declares them anon-tolerant (I-21) and they are part of the same funnel — a guest who buys then opens the receipt/cancel link would otherwise hit the same wall. **If the orchestrator/Seth wants the allowlist strictly limited to the 7 named prefixes, drop the `/o/` and `/booking/` rows only; everything else is unaffected.** Default recommendation: INCLUDE them (completes the contract).
+- **OQ-2 (`/auth*`):** `/auth/callback` (OAuth completion) is gated by the same root predicate. The investigation did not scope it and it is NOT a buyer route, so it is OUT of this SPEC. If logged-out OAuth callback is observed to mis-redirect, that is a SEPARATE ORCH. Flagged so it is not silently swept in.
+- **OQ-3 (`isPublicBuyerRoute` vs `usePathname` shape):** confirmed assumption that `usePathname()` yields a query-stringless, leading-slash pathname. If a future Expo Router upgrade changes this, the matcher's normalization is the single place to adjust. No action now.
+
+---
+
+## 11. Downstream routing
+
+- **Next = mingla-implementor (business-web side).** Build per §4/§8 inside the worktree `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1115-[anon-buyer-access]/` on branch `ORCH-1115-anon-buyer-access`. Touch ONLY the allowlisted files (§ below). Run the gates (§8.5) and prove T-1 fails-on-revert before reporting.
+- **Then = mingla-tester.** Run T-A1/T-A2 — a fresh-context Playwright drive of `/t/ /e/ /exp/ /checkout-trip/` (render + URL-not-sign-in) AND a fresh-context `/account` load (must still redirect), against the MERGED build. Source-only is capped at "suspected"; the runtime drive is the PASS gate.
+- **Then = mingla-orchestrator CLOSE.** Flip I-PROPOSED-1115 ACTIVE; correct/retire the stale `feedback_anon_buyer_routes.md` "lives outside (tabs)" defense note (D-2); deploy is web-only (Vercel) — no OTA, no edge, no migration.
+
+---
+
+## Scoped allowlist (implementor MAY change ONLY these)
+
+1. `mingla-business/src/utils/coldLoadAuthGates.ts` — add constant + helper + AND-clause + JSDoc.
+2. `mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts` — NEW.
+3. `mingla-business/app/_layout.tsx` — import + AND-in `nativeRedirectToSignIn`; comment update. (No web call-site edit expected.)
+4. `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` — head-comment correction ONLY.
+5. `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` — head-comment correction ONLY.
+
+## DO-NOT-TOUCH (stop-and-amend before editing)
+
+- Any RLS policy, migration, edge function, or `supabase/` file (F-2 proved unnecessary).
+- `shouldRedirectToSignIn`, `isSignInRoute`, `isWebAuthResolving`, `isAuthResolutionExpired`, the module-level deadline anchor in `_layout.tsx` — preserve verbatim (only COMPOSE alongside them).
+- `vercel.json`, `public/.well-known/*`, `/og/*`, `/auth/*`, `public/auth/callback.html`, `stripe-onboarding-return*` — edge-served / out of scope.
+- The buyer page bodies / checkout screens / hooks / services — the page render is already correct once the gate lets it mount (F-2).
+- `app-mobile/` — entirely.
+- The shared anchor checkout (`~/Desktop/mingla-main`).
+
+Anything outside the allowlist requires a `SPEC_AMENDMENT_ORCH-1115_*` (or in-file amendment) before the implementor touches it.
+
+---
+
+*Artifact: `Mingla_Artifacts/specs/SPEC_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md`*

--- a/mingla-business/app/_layout.tsx
+++ b/mingla-business/app/_layout.tsx
@@ -76,6 +76,7 @@ import { verifyStripeModeAlignment } from "../src/services/stripeModeHandshake";
 import {
   AUTH_RESOLUTION_CEILING_MS,
   isAuthResolutionExpired,
+  isPublicBuyerRoute,
   isSignInRoute,
   isWebAuthResolving,
   shouldRedirectToSignInFromRoute,
@@ -129,6 +130,15 @@ const BRAND_FETCH_TIMEOUT_MS = 2000;
 // mid-process, route them back too. Users are never left hanging. The decision
 // is route-agnostic (no route list, no firewall, no per-route card): see
 // `shouldRedirectToSignIn` + `isWebAuthResolving` in coldLoadAuthGates.ts.
+//
+// ORCH-1115 [anon-buyer web funnel restored]: the ONE intentional exception to
+// "route-agnostic" is the PUBLIC BUYER allowlist (`PUBLIC_BUYER_ROUTE_PREFIXES`
+// in coldLoadAuthGates.ts). A genuinely logged-out guest on a share-link /
+// guest-checkout / receipt route (`/e/ /t/ /b/ /exp/ /checkout* /o/ /booking/`)
+// must NOT be bounced to the sign-in wall — `shouldRedirectToSignInFromRoute`
+// (web) and `nativeRedirectToSignIn` (native) both consult `isPublicBuyerRoute`
+// so the exemption lives in exactly one place. The exemption can ONLY suppress a
+// redirect on a public route; every authed-only route still redirects.
 
 // ORCH-1102 Wave 2 — REMOUNT-IMMUNE auth-resolution deadline anchor.
 //
@@ -326,8 +336,19 @@ function RootLayoutInner(): React.ReactElement {
   // mid-bootstrap (would race the splash / cause a sign-in flash on a warming
   // session). Only when there is genuinely NO user. Loop-safe: never redirect
   // to `/` while already at `/` (same React-#185 protection as the web path).
+  //
+  // ORCH-1115 [anon-buyer web funnel restored]: ALSO exempt the PUBLIC BUYER
+  // routes (`isPublicBuyerRoute` / `PUBLIC_BUYER_ROUTE_PREFIXES` — the SINGLE
+  // source of truth shared with the web path above). This is a NO-OP on native
+  // today (business native serves none of these routes), but routing the
+  // public-route exemption through the one shared helper keeps the allowlist in
+  // exactly one place and hardens against a future native public route.
   const nativeRedirectToSignIn =
-    !isWeb && !loading && user === null && !isSignInRoute(pathname);
+    !isWeb &&
+    !loading &&
+    user === null &&
+    !isSignInRoute(pathname) &&
+    !isPublicBuyerRoute(pathname);
 
   // ORCH-1102 Wave 2 — BOUNDED-LOADING backstop at the UI gate. The AuthContext
   // hard ceiling (AUTH_RESOLUTION_HARD_CEILING_MS) releases `loading` if the

--- a/mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx
+++ b/mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx
@@ -4,9 +4,13 @@
  * full-bleed cover hero, X-close + share IconChrome overlays, a ScrollView of
  * ExperiencePreview + ExperienceCheckoutFlow.
  *
- * Anon-tolerant per feedback_anon_buyer_routes.md: no useAuth, no sign-in
- * redirect — anyone with the share link sees the page. Lives OUTSIDE
- * app/(tabs)/ (same as /t/, /e/, /b/, /checkout-trip/).
+ * Anon-tolerant per feedback_anon_buyer_routes.md: no useAuth on this page.
+ * The "no sign-in redirect" guarantee is enforced at the ROOT layout by the
+ * `PUBLIC_BUYER_ROUTE_PREFIXES` allowlist in coldLoadAuthGates.ts (ORCH-1115) —
+ * the `/exp/` prefix is exempted from the ORCH-1102 unauthenticated redirect, so
+ * a logged-out guest with the share link sees the page (NOT the sign-in wall).
+ * (Living OUTSIDE app/(tabs)/ is no longer sufficient on its own — ORCH-1102
+ * moved the redirect to the root layout that wraps every route.)
  *
  * ExperienceMiniCard already pushes /exp/{brandSlug}/{experienceSlug}; this
  * route resolves it.

--- a/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
+++ b/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
@@ -4,8 +4,13 @@
  * adds the X-close + share IconChrome overlays mirroring the public event
  * page hero pattern. Per SPEC §4.5 + SPEC_ORCH-0874 §3.3.7.
  *
- * Anon-tolerant per feedback_anon_buyer_routes.md: no useAuth, no
- * sign-in redirect. Anyone with the share link sees this page.
+ * Anon-tolerant per feedback_anon_buyer_routes.md: no useAuth on this page.
+ * The "no sign-in redirect" guarantee is enforced at the ROOT layout by the
+ * `PUBLIC_BUYER_ROUTE_PREFIXES` allowlist in coldLoadAuthGates.ts (ORCH-1115) —
+ * the `/t/` prefix is exempted from the ORCH-1102 unauthenticated redirect, so a
+ * logged-out guest with the share link sees this page (NOT the sign-in wall).
+ * (Living OUTSIDE app/(tabs)/ is no longer sufficient on its own — ORCH-1102
+ * moved the redirect to the root layout that wraps every route.)
  *
  * Renders TripPreview (full trip detail) + TripCheckoutFlow (Reserve CTA +
  * tier picker that routes to the existing /checkout/{tripEventId} chain).

--- a/mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts
@@ -1,0 +1,256 @@
+/**
+ * ORCH-1115 [anon-buyer web funnel restored] regression.
+ *
+ * Root cause: ORCH-1102 moved the unauthenticated "no dead-end" sign-in redirect
+ * to the ROOT layout (`mingla-business/app/_layout.tsx`), which wraps EVERY
+ * route, with NO allowlist for the intentionally-public buyer routes. A
+ * genuinely logged-out guest opening a share link (`/e/ /t/ /b/ /exp/`), a guest
+ * checkout (`/checkout/ /checkout-trip/ /checkout-experience/`), or a
+ * post-purchase receipt / emailed cancel link (`/o/ /booking/`) was bounced to
+ * the business sign-in wall; the buyer page + checkout never rendered. RLS is
+ * fully permissive to anon — this was purely a client route-gate bug.
+ *
+ * The fix adds `PUBLIC_BUYER_ROUTE_PREFIXES` (single source of truth) +
+ * `isPublicBuyerRoute` (segment-safe prefix matcher) to coldLoadAuthGates.ts and
+ * ANDs `!isPublicBuyerRoute(pathname)` into `shouldRedirectToSignInFromRoute`
+ * (and into the native `nativeRedirectToSignIn` path in _layout.tsx). The clause
+ * can ONLY suppress a redirect on a public route — it never causes a redirect
+ * that did not already fire, so no authed-only route's behavior can change.
+ *
+ * FAILS ON REVERT: T-1 asserts `shouldRedirectToSignInFromRoute` returns `false`
+ * for a logged-out user on every public prefix. Delete the
+ * `&& !isPublicBuyerRoute(pathname)` clause (or the constant) → T-1 flips to
+ * `true` and FAILS, while T-2 (authed route) stays `true` and PASSES — proving
+ * the allowlist is what suppresses the redirect, not a blanket change.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  PUBLIC_BUYER_ROUTE_PREFIXES,
+  isPublicBuyerRoute,
+  shouldRedirectToSignInFromRoute,
+} from "../coldLoadAuthGates";
+
+// __dirname = mingla-business/src/utils/__tests__ → up 3 = mingla-business.
+const BUSINESS_ROOT = join(__dirname, "..", "..", "..");
+const businessFile = (relativePath: string): string =>
+  readFileSync(join(BUSINESS_ROOT, relativePath), "utf8");
+
+const loggedOutOnWeb = {
+  isWeb: true,
+  loading: false,
+  hasUser: false,
+  hasStoredWebSession: false,
+};
+
+// Every public prefix + a representative deep sub-path under each, exactly as a
+// real share link / guest checkout would arrive.
+const PUBLIC_ROUTE_SAMPLES: string[] = [
+  "/e/travelbrand",
+  "/e/travelbrand/summer-rooftop",
+  "/t/travelbrand",
+  "/t/travelbrand/the-dc-adventure",
+  "/b/travelbrand",
+  "/exp/travelbrand",
+  "/exp/travelbrand/sunset-sail",
+  "/checkout/abc123",
+  "/checkout/abc123/payment",
+  "/checkout/abc123/confirm",
+  "/checkout-trip/trip-event-9",
+  "/checkout-trip/trip-event-9/buyer",
+  "/checkout-experience/exp-event-3",
+  "/checkout-experience/exp-event-3/payment",
+  "/o/order-77",
+  "/booking/order-77/cancel",
+];
+
+// Representative authed-ONLY routes that MUST still redirect a logged-out guest.
+const AUTHED_ONLY_ROUTE_SAMPLES: string[] = [
+  "/account",
+  "/(tabs)/home",
+  "/(tabs)/account",
+  "/brand/123",
+  "/event/456",
+  "/trip/789",
+  "/experience/012",
+  "/venue/345",
+  "/partner/onboarding",
+  "/ari",
+  "/support",
+  "/notifications",
+  "/connect-partner-onboarding",
+  "/accept-invite",
+  "/stripe-onboarding-return",
+];
+
+describe("ORCH-1115 T-1 (happy) — logged-out guest on a PUBLIC buyer route is NOT redirected", () => {
+  test.each(PUBLIC_ROUTE_SAMPLES)(
+    "%s → shouldRedirectToSignInFromRoute === false",
+    (pathname) => {
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1115 T-2 (guard) — logged-out guest on an AUTHED-only route STILL redirects", () => {
+  test.each(AUTHED_ONLY_ROUTE_SAMPLES)(
+    "%s → shouldRedirectToSignInFromRoute === true (allowlist did NOT over-widen)",
+    (pathname) => {
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1115 T-3 (edge) — segment-safety: lookalike paths must NOT match", () => {
+  test.each([
+    "/checkouter",
+    "/checkout-thing",
+    "/exposed",
+    "/booking-x",
+    "/events",
+    "/trips",
+    "/branded",
+    "/expo",
+  ])("isPublicBuyerRoute(%p) === false", (pathname) => {
+    expect(isPublicBuyerRoute(pathname)).toBe(false);
+  });
+
+  test("a lookalike authed route still redirects (composed with the predicate)", () => {
+    expect(
+      shouldRedirectToSignInFromRoute({
+        ...loggedOutOnWeb,
+        pathname: "/checkouter",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("ORCH-1115 T-4 (edge) — trailing slash + bare prefix both match", () => {
+  test.each([
+    "/checkout",
+    "/checkout/",
+    "/t/",
+    "/t",
+    "/e/",
+    "/e",
+    "/b/",
+    "/b",
+    "/exp/",
+    "/exp",
+    "/checkout-trip/",
+    "/checkout-experience/",
+    "/o/",
+    "/o",
+    "/booking/",
+    "/booking",
+  ])("isPublicBuyerRoute(%p) === true", (pathname) => {
+    expect(isPublicBuyerRoute(pathname)).toBe(true);
+  });
+});
+
+describe("ORCH-1115 T-5 (edge) — null/empty/whitespace pathname is NOT a public route", () => {
+  test.each([null, undefined, "", " ", "   "])(
+    "isPublicBuyerRoute(%p) === false",
+    (pathname) => {
+      expect(isPublicBuyerRoute(pathname as string | null | undefined)).toBe(
+        false,
+      );
+    },
+  );
+});
+
+describe("ORCH-1115 T-6 (regression) — logged-IN user on a public route still renders", () => {
+  test.each(PUBLIC_ROUTE_SAMPLES)(
+    "%s with hasUser:true → no redirect (already false; pins it stays so)",
+    (pathname) => {
+      expect(
+        shouldRedirectToSignInFromRoute({
+          isWeb: true,
+          loading: false,
+          hasUser: true,
+          hasStoredWebSession: true,
+          pathname,
+        }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1115 T-7 (regression) — a warming session never redirects (public OR authed)", () => {
+  const warming = {
+    isWeb: true,
+    loading: false,
+    hasUser: false,
+    hasStoredWebSession: true,
+  };
+
+  test("warming on a public route → no redirect", () => {
+    expect(
+      shouldRedirectToSignInFromRoute({
+        ...warming,
+        pathname: "/t/brand/slug",
+      }),
+    ).toBe(false);
+  });
+
+  test("warming on an authed route → no redirect (spinner branch owns this)", () => {
+    expect(
+      shouldRedirectToSignInFromRoute({ ...warming, pathname: "/account" }),
+    ).toBe(false);
+  });
+});
+
+describe("ORCH-1115 T-8 (regression) — ORCH-1103 '/' loop guard intact", () => {
+  test("logged-out on '/' → no redirect (the self-redirect loop guard is preserved)", () => {
+    expect(
+      shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname: "/" }),
+    ).toBe(false);
+  });
+
+  test("'/' is NOT in the public allowlist (it is the sign-in route)", () => {
+    expect(isPublicBuyerRoute("/")).toBe(false);
+  });
+});
+
+describe("ORCH-1115 T-9 (single source of truth) — exactly one allowlist; web + native both consult it", () => {
+  test("PUBLIC_BUYER_ROUTE_PREFIXES contains exactly the 9 spec'd prefixes", () => {
+    expect([...PUBLIC_BUYER_ROUTE_PREFIXES]).toEqual([
+      "/e/",
+      "/t/",
+      "/b/",
+      "/exp/",
+      "/checkout/",
+      "/checkout-trip/",
+      "/checkout-experience/",
+      "/o/",
+      "/booking/",
+    ]);
+  });
+
+  test("coldLoadAuthGates.ts defines the constant exactly once", () => {
+    const src = businessFile("src/utils/coldLoadAuthGates.ts");
+    const occurrences = (
+      src.match(/export const PUBLIC_BUYER_ROUTE_PREFIXES/g) ?? []
+    ).length;
+    expect(occurrences).toBe(1);
+  });
+
+  test("the web predicate ANDs in the public-route exemption", () => {
+    const src = businessFile("src/utils/coldLoadAuthGates.ts");
+    expect(src).toContain("!isPublicBuyerRoute(pathname)");
+  });
+
+  test("the native redirect path in _layout.tsx also consults isPublicBuyerRoute", () => {
+    const layout = businessFile("app/_layout.tsx");
+    expect(layout).toContain("isPublicBuyerRoute");
+    // The native path explicitly ANDs the exemption in.
+    expect(layout).toContain("!isPublicBuyerRoute(pathname)");
+  });
+});

--- a/mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_path_confusion.adversarial.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_path_confusion.adversarial.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ORCH-1115 [anon-buyer web funnel restored] — TESTER ADVERSARIAL (path-confusion).
+ *
+ * DIFFERENT ANGLE than the implementor's happy-path allowlist suite
+ * (`orch_1115_anon_buyer_route_allowlist.test.ts`, which proves the 9 public
+ * prefixes are exempted and a handful of lookalikes — `/checkouter`, `/exposed`
+ * — are not). This suite attacks the SECURITY failure mode: can a crafted path
+ * that is REALLY an authed-only route (or no route at all) wrongly MATCH the
+ * public allowlist and thereby LEAK an authed surface to a logged-out guest, or
+ * conversely bypass the matcher with encoding / traversal / empty-segment junk?
+ *
+ * The allowlist can only ever flip a redirect TRUE→FALSE, so the dangerous
+ * direction is a FALSE-POSITIVE match: `isPublicBuyerRoute(x) === true` for an
+ * `x` that should have stayed gated. Every assertion below pins that the matcher
+ * does NOT over-match, and that the COMPOSED predicate
+ * `shouldRedirectToSignInFromRoute` still returns `true` for a logged-out guest
+ * on any such crafted path.
+ *
+ * Tester-owned, append-only, on-branch, in the closing diff. Fails-on-revert is
+ * NOT this file's contract (the implementor's T-1 owns that); this file's job is
+ * to prove the fix did not open a path-confusion hole. It must PASS on the fix.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  isPublicBuyerRoute,
+  shouldRedirectToSignInFromRoute,
+} from "../coldLoadAuthGates";
+
+const loggedOutOnWeb = {
+  isWeb: true,
+  loading: false,
+  hasUser: false,
+  hasStoredWebSession: false,
+};
+
+/**
+ * RUNTIME-PROVEN PRECONDITION (tester drive, 2026-06-11, headless Chromium
+ * against the branch web export served SPA-fallback):
+ *
+ * Dot-segment traversal paths (`/e/../account`, `/checkout/../account`,
+ * `/exp/../../brand/x`, `/e/%2e%2e/account`) are NORMALIZED BY THE BROWSER per
+ * RFC-3986 / WHATWG-URL BEFORE the request is sent — so `/e/../account` arrives
+ * at the SPA (and therefore at `usePathname()` / this gate) already collapsed to
+ * `/account`. The proof: all five traversal forms were driven logged-out and
+ * every one resolved to `/` showing the BusinessWelcomeScreen sign-in wall (NOT
+ * a public page). The gate therefore NEVER receives the raw dotted form at
+ * runtime; asserting `isPublicBuyerRoute("/e/../account")` is asserting an input
+ * the production gate cannot see. (The textual matcher WOULD treat `/e/../x` as
+ * an `/e/` subpath, but that is unreachable — and even if reached, the SPA
+ * router, not this gate, resolves the segment to the authed screen which then
+ * applies its own gate.) These cases are intentionally NOT in MUST_NOT_MATCH;
+ * the runtime traversal proof lives in the TEST report, and the encoding suite
+ * (ADV-3) pins the non-normalized encoded forms the gate CAN see.
+ */
+
+/**
+ * Paths that are NOT legitimate public buyer routes AND that the gate genuinely
+ * receives (no browser pre-normalization). A `true` from `isPublicBuyerRoute` on
+ * ANY of these would be a security regression — an authed surface or junk would
+ * be exempted from the sign-in redirect.
+ */
+const MUST_NOT_MATCH: [string, string][] = [
+  // --- authed first-segment must never match, even with public-looking tails ---
+  ["/account/e/x", "authed /account with a /e/ tail"],
+  ["/account/checkout/x", "authed /account with a /checkout/ tail"],
+  ["/brand/123/e/x", "authed /brand with /e/ tail"],
+  ["/(tabs)/home/checkout/x", "authed tabs with /checkout/ tail"],
+  ["/notifications/o/1", "authed /notifications with /o/ tail"],
+
+  // --- segment-boundary confusion (extends the implementor's /checkouter case) ---
+  ["/echo", "/e + cho — must not match /e/"],
+  ["/blog", "/b + log — must not match /b/"],
+  ["/orders", "/o + rders — must not match /o/"],
+  ["/experience", "/exp... but the AUTHED experience route, not /exp/"],
+  ["/experiences", "plural authed-ish — not /exp/"],
+  ["/checkout-experiences", "trailing junk on /checkout-experience"],
+  ["/bookings", "/booking + s — must not match /booking/"],
+  ["/tickets", "/t + ickets — must not match /t/"],
+
+  // --- empty-segment / double-slash junk ---
+  ["//account", "protocol-relative-ish // then account"],
+  ["//e/x", "leading double slash before a public-looking tail"],
+
+  // --- whitespace / control padding around an authed route ---
+  ["  /account  ", "whitespace-padded authed route"],
+];
+
+describe("ORCH-1115 ADV-1 (path-confusion) — crafted non-public paths must NOT match the allowlist", () => {
+  test.each(MUST_NOT_MATCH)(
+    "isPublicBuyerRoute(%j) === false  (%s)",
+    (pathname) => {
+      expect(isPublicBuyerRoute(pathname)).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1115 ADV-2 (composed guard) — a logged-out guest on any crafted non-public path STILL redirects", () => {
+  test.each(MUST_NOT_MATCH)(
+    "shouldRedirectToSignInFromRoute(%j) === true  (%s)",
+    (pathname) => {
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1115 ADV-3 (encoding) — URL-encoded authed routes do not bypass the redirect", () => {
+  // The gate matches on a literal pathname. An encoded path that does NOT
+  // textually equal/prefix a public base must NOT match, so the guest is still
+  // redirected. (Expo Router decodes before the gate sees it; we pin both the
+  // raw-encoded and a hostile decoded-looking string.)
+  const ENCODED: string[] = [
+    "/%61ccount", // %61 = 'a' → "/account" only AFTER decode; raw must not match a public prefix
+    "/account%2Fe", // encoded slash inside an authed route
+    "/e%2F..%2Faccount", // encoded traversal — must not match /e/
+    "/checkout%00/x", // null-byte injection attempt
+  ];
+  test.each(ENCODED)("isPublicBuyerRoute(%j) === false", (pathname) => {
+    expect(isPublicBuyerRoute(pathname)).toBe(false);
+  });
+  test.each(ENCODED)(
+    "shouldRedirectToSignInFromRoute(%j) === true",
+    (pathname) => {
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1115 ADV-4 (positive control) — a genuine deep public subpath DOES match (proves the suite is not vacuously passing)", () => {
+  test.each([
+    "/e/brand/event",
+    "/checkout/evt-1/payment",
+    "/exp/lanternvine/raleigh-wine-and-dine-crawl",
+    "/o/order-123",
+    "/booking/order-123/cancel",
+  ])("isPublicBuyerRoute(%j) === true", (pathname) => {
+    expect(isPublicBuyerRoute(pathname)).toBe(true);
+  });
+});

--- a/mingla-business/src/utils/coldLoadAuthGates.ts
+++ b/mingla-business/src/utils/coldLoadAuthGates.ts
@@ -112,14 +112,92 @@ export const isSignInRoute = (pathname: string | null | undefined): boolean => {
 };
 
 /**
- * REDIRECT-TO-SIGN-IN, loop-safe — ORCH-1103.
+ * PUBLIC-BUYER-ROUTE ALLOWLIST — ORCH-1115 [anon-buyer web funnel restored].
+ *
+ * THE P0 SYMPTOM: ORCH-1102 moved the unauthenticated "no dead-end" sign-in
+ * redirect from a route-list / `(tabs)`-scoped gate to the ROOT layout, which
+ * wraps EVERY route — with no allowlist for the intentionally-public buyer
+ * routes. A genuinely logged-out guest opening a share link (`/e/ /t/ /b/
+ * /exp/`), a guest checkout (`/checkout/ /checkout-trip/ /checkout-experience/`),
+ * or a post-purchase receipt / emailed cancel link (`/o/ /booking/`) was bounced
+ * to the business sign-in wall; the buyer page + checkout never rendered. RLS is
+ * fully permissive to anon — this is purely a client route-gate bug.
+ *
+ * THIS CONSTANT is the SINGLE SOURCE OF TRUTH for the anon-tolerant public buyer
+ * routes (`feedback_anon_buyer_routes.md`). Any NEW public buyer route MUST be
+ * added HERE (and to `orch_1115_anon_buyer_route_allowlist.test.ts`) and ONLY
+ * here — do not duplicate the prefix list anywhere else. Carries
+ * I-PROPOSED-1115-PUBLIC-BUYER-ROUTE-ALLOWLIST.
+ *
+ * Each entry is matched as a path-SEGMENT prefix by `isPublicBuyerRoute` (so
+ * `/checkout/x` matches but `/checkouter` does NOT).
+ */
+export const PUBLIC_BUYER_ROUTE_PREFIXES = [
+  "/e/", // /e/[brandSlug]/[eventSlug] — public event page (share link)
+  "/t/", // /t/[brandSlug]/[tripSlug] — public trip page (share link)
+  "/b/", // /b/[brandSlug] — public brand page (share link)
+  "/exp/", // /exp/[brandSlug]/[experienceSlug] — public experience page (share link)
+  "/checkout/", // /checkout/[eventId]/… — event guest checkout
+  "/checkout-trip/", // /checkout-trip/[tripEventId]/… — trip guest checkout
+  "/checkout-experience/", // /checkout-experience/[experienceEventId]/… — experience guest checkout
+  "/o/", // /o/[orderId] — buyer order receipt (post-purchase, anon-tolerant per I-21)
+  "/booking/", // /booking/[orderId]/cancel — buyer cancel-from-email (anon-buyer-tolerant)
+] as const;
+
+/**
+ * Is the current pathname an anon-tolerant PUBLIC BUYER route — ORCH-1115?
+ *
+ * Pure, RN-import-free (same discipline as the rest of the file so it is
+ * node-jest-unit-testable and fails-on-revert). Used to EXEMPT a public buyer
+ * route from the root-layout unauthenticated redirect (the exemption can only
+ * ever turn a redirect OFF on a public route — never ON).
+ *
+ * Matching (segment-safe prefix match on the pathname only — no query string):
+ * - null / undefined / empty / whitespace-only → false (a missing pathname is
+ *   NOT a public route; it falls through to the existing `isSignInRoute`
+ *   behavior, which treats empty as `/`).
+ * - Trim; strip a single trailing slash for `length > 1` (mirrors
+ *   `isSignInRoute` normalization) so `/checkout/` and `/checkout` both behave.
+ * - For each prefix `P`, let `base = P` without its trailing slash (e.g.
+ *   `/checkout`). Match iff `normalized === base` OR
+ *   `normalized.startsWith(base + "/")`. The `+ "/"` keeps it SEGMENT-SAFE:
+ *   `/checkouter` does NOT match `/checkout/`.
+ */
+export const isPublicBuyerRoute = (
+  pathname: string | null | undefined,
+): boolean => {
+  if (pathname === null || pathname === undefined) return false;
+  const trimmed = pathname.trim();
+  if (trimmed === "") return false;
+  // Strip a single trailing slash (but never the root "/" itself).
+  const normalized =
+    trimmed.length > 1 && trimmed.endsWith("/")
+      ? trimmed.slice(0, -1)
+      : trimmed;
+  return PUBLIC_BUYER_ROUTE_PREFIXES.some((prefix) => {
+    const base = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+    return normalized === base || normalized.startsWith(`${base}/`);
+  });
+};
+
+/**
+ * REDIRECT-TO-SIGN-IN, loop-safe + public-buyer-aware — ORCH-1103 + ORCH-1115.
  *
  * Combines the ORCH-1102 `shouldRedirectToSignIn` decision with the
- * already-at-sign-in guard: only emit the `<Redirect href="/" />` when the user
- * genuinely needs to leave the CURRENT route to reach sign-in. When already on
- * `/`, return false so the layout renders the Stack (welcome screen) instead of
- * redirecting to itself — killing the #185 self-redirect loop. Native is never
- * web, so this is a no-op off-web (matches `shouldRedirectToSignIn`).
+ * already-at-sign-in guard (ORCH-1103): only emit the `<Redirect href="/" />`
+ * when the user genuinely needs to leave the CURRENT route to reach sign-in.
+ * When already on `/`, return false so the layout renders the Stack (welcome
+ * screen) instead of redirecting to itself — killing the #185 self-redirect
+ * loop. Native is never web, so this is a no-op off-web (matches
+ * `shouldRedirectToSignIn`).
+ *
+ * ORCH-1115: ALSO returns false when the pathname is a PUBLIC BUYER route
+ * (`isPublicBuyerRoute` / `PUBLIC_BUYER_ROUTE_PREFIXES`), so a logged-out guest
+ * on a share-link / guest-checkout / receipt route is NOT bounced to the sign-in
+ * wall. This clause composes BEFORE the existing ORCH-1102 + ORCH-1103 logic and
+ * can ONLY flip a `true` to `false` (suppress a redirect on a public route) — it
+ * NEVER causes a redirect that did not already fire, so no authed-only route's
+ * behavior can change.
  */
 export const shouldRedirectToSignInFromRoute = ({
   isWeb,
@@ -135,7 +213,8 @@ export const shouldRedirectToSignInFromRoute = ({
   pathname: string | null | undefined;
 }): boolean =>
   shouldRedirectToSignIn({ isWeb, loading, hasUser, hasStoredWebSession }) &&
-  !isSignInRoute(pathname);
+  !isSignInRoute(pathname) &&
+  !isPublicBuyerRoute(pathname);
 
 /**
  * The companion LOADING gate — ORCH-1102.


### PR DESCRIPTION
## ORCH-1115 — P0 launch-blocker: anonymous buyers can't reach OR buy on web

**Discovered while answering: \"can anonymous buyers not buy trips/experiences like events?\"** — the answer is worse: **no logged-out web buyer can reach or buy ANY offering (event, trip, OR experience).** No event-vs-trip asymmetry — the entire anonymous share-link → checkout funnel is collapsed.

**Root cause (forensics-proven, live Chromium against production, logged-out):** ORCH-1102's auth fix (shipped \`[deploy]\` 2026-06-08, 3 days ago) moved the sign-in redirect from a tab-group-scoped gate to the **root layout that wraps every route**, with no allowlist for the public buyer route prefixes. Every public page — \`/e/\`, \`/t/\`, \`/b/\`, \`/exp/\`, and all checkout routes — instantly bounces a guest to the business sign-in screen; content never renders. RLS is permissive to anon (verified) — purely a route-gate bug.

**Fix:** single source-of-truth allowlist \`PUBLIC_BUYER_ROUTE_PREFIXES\` + segment-safe \`isPublicBuyerRoute()\` in \`coldLoadAuthGates.ts\`; AND \`!isPublicBuyerRoute(pathname)\` into the redirect predicate in \`coldLoadAuthGates.ts\` + \`app/_layout.tsx\`. The clause can only turn a redirect OFF on a public route — authed-only routes (\`/account\`, \`/(tabs)/\`, \`/brand/\`, etc.) still redirect. Preserves ORCH-1102 no-dead-end + ORCH-1103/1106 loop-safety + Constitution #14 hydration gate. Prefixes: \`/e/ /t/ /b/ /exp/ /checkout/ /checkout-trip/ /checkout-experience/ /o/ /booking/\`. The \`/t/\` + \`/exp/\` page changes are doc-comment-only.

**Scope:** route-gate layer only. No RLS/schema/edge/vercel.json change. Buyer-web only; native apps untouched.

## Evidence
- Investigation: \`Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1115_ANON_BUYER_TRIP_EXPERIENCE_ACCESS.md\`
- Spec: \`Mingla_Artifacts/specs/SPEC_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md\`
- Implementation: \`Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md\`
- QA: \`Mingla_Artifacts/reports/TEST_ORCH-1115_ANON_BUYER_WEB_FUNNEL.md\` — **PASS**, fresh logged-out headless Chromium against the branch web export: 9/9 public routes render with URL preserved (no sign-in wall); 3/3 authed routes still redirect; 231 tests green.

## Regression tests (Step-0.5 gate)
- Implementor happy-path: \`orch_1115_anon_buyer_route_allowlist.test.ts\` — no-redirect for every public prefix, YES-redirect for authed routes; fails-on-revert at \`551f1749\`.
- Tester adversarial (different angle): path-confusion / segment-safety suite (45 cases, 14 fail on a weakened matcher) at \`cdc5d6595\`.

QA verdict: PASS. Frontend-only — no migration, no edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)