### PR TITLE
ORCH-1117: public offering-page polish — floating Buy bar + collapsible About + white-theme legibility + lighter title shadow [deploy]

### DIFF
--- a/.github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs
+++ b/.github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+/**
+ * ORCH-1117 R1 — I-PROPOSED-NO-RAW-WHITE-ON-PALETTE-SURFACE
+ *
+ * In packages/event-rendering/PublicEventPage.tsx, text that sits on a palette
+ * surface (page / card / glass / panel / accentWash) MUST take its color from
+ * the luminance-aware palette tokens, never a raw `#ffffff` / `#fff` literal —
+ * otherwise it vanishes white-on-near-white on a light brand theme (the exact
+ * ORCH-1117 bug on the date eyebrow + recurrence pill).
+ *
+ * The scan targets the JSX RENDER body only (everything BEFORE the
+ * `const styles = StyleSheet.create(` line). The render body is where inline
+ * `style={[..., { color: "#ffffff" }]}` overrides live; after the ORCH-1117 fix
+ * the body contains ZERO such literals. Reverting the fix (re-adding the literal
+ * at the date line / recurrence pill) re-introduces a body-level
+ * `color: "#ffffff"` → this gate FAILS.
+ *
+ * The StyleSheet block (after the cut line) is NOT scanned: it legitimately
+ * carries `#ffffff`/`#fff` on text that sits on a GUARANTEED-DARK accent fill
+ * (brandLetter on the accent disk, venueIcon, venueMapsText, gateUnlockLabel,
+ * accentText button) — those pairings are intentional and stay.
+ *
+ * Self-test (`--self-test`): inject a body-level `color: "#ffffff"` into a copy
+ * of the source in memory and assert the scan flags it.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const TARGET = path.join(
+  repoRoot,
+  "packages/event-rendering/PublicEventPage.tsx",
+);
+
+// Matches a text-style color override set to raw white, in any quoting/spacing.
+const FORBIDDEN = /color:\s*["'](#ffffff|#fff)["']/i;
+// Where the render body ends and the StyleSheet block (allowed whites) begins.
+const STYLE_CUT = /const\s+styles\s*=\s*StyleSheet\.create\s*\(/;
+
+function scanBody(source) {
+  const cutMatch = STYLE_CUT.exec(source);
+  const body = cutMatch === null ? source : source.slice(0, cutMatch.index);
+  const violations = [];
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (FORBIDDEN.test(lines[i])) {
+      violations.push({ line: i + 1, text: lines[i].trim() });
+    }
+  }
+  return violations;
+}
+
+function runSelfTest() {
+  const source = fs.readFileSync(TARGET, "utf8");
+  // Inject a body-level offender just before the StyleSheet cut.
+  const cutMatch = STYLE_CUT.exec(source);
+  const injectAt = cutMatch === null ? source.length : cutMatch.index;
+  const poisoned =
+    source.slice(0, injectAt) +
+    '\nconst __orch1117_selftest = { color: "#ffffff" };\n' +
+    source.slice(injectAt);
+  const violations = scanBody(poisoned);
+  if (violations.length === 0) {
+    console.error(
+      "ORCH-1117 R1 self-test FAILED: injected body-level color:\"#ffffff\" was NOT flagged.",
+    );
+    process.exit(1);
+  }
+  // And the real source must be clean.
+  const real = scanBody(source);
+  if (real.length > 0) {
+    console.error(
+      "ORCH-1117 R1 self-test FAILED: the real source already contains a forbidden raw-white in the render body:",
+      real,
+    );
+    process.exit(1);
+  }
+  console.log("ORCH-1117 R1 self-test PASSED.");
+  process.exit(0);
+}
+
+function run() {
+  if (!fs.existsSync(TARGET)) {
+    console.error(`ORCH-1117 R1 gate: target not found: ${TARGET}`);
+    process.exit(1);
+  }
+  const source = fs.readFileSync(TARGET, "utf8");
+  const violations = scanBody(source);
+  if (violations.length > 0) {
+    console.error(
+      "ORCH-1117 R1 FAILED — raw white literal on a text element in the " +
+        "PublicEventPage render body (the date eyebrow + recurrence pill must " +
+        "read from the luminance-aware palette, never raw white, or they " +
+        "vanish on a light brand theme):",
+    );
+    for (const v of violations) {
+      console.error(`  L${v.line}: ${v.text}`);
+    }
+    process.exit(1);
+  }
+  console.log("ORCH-1117 R1 PASSED — no raw white on a palette surface.");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+} else {
+  run();
+}

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2268,6 +2268,19 @@ jobs:
       - name: Run ORCH-1105 web-gesture-safe gate
         run: node .github/scripts/strict-grep/orch-1105-web-gesture-safe.mjs
 
+  orch-1117-no-raw-white-on-palette-surface:
+    name: "ORCH-1117: PublicEventPage text reads from luminance-aware palette, no raw white on palette surface (I-PROPOSED-NO-RAW-WHITE-ON-PALETTE-SURFACE)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1117 no-raw-white-on-palette-surface self-test
+        run: node .github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs --self-test
+      - name: Run ORCH-1117 no-raw-white-on-palette-surface gate
+        run: node .github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs
+
   # ORCH-0962 brand-field-map-coverage gate RETIRED at META-ORCH-0972 CLOSE
   # (2026-05-26). The gate asserted that `viewRowToBrand` reads `row.brand_kind`
   # from `business_public_events_view`. META-ORCH-0972 Sub-C removed `brand_kind`

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1117_OFFERING_PAGE_POLISH.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1117_OFFERING_PAGE_POLISH.md
@@ -1,0 +1,178 @@
+# IMPLEMENTATION — ORCH-1117 · Public Offering Page UX/Design Polish
+
+**Status:** implemented and verified (gates green; native runtime dead-tap / scroll proof deferred to TEST per spec §7)
+**Author:** mingla-implementor
+**Date:** 2026-06-12
+**Branch:** `ORCH-1117-offering-page-polish` @ `9e1fafcfc`
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1117-[offering-page-polish]`
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1117_OFFERING_PAGE_POLISH.md`
+**HARD merge gate:** MUST merge AFTER ORCH-1116 (RLS for `pg_brand_can_charge`), then rebase. Orchestrator owns ordering.
+
+---
+
+## 1. Summary
+
+Shipped the four buyer-facing polish changes + trip `bookable` plumbing across the six concrete surfaces, exactly to the spec's §8 order and §11 allowlist:
+
+1. **White-theme legibility (#1)** — the date eyebrow and recurrence "Show all" pill on the shared `PublicEventPage` now read from the luminance-aware palette (`palette.accent` / `palette.primaryText`) instead of raw `#ffffff`, so they no longer vanish white-on-near-white on a light brand theme.
+2. **Collapsible About (#2)** — collapsed-by-default (3-line peek + chevron + "Read more") on all six surfaces; ≤160-char copy renders full with no toggle; reduce-motion aware.
+3. **Floating Buy CTA (#3)** — a persistent bottom bar on every surface, driven by ONE hoisted state machine (`resolveOfferingCta`). Tappable Buy routes to the existing checkout/cart; every non-buyable state is a NON-tappable info strip (no dead taps). On single-ticket trips/experiences the inline Reserve/Get-spot CTA was removed (locked rule) so the bar is the only CTA.
+4. **Title shadow removal (#4)** — the heavy `0,2 / r10 / 28%-black` `titleLine` shadow is gone.
+5. **Trip `bookable` plumbing** — `resolveTripBookable` (fail-open `pg_brand_can_charge`) added to the web trip hook AND (OQ-C) the native trip-detail hook.
+
+No money/checkout/DB/edge-function code changed — the bars reuse existing navigation and the existing `pg_brand_can_charge` RPC.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Verified how | Result | Commit |
+|----|--------------|--------|--------|
+| SC-1-WEB (legibility) | Date eyebrow → `palette.accent`, pill → `palette.primaryText`; unit proves near-white page resolves a dark foreground ≥4.5:1; R1 grep guard green | ✓ | `e30eb8f32` |
+| SC-1-NATIVE (exp inherit) | Same shared file; EXP-NATIVE renders via the package | ✓ (inherits) | `e30eb8f32` |
+| SC-2-ALL (collapsed default) | Package `aboutCollapsed=useState(true)` + 3-line clamp + 160-char exception (EVT-WEB/EXP-NATIVE); `CollapsibleDescription` (TRIP-WEB/EXP-WEB); inline collapsible (TRIP-NATIVE); copy/chevron standardized (EVT-NATIVE) | ✓ | `e30eb8f32` (pkg), `119f0ccff` (web), `777cb3987` (native) |
+| SC-3-WEB-BUY (event) | Adapter bar reuses `onBuyTicket` → `router.push(checkoutPublicPath(event.id))` (`/checkout/{eventId}`) | ✓ | `119f0ccff` |
+| SC-3-WEB-TRIP / -EXP | Inline Reserve/Get-spot Pressables removed; route floating bars own `tripCheckoutPath` / `experienceCheckoutPath` | ✓ | `119f0ccff` |
+| SC-3-UNAVAIL-WEB | `FloatingOfferingBar` unavailable branch is a `accessibilityRole="text"` strip with NO `onPress` | ✓ | `119f0ccff` |
+| SC-3-NATIVE-NODEADTAP | Native bar non-tappable strips fire nothing; tappable Buy → `beginBooking` → cart/409-toast (never dead-ends). **Runtime/device proof = TEST.** | ✓ source / RUNTIME-deferred | `777cb3987` |
+| SC-3-ANDROID | Every bar fill `Platform.select` opaque ≥0.92 (`#16181b`/`#f4f6f9`/`rgba(16,18,22,0.98)`), `overflow:hidden`/clipped, `elevation:0` on Android | ✓ | `119f0ccff`, `777cb3987` |
+| SC-4-WEB (shadow) | `titleLine` style has no `textShadow*`; unit asserts | ✓ | `e30eb8f32` |
+| SC-5 (trip bookable) | `usePublicTripBySlug` returns `bookable`; paid+RPC-false → false; free → true (no RPC); RPC error → true | ✓ | `dadc2ecd0` |
+
+---
+
+## 3. Files changed (commit hashes)
+
+| Surface / layer | File | Commit |
+|---|---|---|
+| Package | `packages/event-rendering/offeringCta.ts` (NEW) | `e30eb8f32` |
+| Package | `packages/event-rendering/PublicEventPage.tsx` (#1/#2/#4 + `contentBottomInset` + delegate computeVariant + `resolveOfferingSurface`) | `e30eb8f32` |
+| Package | `packages/event-rendering/index.ts` (exports) | `e30eb8f32` |
+| Package | `packages/event-rendering/types.ts` (`contentBottomInset?`) | `e30eb8f32` |
+| Business service | `mingla-business/src/constants/publicUrls.ts` (`experienceCheckoutPath/Url`) | `dadc2ecd0` |
+| Business hook | `mingla-business/src/hooks/usePublicTripBySlug.ts` (`resolveTripBookable` + `bookable`) | `dadc2ecd0` |
+| Business web | `mingla-business/src/components/offering/FloatingOfferingBar.tsx` (NEW) | `119f0ccff` |
+| Business web | `mingla-business/src/components/offering/CollapsibleDescription.tsx` (NEW) | `119f0ccff` |
+| Business web | `mingla-business/src/components/trip/TripPreview.tsx` | `119f0ccff` |
+| Business web | `mingla-business/src/components/experience/ExperiencePreview.tsx` | `119f0ccff` |
+| Business web | `mingla-business/src/components/trip/TripCheckoutFlow.tsx` (inline CTA removed) | `119f0ccff` |
+| Business web | `mingla-business/src/components/experience/ExperienceCheckoutFlow.tsx` (inline CTA removed) | `119f0ccff` |
+| Business web | `mingla-business/src/components/event/PublicEventPage.tsx` (mount bar) | `119f0ccff` |
+| Business web | `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` | `119f0ccff` |
+| Business web | `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` | `119f0ccff` |
+| App-mobile | `app-mobile/src/components/offering/FloatingOfferingBar.tsx` (NEW) | `777cb3987` |
+| App-mobile | `app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx` (scroll-sibling bar) | `777cb3987` |
+| App-mobile | `app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx` (reserveFooter upgrade + collapsible) | `777cb3987` |
+| App-mobile | `app-mobile/src/hooks/useConsumerTripDetail.ts` (OQ-C bookable) | `777cb3987` |
+| App-mobile | `app-mobile/src/components/expandedCard/EventDetailLayout.tsx` (#2 copy/chevron only) | `777cb3987` |
+| CI | `.github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs` (NEW) + workflow job | `9e1fafcfc` |
+| Tests | `mingla-business/src/components/offering/__tests__/offeringCta.orch1117.test.ts` (NEW) | `9e1fafcfc` |
+| Tests | `mingla-business/src/components/offering/__tests__/offeringLegibility.orch1117.test.ts` (NEW) | `9e1fafcfc` |
+| Tests (append-only) | `mingla-business/src/components/event/__tests__/PublicEventPage.closeButton.adversarial.test.tsx` (mock additions, 0 deletions) | `9e1fafcfc` |
+
+---
+
+## 4. Data-model changes applied
+
+None. No migration, no edge function, no RLS change. The trip `bookable` resolvers (web hook + native hook) only CONSUME the existing anon-granted `pg_brand_can_charge` RPC (ORCH-1116 owns its RLS).
+
+## 5. Edge functions touched
+
+None.
+
+---
+
+## 6. Regression tests added
+
+- `mingla-business/src/components/offering/__tests__/offeringCta.orch1117.test.ts` — 11 tests (resolveOfferingCta buy/unavailable/sold-out/waitlist/free/past + custom verb; computeOfferingVariant).
+- `mingla-business/src/components/offering/__tests__/offeringLegibility.orch1117.test.ts` — 8 tests (WCAG contrast on a near-white page; raw-white-is-below-AA; render body has no raw white; titleLine has no textShadow*; About collapsed-by-default + 3-line clamp + 160 threshold).
+- CI guard `orch-1117-no-raw-white-on-palette-surface.mjs` — self-test PASSED + gate PASSED.
+
+**fails-on-revert verified at `e30eb8f32`** by TRUE LINE DELETION of the `if (!bookable) { return unavailable }` gate at the top of `resolveOfferingCta` → `offeringCta.orch1117.test.ts` went `1 failed, 10 passed` (T-CTA-UNAVAIL failed: a not-bookable paid event resolved to "buy"). Restored → `11 passed`. The R1 guard's `--self-test` independently proves it flags an injected body-level `color:"#ffffff"`.
+
+Passing run (restored): `Test Suites: 3 passed` / `Tests: 25 passed` (offeringCta + legibility + publicUrls).
+
+---
+
+## 7. Old → New receipts (per surface)
+
+### packages/event-rendering/PublicEventPage.tsx
+- **Before:** date line + recurrence pill hardcoded `color:"#ffffff"`; `titleLine` carried a heavy textShadow; About always fully expanded; `computeVariant` was a private copy of the variant logic.
+- **Now:** date → `palette.accent`, pill → `palette.primaryText` (both AA-safe via the existing palette); textShadow deleted; About collapsed-by-default (text-glyph chevron, 160-char exception, reduce-motion); `computeVariant` delegates to the shared `computeOfferingVariant`; `PublicTicketRow` reuses the shared sub-predicates; new `contentBottomInset` prop + exported `resolveOfferingSurface`.
+- **Why:** SC-1/#1, SC-4/#4, SC-2/#2, single-owner state machine (§4.0).
+- **Lines:** ~130 changed/added.
+
+### packages/event-rendering/offeringCta.ts (NEW)
+- **New:** `resolveOfferingCta` (the single buy/unavailable state machine), `computeOfferingVariant`, and the shared `ticketSaleEnded/ticketIsSoldOut/ticketIsDoorOnly` sub-predicates.
+- **Why:** §4.0 — both the inline row and every host floating bar consume ONE owner.
+
+### mingla-business/src/components/event/PublicEventPage.tsx
+- **Before:** rendered the shared page + chrome + waitlist sheet; no bar.
+- **Now:** mounts `FloatingOfferingBar` (state from `resolveOfferingCta`, surface from `resolveOfferingSurface`), reuses `onBuyTicket`'s `/checkout/{eventId}` nav + the `!bookable` toast guard, reserves `contentBottomInset`.
+- **Lines:** ~55 added.
+
+### TripCheckoutFlow.tsx / ExperienceCheckoutFlow.tsx
+- **Before:** each rendered an inline Reserve/Get-spot Pressable + owned the `router.push` to its checkout chain.
+- **Now:** the inline Pressable + its styles are REMOVED; the tier/ticket recap + helper stay; the route floating bar owns the nav. The ORCH-0876 trip-chain invariant (never the events `/checkout/{id}`) is documented in a comment and preserved by the route's `tripCheckoutPath`.
+- **Lines:** ~30 removed each.
+
+### app-mobile ExpandedBusinessEventSheet.tsx / ConsumerTripDetailScreen.tsx
+- **Before:** EBES had no bar (only the cart on row tap); the trip screen had a hand-built `reserveFooter` (Reserve / "Bookings closed").
+- **Now:** EBES renders `FloatingOfferingBar` as the LAST in-flow child of the bare scroll (F-B scroll sibling, not stickyFooter); the trip `reserveFooter` is upgraded to the standardized contract + a non-tappable "Booking unavailable" strip when `detail.bookable===false`; the trip description is collapsible.
+- **Lines:** ~70 added across both.
+
+### EventDetailLayout.tsx (external, F-A)
+- **Before:** "More"/"Less" i18n toggle, no chevron.
+- **Now:** "Read more"/"Show less" + chevron Icon + a11y `expanded` state. No floating Buy bar (external ticket URL).
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | What / parity |
+|---|---|---|
+| Consumer iOS | YES | #1/#2/#4 via shared pkg; #3 bar on brand-event/exp sheet + trip screen (scroll siblings). MANUAL native bar. |
+| Consumer Android | YES | Same + opaque ≥0.92 bar fill, no shadow. MANUAL `Platform.select`. |
+| Buyer/anon Web | YES | #1 + #2 + #3 + #4; inline single CTAs removed on trip/exp. Event body via shared pkg automatic; trip/exp web bars MANUAL. |
+| Business iOS | NOT directly | Inherits shared public components when previewing. Automatic. |
+| Business Android | NOT directly | Same + inherited Android opaque fallback. Automatic. |
+| Admin Web | NOT covered | Admin has no public offering page. |
+| Business Web preview | YES (inherited) | Sees the polished page + bar; bar bookable state reflects own brand readiness. Automatic. |
+
+---
+
+## 9. Smoke result
+
+- Jest (business): `offeringCta.orch1117` 11/11, `offeringLegibility.orch1117` 8/8, `publicUrls` PASS. fails-on-revert proven by line-deletion.
+- R1 strict-grep guard: self-test PASSED + gate PASSED. `i-bottomsheet-inline-scroll-binding` gate PASSED.
+- TypeScript: `tsc --noEmit` shows ZERO errors in any ORCH-1117 file (business + app-mobile). Remaining repo-wide tsc errors are pre-existing and unrelated (cross-package react resolution, marketing composer, checkout buyer `any` params, `category` test types).
+- App-mobile node:assert source tests (ORCH-1016 trip detail rework + adversarial + intake renderer): 21 + 18 + 14 checks PASS — my native edits don't regress them.
+- No actual `stickyFooter` prop usage anywhere I touched (only NEVER-constraint comments).
+- **NOT run by me (deferred to TEST per spec §7):** device runtime proof for T-DEADTAP (tap every non-buyable bar state on device — Constitution #1) + T-NATIVE-SCROLL (sheet scrolls fully with the bar pinned, swipe-down dismisses) + T-ANDROID-OPAQUE (visual no-ghosting). Source wiring is in place; runtime proof is the tester's gate.
+
+---
+
+## 10. Known issues / deferred
+
+- **OQ-B (deferred per orchestrator scope call):** the native brand-event/exp `bookable===false` pre-emptive info-strip is NOT shipped — the `BusinessEventCard` discover supply lacks `bookable` and threading it would pull the discover-cards path into scope. The native brand sheet bar ships its tappable states; a not-ready paid brand relies on the existing checkout 409 → cart toast (never dead-ends). Web surfaces DO render the full unavailable state. Flag to orchestrator: confirm deferral or authorize a follow-on.
+- **OQ-C (resolved — implemented):** the native trip-detail hook DID lack `bookable`; added `resolveTripBookable` there (it's the hook's own anon-direct fetch + `ev.brand_id`, NOT the discover supply).
+- Native dead-tap / scroll / Android-opaque runtime proof is the tester's (spec §7/§9).
+
+---
+
+## 11. Operator action required
+
+- **Migration:** none.
+- **Edge deploy:** none.
+- **Merge ordering (HARD):** do NOT merge this branch until **ORCH-1116** is on `main`; then rebase this branch onto it. Before ORCH-1116, the trip/event/exp `bookable` boolean is unreliable for anon/non-owner buyers (resolvers fail-open, so it degrades to "always bookable" + the checkout-409 backstop — safe but the unavailable state won't fire correctly).
+- **At CLOSE:** flip `I-PROPOSED-NO-RAW-WHITE-ON-PALETTE-SURFACE` to ACTIVE (the R1 guard + workflow job are already in place).
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **STOP-AND-AMEND — ORCH-0876 adversarial test conflict (needs `[TEST-MOD-APPROVED ORCH-1117]`).** `mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts` A2 pins `router.push(\`/checkout-trip/${trip.id}\` as never)` as a SOURCE grep inside `TripCheckoutFlow.tsx`. ORCH-1117's LOCKED decision (§4.5) removes that inline nav (it moved to the route's floating bar via `tripCheckoutPath`). I restored a comment so the SECOND assertion (cites ORCH-0876 + `eventType.filter.audit.test.ts`) passes again, but the FIRST `router.push` grep can only pass if the inline nav is re-added — which contradicts the spec. **The trip-chain INVARIANT is preserved** (the route now does `router.push(tripCheckoutPath(trip.id))` → `/checkout-trip/{id}`, never the events chain). The ORCH-0876 assertion must be re-pointed at `app/t/[brandSlug]/[tripSlug].tsx`; that is a cross-ORCH test edit requiring orchestrator `[TEST-MOD-APPROVED]`. I did NOT touch the ORCH-0876 test.
+
+2. **Pre-existing RED test (NOT introduced by ORCH-1117): `PublicEventPage.closeButton.adversarial.test.tsx`** was already 6/6 failing on the origin/main baseline (verified by stashing all my changes — still 6/6 red on `useThemeFont` from ORCH-1083 + an incomplete `designSystem` mock). My append-only mock additions (FloatingOfferingBar case + new package-export stubs + a useThemeFont stub) are necessary for my change but do not fully repair the unrelated pre-existing `semantic`/`text` mock gap. Recommend a small follow-on to complete that test's `designSystem` mock.
+
+3. **Pre-existing RED test (NOT introduced by ORCH-1117): `OfferingParity.test.ts`** asserts `<OfferingManageSheet` in `app/(tabs)/hub/trips.tsx` / `hub/experiences.tsx` — files I never touched. Pre-existing failure unrelated to this ORCH.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1117_OFFERING_PAGE_POLISH.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1117_OFFERING_PAGE_POLISH.md
@@ -1,0 +1,154 @@
+# TEST — ORCH-1117 · Public Offering Page UX/Design Polish
+
+**Verdict:** **PASS** — P0: 0 · P1: 0 · P2: 1 (documented gap, deferred) · P3: 0 · P4: 2
+**Tester:** mingla-tester (production gatekeeper)
+**Date:** 2026-06-12
+**Branch:** `ORCH-1117-offering-page-polish` @ `2a2bd67eb` (tester commit on top of impl `135a81950`)
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1117-[offering-page-polish]`
+**Driven on:** iOS Simulator iPhone 17 Pro (iOS 26.4, UDID `17091E60-…`), branch Metro on :8090, consumer dev build `com.mingla.app.v2`, Maestro-driven. Physical Android (Samsung `R58R54YV7JT`) available; Android opaque verified by source + `Platform.select` (visual ghosting deferred — see Device matrix).
+**Comms:** factored + acked **COMMS-0024** (WARN — ORCH-1116/1117 ID collision; ORCH-1117 is legitimately held by this lineage, no code conflict, no renumber).
+
+---
+
+## 1. Verdict + counts
+
+**PASS.** Zero P0, zero P1. One P2 (a mixed-unavailable-tiers edge that resolves to a misleading-but-not-dead-tap Buy; spec-gap, not a spec violation — recommended as a follow-on, does not block). Two P4 notes (clean patterns). Regression gate satisfied (both implementor happy-path tests + tester adversarial test in the closing diff, both fail-on-revert). All runtime UI claims are `proven` on the iOS sim at the live-fire bar.
+
+**The four dispatch headline answers:**
+- **T-DEADTAP:** No state dead-ended. Native floating Buy bar FIRED its handler at runtime (route transition + booking flow — not inert). Non-buyable native + web states are non-tappable `accessibilityRole="text"` info strips with NO onPress (source + type-system proven; the discriminated union makes `unavailable` structurally non-tappable — flipping it to `tappable:true` is a TS compile error). One P2 mixed-unavailable edge routes to the cart (soft dead-end, NOT a hard dead tap).
+- **T-NATIVE-SCROLL:** Scroll-sibling CONFIRMED at runtime. The trip sheet AND the brand-event sheet scrolled their full content with the bar PINNED at the bottom, and swipe-down-to-dismiss still worked — proving the bar is a scroll sibling, NOT `BaseBottomSheet.stickyFooter` (ORCH-1016 frozen-scroll regression avoided).
+- **T-LEGIBILITY:** Legible. On the live dark sheet the date eyebrow rendered as a legible orange (`palette.accent`), not invisible. White-on-near-white BUG fix proven by WCAG unit (≥4.5:1) + the R1 strict-grep guard (fails-on-revert verified). No live near-white-theme brand existed to drive a light-theme screenshot → that specific visual is `probable` (math + guard proven).
+- **Device/sim driven:** iOS Simulator iPhone 17 Pro, branch code via Metro :8090, Maestro.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Surface | Result | Evidence |
+|----|---------|--------|----------|
+| SC-1-WEB (legibility) | Web event page | PASS (math+guard); light-theme visual `probable` | `offeringLegibility.orch1117.test.ts` WCAG ≥4.5:1 on near-white page; R1 guard fails-on-revert (raw `#ffffff` at L665 → guard exit 1) |
+| SC-1-NATIVE (exp inherit) | iOS brand/exp sheet | **PASS (proven)** | `native_reserve_sheet_12.png` / `native_brand_sheet_bottom_13.png` — date eyebrow "SAT 19 SEP…" renders legible orange on the dark sheet; shared package path live |
+| SC-2-ALL (collapsed default) | All | PASS | `offeringLegibility.orch1117.test.ts` asserts `useState(true)` + `numberOfLines 3` + 160-char threshold; runtime: short "Details coming soon." About shows NO toggle (≤160 exception) `native_reserve_sheet_12.png` |
+| SC-3-WEB-BUY (event) | Web event | PASS | adapter `onBuyTicket → checkoutPublicPath(event.id)` (`PublicEventPage.tsx:291/329`); reused by bar `handleFloatingBarPress` |
+| SC-3-WEB-TRIP / -EXP | Web trip/exp routes | PASS | inline `trip-checkout-reserve` / `experience-checkout-get-spot` ABSENT (grep=0); routes mount `FloatingOfferingBar` → `tripCheckoutPath`/`experienceCheckoutPath` (adversarial B4) |
+| SC-3-UNAVAIL-WEB | Web | PASS | `FloatingOfferingBar.tsx` unavailable branch = `View accessibilityRole="text"`, no onPress; B1 exhaustiveness + type-system |
+| SC-3-NATIVE-NODEADTAP | iOS brand/exp/trip | **PASS (proven)** | floating Buy bar FIRED `beginBooking` at runtime (`native_bar_fired_18.png` shows route transition + booking-flow network attempt — not inert); inline row → cart `native_inline_buy_16.png`; trip `bookable===false` → non-tappable strip (source `ConsumerTripDetailScreen.tsx:565`) |
+| SC-3-ANDROID | Android | PASS (source); visual `probable` | both bars: opaque `#16181b`/`#f4f6f9`/`rgba(16,18,22,0.98)` (≥0.92) via `Platform.select`, `overflow:hidden`, `elevation:0`, no Android shadow |
+| SC-4-WEB (shadow) | Web event title | PASS | `titleLine` has no `textShadow*` (`offeringLegibility.orch1117.test.ts`); runtime: native titles render flat (`native_trip_sheet_09.png`) |
+| SC-5 (trip bookable) | Web + native trip hook | PASS | `usePublicTripBySlug` + `useConsumerTripDetail` add `resolveTripBookable` (paid→RPC, free→true, RPC-error→true fail-open); additive only |
+
+---
+
+## 3. Findings
+
+### P2-1 (DOCUMENTED GAP, deferred — does NOT block) — mixed-unavailable tiers resolve to a misleading tappable Buy
+- **Evidence:** `packages/event-rendering/offeringCta.ts:198-234`. The unavailable branches are HOMOGENEOUS `.every()` checks (all-door / all-ended / all-sold-out). When unavailable tiers are MIXED by DIFFERENT reasons (e.g. one `availableAt:"door"` + one `saleEndAt` past), no `.every()` fires; `sellable` is empty so `considered = visible` (L234) and it resolves to `{kind:"buy", tappable:true}`. Proven by tester adversarial B2 (`offeringCtaDeadTap.orch1117.adversarial.test.ts`, the two `[GAP]` cases).
+- **Impact:** the floating bar shows a tappable "Buy ticket" that routes to the cart (`/checkout/{eventId}`) where no tier is purchasable — a misleading CTA / soft dead-end. NOT a hard dead-tap (the tap DOES navigate; the cart is the existing backstop). Requires an event with multiple visible tiers each unavailable via a DIFFERENT reason — an uncommon configuration.
+- **Why not a blocker:** the SPEC §4.0 precedence only defines HOMOGENEOUS unavailable states; mixed-reason is unspecified. The implementor faithfully built the spec. The inline `PublicTicketRow` per-tier rows still each show their own correct unavailable state, so the buyer is not left without information.
+- **Required fix (follow-on):** in `resolveOfferingCta`, when `sellable.length === 0` after the homogeneous checks, return `unavailable("Not on sale", null)` instead of falling back to `considered = visible`.
+- **Retest:** flip the two B2 `[GAP]` assertions to expect `tappable:false` (with a `[TEST-MOD-APPROVED]` since they're append-only pins of current behavior); they fail before the fix, pass after.
+
+### P4-1 (praise) — dead-tap invariant enforced at the TYPE LEVEL
+`CtaState`'s discriminated union makes `unavailable` structurally `tappable:false`. My fails-on-revert attempt to flip the "Sold out" branch to `tappable:true` produced a **TS2322 compile error**, not a runtime regression — the strongest possible no-dead-tap guarantee. Replicate this pattern.
+
+### P4-2 (praise) — scroll-sibling discipline + opaque-fallback done correctly
+Native bars are in-flow scroll siblings (NOT `position:absolute`, NOT `stickyFooter`), matching the proven `reserveFooter` pattern; Android opaque fill + `elevation:0` + `overflow:hidden` per `ANDROID_GLASS_USES_OPAQUE_FALLBACK`. Verified scrolling + dismiss at runtime.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Re-ran the implementor's claimed proof myself (not trusted):
+- **Implementor claim:** deleting the `if (!bookable) {…}` gate at the top of `resolveOfferingCta` makes `offeringCta.orch1117.test.ts` go `1 failed, 10 passed`.
+- **My re-run:** checked out `packages/event-rendering/offeringCta.ts` @ branch HEAD, deleted lines 151-159 (the `!bookable` gate) by true line-deletion, ran `offeringCta.orch1117.test.ts` → **`Tests: 1 failed, 10 passed`** — exactly `T-CTA-UNAVAIL` failed (`Expected "unavailable", Received "buy"` at test L91). Restored → **`11 passed`**. **CONFIRMED** at branch HEAD.
+- **R1 guard fails-on-revert:** injected `color: "#ffffff"` at `PublicEventPage.tsx:665` → `orch-1117-no-raw-white-on-palette-surface.mjs` reported FAILED + **exit code 1** (detected L665); restored → exit 0. **CONFIRMED.**
+
+## 5. Adversarial test added (tester, different angle)
+
+**Path:** `mingla-business/src/components/offering/__tests__/offeringCtaDeadTap.orch1117.adversarial.test.ts` (NEW, 21 tests).
+**Angles (DIFFERENT from the implementor's single-state happy path):**
+- **B1** dead-tap EXHAUSTIVENESS: every terminal `unavailable` state (`!bookable`/cancelled/past/pre-sale/no-tickets/all-door/all-ended/all-sold-out) is non-tappable; the only tappable kinds are buy/free/waitlist; + a SOURCE invariant that no `unavailable` literal carries `tappable:true`.
+- **B2** mixed/precedence-collision states (door+ended, sold-out+door) + the not-bookable-gate-wins precedence + a positive control (one sellable among unavailable IS tappable). **This angle surfaced P2-1.**
+- **B3** WYSIWYP / no-fee-recompute: bar price == all-in `priceAllInGbp` verbatim (not base, not fee-adjusted); lowest-not-summed for multi-tier; + source has no fee/tax-math tokens.
+- **B4** inline single-CTA truly ABSENT on the trip + experience ROUTES; floating bar present + routes to the correct chain (never the events `/checkout/{id}`).
+
+**fails-on-revert verified at `2a2bd67eb`:**
+- B4 — re-adding `testID="trip-checkout-reserve"` to `TripCheckoutFlow.tsx` → B4 test FAILS (`1 failed, 17 skipped, 3 passed`). Restored → pass.
+- B1 — flipping any `unavailable` branch to `tappable:true` is a **TS2322 compile error** (stronger than a runtime fail).
+- Both implementor tests (`offeringCta.orch1117.test.ts`, `offeringLegibility.orch1117.test.ts`) AND this adversarial test appear in `git diff origin/main...HEAD --name-only`. Append-only confirmed (new file; no existing test deleted).
+
+### 5.1 [TEST-MOD-APPROVED by orchestrator, ORCH-1117 CLOSE] — ORCH-0876 A2 re-point
+The implementor's Discovery #1 flagged that `ORCH-0876.adversarial.test.ts` A2 pinned `router.push(\`/checkout-trip/${trip.id}\`)` as a SOURCE grep inside `TripCheckoutFlow.tsx`. ORCH-1117's LOCKED §4.5 moved that LOUD nav to the public trip route's floating bar. Per the dispatch authorization, I re-pointed A2's source read from `TripCheckoutFlow.tsx` to `app/t/[brandSlug]/[tripSlug].tsx` and asserted the **destination invariant is preserved**: `router.push(tripCheckoutPath(trip.id) as never)` PRESENT, and the events chain (`/checkout/${trip.id}` AND `checkoutPublicPath(trip.id)`) ABSENT. A2's comment-pin assertions (cite ORCH-0876 + `eventType.filter.audit.test.ts`) still read `TripCheckoutFlow.tsx` (the implementor preserved that comment). Result: ORCH-0876 went **21/22 → 22/22**. Documented in the test file with the `[TEST-MOD-APPROVED…]` tag.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | **PASS** | unavailable strips non-tappable (type+runtime); floating Buy bar fires (`native_bar_fired_18.png`); P2-1 is a soft (navigating) edge, not a dead tap |
+| 2 | One owner per truth | PASS | `resolveOfferingCta`/`computeOfferingVariant` is the single buy-state owner; both inline row + bar consume it |
+| 3 | No silent failures | PASS | resolvers fail-OPEN with an explicit comment; checkout 409 backstop; no swallowed catch in the bar |
+| 4 | One query key per entity | N/A | no new query keys (additive field on existing trip hooks) |
+| 5 | Server state server-side | PASS | bars are pure presentational; no Zustand server-state |
+| 6 | Logout clears | N/A | no auth/persisted state touched |
+| 7 | `[TRANSITIONAL]` labels | PASS | OQ-B native unavailable-strip deferral documented in source (`ExpandedBusinessEventSheet.tsx:457-462`) |
+| 8 | Subtract before adding | PASS | inline trip/exp CTAs REMOVED before the bar added; shared state machine hoisted (no fork) |
+| 9 | No fabricated data | PASS | price reads all-in field verbatim; B3 proves no fee math |
+| 10 | Currency-aware | PASS | `formatPrice` uses ticket/fallback currency via `Intl.NumberFormat` (runtime €500 rendered) |
+| 11 | One auth instance | PASS | bars + resolvers are anon-tolerant; no new `useAuth` on public routes |
+| 12 | Validate at right time | N/A | no datetime validation added (variant uses existing computed times) |
+| 13 | Exclusion consistency | PASS | `visibility!=="hidden"` filter consistent between variant + cta |
+| 14 | Persisted-state startup | N/A | no persisted state |
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Result | Evidence |
+|---------|--------|----------|
+| Consumer iOS | **PASS (proven)** | iPhone 17 Pro: trip sheet + brand-event sheet scroll w/ bar pinned, bar fires, swipe-dismiss works, legible eyebrow, short-copy About no-toggle (`native_*` shots 09-21) |
+| Consumer Android | PASS (source) / visual `probable` | `Platform.select` opaque fill + `elevation:0`; physical Samsung available but visual-ghosting screenshot deferred — same RN bar component as iOS, opaque hex proven in source |
+| Buyer/anon Web | PASS (source+jest) | `FloatingOfferingBar.tsx` (web) non-tappable strip role="text"; routes mount bar + remove inline CTA; jest 62/62. Branch not yet deployed → no live-web screenshot (deploys after ORCH-1116, OTA pending) |
+| Business iOS / Android | PASS (inherited) | renders the same shared public components when previewing |
+| Admin Web | N/A | no public offering page |
+| Business Web preview | PASS (inherited) | same shared bar; bookable reflects own brand readiness |
+
+**T-BOOKABLE-PARITY (proven):** Travel Brand / Leggo This (`stripe_charges_enabled=true`) → LIVE tappable bar (€500 Reserve/Buy bars rendered + fired). A genuinely not-ready brand exists in data (Paystack NG Test Brand `stripe_charges_enabled=false`, no Paystack) → web unavailable strip path (source-verified; OQ-B defers the native pre-emptive strip to the cart-toast backstop, which `beginBooking` provides).
+
+---
+
+## 8. Discoveries for Orchestrator
+
+1. **PRE-EXISTING RED (NOT ORCH-1117): `OfferingParity.test.ts`** — asserts `<OfferingManageSheet` in `app/(tabs)/hub/trips.tsx`/`hub/experiences.tsx`, but those files now use `<LazyOfferingManageSheet` (a React.lazy refactor by another ORCH). ORCH-1117 never touched these files (confirmed empty `git diff` stat). Pre-existing baseline failure. Recommend a one-line test update in a follow-on.
+2. **PRE-EXISTING RED (NOT ORCH-1117): `PublicEventPage.closeButton.adversarial.test.tsx`** — 6/6 failing on `Cannot read properties of undefined (reading 'error')` (incomplete `designSystem` mock, `useThemeFont` from ORCH-1083). PROVEN pre-existing: the origin/main version of the file also fails 6/6. ORCH-1117's 13 insertions are append-only (0 deletions, CI `tests-append-only` compliant) mock additions needed for the FloatingOfferingBar import — they do not (and were not meant to) repair the unrelated `semantic.error` mock gap. Recommend a small follow-on to complete that mock.
+3. **PRE-EXISTING DEEP-LINK COLD-OPEN GAP (NOT ORCH-1117):** the app-mobile `app/t/[brandSlug]/[tripSlug].tsx` deep-link route, when COLD-opened directly (`com.mingla.app.v2://t/{brand}/{trip}`), throws **"No QueryClient set"** — because `QueryClientProvider` is mounted in `app/index.tsx`, NOT the root `app/_layout.tsx`, so sibling Stack routes render outside the provider. ORCH-1117 did NOT touch the route, `_layout`, or the provider placement (only the business `app/t/…` route). The in-app deck→sheet path works (inside the provider). Real bug worth its own ORCH; affects any cold deep-link into a trip.
+4. **Worktree Metro hazard (env):** `app-mobile/node_modules` was a SYMLINK to the anchor; combined with the bracketed worktree path `ORCH-1117-[…]`, Metro computed a malformed serverRoot/entry (`./mingla-main/app-mobile/node_modules/expo-router/entry`) → red-screen "Unable to resolve module". Fixed by APFS COW-cloning the anchor `node_modules` into the worktree (de-symlink). Reusable fix for future bracketed-worktree native runs.
+
+## 9. Accepted conditions
+
+None required for PASS (zero P0/P1). P2-1 is a documented gap recommended as a follow-on, not a release blocker.
+
+---
+
+## 10. Evidence index (`Mingla_Artifacts/evidence/ORCH-1117/`)
+
+| Shot | What it proves |
+|------|----------------|
+| `sim_state_01/02.png` | Metro worktree-symlink red-screen (env blocker, then fixed) |
+| `sim_app_live_03.png` | branch code live on iOS sim (consumer Explore) |
+| `native_trip_detail_04.png` | (pre-existing) cold deep-link "No QueryClient" — Discovery #3 |
+| `native_discover_trips_08.png` | brand trips in Discover (in-app path) |
+| `native_trip_sheet_09.png` | trip sheet — title no shadow, legible eyebrow |
+| `native_trip_scrolled_10.png` | **T-NATIVE-SCROLL** — content scrolled, Reserve bar PINNED (From €500 + Reserve) |
+| `native_reserve_sheet_12.png` | Reserve FIRED → reserve flow; legible orange eyebrow; short-copy About no-toggle |
+| `native_brand_sheet_bottom_13.png` | EXP-NATIVE floating Buy bar (€500 + Buy ticket) pinned, opaque |
+| `native_inline_buy_16.png` | inline Buy row → cart (Get tickets) opens |
+| `native_bar_fired_18.png` | **T-DEADTAP** — floating Buy bar FIRED (route transition + booking attempt, not inert) |
+| `native_dismissed_21.png` | **T-NATIVE-SCROLL** — swipe-down-to-dismiss still works (scroll-sibling, not stickyFooter) |
+
+---
+
+## 11. Routing
+
+**PASS → CLOSE (orchestrator).** At CLOSE: flip `I-PROPOSED-NO-RAW-WHITE-ON-PALETTE-SURFACE` to ACTIVE (R1 guard + workflow job in place); enforce the HARD merge order (ORCH-1117 merges AFTER ORCH-1116, already on main — branch is rebased on it). Consider spawning a follow-on for P2-1 (mixed-unavailable strip) + Discoveries #1/#2/#3.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1117_OFFERING_PAGE_POLISH.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1117_OFFERING_PAGE_POLISH.md
@@ -1,0 +1,394 @@
+# SPEC — ORCH-1117 · Public Offering Page UX/Design Polish
+
+**Status:** SPEC complete — build-ready contract
+**Author:** mingla-forensics (SPEC mode)
+**Date:** 2026-06-11
+**Source design:** `Mingla_Artifacts/specs/DESIGN_ORCH-1117_PUBLIC_OFFERING_PAGE_POLISH.md` (mingla-designer, APPROVED)
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1117-[offering-page-polish]` on branch `ORCH-1117-offering-page-polish` (rebased on origin/main)
+**Next phase:** mingla-implementor → mingla-tester → orchestrator CLOSE
+**Hard merge-order dependency:** MUST merge AFTER ORCH-1116 (RLS fix to `pg_brand_can_charge`). See §2.4 + §10 OQ-D.
+
+---
+
+## 1. Executive summary
+
+Four buyer-facing polish changes on the public/in-app offering view, applied with full cross-surface parity across six concrete surfaces (event/trip/experience × web/native):
+
+1. **White-theme legibility** — on the theme-color-driven public event page, the date eyebrow (L583) and the recurrence "Show all" pill (L617) are hardcoded `#ffffff`; on a light brand theme they render white-on-near-white (invisible). Fix: take their color from the already-computed luminance-aware palette. Isolated to `packages/event-rendering/PublicEventPage.tsx` (renders BOTH the web event page AND the in-app experience detail). Other surfaces are fixed-dark → preventive rule only.
+2. **Collapsible About** — the description block starts **collapsed by default** (3-line peek + chevron + "Read more"), expanding on tap. Standardizes the pattern that already exists on one native surface; rolls it out to all six.
+3. **Floating Buy CTA** — a persistent bottom bar that is the primary buy action. Two top-level states: a tappable Buy button (routes to the **existing** checkout/cart) and a **non-tappable info strip** (when not bookable / sold out / ended / pre-sale / door-only). No dead taps (Constitution #1).
+4. **Reduce title drop-shadow** — remove the heavy `0,2 / radius 10 / 28%-black` text shadow on the event title (L1349-1351); it reads as smudged on a light card and does no legibility work (the title sits on a solid surface). Other surfaces have no shadow → preventive rule only.
+
+Plus one data-plumbing addition required by #3: thread a `bookable` flag onto the **public trip payload** (events + experiences already carry it) so the trip floating bar can render its unavailable state. This consumes `pg_brand_can_charge`, whose RLS is fixed by sibling **ORCH-1116** — hence the merge-order dependency.
+
+**Locked product decisions (Seth, 2026-06-11 — baked in, resolve design OQ-2):**
+- Floating "Buy ticket" on **multi-tier events** routes to the **existing checkout/cart page** (`router.push(checkoutPublicPath(event.id))` → `/checkout/{eventId}`, which lists all tickets) — NOT a tier-picker, NOT cheapest-tier auto-buy. The floating bar reuses the SAME navigation the inline ticket-row CTA already uses.
+- On **single-ticket trips & experiences**, the inline Reserve / Get-my-spot CTA is **REMOVED entirely**; the floating bottom bar is the **only** CTA. (Multi-tier event inline ticket rows stay as-is.)
+
+---
+
+## 2. Scope & non-goals
+
+### 2.1 In scope (the four changes + trip bookable plumbing, across six surfaces)
+
+| Change | Applies to |
+|--------|-----------|
+| #1 legibility | EVT-WEB + EXP-NATIVE (shared file, real bug); preventive note for the four fixed-dark surfaces |
+| #2 collapsible About | ALL six surfaces |
+| #3 floating Buy CTA | ALL six surfaces |
+| #4 title shadow | EVT-WEB + EXP-NATIVE (shared file, real bug); preventive note elsewhere |
+| trip `bookable` plumbing | TRIP-WEB (hook) + the trip floating bar's unavailable state |
+
+### 2.2 Non-goals (explicitly OUT — do not touch)
+
+- **No money-engine change.** The floating bar reuses existing navigation / existing cart sheets / existing `ticket-checkout-create` and `pg_brand_can_charge`. Zero new payment code, zero fee recompute (WYSIWYP: read `priceAllInGbp`/`priceCents` as-is).
+- **No new `bookable` computation for events/experiences.** They already resolve it (`resolveEventBookable`, `resolveBookable`). Only TRIP gains the resolver.
+- **No change to `pg_brand_can_charge` itself** — that RLS fix is ORCH-1116's. ORCH-1117 only CONSUMES it for trips.
+- **No auto-hide-on-scroll** for the floating bar (design §3.7 — future enhancement, out of scope).
+- **No redesign of the inline multi-tier ticket rows** on EVT-WEB (they stay; the floating bar coexists and routes to `/checkout`).
+- **No change to the external/Ticketmaster event detail** (`app-mobile/.../EventDetailLayout.tsx`) buy/CTA behavior — see §2.3 finding F-A. Its existing `aboutCollapsed` toggle is the reference for #2 only; it gets copy/chevron standardization, not a floating bar (it has no Mingla checkout — it deep-links an external ticket URL).
+- **No `stickyFooter`-prop rerouting** of the native sheets (TRIP-NATIVE / EVT-NATIVE / EXP-NATIVE). See §2.3 finding F-B (HARD constraint — `stickyFooter` froze the gorhom scroll in ORCH-1016).
+
+### 2.3 Investigation findings that bind this SPEC (read during SPEC ingest)
+
+- **F-A — EVT-NATIVE `EventDetailLayout.tsx` is the EXTERNAL event detail, not a Mingla-brand offering.** It renders artist/genre/seat-map and its CTA opens an external ticket URL via browser; it already has `aboutCollapsed=useState(true)` at L72 + a 160-char threshold (the design's reference). The Mingla-brand consumer event/experience detail is the **shared `@mingla/event-rendering` `PublicEventPage`** hosted in `app-mobile/.../ExpandedBusinessEventSheet.tsx`. Therefore "EVT-NATIVE floating Buy bar" in the design maps to the **brand-event sheet** (`ExpandedBusinessEventSheet`), and `EventDetailLayout` gets ONLY the #2 copy/chevron standardization. Do not add a Mingla floating Buy bar to `EventDetailLayout`.
+- **F-B — the native brand sheets use a BARE `scrollMode="scroll"` and MUST NOT be rerouted through `BaseBottomSheet`'s `stickyFooter` prop.** ORCH-1016 proved (on-device, measured) that a `stickyFooter`/header/wrapper makes gorhom size the sheet to content → viewport == content → `maxScroll=0` → frozen scroll. `ConsumerTripDetailScreen.tsx` already pins its Reserve bar as a **sibling second child of the bare scroll** (`{detailBody}{reserveFooter}`), NOT via `stickyFooter` (see its L459-465 comment). The native floating bar on EVT-NATIVE/EXP-NATIVE/TRIP-NATIVE MUST use this same proven sibling-at-end-of-scroll pattern, never `stickyFooter`.
+- **F-C — the shared package deliberately has NO `Icon`, NO `safe-area-context`, NO `Animated`/`LayoutAnimation`.** It is self-contained with inline RN primitives + the local `GlassBlur`, and uses **text glyphs** (`×`, `↗`) for chrome. Therefore: (a) the collapsible-About chevron in the package is a **text glyph** (`⌄` collapsed / `⌃` expanded) consistent with existing package style, NOT an `Icon` import; (b) the floating Buy bar is NOT built inside the package (it needs safe-area + router + Icon) — it is built in the **host adapters/sheets** that already import those. The package gets #1, #2, #4 only.
+- **F-D — EVT-WEB checkout navigation already lives in the adapter** (`mingla-business/.../PublicEventPage.tsx` `onBuyTicket` → `router.push(checkoutPublicPath(event.id))`, neutralized to a toast when `!bookable`). The web floating bar mounts in this adapter and reuses the SAME handler. This realizes the locked "one Buy action → the cart page that lists all tickets" decision with zero new routing.
+- **F-E — TRIP-NATIVE already has a floating Reserve bar** (the `reserveFooter` sibling, disabled on bookings-closed). Change #3 on TRIP-NATIVE = upgrade that existing bar to the standardized contract (price-left/action-right anatomy already matches) + add the `bookable===false` unavailable state. It does NOT get a brand-new bar.
+- **F-F — the public TRIP fetch is a HOOK with direct Supabase queries (`usePublicTripBySlug.ts`), NOT a `publicTripsService`.** The dispatch's "`resolveTripBookable` in `publicTripsService`" maps to: add the resolver + thread `bookable` into the hook's `PublicTripPayload`. (Event/experience resolvers live in `publicEventsService`/`publicExperienceService`; mirror their shape.)
+
+### 2.4 ORCH-1116 merge-order dependency (HARD)
+
+`bookable` for paid offerings = `pg_brand_can_charge(p_brand_id)`. ORCH-1116 fixes that RPC's **RLS so it returns the correct boolean for anonymous / non-owner buyers**. Before ORCH-1116 lands, the RPC under anon RLS returns the wrong value for non-owners → **every brand would false-gate** (or the fail-open masks it but the unavailable state never fires correctly). After ORCH-1116, the flag is correct.
+
+**Therefore ORCH-1117 MUST merge AFTER ORCH-1116.** The implementor must NOT merge this branch until ORCH-1116 is on `main` and this branch is rebased on it. The resolvers fail OPEN on RPC error (page stays bookable; the checkout 409 is the terminal backstop) — this is the same contract as the event/experience resolvers and must be preserved so a transient RPC error never wrongly hides a bookable listing.
+
+### 2.5 Assumptions
+
+- The all-in price for the floating bar comes from existing server-computed fields only (`priceAllInGbp` events/exp via package data; `priceCents` trips/exp web). Never recompute fees.
+- `useSafeAreaInsets()` is available in every host (it is — all adapters/screens already import it).
+- The default Mingla theme (`#eb7825`) resolves `useDark=true` → no visible change for the common case under change #1/#4.
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY)
+
+| # | Surface | Covered? | User-visible behavior demanded | Files touched | Parity |
+|---|---------|----------|--------------------------------|---------------|--------|
+| 1 | **Consumer iOS** (`app-mobile/` iOS) | YES | #1 (via shared pkg), #2 collapsible About (brand-event/exp sheet + trip screen + external-event layout), #3 floating Buy bar on brand-event/exp sheet + trip screen (sibling-at-end-of-scroll), #4 (via shared pkg) | `packages/event-rendering/PublicEventPage.tsx`; `app-mobile/.../ExpandedBusinessEventSheet.tsx`; `app-mobile/.../ConsumerTripDetailScreen.tsx`; `app-mobile/.../EventDetailLayout.tsx` (#2 copy/chevron only) | Shared pkg = automatic for #1/#2/#4 of the brand-event/exp body; native bar = MANUAL per host |
+| 2 | **Consumer Android** (`app-mobile/` Android) | YES | Same as iOS PLUS the Android opaque-glass fallback on every floating bar (solid ≥0.92 fill, clipped, no shadow) | Same files | MANUAL Android `Platform.select` branch per bar |
+| 3 | **Buyer/anonymous Web** (`mingla-business/` `/e/…`, `/t/…`, `/exp/…`, `/checkout*`) | YES | #1 (event page), #2 collapsible About (event + trip + exp), #3 floating Buy bar (event adapter + trip route + exp route), #4 (event page); single inline Reserve/Get-spot **removed** on trip + exp | `packages/event-rendering/PublicEventPage.tsx`; `mingla-business/src/components/event/PublicEventPage.tsx`; `mingla-business/app/t/[brandSlug]/[tripSlug].tsx`; `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx`; `mingla-business/src/components/trip/TripCheckoutFlow.tsx`; `mingla-business/src/components/experience/ExperienceCheckoutFlow.tsx`; `mingla-business/src/components/trip/TripPreview.tsx`; `mingla-business/src/components/experience/ExperiencePreview.tsx`; `mingla-business/src/hooks/usePublicTripBySlug.ts`; `mingla-business/src/constants/publicUrls.ts` (add `experienceCheckoutPath` helper) | Event body via shared pkg automatic; trip/exp web bars MANUAL |
+| 4 | **Business iOS** | NOT directly | Business app renders the SAME `mingla-business` web/native public components when previewing; no business-only authoring screen changes here | (inherits #3 surface files when business previews a public page) | Automatic via shared components |
+| 5 | **Business Android** | NOT directly | Same as Business iOS + Android opaque fallback inherited from the shared bar | (inherits) | Automatic |
+| 6 | **Admin Web** (`mingla-admin/`) | NOT covered | Admin has no public offering page | — | Reason: admin never renders the buyer offering view |
+| 7 | **Business Web preview** (adjacent) | YES (inherited) | When a business user previews their own public event/trip/exp page in-app, they see the same polished page (legibility, collapsed About, floating bar). The floating bar's bookable state reflects their own brand's charge-readiness. | (inherits #3 surface files) | Automatic via shared components |
+
+---
+
+## 4. Layered specification
+
+> **No database / edge-function / realtime layers are touched.** The only "backend-adjacent" change is consuming the existing `pg_brand_can_charge` RPC from the trip hook (read-only RPC call, already anon-granted). All work is service/hook/component.
+
+### 4.0 The single source of truth — buy state machine (hoist, do not fork)
+
+The floating bar's label + tappability + reason MUST be a **pure projection of the same state machine** already in `PublicTicketRow` (`PublicEventPage.tsx:944-982`) and the page banners — NOT a parallel copy.
+
+**Contract:** introduce one pure helper, exported from the package, that both the inline row and the floating bar consume:
+
+```
+// packages/event-rendering/offeringCta.ts  (NEW small pure module)
+export type CtaState =
+  | { kind: "buy";       label: string; price: string; tappable: true  }
+  | { kind: "free";      label: string;                tappable: true  }
+  | { kind: "waitlist";  label: string;                tappable: true  }
+  | { kind: "unavailable"; title: string; subline: string | null; tappable: false };
+
+export const resolveOfferingCta(input: {
+  variant: Variant; bookable: boolean; tickets: PublicTicketProps[]; currency: string;
+}): CtaState
+```
+
+Precedence (mirrors the inline machine + adds the `bookable` gate FIRST):
+`!bookable → unavailable("Booking unavailable", "The organizer is finishing payment setup.")` →
+`variant==="past" → unavailable("Sales ended")` →
+`variant==="pre-sale" → unavailable("On sale {countdown}")` →
+`all door-only → unavailable("Pay at the door")` →
+`all sold-out + any waitlist → waitlist("Join waitlist")` →
+`all sold-out → unavailable("Sold out")` →
+`any free, none paid → free("Get free ticket")` →
+else `buy("Buy ticket", "From {minAllInPrice}")`.
+
+The price uses the existing `formatTicketPrice` (all-in, never recomputed). "From" prefix when >1 visible non-free tier; bare price for single tier.
+
+> The inline `PublicTicketRow` keeps its per-tier label (it is per-ticket); the floating bar uses the **page-level** projection above. Both import the same module so the gate logic (`bookable`, sold-out, ended, pre-sale, door) lives in ONE place. The implementor may refactor `PublicTicketRow`'s shared sub-predicates (`saleEnded`, `isSoldOutTicket`, `isDoorOnly`) into this module if it reduces duplication, but MUST NOT change `PublicTicketRow`'s existing per-tier behavior.
+
+### 4.1 CHANGE #1 — White-theme legibility (`packages/event-rendering/PublicEventPage.tsx`)
+
+The luminance machinery already exists (`createThemePalette`, `readableTextFor`, `contrastAdjustedAccent`, `contrastAdjustedForWhiteText` — L185-225). No new computation; the two offending literals just consume the palette.
+
+**Rule R1 (codify in a guard comment):** No raw `#ffffff`/`#fff` on text that sits on a palette surface (`palette.page/card/glass/panel/accentWash`). The ONLY allowed white-on-X is `accentText` (`#ffffff`) on a guaranteed-dark fill (the accent button) — that pairing stays.
+
+**Exact edits:**
+
+| Anchor | Before | After | Why AA-safe |
+|--------|--------|-------|-------------|
+| L582-584 date line | `{ color: "#ffffff", fontFamily: theme.fontFamilyValue }` | `{ color: palette.accent, fontFamily: theme.fontFamilyValue }` | `palette.accent` passed `contrastAdjustedForWhiteText(…, 4.5)` ⇒ ≥4.5:1 as text on `page`; keeps the "orange uppercase eyebrow" identity |
+| L616-617 recurrence pill label | `[styles.recurrencePillLabel, { color: "#ffffff" }]` | `[styles.recurrencePillLabel, { color: palette.primaryText }]` | pill bg is `accentWash` (thin wash over `page`) ⇒ effective bg ≈ `page` ⇒ `primaryText = readableTextFor(page)` is ≈19:1 |
+
+`palette` is already in scope at both anchors (computed at `PublishedBody` L473). No prop threading.
+
+**Per-surface delta:** EVT-WEB = the fix; EXP-NATIVE = inherits same file automatically; the four fixed-dark surfaces = no change (preventive R1 only — they never put theme-color text on a light surface).
+
+**Resolved OQ-1:** date eyebrow = `palette.accent` (emphasis, the default that preserves today's look). Do NOT use `secondaryText`.
+
+### 4.2 CHANGE #2 — Collapsible About (collapsed by default)
+
+**Shared interaction contract (identical semantics on all six surfaces):**
+
+- Header row: the section label ("About" web / "About" or description heading native) on the left, a **chevron glyph** on the right; the WHOLE row is one tap target, min 44×44.
+- Collapsed (default): body clamped to `numberOfLines={3}`, `ellipsizeMode="tail"`; an affordance reading **"Read more"** in the accent color under the peek; chevron points DOWN (`⌄`).
+- Expanded: full body (no clamp); affordance reads **"Show less"**; chevron points UP (`⌃`).
+- **Short-copy exception:** if `description.length <= 160` (the existing EVT-NATIVE threshold), render full body + NO chevron + NO affordance (a toggle for 2 lines is noise).
+- **Default = COLLAPSED on every surface** (for copy over the threshold).
+
+**Motion:** toggle via `numberOfLines` swap (3 ↔ undefined). On native wrap the `setState` in `LayoutAnimation.easeInEaseOut(200)` for a 200ms height settle; on web the same `numberOfLines` swap via RN-web is acceptable (Framer height optional, not required). **Reduce-motion:** when `AccessibilityInfo.isReduceMotionEnabled()` (native) / `prefers-reduced-motion` (web), skip the `LayoutAnimation` call — instant toggle; chevron still flips (static).
+
+> **Native-sheet caution (HARD, F-B):** EVT-WEB-in-app + EXP-NATIVE render inside the gorhom `BottomSheetScrollView`. Use the `numberOfLines`+`LayoutAnimation` approach (content-driven, no measured-height race) — do NOT animate a measured height inside the virtualized sheet scroll (can jump scroll position).
+
+**A11y:** header row `accessibilityRole="button"`, `accessibilityState={{ expanded }}`, `accessibilityLabel="About"`, `accessibilityHint={collapsed ? "Expands the description" : "Collapses the description"}`. Chevron is decorative (`accessibilityElementsHidden`/`importantForAccessibility="no"`). State is signaled by BOTH the chevron rotation and the "Read more/Show less" word — never color alone.
+
+**Per-surface contract:**
+
+| Surface | File + anchor | Implementation |
+|---------|---------------|----------------|
+| EVT-WEB / EXP-NATIVE | `packages/event-rendering/PublicEventPage.tsx` About block L856-872 | Add `const [aboutCollapsed, setAboutCollapsed] = useState(true)` in `PublishedBody`. Replace the static About `<Text>` with: a pressable header row (`About` + text-glyph chevron `aboutCollapsed ? "⌄" : "⌃"`, chevron color `palette.tertiaryText`), the body `<Text numberOfLines={aboutCollapsed ? 3 : undefined}>`, and a "Read more"/"Show less" affordance (`palette.accent`). Apply the ≤160-char short-copy exception. Use the package text-glyph chevron (F-C) — NO Icon import. |
+| TRIP-WEB | `mingla-business/src/components/trip/TripPreview.tsx` description block L163-167 | Wrap the `description` `<Text>` in the same collapsible pattern. TripPreview is dark-surface; chevron `rgba(255,255,255,0.52)`, affordance `accent.warm`. May use `Icon name="chevron-down"` here (business app HAS the Icon primitive). |
+| EXP-WEB | `mingla-business/src/components/experience/ExperiencePreview.tsx` description block L125-128 | Same as TRIP-WEB. |
+| EVT-NATIVE (external) | `app-mobile/.../EventDetailLayout.tsx` L331-356 | Already collapsed-by-default (`aboutCollapsed=useState(true)` L72, 160-char threshold L342). **Standardize ONLY:** copy → "Read more"/"Show less"; add the chevron glyph/Icon next to the toggle; keep its existing `numberOfLines`+threshold engine. Do not alter its CTA. |
+| TRIP-NATIVE | `app-mobile/.../ConsumerTripDetailScreen.tsx` description L390-392 | Wrap the description `<Text>` in the collapsible pattern (dark-surface tokens). |
+
+### 4.3 CHANGE #3 — Floating Buy CTA (per-surface, host-level)
+
+**The bar is built per host (F-C), all consuming `resolveOfferingCta` (§4.0). It is NEVER built inside the package.** Recommended: one shared presentational component `FloatingOfferingBar` in **each app** (or a shared `packages/` primitive if the implementor prefers — but it needs `useSafeAreaInsets`, so it lives in app space, not `event-rendering`). Acceptable to implement it twice (business + app-mobile) given the divergent hosts; the STATE comes from the one shared `resolveOfferingCta`.
+
+**Anatomy — bookable:** left = price block (`From {price}` micro-uppercase tertiary label + value 18-20/900 primary); right = accent action button (`Buy ticket`/`Get free ticket`/`Reserve my spot`/`Get my spot`), min height 56, radius `radius.lg`, label white 17/900, press `opacity 0.85`/scale 0.98 + Light haptic (native).
+
+**Anatomy — unavailable (NON-tappable, no dead taps, Constitution #1):** an info strip, `accessibilityRole` NOT "button", NO `onPress`. `ⓘ` glyph + title ("Booking unavailable" / "Sold out" / "Sales ended" / "On sale {countdown}" / "Pay at the door") + optional subline ("The organizer is finishing payment setup."). Fill `palette.panel`/quiet, NOT accent.
+
+**Placement / safe-area / glass:**
+
+| Property | Value |
+|----------|-------|
+| Web/route | `position:absolute, left:0, right:0, bottom:0`, above scroll content; inner content `maxWidth:660, alignSelf:center` (matches body column) |
+| Native sheet (EVT/EXP) | **sibling at the END of the bare `scrollMode="scroll"` content** (F-B) — NOT `stickyFooter`. Mirrors `ConsumerTripDetailScreen`'s `reserveFooter`. |
+| Bottom safe area | `paddingBottom: insets.bottom + spacing.sm` (native) / `spacing.md` (web) |
+| Min button height | 56 |
+| Top edge | 1px hairline `palette.panelBorder` (web/iOS) / `rgba(255,255,255,0.12)` (native dark) |
+| Scroll spacer | increase the scroll content bottom padding by bar height + safe area so the last inline element clears the bar. EVT-WEB pkg `scrollContent.paddingBottom` (currently `spacing.xl*2`=64, L1295) is OWNED BY THE HOST that mounts the bar — the **adapter** must pass extra bottom clearance (it cannot edit the pkg style cleanly), OR the pkg adds an optional `extraScrollBottomInset` prop the adapter sets. **Decision:** add an optional `contentBottomInset?: number` prop to the package consumed at `scrollContent` so the web adapter and the native sheet can both reserve bar clearance without forking the style. Native sheets already inject bottom padding via `SheetScrollHost`/`scrollContent` — extend that value by the bar height. |
+
+**Android opaque-glass fallback (HARD — `ANDROID_GLASS_USES_OPAQUE_FALLBACK`):**
+
+| Platform | Bar fill |
+|----------|----------|
+| iOS | `GlassBlur` intensity 28-34 + `palette.panelStrong`; `overflow:'hidden'`; upward shadow `shadowOffset {0,-8}`, opacity 0.28, radius 24 |
+| Android | **opaque ≥0.92 solid fill via `Platform.select`** — dark surface `#16181b`, light EVT-WEB page `#f4f6f9`; `overflow:'hidden'`; **NO Android shadow**; rely on hairline top border for separation |
+| Web | `palette.panelStrong` + backdrop-blur + hairline top border; no transparency that lets text bleed through |
+
+**States (full matrix — projection of §4.0):**
+
+| State | Bar | Tappable | Target |
+|-------|-----|----------|--------|
+| bookable / paid | price + "Buy ticket" | YES | event: `/checkout/{eventId}` (existing); trip: `/checkout-trip/{id}`; exp: `/checkout-experience/{id}` |
+| bookable / free | "Free" + "Get free ticket" | YES | same checkout/claim entry |
+| bookable / trip | "From {price}" + "Reserve my spot" | YES | `/checkout-trip/{id}` |
+| bookable / experience | "From {price}" + "Get my spot" | YES | `/checkout-experience/{id}` |
+| `bookable===false` | info strip "Booking unavailable" + subline | NO | — |
+| sold out (no waitlist) | strip "Sold out" | NO | — |
+| sold out + waitlist | "Join waitlist" | YES | existing waitlist sheet |
+| sales ended / past | strip "Sales ended" | NO | — |
+| pre-sale | strip "On sale {countdown}" | NO | — |
+| door only | strip "Pay at the door" | NO | — |
+| loading | bar hidden OR skeleton (panel bar, shimmer pill) | NO | — |
+| pressed | opacity 0.85 / scale 0.98 + Light haptic (native) | — | — |
+
+**Motion:** mount slide-up `translateY 100%→0` + fade 260ms `easings.out`; state crossfade 120ms; press 80ms. Reduce-motion: appear instantly. Native sheet: the bar appears with the sheet (no separate slide needed if it's a scroll sibling).
+
+**A11y:** bookable button `accessibilityRole="button"`, label "Buy ticket, from £25"; unavailable strip `accessibilityRole="text"`, label "Booking unavailable. The organizer is finishing payment setup." (NOT a button). Wrapper `pointerEvents="box-none"`, bar `auto`. Every non-bookable state carries a WORD + icon, not color alone.
+
+**Per-surface contract:**
+
+| Surface | File | Inline CTA fate | Bar target |
+|---------|------|-----------------|-----------|
+| **EVT-WEB** | `mingla-business/src/components/event/PublicEventPage.tsx` (adapter) | KEEP per-ticket rows (multi-tier) | reuse adapter `onBuyTicket` → `router.push(checkoutPublicPath(event.id))` (LOCKED: cart page lists all tickets). When `!bookable`, the bar is the info strip (the adapter already has the `bookable` prop + the toast guard). |
+| **EXP-NATIVE** | `app-mobile/.../ExpandedBusinessEventSheet.tsx` | n/a (sheet, single ticket) | bar = scroll sibling; tap → `beginBooking(ticketId)` (existing cart/occurrence flow). Needs `bookable` threaded — see §4.4 native note. |
+| **EVT-NATIVE (brand sheet)** | same file as EXP-NATIVE (`ExpandedBusinessEventSheet`) | KEEP cart rows | same as EXP-NATIVE |
+| **TRIP-WEB** | `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` | **REMOVE** the inline Reserve CTA (LOCKED single-ticket rule) — see §4.5 | bar tap → `/checkout-trip/{trip.id}`; `bookable===false` → info strip (needs trip `bookable`, §4.4) |
+| **EXP-WEB** | `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx` | **REMOVE** the inline Get-spot CTA (LOCKED) — see §4.5 | bar tap → `/checkout-experience/{experience.id}`; uses existing `experience.bookable` |
+| **TRIP-NATIVE** | `app-mobile/.../ConsumerTripDetailScreen.tsx` | already a single pinned bar (`reserveFooter`) — UPGRADE it | add `bookable===false` info-strip state to the existing bar; keep `Bookings closed` state; tap → `setReserveSheetVisible(true)` (existing) |
+
+### 4.4 Trip `bookable` plumbing (NEW — the only data addition)
+
+**Service-layer contract:** add `resolveTripBookable` mirroring `resolveEventBookable` (`publicEventsService.ts:914-924`) and `resolveBookable` (`publicExperienceService.ts:168-181`):
+
+```
+// in mingla-business/src/hooks/usePublicTripBySlug.ts (the trip fetch lives here, F-F)
+const resolveTripBookable = async (brandId: string, isPaid: boolean): Promise<boolean> => {
+  if (!isPaid) return true;
+  const { data, error } = await supabase.rpc("pg_brand_can_charge", { p_brand_id: brandId });
+  if (error !== null) return true;       // FAIL OPEN — checkout 409 is the backstop
+  return data === true;
+};
+```
+
+- `isPaid` for a trip = first pricing tier `priceCents > 0` (mirror the trip price source at hook L196-204).
+- Add `bookable: boolean` to the `PublicTripPayload` interface (hook L29-37) and set it in the returned payload (`const bookable = await resolveTripBookable(brand.id, isPaid)`).
+- `brandId` = `event.brand_id` (already in scope in the hook).
+
+**Component-layer:** `[tripSlug].tsx` reads `payload.bookable` and passes it to the floating bar (info-strip when false). Mirrors how `[experienceSlug].tsx` reads `experience.bookable` (L170).
+
+**Native trip:** `ConsumerTripDetailScreen` consumes whatever its trip-detail hook returns. If that hook does NOT carry `bookable`, thread it the same way (resolver on the brand_id + paid check). **OQ-C:** confirm the native trip-detail hook's fetch path during IMPLEMENT and add the resolver there too if absent (the screen is in scope for #3's bookable state).
+
+**Native brand-event/exp (`ExpandedBusinessEventSheet`):** the consumer `BusinessEventCard` payload does **not** currently carry `bookable` (confirmed — `mergedDiscover.ts` has no `bookable` field). To render the native floating bar's unavailable state, `bookable` must reach the sheet. **OQ-B (scope decision):** either (a) thread `bookable` onto `BusinessEventCard` from the discover/card supply (larger change, touches `discover-cards`), or (b) for v1 render the native floating bar's bookable states only and rely on the existing checkout 409 + cart-sheet guards for the not-ready case (the native cart never dead-ends — it shows a toast). **SPEC default = (b)** to keep ORCH-1117 from widening into the discover supply path: the native brand sheets get the floating Buy bar in its tappable states; the `bookable===false` info-strip on native brand-event/exp is **deferred** (flag to orchestrator). The web surfaces (which DO have `bookable`) get the full unavailable state now. This keeps the dead-tap guarantee (native cart toasts, never dead-ends) while not pulling the discover payload into scope. Tester verifies native never dead-ends via the existing 409/toast path.
+
+### 4.5 Remove single inline CTA (LOCKED decision)
+
+- **TRIP-WEB** `[tripSlug].tsx`: the inline Reserve CTA is inside `TripCheckoutFlow` (its `cta`/`trip-checkout-reserve` Pressable L126-134). Remove the inline Reserve button from `TripCheckoutFlow`'s render (keep the tier card + payment-plan disclosure + helper copy as a quiet "details" block IF still wanted, but the LOUD Reserve action moves to the floating bar). Cleanest: keep `TripCheckoutFlow` for the tier/plan recap, delete its `<Pressable testID="trip-checkout-reserve">`, and let the floating bar own the navigation (`/checkout-trip/{id}`). The `handleReserve` navigation logic moves to the bar.
+- **EXP-WEB** `[experienceSlug].tsx`: the inline Get-spot CTA is inside `ExperienceCheckoutFlow` (its `experience-checkout-get-spot` Pressable L123-143). Same treatment: remove the inline Pressable; the floating bar owns `/checkout-experience/{id}`. Keep the ticket recap + helper.
+- Do NOT remove inline CTAs anywhere on EVT-WEB (multi-tier rows stay).
+- **`publicUrls.ts`:** add `experienceCheckoutPath(experienceEventId)` → `/checkout-experience/{id}` (currently inlined; add the helper for parity with `tripCheckoutPath`/`checkoutPublicPath` and so the floating bar uses a single source).
+
+### 4.6 CHANGE #4 — Remove title shadow (`packages/event-rendering/PublicEventPage.tsx`)
+
+**Rule R4:** title text shadow is removed when the title sits on a solid surface (it always does today). Edit `titleLine` style L1343-1352: **delete** `textShadowColor`, `textShadowOffset`, `textShadowRadius` (L1349-1351). Keep `fontSize:36, lineHeight:41, fontWeight:"900", color:text.primary, marginBottom`. No motion, no a11y change (AA still met by `primaryText` on `page`). Preventive elsewhere (the four other surfaces already have no title shadow — verify none creeps in).
+
+---
+
+## 5. Success criteria (per-surface where parity is manual)
+
+- **SC-1-WEB (legibility):** On a brand with a white/near-white theme color, the `/e/{brand}/{event}` date eyebrow and recurrence pill render with ≥4.5:1 (eyebrow) / ≥4.5:1 (pill) contrast against the body card — legible, not invisible. A contrast probe on `palette.accent` vs `palette.page` and `palette.primaryText` vs effective pill bg both return ≥4.5:1.
+- **SC-1-NATIVE (exp inherit):** The in-app experience detail (hosted on the shared package) shows the same legible eyebrow/pill (inherits the file).
+- **SC-2-ALL (collapsed default):** On every surface, an offering with a description >160 chars renders the About/description **collapsed to 3 lines** with a "Read more" affordance + down chevron on first paint; tapping the header expands to full text, affordance → "Show less", chevron → up. An offering with ≤160-char description renders full with no toggle.
+- **SC-3-WEB-BUY (event):** The `/e/{…}` floating bar shows "Buy ticket" + "From {all-in price}" when bookable; tapping it navigates to `/checkout/{eventId}` (the cart that lists all tickets) — identical target to the inline ticket-row CTA.
+- **SC-3-WEB-TRIP / SC-3-WEB-EXP:** The trip/exp routes show NO inline Reserve/Get-spot button; the floating bar is the only CTA and navigates to `/checkout-trip/{id}` / `/checkout-experience/{id}`.
+- **SC-3-UNAVAIL-WEB:** When `bookable===false` (trip/event/exp web), the floating bar is a NON-tappable info strip ("Booking unavailable" + subline), `accessibilityRole!=="button"`, fires no navigation/handler on tap.
+- **SC-3-NATIVE-NODEADTAP:** On the native brand-event/exp sheet + trip screen, the floating bar in EVERY non-buyable state either (a) is non-tappable, or (b) on a not-ready paid brand routes through the existing cart/toast path that shows a message and never dead-ends. (Runtime/device proof required — Constitution #1.)
+- **SC-3-ANDROID:** On Android, every floating bar renders with a SOLID ≥0.92 fill (no scroll text ghosting through), clipped, with NO Android shadow.
+- **SC-4-WEB (shadow):** The `/e/{…}` title renders with no text shadow (clean/flat); `titleLine` style contains no `textShadow*` keys.
+- **SC-5 (trip bookable):** `usePublicTripBySlug` returns `payload.bookable`; for a paid trip whose brand `pg_brand_can_charge=false`, `bookable===false`; for a free trip, `bookable===true`; on RPC error, `bookable===true` (fail-open).
+
+---
+
+## 6. Invariants
+
+| Invariant | How preserved | Verifying test |
+|-----------|---------------|----------------|
+| **Constitution #1 — no dead taps** | Every non-bookable floating-bar state is a non-button info strip OR routes through an existing toast/guard path; runtime dead-tap proof at TEST | T-DEADTAP (runtime, §7) |
+| **I-PAID-SUPPLY-REQUIRES-CHARGES-ENABLED** (ORCH-1076) | Trip gains the same `pg_brand_can_charge` gate events/exp already have; fail-open + checkout-409 backstop preserved | T-TRIP-BOOKABLE |
+| **WYSIWYP / all-in pricing** | Floating bar reads `priceAllInGbp`/`priceCents` as-is; never recomputes fees | T-PRICE-NORECOMPUTE (assert no fee math in bar) |
+| **ANDROID_GLASS_USES_OPAQUE_FALLBACK** | Every bar uses `Platform.select` opaque ≥0.92 Android fill, clipped, no shadow | T-ANDROID-OPAQUE |
+| **Anon-tolerant public routes** (`feedback_anon_buyer_routes`) | No new `useAuth` on `/t/`,`/exp/`,`/e/`; trip `bookable` resolved via anon-granted RPC | unchanged routes |
+| **Single-scroll native sheet** (ORCH-1016 / META-ORCH-0991) | Native floating bar is a scroll SIBLING, never `BaseBottomSheet.stickyFooter` (F-B) | T-NATIVE-SCROLL (manual on-device) |
+
+**Proposed new invariant (DRAFT — orchestrator flips ACTIVE on CLOSE):**
+`I-PROPOSED-NO-RAW-WHITE-ON-PALETTE-SURFACE` — in `packages/event-rendering/PublicEventPage.tsx`, no `color: "#ffffff"`/`"#fff"` literal on a text element on a palette surface, except `accentText` on the accent button. Enforced by a strict-grep CI guard (§9).
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-LUM-HAPPY | Light theme contrast | brand theme `#ffffff` → `createThemePalette` | `contrastRatio(palette.accent, palette.page) ≥ 4.5` AND `contrastRatio(palette.primaryText, palette.page) ≥ 4.5` | unit (package) |
+| T-LUM-DARK | Default theme unchanged | theme `#eb7825` | `useDark===true`; eyebrow accent + pill primaryText render as today (white on near-black) | unit |
+| T-LUM-REVERT | Fails-on-revert | re-introduce `color:"#ffffff"` at L583 | strict-grep guard FAILS | CI grep |
+| T-ABOUT-DEFAULT | Collapsed by default | description 400 chars | `aboutCollapsed===true` initial; body `numberOfLines===3`; "Read more" present | unit/render |
+| T-ABOUT-SHORT | Short-copy exception | description 80 chars | no chevron, no affordance, full text | unit/render |
+| T-ABOUT-TOGGLE | Expand | tap header | `numberOfLines===undefined`; "Show less"; chevron up | render |
+| T-CTA-BUY | Bookable event | bookable=true, 2 paid tiers | `resolveOfferingCta → {kind:"buy", price:"From £X", tappable:true}` | unit (offeringCta) |
+| T-CTA-UNAVAIL | Not bookable | bookable=false | `{kind:"unavailable", title:"Booking unavailable", tappable:false}` | unit |
+| T-CTA-SOLDOUT | Sold out no waitlist | all tiers cap 0 | `{kind:"unavailable", title:"Sold out", tappable:false}` | unit |
+| T-CTA-WAITLIST | Sold out + waitlist | cap 0, waitlist on | `{kind:"waitlist", tappable:true}` | unit |
+| T-NAV-EVENT | Event bar target | tap bookable bar | `router.push("/checkout/{eventId}")` called | render/spy |
+| T-NAV-TRIP-REMOVE-INLINE | Trip inline removed | render `/t/…` | no `testID="trip-checkout-reserve"` in tree; floating bar present → `/checkout-trip/{id}` | render |
+| T-NAV-EXP-REMOVE-INLINE | Exp inline removed | render `/exp/…` | no `testID="experience-checkout-get-spot"`; floating bar → `/checkout-experience/{id}` | render |
+| T-TRIP-BOOKABLE | Trip resolver | paid trip, RPC=false | `payload.bookable===false` | unit (hook) |
+| T-TRIP-BOOKABLE-FAILOPEN | RPC error | RPC throws | `payload.bookable===true` | unit |
+| T-TRIP-BOOKABLE-FREE | Free trip | tier price 0 | `bookable===true`, no RPC call | unit |
+| T-SHADOW-GONE | Title shadow removed | inspect `titleLine` style | no `textShadowColor/Offset/Radius` keys | unit/snapshot |
+| T-ANDROID-OPAQUE | Android fill | `Platform.OS==="android"` | bar fill is solid hex (`#16181b`/`#f4f6f9`), no rgba alpha <0.92, no shadow | unit (Platform.select) |
+| T-DEADTAP | Runtime no dead tap | drive sim/device, tap bar in each non-buyable state | never dead-ends; non-button strips fire nothing; not-ready native shows toast | RUNTIME (device) |
+| T-NATIVE-SCROLL | Sheet still scrolls | drive native sheet with floating bar | body scrolls fully, bar pinned, swipe-down dismisses | RUNTIME (device) |
+
+---
+
+## 8. Implementation order
+
+1. **`packages/event-rendering/offeringCta.ts`** (NEW) — `resolveOfferingCta` + `CtaState` (the hoisted state machine). Unit-test first.
+2. **`packages/event-rendering/PublicEventPage.tsx`** — #1 (L583, L617 → palette tokens), #4 (delete L1349-1351 shadow), #2 (collapsible About L856-872 with `aboutCollapsed` state + text-glyph chevron + 160-char exception), optional `contentBottomInset?` prop, R1 guard comment. Have `PublicTicketRow` import the shared predicates from offeringCta (no behavior change).
+3. **`mingla-business/src/constants/publicUrls.ts`** — add `experienceCheckoutPath`.
+4. **`mingla-business/src/hooks/usePublicTripBySlug.ts`** — add `resolveTripBookable` + `bookable` on `PublicTripPayload`.
+5. **`mingla-business/src/components/trip/TripPreview.tsx`** + **`ExperiencePreview.tsx`** — collapsible description.
+6. **`mingla-business/src/components/trip/TripCheckoutFlow.tsx`** + **`ExperienceCheckoutFlow.tsx`** — remove inline Reserve/Get-spot Pressable; expose the nav target for the bar.
+7. **`mingla-business/src/components/event/PublicEventPage.tsx`** (adapter) — mount the web floating bar (reuse `onBuyTicket`/`bookable`); reserve scroll-bottom clearance via `contentBottomInset`.
+8. **`mingla-business/app/t/[brandSlug]/[tripSlug].tsx`** + **`app/exp/[brandSlug]/[experienceSlug].tsx`** — mount the floating bar (absolute bottom), pass `bookable`, target the checkout paths.
+9. **`app-mobile/.../ConsumerTripDetailScreen.tsx`** — upgrade `reserveFooter` to the standardized bar contract + bookable state; collapsible description.
+10. **`app-mobile/.../ExpandedBusinessEventSheet.tsx`** — add the floating Buy bar as a scroll sibling (F-B); tappable states route through `beginBooking`; collapsible About inherits from the package.
+11. **`app-mobile/.../EventDetailLayout.tsx`** — #2 copy/chevron standardization only.
+12. **CI strict-grep guard** for R1 (§9).
+13. Run all jest gates; prove fails-on-revert; device runtime proof for T-DEADTAP + T-NATIVE-SCROLL.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+- **R1 guard (structural):** add a strict-grep CI check (in the existing CI grep harness / a new audit test under `mingla-business/src/**/__tests__/` that reads the package source) that FAILS if `packages/event-rendering/PublicEventPage.tsx` contains `color: "#ffffff"` or `color: "#fff"` on a text element, EXCEPT the single `accentText` button pairing. Reverting the #1 fix (re-adding the literal at L583/L617) makes this FAIL; restoring it PASSES. Protective comment: "ORCH-1117 R1 — date eyebrow + recurrence pill must read from the luminance-aware palette, never raw white, or they vanish on a light brand theme."
+- **#4 guard:** a snapshot/style unit asserting `titleLine` has no `textShadow*` keys — FAILS if the shadow is restored.
+- **Inline-CTA-removed guard:** render tests assert `trip-checkout-reserve` / `experience-checkout-get-spot` testIDs are ABSENT and the floating-bar testID is present — FAIL if an inline single CTA is reintroduced alongside the bar.
+- **Trip-bookable guard:** unit asserting `usePublicTripBySlug` returns `bookable` and fails-open — FAILS if the field is dropped.
+- **Dead-tap (runtime):** Constitution #1 — the tester MUST drive each non-buyable bar state on device and prove no dead-end. Source wiring is insufficient (memory: "interactive elements must fire — runtime proof").
+
+---
+
+## 10. Open questions
+
+- **OQ-A (RESOLVED by locked decisions):** design OQ-2 is closed — multi-tier event bar → existing `/checkout/{eventId}`; single-ticket trip/exp inline CTA → removed. No further decision needed.
+- **OQ-B (scope, SPEC default chosen):** native brand-event/exp `bookable===false` info-strip is DEFERRED (the consumer `BusinessEventCard` lacks `bookable`; threading it pulls in the discover-cards supply). v1 native bar ships tappable states + relies on the existing 409/cart-toast for not-ready (never dead-ends). Flagging to orchestrator: confirm deferral, or authorize a follow-on to thread `bookable` onto `BusinessEventCard`.
+- **OQ-C:** confirm during IMPLEMENT whether the native trip-detail hook (feeding `ConsumerTripDetailScreen`) carries `bookable`; if not, add `resolveTripBookable` there too (it's the same brand_id + paid check).
+- **OQ-D (HARD merge order):** ORCH-1117 MUST merge AFTER ORCH-1116. Do not merge this branch until ORCH-1116 is on `main` and this branch is rebased on it. Before then the trip/exp/event `bookable` boolean is unreliable for anon/non-owner buyers.
+
+---
+
+## 11. Downstream routing
+
+**Next = mingla-implementor (build this contract).** Then mingla-tester (adversarial + device runtime proof for T-DEADTAP/T-NATIVE-SCROLL/T-ANDROID-OPAQUE; verify legibility on a white-theme brand; verify inline-CTA removal; verify trip bookable fail-open). Then orchestrator CLOSE (flip `I-PROPOSED-NO-RAW-WHITE-ON-PALETTE-SURFACE` to ACTIVE; enforce the ORCH-1116-first merge order).
+
+**Working tree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1117-[offering-page-polish]/` on branch `ORCH-1117-offering-page-polish` (rebase on origin/main after ORCH-1116 merges, before merging this).
+
+### Allowlist (implementor MAY edit ONLY these)
+
+- `packages/event-rendering/PublicEventPage.tsx`
+- `packages/event-rendering/offeringCta.ts` (NEW)
+- `mingla-business/src/components/event/PublicEventPage.tsx`
+- `mingla-business/src/components/trip/TripPreview.tsx`
+- `mingla-business/src/components/trip/TripCheckoutFlow.tsx`
+- `mingla-business/src/components/experience/ExperiencePreview.tsx`
+- `mingla-business/src/components/experience/ExperienceCheckoutFlow.tsx`
+- `mingla-business/app/t/[brandSlug]/[tripSlug].tsx`
+- `mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx`
+- `mingla-business/src/hooks/usePublicTripBySlug.ts`
+- `mingla-business/src/constants/publicUrls.ts`
+- `app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx`
+- `app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx`
+- `app-mobile/src/components/expandedCard/EventDetailLayout.tsx` (#2 copy/chevron only)
+- a NEW shared `FloatingOfferingBar` component in each app's component tree (business + app-mobile) + co-located `__tests__/`
+- the CI strict-grep guard / audit test file (§9)
+- the native trip-detail hook ONLY IF OQ-C requires the trip `bookable` resolver there
+
+### DO-NOT-TOUCH (stop-and-amend before editing)
+
+- `supabase/` migrations, `pg_brand_can_charge`, any edge function, any Stripe/Paystack money path (ORCH-1116 owns the RPC; ORCH-1117 only reads it).
+- `BaseBottomSheet.tsx` (do NOT add/reroute through `stickyFooter` — F-B).
+- `discover-cards` edge fn + `BusinessEventCard` supply (OQ-B deferral — do not widen into the discover payload without orchestrator authorization).
+- the existing multi-tier inline ticket rows on EVT-WEB (`PublicTicketRow` per-tier behavior).
+- `nativeCheckoutFlow`, `TicketCartSheet`, `ticket-checkout-create` request shape.

--- a/app-mobile/src/components/expandedCard/EventDetailLayout.tsx
+++ b/app-mobile/src/components/expandedCard/EventDetailLayout.tsx
@@ -344,12 +344,25 @@ export default function EventDetailLayout({
               onPress={() => setAboutCollapsed((c) => !c)}
               activeOpacity={0.7}
               accessibilityRole="button"
+              accessibilityState={{ expanded: !aboutCollapsed }}
+              accessibilityHint={
+                aboutCollapsed
+                  ? "Expands the description"
+                  : "Collapses the description"
+              }
+              style={styles.moreToggleRow}
             >
+              {/* ORCH-1117 — standardized copy ("Read more"/"Show less") +
+                  chevron glyph. EXTERNAL event detail (F-A) gets only this
+                  copy/chevron standardization — no Mingla floating Buy bar. */}
               <Text style={styles.moreToggle}>
-                {aboutCollapsed
-                  ? t("cards:expanded.show_more")
-                  : t("cards:expanded.show_less")}
+                {aboutCollapsed ? "Read more" : "Show less"}
               </Text>
+              <Icon
+                name={aboutCollapsed ? "chevron-down" : "chevron-up"}
+                size={16}
+                color={colors.primary}
+              />
             </TouchableOpacity>
           )}
         </View>
@@ -559,11 +572,17 @@ const styles = StyleSheet.create({
     color: colors.primary,
     marginTop: 4,
   },
+  moreToggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginTop: 6,
+    minHeight: 44,
+  },
   moreToggle: {
     fontSize: 13,
     fontWeight: "600",
     color: colors.primary,
-    marginTop: 6,
   },
   metaItem: {
     flexDirection: "row",

--- a/app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx
+++ b/app-mobile/src/components/expandedCard/ExpandedBusinessEventSheet.tsx
@@ -33,10 +33,13 @@ import * as Haptics from "expo-haptics";
 
 import {
   type PublicBrandProps,
+  type CtaState,
   type PublicEventCallbacks,
   PublicEventPage,
   type PublicEventProps,
   type ViewerRole,
+  computeOfferingVariant,
+  resolveOfferingCta,
   resolveTheme,
 } from "@mingla/event-rendering";
 
@@ -74,6 +77,10 @@ import {
   type ExperienceOccurrence,
 } from "./ExperienceOccurrencePicker";
 import { ExperienceItinerary } from "./ExperienceItinerary";
+// ORCH-1117 — the floating Buy bar pinned at the END of the sheet's bare scroll
+// (F-B scroll-sibling, NEVER stickyFooter). State from the shared
+// resolveOfferingCta (one owner).
+import { FloatingOfferingBar } from "../offering/FloatingOfferingBar";
 
 interface ExpandedBusinessEventSheetProps {
   visible: boolean;
@@ -447,6 +454,35 @@ export const ExpandedBusinessEventSheet: React.FC<
     [bookableOccurrences],
   );
 
+  // ORCH-1117 — floating Buy bar state. PURE projection of resolveOfferingCta
+  // (same machine the inline rows read). OQ-B: the BusinessEventCard supply has
+  // no `bookable`, so v1 passes bookable=true and relies on the existing
+  // checkout 409 → cart toast for the not-ready case (never dead-ends). The bar's
+  // tappable Buy opens the cart at the first sellable ticket via beginBooking;
+  // the inline per-tier rows stay for multi-tier picking.
+  const floatingCta: CtaState = useMemo(() => {
+    const tickets = ticketsQuery.data ?? [];
+    return resolveOfferingCta({
+      variant: computeOfferingVariant(publicEvent, false),
+      bookable: true,
+      tickets,
+      currency: publicEvent.currency,
+    });
+  }, [ticketsQuery.data, publicEvent]);
+  const handleFloatingBarPress = useCallback((): void => {
+    const tickets = ticketsQuery.data ?? [];
+    // Open the cart at the first sellable, non-hidden ticket (the inline rows
+    // remain for explicit per-tier selection).
+    const sellable = tickets.find(
+      (t) =>
+        t.visibility !== "hidden" &&
+        !(t.availableAt === "door") &&
+        (t.isUnlimited || (t.capacity ?? 0) > 0),
+    );
+    const target = sellable ?? tickets.find((t) => t.visibility !== "hidden");
+    if (target !== undefined) beginBooking(target.id);
+  }, [ticketsQuery.data, beginBooking]);
+
   // ORCH-1072 — the picker chose a date → carry it + open the cart for qty/pay.
   const handleOccurrenceSelect = useCallback((eventDateId: string): void => {
     setSelectedEventDateId(eventDateId);
@@ -530,12 +566,26 @@ export const ExpandedBusinessEventSheet: React.FC<
         {children}
         {/* ORCH-1072 — itinerary section (experience-only). */}
         <ExperienceItinerary stops={itineraryStops} />
-        <View style={{ height: bottomPad }} pointerEvents="none" />
+        {/* ORCH-1117 — floating Buy bar pinned at the END of the bare scroll
+            (F-B scroll-sibling; NEVER stickyFooter). It carries its own bottom
+            inset, so it replaces the old spacer as the last in-flow element. */}
+        <FloatingOfferingBar
+          cta={floatingCta}
+          onPress={handleFloatingBarPress}
+          bottomInset={bottomPad}
+          testID="orch-1117-brand-event-floating-bar"
+        />
       </View>
     );
     Host.displayName = "EbesPassthroughHost";
     return Host;
-  }, [bottomContentInset, bottomSheetInset, itineraryStops]);
+  }, [
+    bottomContentInset,
+    bottomSheetInset,
+    itineraryStops,
+    floatingCta,
+    handleFloatingBarPress,
+  ]);
 
   // META-ORCH-0991 Wave A — migrated onto BaseBottomSheet. Declarative
   // `visible` + initialIndex=1 (90% snap) replicate the proven inline

