### PR TITLE
ORCH-1128: free-ticket CTA full-width + cover mute-pill bottom clearance [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1128_FREE_CTA_MUTE_SPACING.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1128_FREE_CTA_MUTE_SPACING.md
@@ -1,0 +1,141 @@
+# IMPLEMENTATION — ORCH-1128 [public offering-page polish: free-ticket CTA full-width + cover mute-pill bottom clearance]
+
+**Status:** implemented and verified (source-level + fails-on-revert; native runtime UNVERIFIED — UI-only, no device run this pass)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1128-[free-cta-mute-spacing]` on branch `ORCH-1128-free-cta-mute-spacing`
+**Base:** origin/main `40ca2da30` (includes ORCH-1117 floating bar + ORCH-1124 mute-pill bottomRight)
+
+---
+
+## 1. Summary
+
+Two follow-up tweaks to the buyer-web public offering page, both reported by Seth:
+
+- **Item 1 — free-ticket CTA full width.** On the floating Buy bar, a PAID ticket shows a price column (flex:1) + a content-width button sharing the row. A FREE / waitlist ticket has no price, but the code still rendered an EMPTY `flex:1` placeholder column, so the sole "Get free ticket" button hugged the right half of the bar instead of spanning it. Fix: render the price column ONLY for `kind === "buy"`; for the non-buy tappable kinds the button gets a new `buttonFull` style (`flex:1`, `marginLeft:0`) so it fills the bar. The paid price-left / button-right split is unchanged. Applied to BOTH the buyer-web bar (`mingla-business`) and the consumer-native bar (`app-mobile`) — they shared the identical empty-placeholder defect.
+
+- **Item 2 — cover mute pill bottom clearance.** The shared `EventCoverMedia` bottom-right Sound/Mute pill sat at `bottom:14`, flush on the cover seam, bleeding into the details section that begins immediately below the public hero (the hero is `radius:0` + `StyleSheet.absoluteFill`, so there is no rounded inset). Raised the single shared `audioControlBottomRight.bottom` from `14` → `22` (8px extra clearance). One shared value → the web public page AND the native consumer gallery both inherit it; the native gallery pill simply moves up 8px, still safely within the cover. The ORCH-1124 bottom-right POSITION is preserved — NOT reverted to topRight.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Description | Status | Commit |
+|----|-------------|--------|--------|
+| SC-1-Web | Free-ticket CTA spans full bar width on buyer web | ✓ | `<C_BIZ>` |
+| SC-1-Native | Free-ticket CTA spans full bar width on consumer native | ✓ | `<C_NATIVE>` |
+| SC-1-paid | Paid (buy) price-left / button-right layout UNCHANGED | ✓ | `<C_BIZ>` / `<C_NATIVE>` |
+| SC-2 | Mute pill bottom offset raised so it clears the details (14 → 22) | ✓ | `<C_ECM>` |
+| SC-2-pos | ORCH-1124 bottomRight position preserved (no topRight regression) | ✓ | `<C_ECM>` |
+| SC-2-parity | Native gallery inherits the shared value (no separate path) | ✓ (automatic) | `<C_ECM>` |
+| SC-G1 | ORCH-1117 state machine (non-tappable unavailable) untouched | ✓ (35/35 sibling tests green) | — |
+| SC-G2 | ORCH-1124 mute-pill firing/wiring untouched | ✓ (adversarial test green) | — |
+
+---
+
+## 3. Files changed
+
+| File | +/− | Item |
+|------|-----|------|
+| `mingla-business/src/components/offering/FloatingOfferingBar.tsx` | +12 −3 | 1 (web) |
+| `app-mobile/src/components/offering/FloatingOfferingBar.tsx` | +12 −4 | 1 (native) |
+| `packages/event-rendering/EventCoverMedia.tsx` | +3 −1 | 2 (shared) |
+| `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` | +7 −4 | 2 test (TEST-MOD-APPROVED) |
+| `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts` | NEW (+~115) | regression (both items) |
+
+### Exact lines changed
+
+**Item 1 — both `FloatingOfferingBar.tsx`:**
+- Removed the `) : ( <View style={styles.priceCol} /> )` empty-placeholder branch → `) : null`.
+- Added `cta.kind !== "buy" && styles.buttonFull` to the Pressable's style array.
+- Added style `buttonFull: { flex: 1, marginLeft: 0 }`.
+
+**Item 2 — `packages/event-rendering/EventCoverMedia.tsx`, `audioControlBottomRight` style:**
+- `bottom: 14` → `bottom: 22` (the only value change; `right: 14` and the `zIndex`/position contract untouched).
+
+---
+
+## 4. Data-model changes applied
+
+None. UI-only.
+
+## 5. Edge functions touched
+
+None.
+
+---
+
+## 6. Regression tests added
+
+**New (implementor happy-path):** `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts` — 4 tests, all green:
+1. web bar free CTA full-width (priceCol placeholder gone, `buttonFull` flex:1/marginLeft:0, applied for non-buy, paid split preserved)
+2. native bar free CTA full-width (same assertions on `app-mobile`)
+3. mute pill `bottom: 22` (and NOT `14`, right:14 preserved)
+4. public page still inherits `bottomRight` default
+
+**Modified (1 assertion):** `eventCoverMedia.test.ts` line ~360 — updated `bottom: 14` → `bottom: 22` and widened the source slice; carries `[TEST-MOD-APPROVED ORCH-1128]` in the commit body.
+
+**fails-on-revert — verified by TRUE LINE DELETION (not comment-out):**
+- Item 1 web — deleted the `buttonFull` style def → web test FAILS (1 failed, 3 passed); restored → 4 passed.
+- Item 1 native — deleted the `app-mobile` `buttonFull` style def → native test FAILS; restored → 4 passed.
+- Item 2 — restored `bottom: 14` → mute-pill test FAILS; restored `bottom: 22` → 4 passed.
+
+`fails-on-revert verified at HEAD of ORCH-1128-free-cta-mute-spacing` (see commit hashes §11).
+
+---
+
+## 7. Old → New receipts
+
+### `mingla-business/src/components/offering/FloatingOfferingBar.tsx`
+- **Before:** non-buy tappable CTA rendered an empty `<View style={styles.priceCol} />` (flex:1) beside a content-width button → free CTA hugged ~half the bar.
+- **Now:** non-buy renders no price column; the button carries `buttonFull` (flex:1, marginLeft:0) → spans the full bar (within the 660 maxWidth container).
+- **Why:** SC-1 — free CTA must be full-width.
+- **Lines:** ~12.
+
+### `app-mobile/src/components/offering/FloatingOfferingBar.tsx`
+- Identical defect and identical fix (native parity). **Why:** SC-1-Native. **Lines:** ~12.
+
+### `packages/event-rendering/EventCoverMedia.tsx`
+- **Before:** `audioControlBottomRight.bottom = 14` → pill flush on the cover seam, bleeding into details.
+- **Now:** `bottom = 22` → clears the seam.
+- **Why:** SC-2. **Lines:** 1 value + comment.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected? | What changes / why not | Parity |
+|---------|-----------|------------------------|--------|
+| Buyer / anonymous Web | YES | Item 1 (free CTA full-width) + Item 2 (mute pill clearance on public hero) | — |
+| Consumer iOS | YES | Item 1 (native bar) + Item 2 (shared cover, gallery pill +8px up) | manual (item 1) / automatic (item 2 shared pkg) |
+| Consumer Android | YES | same as iOS (shared RN) | same |
+| Business iOS | Item 2 only | shares `EventCoverMedia`; no offering floating bar there | automatic |
+| Business Android | Item 2 only | same | automatic |
+| Admin Web (adjacent) | NO | does not import these components | — |
+| Business Web preview (adjacent) | YES (item 2 in cover preview) | shares `EventCoverMedia`; offering bar is buyer-web | automatic |
+
+Item 1 parity is MANUAL (two separate files: business + app-mobile) — both edited. Item 2 parity is AUTOMATIC (single shared package value).
+
+---
+
+## 9. Smoke result
+
+No device/sim run this pass (UI-only, low-risk style change). Source-level + jest verification:
+- New ORCH-1128 suite: 4/4 green.
+- ORCH-1124 adversarial + ORCH-1117 cta/dead-tap suites: 35/35 green (no state-machine or mute-firing regression).
+- TypeScript: zero errors on any edited line in either FloatingOfferingBar or the EventCoverMedia style (the 29 `EventCoverMedia.tsx` `react`-module-resolution errors are PRE-EXISTING on base `40ca2da30`, a cross-package tsconfig boundary, not introduced here).
+
+**UNVERIFIED (needs runtime/device):** visual confirmation on a physical device that the free CTA renders edge-to-edge and the mute pill no longer touches the details. Recommend the tester drive the live public video-cover page (e.g. `/e/leggothis/a-life-in-vegas`) for item 2 and a free-ticket public event for item 1.
+
+---
+
+## 10. Known issues / deferred
+
+- The 5 pre-existing FAILs in `eventCoverMedia.test.ts` (upload limits / iOS image output / GIF picking / playback gating / render-failure surfacing) are UNRELATED to this ORCH — they fail identically on base `40ca2da30` (verified by `git stash` run). NOT touched. See Discoveries.
+
+## 11. Operator action required
+
+- No migration, no edge deploy. Route to orchestrator REVIEW → tester.
+- Edge-fn deploy list: NONE.
+
+## 12. Discoveries for Orchestrator
+
+- **D1 — pre-existing test rot:** `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` has 5 PRE-EXISTING failing tests on origin/main `40ca2da30` (event-creator upload-limits / iOS-compatible image output / image-GIF-vs-video split / playback-gating / render-failure-surfacing). They reference `EventCover`/`CoverPicker` source that no longer matches the asserted tokens in this worktree. Unrelated to ORCH-1128; flagging for a cleanup ORCH.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1128_FREE_CTA_MUTE_SPACING.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1128_FREE_CTA_MUTE_SPACING.md
@@ -1,0 +1,122 @@
+# TEST — ORCH-1128 [public offering-page polish: free-ticket CTA full-width + cover mute-pill bottom clearance]
+
+**Verdict:** PASS — 0 P0 · 0 P1 · 0 P2 · 0 P3 · 2 P4 (praise)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1128-[free-cta-mute-spacing]` on branch `ORCH-1128-free-cta-mute-spacing`
+**Tested HEAD:** `8746b8964` (rebased onto origin/main `40ca2da30` — branch was 1 commit behind anchor at dispatch HEAD `a5e5747a5`; rebased clean, no conflicts).
+**Mode:** TARGETED. Live-fire: buyer-web Chromium (Playwright + system Chrome, headless) against production `business.usemingla.com` (BEFORE baseline) AND a clean `expo export -p web` static build of the branch (AFTER proof). Native: source + fails-on-revert (sim deferred per dispatch "sim optional for native"; same code-shape as the runtime-proven web bar).
+
+---
+
+## 1. Verdict + counts
+
+PASS. Both fixes are runtime-proven on buyer-web. No P0/P1/P2/P3. The paid layout is byte-identical between prod and branch (unchanged). The mute pill clearance is numerically confirmed at 22px (was 14px), still bottom-right, and still fires (Sound↔Mute toggle) on the branch build. Regression gate satisfied: implementor happy-path test (fails-on-revert independently re-run) + tester adversarial test (different angle, on-branch, in-diff, own fails-on-revert) both present.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Description | Verdict | Evidence |
+|----|-------------|---------|----------|
+| SC-1-Web | Free-ticket CTA spans full bar width on buyer web | **PASS** (runtime) | Branch export `EXPORT_free_floatingbar.png`: "Get free ticket" spans the full 660px bar (x≈310→970). PROD baseline `free_event_floatingbar.png`: same button hugged right, w≈169px (the bug). |
+| SC-1-Native | Free-ticket CTA full-width on consumer native | **PASS** (source + fails-on-revert) | `app-mobile/.../FloatingOfferingBar.tsx` carries identical fix (`buttonFull {flex:1, marginLeft:0}` applied only for `kind!=="buy"`); native happy-path test green; deleting native `buttonFull` → native test FAILS (re-run by tester). Sim deferred per dispatch. |
+| SC-1-paid | Paid (buy) price-left / button-right split UNCHANGED | **PASS** (runtime) | `vibes-and-stuff` paid page: PROD vs EXPORT byte-identical — "Buy ticket" button `x:836, w:133.5, right:970`, price "$67.93" left of it, bar row `x:310 w:660` on BOTH. `EXPORT_paid_vibesandstuff.png` shows price-left / orange-button-right. |
+| SC-2 | Mute pill bottom raised 14→22 (clears the details) | **PASS** (runtime) | Branch export measured `gapFromCoverBottom: 22` (pill bottom edge 22px above cover seam); PROD measured 14. |
+| SC-2-pos | ORCH-1124 bottomRight position preserved (no topRight) | **PASS** (runtime) | Branch export `gapFromCoverRight: 14`, anchored to the cover's bottom edge; `audioControlPosition = "bottomRight"` default intact; no `top:` key in `audioControlBottomRight`. |
+| SC-2-parity | Native gallery inherits the shared value | **PASS** (automatic) | Single shared `packages/event-rendering/EventCoverMedia.tsx` value; no per-platform branch. |
+| SC-2-fires | Mute pill still FIRES (not a dead tap) | **PASS** (runtime) | Branch export: tap toggled `Sound → Mute` (`FIRED: true`). PROD also fires (Sound→Mute). `onPress` runs `setIsMuted` + `onMutedChange?.(next)` — Constitution #1 satisfied. |
+| SC-G1 | ORCH-1117 non-tappable unavailable states untouched | **PASS** | Unavailable branch (`accessibilityRole="text"`, no onPress) is on a separate `cta.tappable === false` path the diff never touches; ORCH-1117 suites green (`offeringCta.orch1117`, `offeringCtaDeadTap.orch1117.adversarial`, `offeringLegibility.orch1117`). |
+| SC-G2 | ORCH-1124 mute-pill firing/wiring untouched | **PASS** | Only the `bottom` value changed; onPress/position-switch untouched; firing re-proven at runtime. |
+
+---
+
+## 3. Findings
+
+None at P0–P3.
+
+**P4 (praise):**
+- **P4-1** — Root-cause fix, not a patch. The defect was an empty `flex:1` placeholder `<View style={styles.priceCol} />` on the non-buy branch; the fix REMOVES it (`) : null`) and gives the sole CTA `flex:1` rather than hacking a width. Subtract-before-add (Constitution #8).
+- **P4-2** — Single shared value for the mute-pill clearance (`packages/event-rendering`) means web public page + native gallery + business cover preview all inherit the 8px raise with zero parity drift. One owner.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Re-ran each revert by TRUE line-deletion / value-swap on the tested tree, then restored (tree returned clean each time):
+
+| Fix reverted | Implementor test result | Restored |
+|--------------|-------------------------|----------|
+| Item 1 web — delete `buttonFull` style block in `mingla-business/.../FloatingOfferingBar.tsx` | `orch1128FreeCtaMutePill.test.ts` "buyer web" → **FAILS** at `expect(src).toMatch(/buttonFull:\s*{[^}]*flex:\s*1/)` (line 73) | 4/4 PASS |
+| Item 1 native — delete `buttonFull` in `app-mobile/.../FloatingOfferingBar.tsx` | "consumer native" → **FAILS** at the same `buttonFull` flex:1 assertion | 4/4 PASS |
+| Item 2 — `audioControlBottomRight.bottom` 22 → 14 | "mute pill clears" → **FAILS** at `expect(block).toMatch(/bottom:\s*22/)` | 4/4 PASS |
+
+Implementor's claim independently confirmed at tested HEAD `8746b8964`.
+
+---
+
+## 5. Adversarial test added (tester)
+
+**Path:** `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts` (NEW, append-only).
+**Angle (distinct from implementor's existence/application checks):**
+- **A1** — the full-width style must be gated STRICTLY behind `kind !== "buy"`; a regression to `=== "free"` (silently drops the waitlist kind) OR an unconditional apply is caught (asserts the guarded-apply count equals the total `styles.buttonFull` reference count). Defends the PAID split.
+- **A2** — the empty `priceCol` placeholder (the actual root cause) must NOT reappear in either bar.
+- **A3** — mute `bottom` parsed NUMERICALLY and asserted `> 14` (a partial bump like 16 that still bleeds also fails, not just a literal-22 mismatch), with NO `top:` key in the bottomRight block (topRight-regression guard) and `right:14` preserved.
+
+**Result:** 6/6 PASS. **fails-on-revert verified by tester at HEAD `8746b8964`:**
+- A1 — guard → `cta.kind === "free" && styles.buttonFull` → web test FAILS; restored → PASS.
+- A2 — re-insert `) : ( <View style={styles.priceCol} /> )` → web test FAILS; restored → PASS.
+- A3 — `bottom: 22` → `14` → numeric `>14` assertion FAILS; restored → PASS.
+
+Both the implementor happy-path test and the tester adversarial test appear in `git diff origin/main...HEAD --name-only` for the closing branch (adversarial committed this turn). The single MODIFIED existing test (`eventCoverMedia.test.ts`, one assertion 14→22) carries `[TEST-MOD-APPROVED ORCH-1128]` in the implementor commit body AND is re-carried in the tester's HEAD commit body (append-only CI gate reads HEAD only).
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | PASS | Mute pill fires (Sound↔Mute) at runtime; free CTA fires `onPress`; unavailable strip is intentionally non-tappable (`role="text"`, no onPress) and untouched. |
+| 2 | One owner per truth | PASS | Bar is a pure projection of `resolveOfferingCta`; mute clearance is one shared style value. |
+| 3 | No silent failures | N/A | No error paths added. |
+| 4 | One query key | N/A | No data layer. |
+| 5 | Server state server-side | N/A | Pure presentational. |
+| 6 | Logout clears | N/A | Anon-tolerant component. |
+| 7 | `[TRANSITIONAL]` labels | N/A | No transitional code. |
+| 8 | Subtract before adding | PASS | Empty placeholder column REMOVED (not worked around). |
+| 9 | No fabricated data | N/A | No data. |
+| 10 | Currency-aware | PASS (untouched) | Paid price renders `cta.price` unchanged (`$67.93` verified). |
+| 11 | One auth instance | PASS | No `useAuth` in these buyer-web components. |
+| 12 | Validate at right time | N/A | No datetime logic. |
+| 13 | Exclusion consistency | N/A | — |
+| 14 | Persisted-state startup | N/A | — |
+
+No violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Notes |
+|---------|---------|-------|
+| Buyer / anonymous Web | **PASS (runtime, proven)** | Free full-width + paid-unchanged + mute 22/bottomRight/fires all proven on a clean branch web export driven by Chromium. |
+| Consumer iOS | PASS (source + fails-on-revert) | Identical native diff; happy-path + fails-on-revert green. Sim deferred per dispatch ("sim optional for native"); same logic shape as the runtime-proven web bar. |
+| Consumer Android | PASS (source + fails-on-revert) | Same shared RN code as iOS. |
+| Business iOS / Android | PASS (automatic, item 2 only) | Share `EventCoverMedia`; no offering floating bar there. |
+| Admin Web | N/A | Does not import these components. |
+| Business Web preview | PASS (automatic, item 2) | Shares `EventCoverMedia` cover value. |
+
+Physical iPhone HITL: not requested by dispatch; web runtime proof obtained autonomously, so no operator-unblock ask raised.
+
+**Environment note (resolved, not blocking):** the local `expo start --web` DEV server redboxed on a dynamic font `import()` whose relative path got mangled by the bracketed worktree dir name (`[free-cta-mute-spacing]`) — a Metro dev-server path quirk, NOT a product defect. Resolved by using a production `expo export -p web` static build instead (no dev-server dynamic-import path resolution), which rendered cleanly and yielded all the AFTER proofs above.
+
+---
+
+## 8. Discoveries for Orchestrator
+
+- **D1 (confirmed, count = 5)** — `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` has **5 pre-existing FAILs** (event-creator upload limits / iOS-compatible image output / image-GIF-vs-video picking / playback-gating / render-failure-surfacing). Verified pre-existing: their test-block titles exist verbatim on origin/main and this ORCH only modified the unrelated bottomRight assertion body (no title changed). OUT OF SCOPE per dispatch — not fixed. Cleanup ORCH candidate.
+- **D2 (new this run)** — `mingla-business/src/components/offering/__tests__/OfferingParity.test.ts` has **1 pre-existing FAIL**: "trip + experience Hub lists pass onManageOpen (3-dot opens shared sheet)". File is NOT in the ORCH-1128 diff; asserts trip/experience Hub manage-sheet source untouched by this ORCH → pre-existing. Flagging for the same cleanup ORCH as D1.
+
+---
+
+## 9. Accepted conditions
+
+None — this is a clean PASS, not a CONDITIONAL.

--- a/app-mobile/src/components/offering/FloatingOfferingBar.tsx
+++ b/app-mobile/src/components/offering/FloatingOfferingBar.tsx
@@ -79,9 +79,7 @@ export const FloatingOfferingBar: React.FC<FloatingOfferingBarProps> = ({
         <View style={styles.priceCol}>
           <Text style={styles.priceValue}>{cta.price}</Text>
         </View>
-      ) : (
-        <View style={styles.priceCol} />
-      )}
+      ) : null}
       <Pressable
         onPress={handlePress}
         accessibilityRole="button"
