### PR TITLE
ORCH-1127: GIF cover-picker key reachability — fix "This source is taking a break" [deploy]

### DIFF
--- a/.github/scripts/strict-grep/i-giphy-key-wired.mjs
+++ b/.github/scripts/strict-grep/i-giphy-key-wired.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Strict-grep gate — ORCH-1116 [Cover picker GIF tab "This source is taking a break"]
+ * I-PROPOSED-GIPHY-KEY-WIRED + I-PROPOSED-GIPHY-KEY-FAIL-LOUD (DRAFT)
+ *
+ * The client-direct GIPHY public key (EXPO_PUBLIC_GIPHY_API_KEY) cannot be
+ * edge-proxied (GIPHY ToS), so a missing key silently breaks the cover-picker
+ * GIF tab on the affected build. This gate asserts the repo-side wiring that
+ * prevents that recurrence cannot be silently removed:
+ *
+ *   1. mingla-business/app.config.ts carries the GIPHY fail-loud config-eval
+ *      guard — it references EXPO_PUBLIC_GIPHY_API_KEY AND throws when the key
+ *      is absent on a release-bound profile.
+ *   2. mingla-business/.env.example documents EXPO_PUBLIC_GIPHY_API_KEY.
+ *
+ * The build-time PRESENCE of the key in the EAS environment is enforced by the
+ * config-eval guard itself (§4.B); this gate enforces the SOURCE wiring so the
+ * guard + docs can't be reverted without CI catching it.
+ *
+ * Exit codes: 0 pass · 1 fail · 2 fs error
+ * Self-test mode (--self-test) validates the detectors against fixtures.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+const APP_CONFIG = path.join(REPO_ROOT, "mingla-business/app.config.ts");
+const ENV_EXAMPLE = path.join(REPO_ROOT, "mingla-business/.env.example");
+
+// The guard must (a) reference the key name and (b) throw referencing the same
+// key — a `throw new Error("...EXPO_PUBLIC_GIPHY_API_KEY...required...")`. We
+// match a throw whose message names the key, which is the structural shape of
+// the §4.B fail-loud guard. A simple read/passthrough of the key without a
+// throw is NOT enough (that would not fail a mis-provisioned release build).
+const GUARD_THROW_RE =
+  /throw new Error\(\s*[`"'][^`"']*EXPO_PUBLIC_GIPHY_API_KEY[^`"']*required[^`"']*[`"']/i;
+const KEY_REF_RE = /EXPO_PUBLIC_GIPHY_API_KEY/;
+// .env.example documents the key as a top-level entry (`EXPO_PUBLIC_GIPHY_API_KEY=`).
+const ENV_EXAMPLE_RE = /^EXPO_PUBLIC_GIPHY_API_KEY=/m;
+
+let failures = 0;
+function fail(check, msg) {
+  failures += 1;
+  console.error(`FAIL [${check}] ${msg}`);
+}
+function ok(check, msg) {
+  console.log(`OK   [${check}] ${msg}`);
+}
+
+function readSource(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (e) {
+    console.error(`fs error reading ${filePath}: ${e.message}`);
+    process.exit(2);
+  }
+}
+
+function runSelfTest() {
+  let selfFail = 0;
+  const goodGuard = `
+    EXPO_PUBLIC_GIPHY_API_KEY: (() => {
+      const fromEnv = process.env.EXPO_PUBLIC_GIPHY_API_KEY ?? null;
+      if (isReleaseBound && (fromEnv === null || fromEnv.length === 0)) {
+        throw new Error(
+          \`EXPO_PUBLIC_GIPHY_API_KEY is required for the \${profileLabel} build (cover-picker GIF tab). Provision it in the matching EAS environment.\`,
+        );
+      }
+      return fromEnv;
+    })(),`;
+  const passthroughOnly = `
+    EXPO_PUBLIC_GIPHY_API_KEY: process.env.EXPO_PUBLIC_GIPHY_API_KEY ?? null,`;
+  const goodEnv = `EXPO_PUBLIC_OPENWEATHER_API_KEY=foo\nEXPO_PUBLIC_GIPHY_API_KEY=\n`;
+  const badEnv = `EXPO_PUBLIC_OPENWEATHER_API_KEY=foo\n`;
+
+  if (!(KEY_REF_RE.test(goodGuard) && GUARD_THROW_RE.test(goodGuard))) {
+    console.error("SELF-TEST FAIL: valid GIPHY fail-loud guard not detected");
+    selfFail++;
+  }
+  if (GUARD_THROW_RE.test(passthroughOnly)) {
+    console.error(
+      "SELF-TEST FAIL: passthrough-without-throw false-positive as a fail-loud guard",
+    );
+    selfFail++;
+  }
+  if (!ENV_EXAMPLE_RE.test(goodEnv)) {
+    console.error("SELF-TEST FAIL: documented .env.example entry not detected");
+    selfFail++;
+  }
+  if (ENV_EXAMPLE_RE.test(badEnv)) {
+    console.error("SELF-TEST FAIL: .env.example false-positive on missing entry");
+    selfFail++;
+  }
+  if (selfFail > 0) {
+    console.error(`SELF-TEST: ${selfFail} expectation(s) failed`);
+    process.exit(1);
+  }
+  console.log("SELF-TEST OK: I-GIPHY-KEY-WIRED detectors behave");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+}
+
+// Check 1 — app.config.ts fail-loud guard present
+if (!fs.existsSync(APP_CONFIG)) {
+  fail("INV-1: app-config-present", "mingla-business/app.config.ts missing");
+} else {
+  const src = readSource(APP_CONFIG);
+  const hasKeyRef = KEY_REF_RE.test(src);
+  const hasGuardThrow = GUARD_THROW_RE.test(src);
+  if (hasKeyRef && hasGuardThrow) {
+    ok(
+      "INV-1: giphy-fail-loud-guard",
+      "app.config.ts references EXPO_PUBLIC_GIPHY_API_KEY and throws when it is absent on a release-bound profile",
+    );
+  } else {
+    fail(
+      "INV-1: giphy-fail-loud-guard",
+      `app.config.ts is missing the GIPHY fail-loud guard (keyRef=${hasKeyRef}, guardThrow=${hasGuardThrow}) — see SPEC_ORCH-1116 §4.B`,
+    );
+  }
+}
+
+// Check 2 — .env.example documents the key
+if (!fs.existsSync(ENV_EXAMPLE)) {
+  fail("INV-2: env-example-present", "mingla-business/.env.example missing");
+} else {
+  const env = readSource(ENV_EXAMPLE);
+  if (ENV_EXAMPLE_RE.test(env)) {
+    ok("INV-2: env-example-documents-key", ".env.example documents EXPO_PUBLIC_GIPHY_API_KEY");
+  } else {
+    fail(
+      "INV-2: env-example-documents-key",
+      ".env.example does NOT document EXPO_PUBLIC_GIPHY_API_KEY — see SPEC_ORCH-1116 §4.A2",
+    );
+  }
+}
+
+if (failures > 0) {
+  console.error(`\nI-GIPHY-KEY-WIRED: ${failures} violation(s)`);
+  process.exit(1);
+}
+console.log("\nI-GIPHY-KEY-WIRED: PASS · violations=0");
+process.exit(0);

--- a/.github/scripts/strict-grep/i-giphy-key-wired.mjs
+++ b/.github/scripts/strict-grep/i-giphy-key-wired.mjs
@@ -13,10 +13,15 @@
  *      guard — it references EXPO_PUBLIC_GIPHY_API_KEY AND throws when the key
  *      is absent on a release-bound profile.
  *   2. mingla-business/.env.example documents EXPO_PUBLIC_GIPHY_API_KEY.
+ *   3. (ORCH-1127) BOTH giphy services read the key from
+ *      `Constants.expoConfig.extra` FIRST (manifest-backed, build-safe) and do
+ *      NOT regress to a dynamic-only `process.env[<var>]` / `globalThis.process
+ *      ?.env?.[<var>]` read — which babel-preset-expo never inlines, leaving the
+ *      key undefined in every Hermes standalone / OTA / production build.
  *
  * The build-time PRESENCE of the key in the EAS environment is enforced by the
  * config-eval guard itself (§4.B); this gate enforces the SOURCE wiring so the
- * guard + docs can't be reverted without CI catching it.
+ * guard + docs + extra-first read can't be reverted without CI catching it.
  *
  * Exit codes: 0 pass · 1 fail · 2 fs error
  * Self-test mode (--self-test) validates the detectors against fixtures.
@@ -32,6 +37,11 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 
 const APP_CONFIG = path.join(REPO_ROOT, "mingla-business/app.config.ts");
 const ENV_EXAMPLE = path.join(REPO_ROOT, "mingla-business/.env.example");
+// ORCH-1127 — the two client-direct GIPHY services that read the public key.
+const GIPHY_SERVICES = [
+  "mingla-business/src/services/giphyEventCoverService.ts",
+  "mingla-business/src/services/coverProviderBrowseService.ts",
+];
 
 // The guard must (a) reference the key name and (b) throw referencing the same
 // key — a `throw new Error("...EXPO_PUBLIC_GIPHY_API_KEY...required...")`. We
@@ -43,6 +53,15 @@ const GUARD_THROW_RE =
 const KEY_REF_RE = /EXPO_PUBLIC_GIPHY_API_KEY/;
 // .env.example documents the key as a top-level entry (`EXPO_PUBLIC_GIPHY_API_KEY=`).
 const ENV_EXAMPLE_RE = /^EXPO_PUBLIC_GIPHY_API_KEY=/m;
+
+// ORCH-1127 — each giphy service MUST read the manifest-backed extra first.
+const EXTRA_READ_RE = /Constants\.expoConfig\??\.extra/;
+// ...and MUST NOT regress to a dynamic-only process.env bracket read with a
+// VARIABLE key (`process.env[name]` / `process.env?.[name]` / `.env?.[name]`).
+// A STATIC member read (`process.env.EXPO_PUBLIC_GIPHY_API_KEY`) is fine — it is
+// inlined by babel-preset-expo — so this only matches the bracket form whose
+// subscript is NOT a quoted string literal.
+const DYNAMIC_ENV_BRACKET_RE = /\.env\??\.?\[\s*(?!['"`])[^\]]+\]/;
 
 let failures = 0;
 function fail(check, msg) {
@@ -60,6 +79,15 @@ function readSource(filePath) {
     console.error(`fs error reading ${filePath}: ${e.message}`);
     process.exit(2);
   }
+}
+
+// Strip // line comments and /* */ block comments so the dynamic-bracket
+// detector only inspects executable code — the protective ORCH-1127 comments
+// intentionally name `process.env[<var>]` and must not self-trip the gate.
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
 }
 
 function runSelfTest() {
@@ -97,6 +125,49 @@ function runSelfTest() {
     console.error("SELF-TEST FAIL: .env.example false-positive on missing entry");
     selfFail++;
   }
+
+  // ORCH-1127 — extra-first read + no dynamic-bracket regression.
+  const goodService = `
+    import Constants from "expo-constants";
+    const readExtra = (name) => {
+      const extra = Constants.expoConfig?.extra;
+      return extra?.[name];
+    };
+    const readStatic = (name) =>
+      name === "EXPO_PUBLIC_GIPHY_API_KEY"
+        ? process.env.EXPO_PUBLIC_GIPHY_API_KEY
+        : process.env.EXPO_PUBLIC_GIPHY_KEY;
+    const envValue = (name) => readExtra(name) ?? readStatic(name);
+  `;
+  const dynamicOnlyService = `
+    const envValue = (name) => {
+      const value = globalThis.process?.env?.[name];
+      return value ?? null;
+    };
+  `;
+  if (!EXTRA_READ_RE.test(goodService)) {
+    console.error("SELF-TEST FAIL: extra-first read not detected in a correct service");
+    selfFail++;
+  }
+  if (DYNAMIC_ENV_BRACKET_RE.test(goodService)) {
+    console.error(
+      "SELF-TEST FAIL: dynamic-bracket detector false-positives on a correct (static + extra) service",
+    );
+    selfFail++;
+  }
+  if (EXTRA_READ_RE.test(dynamicOnlyService)) {
+    console.error(
+      "SELF-TEST FAIL: extra-read detector false-positives on a dynamic-only service",
+    );
+    selfFail++;
+  }
+  if (!DYNAMIC_ENV_BRACKET_RE.test(dynamicOnlyService)) {
+    console.error(
+      "SELF-TEST FAIL: dynamic-bracket detector missed the regressed dynamic-only reader",
+    );
+    selfFail++;
+  }
+
   if (selfFail > 0) {
     console.error(`SELF-TEST: ${selfFail} expectation(s) failed`);
     process.exit(1);
@@ -140,6 +211,31 @@ if (!fs.existsSync(ENV_EXAMPLE)) {
     fail(
       "INV-2: env-example-documents-key",
       ".env.example does NOT document EXPO_PUBLIC_GIPHY_API_KEY — see SPEC_ORCH-1116 §4.A2",
+    );
+  }
+}
+
+// Check 3 — ORCH-1127: both giphy services read Constants.expoConfig.extra
+// first and do NOT regress to a dynamic-only process.env bracket read.
+for (const rel of GIPHY_SERVICES) {
+  const abs = path.join(REPO_ROOT, rel);
+  if (!fs.existsSync(abs)) {
+    fail("INV-3: giphy-service-present", `${rel} missing`);
+    continue;
+  }
+  const src = readSource(abs);
+  const code = stripComments(src);
+  const hasExtraRead = EXTRA_READ_RE.test(code);
+  const hasDynamicBracket = DYNAMIC_ENV_BRACKET_RE.test(code);
+  if (hasExtraRead && !hasDynamicBracket) {
+    ok(
+      "INV-3: giphy-extra-first-read",
+      `${rel} reads Constants.expoConfig.extra and has no dynamic process.env[<var>] read`,
+    );
+  } else {
+    fail(
+      "INV-3: giphy-extra-first-read",
+      `${rel} must read Constants.expoConfig.extra (found=${hasExtraRead}) and must NOT use a dynamic process.env[<var>] read (foundDynamic=${hasDynamicBracket}) — see SPEC_AMENDMENT_ORCH-1127 §A2/§A3.4`,
     );
   }
 }

--- a/.github/scripts/strict-grep/i-giphy-key-wired.test.mjs
+++ b/.github/scripts/strict-grep/i-giphy-key-wired.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+const SCRIPT = new URL("./i-giphy-key-wired.mjs", import.meta.url);
+const SCRIPT_PATH = fileURLToPath(SCRIPT);
+const SCRIPT_SOURCE = readFileSync(SCRIPT_PATH, "utf8");
+
+function writeFixture(root, rel, source) {
+  const file = join(root, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, source);
+  return file;
+}
+
+/**
+ * The gate resolves REPO_ROOT three levels up from the script and reads fixed
+ * paths under mingla-business/. To exercise it against fixtures we copy the
+ * script into a temp repo root so its relative resolution points at our
+ * fixtures.
+ */
+function runAgainstRepo(appConfig, envExample) {
+  const root = mkdtempSync(join(tmpdir(), "orch-1116-giphy-wired-"));
+  try {
+    // Recreate the .github/scripts/strict-grep/ layout so the script's
+    // `path.resolve(__dirname, "..","..","..")` lands on `root`.
+    const scriptCopy = writeFixture(
+      root,
+      ".github/scripts/strict-grep/i-giphy-key-wired.mjs",
+      SCRIPT_SOURCE,
+    );
+    writeFixture(root, "mingla-business/app.config.ts", appConfig);
+    writeFixture(root, "mingla-business/.env.example", envExample);
+    return spawnSync(process.execPath, [scriptCopy], { encoding: "utf8" });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const GOOD_APP_CONFIG = `
+export default () => ({
+  extra: {
+    EXPO_PUBLIC_GIPHY_API_KEY: (() => {
+      const fromEnv = process.env.EXPO_PUBLIC_GIPHY_API_KEY ?? null;
+      if (isReleaseBound && (fromEnv === null || fromEnv.length === 0)) {
+        throw new Error(
+          \`EXPO_PUBLIC_GIPHY_API_KEY is required for the \${profileLabel} build (cover-picker GIF tab). Provision it in the matching EAS environment.\`,
+        );
+      }
+      return fromEnv;
+    })(),
+  },
+});
+`;
+
+const PASSTHROUGH_ONLY_APP_CONFIG = `
+export default () => ({
+  extra: {
+    EXPO_PUBLIC_GIPHY_API_KEY: process.env.EXPO_PUBLIC_GIPHY_API_KEY ?? null,
+  },
+});
+`;
+
+const GOOD_ENV = `EXPO_PUBLIC_OPENWEATHER_API_KEY=x\nEXPO_PUBLIC_GIPHY_API_KEY=\n`;
+const BAD_ENV = `EXPO_PUBLIC_OPENWEATHER_API_KEY=x\n`;
+
+test("self-test passes (detectors behave)", () => {
+  const out = execFileSync(process.execPath, [SCRIPT_PATH, "--self-test"], {
+    encoding: "utf8",
+  });
+  assert.match(out, /SELF-TEST OK/);
+});
+
+test("gate passes the post-fix repo HEAD", () => {
+  const out = execFileSync(process.execPath, [SCRIPT_PATH], {
+    encoding: "utf8",
+  });
+  assert.match(out, /PASS · violations=0/);
+});
+
+test("gate passes a guarded app.config + documented .env.example", () => {
+  const r = runAgainstRepo(GOOD_APP_CONFIG, GOOD_ENV);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /PASS · violations=0/);
+});
+
+test("fails-on-revert: gate FAILS when the fail-loud guard is removed (passthrough only)", () => {
+  const r = runAgainstRepo(PASSTHROUGH_ONLY_APP_CONFIG, GOOD_ENV);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /giphy-fail-loud-guard/);
+});
+
+test("fails-on-revert: gate FAILS when .env.example entry is removed", () => {
+  const r = runAgainstRepo(GOOD_APP_CONFIG, BAD_ENV);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /env-example-documents-key/);
+});

--- a/.github/scripts/strict-grep/i-giphy-key-wired.test.mjs
+++ b/.github/scripts/strict-grep/i-giphy-key-wired.test.mjs
@@ -23,7 +23,7 @@ function writeFixture(root, rel, source) {
  * script into a temp repo root so its relative resolution points at our
  * fixtures.
  */
-function runAgainstRepo(appConfig, envExample) {
+function runAgainstRepo(appConfig, envExample, services) {
   const root = mkdtempSync(join(tmpdir(), "orch-1116-giphy-wired-"));
   try {
     // Recreate the .github/scripts/strict-grep/ layout so the script's
@@ -35,6 +35,22 @@ function runAgainstRepo(appConfig, envExample) {
     );
     writeFixture(root, "mingla-business/app.config.ts", appConfig);
     writeFixture(root, "mingla-business/.env.example", envExample);
+    // ORCH-1127 — INV-3 reads the two giphy services; provide them so the gate
+    // doesn't fail merely because the fixture files are absent.
+    const svc = services ?? {
+      giphy: GOOD_GIPHY_SERVICE,
+      browse: GOOD_GIPHY_SERVICE,
+    };
+    writeFixture(
+      root,
+      "mingla-business/src/services/giphyEventCoverService.ts",
+      svc.giphy,
+    );
+    writeFixture(
+      root,
+      "mingla-business/src/services/coverProviderBrowseService.ts",
+      svc.browse,
+    );
     return spawnSync(process.execPath, [scriptCopy], { encoding: "utf8" });
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -68,6 +84,27 @@ export default () => ({
 const GOOD_ENV = `EXPO_PUBLIC_OPENWEATHER_API_KEY=x\nEXPO_PUBLIC_GIPHY_API_KEY=\n`;
 const BAD_ENV = `EXPO_PUBLIC_OPENWEATHER_API_KEY=x\n`;
 
+// ORCH-1127 — service fixtures for the INV-3 extra-first-read check.
+const GOOD_GIPHY_SERVICE = `
+import Constants from "expo-constants";
+const readExtra = (name) => {
+  const extra = Constants.expoConfig?.extra;
+  return extra?.[name];
+};
+const readStatic = (name) =>
+  name === "EXPO_PUBLIC_GIPHY_API_KEY"
+    ? process.env.EXPO_PUBLIC_GIPHY_API_KEY
+    : process.env.EXPO_PUBLIC_GIPHY_KEY;
+const envValue = (name) => readExtra(name) ?? readStatic(name);
+`;
+// The regressed reader: dynamic-only process.env bracket access, no extra read.
+const DYNAMIC_ONLY_GIPHY_SERVICE = `
+const envValue = (name) => {
+  const value = globalThis.process?.env?.[name];
+  return typeof value === "string" ? value : null;
+};
+`;
+
 test("self-test passes (detectors behave)", () => {
   const out = execFileSync(process.execPath, [SCRIPT_PATH, "--self-test"], {
     encoding: "utf8",
@@ -98,4 +135,22 @@ test("fails-on-revert: gate FAILS when .env.example entry is removed", () => {
   const r = runAgainstRepo(GOOD_APP_CONFIG, BAD_ENV);
   assert.equal(r.status, 1);
   assert.match(r.stderr, /env-example-documents-key/);
+});
+
+test("ORCH-1127: gate PASSES when both services read extra first", () => {
+  const r = runAgainstRepo(GOOD_APP_CONFIG, GOOD_ENV, {
+    giphy: GOOD_GIPHY_SERVICE,
+    browse: GOOD_GIPHY_SERVICE,
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /PASS · violations=0/);
+});
+
+test("ORCH-1127 fails-on-revert: gate FAILS when a service regresses to a dynamic-only process.env read", () => {
+  const r = runAgainstRepo(GOOD_APP_CONFIG, GOOD_ENV, {
+    giphy: DYNAMIC_ONLY_GIPHY_SERVICE,
+    browse: GOOD_GIPHY_SERVICE,
+  });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /giphy-extra-first-read/);
 });

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -126,6 +126,7 @@ on:
 #   - I-BIZ-VENUE-INPUT-USES-MAPBOX (i-biz-venue-input-uses-mapbox.mjs) — venue/brand/trip pickers import the shared MapboxAddressInput + zero Google AddressAutocompleteInput/googlePlacesService/parseGooglePlaceResult tokens; self-tested (ORCH-1079 INV-1)
 #   - I-NO-BIZ-GOOGLE-PLACES-AUTOCOMPLETE (i-no-biz-google-places-autocomplete.mjs) — the 4 dead Google files are gone + no mingla-business/src ref, BUT GOOGLE_MAPS_API_KEY still present in a keep-list edge fn (P0 guard); self-tested (ORCH-1079 INV-2)
 #   - I-MAPBOX-SUGGEST-NO-TYPES-FILTER (i-mapbox-suggest-no-types-filter.mjs) — mapbox-geocode suggest call stays filter-free so POIs/venues resolve by name; self-tested (ORCH-1079 INV-3)
+#   - I-GIPHY-KEY-WIRED (i-giphy-key-wired.mjs) — app.config.ts carries the GIPHY fail-loud config-eval guard + .env.example documents EXPO_PUBLIC_GIPHY_API_KEY; self-tested (ORCH-1116 — DRAFT until CLOSE)
 #
 # Future gates to register (proposed but not yet implemented):
 #   - I-32 rank parity (Cycle 13a proposal)
@@ -2280,6 +2281,19 @@ jobs:
         run: node .github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs --self-test
       - name: Run ORCH-1117 no-raw-white-on-palette-surface gate
         run: node .github/scripts/strict-grep/orch-1117-no-raw-white-on-palette-surface.mjs
+
+  orch-1116-giphy-key-wired:
+    name: "ORCH-1116: GIPHY key wired — app.config fail-loud guard + .env.example documented (I-GIPHY-KEY-WIRED)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1116 giphy-key-wired self-test
+        run: node .github/scripts/strict-grep/i-giphy-key-wired.mjs --self-test
+      - name: Run ORCH-1116 giphy-key-wired gate
+        run: node .github/scripts/strict-grep/i-giphy-key-wired.mjs
 
   # ORCH-0962 brand-field-map-coverage gate RETIRED at META-ORCH-0972 CLOSE
   # (2026-05-26). The gate asserted that `viewRowToBrand` reads `row.brand_kind`

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1116_GIF_COVER_PICKER.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1116_GIF_COVER_PICKER.md
@@ -1,0 +1,163 @@
+# IMPLEMENTATION — ORCH-1116 [Cover picker GIF tab "This source is taking a break"]
+
+**Skill:** mingla-implementor (business side) · **Phase:** IMPLEMENT · **Date:** 2026-06-11
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1116-[gif-cover-key]/` · **Branch:** `ORCH-1116-gif-cover-key`
+**Commit:** `9b10dd2b1` (single scoped commit) · **Base:** `origin/main` @ `0f9860b4a` (0 behind — no rebase needed)
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1116_GIF_COVER_PICKER.md`
+**Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1116_GIF_COVER_PICKER.md`
+**Status:** implemented and verified (code + gates green; behavioral guard probe + fails-on-revert proven). EAS-env provisioning + fresh dev/preview rebuild remain Seth's operator steps.
+
+---
+
+## 1. Summary
+
+The business cover-picker GIF tab showed "This source is taking a break." on every
+dev/preview build (and local Metro) because the client-direct GIPHY public key
+(`EXPO_PUBLIC_GIPHY_API_KEY`) is provisioned only in the EAS **production**
+environment. This change does three things, exactly per the SPEC: (Fix) documents
+the key in `.env.example` with the rebuild-vs-OTA implication; (Prevent) adds a
+config-eval **fail-loud guard** in `app.config.ts` (modeled on the `pk_live`
+guard) so a release-bound build can no longer ship without the key, plus a
+strict-grep CI gate; (Detect) routes the `not_configured` CONFIG error to
+engineering telemetry via the existing Sentry-backed `reportNonFatal`, while
+leaving transient faults user-facing-only. The friendly UI copy is unchanged.
+
+The key value itself is NOT in code — provisioning the EAS dev/preview env and a
+fresh dev/preview rebuild are Seth's operator steps.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Description | Status | Evidence / commit |
+|----|-------------|--------|-------------------|
+| SC-1-iOS/Android | GIF tab loads trending on a built dev/preview-with-key build | ✓ (config-eval verified; runtime needs operator rebuild) | `9b10dd2b1` guard returns key when present (probe T1); operator must provision EAS env + rebuild |
+| SC-2-iOS/Android | GIF search returns results | ✓ (same as SC-1 — same key path) | `9b10dd2b1` |
+| SC-3 | Release build WITHOUT key FAILS at config-eval with explicit message | ✓ verified | `9b10dd2b1` guard probe: preview/production-apk/vercel-production THROW (§9 below) |
+| SC-4 | Development/local build WITHOUT key still builds (friendly copy) | ✓ verified | `9b10dd2b1` guard probe: development/local return null + warn, NO throw |
+| SC-5 | `not_configured` emits console.warn + Sentry capture; transient emits nothing | ✓ verified | `9b10dd2b1` jest `CoverPicker.providerTelemetry` T5/T6/T6b |
+| SC-6 | `.env.example` documents `EXPO_PUBLIC_GIPHY_API_KEY` | ✓ verified | `9b10dd2b1` `.env.example` |
+| SC-7 | Strict-grep gate PASSES with guard present, FAILS on removal | ✓ verified | `9b10dd2b1` `i-giphy-key-wired.mjs` + `.test.mjs` (5/5 pass incl. 2 fails-on-revert cases) |
+
+---
+
+## 3. Files changed (all within SPEC §11 allowlist)
+
+| File | +lines | Change |
+|------|--------|--------|
+| `mingla-business/.env.example` | +6 | Documented `EXPO_PUBLIC_GIPHY_API_KEY=` placeholder + rebuild-vs-OTA note |
+| `mingla-business/app.config.ts` | +45 | GIPHY config-eval fail-loud guard IIFE (modeled on the `pk_live` guard) |
+| `mingla-business/src/components/ui/CoverPicker.tsx` | +23 | `reportNonFatal` import + single `reportProviderError` helper (gated on `not_configured`) wired at all 4 provider catch sites |
+| `.github/scripts/strict-grep/i-giphy-key-wired.mjs` | +152 (new) | Strict-grep gate: app.config guard + .env.example documented; `--self-test` |
+| `.github/scripts/strict-grep/i-giphy-key-wired.test.mjs` | +101 (new) | node:test companion incl. 2 fails-on-revert cases |
+| `.github/workflows/strict-grep-mingla-business.yml` | +14 | Registry comment line + `orch-1116-giphy-key-wired` job (self-test + gate) |
+
+Closing diff `git diff origin/main...HEAD --name-only` = exactly these 7 files. Both test files are visible in the closing diff.
+
+---
+
+## 4. Data-model changes applied
+
+None. No DB / migration / edge function / hook / realtime layer touched (per SPEC §4).
+
+---
+
+## 5. Edge functions touched
+
+None. The Pexels edge path (`event-cover-pexels-curated`) is untouched (DO-NOT-TOUCH honored).
+
+---
+
+## 6. Regression tests added
+
+- **Happy-path (implementor):** `mingla-business/src/components/ui/__tests__/CoverPicker.providerTelemetry.test.ts` (8 tests). Behavioral CONFIG-vs-transient split (T5/T6/T6b + non-provider Error) with `reportNonFatal` mocked, plus source-wiring assertions (import present, single gated helper, all 4 call-sites, friendly copy unchanged). **Run: 8/8 PASS.**
+- **Gate companion:** `.github/scripts/strict-grep/i-giphy-key-wired.test.mjs` (5 tests incl. self-test + 2 fails-on-revert cases). **Run: 5/5 PASS** via `node --test`.
+- **fails-on-revert verified at `9b10dd2b1`:** deleted the gate condition line `if (code !== "not_configured") return;` from `CoverPicker.tsx` (TRUE line deletion, not comment-out) → `CoverPicker.providerTelemetry` test FAILED (1 failed / 7 passed). Restored via `git checkout -- CoverPicker.tsx` → 8/8 PASS again. The strict-grep gate's own `.test.mjs` additionally proves the gate FAILS when the app.config guard is reduced to a passthrough (no throw) and when the `.env.example` entry is removed.
+
+---
+
+## 7. Old → New receipts
+
+### `mingla-business/.env.example`
+- **Before:** No GIPHY entry; local Metro dev had no documented key (F-3/F-5).
+- **Now:** Documents `EXPO_PUBLIC_GIPHY_API_KEY=` with GIPHY dashboard link + the EXPO_PUBLIC build-time-inlining (rebuild-not-OTA) note.
+- **Why:** SC-6 / §4.A2.
+- **Lines:** +6.
+
+### `mingla-business/app.config.ts`
+- **Before:** No GIPHY validation; a release build with a missing key silently shipped a broken GIF tab.
+- **Now:** Config-eval IIFE reads `EXPO_PUBLIC_GIPHY_API_KEY ?? EXPO_PUBLIC_GIPHY_KEY`; THROWS for release-bound profiles (`production`/`production-apk`/`preview`/`preview-sim` via `EAS_BUILD_PROFILE`, plus Vercel `production`/`preview` via `VERCEL_ENV`) when absent; warns (no crash) for `development`/local. Returns the value into `extra` (belt-and-suspenders, matching the Stripe model); runtime services still read `process.env` directly.
+- **Why:** SC-3 / SC-4 / §4.B; I-PROPOSED-GIPHY-KEY-FAIL-LOUD.
+- **Lines:** +45.
+
+### `mingla-business/src/components/ui/CoverPicker.tsx`
+- **Before:** All 4 provider catch sites set `errorCode`/status and showed friendly copy with ZERO telemetry — a silent CONFIG failure (I-NO-SILENT-FAILURES gap).
+- **Now:** Single exported `reportProviderError(kind, error)` helper containing the sole `reportNonFatal("coverPicker.provider", error, { provider, code })` call, gated on `code === "not_configured"` only; invoked from all 4 catch sites (`loadTrending`, `loadCurated`, `runProviderSearch` gif + stock). Friendly copy untouched.
+- **Why:** SC-5 / §4.C; strengthens I-NO-SILENT-FAILURES.
+- **Lines:** +23 (import + helper + 4 call-site lines).
+
+### `.github/scripts/strict-grep/i-giphy-key-wired.mjs` (+ `.test.mjs`, workflow job)
+- **Before:** No CI gate inspected GIPHY key wiring (F-7 detection gap).
+- **Now:** Gate asserts the app.config fail-loud guard (key ref + throw) AND the `.env.example` entry; FAILS on removal of either. Registered as workflow job `orch-1116-giphy-key-wired` (self-test + run).
+- **Why:** SC-7 / §4.D; I-PROPOSED-GIPHY-KEY-WIRED.
+
+---
+
+## 8. Cross-surface impact table
+
+| Surface | Affected? | Parity | Note |
+|---------|-----------|--------|------|
+| Consumer iOS | NO | — | No CoverPicker / no GIPHY ref |
+| Consumer Android | NO | — | Same |
+| Buyer/anon Web | NO | — | Authoring surface, not buyer |
+| Business iOS | YES | Automatic (shared CoverPicker + app.config) | GIF tab fix + telemetry |
+| Business Android | YES | Automatic (shared code + EAS env per profile spans both platforms) | Same |
+| Admin Web | NO | — | No CoverPicker |
+| Business Web preview | PARTIAL (config) | Manual — web export needs the env at build time too (Vercel guard branch added; O-4 deferred) | Pexels still works regardless |
+
+---
+
+## 9. Smoke / verification result
+
+- **Strict-grep gate:** `i-giphy-key-wired.mjs --self-test` → `SELF-TEST OK`. Real run → `PASS · violations=0`. `node --test i-giphy-key-wired.test.mjs` → 5/5 pass.
+- **Jest:** `CoverPicker.providerTelemetry` 8/8; `giphyEventCoverService` + `coverProviderBrowseService` + `pexelsEventCoverService` + `reportNonFatal` + full `CoverPicker.*` suites → 43/43 pass (no regression).
+- **TypeScript:** `tsc --noEmit` produces ZERO errors referencing the 4 touched files (pre-existing unrelated errors in other files only).
+- **Config-eval guard probe** (isolated guard logic, env-var matrix):
+  - `EAS_BUILD_PROFILE=preview`, no key → THROWS (explicit message). ✓ SC-3
+  - `EAS_BUILD_PROFILE=production-apk`, no key → THROWS. ✓
+  - `VERCEL_ENV=production`, no key → THROWS. ✓
+  - `EAS_BUILD_PROFILE=development`, no key → returns null + warn, NO throw. ✓ SC-4
+  - local (no profile), no key → returns null + warn, NO throw. ✓
+  - `EAS_BUILD_PROFILE=preview` + key present → returns key. ✓ SC-1/SC-2 path
+- **Not verified (operator-gated):** the actual GIF thumbnails rendering on a fresh dev/preview build — requires Seth to provision the EAS dev/preview env vars and rebuild (the key value is not in the repo). Labeled `implemented, partially verified` for SC-1/SC-2 runtime only.
+
+---
+
+## 10. Known issues / deferred
+
+- **O-1 (key provenance):** Reuse the production GIPHY key for dev/preview (Seth's locked decision: reuse). No code reflects a value.
+- **O-2 (Sentry DSN dev/preview):** `EXPO_PUBLIC_SENTRY_DSN` is production-only, so the `not_configured` Sentry capture is a no-op on dev/preview builds (only `console.warn` fires there). Seth's call whether to provision the DSN for dev/preview; not blocking. (D-1)
+- **O-4 (business web export):** the Vercel/web export needs `EXPO_PUBLIC_GIPHY_API_KEY` at build time for the GIF tab to work on web; the guard already covers Vercel production/preview, but env provisioning there is an operator step if web authoring is in use. Deferred.
+- No `[TRANSITIONAL]` code introduced.
+
+---
+
+## 11. Operator action required (Seth)
+
+1. Provision the GIPHY key into the EAS development + preview environments:
+   ```
+   eas env:create --environment development --name EXPO_PUBLIC_GIPHY_API_KEY --value <prod key> --visibility plaintext
+   eas env:create --environment preview     --name EXPO_PUBLIC_GIPHY_API_KEY --value <prod key> --visibility plaintext
+   ```
+   (Optionally repeat for `EXPO_PUBLIC_GIPHY_KEY` to preserve the dual-name fallback.)
+2. Fresh dev/preview build (EXPO_PUBLIC_* is inlined at build time — an OTA on the already-installed dev build will NOT pick up the key).
+3. (Optional, O-2) provision `EXPO_PUBLIC_SENTRY_DSN` for dev/preview if you want config alerts to fire from those builds.
+4. No migration. No edge-function deploy.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- The `app.config.ts` GIPHY guard intentionally uses BOTH `EAS_BUILD_PROFILE` (native) and `VERCEL_ENV` (web export) so the web authoring path is also fail-loud — a small superset of the SPEC's native-only emphasis, justified by Cross-Surface row 7 (PARTIAL web). No scope widening beyond the allowlisted file.
+- At CLOSE, flip the three DRAFT invariants ACTIVE (I-PROPOSED-GIPHY-KEY-FAIL-LOUD, I-PROPOSED-GIPHY-KEY-WIRED, I-PROPOSED-CONFIG-ERROR-IS-OBSERVABLE) and update the README "Active gates registered" table + INVARIANT_REGISTRY per the 4-step gate registration doc.
+- No COMMS-ledger entry written (no cross-ORCH discovery this turn). No OPEN ledger rows addressed to implementor / ORCH-1116 / ALL.

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md
@@ -1,0 +1,153 @@
+# IMPLEMENTATION — ORCH-1127 (ex-1116) [GIF cover-key reachability fix]
+
+**Skill:** mingla-implementor (business side) · **Phase:** IMPLEMENT
+**Date:** 2026-06-12
+**Working tree:** `~/Desktop/mingla-orchs/ORCH-1116-[gif-cover-key]/` on branch `ORCH-1116-gif-cover-key`
+**Binding contract:** `Mingla_Artifacts/specs/SPEC_AMENDMENT_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md` (amends `SPEC_ORCH-1116_GIF_COVER_PICKER.md`)
+**Comms:** acknowledged **COMMS-0028** (WARN, ALL) — this implementation is the code fix COMMS-0028 dispatched; appended ack.
+
+---
+
+## 1. Summary (plain English)
+
+The cover-picker GIF tab showed "This source is taking a break." in every real build (dev-channel OTA, TestFlight, production) even after the GIPHY key was provisioned, because the two GIPHY services read the key via a **dynamic** `process.env[name]` lookup that Expo/babel never inlines — so the value was `undefined` in any Hermes standalone bundle. This change makes both services read the key from `Constants.expoConfig.extra` FIRST (the manifest-backed path `app.config.ts` already populates), with a **static** `process.env` fallback for Metro-dev/web, exactly mirroring the house pattern in `supabase.ts`. Proven on a standalone `expo export`: the key value now lands in the bundle (was 0 occurrences with the old reader, now 1).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| Criterion | Status | Evidence / commit |
+|-----------|--------|-------------------|
+| SC-CORRECT-1 — standalone export carries the key | ✓ | Standalone `expo export --platform ios` with sentinel key → grep value present (count 1) in `_expo/static/js/ios/index-*.hbc`; was 0 with the original dynamic reader. T-CORRECT-1 jest also proves extra→resolved with empty `process.env`. |
+| SC-CORRECT-2 — verify on the RIGHT bundle (not Metro) | ✓ (implementor scope) | Verified via standalone `expo export` + jest empty-`process.env` simulation, NOT the Metro bundle. On-device dev-channel OTA pull is the tester's remaining step per A3.2. |
+| SC-CORRECT-3 — both services fixed identically | ✓ | Both `giphyEventCoverService.ts` + `coverProviderBrowseService.ts` import `expo-constants`, read `Constants.expoConfig?.extra` first, drop the dynamic bracket reader. Strict-grep INV-3 enforces it. |
+| SC-CORRECT-4 — strict-grep gate extended | ✓ | `i-giphy-key-wired.mjs` Check 3 (INV-3): requires `Constants.expoConfig?.extra` read + forbids dynamic `process.env[<var>]`; fails-on-revert covered by the gate's own test. |
+| §4.B comment correction in app.config.ts | ✓ | Lines 181-190 comment corrected (the "EAS inlines it / not a plumbing path" claim removed). |
+| Retained §4.A/B/C/D (provision, guard, telemetry, gate) | ✓ | Untouched from `9b10dd2b1`; only the gate is EXTENDED and the comment corrected. |
+
+---
+
+## 3. Files changed
+
+| File | Δ | Nature |
+|------|---|--------|
+| `mingla-business/src/services/giphyEventCoverService.ts` | +32/-9 | env reader → extra-first (A2); `import Constants`; protective comment |
+| `mingla-business/src/services/coverProviderBrowseService.ts` | +32/-9 | identical fix |
+| `mingla-business/app.config.ts` | +12/-3 | comment-only correction (A5) |
+| `.github/scripts/strict-grep/i-giphy-key-wired.mjs` | +98 | Check 3 INV-3 (extra-first + no-dynamic-bracket) + self-test fixtures + comment-strip helper |
+| `.github/scripts/strict-grep/i-giphy-key-wired.test.mjs` | +57 | service fixtures + 2 new tests (pass + fails-on-revert for INV-3) |
+| `mingla-business/src/services/__tests__/giphyKeyReachability.test.ts` | NEW | T-CORRECT-1..4 |
+| `mingla-business/src/services/__tests__/giphyEventCoverService.test.ts` | +7 | adds `jest.mock("expo-constants")` (service now imports it) |
+| `mingla-business/src/services/__tests__/coverProviderBrowseService.test.ts` | +7 | adds `jest.mock("expo-constants")` |
+
+Plus carried artifacts: `SPEC_AMENDMENT_ORCH-1127_*.md` + `SPEC_ORCH-1116_GIF_COVER_PICKER.md` (forensics-authored contracts).
+
+---
+
+## 4. Data-model changes applied
+
+None. No migrations, no schema, no RLS.
+
+---
+
+## 5. Edge functions touched
+
+None. (The Pexels edge path is untouched per A5 DO-NOT-TOUCH.)
+
+---
+
+## 6. Regression tests added
+
+- **New:** `mingla-business/src/services/__tests__/giphyKeyReachability.test.ts` — T-CORRECT-1..4 (7 tests).
+- **Existing extended (additive only):** the two service tests gained an `expo-constants` mock (no deletions).
+- **Gate test extended (additive only):** `i-giphy-key-wired.test.mjs` +2 tests.
+
+**fails-on-revert verified at `70f799e156898bed679b30038c60cb2410272297`** (post-rebase HEAD with the fix). Method = TRUE line deletion of `readExtra(name) ?? ` in both services (NOT a comment-out):
+- Reverted → `npx jest giphyKeyReachability.test.ts`: **4 tests FAIL** (`not_configured` thrown for the extra-only inputs: T-CORRECT-1 x2, T-CORRECT-2, T-CORRECT-4-extra); the 3 static-`process.env` tests still pass.
+- Restored → all 7 PASS again.
+- Strict-grep gate fails-on-revert: the gate's own `i-giphy-key-wired.test.mjs` test "ORCH-1127 fails-on-revert" feeds a dynamic-only service fixture → gate exits 1 with `giphy-extra-first-read`.
+
+Test runs (post-restore):
+```
+giphyKeyReachability.test.ts          7 passed
+giphyEventCoverService.test.ts        (suite) passed
+coverProviderBrowseService.test.ts    (suite) passed
+=> Test Suites: 3 passed, Tests: 14 passed
+node --test i-giphy-key-wired.test.mjs => 7 pass / 0 fail
+node i-giphy-key-wired.mjs --self-test => SELF-TEST OK
+node i-giphy-key-wired.mjs            => PASS · violations=0
+```
+
+---
+
+## 7. Old → New receipts
+
+### giphyEventCoverService.ts / coverProviderBrowseService.ts (identical)
+**Before:** `envValue(name)` read `globalThis.process?.env?.[name]` (DYNAMIC bracket) — never inlined by babel-preset-expo → `undefined` in Hermes standalone/OTA → `publicGiphyKey()` null → `not_configured` → friendly copy on every non-Metro build.
+**Now:** `envValue(name)` reads `Constants.expoConfig?.extra?.[name]` first (manifest-backed, runtime-populated), then a STATIC `process.env.EXPO_PUBLIC_GIPHY_API_KEY`/`EXPO_PUBLIC_GIPHY_KEY` fallback (inlined for Metro/web). Dual-name fallback + trim/empty→null normalization preserved. All network/normalization/clamp/fail-close logic untouched.
+**Why:** SC-CORRECT-1/3 — make the key reachable in standalone/OTA builds (COMMS-0028 / amendment F-CORRECT-1..4).
+**Lines:** ~+32/-9 each.
+
+### app.config.ts
+**Before:** comment claimed "runtime services read process.env directly (EAS inlines it), so this IIFE is a build-time validation GATE, not a new plumbing path."
+**Now:** comment states the IIFE's emission into `extra` IS the plumbing path the services read; corrects the wrong inlining assumption.
+**Why:** A5 — comment-only correction; guard LOGIC unchanged.
+**Lines:** +12/-3.
+
+### i-giphy-key-wired.mjs (+ .test.mjs)
+**Before:** asserted only (1) app.config fail-loud guard + (2) `.env.example` documents the key.
+**Now:** also asserts (3, INV-3) both giphy services read `Constants.expoConfig.extra` and contain NO dynamic `process.env[<var>]` bracket read; protective comments are comment-stripped before the dynamic-bracket check so they don't self-trip.
+**Why:** A3.4 — make the exact bug un-reintroducible.
+**Lines:** +98 / +57.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected? | Detail |
+|---------|-----------|--------|
+| Consumer iOS | No | GIPHY cover picker is business-app only. |
+| Consumer Android | No | same |
+| Buyer/anon Web | No | not on buyer routes |
+| Business iOS | YES | GIF tab in CoverPicker now renders trending/search GIFs in standalone/OTA/prod builds (shared RN code) |
+| Business Android | YES | same shared code path |
+| Admin Web (adjacent) | No | no admin code touched |
+| Business Web preview (adjacent) | YES (positive) | web export now also carries the key via the static `process.env` inline fallback |
+
+Parity is **automatic** (one shared RN codebase; both services fixed identically).
+
+---
+
+## 9. Smoke result
+
+Standalone `expo export --platform ios` (NOT Metro), three variants of the reader:
+
+| Reader | Sentinel key value count in dist |
+|--------|----------------------------------|
+| Original DYNAMIC `globalThis.process?.env?.[name]` (the bug) | **0** |
+| Fix A static-only fallback | 1 |
+| **Fix A (extra-first + static fallback) — shipped** | **1** |
+
+The 0→1 jump on the export is the load-bearing proof the key is now reachable. jest also proves resolution from `extra` with `process.env` emptied (standalone simulation).
+
+---
+
+## 10. Known issues / deferred
+
+- On-device dev-channel OTA + standalone dev-client GIF-tab render (SC-CORRECT-2 step 2) is the **tester's** runtime step (A3.2) — implementor scope ends at the standalone-export proof + jest simulation. No `[TRANSITIONAL]` code introduced.
+- Renumber 1116→1127 deferred to CLOSE (ID collision with `SPEC_ORCH-1116_BOOKING_GATE_RLS.md`); worktree/branch kept as-is per A6.
+
+---
+
+## 11. Operator action required
+
+- **No migration. No edge-fn deploy.** Nothing for `db push`.
+- Tester (mingla-tester, business side): verify SC-CORRECT-1..4 on a **standalone export AND a dev-channel `eas update` pulled by a real installed build** — explicitly NOT the Metro bundle (A3.2). Re-publish the ORCH-1119 dev update afterward (COMMS-0028 notes this session's prior dev OTAs were ineffective + superseded ORCH-1119's head).
+- Orchestrator: REVIEW → tester dispatch; at CLOSE flip the original §6 DRAFT invariants to ACTIVE and renumber to ORCH-1127.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- During rebase onto `origin/main`, a conflict in `.github/workflows/strict-grep-mingla-business.yml` — ORCH-1117 added a job at the same anchor point as the ORCH-1116 job from `9b10dd2b1`. Resolved by keeping BOTH jobs (no logic lost). FYI only.
+- The two existing service tests previously passed ONLY because Node/jest populates `process.env` (the same illusion as Metro, per F-CORRECT-5). They now carry an explicit empty-`extra` mock so they genuinely exercise the static-`process.env` fallback path; the new `giphyKeyReachability.test.ts` is the one that exercises the standalone (extra-only) condition.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1116_GIF_COVER_PICKER.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1116_GIF_COVER_PICKER.md
@@ -1,0 +1,145 @@
+# TEST — ORCH-1116 [Cover picker GIF tab "This source is taking a break"]
+
+**Skill:** mingla-tester (business side) · **Phase:** TEST · **Date:** 2026-06-12
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1116-[gif-cover-key]/` · **Branch:** `ORCH-1116-gif-cover-key`
+**Branch head under test:** `b4d4d9991` (impl `9b10dd2b1` + report `78df87f52` + tester adversarial `b4d4d9991`)
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1116_GIF_COVER_PICKER.md` (SC-1..SC-7)
+**Sim:** iPhone 17 Pro `17091E60-C3B6-4167-980D-60C348E177F6` (iOS 26.4) · **Metro:** port 8086 (this worktree, `.env` loaded)
+
+---
+
+## 1. Verdict
+
+**CONDITIONAL PASS** — 0 P0 · 0 P1 · 0 P2 · 1 P3 · 1 P4.
+
+Conditional on ONE deferral that genuinely requires Seth (not an accepted defect):
+the final **on-screen** GIF-tab render (SC-1/SC-2) could not be eyeballed because the
+CoverPicker is behind the business-app **sign-in gate** and there is no active session on
+the sim — sim login is an orchestrator/Seth touch-point (dispatch hard guard). Confidence on
+SC-1/SC-2 is **`probable`** (deterministic runtime-path proof short of the pixel), NOT
+`proven`. Everything else is `proven`.
+
+> **CLOSE-GATING (not a TEST defect):** per COMMS-0024 this `gif-cover-key` branch shares the
+> stale-anchor ID `ORCH-1116` with the booking-gate-rls session that legitimately keeps the
+> number. This fix MUST be **renumbered off 1116** (lowest free ID ≥1122 at the time) before
+> CLOSE/merge. Acked in the ledger.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Verdict | Evidence (confidence) |
+|----|-----------|---------|-----------------------|
+| **SC-1-iOS** | Fresh build → GIF tab shows GIPHY trending (NOT "This source is taking a break.") | **PROBABLE PASS** | Metro 8086 boot log: `env: load .env` + `env: export EXPO_PUBLIC_GIPHY_API_KEY EXPO_PUBLIC_GIPHY_KEY`. `.env` carries a 32-char GIPHY key (correct GIPHY public-key length; value not printed). Fetched the live iOS bundle from Metro 8086 (`/index.bundle?platform=ios`, 31 MB) → the **key VALUE is inlined** as `{"EXPO_PUBLIC_GIPHY_API_KEY": { enumerable: true, value: "<redacted>" }}` (4 occurrences) — the exact `process.env` shim the runtime reader `coverProviderBrowseService.ts:55-67 envValue()/publicGiphyKey()` walks. Therefore `publicGiphyKey()` returns non-null → `trendingGiphyCovers()` cannot throw `not_configured` → the GIF tab populates. **On-screen pixel BLOCKED on sim login** (see §7). Confidence `probable`. |
+| **SC-1-Android** | Same on Android | **NOT RUN (skip+reason)** | Android emulator not in the dispatch device set; the fix is platform-agnostic (shared `coverProviderBrowseService` + EAS env spans both platforms of a profile). Same `probable` mechanism applies. State as skip. |
+| **SC-2-iOS** | GIF search (≥2 chars) returns results | **PROBABLE PASS** | Same key path: `searchGiphyEventCovers` (giphyEventCoverService) reads the same `publicGiphyKey()`. `searchGiphyEventCovers` jest suite green (key-present + fail-close paths). On-screen typing BLOCKED on sim login. Confidence `probable`. |
+| Pexels/Stock no-regression | Stock tab still works | **PASS** | Untouched edge-proxied path; `pexelsEventCoverService` + `coverProviderBrowseService` jest 25/25; CoverPicker stock catch-site only gained the same gated `reportProviderError("stock", error)` (no behavior change unless `not_configured`). |
+| Library no-regression | Library tab still works | **PASS** (source) | No Library-tab code touched in the diff (`git show 9b10dd2b1` = .env.example + app.config guard IIFE + 4 catch-site lines + telemetry helper). |
+| **SC-3** | Release-bound build w/o key FAILS at config-eval w/ explicit message | **PASS (proven)** | Tester adversarial test A1–A4 invoke the **real** `app.config.ts` default fn → THROW for `EAS_BUILD_PROFILE` preview/production-apk AND `VERCEL_ENV` production/preview, message `EXPO_PUBLIC_GIPHY_API_KEY is required for the <profile> build`. fails-on-revert proven (A1–A4 fail when the throw is removed). |
+| **SC-4** | Dev/local build w/o key still builds (friendly copy, no crash) | **PASS (proven)** | Adversarial A5 (`development`) + A6 (local, no profile) → real default fn does NOT throw, returns null into `extra` + warns. |
+| **SC-5** | `not_configured` emits telemetry; transient does NOT | **PASS (proven)** | Implementor jest T5/T6/T6b + non-provider-Error (8/8). Code review: `CoverPicker.tsx:129-137 reportProviderError` gated `if (code !== "not_configured") return;` then single `reportNonFatal("coverPicker.provider", …)`; wired at all 4 catch sites (`:614, :633, :665, :680`). Transient/`invalid_response`/`provider_unavailable`/`rate_limited` short-circuit before the emit. (Runtime Sentry delivery is a no-op on dev — DSN prod-only, per O-2/D-1 — gating logic verified, not Sentry transport.) |
+| **SC-6** | `.env.example` documents the key | **PASS (proven)** | `.env.example` carries `EXPO_PUBLIC_GIPHY_API_KEY=` + dashboard link + rebuild-vs-OTA note (diff). Strict-grep INV-2 enforces it. |
+| **SC-7** | Strict-grep gate PASSES w/ guard, FAILS on revert | **PASS (proven)** | `i-giphy-key-wired.mjs --self-test` → `SELF-TEST OK`; real run → `PASS · violations=0` (INV-1 guard+throw, INV-2 .env.example); `node --test i-giphy-key-wired.test.mjs` → **5/5** incl. 2 fails-on-revert cases (guard→passthrough; .env.example entry removed). |
+
+---
+
+## 3. Findings (P-numbered)
+
+### P3 — Implementor happy-path test exercises a re-implemented MIRROR, not the real exported helper
+- **Evidence:** `CoverPicker.providerTelemetry.test.ts:49-54` defines a private `gateUnderTest` copy of `reportProviderError`; T5/T6 call the copy, not the real exported `reportProviderError` (CoverPicker.tsx:129). The real call-site coverage is source-string greps (`:101-124`).
+- **Impact:** the behavioral split is proven on a byte-copy; a divergence between the copy and the real helper would not be caught behaviorally (only the source-grep would). LOW — the source greps do catch a real-helper edit, and the tester adversarial test exercises the real `app.config.ts` guard. Not blocking.
+- **Required fix:** none required for CLOSE; optional future hardening = import the real `reportProviderError` with native deps mocked (high mock cost under the plain `ts-jest` node preset — why both implementor and tester avoided it for the CoverPicker module).
+- **Retest:** n/a (informational).
+
+### P4 — Clean, scope-disciplined change + correct CONFIG-vs-transient gating
+- The diff is exactly the SPEC allowlist (7 files); the telemetry gate is a single helper at one call-site, gated `not_configured`-only as specified; the app.config guard faithfully mirrors the Stripe `pk_live` guard incl. the dev/local asymmetry and the VERCEL_ENV web-export superset. Friendly copy untouched. Good work.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+- Checked out branch head `b4d4d9991`; ran `CoverPicker.providerTelemetry` → **8/8 PASS**.
+- TRUE line-deletion of the gate `if (code !== "not_configured") return;` from `CoverPicker.tsx` (via `perl -ni`, confirmed `grep -c` → 0) → re-ran → **1 failed / 7 passed**; exact failing assertion:
+  `CoverPicker.providerTelemetry.test.ts:109` → `expect(coverPickerSrc).toMatch(/if \(code !== "not_configured"\) return;/)`.
+- Restored via `cp` of the pre-edit backup → `git diff --stat` empty → re-ran → **8/8 PASS**.
+- **Implementor fails-on-revert independently confirmed at `9b10dd2b1`.** (Note: the failing assertion is the source-wiring grep, not the behavioral mirror — consistent with P3.)
+
+---
+
+## 5. Adversarial test added (tester, different angle)
+
+- **Path:** `mingla-business/src/__tests__/orch1116GiphyConfigGuard.test.ts` (NEW, append-only).
+- **Commit:** `b4d4d9991` (on-branch; in `git diff origin/main...HEAD --name-only`).
+- **Angle (DIFFERENT from implementor):** the implementor attacked the *telemetry split* via a mirror + source greps and only manually probed the `app.config.ts` guard (uncommitted). This test exercises the **REAL `app.config.ts` default function** at runtime across the env matrix — including the **VERCEL_ENV web-export THROW branches** the implementor never committed-tested, plus key-plumbing-into-`extra` and the legacy `EXPO_PUBLIC_GIPHY_KEY` fallback. 8 cases (A1–A8): EAS preview/production-apk THROW; VERCEL_ENV production/preview THROW; development/local NO-throw; key-present plumbs value; legacy-name fallback satisfies. Masking note documented (supplies a shape-valid Stripe pk for the VERCEL_ENV cases so the sibling Stripe guard passes first).
+- **Run:** 8/8 PASS at HEAD.
+- **fails-on-revert verified at `b4d4d9991`:** reducing the GIPHY guard throw to a passthrough (perl, `grep -c` → 0) → **A1–A4 FAIL** (the THROW assertions), A5–A8 correctly still pass → restored → 8/8 PASS.
+- **Both tests in the closing diff:** confirmed — `git diff origin/main...HEAD --name-only` lists `orch1116GiphyConfigGuard.test.ts` AND `CoverPicker.providerTelemetry.test.ts`.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | N/A | No new control; "Use Library"/"Try again" buttons unchanged. |
+| 2 | One owner per truth | PASS | Key read by one helper `publicGiphyKey()`; guard is validation-only, not a new plumbing path. |
+| 3 | No silent failures | PASS (strengthened) | This change ADDS telemetry to the previously-silent `not_configured`; transient stays user-facing (intentional). |
+| 4 | One query key per entity | N/A | No React Query change. |
+| 5 | Server state server-side | N/A | No Zustand/server-state change. |
+| 6 | Logout clears everything | N/A | Not touched. |
+| 7 | `[TRANSITIONAL]` labeled | PASS | None introduced. |
+| 8 | Subtract before adding | PASS | Net +1 helper, reuses existing `reportNonFatal`; no parallel mechanism. |
+| 9 | No fabricated data | PASS | Missing key → friendly "unavailable" + Library fallback; nothing faked. |
+| 10 | Currency-aware | N/A | |
+| 11 | One auth instance | PASS | No new `useAuth`; CoverPicker's existing single instance unchanged. |
+| 12 | Validate at right time | PASS | Guard validates at BUILD/config-eval time (correct for an `EXPO_PUBLIC_*` build-time inline). |
+| 13 | Exclusion consistency | N/A | |
+| 14 | Persisted-state startup | N/A | |
+
+No violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Note |
+|---------|---------|------|
+| Consumer iOS | N/A | No CoverPicker / no GIPHY ref. |
+| Consumer Android | N/A | Same. |
+| Buyer/anon Web | N/A | Authoring surface, not buyer. |
+| **Business iOS** | **PROBABLE (BLOCKED on sim login for pixel)** | App launched on sim `17091E60…` against Metro 8086; bundle built (4739 modules) WITH the GIPHY key inlined (§2 SC-1). App landed on the **sign-in screen** — async-storage manifest shows `currentBrand`/`brandTeamStore` persisted but **NO Supabase auth-token key** → no active session. Every CoverPicker mount (`ExperienceCoverStep`, `BrandCreationFlow`, `BrandEditView`, `VenueCreatorWizard`, `TripCreatorStep1Basics`, `EditPublishedTripScreen`, Ari `ToolProposalCard`) is behind auth — none anon-reachable. Cannot log in without guessing credentials (dispatch hard guard). |
+| Business Android | SKIP | Not in device set; platform-agnostic fix. |
+| Admin Web | N/A | No CoverPicker. |
+| Business Web preview | N/A (config covered) | Guard adds VERCEL_ENV fail-loud branch (adversarial A3/A4); web env-provisioning is the deferred O-4 operator step. |
+
+**Physical iPhone HITL:** not requested in dispatch; not run.
+
+**Operator-unblock ask:** to convert SC-1/SC-2 to `proven`, Seth logs into the business app on sim `17091E60-C3B6-4167-980D-60C348E177F6` (Metro 8086) with a real business account, opens any cover authoring surface (e.g. create an experience/event → Cover step), taps the **GIFs** tab, and confirms GIPHY trending thumbnails render (no "This source is taking a break."). Then type ≥2 chars to confirm search.
+
+---
+
+## 8. Discoveries for Orchestrator
+
+1. **Renumber-before-CLOSE (COMMS-0024):** this `gif-cover-key` branch must drop ORCH-1116 for the lowest free ID (≥1122) before merge — booking-gate-rls keeps 1116. Acked in ledger (`COMMS_LEDGER` commit on main).
+2. **COMMS-0026 corroborates the fix:** an independent forensics session proved the root cause = the 2026-05-25 channel-flip `4c3bdfe8f` pointing the `development` profile at a keyless channel, and proved the fix = provision the GIPHY key into dev/preview + REBUILD (the installed binary bakes the null in). This TEST's bundle-inlining evidence is the same mechanism from the build side. The "June-3 runtime regression" theory is a red herring (killed by COMMS-0026). Acked.
+3. **Operator pre-req for production parity:** the dispatch states EAS dev/preview env + local `.env` were already provisioned; this was confirmed (Metro env export + `.env` key + bundle inlining). The remaining operator step for a **fresh installed dev/preview build** on Seth's physical device (vs the Metro-served bundle on sim) still applies — EXPO_PUBLIC bakes at build time.
+4. **At CLOSE:** flip the 3 DRAFT invariants ACTIVE (I-PROPOSED-GIPHY-KEY-FAIL-LOUD, I-PROPOSED-GIPHY-KEY-WIRED, I-PROPOSED-CONFIG-ERROR-IS-OBSERVABLE) + register `i-giphy-key-wired` in README/INVARIANT_REGISTRY (already wired into `strict-grep-mingla-business.yml`).
+
+---
+
+## 9. Accepted conditions (CONDITIONAL PASS)
+
+- **C-1 (deferral, needs Seth — NOT an accepted P1):** SC-1/SC-2 on-screen pixel render at `probable` (sim login blocker; mechanism proven via bundle inlining + runtime reader trace). Convert to `proven` via the §7 operator-unblock ask. No code defect underlies this — purely an environment/auth touch-point reserved for Seth.
+
+---
+
+## 10. Test/gate run log (this session)
+
+- `i-giphy-key-wired.mjs --self-test` → `SELF-TEST OK`
+- `i-giphy-key-wired.mjs` → `PASS · violations=0`
+- `node --test i-giphy-key-wired.test.mjs` → 5/5
+- `jest CoverPicker.providerTelemetry coverProviderBrowseService giphyEventCoverService pexelsEventCoverService reportNonFatal` → 25/25 (5 suites)
+- `jest orch1116GiphyConfigGuard` (tester adversarial) → 8/8; revert → 4 failed/4 passed; restore → 8/8
+- `jest CoverPicker.providerTelemetry` revert→restore (Step 0.5) → 1 failed/7 → 8/8
+- `tsc --noEmit` → 0 errors in any touched file (255 pre-existing baseline errors elsewhere, unchanged)
+- Metro 8086 iOS bundle fetch → GIPHY key value inlined (4 occurrences)

--- a/Mingla_Artifacts/reports/TEST_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md
@@ -1,0 +1,123 @@
+# TEST VERDICT — ORCH-1127 (ex-1116) [GIF cover-key reachability]
+
+**Skill:** mingla-tester (business side) · **Mode:** SPEC-COMPLIANCE + adversarial regression
+**Date:** 2026-06-12 · **Working tree:** `~/Desktop/mingla-orchs/ORCH-1116-[gif-cover-key]/`
+**Branch:** `ORCH-1116-gif-cover-key` · **HEAD under test:** `0a405cc0d` (fix) → adversarial commit `67408341d`
+**Spec:** `SPEC_AMENDMENT_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md`
+**Impl report:** `IMPLEMENTATION_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md`
+**Comms:** acked + factored **COMMS-0028** (WARN, ALL) — this verdict is the independent confirmation that the COMMS-0028 reachability fix landed and is load-bearing.
+
+---
+
+## 1. Verdict
+
+**PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 0 · P4: 1 (praise).
+
+Confidence: **proven** for the reachability claim (standalone-export grep, 0→1 delta, independently reproduced) and code-level SC. On-device runtime render = **proven by Seth** (device-confirmed dev-channel OTA: GIF tab renders GIPHY trending + search, no "This source is taking a break") — cited as the runtime evidence per the dispatch, so no sim drive was required of the tester.
+
+Regression gate: **satisfied** — implementor happy-path test (`giphyKeyReachability.test.ts`, fails-on-revert re-run by tester) AND tester adversarial test (`giphyKeyReachability.tester_adversarial.test.ts`, different angle, on-branch, in closing diff) both present.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Result | Evidence |
+|----|-----------|--------|----------|
+| **SC-CORRECT-1** | Key VALUE reachable in a STANDALONE export via the extra-first path (NOT Metro) | **PASS (proven, independently reproduced)** | Tester ran `npx expo export --platform ios --clear` with a 32-char sentinel in `EXPO_PUBLIC_GIPHY_API_KEY`/`_KEY`. Fixed reader: `grep -roa <sentinel>` across the entire dist = **1 occurrence** (in the 14.4 MB Hermes `index-*.hbc`). Counter-export with the OLD dynamic reader (commit `70f799e15` state), same sentinel env = **0 occurrences**. The 0→1 delta independently reproduces the implementor's core proof and refutes the original SPEC's "EAS inlines process.env" premise at the bundle layer. Healthy full-route bundle (14.4 MB), not a poisoned cache artifact. |
+| **SC-CORRECT-2** | Verified on the RIGHT bundle type (standalone export + real device OTA), NOT Metro/jest only | **PASS (proven)** | (a) Tester's standalone-export grep above (not the Metro bundle). (b) Seth device-confirmed PASS on a dev-channel OTA build: GIF tab renders GIPHY trending + search. The prior pass's mistake (verifying a Metro/jest-populated `process.env` that masks the bug) is explicitly avoided — see §6. |
+| **SC-CORRECT-3** | BOTH services fixed identically; no straggler dynamic-only read | **PASS** | `giphyEventCoverService.ts:1,31-62` and `coverProviderBrowseService.ts:32,58-89` carry a byte-identical reader (`import Constants from "expo-constants"` → `readExtra` (Constants.expoConfig?.extra) → `readStaticProcessEnv` (STATIC member) → `envValue` extra-first → `publicGiphyKey` dual-name). Grep gate INV-3 confirms both read `extra` and neither has a dynamic bracket read. |
+| **SC-CORRECT-4 (a)** | Strict-grep gate forbids regressing to dynamic-only `process.env?.[...]` | **PASS** | `.github/scripts/strict-grep/i-giphy-key-wired.mjs` INV-3: requires `Constants.expoConfig?.extra` (EXTRA_READ_RE) AND forbids the non-literal bracket form `\.env\??\.?\[\s*(?!['"\`])[^\]]+\]` (DYNAMIC_ENV_BRACKET_RE), comments stripped first. Self-test OK; real run PASS (4 OK, 0 violations); gate's own `--test` suite = 7/7 incl. a fails-on-revert subtest. Fails-on-revert reproduced by tester (§4). |
+| **SC-CORRECT-4 (b)** | Build-time guard + telemetry + `.env.example` + friendly copy intact (no regression) | **PASS** | Guard: `app.config.ts:193-231` IIFE still throws on release-bound profile + emits the key into `extra:` block (line 112). Only the comment was corrected (`git diff` shows comment-only delta, logic untouched). `.env.example:12` `EXPO_PUBLIC_GIPHY_API_KEY=` documented. Telemetry: `CoverPicker.tsx:135-136` `reportNonFatal` gated on `not_configured`. Friendly copy `CoverPicker.tsx:1178/1185` ("This source is taking a break.") preserved. |
+
+---
+
+## 3. Findings
+
+**P4 (praise)** — The fix mirrors the established `supabase.ts`/`platformUrl.ts` house pattern exactly (extra-first + STATIC `process.env` fallback), both services are byte-identical, the protective comment names the banned pattern, and the gate strips comments so the comment doesn't self-trip. Clean, convention-aligned, regression-trapped at three layers (jest reachability, jest source-trap, CI grep gate). No defects.
+
+No P0/P1/P2/P3.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+- **Revert state:** the pre-Fix-A reader from commit `70f799e15` — the dynamic `globalThis.process?.env?.[name]` form in BOTH services (verified: `git show 70f799e15:...giphyEventCoverService.ts` line 29-40 = dynamic reader). Applied both old service files to the working tree, ran, then restored.
+- **Implementor happy-path test (`giphyKeyReachability.test.ts`) on revert:** `Tests: 4 failed, 3 passed`. Exact failing assertion: `searchGiphyEventCovers(...) ` / `trendingGiphyCovers()` reject with `EventCoverProviderError: GIPHY search is not configured yet.` at the `resolves.toHaveLength(1)` / `resolves.toBeDefined()` lines (T-CORRECT-1/2/4). The 3 that passed = T-CORRECT-3 (static process.env path) — the old dynamic reader still resolves via jest's populated `process.env`, the exact masking the SPEC's F-CORRECT-5 calls out.
+- **On restore (Fix A):** all 7 pass.
+- **Grep gate on revert:** `I-GIPHY-KEY-WIRED: 2 violation(s)` — INV-3 FAIL on both services (`found=false, foundDynamic=true`). On restore: PASS, violations=0.
+- **Conclusion:** the implementor's `fails-on-revert verified at 70f799e15` claim is **independently confirmed by the tester** at both the jest layer and the CI-gate layer.
+
+---
+
+## 5. Adversarial test added (tester)
+
+- **Path:** `mingla-business/src/services/__tests__/giphyKeyReachability.tester_adversarial.test.ts`
+- **Commit:** `67408341d` (on branch `ORCH-1116-gif-cover-key`).
+- **Different angle (vs the implementor's mock-based happy-path):**
+  - **G1 — structural source trap:** reads BOTH shipped service files off disk and asserts `import ... "expo-constants"` + `Constants.expoConfig?.extra` read + **NO** non-inlinable dynamic `process.env[<var>]` bracket read (comments stripped). This survives test-suite tampering — it inspects the source, not a mock — and is the layer that fires if a future edit reverts EITHER service to the COMMS-0028 dynamic-only reader.
+  - **G2 — null-manifest boundary:** drives the trending + search paths with `Constants.expoConfig === null` (a runtime state the implementor's always-defined mock never hits): proves `?.extra` does not crash (→ controlled `not_configured`, not a `TypeError`) and the STATIC `process.env` fallback still carries the key when the manifest is null.
+- **fails-on-revert verified at `70f799e15`** (pre-Fix-A dynamic reader applied to both services): G1 FAILS on both services (`expect(raw).toMatch(/from "expo-constants"/)` + extra-read + no-dynamic-bracket all fail) → `Tests: 2 failed, 3 passed`. On restore (Fix A): **5/5 pass**.
+- **In closing diff:** confirmed — `git diff main...HEAD --name-only` lists both `giphyKeyReachability.test.ts` (implementor) and `giphyKeyReachability.tester_adversarial.test.ts` (tester).
+
+---
+
+## 6. The prior-pass mistake, explicitly closed
+
+The earlier ORCH-1116 TEST verdict (`70f799e15`, CONDITIONAL PASS) proved the runtime path against a **Metro/jest-populated `process.env`**, which masks this exact bug (a dynamic `process.env[name]` lookup resolves there but is `undefined` in a Hermes standalone build). This verdict closes that gap two independent ways: (1) a STANDALONE `expo export` grep showing the key value is present (1) with Fix A and absent (0) with the old reader, and (2) Seth's device PASS on a real OTA build. Source-only/Metro-only evidence is NOT used as the basis for this PASS.
+
+---
+
+## 7. Constitution 14-rule matrix (against the diff)
+
+| # | Rule | Result | Note |
+|---|------|--------|------|
+| 1 | No dead taps | N/A | No UI control added; GIF tab now fires (Seth device PASS). |
+| 2 | One owner per truth | PASS | Both services read the single `extra`/env source; no competing owner. |
+| 3 | No silent failures | PASS | `not_configured` still throws + telemetry `reportNonFatal` + friendly copy. |
+| 4 | One query key per entity | N/A | No React Query change. |
+| 5 | Server state stays server-side | N/A | No Zustand/server-state change. |
+| 6 | Logout clears everything | N/A | No auth/session state. |
+| 7 | Label `[TRANSITIONAL]` | N/A | No transitional code. |
+| 8 | Subtract before adding | PASS | Replaced the dynamic reader in place; no duplicate reader left. |
+| 9 | No fabricated data | PASS | Missing key → friendly degraded state, never faked GIFs. |
+| 10 | Currency-aware | N/A | |
+| 11 | One auth instance | N/A | |
+| 12 | Validate at the right time | N/A | |
+| 13 | Exclusion consistency | N/A | |
+| 14 | Persisted-state startup gate | N/A | |
+
+No violations.
+
+---
+
+## 8. Device / parity matrix
+
+| Surface | Ships here? | Result | Evidence |
+|---------|-------------|--------|----------|
+| Business iOS | Yes | PASS (proven) | Seth device-confirmed dev-channel OTA: GIF tab renders trending + search. Tester standalone iOS export carries the key (1 occ). |
+| Business Android | Yes (same RN codebase, same reader) | PASS (proven via Seth + code parity) | Seth device PASS on dev OTA; reader is platform-agnostic (`Constants.expoConfig.extra` materialized for both). Android standalone export not separately grepped — same babel/Metro pipeline, same code path; risk nil. |
+| Buyer/anonymous Web | Indirect | PASS (path intact) | Web export uses the STATIC `process.env` fallback (extra may be absent on web) — preserved by `readStaticProcessEnv`; T-CORRECT-3 covers it. CoverPicker is a business-app surface, not anon-buyer. |
+| Consumer iOS/Android | No | SKIP | GIPHY cover picker is business-app only. |
+| Admin Web | No | SKIP | Not present in admin. |
+
+Physical-iPhone HITL: satisfied by Seth's pre-recorded device PASS (per dispatch — tester not required to re-drive).
+
+---
+
+## 9. Discoveries for Orchestrator
+
+- **D-1 (renumber at CLOSE):** branch/worktree still on `ORCH-1116-gif-cover-key`; the 1116 ID is held by `SPEC_ORCH-1116_BOOKING_GATE_RLS` (shipped-first). Renumber to **ORCH-1127** at CLOSE per COMMS-0024/0028. Artifacts/commits already tagged ORCH-1127.
+- **D-2 (COMMS-0028 OTA re-serve):** COMMS-0028 notes this session must re-serve a WORKING giphy dev-channel OTA after the fix lands, AND the ORCH-1119 dev update must be re-published LAST (last-writer-wins clobber on the shared `development` HEAD). Out of tester scope (no OTA per hard guards) — flag for orchestrator at CLOSE/DEPLOY. Per COMMS-0027, any dev-channel OTA from a worktree must use `--clear-cache` + an isolated per-ORCH `TMPDIR`.
+- **D-3 (no merge state checked):** tester did not deploy/merge (hard guard). Closing PR + CI grep-gate run (`strict-grep-mingla-business.yml` references `i-giphy-key-wired.mjs`) is the orchestrator's CLOSE step.
+
+---
+
+## 10. Test/gate run log (citations)
+
+- `npx jest` (5 suites: giphyKeyReachability + giphyEventCoverService + coverProviderBrowseService + CoverPicker.providerTelemetry + orch1116GiphyConfigGuard) → **30 passed, 30 total**.
+- Adversarial suite alone → **5 passed**; full giphy/cover 4-suite combined → **19 passed**.
+- `node i-giphy-key-wired.mjs --self-test` → SELF-TEST OK; real run → PASS, violations=0; `node --test i-giphy-key-wired.test.mjs` → **7/7 pass** (incl. fails-on-revert subtest).
+- Standalone export grep: Fix A = **1** sentinel occurrence (Hermes hbc); old dynamic reader = **0**.
+- Fails-on-revert (revert to `70f799e15` reader): implementor test 4 fail / grep gate 2 violations / tester adversarial G1 2 fail; all PASS on restore.
+
+Working tree left clean; temp export dirs removed.

--- a/Mingla_Artifacts/specs/SPEC_AMENDMENT_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md
+++ b/Mingla_Artifacts/specs/SPEC_AMENDMENT_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md
@@ -1,0 +1,188 @@
+# SPEC AMENDMENT — ORCH-1127 (ex-1116) [Cover picker GIF tab "This source is taking a break"]
+
+**Skill:** mingla-forensics · **Phase:** INVESTIGATE(confirm) → SPEC(correct) · **Date:** 2026-06-12
+**Amends / partially supersedes:** `SPEC_ORCH-1116_GIF_COVER_PICKER.md` (2026-06-11).
+**Working tree:** `~/Desktop/mingla-orchs/ORCH-1116-[gif-cover-key]/` on branch `ORCH-1116-gif-cover-key` (renumber to **ORCH-1127** pending at CLOSE; ID collides with `SPEC_ORCH-1116_BOOKING_GATE_RLS.md`).
+**Comms:** acknowledges + factors in **COMMS-0028** (WARN, ALL) — this amendment is the forensic confirmation that COMMS-0028's deeper finding is correct.
+
+---
+
+## A0. Why this amendment exists (one paragraph)
+
+The shipped ORCH-1116 fix (provision the GIPHY key in EAS dev/preview + Vercel, add a config-eval fail-loud guard, add telemetry + a strict-grep gate) is **necessary but INSUFFICIENT**. After provisioning the key the orchestrator tried to serve a dev-channel OTA and found the GIF tab STILL broken: the key value is **absent from the actual app bundle**. The original SPEC's core technical premise — §4.B line 91 and §11 DO-NOT-TOUCH line 201, which assert *"the services already read `process.env.EXPO_PUBLIC_*` directly (which EAS inlines)"* and therefore mark the two GIPHY services as DO-NOT-TOUCH — is **factually wrong**. The services read the key **dynamically** (`process.env[name]` with a variable key), which `babel-preset-expo` does **not** inline, so in any Hermes standalone / OTA / production build the value is `undefined` regardless of how the env is provisioned. This amendment records the corrected root cause with live evidence and specifies the actual code fix (read from `Constants.expoConfig.extra` first, mirroring `supabase.ts`), while keeping everything the original SPEC got right (the build-time guard, the `.env.example` doc, the telemetry, the strict-grep gate).
+
+---
+
+## A1. Corrected root cause (CONFIRMED — live evidence, supersedes the "missing env var alone" framing)
+
+### A1.1 What the original SPEC concluded (now superseded)
+> §1: *"the public GIPHY key is provisioned in the EAS `production` environment ONLY … dev/preview builds and local Metro have no key."*
+> §4.B line 91: *"the services already read `process.env.EXPO_PUBLIC_*` directly (which EAS inlines), so the guard's PRIMARY job is to FAIL THE BUILD, not to plumb the value."*
+> §11 line 201: *"DO-NOT-TOUCH: `coverProviderBrowseService.ts` / `giphyEventCoverService.ts` … (correct as-is)."*
+
+The "key absent from dev/preview" sub-fact is TRUE and the provisioning step was correct. The premise that the services would then pick the key up — i.e. that `process.env.EXPO_PUBLIC_*` is inlined into these services — is FALSE. That is the gap that left the bug live after provisioning.
+
+### A1.2 The deeper root cause (CONFIRMED)
+
+**F-CORRECT-1 — the GIPHY services read the key via DYNAMIC `process.env` access, which is never inlined.**
+- **Symptom:** GIF tab shows "This source is taking a break." on every non-Metro build even with the key provisioned in EAS dev env + local `.env` + shell env.
+- **Layer:** code (bundler/transform) + runtime.
+- **Probe / Evidence (file:line, verbatim):**
+  - `mingla-business/src/services/giphyEventCoverService.ts:29-40` and `mingla-business/src/services/coverProviderBrowseService.ts:56-67` — identical reader:
+    ```ts
+    const envValue = (name: string): string | null => {
+      const maybeProcess = globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> };
+      };
+      const value = maybeProcess.process?.env?.[name];   // DYNAMIC bracket access
+      ...
+    };
+    const publicGiphyKey = (): string | null =>
+      envValue("EXPO_PUBLIC_GIPHY_API_KEY") ?? envValue("EXPO_PUBLIC_GIPHY_KEY");
+    ```
+  - `grep -rn "Constants" giphyEventCoverService.ts coverProviderBrowseService.ts` → **0 matches** (exit 1). Neither service imports `expo-constants` or reads `Constants.expoConfig.extra`.
+- **Mechanism:** `babel-preset-expo` only inlines **static** `process.env.EXPO_PUBLIC_X` member expressions. A dynamic `process.env[name]` / `globalThis.process?.env?.[name]` (variable key) is left as a runtime lookup. A Hermes standalone bundle has no populated `process.env` object → resolves `undefined` → `publicGiphyKey()` returns `null` → both paths fail-close to `not_configured` → friendly copy.
+- **Severity:** **CONFIRMED ROOT CAUSE**.
+
+**F-CORRECT-2 — babel inlining contrast, PROVEN.**
+- **Probe:** transformed a 4-line probe with `babel-preset-expo` (`caller: {name:'metro', platform:'ios', isDev:false}`), `EXPO_PUBLIC_GIPHY_API_KEY="ZZZSENTINEL…"` in env.
+- **Evidence (verbatim transform output):**
+  - `const a = process.env.EXPO_PUBLIC_GIPHY_API_KEY;` → `var a="ZZZSENTINEL12345678901234567890Z";` (**inlined**, sentinel count = 1).
+  - `process.env[name]` → `var b=process.env[name];` (**NOT inlined**).
+  - `globalThis.process?.env?.[name]` → `…globalThis.process…[name]` (**NOT inlined** — the exact service pattern).
+- **Mechanism:** confirms only the static member form is replaced at build time; the services use the non-inlinable dynamic form.
+- **Severity:** CONFIRMED (supporting F-CORRECT-1).
+
+**F-CORRECT-3 — standalone export grep: key ABSENT; JS bundle content invariant to the var.**
+- **Probe:** `npx expo export --platform ios --output-dir /tmp/withkey --clear` with `EXPO_PUBLIC_GIPHY_API_KEY` (32-char value) + `EXPO_PUBLIC_GIPHY_KEY` set in shell env AND present in local `.env`; then `grep -ral "<key>" /tmp/withkey/`.
+- **Evidence:**
+  - GIPHY key value across the **entire** dist (Hermes `.hbc` + `metadata.json` + all files): **0 matches** (grep exit 1).
+  - `JSON.stringify(metadata.json).includes("GIPHY")` → `false`.
+  - Re-exported WITHOUT the var → JS bundle **filename identical** (`index-4e144ddc0245e6ce0d0b5588910ec9c2.hbc` in both — Metro's content hash of the JS source is unchanged). (`cmp` shows the two files differ at byte 33 only — the Hermes header's build/source-map hash, NOT the key, which grep proves absent from both. The COMMS-0028 phrase "byte-identical" is slightly imprecise; the load-bearing fact — **the GIPHY env var changes nothing in the JS bundle and the key never lands in the export** — holds.)
+- **Mechanism:** the var is genuinely not part of the JS bundle. The original SPEC's "EAS inlines it" assumption is refuted at the bundle layer.
+- **Severity:** CONFIRMED ROOT CAUSE.
+
+**F-CORRECT-4 — the CORRECT plumbing path is already provisioned but unread.**
+- **Probe:** `npx expo config --json` with the key set; inspect `extra`.
+- **Evidence:** `extra.EXPO_PUBLIC_GIPHY_API_KEY present: true` (length 32). The guard IIFE at `app.config.ts:187-225` returns `fromEnv` into `expo.extra` (sibling to `EXPO_PUBLIC_SUPABASE_URL`/`_ANON_KEY`). `extra` is baked into the app manifest (`Constants.expoConfig.extra`) at build time — the channel/standalone/OTA-safe path.
+- **Mechanism:** the manifest CAN carry the key; the services just never read `extra`. The fix is to make them read it.
+- **Severity:** CONFIRMED (this is the fix vector).
+
+**F-CORRECT-5 — why it ever "worked" (and why unit tests missed it).**
+- Metro dev injects a live `process.env`, so the dynamic lookup resolves in dev-via-Metro. Seth historically ran Metro dev builds; the 2026-05-25 channel flip (`4c3bdfe8f`) made his dev build run standalone off the keyless `development` channel, exposing it.
+- The existing jest test `giphyEventCoverService.test.ts:8-9,20-21,43-44` sets `process.env.EXPO_PUBLIC_GIPHY_API_KEY` and the dynamic reader resolves it because **Node/jest has a populated `process.env`** — the same illusion as Metro. This is exactly why no unit test caught the standalone failure (see A4 regression note).
+- **Severity:** CONFIRMED (explains the history; no code impact beyond the regression-test gap).
+
+### A1.3 The established codebase pattern the fix must mirror
+- `mingla-business/src/services/supabase.ts:6-19` — `import Constants from "expo-constants"; const extra = Constants.expoConfig?.extra; … extra?.EXPO_PUBLIC_SUPABASE_URL || process.env.EXPO_PUBLIC_SUPABASE_URL || "<fallback>"`. **STATIC** `process.env.X` member access, `extra` first.
+- Same pattern: `src/constants/platformUrl.ts:17-22` (whose comment at line 8 even states the `extra` block is *"baked into"* the bundle/manifest — the correct mental model) and `src/services/stripeModeHandshake.ts`.
+- These are 3 sibling precedents; the GIPHY services are the deviation (F-CORRECT-1) and the SUSPECTED-CONTRIBUTOR-by-pattern that became the proven root cause.
+
+---
+
+## A2. Corrected fix decision — **Fix (A): read `Constants.expoConfig.extra` first, mirror `supabase.ts`.**
+
+Both services must be fixed **identically**.
+
+### A2.1 Chosen fix (A)
+Replace the `envValue` reader in BOTH `giphyEventCoverService.ts` and `coverProviderBrowseService.ts` with an `extra`-first reader that mirrors `supabase.ts`:
+```ts
+// illustrative — implementor writes the real code; ≤ shown for the contract
+import Constants from "expo-constants";
+const extra = Constants.expoConfig?.extra as Record<string, string | undefined> | undefined;
+const envValue = (name: "EXPO_PUBLIC_GIPHY_API_KEY" | "EXPO_PUBLIC_GIPHY_KEY"): string | null => {
+  const value = extra?.[name] ?? readStaticProcessEnv(name); // see A2.2
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+};
+```
+- `extra?.[name]` is dynamic, but that is FINE — `extra` is a runtime object actually populated from the manifest at runtime (proven F-CORRECT-4); it does not depend on babel inlining.
+- The `process.env` fallback (A2.2) MUST be **static member access** so it still works under Metro dev / web export where `extra` may be absent but `process.env.X` is inlined.
+
+### A2.2 The `process.env` fallback must be STATIC, not dynamic
+Because dynamic `process.env[name]` is never inlined (F-CORRECT-2), the fallback cannot keep using the variable-key form. Use explicit static reads, e.g.:
+```ts
+const readStaticProcessEnv = (name: ...): string | undefined =>
+  name === "EXPO_PUBLIC_GIPHY_API_KEY"
+    ? process.env.EXPO_PUBLIC_GIPHY_API_KEY        // static → inlined
+    : process.env.EXPO_PUBLIC_GIPHY_KEY;           // static → inlined
+```
+This preserves the existing dual-name fallback (`EXPO_PUBLIC_GIPHY_API_KEY` then `EXPO_PUBLIC_GIPHY_KEY`) AND the Metro-dev / web-export path, while the `extra` read carries standalone/OTA/production.
+
+### A2.3 Why NOT fix (B) (static-only, no `extra`)
+Fix (B) (replace the dynamic reads with static `process.env.EXPO_PUBLIC_GIPHY_*` only) would also inline correctly, but:
+1. It does NOT use the `extra` plumbing `app.config.ts` already added (wasted, divergent from `supabase.ts`).
+2. It requires the key present in the env at **every** export — including every `eas update` OTA — or the inlined value is empty; `extra` is more robust because it is materialized from the resolved `app.config.ts` (which has the env at build time) and carried in the manifest.
+3. It diverges from the 3-sibling house pattern (A1.3), re-introducing a maintenance deviation.
+Fix (A) subsumes (B)'s correctness (it keeps a static `process.env` fallback) while adding the `extra` path. **Decision: A.** No open question — A is strictly better and matches house convention.
+
+### A2.4 Original SPEC sections that are CORRECT and RETAINED unchanged
+- §4.A (provision the key in EAS dev/preview + `.env.example`) — still required (the `extra` path needs the env present at build time to populate `extra`). KEEP.
+- §4.B (config-eval fail-loud guard in `app.config.ts`) — KEEP. It already emits the key into `extra` (F-CORRECT-4); only its line-91 comment ("services read process.env directly… EAS inlines it… guard is not a plumbing path") is now WRONG and must be corrected: the guard's emission into `extra` IS the plumbing path the services will read.
+- §4.C (telemetry: `reportNonFatal` on `not_configured`) — KEEP.
+- §4.D (strict-grep gate) — KEEP, with one addition (A3.4).
+- §5 SC-3..SC-7, §6 invariants, §10 open questions — KEEP (SC-1/SC-2 retest criterion is hardened in A3).
+
+---
+
+## A3. Corrected / added acceptance criteria (hard gates)
+
+### A3.1 SC-CORRECT-1 (replaces the implicit "provision = fixed" assumption) — STANDALONE EXPORT carries the key
+On a standalone export built with the key provisioned, the key value MUST be reachable to the runtime. Verify by **at least one** of:
+- (preferred) Build a `development`/`preview` standalone/dev-client build with the key in the matching EAS env and confirm on-device the GIF tab renders trending GIFs (not the friendly copy); OR
+- (bundle-level proof) After the fix, `Constants.expoConfig.extra.EXPO_PUBLIC_GIPHY_API_KEY` resolves to the key at runtime in a standalone build — assert via a runtime log / a temporary `__DEV__`-guarded probe, or via the regression test in A4 simulating empty `process.env`.
+
+### A3.2 SC-CORRECT-2 (HARD — call out the prior tester's mistake) — verify on the RIGHT bundle type
+The fix MUST be verified on a **STANDALONE export AND a dev-channel OTA pulled by a real installed build** — **NOT** on the Metro dev bundle. **The prior TEST verdict's runtime-path proof was against a Metro/jest-populated `process.env`, which masks this exact bug** (F-CORRECT-5). A green Metro/jest result is NOT acceptance for this ORCH. The tester must:
+1. Run `npx expo export --platform ios` (and android) and confirm the GIF path works against that bundle (or against an installed dev-client/standalone build), and
+2. Pull a dev-channel `eas update` into a real installed build and confirm the GIF tab renders.
+Source-only / Metro-only verification is capped at "suspected" for this ORCH per Prime Directive 7.
+
+### A3.3 SC-CORRECT-3 — both services fixed identically
+Grep proof: after the fix, BOTH `giphyEventCoverService.ts` and `coverProviderBrowseService.ts` import `expo-constants` and read `Constants.expoConfig?.extra` before any `process.env` fallback; neither retains the dynamic `process.env?.[name]` variable-key form as its only/primary read.
+
+### A3.4 SC-CORRECT-4 — strict-grep gate extended
+Extend the §4.D gate (or add a sibling rule) to assert the services read `Constants.expoConfig.extra` and do NOT regress to dynamic-only `process.env[<var>]` access for the GIPHY key. Fails-on-revert: removing the `extra` read (reverting to the dynamic-only reader) FAILS the gate.
+
+---
+
+## A4. Regression-test contract (corrected — the load-bearing addition)
+
+**The prior tests do not catch this class of bug** because Node/jest and Metro both populate `process.env` (F-CORRECT-5). Add a test that simulates the STANDALONE condition:
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-CORRECT-1 | Standalone simulation: empty `process.env`, key only in `extra` | mock `expo-constants` so `Constants.expoConfig.extra.EXPO_PUBLIC_GIPHY_API_KEY = "k"`; delete `process.env.EXPO_PUBLIC_GIPHY_*` | `publicGiphyKey()` (both services) resolves `"k"` (NOT null); `searchGiphyEventCovers`/`trendingGiphyCovers` do NOT throw `not_configured` | code |
+| T-CORRECT-2 (fails-on-revert) | Same input, reader reverted to dynamic-only `process.env[name]` | as above | reader returns null → `not_configured` thrown → **test FAILS** (proves the fix is load-bearing) | code |
+| T-CORRECT-3 | Metro/dev path still works | key only in `process.env.EXPO_PUBLIC_GIPHY_API_KEY` (static), `extra` empty | reader resolves the key (static `process.env` fallback intact) | code |
+| T-CORRECT-4 | dual-name fallback preserved | only `EXPO_PUBLIC_GIPHY_KEY` set (in `extra` or static env) | reader resolves it | code |
+
+**Fails-on-revert contract:** T-CORRECT-2 MUST FAIL when the `extra`-first read is reverted to the dynamic-only `globalThis.process?.env?.[name]` reader, and PASS when restored. This is the structural safeguard against re-introducing the non-inlinable dynamic read.
+
+**Protective comment to carry in both services:**
+`// ORCH-1127: read the GIPHY key from Constants.expoConfig.extra FIRST (mirror supabase.ts). Dynamic process.env[name] is NOT inlined by babel-preset-expo and is undefined in Hermes standalone/OTA builds — extra is the manifest-backed, build-safe path. Do NOT revert to process.env[<var>].`
+
+---
+
+## A5. Corrected allowlist / DO-NOT-TOUCH (overrides original §11)
+
+**ADDED to the allowlist (the original §11 wrongly excluded these):**
+- `mingla-business/src/services/giphyEventCoverService.ts` — env reader only (A2).
+- `mingla-business/src/services/coverProviderBrowseService.ts` — env reader only (A2).
+- A regression test file for T-CORRECT-1..4 (e.g. extend `giphyEventCoverService.test.ts` + `coverProviderBrowseService.test.ts`, or a new focused test).
+- `mingla-business/app.config.ts` — **comment-only** correction of the now-wrong lines 184-186/91 ("services read process.env directly… not a plumbing path"); the guard LOGIC stays.
+
+**Still allowlisted (from original §11, retained):** `.env.example`, `app.config.ts` guard block, `CoverPicker.tsx` telemetry call-site, the strict-grep gate (+ A3.4 extension).
+
+**DO-NOT-TOUCH (corrected — REMOVE the two GIPHY services from the original DO-NOT-TOUCH list; their network/normalization/clamping/fail-close LOGIC is still untouchable, only the env reader changes):**
+- GIPHY services' network/normalization/clamping/fail-close guards (UNCHANGED — only `envValue`/`publicGiphyKey` change).
+- `eas.json` values, the Pexels edge path, the Stripe `pk_live` guard, consumer/admin/buyer-web files, the friendly UI copy / error-state layout.
+
+**Stop-and-amend** before touching anything outside this corrected allowlist.
+
+---
+
+## A6. Downstream routing
+
+**Next handoff:** mingla-implementor (business side) — apply Fix (A) to both services (A2), add the comment-correction in `app.config.ts`, add the T-CORRECT regression tests (A4) + the §4.D gate extension (A3.4). Then mingla-tester verifies under SC-CORRECT-1..4 — **explicitly NOT on the Metro bundle** (A3.2): a standalone export grep/runtime + a dev-channel OTA on a real build. Then orchestrator REVIEW → CLOSE (flip the three DRAFT invariants from the original §6 ACTIVE; optionally add an I-PROPOSED for the extra-first read).
+
+**Open question for Seth (single):** none blocking — Fix (A) is the clear choice. FYI only: the renumber to ORCH-1127 should happen at CLOSE (the 1116 ID already carries `SPEC_ORCH-1116_BOOKING_GATE_RLS.md`); keep the worktree path/branch as-is until then.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1116_GIF_COVER_PICKER.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1116_GIF_COVER_PICKER.md
@@ -1,0 +1,210 @@
+# SPEC — ORCH-1116 [Cover picker GIF tab shows "This source is taking a break"]
+
+**Skill:** mingla-forensics · **Phase:** SPEC · **Date:** 2026-06-11
+**Upstream investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1116_GIF_COVER_PICKER.md` (root cause PROVEN at build-config layer).
+**Type:** config + observability fix. NOT a CoverPicker redesign.
+
+---
+
+## 1. Executive summary
+
+The GIF tab in the business-app cover picker shows "This source is taking a break." because the public **GIPHY key is provisioned in the EAS `production` environment ONLY** — it is absent from the `development` and `preview` EAS environments and from local `.env`. GIPHY is client-direct (ToS forbids proxying), so dev/preview builds and local Metro have no key, `publicGiphyKey()` returns `null`, and both the trending and search paths fail-close to `not_configured`. Pexels works because it is edge-proxied (server-side key, build-independent). Production builds already work.
+
+This SPEC delivers three things, exactly per Seth's asks: **(Fix)** propagate the GIPHY key to the dev/preview environments + document it in `.env.example`, with the rebuild-vs-OTA implication spelled out so the fix actually reaches devices; **(Prevent)** a config-eval fail-loud guard for required public keys (modeled on the existing `pk_live` guard in `app.config.ts`) plus a strict-grep CI gate, both staged as DRAFT invariants; **(Detect)** route the `not_configured` CONFIG error to engineering telemetry (Sentry breadcrumb/event via the existing `reportNonFatal`) while keeping transient `provider_unavailable`/`rate_limited` user-facing-only — so a mis-provisioned build is no longer a silent failure.
+
+---
+
+## 2. Scope & non-goals
+
+**In scope:**
+1. Provision `EXPO_PUBLIC_GIPHY_API_KEY` for the EAS `development` and `preview` environments (operator action — see §4 Build-config), and add `EXPO_PUBLIC_GIPHY_API_KEY=` to `.env.example` with a comment pointing at the GIPHY dashboard.
+2. A config-eval fail-loud guard in `mingla-business/app.config.ts` for the GIPHY public key, scoped so it fails the BUILD (not the user) when a key is required but absent.
+3. A strict-grep CI gate asserting the GIPHY key wiring is present and the fail-loud guard is not removed.
+4. Telemetry: emit a Sentry event/breadcrumb (via existing `reportNonFatal`) when a provider error is `not_configured`, so engineers are alerted; leave `provider_unavailable`/`rate_limited`/`invalid_response` as user-facing-only (no engineer alert).
+
+**Non-goals (explicitly OUT):**
+- Any change to the CoverPicker UI/UX, copy, layout, or the error-state component beyond the single telemetry call-site. The friendly copy stays.
+- Any change to the Pexels edge path or its key handling.
+- Any change to the GIPHY service network logic, normalization, clamping, or the existing fail-close guards (they are correct).
+- Re-architecting GIPHY to be edge-proxied (forbidden by GIPHY ToS — `coverProviderBrowseService.ts:6-8`).
+- Consumer app, admin web, buyer web (no CoverPicker / no GIPHY there).
+- Provisioning a brand-new GIPHY account — a key already exists (Open question O-1 confirms reuse vs. new dev key).
+
+**Assumptions:** the existing EAS `production` GIPHY key is valid and may be reused for dev/preview (pending O-1); EAS environments map to build profiles by name as proven in the investigation (development→development, preview/preview-sim→preview, production/production-apk→production).
+
+---
+
+## 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered? | User-visible behavior demanded | Files touched | Parity |
+|---|---------|----------|--------------------------------|---------------|--------|
+| 1 | Consumer iOS (`app-mobile/`) | NO | — | none | No CoverPicker / no GIPHY ref there. |
+| 2 | Consumer Android | NO | — | none | Same. |
+| 3 | Buyer/anon Web | NO | — | none | Authoring surface, not buyer. |
+| 4 | **Business iOS** | **YES** | GIF tab loads trending + search on dev/preview/production builds. | `app.config.ts`, `eas.json` (comment/anchor), `.env.example`, `CoverPicker.tsx` or service (1 telemetry call), strict-grep gate | Automatic (shared CoverPicker + services). |
+| 5 | **Business Android** | **YES** | Same as iOS. | Same | Automatic (shared code + EAS env applies to both platforms of a profile). |
+| 6 | Admin Web | NO | — | none | No CoverPicker. |
+| 7 | Business Web preview | PARTIAL (config-only) | If/when the web export is built with the GIPHY env set, GIF tab works; otherwise Pexels still works. | covered transitively by `.env`/build env | Manual — the web export must also receive the env var at build time (Vercel env or build env). Lower priority; note in Open questions. |
+
+This is a HARD gate: surfaces 1/2/3/6 are NOT-covered because none contain the unified CoverPicker or any `EXPO_PUBLIC_GIPHY` reference (proven F-3 blast-radius grep).
+
+---
+
+## 4. Layered specification
+
+This change touches **build-config**, **app-config (config-eval)**, **service/component (1 telemetry line)**, and **CI**. No DB, edge function, hook, or realtime layer is affected.
+
+### 4.A Build-config (operator + repo)
+
+**A1 — EAS remote env (operator action, no repo change):**
+Provision `EXPO_PUBLIC_GIPHY_API_KEY` (and, to match the existing belt-and-suspenders fallback, `EXPO_PUBLIC_GIPHY_KEY`) into the `development` and `preview` EAS environments, mirroring how `production` already has them. Exact commands (Seth runs; values not in repo):
+```
+eas env:create --environment development --name EXPO_PUBLIC_GIPHY_API_KEY --value <key> --visibility plaintext
+eas env:create --environment preview     --name EXPO_PUBLIC_GIPHY_API_KEY --value <key> --visibility plaintext
+```
+(Repeat for `EXPO_PUBLIC_GIPHY_KEY` if the dual-name fallback is to be preserved; otherwise the single `EXPO_PUBLIC_GIPHY_API_KEY` suffices since the service reads it first.)
+
+**A2 — `.env.example` (repo change):**
+Add, under the existing `EXPO_PUBLIC_*` block:
+```
+# GIPHY public key (client-direct; GIPHY ToS forbids proxying). Get from
+# https://developers.giphy.com/dashboard/ . Required for the cover-picker GIF tab.
+EXPO_PUBLIC_GIPHY_API_KEY=
+```
+This closes F-3/F-5 (local Metro dev currently has no documented key) and gives developers a place to paste their own key for local `expo start`.
+
+**A3 — `eas.json` (repo change, OPTIONAL belt-and-suspenders):**
+The investigation proved EAS resolves env from the named environment, so A1 is sufficient. Do NOT hardcode the GIPHY key value into `eas.json` `env` blocks (it would put a credential in version control and override the EAS env). The only acceptable `eas.json` edit is a comment documenting that the GIPHY key is provisioned via EAS environments — but `eas.json` is strict JSON (no comments). Therefore: **no eas.json value edit**; the strict-grep gate (§4.D) and the config-eval guard (§4.B) carry the enforcement instead.
+
+**Rebuild-vs-OTA implication (LOAD-BEARING — must be stated in the implementation report and to Seth):**
+`EXPO_PUBLIC_*` variables are **inlined into the JS bundle at BUILD/bundle time** from the resolved environment. The fix therefore requires:
+- A **new EAS build** of the affected profile(s) (`development`, `preview`/`preview-sim`) so the bundler re-resolves `process.env.EXPO_PUBLIC_GIPHY_API_KEY` to the now-present value. An OTA (`eas update`) alone re-publishes the JS bundle and CAN pick up the new env IF the update is exported with the env present in the export environment — but the safest, deterministic path is a fresh dev/preview build. Per memory `project_ota_deferred_until_new_build`, a native rebuild is warranted here only if a config/native change is needed; this is an env-only change, so a fresh dev build (which Seth already runs for business-app testing) is the minimum to verify. For production, the key is already present — no action needed.
+- State explicitly: **the already-installed dev build on Seth's device will NOT pick up the key until rebuilt/re-bundled.**
+
+### 4.B App-config fail-loud guard (`mingla-business/app.config.ts`)
+
+Add a config-eval IIFE for the GIPHY key, modeled EXACTLY on the existing `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY` guard at `app.config.ts:135-180`. Contract (≤ illustrative, implementor writes the real code):
+- Read `process.env.EXPO_PUBLIC_GIPHY_API_KEY ?? process.env.EXPO_PUBLIC_GIPHY_KEY`.
+- Read `process.env.EAS_BUILD_PROFILE` (EAS sets this at build time) — OR `VERCEL_ENV` for the web export, matching the existing dual-context handling in this file.
+- **Fail-loud rule:** if the build is a **release-bound profile** (`production`, `production-apk`, `preview`, `preview-sim` — i.e. profiles a tester/user will actually touch) and the GIPHY key is absent/blank → `throw new Error("EXPO_PUBLIC_GIPHY_API_KEY is required for the <profile> build (cover-picker GIF tab). Provision it in the matching EAS environment.")`.
+- **Do NOT throw** for `development` profile or local (`EAS_BUILD_PROFILE`/`VERCEL_ENV` undefined) — a developer without a key should still get a working dev build with a degraded GIF tab (the friendly copy), not a hard config crash. (This mirrors the Stripe guard's local-vs-production asymmetry.) Optionally `console.warn` in the dev/local case.
+- The returned value is injected into `expo.extra` or `process.env` passthrough so the runtime services read it — but note the services already read `process.env.EXPO_PUBLIC_*` directly (which EAS inlines), so the guard's PRIMARY job is to FAIL THE BUILD, not to plumb the value. Keep the guard a validation gate, not a new plumbing path.
+
+This satisfies the "prevent recurrence" ask analogous to `feedback_mingla_business_pk_live_in_production`.
+
+### 4.C Telemetry / Detect (1 call-site)
+
+The investigation (F-7, D-1) showed the `not_configured` CONFIG error is collapsed into friendly copy with zero telemetry. Add a single, surgical telemetry emit that distinguishes CONFIG from transient:
+
+- **Where:** at the point the provider error becomes an error STATE — preferred location is the catch/error handler in `CoverPicker.tsx` that sets `errorCode` for the GIF/Stock grid (the same place `noRetry`/copy is derived). Use the existing diagnostics helper:
+  ```
+  import { reportNonFatal } from "../../diagnostics/reportNonFatal";  // illustrative path
+  if (errorCode === "not_configured") {
+    reportNonFatal("coverPicker.provider", err, { provider: kind, code: errorCode });
+  }
+  ```
+- **Rule:** emit ONLY for `not_configured` (and optionally `auth_required`, which is also a non-transient config/session fault). Do NOT emit for `provider_unavailable`, `rate_limited`, `invalid_response` — those are transient and user-facing-only (avoid alert noise).
+- `reportNonFatal` already `console.warn`s always (honoring I-NO-SILENT-FAILURES) and `captureException`s to Sentry when configured — exactly the CONFIG-vs-transient split required, with no new dependency.
+- **Caveat (D-1):** Sentry DSN (`EXPO_PUBLIC_SENTRY_DSN`) is itself provisioned in EAS `production` only, so on dev/preview builds the Sentry side is a no-op (only the console.warn fires). For the alert to fire from production builds (where the key SHOULD be present so this should be rare) it works as-is. **Open question O-2:** provision the Sentry DSN for dev/preview too if Seth wants config alerts from those builds. Recommended: yes, lightweight, closes the observability loop.
+
+### 4.D Strict-grep CI gate
+
+Add a new gate under `.github/scripts/strict-grep/` (convention: a `.mjs` rule + a `.test.mjs` companion, matching the existing `i-*.mjs` files), e.g. `i-giphy-key-wired.mjs`. It asserts:
+1. `mingla-business/app.config.ts` contains the GIPHY fail-loud guard (grep for `EXPO_PUBLIC_GIPHY_API_KEY` AND a `throw` in the same guard region) — i.e. the prevent guard cannot be silently deleted.
+2. `mingla-business/.env.example` documents `EXPO_PUBLIC_GIPHY_API_KEY`.
+3. (Optional, if feasible without network) a build-config check is NOT possible in pure grep against EAS remote env — so the gate enforces the REPO-side wiring (guard + docs), and the config-eval guard (§4.B) enforces the actual presence at build time. Together they close the F-7 detection gap.
+
+Register the gate in the strict-grep runner manifest the same way sibling gates are registered.
+
+---
+
+## 5. Success criteria (per-surface where parity is manual)
+
+- **SC-1-iOS / SC-1-Android:** On a freshly-built `preview` (or `development` with key provisioned) business build, opening the cover picker and tapping the GIF tab shows GIPHY trending thumbnails (NOT "This source is taking a break.").
+- **SC-2-iOS / SC-2-Android:** Typing ≥2 chars in the GIF search field returns GIPHY search results.
+- **SC-3:** A `preview`/`production` build attempted WITHOUT the GIPHY key in the matching EAS environment FAILS at config-eval with the explicit error message (proves the §4.B guard).
+- **SC-4:** A `development` profile / local build WITHOUT the key still builds successfully (no hard crash) and the GIF tab shows the friendly copy (proves the dev asymmetry).
+- **SC-5:** When the GIF path hits `not_configured`, a `console.warn("[coverPicker.provider] ...")` is emitted and (on a Sentry-configured build) a Sentry event is captured; when it hits `provider_unavailable`/`rate_limited`, NO telemetry is emitted (proves the CONFIG-vs-transient split).
+- **SC-6:** `.env.example` documents `EXPO_PUBLIC_GIPHY_API_KEY`.
+- **SC-7:** The strict-grep gate PASSES with the guard present and FAILS if the guard/`.env.example` entry is removed (proves the prevent gate is live).
+
+---
+
+## 6. Invariants
+
+**Preserved:**
+- **I-NO-SILENT-FAILURES** — the telemetry addition strengthens this; the friendly copy already shows, now the engineer is also alerted for CONFIG faults.
+- The existing GIPHY fail-close guards (`coverProviderBrowseService.ts:103`, `giphyEventCoverService.ts:83`) are UNCHANGED — they are correct.
+- The Stripe `pk_live` config-eval guard (`app.config.ts:135-180`) is the model and must remain untouched.
+
+**New (proposed DRAFT — flip ACTIVE on CLOSE; orchestrator owns the flip):**
+- **I-PROPOSED-GIPHY-KEY-FAIL-LOUD (DRAFT):** A release-bound business build (`production`/`production-apk`/`preview`/`preview-sim`) MUST fail at config-eval if `EXPO_PUBLIC_GIPHY_API_KEY` is absent. Verified by SC-3 + the strict-grep gate. Modeled on `feedback_mingla_business_pk_live_in_production`.
+- **I-PROPOSED-GIPHY-KEY-WIRED (DRAFT):** `app.config.ts` carries the GIPHY fail-loud guard and `.env.example` documents the key. Verified by the strict-grep gate (§4.D) which FAILS on removal.
+- **I-PROPOSED-CONFIG-ERROR-IS-OBSERVABLE (DRAFT, generalizable):** A provider `not_configured` error MUST emit engineering telemetry (not just user copy); transient provider errors MUST NOT. Verified by SC-5.
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T1 (happy) | Key present, tab opened | preview build w/ GIPHY env | Trending GIFs render | runtime/build |
+| T2 (happy) | Key present, search | "jazz" | Search results render | runtime |
+| T3 (error) | Release build, key absent | `EAS_BUILD_PROFILE=preview`, no key | config-eval THROWS with explicit message | config-eval |
+| T4 (edge) | Dev build, key absent | `EAS_BUILD_PROFILE=development`, no key | Build succeeds; GIF tab shows friendly copy | config-eval + runtime |
+| T5 (detect) | not_configured at runtime | force null key in dev | `console.warn("[coverPicker.provider]")` fires; Sentry capture on configured build | code |
+| T6 (detect-negative) | provider_unavailable | mock 503 from GIPHY | NO telemetry emit; user sees "Couldn't reach GIPHY." | code |
+| T7 (gate) | strict-grep with guard present | repo HEAD | gate PASS | CI |
+| T8 (gate fails-on-revert) | strict-grep with guard removed | guard deleted from app.config.ts | gate FAIL | CI |
+| T9 (regression) | existing jest suites | unchanged | 7/7 still pass | code |
+
+---
+
+## 8. Implementation order
+
+1. **`.env.example`** — add the documented `EXPO_PUBLIC_GIPHY_API_KEY=` entry (§4.A2).
+2. **`app.config.ts`** — add the GIPHY config-eval fail-loud guard modeled on the Stripe guard (§4.B).
+3. **Telemetry** — add the single `reportNonFatal` call at the GIF/Stock error-state derivation in `CoverPicker.tsx`, gated on `errorCode === "not_configured"` (§4.C).
+4. **Strict-grep gate** — add `i-giphy-key-wired.mjs` + `.test.mjs`, register in the runner (§4.D).
+5. **Tests** — extend `CoverPicker` test (or add a focused test) for T5/T6; the gate's own `.test.mjs` covers T7/T8.
+6. **Operator (Seth, OUT of implementor scope — handoff item):** run the `eas env:create` commands (§4.A1) for development+preview, then a fresh dev/preview build to verify SC-1/SC-2.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+- **Structural safeguard:** the config-eval guard (§4.B) makes a release-bound build IMPOSSIBLE without the key — the build fails loudly instead of shipping a broken GIF tab.
+- **Fails-on-revert test:** the strict-grep gate `i-giphy-key-wired.mjs` MUST FAIL when the `app.config.ts` GIPHY guard or the `.env.example` entry is reverted, and PASS when restored (T7/T8). The `.test.mjs` companion asserts both directions.
+- **Protective comment:** the §4.B guard carries a comment: `// ORCH-1116: fail the build (not the user) if the client-direct GIPHY key is missing on a release-bound profile. GIPHY cannot be edge-proxied (ToS); a missing key silently breaks the cover-picker GIF tab. Mirrors the EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY guard above.`
+
+---
+
+## 10. Open questions (need Seth's steering)
+
+- **O-1 (key provenance):** Reuse the existing EAS `production` GIPHY public key for the `development`/`preview` environments, OR mint a separate dev key in the GIPHY dashboard (cleaner rate-limit isolation; the beta key is 100 req/hr per `coverProviderBrowseService.ts:20-21`)? Recommendation: reuse for speed now; mint a dev key later if rate limits bite.
+- **O-2 (Sentry DSN for dev/preview):** Provision `EXPO_PUBLIC_SENTRY_DSN` for dev/preview EAS environments so the `not_configured` alert fires from those builds too (D-1)? Recommendation: yes — low cost, closes the detection loop where the bug actually manifests.
+- **O-3 (alerting now vs defer):** Ship the `reportNonFatal` telemetry now (recommended — it's one line and reuses existing infra) vs. defer to console-only? Recommendation: ship now.
+- **O-4 (business web export):** Does the Vercel/web business-app export need the GIPHY env at build time too (surface 7)? If web authoring is in use, add `EXPO_PUBLIC_GIPHY_API_KEY` to the web build env; otherwise defer.
+
+---
+
+## 11. Downstream routing
+
+**Allowlist (implementor may edit ONLY these):**
+- `mingla-business/.env.example`
+- `mingla-business/app.config.ts` (GIPHY guard block only)
+- `mingla-business/src/components/ui/CoverPicker.tsx` (single telemetry call-site only)
+- `.github/scripts/strict-grep/i-giphy-key-wired.mjs` + `.test.mjs` + the runner manifest entry
+- A focused test file for the telemetry split (T5/T6)
+
+**DO-NOT-TOUCH:**
+- `coverProviderBrowseService.ts` / `giphyEventCoverService.ts` network/guard logic (correct as-is).
+- `eas.json` values (no key in version control).
+- The Pexels edge path / `event-cover-pexels-curated`.
+- The Stripe `pk_live` guard.
+- Any consumer / admin / buyer-web file.
+- The friendly UI copy / error-state component layout.
+
+**Stop-and-amend** before touching anything outside the allowlist.
+
+**Next handoff:** mingla-implementor (business side) executes §8 steps 1–5. Then mingla-tester verifies SC-1..SC-7 (with a fresh dev/preview build after Seth runs §8 step 6 / §4.A1). Then orchestrator REVIEW → CLOSE (flips the three DRAFT invariants ACTIVE). **Operator pre-req:** Seth provisions the EAS env vars (§4.A1) — without that, SC-1/SC-2 cannot pass even with perfect code.

--- a/mingla-business/.env.example
+++ b/mingla-business/.env.example
@@ -5,6 +5,12 @@ EXPO_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 EXPO_PUBLIC_OPENWEATHER_API_KEY=your_openweather_api_key_here
 EXPO_PUBLIC_FOURSQUARE_API_KEY=your_foursquare_api_key_here
 
+# GIPHY public key (client-direct; GIPHY ToS forbids proxying). Get from
+# https://developers.giphy.com/dashboard/ . Required for the cover-picker GIF tab.
+# EXPO_PUBLIC_* values are inlined into the JS bundle at build time, so a fresh
+# dev/preview build (not an OTA) is needed to pick up a newly-provisioned key.
+EXPO_PUBLIC_GIPHY_API_KEY=
+
 # Google OAuth (client IDs — registered in Google Cloud Console under mingla-dev project)
 GOOGLE_WEB_CLIENT_ID=your_google_web_client_id_here
 GOOGLE_IOS_CLIENT_ID=your_google_ios_client_id_here

--- a/mingla-business/app.config.ts
+++ b/mingla-business/app.config.ts
@@ -181,9 +181,15 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       // ORCH-1116: fail the build (not the user) if the client-direct GIPHY key
       // is missing on a release-bound profile. GIPHY cannot be edge-proxied
       // (ToS); a missing key silently breaks the cover-picker GIF tab. Mirrors
-      // the EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY guard above. The runtime services
-      // read process.env.EXPO_PUBLIC_GIPHY_API_KEY directly (EAS inlines it), so
-      // this IIFE is a build-time validation GATE, not a new plumbing path.
+      // the EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY guard above.
+      // ORCH-1127 correction: this IIFE both (a) fails the build when the key is
+      // missing on a release-bound profile AND (b) emits the resolved key into
+      // `extra` below — and THAT emission IS the runtime plumbing path. The
+      // giphy services read Constants.expoConfig.extra.EXPO_PUBLIC_GIPHY_API_KEY
+      // FIRST (mirroring supabase.ts). The earlier assumption that the services
+      // read process.env directly and "EAS inlines it" was WRONG: a DYNAMIC
+      // process.env[name] read is NOT inlined by babel-preset-expo and is
+      // undefined in Hermes standalone/OTA builds — only `extra` survives.
       EXPO_PUBLIC_GIPHY_API_KEY: (() => {
         const fromEnv =
           process.env.EXPO_PUBLIC_GIPHY_API_KEY ??

--- a/mingla-business/app.config.ts
+++ b/mingla-business/app.config.ts
@@ -178,6 +178,51 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         }
         return localValue;
       })(),
+      // ORCH-1116: fail the build (not the user) if the client-direct GIPHY key
+      // is missing on a release-bound profile. GIPHY cannot be edge-proxied
+      // (ToS); a missing key silently breaks the cover-picker GIF tab. Mirrors
+      // the EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY guard above. The runtime services
+      // read process.env.EXPO_PUBLIC_GIPHY_API_KEY directly (EAS inlines it), so
+      // this IIFE is a build-time validation GATE, not a new plumbing path.
+      EXPO_PUBLIC_GIPHY_API_KEY: (() => {
+        const fromEnv =
+          process.env.EXPO_PUBLIC_GIPHY_API_KEY ??
+          process.env.EXPO_PUBLIC_GIPHY_KEY ??
+          null;
+        // EAS sets EAS_BUILD_PROFILE at build time; VERCEL_ENV is set for the
+        // web export. A release-bound profile is one a tester/user actually
+        // touches: production, production-apk, preview, preview-sim, plus the
+        // Vercel production/preview web exports.
+        const easProfile = process.env.EAS_BUILD_PROFILE;
+        const vercelEnv = process.env.VERCEL_ENV;
+        const releaseBoundEasProfiles = [
+          "production",
+          "production-apk",
+          "preview",
+          "preview-sim",
+        ];
+        const isReleaseBound =
+          (easProfile !== undefined &&
+            releaseBoundEasProfiles.includes(easProfile)) ||
+          vercelEnv === "production" ||
+          vercelEnv === "preview";
+        if (isReleaseBound && (fromEnv === null || fromEnv.length === 0)) {
+          const profileLabel = easProfile ?? vercelEnv ?? "release";
+          throw new Error(
+            `EXPO_PUBLIC_GIPHY_API_KEY is required for the ${profileLabel} build (cover-picker GIF tab). Provision it in the matching EAS environment.`,
+          );
+        }
+        // Development profile / local (EAS_BUILD_PROFILE + VERCEL_ENV undefined):
+        // do NOT throw — a developer without a key still gets a working dev
+        // build with a degraded GIF tab (friendly copy), not a hard config
+        // crash. Mirrors the Stripe guard's local-vs-production asymmetry.
+        if (fromEnv === null || fromEnv.length === 0) {
+          console.warn(
+            "[app.config] EXPO_PUBLIC_GIPHY_API_KEY is not set — the cover-picker GIF tab will show the friendly degraded state. Set it in .env for local GIF browsing.",
+          );
+        }
+        return fromEnv;
+      })(),
       // B2a Path C V3 forensics R-1: canonical Mingla Business public web URL.
       // Single source of truth read by mingla-business/src/constants/platformUrl.ts.
       // Production canonical: https://business.usemingla.com (Vercel-hosted Expo Web export).

--- a/mingla-business/src/__tests__/orch1116GiphyConfigGuard.test.ts
+++ b/mingla-business/src/__tests__/orch1116GiphyConfigGuard.test.ts
@@ -1,0 +1,173 @@
+/**
+ * ORCH-1116 [Cover picker GIF tab "This source is taking a break"] — TESTER
+ * ADVERSARIAL regression (different angle from the implementor's happy-path).
+ *
+ * The implementor's happy-path test (CoverPicker.providerTelemetry.test.ts)
+ * attacks the *telemetry split* via a re-implemented mirror of the helper plus
+ * source-string assertions on CoverPicker.tsx. It NEVER exercises the real
+ * `app.config.ts` fail-loud guard at runtime — SC-3 / SC-4 there are only an
+ * uncommitted manual env-probe in the implementation report, and the strict-grep
+ * gate only checks the guard exists *textually*.
+ *
+ * This test attacks the OTHER load-bearing half: the REAL exported
+ * `app.config.ts` default function, invoked with a controlled `process.env`
+ * matrix, asserting the actual THROW / NO-THROW behavior of the GIPHY guard
+ * (§4.B, SC-3/SC-4) — including the VERCEL_ENV web-export branch the implementor
+ * never covered with a committed test, and the key-plumbing (value lands in
+ * `extra`) the SPEC requires. It also proves the dev/local asymmetry does not
+ * crash a keyless dev build.
+ *
+ * Masking note: the sibling `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY` guard runs in
+ * the same `extra` object and throws FIRST on Vercel profiles when the Stripe
+ * key is absent/wrong. So for VERCEL_ENV cases we supply a valid Stripe pk to
+ * get past it and isolate the GIPHY assertion. EAS_BUILD_PROFILE-only cases set
+ * no VERCEL_ENV, so the Stripe guard takes its local sandbox-fallback path and
+ * does not interfere.
+ *
+ * Fails-on-revert: if the GIPHY guard IIFE in app.config.ts is reduced to a
+ * passthrough (the throw removed), the THROW assertions below FAIL.
+ */
+
+// expo/config is types-only at runtime here; app.config.ts imports it solely for
+// ExpoConfig / ConfigContext type names, so no runtime mock is needed under
+// ts-jest's type-erasing transform. We still provide a stub to be safe.
+jest.mock(
+  "expo/config",
+  () => ({}),
+  { virtual: true },
+);
+
+// A minimal ConfigContext.config — the default fn only reads config.plugins,
+// config.name, config.slug, etc., all optional-tolerant.
+const FAKE_CTX = { config: { plugins: [] } } as never;
+
+// Valid live publishable key shape so the Stripe guard passes on Vercel
+// production (stripeMode defaults to "live"). NOT a real secret — shape only.
+const FAKE_PK_LIVE = "pk_live_" + "0".repeat(24);
+const FAKE_PK_TEST = "pk_test_" + "0".repeat(24);
+
+const ORIGINAL_ENV = process.env;
+
+function runConfigWithEnv(env: Record<string, string | undefined>): unknown {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV, ...env } as NodeJS.ProcessEnv;
+  // Re-require after env mutation so the module reads the fresh process.env.
+  // app.config.ts has no top-level env reads that matter to the guard — the
+  // guard IIFE runs when the default fn is invoked.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require("../../app.config").default as (ctx: never) => {
+    extra?: Record<string, unknown>;
+  };
+  return mod(FAKE_CTX);
+}
+
+describe("ORCH-1116 app.config GIPHY fail-loud guard (real default fn)", () => {
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    jest.resetModules();
+  });
+
+  // ---- SC-3: release-bound profiles THROW when the GIPHY key is absent ------
+
+  test("A1 — EAS preview profile, NO giphy key → THROWS with explicit message", () => {
+    expect(() =>
+      runConfigWithEnv({
+        EAS_BUILD_PROFILE: "preview",
+        VERCEL_ENV: undefined,
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+        // No VERCEL_ENV → Stripe guard uses sandbox fallback, no interference.
+      }),
+    ).toThrow(/EXPO_PUBLIC_GIPHY_API_KEY is required for the preview build/);
+  });
+
+  test("A2 — EAS production-apk profile, NO giphy key → THROWS", () => {
+    expect(() =>
+      runConfigWithEnv({
+        EAS_BUILD_PROFILE: "production-apk",
+        VERCEL_ENV: undefined,
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+      }),
+    ).toThrow(/EXPO_PUBLIC_GIPHY_API_KEY is required for the production-apk build/);
+  });
+
+  test("A3 — VERCEL_ENV=production web export, NO giphy key → THROWS (web branch the implementor never committed-tested)", () => {
+    expect(() =>
+      runConfigWithEnv({
+        EAS_BUILD_PROFILE: undefined,
+        VERCEL_ENV: "production",
+        // Stripe pk_live supplied so the Stripe guard passes and we reach GIPHY.
+        EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY: FAKE_PK_LIVE,
+        MINGLA_STRIPE_MODE: "live",
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+      }),
+    ).toThrow(/EXPO_PUBLIC_GIPHY_API_KEY is required for the production build/);
+  });
+
+  test("A4 — VERCEL_ENV=preview web export, NO giphy key → THROWS", () => {
+    expect(() =>
+      runConfigWithEnv({
+        EAS_BUILD_PROFILE: undefined,
+        VERCEL_ENV: "preview",
+        EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY: FAKE_PK_TEST,
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+      }),
+    ).toThrow(/EXPO_PUBLIC_GIPHY_API_KEY is required for the preview build/);
+  });
+
+  // ---- SC-4: dev / local do NOT throw on a missing key ----------------------
+
+  test("A5 — EAS development profile, NO giphy key → does NOT throw (dev asymmetry)", () => {
+    let result: { extra?: Record<string, unknown> } | undefined;
+    expect(() => {
+      result = runConfigWithEnv({
+        EAS_BUILD_PROFILE: "development",
+        VERCEL_ENV: undefined,
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+      }) as { extra?: Record<string, unknown> };
+    }).not.toThrow();
+    // Keyless dev build → the guard returns null into extra (degraded GIF tab).
+    expect(result?.extra?.EXPO_PUBLIC_GIPHY_API_KEY ?? null).toBeNull();
+  });
+
+  test("A6 — local (no EAS_BUILD_PROFILE, no VERCEL_ENV), NO giphy key → does NOT throw", () => {
+    expect(() =>
+      runConfigWithEnv({
+        EAS_BUILD_PROFILE: undefined,
+        VERCEL_ENV: undefined,
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+      }),
+    ).not.toThrow();
+  });
+
+  // ---- Key plumbing + fallback name ----------------------------------------
+
+  test("A7 — release-bound profile WITH key present → no throw AND value plumbed into extra", () => {
+    let result: { extra?: Record<string, unknown> } | undefined;
+    expect(() => {
+      result = runConfigWithEnv({
+        EAS_BUILD_PROFILE: "preview",
+        VERCEL_ENV: undefined,
+        EXPO_PUBLIC_GIPHY_API_KEY: "gphy_dummy_key_value_abcdef ".trim(),
+        EXPO_PUBLIC_GIPHY_KEY: undefined,
+      }) as { extra?: Record<string, unknown> };
+    }).not.toThrow();
+    expect(result?.extra?.EXPO_PUBLIC_GIPHY_API_KEY).toBe("gphy_dummy_key_value_abcdef");
+  });
+
+  test("A8 — only the legacy EXPO_PUBLIC_GIPHY_KEY name set on a release profile → satisfies the guard (no throw, fallback honored)", () => {
+    expect(() =>
+      runConfigWithEnv({
+        EAS_BUILD_PROFILE: "preview",
+        VERCEL_ENV: undefined,
+        EXPO_PUBLIC_GIPHY_API_KEY: undefined,
+        EXPO_PUBLIC_GIPHY_KEY: "legacy_giphy_fallback_key_value",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/mingla-business/src/components/ui/CoverPicker.tsx
+++ b/mingla-business/src/components/ui/CoverPicker.tsx
@@ -96,6 +96,7 @@ import {
   trendingGiphyCovers,
 } from "../../services/coverProviderBrowseService";
 import { EventCoverProviderError } from "../../services/eventCoverProviderError";
+import { reportNonFatal } from "../../diagnostics/reportNonFatal";
 import {
   eventCoverProviderCreditLabel,
   UPLOAD_EVENT_COVER_PROVIDER_METADATA,
@@ -116,6 +117,24 @@ export type { CoverTarget } from "./coverTarget";
 // LOCKED tab ids (SPEC §4.3); display labels are designer-owned copy (DESIGN §3.1).
 type CoverTabId = "library" | "gif" | "stock";
 type ProviderStatus = "idle" | "loading" | "populated" | "empty" | "error";
+
+/**
+ * ORCH-1116: route a provider (GIF/Stock) error to engineering telemetry ONLY
+ * when it is a non-transient CONFIG fault (`not_configured`) — i.e. the build is
+ * mis-provisioned (e.g. a missing client-direct GIPHY key). Transient faults
+ * (`provider_unavailable`/`rate_limited`/`invalid_response`) stay user-facing
+ * only (friendly copy) to avoid alert noise. The friendly UI copy is unchanged;
+ * this only adds an alert for the silent-config case. Single telemetry call-site.
+ */
+export const reportProviderError = (
+  kind: "gif" | "stock",
+  error: unknown,
+): void => {
+  const code =
+    error instanceof EventCoverProviderError ? error.code : "provider_unavailable";
+  if (code !== "not_configured") return;
+  reportNonFatal("coverPicker.provider", error, { provider: kind, code });
+};
 
 /** Full 7-field cover patch emitted on every change. Mirror of the events
  *  table cover_media_* column family. UNCHANGED from prior CoverPicker. */
@@ -592,6 +611,7 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
         error instanceof EventCoverProviderError ? error.code : "provider_unavailable";
       setGiphyError(code);
       setGiphyStatus("error");
+      reportProviderError("gif", error);
       warnHaptic();
     }
   }, [giphyStatus]);
@@ -610,6 +630,7 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
         error instanceof EventCoverProviderError ? error.code : "provider_unavailable";
       setPexelsError(code);
       setPexelsStatus("error");
+      reportProviderError("stock", error);
       warnHaptic();
     }
   }, [pexelsStatus]);
@@ -641,6 +662,7 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
           error instanceof EventCoverProviderError ? error.code : "provider_unavailable";
         setGiphyError(code);
         setGiphyStatus("error");
+        reportProviderError("gif", error);
         warnHaptic();
       }
     } else if (activeTab === "stock") {
@@ -655,6 +677,7 @@ export const CoverPicker: React.FC<CoverPickerProps> = ({
           error instanceof EventCoverProviderError ? error.code : "provider_unavailable";
         setPexelsError(code);
         setPexelsStatus("error");
+        reportProviderError("stock", error);
         warnHaptic();
       }
     }

--- a/mingla-business/src/components/ui/__tests__/CoverPicker.providerTelemetry.test.ts
+++ b/mingla-business/src/components/ui/__tests__/CoverPicker.providerTelemetry.test.ts
@@ -1,0 +1,125 @@
+/**
+ * ORCH-1116 [Cover picker GIF tab "This source is taking a break"] regression.
+ *
+ * The GIF/Stock cover-picker error state collapsed a `not_configured` CONFIG
+ * fault (a mis-provisioned build: missing client-direct GIPHY key) into friendly
+ * copy with ZERO telemetry — a silent config failure (I-NO-SILENT-FAILURES gap).
+ * The fix routes ONLY `not_configured` to engineering telemetry via the existing
+ * Sentry-backed `reportNonFatal`, while transient faults
+ * (`provider_unavailable`/`rate_limited`/`invalid_response`) stay user-facing
+ * only (no alert noise). The friendly UI copy is unchanged.
+ *
+ * Two layers of coverage:
+ *   1. REAL LOGIC — the CONFIG-vs-transient split is exercised behaviorally via
+ *      the same gate the component applies (errorCode === "not_configured"),
+ *      with `reportNonFatal` mocked. T5 (not_configured -> emit) + T6
+ *      (provider_unavailable -> no emit). Fails on revert of the gate condition.
+ *   2. SOURCE WIRING — CoverPicker.tsx carries heavy native deps (expo-video /
+ *      expo-image-picker / react-native-video-trim) the jest env cannot render,
+ *      so the call-site wiring is asserted via source: the single telemetry
+ *      helper exists and is invoked at all four provider catch sites. Each
+ *      assertion fails on revert of the corresponding change.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { EventCoverProviderError } from "../../../services/eventCoverProviderError";
+
+const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+jest.mock("../../../diagnostics/sentry", () => ({
+  captureException: jest.fn(() => "event-id"),
+}));
+
+import { reportNonFatal } from "../../../diagnostics/reportNonFatal";
+import { captureException } from "../../../diagnostics/sentry";
+
+jest.mock("../../../diagnostics/reportNonFatal", () => ({
+  reportNonFatal: jest.fn(),
+}));
+
+/**
+ * Mirror of CoverPicker's `reportProviderError` gate — exercised behaviorally so
+ * the CONFIG-vs-transient split itself is under test (not just the source text).
+ * Kept byte-identical to the component helper so a revert of the gate condition
+ * there is reflected by the source-wiring assertions below; this block proves
+ * the runtime behavior of the gate.
+ */
+function gateUnderTest(kind: "gif" | "stock", error: unknown): void {
+  const code =
+    error instanceof EventCoverProviderError ? error.code : "provider_unavailable";
+  if (code !== "not_configured") return;
+  reportNonFatal("coverPicker.provider", error, { provider: kind, code });
+}
+
+describe("ORCH-1116 cover-picker provider telemetry split", () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+    (reportNonFatal as jest.Mock).mockClear();
+    (captureException as jest.Mock).mockClear();
+  });
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("T5: not_configured emits engineering telemetry (provider=gif)", () => {
+    const err = new EventCoverProviderError("not_configured", "GIPHY is not configured yet.");
+    gateUnderTest("gif", err);
+    expect(reportNonFatal).toHaveBeenCalledTimes(1);
+    expect(reportNonFatal).toHaveBeenCalledWith("coverPicker.provider", err, {
+      provider: "gif",
+      code: "not_configured",
+    });
+  });
+
+  test("T6: provider_unavailable emits NO telemetry", () => {
+    const err = new EventCoverProviderError("provider_unavailable", "Couldn't reach GIPHY.");
+    gateUnderTest("gif", err);
+    expect(reportNonFatal).not.toHaveBeenCalled();
+  });
+
+  test("T6b: rate_limited emits NO telemetry", () => {
+    const err = new EventCoverProviderError("rate_limited", "Hourly limit hit.");
+    gateUnderTest("stock", err);
+    expect(reportNonFatal).not.toHaveBeenCalled();
+  });
+
+  test("non-provider Error (network) emits NO telemetry", () => {
+    gateUnderTest("gif", new Error("network down"));
+    expect(reportNonFatal).not.toHaveBeenCalled();
+  });
+
+  // ---- SOURCE WIRING (fails on revert of the CoverPicker changes) ----------
+
+  const coverPickerSrc = readFileSync(
+    join(__dirname, "..", "CoverPicker.tsx"),
+    "utf8",
+  );
+
+  test("CoverPicker imports the Sentry-backed reportNonFatal helper", () => {
+    expect(coverPickerSrc).toMatch(
+      /import\s*\{\s*reportNonFatal\s*\}\s*from\s*["']\.\.\/\.\.\/diagnostics\/reportNonFatal["']/,
+    );
+  });
+
+  test("CoverPicker defines a single telemetry helper gated on not_configured", () => {
+    expect(coverPickerSrc).toMatch(/reportProviderError/);
+    expect(coverPickerSrc).toMatch(/if \(code !== "not_configured"\) return;/);
+    // Exactly one reportNonFatal call-site in the file (the helper body).
+    const calls = coverPickerSrc.match(/reportNonFatal\(/g) ?? [];
+    expect(calls.length).toBe(1);
+  });
+
+  test("all four provider catch sites invoke the telemetry helper", () => {
+    const gifCalls = coverPickerSrc.match(/reportProviderError\("gif", error\)/g) ?? [];
+    const stockCalls = coverPickerSrc.match(/reportProviderError\("stock", error\)/g) ?? [];
+    expect(gifCalls.length).toBe(2);
+    expect(stockCalls.length).toBe(2);
+  });
+
+  test("friendly not_configured GIF copy is unchanged (no copy regression)", () => {
+    expect(coverPickerSrc).toMatch(/This source is taking a break\./);
+  });
+});

--- a/mingla-business/src/services/__tests__/coverProviderBrowseService.test.ts
+++ b/mingla-business/src/services/__tests__/coverProviderBrowseService.test.ts
@@ -17,6 +17,13 @@ import { readFileSync } from "fs";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
 
+// ORCH-1127: the service now imports expo-constants (extra-first key read).
+// This suite exercises the process.env fallback path, so `extra` is empty.
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { extra: {} } },
+}));
+
 // Mock the supabase client BEFORE importing the service so the curated path
 // resolves to a controllable functions.invoke.
 const invokeMock = jest.fn<(...args: unknown[]) => Promise<unknown>>();

--- a/mingla-business/src/services/__tests__/giphyEventCoverService.test.ts
+++ b/mingla-business/src/services/__tests__/giphyEventCoverService.test.ts
@@ -1,5 +1,12 @@
 import { afterAll, beforeEach, describe, expect, jest, test } from "@jest/globals";
 
+// ORCH-1127: the service now imports expo-constants (extra-first key read).
+// These suites exercise the process.env fallback path, so `extra` is empty.
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { extra: {} } },
+}));
+
 import { EventCoverProviderError } from "../eventCoverProviderError";
 import { searchGiphyEventCovers } from "../giphyEventCoverService";
 

--- a/mingla-business/src/services/__tests__/giphyKeyReachability.test.ts
+++ b/mingla-business/src/services/__tests__/giphyKeyReachability.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ORCH-1127 (ex-1116) — GIF cover-key reachability regression.
+ *
+ * Proves the corrected key-read path: BOTH giphy services resolve the public
+ * GIPHY key from `Constants.expoConfig.extra` FIRST (mirror supabase.ts), with
+ * a STATIC `process.env` fallback — so the key is reachable in a Hermes
+ * standalone / OTA build where `process.env` is empty.
+ *
+ * Root cause this guards against (COMMS-0028 / SPEC_AMENDMENT_ORCH-1127):
+ * the prior reader used DYNAMIC `globalThis.process?.env?.[name]` which
+ * babel-preset-expo never inlines → undefined in every non-Metro build →
+ * `not_configured` → "This source is taking a break.".
+ *
+ * Why the OLD tests missed it: Node/jest (and Metro dev) both populate
+ * `process.env`, so the dynamic lookup resolved. These tests simulate the
+ * STANDALONE condition by EMPTYING `process.env.EXPO_PUBLIC_GIPHY_*` and
+ * placing the key ONLY in the mocked `Constants.expoConfig.extra`.
+ *
+ * T-CORRECT-1  standalone simulation: empty process.env, key in extra → resolves.
+ * T-CORRECT-2  fails-on-revert: with the extra-first read reverted to the
+ *              dynamic-only reader, the same input → not_configured (test FAILS).
+ *              (Structurally enforced: this file asserts the extra path resolves;
+ *              deleting the `readExtra(name) ??` read in the services makes
+ *              T-CORRECT-1 FAIL — see the implementation report's fails-on-revert
+ *              hash.)
+ * T-CORRECT-3  Metro/dev path intact: key only in static process.env, extra empty.
+ * T-CORRECT-4  dual-name fallback preserved: only EXPO_PUBLIC_GIPHY_KEY set.
+ */
+
+import { afterAll, beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+// Mutable extra object the mock returns by reference; tests mutate it per case.
+// The services read Constants.expoConfig?.extra at CALL time, so mutation here
+// is reflected without re-importing the module.
+const mockExtra: Record<string, string | undefined> = {};
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    get expoConfig() {
+      return { extra: mockExtra };
+    },
+  },
+}));
+
+// curatedPexelsCovers (in the browse service) needs a supabase mock at import
+// time even though these tests only call the GIPHY paths.
+jest.mock("../supabase", () => ({
+  supabase: {
+    functions: { invoke: jest.fn(async () => ({ data: null, error: null })) },
+  },
+}));
+
+import { searchGiphyEventCovers } from "../giphyEventCoverService";
+import { trendingGiphyCovers } from "../coverProviderBrowseService";
+
+const ORIGINAL_API_KEY = process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+const ORIGINAL_KEY = process.env.EXPO_PUBLIC_GIPHY_KEY;
+
+const fetchOk = (): Response =>
+  ({
+    json: async () => ({
+      data: [
+        {
+          id: "gif-1",
+          title: "Trending loop",
+          url: "https://giphy.com/gifs/trending",
+          images: {
+            fixed_width: { url: "https://media.giphy.com/preview.gif" },
+            downsized_medium: { url: "https://media.giphy.com/medium.gif" },
+            downsized: { url: "https://media.giphy.com/downsized.gif" },
+            original: { url: "https://media.giphy.com/original.gif" },
+          },
+        },
+      ],
+    }),
+    ok: true,
+    status: 200,
+  }) as Response;
+
+const lastFetchApiKey = (): string | null => {
+  const calls = (global.fetch as jest.Mock).mock.calls;
+  if (calls.length === 0) return null;
+  return new URL(String(calls[calls.length - 1][0])).searchParams.get("api_key");
+};
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Simulate a Hermes standalone bundle: process.env carries NO giphy key.
+  delete process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+  delete process.env.EXPO_PUBLIC_GIPHY_KEY;
+  // Reset the mocked manifest extra.
+  for (const k of Object.keys(mockExtra)) delete mockExtra[k];
+  global.fetch = jest.fn(async () => fetchOk()) as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+  if (ORIGINAL_API_KEY === undefined) delete process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+  else process.env.EXPO_PUBLIC_GIPHY_API_KEY = ORIGINAL_API_KEY;
+  if (ORIGINAL_KEY === undefined) delete process.env.EXPO_PUBLIC_GIPHY_KEY;
+  else process.env.EXPO_PUBLIC_GIPHY_KEY = ORIGINAL_KEY;
+});
+
+describe("T-CORRECT-1 — standalone: empty process.env, key in Constants.expoConfig.extra", () => {
+  test("giphyEventCoverService.searchGiphyEventCovers resolves the key from extra (not null)", async () => {
+    mockExtra.EXPO_PUBLIC_GIPHY_API_KEY = "extra-only-key";
+
+    await expect(searchGiphyEventCovers("jazz night")).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("extra-only-key");
+  });
+
+  test("coverProviderBrowseService.trendingGiphyCovers resolves the key from extra (not null)", async () => {
+    mockExtra.EXPO_PUBLIC_GIPHY_API_KEY = "extra-only-key";
+
+    await expect(trendingGiphyCovers()).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("extra-only-key");
+  });
+});
+
+describe("T-CORRECT-2 — fails-on-revert anchor: extra path is load-bearing", () => {
+  // If the services regress to a dynamic-only process.env reader (no extra
+  // read), these inputs (key ONLY in extra, process.env empty) resolve null →
+  // both calls throw not_configured. The assertions below would then FAIL —
+  // which is the intended fails-on-revert behavior.
+  test("with key only in extra, neither service throws not_configured", async () => {
+    mockExtra.EXPO_PUBLIC_GIPHY_API_KEY = "extra-only-key";
+
+    await expect(searchGiphyEventCovers("supper club")).resolves.toBeDefined();
+    await expect(trendingGiphyCovers()).resolves.toBeDefined();
+  });
+});
+
+describe("T-CORRECT-3 — Metro/dev path: key only in static process.env, extra empty", () => {
+  test("giphyEventCoverService resolves via the static process.env fallback", async () => {
+    process.env.EXPO_PUBLIC_GIPHY_API_KEY = "static-env-key";
+
+    await expect(searchGiphyEventCovers("jazz")).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("static-env-key");
+  });
+
+  test("coverProviderBrowseService resolves via the static process.env fallback", async () => {
+    process.env.EXPO_PUBLIC_GIPHY_API_KEY = "static-env-key";
+
+    await expect(trendingGiphyCovers()).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("static-env-key");
+  });
+});
+
+describe("T-CORRECT-4 — dual-name fallback preserved (EXPO_PUBLIC_GIPHY_KEY)", () => {
+  test("resolves from EXPO_PUBLIC_GIPHY_KEY in extra", async () => {
+    mockExtra.EXPO_PUBLIC_GIPHY_KEY = "extra-secondary-name-key";
+
+    await expect(searchGiphyEventCovers("market")).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("extra-secondary-name-key");
+  });
+
+  test("resolves from EXPO_PUBLIC_GIPHY_KEY in static process.env", async () => {
+    process.env.EXPO_PUBLIC_GIPHY_KEY = "static-secondary-name-key";
+
+    await expect(trendingGiphyCovers()).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("static-secondary-name-key");
+  });
+});

--- a/mingla-business/src/services/__tests__/giphyKeyReachability.tester_adversarial.test.ts
+++ b/mingla-business/src/services/__tests__/giphyKeyReachability.tester_adversarial.test.ts
@@ -1,0 +1,169 @@
+/**
+ * ORCH-1127 (ex-1116) — TESTER adversarial regression for the GIPHY cover-key
+ * reachability fix. DIFFERENT ANGLE than the implementor's happy-path
+ * `giphyKeyReachability.test.ts`:
+ *
+ *  - The implementor's test mocks `expo-constants` so `Constants.expoConfig` is
+ *    ALWAYS a defined object carrying `extra`, and asserts the public service
+ *    APIs resolve the key. It proves the happy `extra` read works.
+ *
+ *  - THIS test attacks two angles the implementor's does NOT cover:
+ *
+ *    (G1) STRUCTURAL SOURCE TRAP — read the actual service source files off disk
+ *         and assert the load-bearing invariant directly: BOTH services import
+ *         expo-constants, read `Constants.expoConfig?.extra`, and contain NO
+ *         non-inlinable dynamic `process.env[<var>]` / `globalThis...env?.[<var>]`
+ *         bracket read in executable code. A future edit that reverts EITHER
+ *         service to the dynamic-only reader (the exact COMMS-0028 root-cause
+ *         pattern) FAILS here even if someone also rewrites the mock-based tests.
+ *         This is the angle that survives test-suite tampering — it inspects the
+ *         shipped source, not a mock.
+ *
+ *    (G2) RUNTIME NULL-MANIFEST BOUNDARY — the implementor always provides a
+ *         defined `Constants.expoConfig`. In a real standalone/edge runtime,
+ *         `Constants.expoConfig` can be NULL. This test drives the trending path
+ *         (coverProviderBrowseService) specifically with `expoConfig = null`
+ *         AND an empty process.env, then with `expoConfig = null` + a STATIC
+ *         process.env key, proving the optional-chained `?.extra` does not throw
+ *         and the static fallback still carries the key. If a revert dropped the
+ *         optional chaining or the static fallback, this throws/returns null.
+ *
+ * Fails-on-revert: reverting either service to the dynamic-only reader fails
+ * G1 (no extra read / dynamic bracket present) AND G2-empty (key unresolved →
+ * not_configured). Verified by line-deletion of the `readExtra(name) ??` read.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { afterAll, beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+// ---- G2 runtime harness: a MUTABLE expoConfig the mock returns by reference.
+// Distinct from the implementor's mock: here expoConfig itself can be set to
+// null to exercise the optional-chaining boundary the implementor never hits.
+const mockState: { expoConfig: { extra?: Record<string, string | undefined> } | null } = {
+  expoConfig: { extra: {} },
+};
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    get expoConfig() {
+      return mockState.expoConfig;
+    },
+  },
+}));
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    functions: { invoke: jest.fn(async () => ({ data: null, error: null })) },
+  },
+}));
+
+import { trendingGiphyCovers } from "../coverProviderBrowseService";
+import { searchGiphyEventCovers } from "../giphyEventCoverService";
+
+const ORIGINAL_API_KEY = process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+const ORIGINAL_KEY = process.env.EXPO_PUBLIC_GIPHY_KEY;
+const originalFetch = global.fetch;
+
+const fetchOk = (): Response =>
+  ({
+    json: async () => ({
+      data: [
+        {
+          id: "gif-1",
+          title: "loop",
+          url: "https://giphy.com/gifs/x",
+          images: {
+            fixed_width: { url: "https://media.giphy.com/p.gif" },
+            downsized_medium: { url: "https://media.giphy.com/m.gif" },
+            downsized: { url: "https://media.giphy.com/d.gif" },
+            original: { url: "https://media.giphy.com/o.gif" },
+          },
+        },
+      ],
+    }),
+    ok: true,
+    status: 200,
+  }) as Response;
+
+const lastFetchApiKey = (): string | null => {
+  const calls = (global.fetch as jest.Mock).mock.calls;
+  if (calls.length === 0) return null;
+  return new URL(String(calls[calls.length - 1][0])).searchParams.get("api_key");
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+  delete process.env.EXPO_PUBLIC_GIPHY_KEY;
+  mockState.expoConfig = { extra: {} };
+  global.fetch = jest.fn(async () => fetchOk()) as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+  if (ORIGINAL_API_KEY === undefined) delete process.env.EXPO_PUBLIC_GIPHY_API_KEY;
+  else process.env.EXPO_PUBLIC_GIPHY_API_KEY = ORIGINAL_API_KEY;
+  if (ORIGINAL_KEY === undefined) delete process.env.EXPO_PUBLIC_GIPHY_KEY;
+  else process.env.EXPO_PUBLIC_GIPHY_KEY = ORIGINAL_KEY;
+});
+
+// ===========================================================================
+// G1 — STRUCTURAL SOURCE TRAP (different angle: inspects shipped source, not a mock)
+// ===========================================================================
+describe("ORCH-1127 G1 — both GIPHY services have the extra-first reader in shipped source", () => {
+  const SERVICES = ["giphyEventCoverService.ts", "coverProviderBrowseService.ts"];
+
+  // Strip comments so the protective ORCH-1127 comment (which names the banned
+  // pattern on purpose) does not self-trip the detector — mirror the gate.
+  const stripComments = (src: string): string =>
+    src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+  // Dynamic bracket read with a NON-string-literal subscript (the non-inlinable
+  // form). A static `process.env.EXPO_PUBLIC_X` member read is allowed.
+  const DYNAMIC_BRACKET = /\.env\??\.?\[\s*(?!['"`])[^\]]+\]/;
+
+  for (const file of SERVICES) {
+    test(`${file} imports expo-constants, reads Constants.expoConfig.extra, and has NO dynamic env bracket read`, () => {
+      const abs = path.join(__dirname, "..", file);
+      const raw = readFileSync(abs, "utf8");
+      const code = stripComments(raw);
+
+      expect(raw).toMatch(/from "expo-constants"/);
+      expect(code).toMatch(/Constants\.expoConfig\??\.extra/);
+      // The killer assertion: no non-inlinable dynamic env read survives.
+      expect(DYNAMIC_BRACKET.test(code)).toBe(false);
+    });
+  }
+});
+
+// ===========================================================================
+// G2 — RUNTIME NULL-MANIFEST BOUNDARY (different angle: expoConfig === null)
+// ===========================================================================
+describe("ORCH-1127 G2 — trending path survives a null Constants.expoConfig", () => {
+  test("expoConfig=null + empty process.env → not_configured (no crash on ?.extra)", async () => {
+    mockState.expoConfig = null; // optional-chaining boundary the implementor never hits
+
+    // Must reject with the controlled not_configured error, NOT a TypeError from
+    // dereferencing null.extra. A revert that drops `?.` here would throw a
+    // different (uncaught) error and fail this assertion.
+    await expect(trendingGiphyCovers()).rejects.toThrow(/not configured/i);
+  });
+
+  test("expoConfig=null + STATIC process.env key → trending still resolves via the static fallback", async () => {
+    mockState.expoConfig = null;
+    process.env.EXPO_PUBLIC_GIPHY_API_KEY = "static-when-manifest-null";
+
+    await expect(trendingGiphyCovers()).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("static-when-manifest-null");
+  });
+
+  test("search path also survives expoConfig=null with static fallback", async () => {
+    mockState.expoConfig = null;
+    process.env.EXPO_PUBLIC_GIPHY_API_KEY = "static-search-when-null";
+
+    await expect(searchGiphyEventCovers("late night")).resolves.toHaveLength(1);
+    expect(lastFetchApiKey()).toBe("static-search-when-null");
+  });
+});

--- a/mingla-business/src/services/coverProviderBrowseService.ts
+++ b/mingla-business/src/services/coverProviderBrowseService.ts
@@ -29,6 +29,8 @@
  * (subtract-before-add — the brand sheet's two duplicates are deleted).
  */
 
+import Constants from "expo-constants";
+
 import { supabase } from "./supabase";
 import { EventCoverProviderError } from "./eventCoverProviderError";
 import type { GiphyCoverSearchResult } from "./giphyEventCoverService";
@@ -53,11 +55,31 @@ type GiphyResult = {
   };
 };
 
-const envValue = (name: string): string | null => {
-  const maybeProcess = globalThis as typeof globalThis & {
-    process?: { env?: Record<string, string | undefined> };
-  };
-  const value = maybeProcess.process?.env?.[name];
+// ORCH-1127: read the GIPHY key from Constants.expoConfig.extra FIRST (mirror
+// supabase.ts). Dynamic process.env[name] is NOT inlined by babel-preset-expo
+// and is undefined in Hermes standalone/OTA builds — extra is the
+// manifest-backed, build-safe path. Do NOT revert to process.env[<var>].
+type GiphyKeyName = "EXPO_PUBLIC_GIPHY_API_KEY" | "EXPO_PUBLIC_GIPHY_KEY";
+
+// `extra` is a runtime object materialized from the resolved app.config.ts and
+// baked into the app manifest at build time, so a dynamic key read here is safe
+// (it does not depend on babel inlining).
+const readExtra = (name: GiphyKeyName): string | undefined => {
+  const extra = Constants.expoConfig?.extra as
+    | Record<string, string | undefined>
+    | undefined;
+  return extra?.[name];
+};
+
+// The process.env fallback MUST use STATIC member access so babel-preset-expo
+// inlines it for the Metro-dev / web-export path (where `extra` may be absent).
+const readStaticProcessEnv = (name: GiphyKeyName): string | undefined =>
+  name === "EXPO_PUBLIC_GIPHY_API_KEY"
+    ? process.env.EXPO_PUBLIC_GIPHY_API_KEY
+    : process.env.EXPO_PUBLIC_GIPHY_KEY;
+
+const envValue = (name: GiphyKeyName): string | null => {
+  const value = readExtra(name) ?? readStaticProcessEnv(name);
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : null;

--- a/mingla-business/src/services/giphyEventCoverService.ts
+++ b/mingla-business/src/services/giphyEventCoverService.ts
@@ -1,3 +1,5 @@
+import Constants from "expo-constants";
+
 import { EventCoverProviderError } from "./eventCoverProviderError";
 
 export interface GiphyCoverSearchResult {
@@ -26,11 +28,31 @@ type GiphyResult = {
   };
 };
 
-const envValue = (name: string): string | null => {
-  const maybeProcess = globalThis as typeof globalThis & {
-    process?: { env?: Record<string, string | undefined> };
-  };
-  const value = maybeProcess.process?.env?.[name];
+// ORCH-1127: read the GIPHY key from Constants.expoConfig.extra FIRST (mirror
+// supabase.ts). Dynamic process.env[name] is NOT inlined by babel-preset-expo
+// and is undefined in Hermes standalone/OTA builds — extra is the
+// manifest-backed, build-safe path. Do NOT revert to process.env[<var>].
+type GiphyKeyName = "EXPO_PUBLIC_GIPHY_API_KEY" | "EXPO_PUBLIC_GIPHY_KEY";
+
+// `extra` is a runtime object materialized from the resolved app.config.ts and
+// baked into the app manifest at build time, so a dynamic key read here is safe
+// (it does not depend on babel inlining).
+const readExtra = (name: GiphyKeyName): string | undefined => {
+  const extra = Constants.expoConfig?.extra as
+    | Record<string, string | undefined>
+    | undefined;
+  return extra?.[name];
+};
+
+// The process.env fallback MUST use STATIC member access so babel-preset-expo
+// inlines it for the Metro-dev / web-export path (where `extra` may be absent).
+const readStaticProcessEnv = (name: GiphyKeyName): string | undefined =>
+  name === "EXPO_PUBLIC_GIPHY_API_KEY"
+    ? process.env.EXPO_PUBLIC_GIPHY_API_KEY
+    : process.env.EXPO_PUBLIC_GIPHY_KEY;
+
+const envValue = (name: GiphyKeyName): string | null => {
+  const value = readExtra(name) ?? readStaticProcessEnv(name);
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : null;


### PR DESCRIPTION
## ORCH-1127 [GIF cover-key reachability] (ex-ORCH-1116; renumbered per COMMS-0024)

**Symptom:** business-app cover picker → GIF tab showed "This source is taking a break" in every real build (dev-channel OTA / TestFlight / production).

**Root cause (proven):** the GIPHY services read the client-direct key via DYNAMIC `process.env?.[name]` access, which Expo/babel never inlines into standalone Hermes bundles (only STATIC `process.env.EXPO_PUBLIC_X` is inlined). It only resolved under Metro dev (live process.env). The 2026-05-25 channel flip (`4c3bdfe8f`) made the dev profile run standalone off the keyless `development` channel, exposing it. Two layers: (1) the GIPHY key was also unprovisioned in dev/preview EAS envs; (2) the deeper code bug above.

**Fix:**
- Both `giphyEventCoverService.ts` + `coverProviderBrowseService.ts` now read `Constants.expoConfig?.extra?.[name]` FIRST, then a STATIC `process.env.EXPO_PUBLIC_GIPHY_API_KEY`/`_KEY` fallback (mirrors `supabase.ts`). app.config.ts already emits the key into `extra`.
- Build-time fail-loud guard in `app.config.ts` (modeled on the Stripe pk_live guard) for release-bound profiles.
- `not_configured`-gated `reportNonFatal` telemetry in `CoverPicker.tsx` (config errors alert; transient outages stay user-facing).
- `.env.example` documented; strict-grep gate `i-giphy-key-wired.mjs` (INV-3 forbids regressing to a dynamic-only read).
- Operator provisioned the GIPHY key into EAS dev/preview + Vercel prod/preview.

**Proof:** standalone `expo export` key value 0→1 occurrences (old reader → fix). fails-on-revert at `70f799e15`. Implementor happy-path (T-CORRECT) + tester adversarial regression tests, 30/30 jest green, strict-grep gate PASS. **Seth device-confirmed PASS** on a dev-channel OTA (GIF trending + search render).

Artifacts: `Mingla_Artifacts/specs/SPEC_AMENDMENT_ORCH-1127_GIF_COVER_KEY_REACHABILITY.md`, `Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1127_*`, `Mingla_Artifacts/reports/TEST_ORCH-1127_*`. See COMMS-0028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)