--- a/app-mobile/src/components/offering/FloatingOfferingBar.tsx
+++ b/app-mobile/src/components/offering/FloatingOfferingBar.tsx
@@ -1,0 +1,141 @@
+/**
+ * FloatingOfferingBar (app-mobile) — ORCH-1117 [public offering page polish].
+ *
+ * The Buy bar for the consumer brand-event / experience sheet. F-B HARD
+ * constraint: inside a gorhom BottomSheetScrollView the bar MUST be an in-flow
+ * SCROLL SIBLING at the END of the bare scroll content — NEVER
+ * BaseBottomSheet.stickyFooter (which froze the scroll in ORCH-1016). This
+ * component is therefore an in-flow row (NOT position:absolute); the host renders
+ * it as the last child of the sheet's scroll passthrough so it pins at the
+ * bottom of the content the same way ConsumerTripDetailScreen's reserveFooter
+ * does.
+ *
+ * State is a PURE projection of the shared resolveOfferingCta (one owner). The
+ * native brand sheets ship the TAPPABLE states for v1; the bookable===false
+ * info-strip is deferred (OQ-B — the BusinessEventCard supply lacks `bookable`),
+ * and the existing checkout 409 → cart toast remains the no-dead-end backstop.
+ * The unavailable info-strip branch is still implemented here (non-tappable) so
+ * sold-out / ended / pre-sale / door states never render a dead Buy button.
+ *
+ * Dark surface only (consumer sheets are fixed-dark #0c0e12). Opaque ≥0.92 fill
+ * satisfies ANDROID_GLASS_USES_OPAQUE_FALLBACK; no Android shadow.
+ */
+
+import React from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import * as Haptics from "expo-haptics";
+
+import type { CtaState } from "@mingla/event-rendering";
+import { colors } from "../../constants/colors";
+
+export interface FloatingOfferingBarProps {
+  cta: CtaState;
+  onPress: () => void;
+  bottomInset?: number;
+  testID?: string;
+}
+
+export const FloatingOfferingBar: React.FC<FloatingOfferingBarProps> = ({
+  cta,
+  onPress,
+  bottomInset = 16,
+  testID,
+}) => {
+  const handlePress = (): void => {
+    if (!cta.tappable) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    onPress();
+  };
+
+  if (!cta.tappable) {
+    // Non-tappable info strip (sold-out / ended / pre-sale / door / not-ready).
+    // accessibilityRole "text" — never "button" (no dead-tap activation prompt).
+    return (
+      <View
+        style={[styles.bar, styles.barStrip, { paddingBottom: bottomInset }]}
+        accessibilityRole="text"
+        accessibilityLabel={
+          cta.subline !== null ? `${cta.title}. ${cta.subline}` : cta.title
+        }
+        testID={testID !== undefined ? `${testID}-unavailable` : undefined}
+      >
+        <Text style={styles.stripGlyph}>ⓘ</Text>
+        <View style={styles.stripTextCol}>
+          <Text style={styles.stripTitle}>{cta.title}</Text>
+          {cta.subline !== null ? (
+            <Text style={styles.stripSubline}>{cta.subline}</Text>
+          ) : null}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.bar, { paddingBottom: bottomInset }]}
+      testID={testID}
+    >
+      {cta.kind === "buy" ? (
+        <View style={styles.priceCol}>
+          <Text style={styles.priceValue}>{cta.price}</Text>
+        </View>
+      ) : (
+        <View style={styles.priceCol} />
+      )}
+      <Pressable
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityLabel={
+          cta.kind === "buy" && cta.price.length > 0
+            ? `${cta.label}, ${cta.price}`
+            : cta.label
+        }
+        style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+        testID={testID !== undefined ? `${testID}-action` : undefined}
+      >
+        <Text style={styles.buttonLabel}>{cta.label}</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    // Opaque ≥0.92 fill (Android opaque-glass fallback); no Android shadow.
+    backgroundColor: "rgba(16,18,22,0.98)",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(255,255,255,0.12)",
+    ...Platform.select({ android: { elevation: 0 }, default: {} }),
+  },
+  barStrip: {
+    justifyContent: "flex-start",
+    gap: 10,
+  },
+  priceCol: { flex: 1, justifyContent: "center" },
+  priceValue: { fontSize: 19, lineHeight: 24, fontWeight: "900", color: "#FFFFFF" },
+  button: {
+    minHeight: 56,
+    paddingHorizontal: 24,
+    borderRadius: 16,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+    marginLeft: 16,
+  },
+  buttonPressed: { opacity: 0.85, transform: [{ scale: 0.98 }] },
+  buttonLabel: { fontSize: 17, fontWeight: "900", color: "#FFFFFF" },
+  stripGlyph: { fontSize: 18, color: "rgba(255,255,255,0.52)" },
+  stripTextCol: { flex: 1 },
+  stripTitle: { fontSize: 14, fontWeight: "700", color: "rgba(255,255,255,0.72)" },
+  stripSubline: {
+    fontSize: 12,
+    color: "rgba(255,255,255,0.52)",
+    marginTop: 2,
+  },
+});
+
+export default FloatingOfferingBar;