@@ -90,7 +88,14 @@ export const FloatingOfferingBar: React.FC<FloatingOfferingBarProps> = ({
             ? `${cta.label}, ${cta.price}`
             : cta.label
         }
-        style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+        style={({ pressed }) => [
+          styles.button,
+          // ORCH-1128 — no price slot (free / waitlist) → the sole CTA spans the
+          // full bar width instead of hugging content on the right of an empty
+          // flex:1 column. Paid "buy" keeps the price-left / button-right split.
+          cta.kind !== "buy" && styles.buttonFull,
+          pressed && styles.buttonPressed,
+        ]}
         testID={testID !== undefined ? `${testID}-action` : undefined}
       >
         <Text style={styles.buttonLabel}>{cta.label}</Text>
@@ -126,6 +131,9 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     marginLeft: 16,
   },
+  // ORCH-1128 — full-width sole CTA (free / waitlist): fill the bar, drop the
+  // left margin that only exists to separate the button from the price column.
+  buttonFull: { flex: 1, marginLeft: 0 },
   buttonPressed: { opacity: 0.85, transform: [{ scale: 0.98 }] },
   buttonLabel: { fontSize: 17, fontWeight: "900", color: "#FFFFFF" },
   stripGlyph: { fontSize: 18, color: "rgba(255,255,255,0.52)" },

