### PR TITLE
ORCH-1129: fix team-wide iOS build break — Google-pods modular headers config plugin

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md
@@ -1,0 +1,170 @@
+# IMPLEMENTATION — ORCH-1129 · mingla-business iOS build: Google-pods modular headers
+
+**Date:** 2026-06-12 · **Skill:** mingla-implementor (Claude) · **Class:** build-config only
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1129-[ios-build-modular-headers]` · branch `ORCH-1129-ios-build-modular-headers`
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md`
+**Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md`
+**Comms:** acked COMMS-0030 (WARN, to ALL) — this ORCH IS the fix for that team-wide iOS build break. Not resolved here (resolves on CLOSE after the GREEN cloud build).
+**Status:** implemented and locally verified (SC-1/SC-2/SC-3/SC-5). **SC-4 (GREEN cloud iOS build) is the orchestrator/tester's gate — NOT provable locally.**
+
+---
+
+## 1. Summary
+
+mingla-business iOS EAS builds have failed at the **Install pods** phase since ~2026-05-30 (COMMS-0030): the Google Sign-In pod chain pulls in the Swift pod `AppCheckCore`, which imports `GoogleUtilities` and `RecaptchaInterop` — ObjC pods with no module maps — and under static-libraries + New-Architecture CocoaPods refuses to integrate the Swift pod and aborts `pod install`.
+
+The fix is a single targeted Expo config plugin (`withGooglePodsModularHeaders.js`) that injects `pod '<name>', :modular_headers => true` for exactly those three pods into the CNG-generated `Podfile`, immediately above `use_expo_modules!` (before pod resolution). It is registered in `app.config.ts` alongside the sibling `withIosFmtConsteval` plugin, and locked in by a strict-grep + behavior regression gate. No global `use_modular_headers!`, no `expo-build-properties`/`useFrameworks` change. Compile-time header-import change only — zero runtime/binary behavior change.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence / commit |
+|----|-----------|--------|-------------------|
+| SC-1 | Plugin exists, exports a function, and is registered in `app.config.ts` plugins array | ✓ PASS | `withGooglePodsModularHeaders.js` (`module.exports = withGooglePodsModularHeaders`); `app.config.ts` line carries `"./plugins/withGooglePodsModularHeaders"`. Gate T-1/T-2. Commit `0350212822da0e55de5d9b13cb3d8a19601c95f9` |
+| SC-2 | `npx expo prebuild -p ios --no-install` yields a Podfile with all 3 `:modular_headers => true` lines INSIDE the target, ABOVE `use_expo_modules!` | ✓ PASS (local prebuild) | Podfile excerpt §6 (lines 23–30). Commit `0350212822da0e55de5d9b13cb3d8a19601c95f9` |
+| SC-3 | Idempotent — re-running prebuild does not duplicate the block | ✓ PASS | Prebuild run TWICE; marker count = 1, GoogleUtilities directive count = 1. §6. Commit `0350212822da0e55de5d9b13cb3d8a19601c95f9` |
+| SC-4 | **GREEN EAS iOS `development` cloud build clears Install pods** | ⏳ NOT PROVABLE LOCALLY — orchestrator/tester gate (T-6) | Local prebuild cannot reproduce the cloud-only `pod install` failure (INVESTIGATE F-4). Hand to tester/Seth: `eas build -p ios --profile development`. |
+| SC-5 | No regression elsewhere — only the 2 files + test; no app-source/DB/edge changes | ✓ PASS | `git diff --stat` = `app.config.ts` (6 insertions) + 2 new files + the test. §3. Commit `0350212822da0e55de5d9b13cb3d8a19601c95f9` |
+
+---
+
+## 3. Files changed
+
+| File | Change | Lines |
+|------|--------|-------|
+| `mingla-business/plugins/withGooglePodsModularHeaders.js` | **NEW** — the config plugin | +93 |
+| `mingla-business/app.config.ts` | registration line + grouped comment after `"./plugins/withIosFmtConsteval"` | +6 |
+| `mingla-business/src/__tests__/iosGooglePodsModularHeaders.gate.test.ts` | **NEW** — strict-grep + behavior regression gate (T-1..T-5b) | +183 |
+| `Mingla_Artifacts/specs/SPEC_ORCH-1129_*.md`, `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1129_*.md` | forensics docs, committed on-branch (untracked in worktree) | (docs) |
+
+`git diff --stat` (code) shows only `app.config.ts | 6 ++++++` modified; the plugin + test are new. No app source, DB, RLS, migration, edge fn, `package.json`/lockfile, or `eas.json` touched.
+
+---
+
+## 4. Data-model changes applied
+
+None. Build-config only — no tables, columns, constraints, indexes, or RLS.
+
+## 5. Edge functions touched
+
+None. No `verify_jwt` to preserve.
+
+---
+
+## 6. Local prebuild proof (SC-2 + SC-3)
+
+`cd mingla-business && rm -rf ios && npx expo prebuild -p ios --no-install` → `✔ Finished prebuild`. Generated `ios/Podfile`, lines 23–32:
+
+```
+23: target 'Business' do
+24:   # ORCH-1129 modular headers: GoogleSignIn 9.x → AppCheckCore (Swift) needs module maps for
+25:   # these non-modular deps under static libraries. Injected by
+26:   # plugins/withGooglePodsModularHeaders.js.
+27:   pod 'GoogleUtilities', :modular_headers => true
+28:   pod 'RecaptchaInterop', :modular_headers => true
+29:   pod 'AppCheckCore', :modular_headers => true
+30:   use_expo_modules!
+31:
+32:   if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
+```
+
+All 3 directives land **inside `target 'Business' do`**, **immediately ABOVE `use_expo_modules!`** (primary anchor) — exactly as SC-2 requires. OQ-1 (anchor confirmation) resolved: the SDK 54 Podfile contains `use_expo_modules!` inside the app target; primary anchor used.
+
+**Idempotency (SC-3):** prebuild run a SECOND time → `ORCH-1129 modular headers` marker count = **1**; `pod 'GoogleUtilities', :modular_headers => true` count = **1**. No duplication (marker guard works). Generated `ios/` removed afterward (gitignored — `git check-ignore ios` = `ios`); NOT committed.
+
+---
+
+## 7. Regression test (fails-on-revert)
+
+**Path:** `mingla-business/src/__tests__/iosGooglePodsModularHeaders.gate.test.ts` — marked `[TEST-MOD-APPROVED ORCH-1129]` (append-only; new file).
+
+6 tests, all PASS:
+- **T-1** — `app.config.ts` registers `"./plugins/withGooglePodsModularHeaders"` (strict-grep).
+- **T-2** — plugin source carries `:modular_headers => true` + the template line + all 3 pod names.
+- **T-3** — drives the REAL exported plugin (via a mocked `withDangerousMod` capturing the inner callback) against a CNG-shaped fixture Podfile → all 3 pods injected ABOVE `use_expo_modules!`, inside the target.
+- **T-4** — idempotent: applying twice → marker + GoogleUtilities directive appear exactly once.
+- **T-5** — fail-soft: no anchor → Podfile returned unchanged, no throw.
+- **T-5b** — missing Podfile → no throw, returns cfg.
+
+```
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+```
+
+**Fails-on-revert proof (true line deletion, NOT comment-out):**
+- Deleted the `"./plugins/withGooglePodsModularHeaders"` registration line from `app.config.ts` AND the `MODULAR_PODS.map(...)` directive-build line from the plugin → re-ran gate → **4 of 6 tests FAILED** (T-1 registration, T-2 directive, T-3 + T-4 behavior). Restored both files from backup → **6/6 PASS** again.
+- `fails-on-revert verified at 34862397bf623be628e27dde11e8cf79ef12070c` (HEAD at the time of the deletion/restore cycle; the fix commit is `0350212822da0e55de5d9b13cb3d8a19601c95f9`).
+
+---
+
+## 8. Old → New receipts
+
+### mingla-business/plugins/withGooglePodsModularHeaders.js (NEW)
+**Before:** did not exist. Fresh iOS pod installs aborted on the AppCheckCore Swift-pod / non-modular-deps conflict.
+**Now:** an idempotent, fail-soft `withDangerousMod` config plugin injects `:modular_headers => true` for `GoogleUtilities`, `RecaptchaInterop`, `AppCheckCore` above `use_expo_modules!` on every prebuild/cloud build, so CocoaPods generates the module maps it needs.
+**Why:** SC-1/SC-2/SC-3; fixes COMMS-0030 team-wide iOS build break.
+**Lines:** +93.
+
+### mingla-business/app.config.ts
+**Before:** plugins array ended at `"./plugins/withIosFmtConsteval"`; the new plugin never ran during prebuild.
+**Now:** `"./plugins/withGooglePodsModularHeaders"` registered immediately after `withIosFmtConsteval`, grouping all iOS Podfile-affecting plugins, with a comment explaining the COMMS-0030 break.
+**Why:** SC-1 (plugin must be registered to run).
+**Lines:** +6.
+
+### mingla-business/src/__tests__/iosGooglePodsModularHeaders.gate.test.ts (NEW)
+**Before:** no gate; a future build-config edit could silently drop the plugin and re-break all iOS builds.
+**Now:** strict-grep + real-behavior regression gate locks the plugin file, the 3 directives, and the registration; fails on revert.
+**Why:** §9 + proposed invariant `I-PROPOSED-IOS-GOOGLE-PODS-MODULAR-HEADERS`.
+**Lines:** +183.
+
+---
+
+## 9. Cross-surface impact table
+
+| # | Surface | Affected | Reason / parity |
+|---|---------|----------|-----------------|
+| 1 | Consumer iOS (`app-mobile/`) | NO | Different app, out of dispatch scope. Will hit the SAME break → DISC-1129-A (parallel fix, manual parity). |
+| 2 | Consumer Android | NO | No CocoaPods. |
+| 3 | Buyer/anon Web | NO | Web export has no pods phase. |
+| 4 | **Business iOS** | **YES** | iOS EAS builds (dev/preview/production) clear Install pods. Automatic parity — single CNG Podfile path for all iOS profiles. |
+| 5 | Business Android | NO | Gradle, not CocoaPods. |
+| 6 | Admin Web | NO | Not RN/iOS. |
+| 7 | Business Web preview | NO | Web export, no pods. |
+
+---
+
+## 10. Gate output
+
+- **Jest gate:** 6/6 PASS (above).
+- **Typecheck (`npx tsc --noEmit`):** ZERO errors in ORCH-1129 files (`app.config.ts`, the test, the plugin). The 30 `packages/phone-input/*` errors are PRE-EXISTING on origin/main (confirmed by checking out origin/main and re-running → same 30) and out of scope — NOT introduced here.
+- **ESLint** (plugin + test + app.config.ts): 0 errors, 0 warnings.
+- **`git diff --stat`:** `app.config.ts | 6 ++++++` only; 2 new files + test untracked-then-added.
+
+---
+
+## 11. Known issues / deferred
+
+- No `[TRANSITIONAL]` markers introduced.
+- **SC-4 cloud gate is unmet by design** — local prebuild succeeds even on the broken state (the failure is cloud/static-library-only), so only a real `eas build -p ios --profile development` clearing Install pods proves the fix. Owned by tester/Seth.
+
+---
+
+## 12. Operator action required
+
+- **No migration.** No `db push`.
+- **No edge-function deploy.**
+- **Cloud build gate (SC-4 / T-6):** run from MERGED main (or this branch for pre-merge proof):
+  ```bash
+  cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1129-[ios-build-modular-headers]/mingla-business" && eas build -p ios --profile development
+  ```
+  Success = the build log no longer contains `cannot yet be integrated as static libraries` / `pod install exited with non-zero code: 1`, and reaches the compile/archive phase. (OQ-2: `development` profile recommended — cheapest + what ORCH-1119 needs next.)
+- **On CLOSE:** merge to main (unblocks team-wide iOS builds + ORCH-1119's device build), resolve COMMS-0030, flip `I-PROPOSED-IOS-GOOGLE-PODS-MODULAR-HEADERS` ACTIVE.
+
+---
+
+## 13. Discoveries for orchestrator
+
+- **DISC-1129-A (already flagged in spec):** `app-mobile/` (consumer) uses google-signin too and will hit the identical break on its next fresh iOS build. Out of this ORCH; register the parallel fix (same plugin pattern under `app-mobile/plugins/`).
+- **Pre-existing (out of scope):** `packages/phone-input/*` has 30 TS errors (`implicitly any`, `Cannot find module 'react'`) under the mingla-business tsconfig on origin/main. Not introduced here; flag for a separate cleanup ORCH if the business tsconfig is meant to type-check that package.
+- **COMMS-0030 acked** (WARN, to ALL / this ORCH): this implementation IS the fix; left OPEN — resolves on CLOSE after the GREEN cloud build.

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md
@@ -1,0 +1,186 @@
+# INVESTIGATION — ORCH-1129 · mingla-business iOS build broken team-wide (CocoaPods modular headers)
+
+**Date:** 2026-06-12
+**Skill:** mingla-forensics (sub-agent of mingla-orchestrator Conductor)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1129-[ios-build-modular-headers]` · branch `ORCH-1129-ios-build-modular-headers` (rebased clean on origin/main)
+**Class:** build-infra / CocoaPods / Expo CNG. NO app source, NO UI, NO DB/RLS/migration.
+**Comms:** ACKED **COMMS-0030** (WARN→ALL, OPEN) — this investigation IS the ORCH-1129 it points to; it is the source-of-truth for the breakage. Factored COMMS-0027/0028/0029 (OTA/cache/trip-RPC) — none bear on iOS pod resolution.
+
+---
+
+## Symptom summary (expected vs actual)
+
+- **Expected:** `eas build -p ios` of `mingla-business` (any profile) installs CocoaPods and produces an artifact.
+- **Actual:** every fresh iOS cloud build since ~2026-05-30 dies at the **Install pods** phase:
+  ```
+  [!] The following Swift pods cannot yet be integrated as static libraries:
+  The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and `RecaptchaInterop`,
+  which do not define modules. To opt into those targets generating module maps
+  (which is necessary to import them from Swift when building as static libraries),
+  you may set `use_modular_headers!` globally in your Podfile, or specify
+  `:modular_headers => true` for particular dependencies.
+  pod install exited with non-zero code: 1
+  ```
+- **Reproduction conditions:** ALWAYS, on a fresh EAS cloud `pod install`. Does NOT reproduce on a LOCAL `npx expo prebuild -p ios` + pod install on the orchestrator's Mac (different CocoaPods spec-repo state — see Q4). Android unaffected.
+
+---
+
+## Investigation manifest (every file read, in trace order)
+
+| # | File / artifact | Why |
+|---|---|---|
+| 1 | `COMMS_LEDGER.md` (anchor) — COMMS-0030, 0029, 0028, 0027 | Entry contract; the breakage is logged in 0030 |
+| 2 | `mingla-business/app.config.ts` (full) | Find the plugins array + existing config-plugin pattern; confirm google-signin plugin entry |
+| 3 | `mingla-business/plugins/withIosFmtConsteval.js` (full) | The existing iOS Podfile-injection config plugin — exact template for the fix |
+| 4 | `mingla-business/plugins/withAndroidBracketSafeCmake.js` (listed) | Sibling plugin; confirm plugin convention |
+| 5 | `mingla-business/package.json` / `package-lock.json` | Resolve `@react-native-google-signin/google-signin` JS version + history |
+| 6 | `node_modules/@react-native-google-signin/google-signin/{package.json,*.podspec}` | Confirm RNGoogleSignin→GoogleSignIn pod pin |
+| 7 | `~/.cocoapods/repos/trunk/Specs/.../GoogleSignIn/9.0.0,9.1.0/*.json` | Prove GoogleSignIn 9.x → AppCheckCore dependency |
+| 8 | `~/.cocoapods/repos/trunk/Specs/.../AppCheckCore/11.2.0/*.json` | Prove AppCheckCore is a Swift pod → GoogleUtilities deps |
+| 9 | `~/.cocoapods/.../GoogleUtilities,GTMSessionFetcher,AppAuth,GTMAppAuth,PromisesObjC/*.json` | Module-definition status of every sibling pod (blast radius) |
+| 10 | `node_modules/@sentry/react-native/*.podspec`; `@react-native-firebase` presence | Rule out OTHER Swift-pod→non-modular chains |
+| 11 | `mingla-business/eas.json` | iOS build profiles + the verification gate profile |
+| 12 | `git grep modular_headers` (all branches) | Confirm NO existing modular-headers config anywhere |
+
+---
+
+## Q-scorecard
+
+### Q1 — What is the exact pod dependency chain that triggers the error?
+`@react-native-google-signin/google-signin` (RNGoogleSignin 16.1.2) → `GoogleSignIn ~> 9.0` → `AppCheckCore ~> 11.0` → `GoogleUtilities/{Environment,UserDefaults} ~> 8.0` + (transitively, in 11.3.0) `RecaptchaInterop`. AppCheckCore is classified by CocoaPods as a **Swift pod**; GoogleUtilities and RecaptchaInterop are ObjC/C pods that do **not** define a module map. Under **static libraries + New Architecture**, a Swift pod cannot `import` a non-modular dependency unless that dependency generates a module map → CocoaPods hard-fails `pod install` and tells you to set `:modular_headers => true` (targeted) or `use_modular_headers!` (global).
+**Verdict: PROVEN** (podspec JSON pasted in F-1/F-2).
+
+### Q2 — Why did it start ~2026-05-30 if the JS package didn't change?
+The JS package did **not** change at the cutover. `package.json` has pinned `"^16.0.0"` unchanged for a long time, and `package-lock.json` already resolved `16.1.2` both **before and after** the 2026-05-28 ORCH-0978 commit (`058fabd7d`) that last touched the lockfile (F-3). The trigger is **CocoaPods cloud-side transitive resolution**: in an Expo CNG project there is **no committed `ios/Podfile.lock`**, so EAS resolves the native Google pods **fresh to the latest spec-repo-compatible versions on every build**. Google published `AppCheckCore 11.3.0` (and the GoogleUtilities 8.1.1 / RecaptchaInterop revs) that the cloud now resolves; that AppCheckCore rev is the one CocoaPods flags as a Swift pod requiring modular headers under static libs. The last GREEN build (`d9bf545a`, 2026-05-30) resolved a pre-11.3.0 AppCheckCore that did not yet trip the static-library Swift-pod guard. So the breakage is **time-based (upstream pod publish), not commit-based** — exactly why every branch is affected and rebasing does nothing.
+**Verdict: PROVEN** (lockfile diff + the absence of any committed Podfile.lock + the "no modular_headers on any branch" grep).
+
+### Q3 — Why does LOCAL prebuild+pod-install pass but the CLOUD fails?
+The orchestrator's Mac has a CocoaPods **trunk spec mirror that predates AppCheckCore 11.3.0** — confirmed: `~/.cocoapods/repos/trunk/Specs/.../AppCheckCore/` tops out at **11.2.0** locally (F-4), while the cloud (fresh `pod repo update`) resolves **11.3.0**. CocoaPods resolves to the highest spec-repo-available version satisfying `~> 11.0`; the Mac picks ≤11.2.0 (no Swift-pod static-lib trip on that rev's classification, or an already-cached `Pods/`), the cloud picks 11.3.0 (which trips it). Same `Podfile`, different resolved graph → the bug is invisible locally and only manifests on a clean cloud resolution. **This is why verification REQUIRES an EAS cloud build, not a local one.**
+**Verdict: PROVEN** (local spec mirror caps at 11.2.0; cloud error names 11.3.0).
+
+### Q4 — Full blast radius: is it ONLY AppCheckCore→{GoogleUtilities,RecaptchaInterop}, or will fixing those expose the next non-modular pod (whack-a-mole)?
+The **only** Swift-pod→non-modular-dependency chain in this project is the Google Sign-In tree. Verified:
+- **No Firebase:** `@react-native-firebase` is **absent** (F-5).
+- **Sentry** (`@sentry/react-native` 7.2.0 → `RNSentry` → `Sentry/HybridSDK 8.56.1`) depends only on the Sentry framework, which ships its own module — not in the non-modular set (F-5).
+- The AppCheckCore sibling pods that ARE in the resolved graph: `GTMSessionFetcher` (DEFINES_MODULE), `AppAuth` (DEFINES_MODULE), `PromisesObjC` (DEFINES_MODULE) all define modules; `GTMAppAuth` is itself a Swift pod (a consumer, not a non-modular dependency) (F-6). The two pods CocoaPods names as non-modular — `GoogleUtilities` and `RecaptchaInterop` — are the complete set the AppCheckCore Swift pod imports.
+- Defensive note: a targeted fix should also mark **`AppCheckCore`** itself `:modular_headers => true` (harmless, and forecloses the edge case where CocoaPods, after the two leaf pods are modularized, re-classifies the chain) — this makes the one-shot fix bulletproof without going global.
+**Verdict: PROVEN-bounded.** Targeted set = `{ GoogleUtilities, RecaptchaInterop, AppCheckCore }`. No further pod in the graph needs it.
+
+### Q5 — Is there any existing modular-headers config to extend, or is this greenfield?
+`git grep -l "modular_headers\|use_modular_headers"` across the worktree + all branches returns **nothing** (F-7). Greenfield. The project already carries the precedent pattern (`plugins/withIosFmtConsteval.js` injects into the generated Podfile via `withDangerousMod`); the fix is a sibling plugin.
+**Verdict: PROVEN.**
+
+---
+
+## Findings (six-field evidence)
+
+### F-1 — GoogleSignIn 9.x depends on AppCheckCore ~> 11.0 [CONFIRMED ROOT CAUSE component]
+- **Symptom:** EAS error names `AppCheckCore` as the failing Swift pod.
+- **Layer:** build / CocoaPods dependency graph.
+- **Probe:** `node -e` over `~/.cocoapods/repos/trunk/Specs/.../GoogleSignIn/9.0.0/9.1.0/GoogleSignIn.podspec.json`.
+- **Evidence:**
+  `GoogleSignIn 9.0.0 deps: {"AppCheckCore":["~> 11.0"],"AppAuth":["~> 2.0"],"GTMAppAuth":["~> 5.0"],"GTMSessionFetcher/Core":["~> 3.3"]}` (identical in 9.1.0).
+  RNGoogleSignin podspec: `s.dependency "GoogleSignIn", package["GoogleSignInPodVersion"]`; installed `package.json` → `GoogleSignInPodVersion: ~> 9.0`, `version: 16.1.2`.
+- **Mechanism:** the google-signin native module pins GoogleSignIn ~> 9.0, which pulls AppCheckCore ~> 11.0 into the graph — the Swift pod CocoaPods then refuses to integrate as a static lib.
+- **Severity:** CONFIRMED ROOT CAUSE (dependency-chain origin).
+
+### F-2 — AppCheckCore (Swift pod) depends on non-modular GoogleUtilities/RecaptchaInterop [CONFIRMED ROOT CAUSE]
+- **Symptom:** "Swift pod `AppCheckCore` depends upon `GoogleUtilities` and `RecaptchaInterop`, which do not define modules."
+- **Layer:** build / CocoaPods.
+- **Probe:** `node -e` over AppCheckCore 11.2.0 + GoogleUtilities podspec JSON.
+- **Evidence:** `AppCheckCore 11.2.0 deps: {"PromisesObjC":["~> 2.4"],"GoogleUtilities/Environment":["~> 8.0"],"GoogleUtilities/UserDefaults":["~> 8.0"]}`; GoogleUtilities podspec has **no** `DEFINES_MODULE`/module_map (`defines module? false`, `pod_target_xcconfig: {GCC_C_LANGUAGE_STANDARD, HEADER_SEARCH_PATHS}`). The cloud resolves AppCheckCore **11.3.0** (local mirror caps at 11.2.0), which CocoaPods classifies as a Swift pod under static libraries.
+- **Mechanism:** static libraries + New Architecture force a Swift pod to import its deps via module maps; GoogleUtilities/RecaptchaInterop don't generate one → `pod install` aborts with the modular-headers instruction.
+- **Severity:** CONFIRMED ROOT CAUSE.
+
+### F-3 — The JS google-signin version did NOT change at the ~May-30 cutover [RULES OUT a JS-bump cause]
+- **Symptom:** breakage onset 2026-05-30 with no obvious code change.
+- **Layer:** code / lockfile.
+- **Probe:** `git show 058fabd7d^:.../package-lock.json` vs `058fabd7d:...` → extract resolved google-signin version.
+- **Evidence:** BEFORE `058fabd7d` = `16.1.2`; AFTER = `16.1.2`. `package.json` spec = `"^16.0.0"` (unchanged). `git log -S google-signin -- package.json` → last real change was `4f5d797d2 "new app"` (project genesis) / `058fabd7d` (whitespace only).
+- **Mechanism:** since the JS version is constant, the only moving part is the cloud's fresh CocoaPods resolution of latest-compatible native Google pods → upstream pod publish is the trigger, not a repo commit.
+- **Severity:** RULED OUT (JS bump) → confirms the upstream-resolution mechanism (Q2).
+
+### F-4 — Local CocoaPods spec mirror predates the offending AppCheckCore rev [CONFIRMED — explains local-passes]
+- **Symptom:** local prebuild + pod install succeeds; cloud fails.
+- **Layer:** runtime / tooling environment.
+- **Probe:** `find ~/.cocoapods/repos/trunk/Specs -path '*AppCheckCore/*' -name '*.podspec.json'` → version list.
+- **Evidence:** local AppCheckCore versions top out at `11.0.0, 11.1.0, 11.2.0` (no 11.3.0). RecaptchaInterop is **absent** from the local mirror entirely. Cloud error names **11.3.0**.
+- **Mechanism:** CocoaPods resolves to the highest available compatible rev per spec repo; Mac (stale mirror / cached Pods) ≤11.2.0 doesn't trip, cloud (fresh `pod repo update`) = 11.3.0 trips → bug is local-invisible. **Verification must be an EAS cloud build.**
+- **Severity:** CONFIRMED ROOT CAUSE (of the local-vs-cloud divergence).
+
+### F-5 — No other Swift-pod→non-modular chain exists (blast radius bounded) [CONFIRMED]
+- **Symptom:** risk that fixing the named pods exposes the next one.
+- **Layer:** build / dependency graph.
+- **Probe:** `ls node_modules/@react-native-firebase` (absent); `grep dependency @sentry/react-native podspec`; sibling podspec module-status scan.
+- **Evidence:** no `@react-native-firebase`; `RNSentry` → `Sentry/HybridSDK 8.56.1` only (Sentry ships its own module); `GTMSessionFetcher 5.3.0`, `AppAuth 2.0.0`, `PromisesObjC 2.4.0` all DEFINES_MODULE; `GTMAppAuth` is itself a Swift consumer. Only `GoogleUtilities` + `RecaptchaInterop` are the non-modular leaves AppCheckCore imports.
+- **Mechanism:** the complete non-modular set the Swift pods import is `{GoogleUtilities, RecaptchaInterop}`; marking those (+ AppCheckCore defensively) closes the entire surface in one shot.
+- **Severity:** CONFIRMED (no whack-a-mole beyond the named set).
+
+### F-6 — Existing `withIosFmtConsteval.js` is the exact fix template [CONFIRMED — fix vector]
+- **Symptom:** N/A (capability finding).
+- **Layer:** build-config / Expo CNG.
+- **Probe:** read `mingla-business/plugins/withIosFmtConsteval.js` + `app.config.ts` plugins array.
+- **Evidence:** the plugin uses `withDangerousMod(config, ["ios", (cfg)=>{ ...edit Podfile... }])`, reads `path.join(cfg.modRequest.platformProjectRoot, "Podfile")`, is **idempotent** (skips if marker present), and is registered as `"./plugins/withIosFmtConsteval"` in the `app.config.ts` plugins array (alongside `"./plugins/withAndroidBracketSafeCmake"`). `@expo/config-plugins` resolves (transitive via expo).
+- **Mechanism:** the established, working pattern for injecting into the CNG-generated Podfile is a `withDangerousMod` config plugin referenced from `app.config.ts` — the ORCH-1129 fix is a sibling of this file.
+- **Severity:** CONFIRMED (fix vector; consumed by the SPEC).
+
+### F-7 — No modular-headers config exists on any branch [CONFIRMED]
+- **Probe:** `git grep -ln "modular_headers\|use_modular_headers"` (worktree) — empty; COMMS-0030 confirms across origin/main + all branches.
+- **Evidence:** zero matches.
+- **Severity:** CONFIRMED (greenfield; rebase cannot help).
+
+---
+
+## Five-Truth-Layer reconciliation
+
+| Layer | Finding |
+|---|---|
+| **Docs** | COMMS-0030 states the breakage is team-wide since ~2026-05-30, NOT caused by ORCH-1119. Matches evidence. |
+| **Schema** | N/A — no DB surface. |
+| **Code** | `app.config.ts` registers the google-signin plugin + two Podfile-injection plugins; NO modular-headers config anywhere (F-7). |
+| **Runtime** | EAS cloud `pod install` aborts naming AppCheckCore/GoogleUtilities/RecaptchaInterop (3 cloud builds + a preview build, per COMMS-0030). |
+| **Data** | Lockfile google-signin = 16.1.2 unchanged across the cutover (F-3); local spec mirror caps AppCheckCore at 11.2.0 vs cloud 11.3.0 (F-4). |
+
+**Contradiction flagged:** Code/Data layers say "nothing changed in the repo," yet Runtime fails — the truth lives in the **CocoaPods cloud resolution layer** (no committed Podfile.lock → fresh transitive resolution to a newly-published pod). That gap IS the bug.
+
+---
+
+## Repro evidence
+
+- **Cloud failure:** authoritatively reported by the orchestrator (COMMS-0030): 3 EAS cloud builds + a `preview` build (`5d513012`) all error at Install pods; last GREEN = `d9bf545a` (2026-05-30). Not re-burned here (build-infra investigation; ~35 min/iteration; the SPEC's verification gate is the cloud build).
+- **Local non-repro (corroborated):** local CocoaPods trunk mirror caps AppCheckCore at 11.2.0 and lacks RecaptchaInterop entirely (F-4) — directly explains why a local prebuild+pod-install resolves a non-tripping graph. This is the proof that **local cannot reproduce or verify**; the fix must be proven by an EAS cloud build.
+
+Per Prime Directive 7 exemption (pure build-config / CI investigation), no simulator run is required. Confidence ceiling is not capped by a missing sim repro — the chain is proven from authoritative podspec JSON + lockfile history + the cloud error text.
+
+---
+
+## Blast radius / cross-surface map
+
+| Surface | In/Out | Note |
+|---|---|---|
+| Business iOS (dev/preview/production/TestFlight) | **IN — blocked** | All iOS EAS builds fail at Install pods until fixed |
+| Business Android | OUT | Android uses Gradle, not CocoaPods — unaffected |
+| Consumer app-mobile iOS/Android | OUT | Separate app; not in scope (NOTE: `app-mobile` ALSO uses google-signin — see Discoveries) |
+| Buyer/anon Web, Admin Web, Business Web preview | OUT | Web export has no CocoaPods phase |
+
+The fix is confined to `mingla-business/` build config: a new plugin file + one line in `app.config.ts`. Zero app source, zero runtime behavior change (modular headers only changes how headers are imported at compile time; the app binary behaves identically).
+
+---
+
+## Invariant impact
+
+- No existing invariant in `INVARIANT_REGISTRY.md` governs modular headers (greenfield).
+- The SPEC proposes a NEW invariant `I-PROPOSED-IOS-GOOGLE-PODS-MODULAR-HEADERS` (DRAFT) — a strict-grep gate asserting the config plugin + the `:modular_headers => true` directives for `{GoogleUtilities, RecaptchaInterop, AppCheckCore}` stay present, so this cannot silently regress when the next session edits build config. (Forensics flags it; the orchestrator flips it ACTIVE on CLOSE.)
+
+## Discoveries for Orchestrator
+
+- **DISC-1129-A (cross-app):** `app-mobile/` (consumer) also depends on `@react-native-google-signin/google-signin`. If the consumer app cuts a fresh iOS build it will hit the IDENTICAL failure. NOT in ORCH-1129 scope (business-app only per dispatch), but the orchestrator should register a parallel fix for `app-mobile/` before its next iOS build, or port the same plugin. (Out-of-scope; flagged, not actioned.)
+- **DISC-1129-B (infra):** the root structural cause is that a CNG project resolves native pods fresh every cloud build with no `Podfile.lock` pin. The modular-headers plugin fixes THIS break; future upstream pod publishes could surface other build breaks the same way. Consider whether to pin critical pod versions long-term (separate, larger decision — not this ORCH).
+
+## Confidence level
+
+**root cause proven.** The full dependency chain, the why-May-30 (upstream pod publish vs unchanged JS lockfile), the local-vs-cloud divergence (local spec mirror caps at 11.2.0), and the bounded blast radius are each backed by pasted podspec/lockfile evidence. The only thing not re-run here is the cloud build itself (the verification gate, owned by the implementor/tester) — which does not lower the diagnosis confidence.
+
+## Recommended next phase + scope
+
+**SPEC (this dispatch, IA mode).** Scope: a single `withDangerousMod` config plugin in `mingla-business/plugins/` injecting **targeted** `:modular_headers => true` for `{GoogleUtilities, RecaptchaInterop, AppCheckCore}` into the CNG-generated Podfile (sibling of `withIosFmtConsteval.js`), registered in `app.config.ts` plugins. Targeted over global (see SPEC §1 justification). Verification gate = a GREEN EAS iOS `development`-profile cloud build that clears Install pods. Regression guard = strict-grep gate. Lands on **main** (unblocks the whole team + ORCH-1119's pending iOS build). Build-config only.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md
@@ -1,0 +1,230 @@
+# SPEC — ORCH-1129 · mingla-business iOS build: Google-pods modular headers
+
+**Date:** 2026-06-12 · **Skill:** mingla-forensics (SPEC) · **Mode:** IA (follows INVESTIGATE_ORCH-1129_IOS_BUILD_MODULAR_HEADERS.md)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1129-[ios-build-modular-headers]` · branch `ORCH-1129-ios-build-modular-headers`
+**Class:** build-config only. NO app source, NO UI, NO DB/RLS/migration, NO edge fn.
+**Comms:** references COMMS-0030. Must land on **main** (unblocks the whole team's iOS builds + ORCH-1119's pending device build).
+
+---
+
+## 1. Executive summary
+
+Every fresh EAS iOS build of `mingla-business` fails at **Install pods** because the Google Sign-In pod chain (`@react-native-google-signin/google-signin` → `GoogleSignIn ~> 9.0` → `AppCheckCore ~> 11.x`) pulls in the **Swift pod AppCheckCore**, which imports `GoogleUtilities` and `RecaptchaInterop` — two ObjC pods that don't define module maps. Under the project's **static libraries + New Architecture** config, CocoaPods refuses to integrate a Swift pod whose deps lack module maps and aborts `pod install`.
+
+The fix is a single **Expo config plugin** (`mingla-business/plugins/withGooglePodsModularHeaders.js`) that injects **targeted** `pod '<name>', :modular_headers => true` lines for `GoogleUtilities`, `RecaptchaInterop`, and `AppCheckCore` into the CNG-generated `Podfile` (Expo regenerates `ios/` on every cloud build, so this MUST be a plugin, not a hand-edit). It is a direct sibling of the existing `withIosFmtConsteval.js` plugin and is registered in `app.config.ts`'s `plugins` array.
+
+**Targeted, not global** (`use_modular_headers!`): the blast radius is bounded to exactly these three pods (INVESTIGATE Q4/F-5 — no Firebase, Sentry self-modular, all other Google siblings define modules). Targeted avoids forcing module maps on every pod in the graph (which raises build time and can break unrelated ObjC pods). See §1a.
+
+### 1a. Targeted vs global — decision
+
+| Option | Verdict | Why |
+|---|---|---|
+| **Targeted `:modular_headers => true` for `{GoogleUtilities, RecaptchaInterop, AppCheckCore}`** | **CHOSEN** | Minimal blast radius; matches CocoaPods' own remediation hint; blast radius proven-bounded (F-5) so it's complete in one shot; no build-time cost on unrelated pods. AppCheckCore included defensively to foreclose re-classification once its leaves are modularized. |
+| Global `use_modular_headers!` | Rejected | Forces module-map generation on ALL pods (React-Core, RCT-Folly, fmt, Sentry, etc.), increasing build time and risking new "redefinition of module" / umbrella-header conflicts on pods that were fine as static libs. Unnecessary given the bounded radius. |
+
+### 1b. `expo-build-properties` `ios.useFrameworks` alternative — considered, rejected
+
+Setting `expo-build-properties` → `ios.useFrameworks: "static"` (or `"dynamic"`) is the OTHER common cure (dynamic frameworks sidestep the static-library Swift-pod rule entirely). **Rejected** because:
+1. It is a **global build-mode change** to the whole pod graph — far broader than the 3-pod targeted directive; it would interact with `withIosFmtConsteval.js` (fmt/consteval) and the New-Architecture/Hermes setup in ways that demand their own cloud-build validation cycles (the exact slow whack-a-mole the dispatch wants to avoid).
+2. `useFrameworks: "dynamic"` changes binary packaging (dynamic frameworks shipped in the app bundle) and can conflict with static-only pods → new failure classes.
+3. The project is intentionally on **static library** build type today; the modular-headers directive keeps that, changing only header-import behavior at compile time — **zero runtime/binary behavior change**. The narrowest correct fix wins.
+
+---
+
+## 2. Scope & non-goals
+
+**In scope**
+- New file `mingla-business/plugins/withGooglePodsModularHeaders.js` (config plugin).
+- One-line registration in `mingla-business/app.config.ts` `plugins` array.
+- A strict-grep regression gate (test file) asserting the plugin + directives persist.
+
+**Non-goals (explicitly OUT)**
+- `app-mobile/` (consumer) — also uses google-signin and will hit the same break, but is OUT of this ORCH per dispatch (DISC-1129-A; orchestrator registers separately).
+- Any `use_modular_headers!` global directive.
+- `expo-build-properties` / `useFrameworks` changes (§1b).
+- Pinning native pod versions / committing a Podfile.lock (DISC-1129-B; separate decision).
+- Any app source, UI, DB, RLS, migration, or edge-function change.
+- Android (uses Gradle, unaffected).
+
+**Assumptions**
+- The CNG-generated Expo SDK 54 Podfile contains a single app `target` block with a `use_expo_modules!` call inside it (canonical Expo template). The plugin anchors on `use_expo_modules!`; if absent it falls back to anchoring on `target '<name>' do` (see §4 plugin code's two-anchor strategy) and, if neither is found, leaves the Podfile untouched (same fail-soft contract as `withIosFmtConsteval.js`).
+- `@expo/config-plugins` resolves (transitive via `expo`) — verified (F-6).
+
+---
+
+## 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behavior demanded | Files touched here | Parity |
+|---|---|---|---|---|---|
+| 1 | Consumer iOS (`app-mobile/`) | **NO** | n/a | none | Manual — separate app; DISC-1129-A flags a parallel fix. One-phrase reason: different app, out of dispatch scope. |
+| 2 | Consumer Android | NO | n/a | none | One-phrase reason: no CocoaPods. |
+| 3 | Buyer/anon Web | NO | n/a | none | One-phrase reason: web export has no pods phase. |
+| 4 | **Business iOS** | **YES** | iOS EAS builds (dev/preview/production) clear Install pods and produce an artifact again | `mingla-business/plugins/withGooglePodsModularHeaders.js`, `mingla-business/app.config.ts`, regression test | Automatic — single CNG Podfile path for all iOS profiles |
+| 5 | Business Android | NO | n/a (already builds) | none | One-phrase reason: Gradle, not CocoaPods. |
+| 6 | Admin Web | NO | n/a | none | One-phrase reason: not RN/iOS. |
+| 7 | Business Web preview | NO | n/a | none | One-phrase reason: web export, no pods. |
+
+---
+
+## 4. Layered specification
+
+Only the **build-config** layer is touched. No DB / edge / service / hook / component / realtime layers apply.
+
+### 4.1 Config plugin (NEW) — `mingla-business/plugins/withGooglePodsModularHeaders.js`
+
+**Contract:**
+- CommonJS module exporting a single config-plugin function (matches `withIosFmtConsteval.js`).
+- Uses `withDangerousMod(config, ["ios", (cfg) => {...}])`.
+- Reads `path.join(cfg.modRequest.platformProjectRoot, "Podfile")`; if it doesn't exist → return `cfg` untouched.
+- **Idempotent:** if the marker string is already present, return untouched.
+- Injects three `pod ... :modular_headers => true` lines **inside the target block, BEFORE pod resolution** — i.e. immediately ABOVE the `use_expo_modules!` line (primary anchor). If `use_expo_modules!` is absent, anchor immediately AFTER the `target '<name>' do` line (secondary). If neither anchor is found → leave the Podfile untouched (fail-soft; surfaces as the original pod error, never a corrupt Podfile).
+- **Why before `use_expo_modules!` / not in `post_install`:** `:modular_headers` is a **pod-declaration-time** directive consumed during dependency resolution; `post_install` runs AFTER resolution and is too late (that's why `withIosFmtConsteval.js` legitimately uses post_install for a build-setting, but THIS fix must precede resolution).
+
+**Reference implementation (illustrative — implementor owns final form; must satisfy the contract + tests):**
+
+```js
+const { withDangerousMod } = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+// ORCH-1129: GoogleSignIn ~> 9.0 → AppCheckCore (Swift pod) imports GoogleUtilities
+// + RecaptchaInterop, which don't define module maps. Under static libraries +
+// New Architecture, CocoaPods refuses to integrate the Swift pod and aborts
+// `pod install`. Force targeted modular headers for the three Google pods so the
+// module maps are generated. Sibling of withIosFmtConsteval.js. CNG-safe (re-runs
+// on every prebuild). Compile-time header-import change only; no runtime impact.
+
+const MARKER = "ORCH-1129 modular headers";
+const MODULAR_PODS = ["GoogleUtilities", "RecaptchaInterop", "AppCheckCore"];
+
+const BLOCK =
+  `  # ${MARKER}: GoogleSignIn 9.x → AppCheckCore (Swift) needs module maps for\n` +
+  `  # these non-modular deps under static libraries. Injected by\n` +
+  `  # plugins/withGooglePodsModularHeaders.js.\n` +
+  MODULAR_PODS.map((p) => `  pod '${p}', :modular_headers => true`).join("\n") +
+  "\n";
+
+const withGooglePodsModularHeaders = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    (cfg) => {
+      const podfile = path.join(cfg.modRequest.platformProjectRoot, "Podfile");
+      if (!fs.existsSync(podfile)) return cfg;
+      let contents = fs.readFileSync(podfile, "utf8");
+      if (contents.includes(MARKER)) return cfg; // idempotent
+
+      const expoAnchor = "use_expo_modules!";
+      const expoIdx = contents.indexOf(expoAnchor);
+      if (expoIdx !== -1) {
+        const lineStart = contents.lastIndexOf("\n", expoIdx) + 1;
+        contents = contents.slice(0, lineStart) + BLOCK + contents.slice(lineStart);
+      } else {
+        const m = contents.match(/^target ['"][^'"]+['"] do[^\n]*\n/m);
+        if (!m) return cfg; // no anchor → leave untouched (fail-soft)
+        const insertAt = m.index + m[0].length;
+        contents = contents.slice(0, insertAt) + BLOCK + contents.slice(insertAt);
+      }
+      fs.writeFileSync(podfile, contents);
+      return cfg;
+    },
+  ]);
+
+module.exports = withGooglePodsModularHeaders;
+```
+
+### 4.2 Registration — `mingla-business/app.config.ts`
+
+Add `"./plugins/withGooglePodsModularHeaders"` to the `plugins` array. Place it **adjacent to the other two custom plugins** (after `"./plugins/withIosFmtConsteval"`), so all three Podfile-affecting plugins are grouped:
+
+```ts
+      "./plugins/withAndroidBracketSafeCmake",
+      "./plugins/withIosFmtConsteval",
+      "./plugins/withGooglePodsModularHeaders", // ORCH-1129
+```
+(Ordering among the iOS plugins is safe: this plugin injects pod declarations before resolution; `withIosFmtConsteval` edits post_install build settings — they touch disjoint Podfile regions and are each idempotent/marker-guarded.)
+
+---
+
+## 5. Success criteria
+
+- **SC-1 (plugin exists & registered):** `mingla-business/plugins/withGooglePodsModularHeaders.js` exists, exports a function, and `app.config.ts` `plugins` includes `"./plugins/withGooglePodsModularHeaders"`.
+- **SC-2 (Podfile injection — local proof):** running `npx expo prebuild -p ios --no-install` (or inspecting the generated Podfile after prebuild) in a throwaway dir yields a Podfile containing all three `pod '<name>', :modular_headers => true` lines INSIDE the target block, ABOVE `use_expo_modules!`. (Local prebuild succeeds — INVESTIGATE Q3 — so this is verifiable locally even though the BUG isn't.)
+- **SC-3 (idempotent):** applying the plugin twice (re-running prebuild) does not duplicate the block (marker guard).
+- **SC-4 (VERIFICATION GATE — cloud, business-iOS):** a fresh **EAS iOS `development`-profile cloud build** (`eas build -p ios --profile development`) **clears the Install pods phase** — i.e. `pod install` exits 0 and the build proceeds past pods (artifact produced, or fails only LATER for an unrelated reason). **This is the load-bearing gate: because local cannot reproduce the failure (F-4), only a GREEN cloud pods phase proves the fix.** Success signal = the build log no longer contains `cannot yet be integrated as static libraries` / `pod install exited with non-zero code: 1`, and reaches the compile/archive phase.
+- **SC-5 (no regression elsewhere):** the change touches only the two files + the test; `git diff --stat` shows no app-source/DB/edge changes.
+
+---
+
+## 6. Invariants
+
+**Preserved:** none broken — greenfield (F-7). The existing `withIosFmtConsteval` post_install injection is untouched (disjoint Podfile region).
+
+**NEW (DRAFT — orchestrator flips ACTIVE on CLOSE):**
+- `I-PROPOSED-IOS-GOOGLE-PODS-MODULAR-HEADERS` — `mingla-business` MUST carry the `withGooglePodsModularHeaders` config plugin registered in `app.config.ts`, and that plugin MUST emit `:modular_headers => true` for `GoogleUtilities`, `RecaptchaInterop`, and `AppCheckCore`. Verified by the §9 strict-grep gate. **Why:** the break is invisible locally and re-emerges on any fresh cloud build; without the gate a future build-config edit could silently drop the plugin and re-break all iOS builds team-wide.
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|---|---|---|---|---|
+| T-1 (happy) | plugin registered | read `app.config.ts` plugins array | contains `"./plugins/withGooglePodsModularHeaders"` | build-config (grep gate) |
+| T-2 (happy) | plugin emits all 3 directives | read plugin source | contains `:modular_headers => true` for each of `GoogleUtilities`, `RecaptchaInterop`, `AppCheckCore` | build-config (grep gate) |
+| T-3 (behavior) | plugin injects into a Podfile | a fixture Podfile string with `target 'mingla-business' do\n  use_expo_modules!\n ... end`; run the exported plugin's mod fn against it | resulting Podfile has the 3 pod lines ABOVE `use_expo_modules!`, inside the target | unit (node) |
+| T-4 (idempotent) | apply twice | run the mod fn twice on the fixture | marker + 3 lines appear exactly once | unit (node) |
+| T-5 (fail-soft) | no anchor | a Podfile fixture with neither `use_expo_modules!` nor a `target ... do` | Podfile returned unchanged (no throw) | unit (node) |
+| T-6 (cloud gate) | real EAS build | `eas build -p ios --profile development` | Install pods phase exits 0; log lacks the modular-headers error | cloud (manual, owned by tester/Seth) |
+
+T-3/T-4/T-5 can run by requiring the plugin and invoking the inner `withDangerousMod` callback with a mocked `cfg` whose `modRequest.platformProjectRoot` points at a temp dir containing a fixture `Podfile` — mirror how Expo dangerous-mod plugins are unit-tested. (If the repo has no existing dangerous-mod unit test harness, T-1/T-2 strict-grep + T-6 cloud gate are the minimum bar; T-3..T-5 are strongly recommended and cheap.)
+
+---
+
+## 8. Implementation order
+
+1. Create `mingla-business/plugins/withGooglePodsModularHeaders.js` per §4.1.
+2. Register it in `mingla-business/app.config.ts` per §4.2.
+3. Add the regression test/gate per §9 (and T-3..T-5 unit tests if a harness exists).
+4. Local proof (SC-2/SC-3): `npx expo prebuild -p ios --no-install` in a scratch checkout (NOT the symlinked worktree node_modules path if it risks cache poisoning — use a clean dir), inspect the generated `ios/Podfile` for the 3 lines above `use_expo_modules!`.
+5. **Hand to tester/Seth for the cloud gate (SC-4 / T-6):** `eas build -p ios --profile development` must clear Install pods.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+**Structural safeguard:** a strict-grep test (jest or the repo's existing grep-gate harness, sibling of the `i-giphy-key-wired` gate referenced in COMMS-0028) named e.g. `iosGooglePodsModularHeaders.gate.test.ts` that asserts:
+1. `mingla-business/app.config.ts` contains `"./plugins/withGooglePodsModularHeaders"`.
+2. `mingla-business/plugins/withGooglePodsModularHeaders.js` exists and contains `:modular_headers => true` AND each of the literal pod names `GoogleUtilities`, `RecaptchaInterop`, `AppCheckCore`.
+
+**Fails-on-revert proof (REQUIRED):** deleting the plugin registration line from `app.config.ts` (or the directives from the plugin) MUST make the gate FAIL; restoring it MUST make it PASS. The implementor records both states in the implementation report.
+
+**Protective comment:** the plugin's header comment (shown in §4.1) explains WHY (the AppCheckCore Swift-pod static-library break) so a future editor doesn't "clean it up."
+
+---
+
+## 10. Open questions
+
+- **OQ-1 (anchor confirmation):** the plugin anchors on `use_expo_modules!` (primary) with a `target ... do` fallback. The implementor should confirm against the actually-generated SDK 54 Podfile at step 4; the dual-anchor + fail-soft design means even an unexpected layout cannot corrupt the Podfile, but the primary anchor should be confirmed present so the injection lands inside the target. No blocker — just a confirm-at-implement.
+- **OQ-2 (cloud gate ownership):** SC-4/T-6 burns ~35 min of EAS minutes. Confirm with Seth which profile to spend it on — recommended `development` (cheapest, dev-client, and it's what ORCH-1119 needs next). No code dependency.
+
+(Neither OQ blocks IMPLEMENT; both are confirm-at-build.)
+
+## 11. Downstream routing
+
+**Next = mingla-implementor.** Build per §4/§8 in the worktree `~/Desktop/mingla-orchs/ORCH-1129-[ios-build-modular-headers]` (branch `ORCH-1129-ios-build-modular-headers`); rebase on origin/main first. Produce the plugin + registration + gate, prove SC-2/SC-3 locally + fails-on-revert (§9), write the implementation report. **Then = mingla-tester** for SC-4/T-6 (the GREEN EAS iOS `development` cloud build clearing Install pods — the load-bearing gate; local cannot prove it). **Then = orchestrator CLOSE** — merge to **main** (unblocks team-wide iOS builds + ORCH-1119's device build; reference COMMS-0030 and resolve it on close), flip `I-PROPOSED-IOS-GOOGLE-PODS-MODULAR-HEADERS` ACTIVE, and register the `app-mobile/` parallel fix (DISC-1129-A).
+
+---
+
+## Scoped allowlist + DO-NOT-TOUCH
+
+**ALLOWLIST (implementor may change ONLY these):**
+- `mingla-business/plugins/withGooglePodsModularHeaders.js` (NEW)
+- `mingla-business/app.config.ts` (add one plugins-array line + the grouped comment)
+- the new regression-gate test file (+ optional T-3..T-5 unit test file) under `mingla-business/`'s test location
+
+**DO-NOT-TOUCH:**
+- `mingla-business/plugins/withIosFmtConsteval.js`, `withAndroidBracketSafeCmake.js`, `withAdiRegistration.js` (disjoint; leave intact)
+- `package.json` / `package-lock.json` (no dependency change — `@expo/config-plugins` already resolves transitively)
+- `eas.json`, any app source, `app-mobile/`, any DB/edge/migration
+- No `use_modular_headers!` global, no `expo-build-properties`/`useFrameworks` edits
+
+Touching anything outside the allowlist → STOP and request a SPEC amendment (`SPEC_AMENDMENT_ORCH-1129_*.md`); never silently widen.

--- a/mingla-business/app.config.ts
+++ b/mingla-business/app.config.ts
@@ -108,6 +108,12 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       // format-string checking. Inject FMT_USE_CONSTEVAL=0 into the generated
       // Podfile post_install so iOS dev/device builds compile on this toolchain.
       "./plugins/withIosFmtConsteval",
+      // ORCH-1129: GoogleSignIn 9.x → AppCheckCore (Swift) imports GoogleUtilities
+      // + RecaptchaInterop, which lack module maps. Under static libraries + New
+      // Architecture, CocoaPods aborts `pod install` (COMMS-0030). Inject targeted
+      // `:modular_headers => true` for those 3 pods before resolution so every iOS
+      // EAS build clears the Install pods phase. Compile-time only; no runtime change.
+      "./plugins/withGooglePodsModularHeaders",
     ],
     extra: {
       ...config.extra,

--- a/mingla-business/plugins/withGooglePodsModularHeaders.js
+++ b/mingla-business/plugins/withGooglePodsModularHeaders.js
@@ -1,0 +1,89 @@
+const { withDangerousMod } = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+// Copyright Mingla. ORCH-1129.
+//
+// The Google Sign-In pod chain
+// (@react-native-google-signin/google-signin → GoogleSignIn ~> 9.0 →
+// AppCheckCore ~> 11.x) pulls in the Swift pod `AppCheckCore`, which imports
+// `GoogleUtilities` and `RecaptchaInterop` — two ObjC pods that don't define
+// module maps. Under this project's static-libraries + New-Architecture config,
+// CocoaPods refuses to integrate a Swift pod whose deps lack module maps and
+// aborts `pod install`:
+//   [!] The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and
+//   `RecaptchaInterop`, which do not define modules ... set
+//   `use_modular_headers!` ... `pod install exited with non-zero code: 1`
+// Every fresh EAS iOS build since ~2026-05-30 died at the Install pods phase
+// because of this (COMMS-0030). Forcing TARGETED `:modular_headers => true` for
+// exactly these three pods generates the module maps CocoaPods needs, keeping
+// the rest of the graph as static libraries (NOT a global `use_modular_headers!`
+// — that would force module maps on every pod and risk new conflicts).
+//
+// This is a compile-time header-import change only; no runtime/binary behavior
+// change. AppCheckCore is included defensively so the directive survives any
+// future re-classification once its leaves are modularized.
+//
+// Because `mingla-business/ios` is gitignored (Expo CNG), this must live as a
+// config plugin so it is re-applied on every `expo prebuild` / cloud build
+// rather than as a hand-edit of the generated Podfile. Sibling of
+// `withIosFmtConsteval.js`. Do NOT remove without re-proving a GREEN EAS iOS
+// build (see SPEC_ORCH-1129).
+
+const MARKER = "ORCH-1129 modular headers";
+const MODULAR_PODS = ["GoogleUtilities", "RecaptchaInterop", "AppCheckCore"];
+
+const BLOCK =
+  `  # ${MARKER}: GoogleSignIn 9.x → AppCheckCore (Swift) needs module maps for\n` +
+  `  # these non-modular deps under static libraries. Injected by\n` +
+  `  # plugins/withGooglePodsModularHeaders.js.\n` +
+  MODULAR_PODS.map((p) => `  pod '${p}', :modular_headers => true`).join("\n") +
+  "\n";
+
+const withGooglePodsModularHeaders = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    (cfg) => {
+      const podfilePath = path.join(
+        cfg.modRequest.platformProjectRoot,
+        "Podfile",
+      );
+      if (!fs.existsSync(podfilePath)) {
+        return cfg;
+      }
+      let contents = fs.readFileSync(podfilePath, "utf8");
+
+      // Idempotent: skip if already applied.
+      if (contents.includes(MARKER)) {
+        return cfg;
+      }
+
+      // `:modular_headers` is a pod-declaration-time directive consumed during
+      // dependency resolution, so it must precede resolution. Inject the block
+      // immediately ABOVE the `use_expo_modules!` line (primary anchor — inside
+      // the app target block, before pods resolve).
+      const expoAnchor = "use_expo_modules!";
+      const expoIdx = contents.indexOf(expoAnchor);
+      if (expoIdx !== -1) {
+        const lineStart = contents.lastIndexOf("\n", expoIdx) + 1;
+        contents =
+          contents.slice(0, lineStart) + BLOCK + contents.slice(lineStart);
+      } else {
+        // Secondary anchor: immediately AFTER the `target '<name>' do` line.
+        const m = contents.match(/^target ['"][^'"]+['"] do[^\n]*\n/m);
+        if (!m) {
+          // No anchor found — leave the Podfile untouched (fail-soft). Surfaces
+          // as the original pod error, never a corrupt Podfile.
+          return cfg;
+        }
+        const insertAt = m.index + m[0].length;
+        contents =
+          contents.slice(0, insertAt) + BLOCK + contents.slice(insertAt);
+      }
+
+      fs.writeFileSync(podfilePath, contents);
+      return cfg;
+    },
+  ]);
+
+module.exports = withGooglePodsModularHeaders;

--- a/mingla-business/src/__tests__/iosGooglePodsModularHeaders.gate.test.ts
+++ b/mingla-business/src/__tests__/iosGooglePodsModularHeaders.gate.test.ts
@@ -1,0 +1,186 @@
+/**
+ * ORCH-1129 [iOS build modular headers] — IMPLEMENTOR happy-path regression gate.
+ *
+ * The team-wide iOS build break (COMMS-0030): GoogleSignIn 9.x → AppCheckCore
+ * (Swift pod) imports GoogleUtilities + RecaptchaInterop, which lack module maps;
+ * under static libraries + New Architecture CocoaPods aborts `pod install`. The
+ * fix is a config plugin (`withGooglePodsModularHeaders.js`) that injects targeted
+ * `:modular_headers => true` for those three pods into the CNG Podfile, plus its
+ * registration in `app.config.ts`.
+ *
+ * SC-4 (a GREEN EAS iOS cloud build clearing Install pods) is NOT provable here —
+ * local prebuild succeeds, only the cloud build reproduces the bug. That gate is
+ * owned by the tester/Seth. This file is the STRUCTURAL safeguard (§9): it locks
+ * the plugin + directives + registration in source so a future build-config edit
+ * can't silently drop them and re-break all iOS builds team-wide.
+ *
+ * Fails-on-revert: deleting the plugin registration from app.config.ts, or the
+ * `:modular_headers => true` directives / pod names from the plugin, makes the
+ * relevant assertions below FAIL.
+ *
+ * [TEST-MOD-APPROVED ORCH-1129]
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const BUSINESS_ROOT = path.resolve(__dirname, "..", "..");
+const PLUGIN_PATH = path.join(
+  BUSINESS_ROOT,
+  "plugins",
+  "withGooglePodsModularHeaders.js",
+);
+const APP_CONFIG_PATH = path.join(BUSINESS_ROOT, "app.config.ts");
+
+const REQUIRED_PODS = ["GoogleUtilities", "RecaptchaInterop", "AppCheckCore"];
+
+describe("ORCH-1129 iOS Google-pods modular-headers gate", () => {
+  // ---- T-1: plugin registered in app.config.ts -----------------------------
+  test("T-1 — app.config.ts registers ./plugins/withGooglePodsModularHeaders", () => {
+    const appConfig = fs.readFileSync(APP_CONFIG_PATH, "utf8");
+    expect(appConfig).toContain('"./plugins/withGooglePodsModularHeaders"');
+  });
+
+  // ---- T-2: plugin file emits all 3 :modular_headers directives ------------
+  // The plugin builds the directive lines via template interpolation
+  // (`pod '${p}', :modular_headers => true`), so the source carries the
+  // `:modular_headers => true` fragment + each pod NAME, and the template
+  // shape — not the fully-expanded literal (that's asserted on generated
+  // output in T-3). Assert all three present so a future edit that drops the
+  // directive or a pod name fails the gate.
+  test("T-2 — plugin file exists and carries :modular_headers => true for all 3 pods", () => {
+    expect(fs.existsSync(PLUGIN_PATH)).toBe(true);
+    const plugin = fs.readFileSync(PLUGIN_PATH, "utf8");
+    expect(plugin).toContain(":modular_headers => true");
+    expect(plugin).toContain("pod '${p}', :modular_headers => true");
+    for (const pod of REQUIRED_PODS) {
+      expect(plugin).toContain(`"${pod}"`);
+    }
+  });
+
+  // ---- Behavior (T-3..T-5): drive the real exported plugin against fixtures -
+  // Build a CNG-shaped fixture Podfile in a temp dir, run the plugin's inner
+  // withDangerousMod callback against it, and assert the resulting file. This
+  // exercises the real injection/idempotency/fail-soft logic, not just strings.
+
+  type DangerousMod = (
+    config: unknown,
+    mod: [string, (cfg: { modRequest: { platformProjectRoot: string } }) => unknown],
+  ) => unknown;
+
+  function loadPluginCallback(): (cfg: {
+    modRequest: { platformProjectRoot: string };
+  }) => unknown {
+    let captured:
+      | ((cfg: { modRequest: { platformProjectRoot: string } }) => unknown)
+      | undefined;
+    jest.resetModules();
+    jest.doMock("@expo/config-plugins", () => ({
+      withDangerousMod: ((_config, [, cb]) => {
+        captured = cb;
+        return _config;
+      }) as DangerousMod,
+    }));
+    // Dynamic require AFTER jest.doMock so the plugin binds the mocked
+    // withDangerousMod (capturing its inner callback). Top-level import would
+    // bind the real module before the mock is installed.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const plugin = require("../../plugins/withGooglePodsModularHeaders.js");
+    plugin({});
+    jest.dontMock("@expo/config-plugins");
+    if (!captured) {
+      throw new Error("plugin did not register a withDangerousMod callback");
+    }
+    return captured;
+  }
+
+  function withTempPodfile(
+    contents: string,
+    run: (dir: string, podfilePath: string) => void,
+  ): void {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "orch1129-"),
+    );
+    const podfilePath = path.join(dir, "Podfile");
+    try {
+      fs.writeFileSync(podfilePath, contents);
+      run(dir, podfilePath);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  const CNG_PODFILE = [
+    "require File.join(File.dirname(`node --print \"require.resolve('expo/package.json')\"`), 'scripts/autolinking')",
+    "platform :ios, '15.1'",
+    "",
+    "target 'minglabusiness' do",
+    "  use_expo_modules!",
+    "  config = use_native_modules!",
+    "  use_react_native!(:path => config[:reactNativePath])",
+    "  post_install do |installer|",
+    "    react_native_post_install(",
+    "      installer,",
+    "    )",
+    "  end",
+    "end",
+    "",
+  ].join("\n");
+
+  test("T-3 — injects the 3 pods ABOVE use_expo_modules!, inside the target", () => {
+    const cb = loadPluginCallback();
+    withTempPodfile(CNG_PODFILE, (dir, podfilePath) => {
+      cb({ modRequest: { platformProjectRoot: dir } });
+      const out = fs.readFileSync(podfilePath, "utf8");
+      for (const pod of REQUIRED_PODS) {
+        expect(out).toContain(`pod '${pod}', :modular_headers => true`);
+      }
+      // Each directive lands above use_expo_modules! ...
+      const useExpoIdx = out.indexOf("use_expo_modules!");
+      for (const pod of REQUIRED_PODS) {
+        expect(out.indexOf(`pod '${pod}'`)).toBeLessThan(useExpoIdx);
+      }
+      // ... and below the target line (i.e. inside the target block).
+      const targetIdx = out.indexOf("target 'minglabusiness' do");
+      expect(targetIdx).toBeGreaterThanOrEqual(0);
+      expect(out.indexOf("pod 'GoogleUtilities'")).toBeGreaterThan(targetIdx);
+    });
+  });
+
+  test("T-4 — idempotent: applying twice does not duplicate the block", () => {
+    const cb = loadPluginCallback();
+    withTempPodfile(CNG_PODFILE, (dir, podfilePath) => {
+      cb({ modRequest: { platformProjectRoot: dir } });
+      cb({ modRequest: { platformProjectRoot: dir } });
+      const out = fs.readFileSync(podfilePath, "utf8");
+      const markerCount = out.split("ORCH-1129 modular headers").length - 1;
+      expect(markerCount).toBe(1);
+      const podCount =
+        out.split("pod 'GoogleUtilities', :modular_headers => true").length - 1;
+      expect(podCount).toBe(1);
+    });
+  });
+
+  test("T-5 — fail-soft: no anchor → Podfile unchanged, no throw", () => {
+    const cb = loadPluginCallback();
+    const noAnchor = "platform :ios, '15.1'\n# no target, no use_expo_modules\n";
+    withTempPodfile(noAnchor, (dir, podfilePath) => {
+      expect(() => cb({ modRequest: { platformProjectRoot: dir } })).not.toThrow();
+      expect(fs.readFileSync(podfilePath, "utf8")).toBe(noAnchor);
+    });
+  });
+
+  test("T-5b — missing Podfile → no throw, returns cfg", () => {
+    const cb = loadPluginCallback();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "orch1129-"));
+    try {
+      expect(() =>
+        cb({ modRequest: { platformProjectRoot: dir } }),
+      ).not.toThrow();
+      expect(fs.existsSync(path.join(dir, "Podfile"))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## ORCH-1129 — mingla-business iOS build broken team-wide (CocoaPods modular headers)

Fixes the iOS build break present since ~2026-05-30 (COMMS-0030). Every fresh `eas build -p ios` died at **Install pods**: the Swift pod `AppCheckCore` (via `@react-native-google-signin/google-signin` → GoogleSignIn) imports `GoogleUtilities`/`RecaptchaInterop`, which lack module maps, and CocoaPods refuses to integrate it under static libs + New Architecture.

**Root cause:** CNG project has no committed `Podfile.lock`, so EAS resolves pods fresh each build; Google published `AppCheckCore 11.3.0` which now requires modular headers. Upstream pod publish — not a repo change — which is why it hit every branch.

**Fix:** targeted config plugin `withGooglePodsModularHeaders.js` injecting `:modular_headers => true` for `GoogleUtilities`, `RecaptchaInterop`, `AppCheckCore` before `use_expo_modules!`. Registered in `app.config.ts`. Strict-grep regression gate added.

**Verified:** GREEN EAS iOS build `9fe3e621` finished with an `.ipa` (cleared Install pods + compiled + archived) — the first green mingla-business iOS build since 2026-05-30. Local prebuild proves idempotent Podfile injection; gate 6/6 fails-on-revert at `34862397`.

Build-config only. Follow-up DISC-1129-A: app-mobile needs the same plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)