--- a/app-mobile/src/hooks/useConsumerTripDetail.ts
+++ b/app-mobile/src/hooks/useConsumerTripDetail.ts
@@ -73,10 +73,33 @@ export interface ConsumerTripDetail {
   minPriceCents: number | null;
   currency: string | null;
   hasFreeTier: boolean;
+  /**
+   * ORCH-1117 / ORCH-1076 — when false this is a PAID trip whose brand can't
+   * charge yet; the floating Reserve bar renders a NON-tappable "Booking
+   * unavailable" info strip. Free trips (and resolver errors) are true
+   * (fail-open; the checkout 409 / cart-toast remains the backstop).
+   */
+  bookable: boolean;
   refundPolicy: RefundPolicyShape | null;
   days: TripDetailDay[];
   inclusions: TripDetailInclusion[];
   tiers: TripDetailTier[];
+}
+
+// ORCH-1117 (OQ-C) — the native trip-detail hook gains the SAME pg_brand_can_charge
+// gate the web trip/event/experience resolvers have. PAID ⇒ gated; FREE ⇒ true;
+// RPC error ⇒ true (fail-open). Uses ev.brand_id from the anon-direct events read
+// (NOT the discover-cards supply — that stays out of scope per OQ-B).
+async function resolveTripBookable(
+  brandId: string | null,
+  isPaid: boolean,
+): Promise<boolean> {
+  if (!isPaid || brandId === null) return true;
+  const { data, error } = await supabase.rpc("pg_brand_can_charge", {
+    p_brand_id: brandId,
+  });
+  if (error !== null) return true;
+  return data === true;
 }
 
 export const consumerTripDetailKeys = {
@@ -227,6 +250,11 @@ async function fetchTripDetail(
     })
     .filter((t): t is TripDetailTier => t !== null);
 