--- a/mingla-business/src/components/offering/FloatingOfferingBar.tsx
+++ b/mingla-business/src/components/offering/FloatingOfferingBar.tsx
@@ -119,9 +119,7 @@ export const FloatingOfferingBar: React.FC<FloatingOfferingBarProps> = ({
                     {cta.price}
                   </Text>
                 </View>
-              ) : (
-                <View style={styles.priceCol} />
-              )}
+              ) : null}
               <Pressable
                 onPress={handlePress}
                 accessibilityRole="button"
@@ -132,6 +130,11 @@ export const FloatingOfferingBar: React.FC<FloatingOfferingBarProps> = ({
                 }
                 style={({ pressed }) => [
                   styles.button,
+                  // ORCH-1128 — no price slot (free / waitlist) → the sole CTA
+                  // spans the full bar width instead of hugging content on the
+                  // right of an empty flex:1 column. Paid "buy" keeps the
+                  // price-left / button-right split (no buttonFull).
+                  cta.kind !== "buy" && styles.buttonFull,
                   pressed && styles.buttonPressed,
                 ]}
                 testID={
@@ -225,6 +228,12 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     marginLeft: spacing.md,
+  },
+  // ORCH-1128 — full-width sole CTA (free / waitlist): fill the bar, drop the
+  // left margin that only exists to separate the button from the price column.
+  buttonFull: {
+    flex: 1,
+    marginLeft: 0,
   },
   buttonPressed: {
     opacity: 0.85,

--- a/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts
+++ b/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ORCH-1128 [public offering-page polish] — TESTER ADVERSARIAL regression.
+ *
+ * Attacks a DIFFERENT ANGLE than the implementor happy-path test
+ * (orch1128FreeCtaMutePill.test.ts), which asserts the `buttonFull` style
+ * EXISTS and is APPLIED for the non-buy kinds, and that the mute `bottom`
+ * equals the literal 22.
+ *
+ * This adversarial suite instead defends the INVARIANTS that a sloppy "fix"
+ * would silently break while still passing the happy-path assertions:
+ *
+ *   A1 — PAID-BUY MUST NOT GO FULL-WIDTH. The full-width style must be gated
+ *        STRICTLY behind `kind !== "buy"`. A regression that applies
+ *        `buttonFull` unconditionally — or gates it on the wrong predicate
+ *        (e.g. `=== "free"`, which silently drops the waitlist kind, or just
+ *        always-on) — would still satisfy the implementor's "applied for
+ *        non-buy" check but would collapse the paid price-left / button-right
+ *        split. We pin the EXACT guard token and assert the price column is
+ *        emitted ONLY on the `buy` branch.
+ *
+ *   A2 — THE EMPTY PLACEHOLDER COLUMN (the actual root cause) IS GONE. The
+ *        non-buy branch must NOT re-introduce a sibling `<View priceCol />`
+ *        that would steal half the row even if `buttonFull` were present.
+ *
+ *   A3 — MUTE PILL CLEARANCE IS A STRICT INCREASE OVER THE ORCH-1124 BASELINE
+ *        (14), parsed NUMERICALLY (not a literal-22 string match), so a
+ *        partial bump that still bleeds (e.g. 16) OR a silent revert to 14
+ *        both FAIL — and the style block must remain a BOTTOM anchor with NO
+ *        `top:` key (catching a topRight regression that the literal default
+ *        string `audioControlPosition = "bottomRight"` check could miss if the
+ *        bottomRight STYLE itself were corrupted to a top offset).
+ *
+ * Source-assertion style, matching the sibling ORCH-1117 / ORCH-1124 / 1128
+ * source tests (Node harness, no react-test-renderer).
+ *
+ * fails-on-revert (verified by the tester via true line-deletion / value swap):
+ *   A1  — change the apply guard to `cta.kind === "free"` or remove the guard  → fails.
+ *   A2  — restore the `) : ( <View style={styles.priceCol} /> )` placeholder    → fails.
+ *   A3  — restore `bottom: 14` (or any value <= 14) in audioControlBottomRight  → fails.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const businessBar = (): string =>
+  readFileSync(path.resolve(__dirname, "../FloatingOfferingBar.tsx"), "utf8");
+
+const nativeBar = (): string =>
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../../app-mobile/src/components/offering/FloatingOfferingBar.tsx",
+    ),
+    "utf8",
+  );
+
+const coverMedia = (): string =>
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../../packages/event-rendering/EventCoverMedia.tsx",
+    ),
+    "utf8",
+  );
+
+describe("ORCH-1128 adversarial A1 — paid 'buy' must keep its split (full-width gated off buy)", () => {
+  const assertBuyNotFullWidth = (src: string): void => {
+    // The full-width style is applied ONLY when the kind is NOT "buy".
+    // A regression to `=== "free"` (drops waitlist) or an unconditional apply
+    // must NOT slip through.
+    expect(src).toMatch(/cta\.kind !== "buy" && styles\.buttonFull/);
+    // It must NOT be gated on the narrower `=== "free"` predicate (that would
+    // leave the waitlist CTA hugging the right of an empty row again).
+    expect(src).not.toMatch(/cta\.kind === "free" && styles\.buttonFull/);
+    // It must NOT be applied unconditionally (no bare `styles.buttonFull,` line
+    // inside the Pressable style array without the kind guard on the same line).
+    const guarded = (src.match(/styles\.buttonFull/g) ?? []).length;
+    const withGuard = (src.match(/cta\.kind !== "buy" && styles\.buttonFull/g) ?? [])
+      .length;
+    expect(guarded).toBe(withGuard);
+    // The paid price column is emitted ONLY on the buy branch.
+    expect(src).toMatch(/cta\.kind === "buy" \?\s*\(?\s*<View style={styles\.priceCol}>/);
+  };
+
+  test("buyer-web bar keeps the paid price-left / button-right split", () => {
+    assertBuyNotFullWidth(businessBar());
+  });
+
+  test("consumer-native bar keeps the paid price-left / button-right split", () => {
+    assertBuyNotFullWidth(nativeBar());
+  });
+});
+
+describe("ORCH-1128 adversarial A2 — the empty placeholder column is gone (root cause)", () => {
+  const assertNoEmptyPlaceholder = (src: string): void => {
+    // The non-buy branch must collapse to `null`, not an empty flex:1 column.
+    expect(src).not.toMatch(
+      /\) : \(\s*<View style={styles\.priceCol}\s*\/>\s*\)/,
+    );
+    // Belt-and-suspenders: there is no self-closing empty priceCol View anywhere.
+    expect(src).not.toMatch(/<View style={styles\.priceCol}\s*\/>/);
+  };
+
+  test("buyer-web bar has no empty priceCol placeholder", () => {
+    assertNoEmptyPlaceholder(businessBar());
+  });
+
+  test("consumer-native bar has no empty priceCol placeholder", () => {
+    assertNoEmptyPlaceholder(nativeBar());
+  });
+});
+
+describe("ORCH-1128 adversarial A3 — mute pill clears the seam by a strict margin, still bottom-anchored", () => {
+  test("bottom offset is numerically > the ORCH-1124 baseline of 14, and no top: key", () => {
+    const src = coverMedia();
+    const idx = src.indexOf("audioControlBottomRight:");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    // Numeric parse of the actual bottom value (not a literal-22 string match):
+    const m = block.match(/bottom:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    const bottom = Number(m?.[1]);
+    // STRICT increase over the flush ORCH-1124 baseline — a partial bump that
+    // still bleeds (<=14) fails just as a full revert to 14 does.
+    expect(bottom).toBeGreaterThan(14);
+    // The bottomRight style must remain a BOTTOM anchor: no `top:` key smuggled
+    // in (which would silently turn it into a top-pinned pill — the exact
+    // ORCH-1124 regression this position contract forbids).
+    expect(block).not.toMatch(/top:\s*\d+/);
+    // And the right anchor is preserved.
+    expect(block).toMatch(/right:\s*14/);
+  });
+
+  test("the shared default position is bottomRight (no topRight regression)", () => {
+    const src = coverMedia();
+    expect(src).toContain('audioControlPosition = "bottomRight"');
+    // The bottomRight style key is referenced by the position switch.
+    expect(src).toMatch(
+      /audioControlPosition === "bottomRight"\s*&&\s*\n?\s*styles\.audioControlBottomRight/,
+    );
+  });
+});

--- a/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts
+++ b/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ORCH-1128 [public offering-page polish] — IMPLEMENTOR happy-path regression.
+ *
+ * Two follow-up tweaks to ORCH-1117 (floating Buy bar) + ORCH-1124 (mute pill
+ * → bottomRight), reported by Seth on the buyer-web public offering page:
+ *
+ *   ITEM 1 — FREE-TICKET CTA FULL WIDTH. On the floating bar a PAID ticket
+ *     shows price (flex:1 column) + button sharing the row; a FREE / waitlist
+ *     ticket has no price, so the sole CTA must span the FULL bar width rather
+ *     than hugging content on the right of an empty flex:1 placeholder column.
+ *     Fix: render the price column ONLY for kind==="buy"; for the non-buy
+ *     tappable kinds the button gets `buttonFull` (flex:1, marginLeft:0). The
+ *     paid price-left / button-right split is unchanged. Mirrored on web
+ *     (mingla-business) AND native consumer (app-mobile) — both shared the
+ *     identical empty-placeholder defect.
+ *
+ *   ITEM 2 — MUTE PILL BOTTOM CLEARANCE. The shared EventCoverMedia bottomRight
+ *     Sound/Mute pill sat at bottom:14, flush on the cover seam, bleeding into
+ *     the details section that begins immediately below the public hero. Raised
+ *     to bottom:22 (8px clearance). Single shared value → web public page AND
+ *     native gallery both inherit it; native gallery pill simply moves up 8px,
+ *     still safely within the cover. The ORCH-1124 bottomRight POSITION (right
+ *     edge, bottom anchor) is preserved — NOT reverted to topRight.
+ *
+ * Source-assertion style (the repo Jest harness runs in Node without
+ * react-test-renderer — see PublicBrandPage.closeButton.test.tsx harness note),
+ * matching the sibling ORCH-1117 / ORCH-1124 source tests.
+ *
+ * fails-on-revert (verified by true line-deletion of the fix, NOT comment-out):
+ *   ITEM 1 web    — delete `styles.buttonFull` style or the `buttonFull` apply  → fails.
+ *   ITEM 1 native — same in app-mobile FloatingOfferingBar                       → fails.
+ *   ITEM 2        — restore `bottom: 14` in audioControlBottomRight             → fails.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const businessBar = (): string =>
+  readFileSync(
+    path.resolve(__dirname, "../FloatingOfferingBar.tsx"),
+    "utf8",
+  );
+
+const nativeBar = (): string =>
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../../app-mobile/src/components/offering/FloatingOfferingBar.tsx",
+    ),
+    "utf8",
+  );
+
+const coverMedia = (): string =>
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../../packages/event-rendering/EventCoverMedia.tsx",
+    ),
+    "utf8",
+  );
+
+describe("ORCH-1128 item 1 — free / waitlist CTA spans the full floating bar", () => {
+  // For BOTH bars: there must be a `buttonFull` style with flex:1 + marginLeft:0,
+  // and the sole-CTA branch must apply it only for the non-"buy" kinds.
+  const assertFullWidthFreeCta = (src: string): void => {
+    // The empty flex:1 placeholder column is GONE — non-buy no longer renders a
+    // sibling that would steal half the row.
+    expect(src).not.toMatch(/\) : \(\s*<View style={styles\.priceCol} \/>\s*\)/);
+    // A full-width style exists with flex:1 (fills the bar) and no left margin
+    // (the margin only ever separated the button from the price column).
+    expect(src).toMatch(/buttonFull:\s*{[^}]*flex:\s*1/);
+    expect(src).toMatch(/buttonFull:\s*{[^}]*marginLeft:\s*0/);
+    // It is applied to the Pressable ONLY for the non-buy tappable kinds.
+    expect(src).toMatch(/cta\.kind !== "buy" && styles\.buttonFull/);
+    // The paid "buy" split is preserved: the price column still renders for buy.
+    expect(src).toMatch(/cta\.kind === "buy" \?\s*\(?\s*<View style={styles\.priceCol}>/);
+  };
+
+  test("mingla-business (buyer web) floating bar makes the free CTA full-width", () => {
+    assertFullWidthFreeCta(businessBar());
+  });
+
+  test("app-mobile (consumer native) floating bar makes the free CTA full-width", () => {
+    assertFullWidthFreeCta(nativeBar());
+  });
+});
+
+describe("ORCH-1128 item 2 — cover mute pill clears the details below", () => {
+  test("audioControlBottomRight bottom offset is raised to 22 (clearance from details)", () => {
+    const src = coverMedia();
+    const idx = src.indexOf("audioControlBottomRight:");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    // The bottom offset is the bumped value, not the flush ORCH-1124 default.
+    expect(block).toMatch(/bottom:\s*22/);
+    expect(block).not.toMatch(/bottom:\s*14\b/);
+    // ORCH-1124 position contract preserved: still bottom-right (right anchor),
+    // NOT reverted to a top position.
+    expect(block).toMatch(/right:\s*14/);
+  });
+
+  test("the public page still inherits the bottomRight default (no topRight regression)", () => {
+    const src = coverMedia();
+    expect(src).toContain('audioControlPosition = "bottomRight"');
+  });
+});

