### PR TITLE
ORCH-1124: cover-video Sound/Mute pill top-right→bottom-right (reachable) [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1124_COVER_MUTE_PILL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1124_COVER_MUTE_PILL.md
@@ -1,0 +1,149 @@
+# IMPLEMENTATION — ORCH-1124 [cover-video Sound/Mute pill unreachable under floating chrome]
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1124-[cover-mute-pill]/` on branch `ORCH-1124-cover-mute-pill`
+**Base:** rebased on `origin/main` (up to date; includes ORCH-1117 floating Buy bar)
+**Status:** implemented and verified (web/source + jest; fails-on-revert proven by true line deletion)
+**Commits:** `fd1de15b4` (fix), `7befb09f0` (test reconcile + regression, carries `[TEST-MOD-APPROVED ORCH-1124]`)
+
+---
+
+## 1. Summary
+
+The cover-video Sound/Mute pill on the public event page (buyer/anon web `/e/...` + business app) was
+unreachable: the shared `PublicEventPage` overrode `EventCoverMedia`'s audio-pill position to
+`"topRight"`, planting the pill directly under the top-right floating close+share chrome — a dead tap.
+The fix drops that one override so the pill inherits `EventCoverMedia`'s `"bottomRight"` default (the
+same position the consumer app already uses). No new layout, no Buy-bar change, no consumer-app touch.
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Commit |
+|----|-----------|--------|--------|
+| SC-1 | Drop the `"topRight"` override; pill inherits `bottomRight` default | ✓ | `fd1de15b4` |
+| SC-2 | `bottomRight` is confirmed the `EventCoverMedia` default, styled `right:14/bottom:14` within the cover | ✓ (verified line 386 + style block 606-609) | n/a (no change needed) |
+| SC-3 | Short-page collision check vs ORCH-1117 floating Buy bar = **NO collide** | ✓ | (analysis below) |
+| SC-4 | Stale `topLeft`/`audioControlTopOffset` test assertions reconciled to reality | ✓ | `7befb09f0` |
+| SC-5 | Buyer/anon web + business app (shared package); consumer app NOT touched | ✓ | `fd1de15b4` |
+| SC-6 | Happy-path regression test asserting `bottomRight` (fails-on-revert) | ✓ | `7befb09f0` |
+
+## 3. Files changed
+
+| File | Δ | What |
+|------|---|------|
+| `packages/event-rendering/PublicEventPage.tsx` | −1 prop / +6 comment lines | Removed `audioControlPosition="topRight"` override (line 592); replaced with an explanatory comment |
+| `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` | −7 / +43 | Reconciled 5 stale `publicPageSource` audio assertions (+ removed the now-unused `publicPageSource` binding in that one test) to target the shared package and assert NO top override; added an ORCH-1124 `describe` block with 2 passing regression tests |
+
+## 4. Data-model changes applied
+
+None. Pure UI / shared-component prop change. No migration, no RLS, no edge function.
+
+## 5. Edge functions touched
+
+None.
+
+## 6. Regression tests added
+
+**Path:** `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts`
+**New describe block:** `ORCH-1124 cover-video audio pill clears top-right floating chrome` (2 tests, both pass).
+- `public event page does not pin the cover audio pill to a top position` — asserts the shared
+  `PublicEventPage.tsx` contains `showAudioControl` but NOT `audioControlPosition="topRight"` / `"topLeft"`.
+- `EventCoverMedia defaults the audio pill to bottomRight, styled within the cover` — asserts the
+  default `audioControlPosition = "bottomRight"` + the `audioControlBottomRight` style (`right: 14` / `bottom: 14`).
+
+Also reconciled (not new): `event cover videos use inline browser-safe playback props` — was FAILING on
+origin/main (asserted strings against the wrong file); now passes against the shared package and asserts
+the no-top-override reality.
+
+**fails-on-revert verified at `4ffc47731`** (pre-commit working state) via TRUE LINE DELETION of the
+fix (re-added `audioControlPosition="topRight"` to `packages/event-rendering/PublicEventPage.tsx`):
+the `public event page does not pin the cover audio pill to a top position` test FAILED
+(`Expected substring: not "audioControlPosition=\"topRight\""`). Restored the fix → both ORCH-1124
+tests PASS again. Confirmed post-commit at HEAD `7befb09f0` (closing diff `git diff origin/main...HEAD --name-only`
+shows both the fix and the test file).
+
+## 7. Old → New receipts
+
+### packages/event-rendering/PublicEventPage.tsx
+**Before:** `<EventCoverMedia ... showAudioControl={...} audioControlPosition="topRight" />` — the
+Sound/Mute pill rendered at `top:14/right:14` inside the cover, directly beneath the top-right floating
+close+share chrome (`floatingChrome` at `top: insets.top + spacing.md`), an unreachable dead tap.
+**After:** the `audioControlPosition` prop is removed; `EventCoverMedia` applies its own
+`"bottomRight"` default (`right:14/bottom:14` within the cover), clearing the chrome.
+**Why:** SC-1 / root cause. **Lines:** −1 prop, +6 comment.
+
+### mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
+**Before:** `event cover videos use inline browser-safe playback props` asserted `showAudioControl`,
+`audioControlLabel="event cover video"`, `audioControlPosition="topLeft"`,
+`audioControlTopOffset={insets.top + 60}`, `isLegacyUnsafeEventCoverVideoUrl` against
+`src/components/event/PublicEventPage.tsx` — strings that no longer exist there (that file is a thin
+adapter delegating to the shared package), so the test was failing on origin/main.
+**After:** those assertions target `packages/event-rendering/PublicEventPage.tsx` and assert the
+current reality (`showAudioControl` present; no `topRight`/`topLeft` override). New ORCH-1124 regression
+block added.
+**Why:** SC-4 / SC-6 (stale-test reconcile + fails-on-revert guard). **Lines:** −7, +43.
+
+## 8. Cross-surface impact
+
+| Surface | Affected? | Detail |
+|---------|-----------|--------|
+| Consumer iOS | No | Already `bottomRight` via `app-mobile/src/components/expandedCard/ImageGallery.tsx:134`; untouched |
+| Consumer Android | No | Same shared consumer path; untouched |
+| Buyer/anonymous Web (`/e/...`) | **Yes** | Mute pill moves top-right → bottom-right; now tappable. Shared package — parity automatic |
+| Business iOS | **Yes** | Same shared `PublicEventPage`; automatic |
+| Business Android | **Yes** | Same shared `PublicEventPage`; automatic |
+| Admin Web (adjacent) | No | Does not render `PublicEventPage` |
+| Business Web preview (adjacent) | **Yes** | Same shared component; automatic |
+
+Parity is **automatic** across all affected surfaces (single shared `packages/event-rendering` change).
+
+## 9. Short-page collision check (SC-3) — result: NO collide
+
+- **ORCH-1117 floating Buy bar** (`FloatingOfferingBar`) is **host-mounted** as a sibling overlay
+  AFTER `<SharedPublicEventPage>` in `mingla-business/src/components/event/PublicEventPage.tsx`
+  (lines 457-462), pinned at the **page base** (host overlay; `contentBottomInset={96 + insets.bottom}`
+  reserves scroll clearance). It is NOT inside the cover and NOT inside the scroll content.
+- **The mute pill** is `position:absolute` at `bottom:14 / right:14` **inside the heroBox** (the cover
+  container), which is the FIRST element inside the scroll content (`packages/event-rendering/PublicEventPage.tsx`
+  hero block, lines 578-610). At scroll-top the heroBox occupies the TOP of the viewport, so the pill
+  sits in the upper region of the screen.
+- On a SHORT page (whole page fits without scrolling), the hero is still at the TOP and the Buy bar at
+  the BOTTOM of the viewport — different vertical zones. The pill is bounded by the cover's own bottom
+  edge, never the page base where the bar lives.
+- **Conclusion:** they do not overlap. The pill remains tappable and unobstructed. No new layout invented.
+
+## 10. Verification matrix / gates
+
+- **jest** `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts`: target test
+  (`inline browser-safe playback props`) now PASS; both ORCH-1124 regression tests PASS. Suite totals
+  15 passed / 5 failed — the 5 failures are **pre-existing** (origin/main has 6; I fixed 1, introduced 0).
+  The 5 are out of contract scope: 4 assert against `src/components/event/CreatorStep4Cover.tsx`
+  (upload-copy/picker-flow drift), 1 (`gated by active surface intent`) asserts moved strings against the
+  adapter — same staleness family but a DIFFERENT test outside the named SC-4 lines. Verified by running
+  the origin/main test file in this worktree: 6 fail on origin/main vs 5 on this branch.
+- **tests-append-only gate** (`node .github/scripts/test-append-only-check.js`): PASS — `6 deleted lines;
+  override token [TEST-MOD-APPROVED ORCH-####] present in commit body`.
+- **tsc:** the `EventCoverMedia.tsx` "cannot find module 'react'" + implicit-any errors are pre-existing
+  cross-package tsconfig artifacts (27 identical errors on origin/main), NOT introduced here. The fix
+  removes an OPTIONAL prop (`audioControlPosition?:`) — type-neutral by construction; zero new errors
+  reference `PublicEventPage.tsx` or `audioControlPosition`.
+
+## 11. Operator action required
+
+- None for DB/edge (no migration, no edge function).
+- Route back to orchestrator for REVIEW → tester dispatch. No deploy/merge/OTA performed.
+- This is a pure-JS shared-package change → ships via `eas update` (per-platform) at close per
+  `project_ota_deferred_until_new_build` (no native rebuild needed). Web/buyer surface deploys with the
+  normal web pipeline.
+
+## 12. Discoveries for Orchestrator
+
+- **Pre-existing test rot in `eventCoverMedia.test.ts` (5 still-failing tests, NOT in this ORCH's scope).**
+  Four assert against `src/components/event/CreatorStep4Cover.tsx` strings that drifted
+  (`EVENT_COVER_UPLOAD_LIMIT_COPY`, `mediaTypes: ["images"]`, `mediaDisplayError`, etc.); one
+  (`event cover video playback is gated by active surface intent`) asserts `usePathname` /
+  `mediaPlaybackActive` / `router.replace("/(tabs)/hub/events"` against the thin adapter — those moved to
+  the shared package, same staleness pattern I fixed for the sibling test. These fail on origin/main today.
+  Recommend a small follow-up ORCH to reconcile the remaining 5 (each a `[TEST-MOD-APPROVED]` reconcile).
+- **`isLegacyUnsafeEventCoverVideoUrl` and `audioControlLabel="event cover video"`** no longer exist
+  anywhere in `packages/event-rendering/` — the legacy-unsafe-URL helper was removed in a prior refactor
+  and the audio label default is now `"cover video audio"`. Confirms the deleted assertions were dead.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1124_COVER_MUTE_PILL.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1124_COVER_MUTE_PILL.md
@@ -1,0 +1,137 @@
+# TEST — ORCH-1124 [cover-video Sound/Mute pill: top-right → bottom-right]
+
+**Tester:** mingla-tester · **Date:** 2026-06-12
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1124-[cover-mute-pill]`
+**Branch:** `ORCH-1124-cover-mute-pill` · **HEAD under test:** `c869a58f5` (fix) → tester commit `87074317a` (adversarial test)
+**Implementation report:** `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1124_COVER_MUTE_PILL.md`
+
+---
+
+## 1. Verdict
+
+### **PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 0 · P4: 1
+
+The one-line fix (drop `audioControlPosition="topRight"` at `PublicEventPage.tsx:592` so the pill
+inherits `EventCoverMedia`'s `bottomRight` default) is correct and runtime-proven. On buyer-web the
+Sound/Mute pill now renders at the BOTTOM-RIGHT of the video cover, FIRES bidirectionally on tap
+(toggles `<video>.muted` and the aria-label), no longer collides with the top-right close+share
+chrome, and does not collide with the ORCH-1117 floating Buy bar on a short page. The consumer app's
+already-correct `bottomRight` control is structurally untouched. Regression gate satisfied (implementor
+happy-path + tester adversarial, both in the closing diff, both fails-on-revert verified).
+
+Regression-gate: implementor `fails-on-revert @ c869a58f5` (verified by me) · tester adversarial
+`mingla-business/src/components/ui/__tests__/orch_1124_cover_audio_pill_fires.adversarial.test.ts`
+fails-on-revert @ tester-broke-wiring.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Surface | Result | Evidence |
+|----|-----------|---------|--------|----------|
+| T-DEADTAP-pos | Pill renders BOTTOM-RIGHT of the video cover | Buyer web (Chromium) | **PASS** (proven) | Pill rect `x:330 y:192 w:86 h:36` → `right:416 bottom:228` inside cover `w:430 h:242` ⇒ right≈14 / bottom≈14. |
+| T-DEADTAP-fire | Pill FIRES on tap (toggles audio), not inert | Buyer web (Chromium) | **PASS** (proven) | Click dispatched on pill node: aria `"Turn on cover video audio"→"Mute cover video audio"→"Turn on…"`; `<video>.muted` `true→false→true`. Bidirectional toggle. |
+| T-DEADTAP-chrome | Top-right close (X) + share still work, no overlap with pill | Buyer web (Chromium) | **PASS** (proven) | Close `x:16 y:16` (top-left), Share `x:374 y:16` (top-right) both bottom-edge y=56; pill top y=192 ⇒ 136px clear gap. Chrome buttons present + hit-testable in their own zone. |
+| T-COLLISION | Bottom-right pill does NOT collide with ORCH-1117 floating Buy bar on a short page | Buyer web (Chromium, 430×740) | **PASS** (proven) | Pill bottom y=228; floating Buy bar ("Get free ticket") top y=659 ⇒ 431px gap. Different vertical zones. |
+| T-NOREGRESS | Consumer app's `bottomRight` audio control unchanged | Consumer app (source-immutable) | **PASS** | `app-mobile/.../ImageGallery.tsx:134 audioControlPosition="bottomRight"` is NOT in `git diff origin/main...HEAD` — the fix cannot touch it; it is the SAME default the shared page now inherits. |
+| T-REGTEST | Implementor regression test passes + fails-on-revert | Jest | **PASS** | Branch 15/20 pass (5 pre-existing out-of-scope fails); main 12/18 (6 fails) ⇒ implementor fixed 1, introduced 0. Fails-on-revert reproduced (§4). |
+| T-ADVERSARIAL | Tester adversarial test (different angle, on-branch, in-diff, fails-on-revert) | Jest | **PASS** | New file, 3/3 pass; Angle-1 fails when firing wiring removed (§5). In closing diff. |
+
+---
+
+## 3. Findings
+
+**P4 (NOTE) — clean, minimal, correct fix.** The fix is the right shape: it does not re-style or
+re-position by hand — it DELETES the override so all surfaces inherit the one shared `bottomRight`
+default the consumer app already used. One owner for the position; the business-native adapter
+(`mingla-business/src/components/event/PublicEventPage.tsx` → `@mingla/event-rendering`) picks it up
+for free. Implementor also reconciled 1 genuinely-stale test assertion (the removed
+`publicPageSource` block that targeted strings no longer present), reducing the pre-existing failure
+count 6→5 with 0 new failures.
+
+No P0/P1/P2/P3 findings.
+
+---
+
+## 4. Step 0.5 — Independent re-run of the implementor's fails-on-revert proof
+
+- Checked out HEAD `c869a58f5`. Ran `npx jest …/eventCoverMedia.test.ts` → **15 passed / 5 failed / 20 total** (the 2 ORCH-1124 tests green).
+- Re-applied the reverted state by re-inserting `audioControlPosition="topRight"` into `packages/event-rendering/PublicEventPage.tsx` (line 592).
+- Re-ran the ORCH-1124 happy-path test: **`public event page does not pin the cover audio pill to a top position` FAILED** (`expect(page).not.toContain('audioControlPosition="topRight"')`), companion bottomRight-default test still passed.
+- Restored the fix → topRight count back to 0, test green.
+- Cross-check: ran main's version of the test file → **12 passed / 6 failed / 18 total**, confirming the implementor fixed exactly 1 pre-existing failure and added 2 passing tests with 0 new failures. **Pre-existing-failure count claim (main 6 → branch 5) VERIFIED.**
+
+The 5 remaining failures are all unrelated to the audio pill (upload limits / iOS image output / GIF
+picking / surface-intent gating / media-render-failure surfacing) — OUT OF SCOPE per dispatch, not
+touched.
+
+## 5. Adversarial test added
+
+- **Path:** `mingla-business/src/components/ui/__tests__/orch_1124_cover_audio_pill_fires.adversarial.test.ts`
+- **Commit:** `87074317a` (on `ORCH-1124-cover-mute-pill`, present in `git diff origin/main...HEAD --name-only`).
+- **Different angle:** the implementor asserts POSITION only (`not topRight/topLeft`; default `bottomRight` at `right:14/bottom:14`). My test attacks **FIRING + STACKING** — the class of regression where a future change keeps the pill bottom-right but breaks the tap (dead tap). Three angles: (1) `onPress` toggles `isMuted` AND calls `onMutedChange` (the tap fires); (2) `audioControl` carries a positive `zIndex` so the bottom-right pill stacks above the cover and stays tappable; (3) the `bottomRight` default is wired to the `audioControlBottomRight` style branch in the Pressable's style chain.
+- **Fails-on-revert verified:** removed `onMutedChange?.(next);` from `EventCoverMedia.tsx` → Angle-1 test `audio pill onPress toggles isMuted and calls onMutedChange (the tap fires)` **FAILED** (other two correctly still passed, as they guard different invariants); restored → 3/3 green. (Repo Jest runs in a Node env without react-test-renderer, so this is a source-wiring lock backstopping the Chromium runtime firing proof — matching the repo's existing harness note in `PublicBrandPage.closeButton.test.tsx`.)
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Result | Evidence |
+|---|------|--------|----------|
+| 1 | No dead taps | **PASS** | The whole point: the pill was an unreachable dead tap under top-right chrome; now bottom-right and runtime-proven to FIRE (aria + `<video>.muted` toggle). |
+| 2 | One owner per truth | **PASS** | Position now owned solely by `EventCoverMedia`'s default; override deleted. |
+| 3 | No silent failures | N/A | No error paths touched. |
+| 4 | One query key per entity | N/A | No data layer. |
+| 5 | Server state server-side | N/A | UI position only. |
+| 6 | Logout clears all | N/A | Anon/public surface. |
+| 7 | `[TRANSITIONAL]` labels | N/A | Permanent change. |
+| 8 | Subtract before adding | **PASS** | Fix is a deletion (removed override), not an addition. |
+| 9 | No fabricated data | N/A | No data. |
+| 10 | Currency-aware | N/A | No money. |
+| 11 | One auth instance | **PASS** | Public route, no `useAuth` introduced. |
+| 12 | Validate at right time | N/A | No validation. |
+| 13 | Exclusion consistency | N/A | No filtering. |
+| 14 | Persisted-state startup | N/A | No persistence. |
+
+No violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Result | Evidence |
+|---------|--------|----------|
+| Buyer / anonymous Web (Chromium, RN-web export) | **PASS (proven)** | Drove `http://localhost:8091/e/leggothis/a-life-in-vegas` (live video-cover event, prod Supabase). Geometry + bidirectional firing + chrome-no-overlap + short-page no-collision all captured. |
+| Business app — iOS sim | **PASS (probable, by shared component)** | The business native app renders the IDENTICAL shared `@mingla/event-rendering` `PublicEventPage` + `EventCoverMedia` via its adapter (`mingla-business/src/components/event/PublicEventPage.tsx`) — same code path, same inherited `bottomRight` default proven on web. A fresh native dev-build run from this worktree was deferred: this worktree's directory name contains a bracket (`[cover-mute-pill]`) which trips Metro's module resolver (surfaced a benign `@expo-google-fonts/inter` redbox via a malformed `./mingla-main/...` path) — an environment artifact of the bracketed worktree path, NOT the fix. Not blocking: the rendered audio-pill code is byte-identical to the web-proven path. |
+| Consumer app (iOS/Android) | **PASS (no-regress, source-immutable)** | Already `bottomRight` via `ImageGallery.tsx:134`; file NOT in the diff. |
+| Admin web | N/A | Does not render public event covers. |
+
+**Physical iPhone HITL:** not requested by this dispatch; web Chromium runtime proof + shared-component
+identity to native were sufficient for a `proven` PASS on the shipping surface (buyer web).
+
+**Note on screenshots:** evidence PNGs in `Mingla_Artifacts/evidence/ORCH-1124/` include the dev-server
+redbox overlay (the bracketed-path Metro artifact above) over part of the frame. The AUTHORITATIVE
+evidence is the live DOM geometry + the firing state-transition captured programmatically (logged in
+this report), which the overlay does not affect — the overlay only intercepts synthetic mouse
+hit-testing, which is why the firing proof was captured by dispatching the click on the pill node
+directly. The pill, cover, close, share, and floating-bar bounds were all read from the live DOM.
+
+---
+
+## 8. Discoveries for Orchestrator
+
+- **D1 (env, P3, not ORCH-1124):** Running an Expo web/native dev server from a worktree whose path
+  contains square brackets (`ORCH-1124-[cover-mute-pill]`) trips Metro's module resolver, producing a
+  spurious `Unable to resolve module ./mingla-main/mingla-business/node_modules/@expo-google-fonts/inter`
+  redbox (malformed relative path) even though the dependency is installed. Survives `--clear`. This is
+  a recurring hazard for ANY tester/implementor driving a dev server from a bracketed per-ORCH worktree.
+  Mitigation: drive via the production web export, or symlink/rename to a bracket-free path for the dev
+  run. Worth a memory entry alongside the worktree-strategy notes. Does not affect shipped behaviour
+  (the redbox is dev-only; the underlying page rendered correctly).
+
+---
+
+## 9. Routing
+
+**PASS → CLOSE** (orchestrator). Do NOT merge/OTA from here (per dispatch). The fix ships to buyer/anon
+web (`/e/`) and the business app (shared component) on merge; consumer app unaffected.

--- a/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
+++ b/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
@@ -105,7 +105,6 @@ describe("EventCoverMedia presentation", () => {
     // ORCH-0964 [TEST-MOD-APPROVED ORCH-0964]: implementation moved to the
     // shared @mingla/event-rendering package; assertions unchanged.
     const source = repoFile("../packages/event-rendering/EventCoverMedia.tsx");
-    const publicPageSource = repoFile("src/components/event/PublicEventPage.tsx");
 
     expect(source).toContain("fullscreenOptions={{ enable: false }}");
     expect(source).toContain("playsInline");
@@ -120,11 +119,27 @@ describe("EventCoverMedia presentation", () => {
     expect(source).toContain("audioControlTopOffset");
     expect(source).toContain("audioControlTopLeft");
     expect(source).toContain("onMutedChange?.(next)");
-    expect(publicPageSource).toContain("showAudioControl");
-    expect(publicPageSource).toContain("audioControlLabel=\"event cover video\"");
-    expect(publicPageSource).toContain("audioControlPosition=\"topLeft\"");
-    expect(publicPageSource).toContain("audioControlTopOffset={insets.top + 60}");
-    expect(publicPageSource).toContain("isLegacyUnsafeEventCoverVideoUrl");
+    // ORCH-1124 [TEST-MOD-APPROVED ORCH-1124] — the audio-pill wiring was
+    // refactored out of the mingla-business src/components/event/PublicEventPage
+    // adapter (now a thin delegate) into the shared @mingla/event-rendering
+    // package's PublicEventPage. The old assertions below targeted
+    // `publicPageSource` (the adapter) for `showAudioControl` /
+    // `audioControlPosition="topLeft"` / `audioControlTopOffset={insets.top + 60}`
+    // — strings that no longer exist there, so they were stale and failing.
+    // Re-point them at the shared page (`sharedPublicPageSource`) and assert the
+    // CURRENT reality: the cover audio control renders via the default
+    // "bottomRight" position (no override), clearing the top-right floating
+    // close+share chrome.
+    const sharedPublicPageSource = repoFile(
+      "../packages/event-rendering/PublicEventPage.tsx",
+    );
+    expect(sharedPublicPageSource).toContain("showAudioControl");
+    expect(sharedPublicPageSource).not.toContain(
+      "audioControlPosition=\"topRight\"",
+    );
+    expect(sharedPublicPageSource).not.toContain(
+      "audioControlPosition=\"topLeft\"",
+    );
     expect(source).not.toContain("allowsFullscreen={false}");
   });
 
@@ -311,5 +326,45 @@ describe("ORCH-0992 reduce-motion ambient cover gate", () => {
         loop: true,
       }),
     ).toBe("video");
+  });
+});
+
+// ORCH-1124 [cover-video Sound/Mute pill unreachable under floating chrome].
+// The shared public event page (buyer/anon web + business app) used to override
+// EventCoverMedia's audio-pill position to "topRight", which planted the
+// Sound/Mute pill directly under the top-right floating close+share chrome — an
+// unreachable dead tap. Fix: drop the override so the pill inherits the
+// "bottomRight" default (the position the consumer app already uses via
+// expandedCard/ImageGallery), clearing the chrome.
+describe("ORCH-1124 cover-video audio pill clears top-right floating chrome", () => {
+  const sharedPublicPage = (): string =>
+    repoFile("../packages/event-rendering/PublicEventPage.tsx");
+  const coverMedia = (): string =>
+    repoFile("../packages/event-rendering/EventCoverMedia.tsx");
+
+  // HAPPY PATH — the public event page must NOT override the audio-pill
+  // position, so it inherits the shared component's "bottomRight" default.
+  // Fails-on-revert: re-adding `audioControlPosition="topRight"` (or any
+  // top-anchored override) on the EventCoverMedia in PublicEventPage.tsx makes
+  // this assertion fail.
+  test("public event page does not pin the cover audio pill to a top position", () => {
+    const page = sharedPublicPage();
+    expect(page).toContain("showAudioControl");
+    expect(page).not.toContain('audioControlPosition="topRight"');
+    expect(page).not.toContain('audioControlPosition="topLeft"');
+  });
+
+  // The shared component's audio-pill default is "bottomRight" and is styled
+  // inside the cover container (bottom:14 / right:14) — not the page base — so
+  // it does not collide with the host-mounted floating Buy bar (ORCH-1117).
+  test("EventCoverMedia defaults the audio pill to bottomRight, styled within the cover", () => {
+    const media = coverMedia();
+    expect(media).toContain('audioControlPosition = "bottomRight"');
+    expect(media).toContain("audioControlBottomRight:");
+    const bottomRightStyle = media
+      .slice(media.indexOf("audioControlBottomRight:"))
+      .slice(0, 80);
+    expect(bottomRightStyle).toContain("right: 14");
+    expect(bottomRightStyle).toContain("bottom: 14");
   });
 });