+  // ORCH-1117 — a trip is PAID when its cheapest tier costs > 0. Resolve the
+  // brand's charge-readiness for the floating Reserve bar's unavailable state.
+  const isPaid = (feedRow.minPriceCents ?? 0) > 0;
+  const bookable = await resolveTripBookable(ev?.brand_id ?? null, isPaid);
+
   return {
     tripId,
     tripSlug: feedRow.tripSlug,
@@ -249,6 +277,7 @@ async function fetchTripDetail(
     minPriceCents: feedRow.minPriceCents,
     currency: feedRow.currency,
     hasFreeTier: feedRow.hasFreeTier,
+    bookable,
     refundPolicy: coerceRefundPolicy(ev?.refund_policy ?? null),
     days,
     inclusions,

--- a/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
+++ b/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
@@ -42,13 +42,23 @@
  * BaseBottomSheet root in the same fragment (feedback_rn_sub_sheet_must_render_inside_parent).
  */
 
-import React, { useMemo, useState, type ReactElement } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+} from "react";
 import {
+  AccessibilityInfo,
   ActivityIndicator,
+  LayoutAnimation,
+  Platform,
   Pressable,
   Share,
   StyleSheet,
   Text,
+  UIManager,
   View,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
@@ -92,6 +102,16 @@ interface ConsumerTripDetailScreenProps {
 
 const ACCENT = "#FF6B35";
 const WARM = "#eb7825";
+
+// ORCH-1117 — collapsible description: copy ≤ this length renders full, no toggle.
+const ABOUT_COLLAPSE_THRESHOLD = 160;
+
+if (
+  Platform.OS === "android" &&
+  UIManager.setLayoutAnimationEnabledExperimental !== undefined
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
 
 // Canonical sheet snap tokens — same as ExpandedBusinessEventSheet (the
 // gold-standard detail sheet). Two snaps give a 50% preview + 90% full view.
@@ -184,6 +204,35 @@ export default function ConsumerTripDetailScreen({
     seed,
   );
   const [reserveSheetVisible, setReserveSheetVisible] = useState(false);
+  // ORCH-1117 — collapsible description (collapsed by default for long copy).
+  const [aboutCollapsed, setAboutCollapsed] = useState<boolean>(true);
+  const [reduceMotion, setReduceMotion] = useState<boolean>(false);
+  useEffect(() => {
+    let mounted = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (mounted) setReduceMotion(value);
+    });
+    const sub = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      (value: boolean) => setReduceMotion(value),
+    );
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+  const toggleAbout = useCallback((): void => {
+    if (!reduceMotion) {
+      LayoutAnimation.configureNext(
+        LayoutAnimation.create(
+          200,
+          LayoutAnimation.Types.easeInEaseOut,
+          LayoutAnimation.Properties.opacity,
+        ),
+      );
+    }
+    setAboutCollapsed((c) => !c);
+  }, [reduceMotion]);
 
   // ORCH-1016 — the SheetOverlayCarrier (RN Modal) is removed: it broke Android
   // scroll gestures and did NOT fix the z-order. The sheets now hide the nav
@@ -387,10 +436,52 @@ export default function ConsumerTripDetailScreen({
           </View>
         ) : null}
 
-        {/* Description */}
-        {detail.description !== null && detail.description.trim().length > 0 ? (
-          <Text style={styles.description}>{detail.description}</Text>
-        ) : null}
+        {/* Description — ORCH-1117 collapsible (collapsed by default; copy ≤160
+            chars renders full with no toggle). State signaled by the word +
+            chevron, never color alone. */}
+        {detail.description !== null && detail.description.trim().length > 0
+          ? (() => {
+              const aboutText = detail.description;
+              const canCollapse = aboutText.length > ABOUT_COLLAPSE_THRESHOLD;
+              const collapsed = canCollapse && aboutCollapsed;
+              return (
+                <View>
+                  <Text
+                    style={styles.description}
+                    numberOfLines={collapsed ? 3 : undefined}
+                    ellipsizeMode="tail"
+                  >
+                    {aboutText}
+                  </Text>
+                  {canCollapse ? (
+                    <Pressable
+                      onPress={toggleAbout}
+                      accessibilityRole="button"
+                      accessibilityState={{ expanded: !collapsed }}
+                      accessibilityLabel={collapsed ? "Read more" : "Show less"}
+                      accessibilityHint={
+                        collapsed
+                          ? "Expands the description"
+                          : "Collapses the description"
+                      }
+                      style={styles.aboutToggleRow}
+                    >
+                      <Text style={styles.aboutToggleText}>
+                        {collapsed ? "Read more" : "Show less"}
+                      </Text>
+                      <Icon
+                        name={
+                          collapsed ? "chevron-down" : "chevron-up"
+                        }
+                        size={16}
+                        color={WARM}
+                      />
+                    </Pressable>
+                  ) : null}
+                </View>
+              );
+            })()
+          : null}
 
         {/* Itinerary */}
         {detail.days.length > 0 ? (
@@ -464,29 +555,57 @@ export default function ConsumerTripDetailScreen({
   // is hidden while it's open and the Reserve CTA has no floating nav to clear.
   const footerNavClearance = Math.max(insets.bottom, 16);
   const scrollBottomClearance = footerNavClearance;
-  const reserveFooter: ReactElement = (
-    <View style={[styles.reserveBar, { paddingBottom: footerNavClearance }]}>
-      <View style={styles.reservePriceCol}>
-        <Text style={styles.reservePriceLabel}>
-          {detail.hasFreeTier && priceLabel === null
-            ? "Free"
-            : priceLabel !== null
-              ? `From ${priceLabel}`
-              : ""}
-        </Text>
-      </View>
-      <Pressable
-        style={[styles.reserveBtn, reserveDisabled && styles.reserveBtnDisabled]}
-        disabled={reserveDisabled}
-        onPress={() => setReserveSheetVisible(true)}
-        accessibilityLabel="Reserve this trip"
+  // ORCH-1117 — standardized Reserve bar (price-left / action-right anatomy).
+  // When the PAID brand can't charge yet (detail.bookable === false), render a
+  // NON-tappable "Booking unavailable" info strip instead of the Reserve action
+  // (no dead taps, Constitution #1). The existing "Bookings closed" disabled
+  // state is preserved. F-E: this UPGRADES the existing scroll-sibling bar — it
+  // is NOT BaseBottomSheet.stickyFooter (which froze the scroll in ORCH-1016).
+  const reserveFooter: ReactElement =
+    detail.bookable === false ? (
+      <View
+        style={[
+          styles.reserveBar,
+          styles.reserveBarUnavailable,
+          { paddingBottom: footerNavClearance },
+        ]}
+        accessibilityRole="text"
+        accessibilityLabel="Booking unavailable. The organizer is finishing payment setup."
       >
-        <Text style={styles.reserveBtnText}>
-          {reserveDisabled ? "Bookings closed" : "Reserve"}
-        </Text>
-      </Pressable>
-    </View>
-  );
+        <Text style={styles.reserveStripGlyph}>ⓘ</Text>
+        <View style={styles.reserveStripTextCol}>
+          <Text style={styles.reserveStripTitle}>Booking unavailable</Text>
+          <Text style={styles.reserveStripSubline}>
+            The organizer is finishing payment setup.
+          </Text>
+        </View>
+      </View>
+    ) : (
+      <View style={[styles.reserveBar, { paddingBottom: footerNavClearance }]}>
+        <View style={styles.reservePriceCol}>
+          <Text style={styles.reservePriceLabel}>
+            {detail.hasFreeTier && priceLabel === null
+              ? "Free"
+              : priceLabel !== null
+                ? `From ${priceLabel}`
+                : ""}
+          </Text>
+        </View>
+        <Pressable
+          style={[
+            styles.reserveBtn,
+            reserveDisabled && styles.reserveBtnDisabled,
+          ]}
+          disabled={reserveDisabled}
+          onPress={() => setReserveSheetVisible(true)}
+          accessibilityLabel="Reserve this trip"
+        >
+          <Text style={styles.reserveBtnText}>
+            {reserveDisabled ? "Bookings closed" : "Reserve"}
+          </Text>
+        </Pressable>
+      </View>
+    );
 
   // ORCH-1016 ROOT-CAUSE FIX (measured on-device): use a BARE scrollMode="scroll"
   // so the gorhom BottomSheetScrollView is the DIRECT child of BottomSheetContent —
@@ -612,6 +731,31 @@ const styles = StyleSheet.create({
   },
   reserveBtnDisabled: { opacity: 0.4 },
   reserveBtnText: { fontSize: 16, fontWeight: "600", color: "#FFFFFF" },
+  // ORCH-1117 — collapsible-description toggle row.
+  aboutToggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    minHeight: 44,
+  },
+  aboutToggleText: { fontSize: 14, fontWeight: "600", color: WARM },
+  // ORCH-1117 — Reserve bar "Booking unavailable" info strip (non-tappable).
+  reserveBarUnavailable: {
+    justifyContent: "flex-start",
+    gap: 10,
+  },
+  reserveStripGlyph: { fontSize: 18, color: "rgba(255,255,255,0.52)" },
+  reserveStripTextCol: { flex: 1 },
+  reserveStripTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "rgba(255,255,255,0.72)",
+  },
+  reserveStripSubline: {
+    fontSize: 12,
+    color: "rgba(255,255,255,0.52)",
+    marginTop: 2,
+  },
   stateBody: {
     alignItems: "center",
     justifyContent: "center",

--- a/mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx
+++ b/mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx
@@ -38,7 +38,12 @@ import {
 import { GlassCard } from "../../../src/components/ui/GlassCard";
 import { IconChrome } from "../../../src/components/ui/IconChrome";
 import { ShareModal } from "../../../src/components/ui/ShareModal";
-import { experiencePublicUrl } from "../../../src/constants/publicUrls";
+import { FloatingOfferingBar } from "../../../src/components/offering/FloatingOfferingBar";
+import type { CtaState } from "@mingla/event-rendering";
+import {
+  experienceCheckoutPath,
+  experiencePublicUrl,
+} from "../../../src/constants/publicUrls";
 import { usePublicExperienceBySlug } from "../../../src/hooks/usePublicExperience";
 import { ExperiencePreview } from "../../../src/components/experience/ExperiencePreview";
 import { ExperienceCheckoutFlow } from "../../../src/components/experience/ExperienceCheckoutFlow";
@@ -140,9 +145,58 @@ export default function PublicExperienceRoute(): React.ReactElement {
     ticket.ticketsRemaining !== null &&
     ticket.ticketsRemaining <= 0;
 
+  // ORCH-1117 — floating Buy bar CTA. Single-ticket; the inline Get-spot CTA was
+  // removed (locked rule) so this bar is the ONLY get-spot action and owns nav to
+  // /checkout-experience/{id}. Precedence mirrors the page's banner states:
+  //   ended → "Ended" · sold out → "Sold out" · !bookable → "Booking unavailable"
+  //   · ticket null → "Not on sale yet" · else → "Get my spot" + "From {price}".
+  const expPrice =
+    ticket !== null && ticket.priceCents > 0
+      ? formatExpPrice(ticket.priceCents, ticket.currency)
+      : "Free";
+  const expCta: CtaState = isEnded
+    ? { kind: "unavailable", title: "Ended", subline: null, tappable: false }
+    : isSoldOut
+      ? {
+          kind: "unavailable",
+          title: "Sold out",
+          subline: null,
+          tappable: false,
+        }
+      : !experience.bookable
+        ? {
+            kind: "unavailable",
+            title: "Booking unavailable",
+            subline: "The organizer is finishing payment setup.",
+            tappable: false,
+          }
+        : ticket === null
+          ? {
+              kind: "unavailable",
+              title: "Not on sale yet",
+              subline: null,
+              tappable: false,
+            }
+          : expPrice === "Free"
+            ? { kind: "free", label: "Get my spot", tappable: true }
+            : {
+                kind: "buy",
+                label: "Get my spot",
+                price: `From ${expPrice}`,
+                tappable: true,
+              };
+  const handleExpGetSpot = (): void => {
+    router.push(experienceCheckoutPath(experience.id) as never);
+  };
+
   return (
     <View style={styles.host}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: spacing.xl + 96 + insets.bottom },
+        ]}
+      >
         <ExperiencePreview
           experience={experience}
           brand={payload.brand}
@@ -223,8 +277,31 @@ export default function PublicExperienceRoute(): React.ReactElement {
           description={experience.description?.slice(0, 200) ?? undefined}
         />
       )}
+
+      {/* ORCH-1117 — floating get-spot bar (the ONLY get-spot action; inline CTA
+          removed). NON-tappable info strip when ended/sold-out/not-bookable. */}
+      <FloatingOfferingBar
+        cta={expCta}
+        onPress={handleExpGetSpot}
+        surface="dark"
+        testID="orch-1117-experience-floating-bar"
+      />
     </View>
   );
+}
+
+// ORCH-1117 — minor-unit price formatter for the floating bar (mirrors
+// ExperienceCheckoutFlow.formatPriceMajor; never recomputes fees).
+function formatExpPrice(priceCents: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency || "USD",
+      maximumFractionDigits: 0,
+    }).format(priceCents / 100);
+  } catch {
+    return `${(priceCents / 100).toFixed(0)} ${currency}`;
+  }
 }
 
 const styles = StyleSheet.create({

--- a/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
+++ b/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
@@ -43,7 +43,12 @@ import {
 import { GlassCard } from "../../../src/components/ui/GlassCard";
 import { IconChrome } from "../../../src/components/ui/IconChrome";
 import { ShareModal } from "../../../src/components/ui/ShareModal";
-import { tripPublicUrl } from "../../../src/constants/publicUrls";
+import { FloatingOfferingBar } from "../../../src/components/offering/FloatingOfferingBar";
+import type { CtaState } from "@mingla/event-rendering";
+import {
+  tripCheckoutPath,
+  tripPublicUrl,
+} from "../../../src/constants/publicUrls";
 import { usePublicTripBySlug } from "../../../src/hooks/usePublicTripBySlug";
 import { TripPreview } from "../../../src/components/trip/TripPreview";
 import { TripCheckoutFlow } from "../../../src/components/trip/TripCheckoutFlow";
@@ -162,9 +167,61 @@ export default function PublicTripRoute(): React.ReactElement {
     }
   }
 
+  // ORCH-1117 — floating Buy bar CTA for the trip. Single-ticket; the inline
+  // Reserve CTA was removed (locked rule) so this bar is the ONLY Reserve action
+  // and owns navigation to /checkout-trip/{id}. States (precedence):
+  //   !bookable          → "Booking unavailable" info strip (NON-tappable)
+  //   bookings closed     → "Bookings closed" info strip (NON-tappable)
+  //   else                → "Reserve my spot" + "From {price}"
+  const tripTier = trip.pricingTiers[0];
+  const tripPrice =
+    tripTier !== undefined && tripTier.priceCents > 0
+      ? formatTripPrice(tripTier.priceCents, tripTier.currency)
+      : tripTier !== undefined && tripTier.priceCents === 0
+        ? "Free"
+        : "";
+  const tripCta: CtaState =
+    payload.bookable === false
+      ? {
+          kind: "unavailable",
+          title: "Booking unavailable",
+          subline: "The organizer is finishing payment setup.",
+          tappable: false,
+        }
+      : isClosed
+        ? {
+            kind: "unavailable",
+            title: "Bookings closed",
+            subline: null,
+            tappable: false,
+          }
+        : tripTier === undefined
+          ? {
+              kind: "unavailable",
+              title: "Not bookable yet",
+              subline: null,
+              tappable: false,
+            }
+          : tripPrice === "Free"
+            ? { kind: "free", label: "Reserve my spot", tappable: true }
+            : {
+                kind: "buy",
+                label: "Reserve my spot",
+                price: `From ${tripPrice}`,
+                tappable: true,
+              };
+  const handleTripReserve = (): void => {
+    router.push(tripCheckoutPath(trip.id) as never);
+  };
+
   return (
     <View style={styles.host}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: spacing.xl + 96 + insets.bottom },
+        ]}
+      >
         <TripPreview
           trip={payload.trip}
           brand={payload.brand}
@@ -244,8 +301,31 @@ export default function PublicTripRoute(): React.ReactElement {
           description={payload.trip.description?.slice(0, 200)}
         />
       )}
+
+      {/* ORCH-1117 — floating Reserve bar (the ONLY Reserve action; inline CTA
+          removed). NON-tappable info strip when not bookable / bookings closed. */}
+      <FloatingOfferingBar
+        cta={tripCta}
+        onPress={handleTripReserve}
+        surface="dark"
+        testID="orch-1117-trip-floating-bar"
+      />
     </View>
   );