--- a/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
+++ b/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
@@ -355,16 +355,19 @@ describe("ORCH-1124 cover-video audio pill clears top-right floating chrome", ()
   });
 
   // The shared component's audio-pill default is "bottomRight" and is styled
-  // inside the cover container (bottom:14 / right:14) — not the page base — so
-  // it does not collide with the host-mounted floating Buy bar (ORCH-1117).
+  // inside the cover container (bottom:22 / right:14) — not the page base — so
+  // it does not collide with the host-mounted floating Buy bar (ORCH-1117) and
+  // (ORCH-1128) clears the cover seam so it stops bleeding into the details
+  // section that begins immediately below the public hero.
   test("EventCoverMedia defaults the audio pill to bottomRight, styled within the cover", () => {
     const media = coverMedia();
     expect(media).toContain('audioControlPosition = "bottomRight"');
     expect(media).toContain("audioControlBottomRight:");
     const bottomRightStyle = media
       .slice(media.indexOf("audioControlBottomRight:"))
-      .slice(0, 80);
+      .slice(0, 400);
     expect(bottomRightStyle).toContain("right: 14");
-    expect(bottomRightStyle).toContain("bottom: 14");
+    // ORCH-1128 — raised from 14 → 22 for bottom clearance from the details.
+    expect(bottomRightStyle).toContain("bottom: 22");
   });
 });

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -605,7 +605,9 @@ const styles = StyleSheet.create({
   },
   audioControlBottomRight: {
     right: 14,
-    bottom: 14,
+    // ORCH-1128 — 14 → 22: clears the cover seam so the pill stops bleeding
+    // into the details section below the public hero (radius:0 + absoluteFill).
+    bottom: 22,
   },
   audioControlPressed: {
     backgroundColor: "rgba(0, 0, 0, 0.72)",


### PR DESCRIPTION
## ORCH-1128 — public offering-page polish (2 items)

Follow-ups to ORCH-1117 (floating Buy bar) + ORCH-1124 (mute pill → bottomRight), reported by Seth on the buyer-web public event page.

1. **Free-ticket CTA full-width** — a free ticket's 'Get free ticket' button was squeezed to ~half-width by an invisible empty price-column placeholder; removed it so the sole free CTA spans the full bar. Paid layout (price-left / button-right) unchanged. Fixed web + consumer native (shared defect).
2. **Mute-pill clearance** — the cover-video Sound/Mute pill (ORCH-1124 bottomRight) sat at `bottom:14` and bled into the details section below; raised to `bottom:22` (shared `EventCoverMedia`, so web + native both clear it). bottomRight position preserved.

**TEST PASS** (buyer-web runtime, headless Chrome, prod-vs-branch side-by-side): free CTA now full-width, paid byte-identical, pill 22px/bottomRight/still-fires. 0 P0/P1/P2/P3. Implementor happy-path + tester adversarial tests, fails-on-revert proven. `[TEST-MOD-APPROVED ORCH-1128]` for one approved single-assertion edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)