--- a/mingla-business/src/components/ui/__tests__/orch_1124_cover_audio_pill_fires.adversarial.test.ts
+++ b/mingla-business/src/components/ui/__tests__/orch_1124_cover_audio_pill_fires.adversarial.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ORCH-1124 [cover-video Sound/Mute pill unreachable under floating chrome]
+ * — TESTER ADVERSARIAL TEST (different angle than the implementor's).
+ *
+ * The implementor's happy-path tests (in eventCoverMedia.test.ts) assert the
+ * POSITION contract only: PublicEventPage must not pin the pill to a top
+ * position, and EventCoverMedia's default is "bottomRight" at right:14/bottom:14.
+ *
+ * Those tests would still pass if a future regression moved the pill correctly
+ * to the bottom-right but BROKE OR REMOVED the tap handler, or buried the pill
+ * under cover children — i.e. the pill renders in the right place yet is a DEAD
+ * TAP. Moving a control without keeping it FIRING is the exact class of bug
+ * ORCH-1124 exists to kill ([[feedback_interactive_elements_must_fire_runtime_proof]]).
+ *
+ * Runtime proof for this ORCH was captured in Chromium against the live
+ * /e/leggothis/a-life-in-vegas video-cover page: dispatching a click on the
+ * bottom-right pill toggled aria-label "Turn on cover video audio" ->
+ * "Mute cover video audio" and the <video>.muted property true -> false -> true.
+ * This source-level adversarial test locks the FIRING WIRING + STACKING so the
+ * runtime-proven behaviour cannot silently regress in CI (the repo Jest harness
+ * runs in a Node env without react-test-renderer, so render-mount is not
+ * available — see PublicBrandPage.closeButton.test.tsx harness note).
+ *
+ * Append-only; targets a DIFFERENT angle (handler firing + stacking) than the
+ * implementor's position-only assertions.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const coverMediaSource = (): string =>
+  readFileSync(
+    path.join(process.cwd(), "../packages/event-rendering/EventCoverMedia.tsx"),
+    "utf8",
+  );
+
+describe("ORCH-1124 adversarial — bottom-right cover audio pill must FIRE, not just sit there", () => {
+  // ANGLE 1 — the pill is a Pressable whose onPress TOGGLES mute state and
+  // notifies the parent. A regression that keeps bottomRight but drops this
+  // wiring (turning the relocated pill into a dead tap) MUST fail here.
+  test("audio pill onPress toggles isMuted and calls onMutedChange (the tap fires)", () => {
+    const src = coverMediaSource();
+    // Isolate the audio-control Pressable block.
+    const pressableIdx = src.indexOf("setIsMuted((prev) =>");
+    expect(pressableIdx).toBeGreaterThan(-1);
+    const block = src.slice(pressableIdx, pressableIdx + 320);
+    // It flips the boolean...
+    expect(block).toContain("const next = !prev;");
+    // ...notifies the parent (the audio actually changes upstream)...
+    expect(block).toContain("onMutedChange?.(next);");
+    // ...and persists the new value.
+    expect(block).toContain("return next;");
+  });
+
+  // ANGLE 2 — a button that renders behind other content is also a dead tap.
+  // The audio control carries a positive zIndex so the bottom-right pill stacks
+  // ABOVE the cover media/overlay. A regression that drops the zIndex would let
+  // the (correctly positioned) pill be swallowed — must fail here.
+  test("audio control is stacked above the cover (positive zIndex) so it stays tappable", () => {
+    const src = coverMediaSource();
+    const styleIdx = src.indexOf("audioControl: {");
+    expect(styleIdx).toBeGreaterThan(-1);
+    const styleBlock = src.slice(styleIdx, styleIdx + 320);
+    expect(styleBlock).toContain("position: \"absolute\"");
+    const zMatch = styleBlock.match(/zIndex:\s*(\d+)/);
+    expect(zMatch).not.toBeNull();
+    expect(Number(zMatch![1])).toBeGreaterThanOrEqual(1);
+  });
+
+  // ANGLE 3 — the "bottomRight" default must actually route to the
+  // audioControlBottomRight style in the style-selection chain (not just exist
+  // as a dead style). Position default + style branch must be connected, else
+  // the default falls back to the unpositioned base and overlaps the chrome
+  // again. The implementor tests check the default value and the style's
+  // coordinates separately; this asserts the WIRING between them.
+  test("the bottomRight position is wired to its style branch in the Pressable", () => {
+    const src = coverMediaSource();
+    expect(src).toContain('audioControlPosition = "bottomRight"');
+    expect(src).toMatch(
+      /audioControlPosition === "bottomRight"[\s\S]{0,60}styles\.audioControlBottomRight/,
+    );
+  });
+});

--- a/packages/event-rendering/PublicEventPage.tsx
+++ b/packages/event-rendering/PublicEventPage.tsx
@@ -589,7 +589,11 @@ const PublishedBody: React.FC<PublishedBodyProps> = ({
                 style={StyleSheet.absoluteFill}
                 onAspectRatio={setHeroAspect}
                 showAudioControl={event.coverMediaType === "video"}
-                audioControlPosition="topRight"
+                // ORCH-1124 — inherit EventCoverMedia's "bottomRight" default so
+                // the Sound/Mute pill clears the top-right floating close+share
+                // chrome (the prior "topRight" override sat directly under it and
+                // was an unreachable dead tap). Consumer app already uses
+                // "bottomRight" via expandedCard/ImageGallery.
               />
             ) : (
               <View


### PR DESCRIPTION
## ORCH-1124 — cover-video Sound/Mute pill unreachable → bottom-right

The Sound/Mute pill on the public event page cover-video sat top-right, directly under the floating close+share chrome, so it couldn't be tapped.

**Fix:** dropped the `audioControlPosition="topRight"` override at `packages/event-rendering/PublicEventPage.tsx` so the pill inherits `EventCoverMedia`'s `bottomRight` default (the position the consumer app already uses). One line.

**Surfaces:** buyer/anon web (`/e/`) + business app (shared `@mingla/event-rendering` adapter). Consumer app already `bottomRight` — untouched.

**TEST PASS (runtime, Chromium vs live video-cover event):** pill renders bottom-right (right≈14/bottom≈14), FIRES bidirectionally (toggles `<video>.muted` + aria-label), clears top-right chrome (136px) and the ORCH-1117 floating Buy bar (431px on a short page). Carved from ORCH-1117 ask #6, Seth-confirmed.

**Regression:** stale `eventCoverMedia.test.ts` assertion reconciled (`[TEST-MOD-APPROVED ORCH-1124]`) + implementor happy-path + tester adversarial tap-fires test, both fails-on-revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)