+}
+
+// ORCH-1117 — minor-unit price formatter for the floating bar (mirrors
+// TripCheckoutFlow.formatPriceMajor; never recomputes fees — reads priceCents).
+function formatTripPrice(priceCents: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency || "USD",
+      maximumFractionDigits: 0,
+    }).format(priceCents / 100);
+  } catch {
+    return `${(priceCents / 100).toFixed(0)} ${currency}`;
+  }
 }
 
 const styles = StyleSheet.create({

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -29,7 +29,12 @@ import {
   type PublicTicketProps,
   type ViewerRole,
   resolveTheme,
+  resolveOfferingCta,
+  resolveOfferingSurface,
+  computeOfferingVariant,
 } from "@mingla/event-rendering";
+
+import { FloatingOfferingBar } from "../offering/FloatingOfferingBar";
 
 import {
   checkoutPublicPath,
@@ -248,6 +253,51 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
     setToast((prev) => ({ ...prev, visible: false }));
   }, []);
 
+  // ORCH-1117 — floating Buy bar state. PURE projection of the shared
+  // resolveOfferingCta (same machine the inline ticket rows read). The bar is
+  // the always-reachable primary action; the per-ticket inline rows stay (multi
+  // tier). Tapping the bar reuses the SAME navigation the row CTA uses
+  // (checkoutPublicPath → the cart page that lists all tickets — LOCKED).
+  const offeringCta = useMemo(
+    () =>
+      resolveOfferingCta({
+        variant: computeOfferingVariant(publicEvent, false),
+        bookable,
+        tickets: publicEvent.tickets,
+        currency: publicEvent.currency,
+      }),
+    [publicEvent, bookable],
+  );
+  const offeringSurface = useMemo(
+    () => resolveOfferingSurface(resolvedTheme),
+    [resolvedTheme],
+  );
+  const handleFloatingBarPress = useCallback((): void => {
+    if (offeringCta.kind === "waitlist") {
+      const wlTicket = publicEvent.tickets.find(
+        (t) => t.visibility !== "hidden" && t.waitlistEnabled,
+      );
+      if (wlTicket !== undefined) setWaitlistTicketId(wlTicket.id);
+      return;
+    }
+    // buy / free → the existing checkout/cart page (or the toast guard when the
+    // brand can't charge — never a dead-end). Mirrors callbacks.onBuyTicket.
+    if (!bookable) {
+      showToast(
+        "Booking unavailable right now — the organizer is finishing payment setup.",
+      );
+      return;
+    }
+    router.push(checkoutPublicPath(event.id) as never);
+  }, [
+    offeringCta.kind,
+    publicEvent.tickets,
+    bookable,
+    router,
+    event.id,
+    showToast,
+  ]);
+
   const handleClose = useCallback((): void => {
     if (router.canGoBack()) {
       router.back();
@@ -396,6 +446,19 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
         callbacks={callbacks}
         hideFloatingChrome
         theme={resolvedTheme}
+        // ORCH-1117 — reserve clearance so the last inline ticket row scrolls
+        // clear of the floating bar (bar height ≈ 96 + bottom safe area).
+        contentBottomInset={96 + insets.bottom}
+      />
+
+      {/* ORCH-1117 — floating Buy bar (primary action). Non-tappable info strip
+          in every unavailable state (no dead taps); the multi-tier inline rows
+          coexist and route to the same /checkout/{eventId} cart. */}
+      <FloatingOfferingBar
+        cta={offeringCta}
+        onPress={handleFloatingBarPress}
+        surface={offeringSurface}
+        testID="orch-1117-event-floating-bar"
       />
 
       <View

--- a/mingla-business/src/components/event/__tests__/PublicEventPage.closeButton.adversarial.test.tsx
+++ b/mingla-business/src/components/event/__tests__/PublicEventPage.closeButton.adversarial.test.tsx
@@ -72,6 +72,12 @@ jest.mock("react-native-safe-area-context", () => ({
 
 jest.mock("@mingla/event-rendering", () => ({
   PublicEventPage: "SharedPublicEventPage",
+  // ORCH-1117 — the adapter now also pulls the shared theme + offering-CTA
+  // helpers + the floating bar. Stub them so the close-callback evaluator runs.
+  resolveTheme: () => ({ color: "#eb7825", foregroundColor: "#ffffff", fontFamilyValue: undefined }),
+  resolveOfferingCta: () => ({ kind: "buy", label: "Buy ticket", price: "£25", tappable: true }),
+  resolveOfferingSurface: () => "dark",
+  computeOfferingVariant: () => "published",
 }), { virtual: true });
 
 jest.mock("../../../context/AuthContext", () => ({
@@ -249,6 +255,13 @@ const renderPublicEventPage = (
         return { IconChrome: "IconChrome" };
       case "../waitlist/JoinWaitlistSheet":
         return { JoinWaitlistSheet: "JoinWaitlistSheet" };
+      // ORCH-1117 — the adapter mounts the floating Buy bar.
+      case "../offering/FloatingOfferingBar":
+        return { FloatingOfferingBar: "FloatingOfferingBar" };
+      // ORCH-1117 — pre-existing ORCH-1083 dependency the evaluator didn't stub
+      // (this adversarial test was already red on origin/main before ORCH-1117).
+      case "../../theme/useThemeFont":
+        return { useThemeFont: () => undefined };
       default:
         throw new Error(`Unexpected PublicEventPage dependency: ${request}`);
     }

--- a/mingla-business/src/components/experience/ExperienceCheckoutFlow.tsx
+++ b/mingla-business/src/components/experience/ExperienceCheckoutFlow.tsx
@@ -17,8 +17,7 @@
  */
 
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
-import { useRouter } from "expo-router";
+import { StyleSheet, Text, View } from "react-native";
 
 import {
   accent,
@@ -66,18 +65,14 @@ export const ExperienceCheckoutFlow: React.FC<ExperienceCheckoutFlowProps> = ({
   brand,
   testID,
 }) => {
-  const router = useRouter();
   const ticket = experience.ticket;
   const dateIsos = experience.dates.map((d) => d.startAt);
   const isEnded = allDatesPast(dateIsos);
-  const isFree = ticket !== null && (ticket.isFree || ticket.priceCents === 0);
 
-  const handleGetSpot = (): void => {
-    // Own chain. The buyer→payment→confirm screens POST to the EXISTING
-    // ticket-checkout-create with the experience's events-row id + the single
-    // ticket line (COMMS-0014/0016).
-    router.push(`/checkout-experience/${experience.id}` as never);
-  };
+  // ORCH-1117 — the inline Get-spot CTA is REMOVED (locked single-ticket rule).
+  // The floating Buy bar on /exp/[brandSlug]/[experienceSlug] is now the ONLY
+  // get-spot action and owns navigation to `/checkout-experience/{id}`
+  // (experienceCheckoutPath). This flow keeps the ticket recap + helper only.
 
   if (ticket === null) {
     return (
@@ -119,28 +114,6 @@ export const ExperienceCheckoutFlow: React.FC<ExperienceCheckoutFlowProps> = ({
           <Text style={styles.endedText}>This experience has ended.</Text>
         </View>
       ) : null}
-
-      <Pressable
-        onPress={handleGetSpot}
-        disabled={isEnded}
-        accessibilityRole="button"
-        accessibilityState={{ disabled: isEnded }}
-        accessibilityLabel={`Get your spot at ${experience.title}`}
-        style={({ pressed }) => [
-          styles.cta,
-          pressed && styles.ctaPressed,
-          isEnded && styles.ctaDisabled,
-        ]}
-        testID="experience-checkout-get-spot"
-      >
-        <Text style={styles.ctaText}>
-          {isEnded
-            ? "Ended"
-            : isFree
-              ? "Get my free spot"
-              : "Get my spot"}
-        </Text>
-      </Pressable>
 
       <Text style={styles.helper}>
         You&rsquo;ll enter your details + pay securely on the next screen.
@@ -212,23 +185,6 @@ const styles = StyleSheet.create({
   endedText: {
     fontSize: typography.bodySm.fontSize,
     color: textTokens.secondary,
-  },
-  cta: {
-    paddingVertical: spacing.md,
-    borderRadius: radiusTokens.md,
-    backgroundColor: accent.warm,
-    alignItems: "center",
-  },
-  ctaPressed: {
-    opacity: 0.85,
-  },
-  ctaDisabled: {
-    opacity: 0.4,
-  },
-  ctaText: {
-    fontSize: typography.body.fontSize,
-    fontWeight: "700",
-    color: "#FFFFFF",
   },
   helper: {
     fontSize: typography.caption.fontSize,

--- a/mingla-business/src/components/experience/ExperiencePreview.tsx
+++ b/mingla-business/src/components/experience/ExperiencePreview.tsx
@@ -24,6 +24,7 @@ import {
   typography,
 } from "../../constants/designSystem";
 import { Icon } from "../ui/Icon";
+import { CollapsibleDescription } from "../offering/CollapsibleDescription";
 import { EventCoverMedia } from "../ui/EventCoverMedia";
 import { formatExperienceDateSubline } from "../../utils/experienceDateSubline";
 import type {
@@ -122,10 +123,15 @@ export const ExperiencePreview: React.FC<ExperiencePreviewProps> = ({
           </Text>
         </View>
 
-        {/* Description / narrative. */}
+        {/* Description / narrative — ORCH-1117 collapsible (collapsed default). */}
         {experience.description !== null &&
         experience.description.trim().length > 0 ? (
-          <Text style={styles.description}>{experience.description}</Text>
+          <View style={styles.descriptionWrap}>
+            <CollapsibleDescription
+              text={experience.description}
+              testID="experience-preview-description"
+            />
+          </View>
         ) : null}
 
         {/* STOPS itinerary. */}
@@ -208,6 +214,11 @@ const styles = StyleSheet.create({
     fontSize: typography.body.fontSize,
     lineHeight: typography.body.lineHeight,
     color: textTokens.secondary,
+    marginTop: spacing.md,
+  },
+  // ORCH-1117 — carries the prior description marginTop now that the body text
+  // lives inside the CollapsibleDescription block.
+  descriptionWrap: {
     marginTop: spacing.md,
   },
   section: {

--- a/mingla-business/src/components/offering/CollapsibleDescription.tsx
+++ b/mingla-business/src/components/offering/CollapsibleDescription.tsx
@@ -1,0 +1,165 @@
+/**
+ * CollapsibleDescription — ORCH-1117 [public offering page polish].
+ *
+ * Shared collapsible description block for the dark-surface buyer previews
+ * (TripPreview, ExperiencePreview). Collapsed by default (3-line peek + "Read
+ * more" + down chevron); expands on tap. Copy ≤160 chars renders full with NO
+ * toggle (a toggle for 2 lines is noise) — mirrors the EVT-NATIVE reference.
+ *
+ * The whole header row is one ≥44pt tap target. State is signaled by BOTH the
+ * chevron rotation AND the "Read more"/"Show less" word — never color alone.
+ * Reduce-motion: skip the LayoutAnimation; chevron still flips (static).
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  AccessibilityInfo,
+  LayoutAnimation,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  UIManager,
+  View,
+} from "react-native";
+
+import { Icon } from "../ui/Icon";
+import {
+  accent,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+
+// Copy ≤ this fits the 3-line peek → render full, no toggle.
+const COLLAPSE_THRESHOLD = 160;
+
+if (
+  Platform.OS === "android" &&
+  UIManager.setLayoutAnimationEnabledExperimental !== undefined
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+export interface CollapsibleDescriptionProps {
+  text: string;
+  /** Optional style override for the body Text (font/size/color). */
+  bodyStyle?: object;
+  testID?: string;
+}
+
+export const CollapsibleDescription: React.FC<CollapsibleDescriptionProps> = ({
+  text,
+  bodyStyle,
+  testID,
+}) => {
+  const [collapsed, setCollapsed] = useState<boolean>(true);
+  const [reduceMotion, setReduceMotion] = useState<boolean>(false);
+
+  useEffect(() => {
+    let mounted = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (mounted) setReduceMotion(value);
+    });
+    const sub = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      (value: boolean) => setReduceMotion(value),
+    );
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+
+  const canCollapse = text.length > COLLAPSE_THRESHOLD;
+
+  const toggle = useCallback((): void => {
+    if (!reduceMotion) {
+      LayoutAnimation.configureNext(
+        LayoutAnimation.create(
+          200,
+          LayoutAnimation.Types.easeInEaseOut,
+          LayoutAnimation.Properties.opacity,
+        ),
+      );
+    }
+    setCollapsed((c) => !c);
+  }, [reduceMotion]);
+
+  if (!canCollapse) {
+    return (
+      <Text style={[styles.body, bodyStyle]} testID={testID}>
+        {text}
+      </Text>
+    );
+  }
+
+  const isClamped = collapsed;
+
+  return (
+    <View testID={testID}>
+      <Pressable
+        onPress={toggle}
+        accessibilityRole="button"
+        accessibilityLabel="About"
+        accessibilityState={{ expanded: !isClamped }}
+        accessibilityHint={
+          isClamped ? "Expands the description" : "Collapses the description"
+        }
+        style={styles.headerRow}
+      >
+        <Text
+          style={[styles.body, bodyStyle, styles.peek]}
+          numberOfLines={isClamped ? 3 : undefined}
+          ellipsizeMode="tail"
+        >
+          {text}
+        </Text>
+      </Pressable>
+      <Pressable
+        onPress={toggle}
+        accessibilityRole="button"
+        accessibilityLabel={isClamped ? "Read more" : "Show less"}
+        style={styles.toggleRow}
+        testID={testID !== undefined ? `${testID}-toggle` : undefined}
+      >
+        <Text style={styles.toggleText}>
+          {isClamped ? "Read more" : "Show less"}
+        </Text>
+        <Icon
+          name={isClamped ? "chevD" : "chevU"}
+          size={16}
+          color={accent.warm}
+        />
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  headerRow: {
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  body: {
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    color: textTokens.secondary,
+  },
+  peek: {
+    marginTop: 0,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    minHeight: 44,
+  },
+  toggleText: {
+    fontSize: typography.buttonMd.fontSize,
+    fontWeight: "600",
+    color: accent.warm,
+  },
+});
+
+export default CollapsibleDescription;

--- a/mingla-business/src/components/offering/FloatingOfferingBar.tsx
+++ b/mingla-business/src/components/offering/FloatingOfferingBar.tsx
@@ -1,0 +1,265 @@
+/**
+ * FloatingOfferingBar — ORCH-1117 [public offering page polish].
+ *
+ * The persistent bottom Buy bar for the buyer-web public offering pages
+ * (event / trip / experience). Pinned `position:absolute` above the scroll
+ * content; the page reserves bottom clearance so the last element clears it.
+ *
+ * The bar's label / tappability / reason are a PURE PROJECTION of the shared
+ * `resolveOfferingCta` (`@mingla/event-rendering`) — the SAME state machine the
+ * inline ticket row reads. This component renders the resolved `CtaState`; it
+ * does NOT compute buy-state itself (one owner).
+ *
+ * Two top-level shapes:
+ *   - tappable (buy / free / waitlist) → accent action button (Constitution #1
+ *     no dead taps: the press fires `onPress`).
+ *   - unavailable → NON-tappable info strip, `accessibilityRole="text"`, NO
+ *     onPress (the bar is informational only — never a dead Buy button).
+ *
+ * Android opaque-glass fallback (ANDROID_GLASS_USES_OPAQUE_FALLBACK): a SOLID
+ * ≥0.92 fill via Platform.select, clipped overflow, NO Android shadow — so a
+ * buyer never sees scroll text ghosting through the price.
+ *
+ * Anon-tolerant: no useAuth, no data fetch. Pure presentational.
+ */
+
+import React from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import * as Haptics from "expo-haptics";
+
+import type { CtaState } from "@mingla/event-rendering";
+import {
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+
+export interface FloatingOfferingBarProps {
+  cta: CtaState;
+  /** Fired ONLY for tappable states (buy / free / waitlist). */
+  onPress: () => void;
+  /**
+   * Surface tone. Trip/experience pages are fixed-dark; the event page is
+   * theme-driven and passes "light" when its resolved palette is a light page.
+   */
+  surface?: "dark" | "light";
+  testID?: string;
+}
+
+const DARK = {
+  fill: "rgba(18,20,24,0.92)",
+  fillAndroid: "#16181b",
+  border: "rgba(255,255,255,0.12)",
+  primary: textTokens.primary,
+  tertiary: textTokens.tertiary,
+  strip: "rgba(255,255,255,0.06)",
+  stripTitle: textTokens.secondary,
+} as const;
+
+const LIGHT = {
+  fill: "rgba(255,255,255,0.94)",
+  fillAndroid: "#f4f6f9",
+  border: "rgba(16,20,31,0.12)",
+  primary: "#0c0e12",
+  tertiary: "rgba(16,20,31,0.56)",
+  strip: "rgba(16,20,31,0.05)",
+  stripTitle: "rgba(16,20,31,0.72)",
+} as const;
+
+const ACCENT = "#eb7825";
+
+export const FloatingOfferingBar: React.FC<FloatingOfferingBarProps> = ({
+  cta,
+  onPress,
+  surface = "dark",
+  testID,
+}) => {
+  const insets = useSafeAreaInsets();
+  const tone = surface === "light" ? LIGHT : DARK;
+
+  // Solid ≥0.92 fill on Android (no rgba bleed), clipped, no shadow.
+  const fill =
+    Platform.OS === "android" ? tone.fillAndroid : tone.fill;
+  const elevation = Platform.OS === "android" ? 0 : undefined;
+
+  const handlePress = (): void => {
+    if (!cta.tappable) return;
+    if (Platform.OS !== "web") {
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+        () => {},
+      );
+    }
+    onPress();
+  };
+
+  return (
+    <View style={styles.wrapper} pointerEvents="box-none">
+      <View
+        style={[
+          styles.bar,
+          {
+            backgroundColor: fill,
+            borderTopColor: tone.border,
+            paddingBottom: insets.bottom + spacing.sm,
+            ...(elevation !== undefined
+              ? { elevation, shadowOpacity: 0 }
+              : {}),
+          },
+        ]}
+        testID={testID}
+      >
+        <View style={styles.inner}>
+          {cta.tappable ? (
+            <>
+              {cta.kind === "buy" ? (
+                <View style={styles.priceCol}>
+                  <Text style={[styles.priceValue, { color: tone.primary }]}>
+                    {cta.price}
+                  </Text>
+                </View>
+              ) : (
+                <View style={styles.priceCol} />
+              )}
+              <Pressable
+                onPress={handlePress}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  cta.kind === "buy" && cta.price.length > 0
+                    ? `${cta.label}, ${cta.price}`
+                    : cta.label
+                }
+                style={({ pressed }) => [
+                  styles.button,
+                  pressed && styles.buttonPressed,
+                ]}
+                testID={
+                  testID !== undefined ? `${testID}-action` : undefined
+                }
+              >
+                <Text style={styles.buttonLabel}>{cta.label}</Text>
+              </Pressable>
+            </>
+          ) : (
+            // Unavailable — NON-tappable info strip. accessibilityRole "text"
+            // (NOT "button"): screen readers must not offer "double-tap to
+            // activate" a dead control. No onPress anywhere on this branch.
+            <View
+              style={[styles.strip, { backgroundColor: tone.strip }]}
+              accessibilityRole="text"
+              accessibilityLabel={
+                cta.subline !== null
+                  ? `${cta.title}. ${cta.subline}`
+                  : cta.title
+              }
+              testID={
+                testID !== undefined ? `${testID}-unavailable` : undefined
+              }
+            >
+              <Text style={[styles.stripGlyph, { color: tone.tertiary }]}>
+                ⓘ
+              </Text>
+              <View style={styles.stripTextCol}>
+                <Text
+                  style={[styles.stripTitle, { color: tone.stripTitle }]}
+                >
+                  {cta.title}
+                </Text>
+                {cta.subline !== null ? (
+                  <Text
+                    style={[styles.stripSubline, { color: tone.tertiary }]}
+                  >
+                    {cta.subline}
+                  </Text>
+                ) : null}
+              </View>
+            </View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 6,
+  },
+  bar: {
+    overflow: "hidden",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    // iOS/web upward shadow (Android suppressed inline — opaque-fill rule).
+    shadowColor: "#000000",
+    shadowOpacity: 0.28,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: -8 },
+  },
+  inner: {
+    maxWidth: 660,
+    width: "100%",
+    alignSelf: "center",
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  priceCol: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  priceValue: {
+    fontSize: 19,
+    lineHeight: 24,
+    fontWeight: "900",
+  },
+  button: {
+    minHeight: 56,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radiusTokens.lg,
+    backgroundColor: ACCENT,
+    alignItems: "center",
+    justifyContent: "center",
+    marginLeft: spacing.md,
+  },
+  buttonPressed: {
+    opacity: 0.85,
+    transform: [{ scale: 0.98 }],
+  },
+  buttonLabel: {
+    fontSize: 17,
+    fontWeight: "900",
+    color: "#ffffff",
+  },
+  strip: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: 56,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radiusTokens.lg,
+    gap: spacing.sm,
+  },
+  stripGlyph: {
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  stripTextCol: {
+    flex: 1,
+  },
+  stripTitle: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "700",
+  },
+  stripSubline: {
+    fontSize: typography.caption.fontSize,
+    marginTop: 2,
+  },
+});
+
+export default FloatingOfferingBar;

--- a/mingla-business/src/components/offering/__tests__/offeringCta.orch1117.test.ts
+++ b/mingla-business/src/components/offering/__tests__/offeringCta.orch1117.test.ts
@@ -1,0 +1,206 @@
+/**
+ * ORCH-1117 happy-path regression tests — the hoisted buy/unavailable state
+ * machine (`resolveOfferingCta`), the luminance-safe palette contrast, and the
+ * collapsed-by-default About contract.
+ *
+ * Owner: mingla-implementor (the tester adds a SECOND adversarial angle).
+ *
+ * fails-on-revert: deleting the `if (!bookable) {...}` gate at the TOP of
+ * resolveOfferingCta makes T-CTA-UNAVAIL fail (a not-bookable paid event would
+ * resolve to "buy" instead of the non-tappable "unavailable" strip).
+ */
+
+// Import the pure module directly from the package source by relative path —
+// offeringCta imports ONLY types from ./types (no RN runtime), so it resolves
+// under ts-jest without the @mingla path alias / a package mock.
+import {
+  resolveOfferingCta,
+  computeOfferingVariant,
+} from "../../../../../packages/event-rendering/offeringCta";
+import type {
+  PublicTicketProps,
+  PublicEventProps,
+} from "../../../../../packages/event-rendering/types";
+
+const baseTicket = (over: Partial<PublicTicketProps> = {}): PublicTicketProps => ({
+  id: over.id ?? "tt-1",
+  name: over.name ?? "General",
+  description: null,
+  priceGbp: over.priceGbp ?? 25,
+  priceAllInGbp: over.priceAllInGbp ?? 25,
+  currency: over.currency ?? "GBP",
+  isFree: over.isFree ?? false,
+  isUnlimited: over.isUnlimited ?? true,
+  capacity: over.capacity ?? null,
+  visibility: over.visibility ?? "visible",
+  passwordProtected: false,
+  password: null,
+  saleStartAt: over.saleStartAt ?? null,
+  saleEndAt: over.saleEndAt ?? null,
+  approvalRequired: false,
+  waitlistEnabled: over.waitlistEnabled ?? false,
+  availableAt: over.availableAt ?? "online",
+  displayOrder: over.displayOrder ?? 0,
+});
+
+describe("ORCH-1117 resolveOfferingCta — buy/unavailable state machine", () => {
+  // T-CTA-BUY
+  it("renders a tappable Buy with a 'From {price}' label for a bookable multi-tier paid event", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        baseTicket({ id: "a", priceAllInGbp: 25 }),
+        baseTicket({ id: "b", priceAllInGbp: 40 }),
+      ],
+      currency: "GBP",
+    });
+    expect(cta.kind).toBe("buy");
+    expect(cta.tappable).toBe(true);
+    if (cta.kind === "buy") {
+      expect(cta.label).toBe("Buy ticket");
+      expect(cta.price).toMatch(/^From /);
+      expect(cta.price).toContain("25");
+    }
+  });
+
+  // single tier → bare price (no "From")
+  it("uses a bare price (no 'From') for a single paid tier", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [baseTicket({ priceAllInGbp: 30 })],
+      currency: "GBP",
+    });
+    if (cta.kind === "buy") {
+      expect(cta.price.startsWith("From ")).toBe(false);
+      expect(cta.price).toContain("30");
+    } else {
+      throw new Error("expected a buy CTA");
+    }
+  });
+
+  // T-CTA-UNAVAIL — fails-on-revert anchor (delete the !bookable gate → this fails)
+  it("renders a NON-tappable 'Booking unavailable' strip when the paid brand can't charge", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: false,
+      tickets: [baseTicket({ priceAllInGbp: 25 })],
+      currency: "GBP",
+    });
+    expect(cta.kind).toBe("unavailable");
+    expect(cta.tappable).toBe(false);
+    if (cta.kind === "unavailable") {
+      expect(cta.title).toBe("Booking unavailable");
+      expect(cta.subline).toBe("The organizer is finishing payment setup.");
+    }
+  });
+
+  // T-CTA-SOLDOUT
+  it("renders a NON-tappable 'Sold out' strip when all tiers are sold out (no waitlist)", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        baseTicket({ isUnlimited: false, capacity: 0, waitlistEnabled: false }),
+      ],
+      currency: "GBP",
+    });
+    expect(cta.kind).toBe("unavailable");
+    expect(cta.tappable).toBe(false);
+    if (cta.kind === "unavailable") expect(cta.title).toBe("Sold out");
+  });
+
+  // T-CTA-WAITLIST
+  it("renders a tappable 'Join waitlist' when sold out + waitlist enabled", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        baseTicket({ isUnlimited: false, capacity: 0, waitlistEnabled: true }),
+      ],
+      currency: "GBP",
+    });
+    expect(cta.kind).toBe("waitlist");
+    expect(cta.tappable).toBe(true);
+  });
+
+  it("renders a tappable free CTA when every visible tier is free", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [baseTicket({ isFree: true, priceAllInGbp: null, priceGbp: null })],
+      currency: "GBP",
+      freeVerb: "Get free ticket",
+    });
+    expect(cta.kind).toBe("free");
+    expect(cta.tappable).toBe(true);
+  });
+
+  it("renders a NON-tappable 'Sales ended' strip for a past offering", () => {
+    const cta = resolveOfferingCta({
+      variant: "past",
+      bookable: true,
+      tickets: [baseTicket()],
+      currency: "GBP",
+    });
+    expect(cta.kind).toBe("unavailable");
+    expect(cta.tappable).toBe(false);
+    if (cta.kind === "unavailable") expect(cta.title).toBe("Sales ended");
+  });
+
+  it("honors a custom buy verb (trip 'Reserve my spot')", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [baseTicket({ priceAllInGbp: 120 })],
+      currency: "GBP",
+      buyVerb: "Reserve my spot",
+    });
+    if (cta.kind === "buy") expect(cta.label).toBe("Reserve my spot");
+    else throw new Error("expected a buy CTA");
+  });
+});
+
+describe("ORCH-1117 computeOfferingVariant — shared variant owner", () => {
+  const baseEvent = (over: Partial<PublicEventProps> = {}): PublicEventProps =>
+    ({
+      id: "e1",
+      name: "Night",
+      brandId: "b1",
+      brandSlug: "b",
+      eventSlug: "e",
+      description: "x",
+      dateLine: "Sat",
+      dateSubline: null,
+      datesList: [],
+      status: over.status ?? "published",
+      endedAt: over.endedAt ?? null,
+      format: "in-person",
+      venueName: null,
+      address: null,
+      hideAddressUntilTicket: false,
+      coverHue: 25,
+      coverMediaUrl: null,
+      coverMediaType: null,
+      coverCredit: null,
+      tickets: over.tickets ?? [baseTicket()],
+      currency: "GBP",
+    }) as PublicEventProps;
+
+  it("flags a cancelled event", () => {
+    expect(computeOfferingVariant(baseEvent({ status: "cancelled" }), false)).toBe(
+      "cancelled",
+    );
+  });
+
+  it("flags an ended event as past", () => {
+    expect(computeOfferingVariant(baseEvent({ status: "ended" }), false)).toBe(
+      "past",
+    );
+  });
+
+  it("returns published for a live sellable event", () => {
+    expect(computeOfferingVariant(baseEvent(), false)).toBe("published");
+  });
+});

--- a/mingla-business/src/components/offering/__tests__/offeringCtaDeadTap.orch1117.adversarial.test.ts
+++ b/mingla-business/src/components/offering/__tests__/offeringCtaDeadTap.orch1117.adversarial.test.ts
@@ -1,0 +1,389 @@
+/**
+ * ORCH-1117 [public offering page polish] — TESTER adversarial regression.
+ *
+ * Owner: mingla-tester. Attacks angles DIFFERENT from the implementor's
+ * happy-path `offeringCta.orch1117.test.ts` (which asserts ONE resolved state
+ * per scenario) and `offeringLegibility.orch1117.test.ts` (near-white WCAG /
+ * shadow / collapse-default).
+ *
+ * Adversarial angles attacked here:
+ *
+ *   B1. DEAD-TAP STATE-MACHINE EXHAUSTIVENESS (Constitution #1, source level).
+ *       The runtime dead-tap proof is on-device; this pins the SOURCE invariant
+ *       that the floating bar's renderer relies on: EVERY `unavailable` CtaState
+ *       carries `tappable:false`, and the ONLY `tappable:true` kinds are
+ *       buy/free/waitlist. A future edit that flips an unavailable branch to
+ *       `tappable:true` (re-introducing a dead Buy button) breaks this. The
+ *       implementor's tests check a handful of titles; none assert the
+ *       exhaustive tappable<->kind coupling across the full enum surface.
+ *
+ *   B2. MIXED / PRECEDENCE-COLLISION STATES never leak a tappable buy. When
+ *       door-only, sale-ended, and sold-out tickets coexist (and the SPEC
+ *       precedence order differs from the impl's check order), the resolved
+ *       state must STILL be non-tappable — no combination of unavailable tiers
+ *       may resolve to a tappable Buy. The happy-path tests only feed single
+ *       homogeneous tier sets.
+ *
+ *   B3. WYSIWYP / no-fee-recompute (I-PAID-SUPPLY + all-in pricing). The bar
+ *       price must equal the ticket's all-in `priceAllInGbp` verbatim — the
+ *       resolver must NOT do fee/tax arithmetic. Asserted both behaviorally
+ *       (price string contains the exact all-in number, not a fee-adjusted one)
+ *       AND structurally (the module source has no fee/tax math tokens).
+ *
+ *   B4. INLINE SINGLE-CTA TRULY ABSENT on the trip + experience ROUTES, and the
+ *       floating bar present. ORCH-1117 LOCKED rule (§4.5): single-ticket
+ *       trips/experiences have NO inline Reserve/Get-spot CTA — the floating bar
+ *       is the only CTA. Reintroducing an inline `trip-checkout-reserve` /
+ *       `experience-checkout-get-spot` Pressable on the route breaks this.
+ *
+ * fails-on-revert (each angle, verified by the tester):
+ *   B1 — flip any `unavailable` branch in offeringCta.ts to `tappable:true` → B1 fails.
+ *   B3 — make formatPrice add a fee (e.g. `price * 1.1`) → B3 behavioral fails.
+ *   B4 — re-add an inline `testID="trip-checkout-reserve"` Pressable to the trip
+ *        route or TripCheckoutFlow → B4 fails.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  resolveOfferingCta,
+  type CtaState,
+} from "../../../../../packages/event-rendering/offeringCta";
+import type { PublicTicketProps } from "../../../../../packages/event-rendering/types";
+
+const PKG_OFFERING_CTA = resolve(
+  __dirname,
+  "../../../../../packages/event-rendering/offeringCta.ts",
+);
+const SRC_ROOT = join(__dirname, "..", "..", "..");
+const APP_ROOT = join(__dirname, "..", "..", "..", "..", "app");
+const read = (rel: string): string =>
+  readFileSync(join(SRC_ROOT, rel), "utf8");
+const readApp = (rel: string): string =>
+  readFileSync(join(APP_ROOT, rel), "utf8");
+
+const ticket = (over: Partial<PublicTicketProps> = {}): PublicTicketProps => ({
+  id: over.id ?? "t",
+  name: over.name ?? "Tier",
+  description: null,
+  priceGbp: over.priceGbp ?? 25,
+  priceAllInGbp: over.priceAllInGbp ?? 25,
+  currency: over.currency ?? "GBP",
+  isFree: over.isFree ?? false,
+  isUnlimited: over.isUnlimited ?? true,
+  capacity: over.capacity ?? null,
+  visibility: over.visibility ?? "visible",
+  passwordProtected: false,
+  password: null,
+  saleStartAt: over.saleStartAt ?? null,
+  saleEndAt: over.saleEndAt ?? null,
+  approvalRequired: false,
+  waitlistEnabled: over.waitlistEnabled ?? false,
+  availableAt: over.availableAt ?? "online",
+  displayOrder: over.displayOrder ?? 0,
+});
+
+const PAST = new Date(Date.now() - 86_400_000).toISOString();
+
+// ============================================================
+// B1 — Dead-tap exhaustiveness: every non-buyable state is non-tappable
+// ============================================================
+
+describe("ORCH-1117 adversarial B1 — no dead taps (tappable<->kind coupling)", () => {
+  // A representative input for EVERY terminal CtaState the resolver can emit.
+  const cases: Array<{ name: string; cta: CtaState }> = [
+    {
+      name: "not-bookable (paid brand can't charge)",
+      cta: resolveOfferingCta({
+        variant: "published",
+        bookable: false,
+        tickets: [ticket()],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "cancelled",
+      cta: resolveOfferingCta({
+        variant: "cancelled",
+        bookable: true,
+        tickets: [ticket()],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "past / sales ended (variant)",
+      cta: resolveOfferingCta({
+        variant: "past",
+        bookable: true,
+        tickets: [ticket()],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "pre-sale",
+      cta: resolveOfferingCta({
+        variant: "pre-sale",
+        bookable: true,
+        tickets: [ticket()],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "no visible tickets",
+      cta: resolveOfferingCta({
+        variant: "published",
+        bookable: true,
+        tickets: [ticket({ visibility: "hidden" })],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "all door-only",
+      cta: resolveOfferingCta({
+        variant: "published",
+        bookable: true,
+        tickets: [ticket({ availableAt: "door" })],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "all sale-ended (per-ticket saleEndAt)",
+      cta: resolveOfferingCta({
+        variant: "published",
+        bookable: true,
+        tickets: [ticket({ saleEndAt: PAST })],
+        currency: "GBP",
+      }),
+    },
+    {
+      name: "all sold-out, no waitlist",
+      cta: resolveOfferingCta({
+        variant: "published",
+        bookable: true,
+        tickets: [ticket({ isUnlimited: false, capacity: 0 })],
+        currency: "GBP",
+      }),
+    },
+  ];
+
+  it.each(cases)(
+    "$name resolves to a NON-tappable unavailable strip",
+    ({ cta }) => {
+      expect(cta.kind).toBe("unavailable");
+      expect(cta.tappable).toBe(false);
+    },
+  );
+
+  it("the ONLY tappable kinds are buy/free/waitlist (no unavailable is ever tappable)", () => {
+    // Buy
+    const buy = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [ticket()],
+      currency: "GBP",
+    });
+    // Free
+    const free = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [ticket({ isFree: true, priceAllInGbp: null, priceGbp: null })],
+      currency: "GBP",
+    });
+    // Waitlist
+    const wl = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        ticket({ isUnlimited: false, capacity: 0, waitlistEnabled: true }),
+      ],
+      currency: "GBP",
+    });
+    for (const cta of [buy, free, wl]) {
+      expect(["buy", "free", "waitlist"]).toContain(cta.kind);
+      expect(cta.tappable).toBe(true);
+    }
+    // The unavailable kind must never carry tappable:true — TYPE + runtime.
+    const unavail = resolveOfferingCta({
+      variant: "past",
+      bookable: true,
+      tickets: [ticket()],
+      currency: "GBP",
+    });
+    expect(unavail.tappable).toBe(false);
+  });
+
+  it("SOURCE INVARIANT: no `unavailable` literal in offeringCta carries tappable:true", () => {
+    const src = readFileSync(PKG_OFFERING_CTA, "utf8");
+    // Find every object literal that sets kind:"unavailable"; none may also set
+    // tappable:true. Cheap structural guard: there is no `tappable: true`
+    // within any unavailable return block. We assert the inverse pairing never
+    // appears: the token sequence `"unavailable"` ... `tappable: true` inside
+    // the same short return object.
+    const unavailBlocks = src.match(
+      /kind:\s*"unavailable"[\s\S]{0,200}?tappable:\s*(true|false)/g,
+    );
+    expect(unavailBlocks).not.toBeNull();
+    for (const block of unavailBlocks ?? []) {
+      expect(block).toMatch(/tappable:\s*false/);
+      expect(block).not.toMatch(/tappable:\s*true/);
+    }
+  });
+});
+
+// ============================================================
+// B2 — Mixed / precedence-collision states never leak a tappable buy
+// ============================================================
+
+describe("ORCH-1117 adversarial B2 — mixed unavailable tiers (DOCUMENTED GAP P2-1)", () => {
+  // P2-1 (tester Discovery): the resolver's unavailable branches are
+  // HOMOGENEOUS `.every()` checks (all-door / all-ended / all-sold-out). When
+  // unavailable tiers are MIXED via DIFFERENT reasons (e.g. one door-only + one
+  // sale-ended), no `.every()` branch fires; `sellable` is empty so it falls
+  // back to `considered = visible` (offeringCta.ts:234) and resolves to a
+  // TAPPABLE "Buy" that routes to a cart with no purchasable tier. This is a
+  // misleading CTA (soft dead-end), NOT a hard dead-tap (the tap DOES navigate
+  // to the cart, the existing backstop). The SPEC §4.0 precedence only defines
+  // homogeneous unavailable states, so this is a spec GAP, not a violation.
+  // These tests PIN the CURRENT behavior so a future fix is intentional and
+  // visible. Recommended fix: when `sellable.length === 0`, return an
+  // unavailable("Not on sale") strip instead of falling back to `visible`.
+
+  it("[GAP] door-only + sale-ended mix currently resolves to a tappable buy (no sellable tier)", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        ticket({ id: "a", availableAt: "door" }),
+        ticket({ id: "b", saleEndAt: PAST }),
+      ],
+      currency: "GBP",
+    });
+    // CURRENT behavior (the gap): a tappable buy. A future fix should flip this
+    // to a non-tappable strip — at which point this assertion is updated in a
+    // follow-on ORCH with its own [TEST-MOD-APPROVED].
+    expect(cta.tappable).toBe(true);
+    expect(cta.kind).toBe("buy");
+  });
+
+  it("[GAP] sold-out + door-only mix (no waitlist) currently resolves to a tappable buy", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        ticket({ id: "a", isUnlimited: false, capacity: 0 }),
+        ticket({ id: "b", availableAt: "door" }),
+      ],
+      currency: "GBP",
+    });
+    expect(cta.tappable).toBe(true);
+  });
+
+  it("not-bookable gate WINS over an otherwise-sellable tier (precedence)", () => {
+    // A perfectly sellable live tier, but the brand can't charge → the gate
+    // must fire FIRST and produce the non-tappable 'Booking unavailable' strip.
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: false,
+      tickets: [ticket({ id: "live", priceAllInGbp: 30 })],
+      currency: "GBP",
+    });
+    expect(cta.kind).toBe("unavailable");
+    expect(cta.tappable).toBe(false);
+    if (cta.kind === "unavailable") {
+      expect(cta.title).toBe("Booking unavailable");
+    }
+  });
+
+  it("one sellable tier among unavailable tiers IS tappable (positive control)", () => {
+    // Guards against an over-broad fix that would hide a genuinely sellable
+    // listing. One live paid tier + a sold-out tier → tappable buy.
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        ticket({ id: "sold", isUnlimited: false, capacity: 0 }),
+        ticket({ id: "live", priceAllInGbp: 45 }),
+      ],
+      currency: "GBP",
+    });
+    expect(cta.tappable).toBe(true);
+    expect(cta.kind).toBe("buy");
+  });
+});
+
+// ============================================================
+// B3 — WYSIWYP: the bar price is the all-in value, never fee-recomputed
+// ============================================================
+
+describe("ORCH-1117 adversarial B3 — no fee recompute (all-in WYSIWYP)", () => {
+  it("a single-tier buy price equals the ticket's all-in value verbatim", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [ticket({ priceAllInGbp: 37, priceGbp: 30 })],
+      currency: "GBP",
+    });
+    if (cta.kind !== "buy") throw new Error("expected a buy CTA");
+    // The all-in is 37 (priceAllInGbp), NOT 30 (base priceGbp) and NOT any
+    // fee-adjusted number — the resolver must read priceAllInGbp as-is.
+    expect(cta.price).toContain("37");
+    expect(cta.price).not.toContain("30");
+  });
+
+  it("multi-tier 'From' price is the LOWEST all-in, not a summed/averaged value", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [
+        ticket({ id: "a", priceAllInGbp: 80 }),
+        ticket({ id: "b", priceAllInGbp: 55 }),
+      ],
+      currency: "GBP",
+    });
+    if (cta.kind !== "buy") throw new Error("expected a buy CTA");
+    expect(cta.price).toMatch(/^From /);
+    expect(cta.price).toContain("55");
+    expect(cta.price).not.toContain("80");
+  });
+
+  it("SOURCE INVARIANT: offeringCta module has no fee/tax arithmetic tokens", () => {
+    const src = readFileSync(PKG_OFFERING_CTA, "utf8");
+    expect(src).not.toMatch(/feeCents|serviceFee|taxRate|computeFee|applyFee/i);
+    // No multiplicative fee scaling on a price (e.g. price * 1.1).
+    expect(src).not.toMatch(/price[A-Za-z]*\s*\*\s*[0-9.]/);
+  });
+});
+
+// ============================================================
+// B4 — Inline single-CTA truly absent on the trip + experience routes
+// ============================================================
+
+describe("ORCH-1117 adversarial B4 — single-ticket inline CTA removed (bar is only CTA)", () => {
+  const TRIP_ROUTE = readApp("t/[brandSlug]/[tripSlug].tsx");
+  const EXP_ROUTE = readApp("exp/[brandSlug]/[experienceSlug].tsx");
+  const TRIP_FLOW = read("components/trip/TripCheckoutFlow.tsx");
+  const EXP_FLOW = read("components/experience/ExperienceCheckoutFlow.tsx");
+
+  it("TripCheckoutFlow no longer renders the inline trip-checkout-reserve Pressable", () => {
+    expect(TRIP_FLOW).not.toMatch(/testID=["']trip-checkout-reserve["']/);
+  });
+
+  it("ExperienceCheckoutFlow no longer renders the inline experience-checkout-get-spot Pressable", () => {
+    expect(EXP_FLOW).not.toMatch(/testID=["']experience-checkout-get-spot["']/);
+  });
+
+  it("the trip route mounts the floating bar and routes it to the trip-specific chain", () => {
+    expect(TRIP_ROUTE).toMatch(/FloatingOfferingBar/);
+    expect(TRIP_ROUTE).toMatch(/orch-1117-trip-floating-bar/);
+    expect(TRIP_ROUTE).toMatch(/tripCheckoutPath\(trip\.id\)/);
+    // Never the events chain that hard-rejects trip rows.
+    expect(TRIP_ROUTE).not.toMatch(/checkoutPublicPath\(trip\.id\)/);
+  });
+
+  it("the experience route mounts the floating bar and routes it to the experience chain", () => {
+    expect(EXP_ROUTE).toMatch(/FloatingOfferingBar/);
+    expect(EXP_ROUTE).toMatch(/orch-1117-experience-floating-bar/);
+    expect(EXP_ROUTE).toMatch(/experienceCheckoutPath\(experience\.id\)/);
+  });
+});

--- a/mingla-business/src/components/offering/__tests__/offeringLegibility.orch1117.test.ts
+++ b/mingla-business/src/components/offering/__tests__/offeringLegibility.orch1117.test.ts
@@ -1,0 +1,107 @@
+/**
+ * ORCH-1117 happy-path regression — white-theme legibility (#1), title-shadow
+ * removal (#4), and the collapsed-by-default About (#2) STRUCTURAL contracts on
+ * the shared package.
+ *
+ * These are source-structure + first-principles WCAG assertions (the package's
+ * full RN render is not unit-mountable here — no react-test-renderer). The
+ * adversarial render-level proof is the tester's job; this locks the contracts.
+ *
+ * fails-on-revert:
+ *   - #1: re-adding `color: "#ffffff"` on the date line / pill makes the
+ *     "no raw white in the render body" assertion FAIL (mirrors the strict-grep
+ *     guard).
+ *   - #4: re-adding `textShadowColor` to `titleLine` makes the shadow assertion
+ *     FAIL.
+ *   - #2: flipping the About default to `useState(false)` makes the
+ *     collapsed-by-default assertion FAIL.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+
+const PKG = path.resolve(
+  __dirname,
+  "../../../../../packages/event-rendering/PublicEventPage.tsx",
+);
+const SRC = readFileSync(PKG, "utf8");
+
+// The render body is everything BEFORE the StyleSheet block (where the
+// intentional white-on-accent literals live).
+const styleCut = SRC.indexOf("const styles = StyleSheet.create(");
+const RENDER_BODY = styleCut === -1 ? SRC : SRC.slice(0, styleCut);
+const STYLE_BLOCK = styleCut === -1 ? "" : SRC.slice(styleCut);
+
+// ── WCAG contrast helpers (mirror the package's own, computed independently) ──
+function linearize(channel: number): number {
+  const n = channel / 255;
+  return n <= 0.03928 ? n / 12.92 : ((n + 0.055) / 1.055) ** 2.4;
+}
+function luminance(hex: string): number {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (m === null) throw new Error(`bad hex ${hex}`);
+  const v = m[1];
+  const r = parseInt(v.slice(0, 2), 16);
+  const g = parseInt(v.slice(2, 4), 16);
+  const b = parseInt(v.slice(4, 6), 16);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+function contrast(a: string, b: string): number {
+  const hi = Math.max(luminance(a), luminance(b));
+  const lo = Math.min(luminance(a), luminance(b));
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe("ORCH-1117 #1 — white-theme legibility (luminance-safe palette)", () => {
+  // T-LUM-HAPPY: on a near-white page the palette's primaryText is the dark
+  // base (#000000), which is AA-safe (≥4.5:1) as text on that page. This proves
+  // the recurrence-pill label (now palette.primaryText) is legible where raw
+  // white was invisible.
+  it("a near-white page resolves a primaryText (dark) that is ≥4.5:1 on the page", () => {
+    const nearWhitePage = "#f8fafc"; // the package's lightBase
+    // readableTextFor picks #000000 vs #ffffff by max contrast.
+    const fg =
+      contrast("#000000", nearWhitePage) >= contrast("#ffffff", nearWhitePage)
+        ? "#000000"
+        : "#ffffff";
+    expect(fg).toBe("#000000");
+    expect(contrast(fg, nearWhitePage)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("raw white on a near-white page is BELOW AA (the bug being fixed)", () => {
+    expect(contrast("#ffffff", "#f8fafc")).toBeLessThan(4.5);
+  });
+
+  it("the render body contains NO raw white on a text element (date/pill use palette)", () => {
+    expect(/color:\s*["'](#ffffff|#fff)["']/i.test(RENDER_BODY)).toBe(false);
+  });
+
+  it("the date line + recurrence pill read from the palette", () => {
+    expect(RENDER_BODY).toContain("color: palette.accent");
+    expect(RENDER_BODY).toContain("color: palette.primaryText");
+  });
+});
+
+describe("ORCH-1117 #4 — title shadow removed", () => {
+  it("the titleLine style carries no textShadow* keys", () => {
+    const m = /titleLine:\s*\{([\s\S]*?)\}/.exec(STYLE_BLOCK);
+    expect(m).not.toBeNull();
+    const titleLineStyle = m === null ? "" : m[1];
+    expect(titleLineStyle).not.toMatch(/textShadow(Color|Offset|Radius)/);
+  });
+});
+
+describe("ORCH-1117 #2 — collapsible About (collapsed by default)", () => {
+  it("the About starts collapsed (useState(true)) in the package", () => {
+    expect(RENDER_BODY).toMatch(/aboutCollapsed.*useState<boolean>\(true\)/);
+  });
+
+  it("the About body clamps to 3 lines when collapsed", () => {
+    expect(RENDER_BODY).toMatch(/numberOfLines=\{collapsed \? 3 : undefined\}/);
+  });
+
+  it("uses the 160-char short-copy exception threshold", () => {
+    expect(RENDER_BODY).toContain("ABOUT_COLLAPSE_THRESHOLD");
+    expect(SRC).toMatch(/ABOUT_COLLAPSE_THRESHOLD\s*=\s*160/);
+  });
+});

--- a/mingla-business/src/components/trip/TripCheckoutFlow.tsx
+++ b/mingla-business/src/components/trip/TripCheckoutFlow.tsx
@@ -20,8 +20,7 @@
  */
 
 import React, { useMemo } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
-import { useRouter } from "expo-router";
+import { StyleSheet, Text, View } from "react-native";
 
 import {
   accent,
@@ -59,7 +58,6 @@ export const TripCheckoutFlow: React.FC<TripCheckoutFlowProps> = ({
   brand,
   testID,
 }) => {
-  const router = useRouter();
   const tier = trip.pricingTiers[0];
 
   // ORCH-0882 [Render Payment Plan Disclosure on Trip Buyer + Planner
@@ -74,14 +72,16 @@ export const TripCheckoutFlow: React.FC<TripCheckoutFlowProps> = ({
     [tier],
   );
 
-  const handleReserve = (): void => {
-    // ORCH-0876: trip-specific chain. Event-side /checkout/[eventId]/*
-    // hard-rejects trips by audit-test invariant — see
-    // mingla-business/src/services/__tests__/eventType.filter.audit.test.ts.
-    // The underlying biz_ticket_checkout_create_session RPC stays shared
-    // (branches on event_type='trip' per Tr3 [ORCH-0869] migration).
-    router.push(`/checkout-trip/${trip.id}` as never);
-  };
+  // ORCH-1117 — the inline Reserve CTA is REMOVED (locked single-ticket rule).
+  // The floating Buy bar on /t/[brandSlug]/[tripSlug] is now the ONLY Reserve
+  // action and owns navigation to `/checkout-trip/{trip.id}` (tripCheckoutPath).
+  // TripCheckoutFlow keeps the tier/plan recap + helper copy only.
+  //
+  // ORCH-0876 trip-specific chain invariant PRESERVED (moved, not dropped): the
+  // Reserve nav still targets `/checkout-trip/{trip.id}`, never the events-side
+  // `/checkout/{id}` chain (getPublicEventById hard-rejects trip rows by
+  // audit-test invariant — eventType.filter.audit.test.ts). The nav now lives in
+  // the route's floating bar via tripCheckoutPath(trip.id).
 
   if (tier === undefined) {
     return (
@@ -122,16 +122,6 @@ export const TripCheckoutFlow: React.FC<TripCheckoutFlowProps> = ({
           />
         </View>
       ) : null}
-
-      <Pressable
-        onPress={handleReserve}
-        accessibilityRole="button"
-        accessibilityLabel={`Reserve your spot on ${trip.title}`}
-        style={styles.cta}
-        testID="trip-checkout-reserve"
-      >
-        <Text style={styles.ctaText}>Reserve my spot</Text>
-      </Pressable>
 
       <Text style={styles.helper}>
         You&rsquo;ll enter your details + pay securely on the next screen.
@@ -192,17 +182,6 @@ const styles = StyleSheet.create({
   // and the Reserve CTA with consistent vertical spacing.
   planWrap: {
     width: "100%",
-  },
-  cta: {
-    paddingVertical: spacing.md,
-    borderRadius: radiusTokens.md,
-    backgroundColor: accent.warm,
-    alignItems: "center",
-  },
-  ctaText: {
-    fontSize: typography.body.fontSize,
-    fontWeight: "700",
-    color: "#FFFFFF",
   },
   helper: {
     fontSize: typography.caption.fontSize,

--- a/mingla-business/src/components/trip/TripPreview.tsx
+++ b/mingla-business/src/components/trip/TripPreview.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../constants/designSystem";
 import { formatTripDateRange } from "@mingla/event-rendering";
 import { Icon } from "../ui/Icon";
+import { CollapsibleDescription } from "../offering/CollapsibleDescription";
 import type {
   Trip,
   TripDay,
@@ -161,9 +162,14 @@ export const TripPreview: React.FC<TripPreviewProps> = ({
           </View>
         ) : null}
 
-        {/* Description */}
+        {/* Description — ORCH-1117 collapsible (collapsed by default). */}
         {trip.description !== null && trip.description.trim().length > 0 ? (
-          <Text style={styles.description}>{trip.description}</Text>
+          <View style={styles.descriptionWrap}>
+            <CollapsibleDescription
+              text={trip.description}
+              testID="trip-preview-description"
+            />
+          </View>
         ) : null}
 
         {/* Itinerary */}
@@ -291,6 +297,11 @@ const styles = StyleSheet.create({
     fontSize: typography.body.fontSize,
     lineHeight: typography.body.lineHeight,
     color: textTokens.secondary,
+    marginTop: spacing.md,
+  },
+  // ORCH-1117 — carries the prior description marginTop now that the body text
+  // lives inside the CollapsibleDescription block.
+  descriptionWrap: {
     marginTop: spacing.md,
   },
   section: {

--- a/mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts
+++ b/mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts
@@ -202,18 +202,34 @@ describe("ORCH-0876 adversarial — A1: editState re-seed on prop change", () =>
 
 describe("ORCH-0876 adversarial — A2: TripCheckoutFlow S-3 fix pinned", () => {
   const SRC = read("components/trip/TripCheckoutFlow.tsx");
+  // [TEST-MOD-APPROVED by orchestrator, ORCH-1117 CLOSE] — ORCH-1117's LOCKED
+  // decision (§4.5) removed the LOUD inline Reserve nav from TripCheckoutFlow
+  // and moved it to the public trip route's floating Buy bar. The S-3
+  // destination invariant (route to /checkout-trip/{id}, NEVER the events
+  // /checkout/{id} chain that hard-rejects trip rows) is UNCHANGED — it simply
+  // lives in app/t/[brandSlug]/[tripSlug].tsx now. The A2 source read is
+  // re-pointed at the route; the destination invariant assertion is preserved
+  // verbatim. Authorized by the ORCH-1117 TEST dispatch.
+  const ROUTE = readApp("t/[brandSlug]/[tripSlug].tsx");
 
-  test("handleReserve routes to /checkout-trip/${trip.id} (NOT the events chain)", () => {
-    // Pre-ORCH-0876 the same callsite pushed to `/checkout/${trip.id}`
+  test("trip floating-bar reserve routes to /checkout-trip/{id} (NOT the events chain)", () => {
+    // Pre-ORCH-0876 the same buyer action pushed to `/checkout/${trip.id}`
     // and buyers saw "Event not found" because getPublicEventById
-    // hard-rejects trip rows by audit-test invariant.
-    expect(SRC).toMatch(/router\.push\(`\/checkout-trip\/\$\{trip\.id\}` as never\)/);
-    // And explicitly NOT the broken pattern.
-    expect(SRC).not.toMatch(/router\.push\(`\/checkout\/\$\{trip\.id\}` as never\)/);
+    // hard-rejects trip rows by audit-test invariant. ORCH-1117 moved the
+    // action to the floating bar in the route, still via tripCheckoutPath.
+    // DESTINATION INVARIANT (preserved): the route navigates to the
+    // trip-specific checkout chain, never the events /checkout/{id} chain.
+    expect(ROUTE).toMatch(/router\.push\(tripCheckoutPath\(trip\.id\) as never\)/);
+    // And explicitly NOT the broken events chain (raw or via helper).
+    expect(ROUTE).not.toMatch(/router\.push\(`\/checkout\/\$\{trip\.id\}` as never\)/);
+    expect(ROUTE).not.toMatch(/router\.push\(checkoutPublicPath\(trip\.id\)/);
   });
 
   test("handleReserve callsite cites ORCH-0876 + audit-test invariant in a comment", () => {
     // Future refactors deserve a sign that says "do not revert this line."
+    // The comment stays in TripCheckoutFlow.tsx (ORCH-1117 preserved it when
+    // it moved the LOUD nav out) so the trip-chain invariant rationale is
+    // documented at the surface the original investigation pointed at.
     expect(SRC).toMatch(/ORCH-0876.*trip-specific chain/);
     expect(SRC).toMatch(/eventType\.filter\.audit\.test\.ts/);
   });

--- a/mingla-business/src/constants/publicUrls.ts
+++ b/mingla-business/src/constants/publicUrls.ts
@@ -67,6 +67,21 @@ export const tripCheckoutPath = (tripEventId: string): string =>
 export const tripCheckoutUrl = (tripEventId: string): string =>
   `${BUSINESS_PUBLIC_ORIGIN}${tripCheckoutPath(tripEventId)}`;
 
+// ORCH-1117: experience-specific buyer-anon checkout entry, mirror of
+// tripCheckoutPath. Experiences route into their own chain at
+// /checkout-experience/[experienceEventId]/* (event-side /checkout/[eventId]
+// hard-rejects non-event rows by audit-test invariant). The floating Buy bar
+// on the public experience page uses this single helper instead of an inline
+// template string (parity with tripCheckoutPath/checkoutPublicPath).
+export const experienceCheckoutPath = (experienceEventId: string): string =>
+  `/checkout-experience/${requireSegment(
+    experienceEventId,
+    "experienceEventId",
+  )}`;
+
+export const experienceCheckoutUrl = (experienceEventId: string): string =>
+  `${BUSINESS_PUBLIC_ORIGIN}${experienceCheckoutPath(experienceEventId)}`;
+
 // ORCH-0876: public trip page path helper (mirror of eventPublicPath).
 export const tripPublicPath = (input: {
   brandSlug: string;

--- a/mingla-business/src/hooks/usePublicTripBySlug.ts
+++ b/mingla-business/src/hooks/usePublicTripBySlug.ts
@@ -34,7 +34,32 @@ interface PublicTripPayload {
     bio: string | null;
     coverMediaUrl: string | null;
   };
+  /**
+   * ORCH-1117 / ORCH-1076 I-PAID-SUPPLY-REQUIRES-CHARGES-ENABLED — when false,
+   * this is a PAID trip whose brand can't charge yet; the public page renders
+   * the floating Buy bar as a NON-tappable "Booking unavailable" info strip
+   * instead of the Reserve action. Free trips (and resolver errors) are
+   * `true` (fail-open; the checkout 409 remains the terminal backstop).
+   */
+  bookable: boolean;
 }
+
+// ORCH-1117 — mirror resolveEventBookable (publicEventsService.ts) /
+// resolveBookable (publicExperienceService.ts): a PAID trip is bookable iff its
+// brand can charge (anon-granted pg_brand_can_charge RPC). FREE ⇒ true. On RPC
+// error fail OPEN (page stays bookable; the checkout 409 is the backstop) so a
+// transient error never wrongly hides a bookable listing.
+const resolveTripBookable = async (
+  brandId: string,
+  isPaid: boolean,
+): Promise<boolean> => {
+  if (!isPaid) return true;
+  const { data, error } = await supabase.rpc("pg_brand_can_charge", {
+    p_brand_id: brandId,
+  });
+  if (error !== null) return true;
+  return data === true;
+};
 
 const DISABLED_KEY = ["trips", "__public_disabled__"] as const;
 
@@ -233,6 +258,12 @@ export const usePublicTripBySlug = (
         ticketsSoldCount: 0,
       };
 
+      // ORCH-1117 — a trip is PAID when its first pricing tier costs > 0
+      // (mirrors the trip price source above). Resolve the brand's
+      // charge-readiness so the floating bar can render its unavailable state.
+      const isPaid = (trip.pricingTiers[0]?.priceCents ?? 0) > 0;
+      const bookable = await resolveTripBookable(brand.id, isPaid);
+
       return {
         trip,
         brand: {
@@ -242,6 +273,7 @@ export const usePublicTripBySlug = (
           bio: brand.description ?? null,
           coverMediaUrl: brand.cover_media_url ?? null,
         },
+        bookable,
       };
     },
   });

--- a/packages/event-rendering/PublicEventPage.tsx
+++ b/packages/event-rendering/PublicEventPage.tsx
@@ -22,15 +22,18 @@
 //   - true: venue NAME shown; address replaced with "Address shared after
 //     ticket purchase"
 //   - false: full address visible
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  AccessibilityInfo,
   Image,
+  LayoutAnimation,
   Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
+  UIManager,
   View,
 } from "react-native";
 import { GlassBlur } from "./GlassBlur";
@@ -48,6 +51,15 @@ import {
   typography,
 } from "./designTokens";
 import { resolveTheme } from "./themeResolver";
+// ORCH-1117 — the single buy/unavailable gate logic. PublicTicketRow reuses the
+// shared per-tier sub-predicates so the inline row and the host floating bar
+// can never disagree about sold-out / sale-ended / door-only.
+import {
+  computeOfferingVariant,
+  ticketIsDoorOnly,
+  ticketIsSoldOut,
+  ticketSaleEnded,
+} from "./offeringCta";
 import { ThemeEntranceAnimation } from "./ThemeEntranceAnimation";
 import { EventCoverMedia } from "./EventCoverMedia";
 import type {
@@ -57,6 +69,41 @@ import type {
 } from "./types";
 
 const SHOW_INITIAL_DATES = 10;
+
+// ORCH-1117 — collapsible About. Copy ≤ this length fits the 3-line peek, so it
+// renders fully expanded with NO toggle (a toggle for 2 lines is noise). Mirrors
+// the existing EVT-NATIVE 160-char threshold.
+const ABOUT_COLLAPSE_THRESHOLD = 160;
+
+// ORCH-1117 — enable LayoutAnimation on Android (no-op on iOS/web where it is
+// already on). Guarded so it runs once at module load.
+if (
+  Platform.OS === "android" &&
+  UIManager.setLayoutAnimationEnabledExperimental !== undefined
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+// ORCH-1117 — track the OS reduce-motion preference so the About toggle skips
+// the height settle when the user asked for reduced motion.
+const useReduceMotion = (): boolean => {
+  const [reduce, setReduce] = useState<boolean>(false);
+  useEffect(() => {
+    let mounted = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (mounted) setReduce(value);
+    });
+    const sub = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      (value: boolean) => setReduce(value),
+    );
+    return () => {
+      mounted = false;
+      sub.remove();
+    };
+  }, []);
+  return reduce;
+};
 
 type Variant =
   | "published"
@@ -224,32 +271,31 @@ const createThemePalette = (theme: ResolvedTheme): ThemePalette => {
   };
 };
 
+// ORCH-1117 — delegates to the shared `computeOfferingVariant` (one owner) so
+// the inline page and the host floating bar compute the SAME variant.
+// ORCH-1117 — surface tone (light vs dark page) for a host-mounted floating bar.
+// Mirrors createThemePalette's `useDark` decision EXACTLY so the bar fill matches
+// the page it sits over (a light brand theme → "light" near-white bar fill).
+export const resolveOfferingSurface = (
+  theme: ResolvedTheme,
+): "light" | "dark" => {
+  const darkBase = "#07070a";
+  const lightBase = "#f8fafc";
+  const accentOnDark = contrastRatio(theme.color, darkBase);
+  const accentOnLight = contrastRatio(theme.color, lightBase);
+  const useDark =
+    accentOnDark >= 3 && accentOnLight < 3
+      ? true
+      : accentOnLight >= 3 && accentOnDark < 3
+        ? false
+        : theme.foregroundColor === "#ffffff";
+  return useDark ? "dark" : "light";
+};
+
 const computeVariant = (
   event: PublicEventProps,
   passwordUnlocked: boolean,
-): Variant => {
-  if (event.status === "cancelled") return "cancelled";
-  const isPast =
-    event.status === "ended" ||
-    (event.endedAt !== null && new Date(event.endedAt).getTime() < Date.now());
-  if (isPast) return "past";
-  const visibleTickets = event.tickets.filter((t) => t.visibility !== "hidden");
-  const requiresPassword = visibleTickets.some((t) => t.passwordProtected);
-  if (requiresPassword && !passwordUnlocked) return "password-gate";
-  const allPreSale =
-    visibleTickets.length > 0 &&
-    visibleTickets.every(
-      (t) =>
-        t.saleStartAt !== null &&
-        new Date(t.saleStartAt).getTime() > Date.now(),
-    );
-  if (allPreSale) return "pre-sale";
-  const allSoldOut =
-    visibleTickets.length > 0 &&
-    visibleTickets.every((t) => !t.isUnlimited && (t.capacity ?? 0) === 0);
-  if (allSoldOut) return "sold-out";
-  return "published";
-};
+): Variant => computeOfferingVariant(event, passwordUnlocked);
 
 const computePreSaleStart = (event: PublicEventProps): string | null => {
   const candidates = event.tickets
@@ -310,6 +356,8 @@ export const PublicEventPage: React.FC<PublicEventPageProps> = ({
   // web/business behavior is unchanged; app-mobile's sheet host injects gorhom's
   // BottomSheetScrollView to collapse the double-scroll into a single host.
   ScrollComponent = ScrollView,
+  // ORCH-1117 — host-mounted floating-bar clearance (0 = no bar).
+  contentBottomInset = 0,
 }) => {
   const [passwordUnlocked, setPasswordUnlocked] = useState<boolean>(false);
   const resolvedTheme = useMemo<ResolvedTheme>(
@@ -351,6 +399,7 @@ export const PublicEventPage: React.FC<PublicEventPageProps> = ({
           callbacks={callbacks}
           theme={resolvedTheme}
           ScrollComponent={ScrollComponent}
+          contentBottomInset={contentBottomInset}
         />
       )}
 
@@ -417,6 +466,8 @@ interface PublishedBodyProps {
   // default; gorhom BottomSheetScrollView when sheet-hosted). Always defined —
   // PublicEventPage supplies its default before passing down.
   ScrollComponent: NonNullable<PublicEventPageProps["ScrollComponent"]>;
+  // ORCH-1117 — extra scroll-bottom clearance for a host-mounted floating bar.
+  contentBottomInset: number;
 }
 
 const PublishedBody: React.FC<PublishedBodyProps> = ({
@@ -426,9 +477,29 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
   callbacks,
   theme,
   ScrollComponent,
+  contentBottomInset,
 }) => {
   const [showAllDates, setShowAllDates] = useState<boolean>(false);
   const [showOverflowDates, setShowOverflowDates] = useState<boolean>(false);
+  // ORCH-1117 — collapsible About (collapsed by default for copy over the
+  // 160-char threshold; short copy renders full with no toggle).
+  const [aboutCollapsed, setAboutCollapsed] = useState<boolean>(true);
+  const reduceMotion = useReduceMotion();
+  const toggleAbout = useCallback((): void => {
+    if (!reduceMotion) {
+      // Content-driven height settle (3-line ↔ full). No measured height inside
+      // the gorhom sheet scroll (F-B) — numberOfLines swap avoids the scroll
+      // jump a measured-height animation would cause.
+      LayoutAnimation.configureNext(
+        LayoutAnimation.create(
+          200,
+          LayoutAnimation.Types.easeInEaseOut,
+          LayoutAnimation.Properties.opacity,
+        ),
+      );
+    }
+    setAboutCollapsed((c) => !c);
+  }, [reduceMotion]);
 
   const titleLine = event.name.length > 0 ? event.name : "Untitled event";
   const brandLetter = (brand?.displayName?.charAt(0) ?? "?").toUpperCase();
@@ -494,7 +565,14 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
           the sheet's gorhom scroll (single scroll host). */}
       <ScrollComponent
         style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[
+          styles.scrollContent,
+          // ORCH-1117 — reserve clearance for a host-mounted floating Buy bar so
+          // the last inline element scrolls clear of it. 0 when no bar.
+          contentBottomInset > 0
+            ? { paddingBottom: spacing.xl * 2 + contentBottomInset }
+            : null,
+        ]}
         showsVerticalScrollIndicator={false}
       >
         {/* Hero cover — column-width, aspect-adaptive, cover-filled */}
@@ -577,10 +655,14 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
           {/* Title block */}
           <View style={styles.titleBlock}>
             <View style={styles.titleBlockText}>
+              {/* ORCH-1117 R1 — the date eyebrow takes the luminance-aware
+                  accent (NOT raw #ffffff). On a light brand theme the page is
+                  near-white, so white text here was invisible; palette.accent
+                  is contrast-adjusted ≥4.5:1 as text on `page`. */}
               <Text
                 style={[
                   styles.dateLine,
-                  { color: "#ffffff", fontFamily: theme.fontFamilyValue },
+                  { color: palette.accent, fontFamily: theme.fontFamilyValue },
                 ]}
               >
                 {event.dateLine}
@@ -613,8 +695,16 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
                       },
                     ]}
                   >
+                    {/* ORCH-1117 R1 — recurrence pill label takes
+                        palette.primaryText (NOT raw #ffffff). The pill bg is a
+                        thin accentWash over `page`, so the effective bg ≈ page;
+                        primaryText = readableTextFor(page) ⇒ ~19:1 on a light
+                        page (was invisible white-on-near-white). */}
                     <Text
-                      style={[styles.recurrencePillLabel, { color: "#ffffff" }]}
+                      style={[
+                        styles.recurrencePillLabel,
+                        { color: palette.primaryText },
+                      ]}
                     >
                       {event.dateSubline} · {showAllDates ? "Hide" : "Show all"}
                     </Text>
@@ -853,23 +943,85 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
             </View>
           ) : null}
 
-          {/* About */}
-          <Text
-            style={[
-              styles.sectionTitle,
-              {
-                color: palette.primaryText,
-                fontFamily: theme.fontFamilyValue,
-              },
-            ]}
-          >
-            About
-          </Text>
-          <Text style={[styles.aboutBody, { color: palette.secondaryText }]}>
-            {event.description.length > 0
-              ? event.description
-              : "Details coming soon."}
-          </Text>
+          {/* About — ORCH-1117 collapsible (collapsed by default). The whole
+              header row is one ≥44pt tap target; the chevron text-glyph (F-C —
+              no Icon import in the package) + the "Read more"/"Show less" word
+              both signal state (never color alone). Copy ≤160 chars renders
+              full with no toggle. */}
+          {(() => {
+            const aboutText =
+              event.description.length > 0
+                ? event.description
+                : "Details coming soon.";
+            const canCollapse = aboutText.length > ABOUT_COLLAPSE_THRESHOLD;
+            const collapsed = canCollapse && aboutCollapsed;
+            return (
+              <>
+                <Pressable
+                  onPress={canCollapse ? toggleAbout : undefined}
+                  disabled={!canCollapse}
+                  accessibilityRole={canCollapse ? "button" : undefined}
+                  accessibilityLabel="About"
+                  accessibilityState={
+                    canCollapse ? { expanded: !collapsed } : undefined
+                  }
+                  accessibilityHint={
+                    canCollapse
+                      ? collapsed
+                        ? "Expands the description"
+                        : "Collapses the description"
+                      : undefined
+                  }
+                  style={styles.aboutHeaderRow}
+                >
+                  <Text
+                    style={[
+                      styles.sectionTitle,
+                      {
+                        color: palette.primaryText,
+                        fontFamily: theme.fontFamilyValue,
+                      },
+                    ]}
+                  >
+                    About
+                  </Text>
+                  {canCollapse ? (
+                    <Text
+                      style={[
+                        styles.aboutChevron,
+                        { color: palette.tertiaryText },
+                      ]}
+                      importantForAccessibility="no"
+                      accessibilityElementsHidden
+                    >
+                      {collapsed ? "⌄" : "⌃"}
+                    </Text>
+                  ) : null}
+                </Pressable>
+                <Text
+                  style={[styles.aboutBody, { color: palette.secondaryText }]}
+                  numberOfLines={collapsed ? 3 : undefined}
+                  ellipsizeMode="tail"
+                >
+                  {aboutText}
+                </Text>
+                {canCollapse ? (
+                  <Pressable
+                    onPress={toggleAbout}
+                    accessibilityRole="button"
+                    accessibilityLabel={collapsed ? "Read more" : "Show less"}
+                    style={styles.aboutToggleRow}
+                  >
+                    <Text
+                      style={[styles.aboutToggle, { color: palette.accent }]}
+                    >
+                      {collapsed ? "Read more" : "Show less"}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </>
+            );
+          })()}
 
           {/* Tickets */}
           <Text
@@ -941,12 +1093,12 @@ const PublicTicketRow: React.FC<PublicTicketRowProps> = ({
 }) => {
   const priceLabel = formatTicketPrice(ticket, fallbackCurrency);
   const isVisDisabled = ticket.visibility === "disabled";
-  const saleEnded =
-    ticket.saleEndAt !== null &&
-    Number.isFinite(new Date(ticket.saleEndAt).getTime()) &&
-    new Date(ticket.saleEndAt).getTime() <= Date.now();
-  const isSoldOutTicket = !ticket.isUnlimited && (ticket.capacity ?? 0) === 0;
-  const isDoorOnly = ticket.availableAt === "door";
+  // ORCH-1117 — shared sub-predicates (one owner; same logic the floating bar
+  // reads via resolveOfferingCta). Behavior is byte-identical to the prior
+  // inline checks.
+  const saleEnded = ticketSaleEnded(ticket);
+  const isSoldOutTicket = ticketIsSoldOut(ticket);
+  const isDoorOnly = ticketIsDoorOnly(ticket);
 
   const handleTap = (): void => {
     if (variant === "past" || isVisDisabled || saleEnded) return;
@@ -1346,9 +1498,11 @@ const styles = StyleSheet.create({
     fontWeight: "900",
     color: text.primary,
     marginBottom: spacing.sm,
-    textShadowColor: "rgba(0,0,0,0.28)",
-    textShadowOffset: { width: 0, height: 2 },
-    textShadowRadius: 10,
+    // ORCH-1117 R4 — title sits inside the solid body card (palette.page), so
+    // the heavy 0,2 / radius-10 / 28%-black text shadow did no legibility work
+    // and read as smudged on a light theme. Removed (primaryText on page is
+    // already AA-safe). Do NOT reintroduce a textShadow* here while the title
+    // sits on a solid surface.
   },
   recurrencePillRow: {
     flexDirection: "row",
@@ -1540,6 +1694,29 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: text.secondary,
     lineHeight: 24,
+  },
+  // ORCH-1117 — collapsible About header row (whole row is the tap target).
+  aboutHeaderRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    minHeight: 44,
+  },
+  aboutChevron: {
+    fontSize: 20,
+    fontWeight: "900",
+    lineHeight: 26,
+    marginBottom: spacing.sm,
+    paddingHorizontal: spacing.xs,
+  },
+  aboutToggleRow: {
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  aboutToggle: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginTop: spacing.xs,
   },
 
   // Tickets

--- a/packages/event-rendering/index.ts
+++ b/packages/event-rendering/index.ts
@@ -6,7 +6,7 @@
 //
 // Per META-ORCH-0827 Pass 2 (Option C). Established 2026-05-13.
 
-export { PublicEventPage } from "./PublicEventPage";
+export { PublicEventPage, resolveOfferingSurface } from "./PublicEventPage";
 export { PublicEventNotFound } from "./PublicEventNotFound";
 export { EventCoverMedia } from "./EventCoverMedia";
 export { ThemeEntranceAnimation } from "./ThemeEntranceAnimation";
@@ -56,6 +56,20 @@ export type {
 // ORCH-0964 — BlurView wrapper that skips backdrop-filter on mobile web (where
 // stacked blur hard-crashes the renderer). Used by public brand + event pages.
 export { GlassBlur } from "./GlassBlur";
+// ORCH-1117 — the single buy/unavailable state machine consumed by BOTH the
+// inline ticket row AND the per-host floating Buy bar (no forked gate logic).
+export {
+  resolveOfferingCta,
+  computeOfferingVariant,
+  ticketSaleEnded,
+  ticketIsSoldOut,
+  ticketIsDoorOnly,
+} from "./offeringCta";
+export type {
+  CtaState,
+  OfferingVariant,
+  ResolveOfferingCtaInput,
+} from "./offeringCta";
 export type {
   PublicEventProps,
   PublicBrandProps,

--- a/packages/event-rendering/offeringCta.ts
+++ b/packages/event-rendering/offeringCta.ts
@@ -1,0 +1,284 @@
+// offeringCta — ORCH-1117 [public offering page polish].
+//
+// The SINGLE source of truth for the buy/unavailable state machine that BOTH
+// the inline `PublicTicketRow` per-tier predicates AND the new floating Buy bar
+// consume. Hoisted out of PublicEventPage so the gate logic (`bookable`,
+// sold-out, ended, pre-sale, door-only, free, paid) lives in ONE place and the
+// floating bar can never drift from the inline row's notion of "buyable".
+//
+// Pure module: no React, no RN, no side effects. Self-contained inline price
+// formatting mirrors PublicEventPage.formatTicketPrice (all-in, never recompute
+// fees — WYSIWYP). The floating bar uses the PAGE-LEVEL projection
+// (`resolveOfferingCta`); the inline row keeps its per-tier label by reusing the
+// shared sub-predicates exported here.
+
+import type { PublicEventProps, PublicTicketProps } from "./types";
+
+/** A single ticket's per-tier sale-state sub-predicates (shared with the row). */
+export const ticketSaleEnded = (ticket: PublicTicketProps): boolean =>
+  ticket.saleEndAt !== null &&
+  Number.isFinite(new Date(ticket.saleEndAt).getTime()) &&
+  new Date(ticket.saleEndAt).getTime() <= Date.now();
+
+export const ticketIsSoldOut = (ticket: PublicTicketProps): boolean =>
+  !ticket.isUnlimited && (ticket.capacity ?? 0) === 0;
+
+export const ticketIsDoorOnly = (ticket: PublicTicketProps): boolean =>
+  ticket.availableAt === "door";
+
+/** The page-level offering variant (matches PublicEventPage's `Variant`). */
+export type OfferingVariant =
+  | "published"
+  | "sold-out"
+  | "pre-sale"
+  | "past"
+  | "password-gate"
+  | "cancelled";
+
+/**
+ * Compute the page-level offering variant from the event payload. Single owner:
+ * PublicEventPage's internal `computeVariant` delegates here, and host adapters
+ * (e.g. the buyer-web event floating bar) reuse the SAME computation so the bar
+ * can never disagree with the inline page about cancelled/past/pre-sale/sold-out.
+ * `password-gate` is page-render-only state and is resolved by PublicEventPage;
+ * for the bar's purposes a password-gated event is treated as "published".
+ */
+export const computeOfferingVariant = (
+  event: PublicEventProps,
+  passwordUnlocked: boolean,
+): OfferingVariant => {
+  if (event.status === "cancelled") return "cancelled";
+  const isPast =
+    event.status === "ended" ||
+    (event.endedAt !== null && new Date(event.endedAt).getTime() < Date.now());
+  if (isPast) return "past";
+  const visibleTickets = event.tickets.filter((t) => t.visibility !== "hidden");
+  const requiresPassword = visibleTickets.some((t) => t.passwordProtected);
+  if (requiresPassword && !passwordUnlocked) return "password-gate";
+  const allPreSale =
+    visibleTickets.length > 0 &&
+    visibleTickets.every(
+      (t) =>
+        t.saleStartAt !== null &&
+        new Date(t.saleStartAt).getTime() > Date.now(),
+    );
+  if (allPreSale) return "pre-sale";
+  const allSoldOut =
+    visibleTickets.length > 0 &&
+    visibleTickets.every((t) => !t.isUnlimited && (t.capacity ?? 0) === 0);
+  if (allSoldOut) return "sold-out";
+  return "published";
+};
+
+/**
+ * The resolved floating-bar state. `tappable:false` states are rendered as a
+ * NON-button info strip (Constitution #1 — no dead taps). `tappable:true`
+ * states render the accent action button.
+ */
+export type CtaState =
+  | { kind: "buy"; label: string; price: string; tappable: true }
+  | { kind: "free"; label: string; tappable: true }
+  | { kind: "waitlist"; label: string; tappable: true }
+  | {
+      kind: "unavailable";
+      title: string;
+      subline: string | null;
+      tappable: false;
+    };
+
+export interface ResolveOfferingCtaInput {
+  /** The page-level computed variant. */
+  variant: OfferingVariant;
+  /**
+   * I-PAID-SUPPLY-REQUIRES-CHARGES-ENABLED (ORCH-1076) — the brand can charge.
+   * Gated FIRST: a not-ready paid brand is "Booking unavailable" regardless of
+   * ticket state. Callers that cannot resolve `bookable` pass `true` (fail-open;
+   * the checkout 409 / cart-toast remains the terminal backstop).
+   */
+  bookable: boolean;
+  /** The visible (non-hidden) tickets, already display-sorted. */
+  tickets: PublicTicketProps[];
+  /** Fallback currency when a ticket omits its own. */
+  currency: string;
+  /**
+   * The action verb for the buyable accent button on a NON-event offering
+   * (trip: "Reserve my spot"; experience: "Get my spot"). Events default to
+   * "Buy ticket" / "Get free ticket". Optional — events omit it.
+   */
+  buyVerb?: string;
+  freeVerb?: string;
+}
+
+const formatPrice = (
+  ticket: PublicTicketProps,
+  fallbackCurrency: string,
+): string | null => {
+  if (ticket.isFree) return "Free";
+  const price = ticket.priceAllInGbp ?? ticket.priceGbp;
+  if (price === null || price === undefined) return null;
+  const currency = ticket.currency ?? fallbackCurrency;
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    }).format(price);
+  } catch {
+    return `${currency} ${price.toFixed(2)}`;
+  }
+};
+
+/**
+ * Resolve the page-level floating-bar CTA state. Precedence mirrors the inline
+ * `PublicTicketRow` state machine + adds the `bookable` gate FIRST:
+ *
+ *   !bookable                 → unavailable("Booking unavailable" + subline)
+ *   variant past              → unavailable("Sales ended")
+ *   variant pre-sale          → unavailable("On sale soon")
+ *   variant cancelled         → unavailable("Cancelled")
+ *   all door-only             → unavailable("Pay at the door")
+ *   all sold-out + any wl     → waitlist("Join waitlist")
+ *   all sold-out              → unavailable("Sold out")
+ *   any free, none paid       → free(freeVerb ?? "Get free ticket")
+ *   else                      → buy(buyVerb ?? "Buy ticket", "From {price}")
+ */
+export const resolveOfferingCta = (
+  input: ResolveOfferingCtaInput,
+): CtaState => {
+  const { variant, bookable, tickets, currency, buyVerb, freeVerb } = input;
+
+  if (!bookable) {
+    return {
+      kind: "unavailable",
+      title: "Booking unavailable",
+      subline: "The organizer is finishing payment setup.",
+      tappable: false,
+    };
+  }
+
+  if (variant === "cancelled") {
+    return {
+      kind: "unavailable",
+      title: "Cancelled",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  if (variant === "past") {
+    return {
+      kind: "unavailable",
+      title: "Sales ended",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  if (variant === "pre-sale") {
+    return {
+      kind: "unavailable",
+      title: "On sale soon",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  const visible = tickets.filter((t) => t.visibility !== "hidden");
+
+  if (visible.length === 0) {
+    return {
+      kind: "unavailable",
+      title: "Not on sale yet",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  if (visible.every(ticketIsDoorOnly)) {
+    return {
+      kind: "unavailable",
+      title: "Pay at the door",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  if (visible.every(ticketSaleEnded)) {
+    return {
+      kind: "unavailable",
+      title: "Sales ended",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  const allSoldOut = visible.every(ticketIsSoldOut);
+  if (allSoldOut) {
+    if (visible.some((t) => t.waitlistEnabled)) {
+      return { kind: "waitlist", label: "Join waitlist", tappable: true };
+    }
+    return {
+      kind: "unavailable",
+      title: "Sold out",
+      subline: null,
+      tappable: false,
+    };
+  }
+
+  // Sellable tickets = visible, not sold-out, not door-only, sale not ended.
+  const sellable = visible.filter(
+    (t) =>
+      !ticketIsSoldOut(t) && !ticketIsDoorOnly(t) && !ticketSaleEnded(t),
+  );
+  const considered = sellable.length > 0 ? sellable : visible;
+
+  const anyPaid = considered.some((t) => !t.isFree);
+  if (!anyPaid) {
+    return {
+      kind: "free",
+      label: freeVerb ?? "Get free ticket",
+      tappable: true,
+    };
+  }
+
+  // Lowest visible all-in price across the paid (non-free) sellable tickets.
+  const paidPrices = considered
+    .filter((t) => !t.isFree)
+    .map((t) => formatPrice(t, currency))
+    .filter((p): p is string => p !== null);
+  const paidTierCount = considered.filter((t) => !t.isFree).length;
+  // "From" only when >1 priced tier; a single tier shows the bare price.
+  const lowest = lowestPriceString(considered, currency);
+  const priceText =
+    paidTierCount > 1 && lowest !== null
+      ? `From ${lowest}`
+      : (lowest ?? paidPrices[0] ?? "");
+
+  return {
+    kind: "buy",
+    label: buyVerb ?? "Buy ticket",
+    price: priceText,
+    tappable: true,
+  };
+};
+
+/** Lowest numeric all-in price among paid tickets, formatted, or null. */
+const lowestPriceString = (
+  tickets: PublicTicketProps[],
+  fallbackCurrency: string,
+): string | null => {
+  let lowestTicket: PublicTicketProps | null = null;
+  let lowestValue = Number.POSITIVE_INFINITY;
+  for (const t of tickets) {
+    if (t.isFree) continue;
+    const value = t.priceAllInGbp ?? t.priceGbp;
+    if (value === null || value === undefined) continue;
+    if (value < lowestValue) {
+      lowestValue = value;
+      lowestTicket = t;
+    }
+  }
+  if (lowestTicket === null) return null;
+  return formatPrice(lowestTicket, fallbackCurrency);
+};

--- a/packages/event-rendering/types.ts
+++ b/packages/event-rendering/types.ts
@@ -131,6 +131,15 @@ export interface PublicEventPageProps {
    * props (`style`, `contentContainerStyle`, `showsVerticalScrollIndicator`).
    */
   ScrollComponent?: ComponentType<ScrollViewProps>;
+  /**
+   * ORCH-1117 — extra bottom padding (px) added to the scroll content so the
+   * last inline element clears a host-mounted floating Buy bar. The bar itself
+   * is built per host (it needs safe-area + router + Icon), but it overlaps the
+   * scroll; the host passes its measured bar height + safe area here so the
+   * package reserves clearance without the host forking the package style.
+   * Defaults to 0 (no bar → unchanged layout).
+   */
+  contentBottomInset?: number;
 }
 
 export interface PublicEventNotFoundProps {


### PR DESCRIPTION
## ORCH-1117 — public offering page UX/design polish (full cross-surface parity)

Four Seth-requested changes across web event/trip/experience + consumer iOS/Android detail:
1. **White-theme legibility** — date eyebrow + recurrence pill were white-on-white on light brand themes; now luminance-safe palette tokens (CI guard `orch-1117-no-raw-white-on-palette-surface.mjs` blocks regressions).
2. **Collapsible About** — collapsed by default, Read more/Show less, specced motion + a11y.
3. **Floating Buy bar** — pinned at base of every public offering page; routes to the existing cart/checkout; non-tappable info strip in every unavailable/sold-out/ended state (no dead taps, Constitution #1); Android opaque-glass fallback; native bars are scroll-siblings (NOT stickyFooter). Single-ticket trips/experiences: inline CTA removed, floating bar is the only CTA.
4. **Lighter title shadow** — heavy drop-shadow removed for a cleaner look.

One hoisted buy-state machine (`packages/event-rendering/offeringCta.ts`) so inline + floating CTA can never disagree. Trip `bookable` plumbing added (reads the ORCH-1116-fixed RPC).

**Merge order:** rebased on top of ORCH-1116 (already on main).
**TEST: PASS** (iPhone 17 Pro sim runtime proof — floating bar fires, scroll-sibling + swipe-dismiss confirmed, white-theme legible). P0:0 P1:0, one deferred P2. `[TEST-MOD-APPROVED]` re-point of the ORCH-0876 trip-checkout assertion (destination invariant preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)