### PR TITLE
ORCH-1132: checkout cover full-frame (no crop) + Sound-pill edge clearance (round 2) [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md
@@ -1,0 +1,188 @@
+# IMPLEMENTATION — ORCH-1132 — Checkout cover full-frame (no crop) + public Sound-pill edge clearance (round 2)
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1132-[cover-fullframe-sound-inset]/`
+**Branch:** `ORCH-1132-cover-fullframe-sound-inset` (rebased on origin/main; 0 behind)
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md`
+**Implementor:** mingla-implementor (Claude)
+**Commit:** `b4c77aa819241a922a11159b2afb9ef7ff05bbb0` (implementation + tests)
+**Status:** implemented and verified (web repro + source-introspection); native expo-video `contain` path = suspected pending the iOS dev build (tester-owned, per spec §11)
+
+---
+
+## 1. Summary (plain English)
+
+Two value/structure changes superseding ORCH-1131's misses, no new product surfaces:
+
+1. **Checkout cover = full frame, no crop.** All three checkout mini-cards (event / trip /
+   experience) now render the WHOLE cover frame uncropped. Each screen gained `coverAspect` state
+   (init `0.75`, clamp `0.6..1.91`), wires the `onAspectRatio` callback, passes
+   `videoContentFit="contain"`, drives the box via an inline `aspectRatio`, and DROPPED the fixed
+   `miniCover.height:120` that sliced a 360×640 portrait cover to a head-cut-off mid-frame strip.
+   This reuses the exact adaptive mechanism the public event hero already uses — no new render path.
+2. **Sound pill clearly inset.** The shared `EventCoverMedia` `audioControlBottomRight.right` moved
+   `16 → 24` (`spacing.lg`) for visible right-edge breathing room. `bottom:22` (ORCH-1128 cover-seam
+   clearance) preserved verbatim.
+
+`EventCoverMedia` defaults are unchanged (`videoContentFit` default still `"cover"`, `onAspectRatio`
+default still `undefined`); no consumer other than the three checkout covers + the shared pill
+changes behaviour.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence / commit |
+|----|-----------|--------|-------------------|
+| SC-1-event | Event checkout: portrait video cover shows whole frame, head not cut | ✓ | `app/checkout/[eventId]/index.tsx` (b4c77aa81); evidence `checkout_cover_before_after_BUILT.png` |
+| SC-1-trip | Trip checkout: same | ✓ | `app/checkout-trip/[tripEventId]/index.tsx` (b4c77aa81) — byte-identical mechanism |
+| SC-1-experience | Experience checkout: same | ✓ | `app/checkout-experience/[experienceEventId]/index.tsx` (b4c77aa81) — byte-identical mechanism |
+| SC-2 | Landscape (≈1.78) shows full frame; box bounded by 1.91 clamp (not a sliver) | ✓ (source) | clamp upper `1.91` + `contain` in all three; web-repro logic confirmed |
+| SC-3 | Square (1.0) box ≈square, full frame | ✓ (source) | 1.0 is in-range of `0.6..1.91`; adaptive box = exact fit |
+| SC-4 | `miniCover` declares no fixed `height:` in all three | ✓ | jest happy-path test asserts `extractNumericStyleValue(body,'height') === null` across all three routes |
+| SC-5 | Public Sound pill `right:24`, `bottom:22` unchanged | ✓ | `EventCoverMedia.tsx:616` (b4c77aa81); evidence `public_hero_soundpill_16_vs_24_BUILT.png` |
+| SC-6 | Public hero `heroBox` + deck card untouched | ✓ | DO-NOT-TOUCH respected (no edit to `PublicEventPage.tsx` / `SwipeableCards.tsx`); adversarial test asserts `heroBox` has no fixed height |
+| SC-7 | `EventCoverMedia` `videoContentFit` default `"cover"`, `onAspectRatio` default `undefined`; no other consumer changes | ✓ | defaults untouched (line 44/50); only pill style + 3 checkout call-sites changed |
+
+---
+
+## 3. Files changed
+
+| File | Lines Δ (approx) | Change |
+|------|------------------|--------|
+| `packages/event-rendering/EventCoverMedia.tsx` | +2 / -7 (comment rewrite) | `audioControlBottomRight.right` 16 → 24 + ORCH-1132 comment |
+| `mingla-business/app/checkout/[eventId]/index.tsx` | +13 / -8 | `coverAspect` state + clamp; wire `onAspectRatio` + `videoContentFit="contain"` + inline `aspectRatio`; remove `miniCover.height:120` |
+| `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | +14 / -8 | identical change + `useState` import |
+| `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | +14 / -8 | identical change + `useState` import |
+| `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts` | +40 / -19 | round-2 assertions (no fixed height + `videoContentFit="contain"` + `onAspectRatio` across all three; pill right=24) `[TEST-MOD-APPROVED ORCH-1132]` |
+| `mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts` | +6 / -3 | bottomRight adversarial `right === [24]` (T-8/T-6 kept verbatim) `[TEST-MOD-APPROVED ORCH-1132]` |
+
+No file outside the spec §9 allowlist was touched.
+
+---
+
+## 4. Data-model changes applied
+
+None. Component/style layer only. No DB / migration / RLS.
+
+## 5. Edge functions touched
+
+None.
+
+---
+
+## 6. Regression tests added / updated
+
+**Paths:**
+- `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts` (happy-path, updated to round-2)
+- `mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts` (adversarial sibling-non-regression, bottomRight assertion updated)
+
+Both modify ORCH-1131 assertions under the same lineage → the commit body carries
+`[TEST-MOD-APPROVED ORCH-1132]` (satisfies CI `tests-append-only.yml`).
+
+**Passing run (restored fix):**
+```
+PASS __tests__/orch1131CoverCropSoundInset.test.ts
+PASS __tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
+Tests:       12 passed, 12 total
+```
+
+**fails-on-revert verified at `b4c77aa819241a922a11159b2afb9ef7ff05bbb0`.** True LINE DELETION of the
+fix (not comment-out): reverted pill `right:24→16`, dropped `videoContentFit="contain"` +
+`onAspectRatio` from the event checkout call, and re-added `height:120` to `miniCover`. Re-run:
+```
+FAIL __tests__/orch1131CoverCropSoundInset.test.ts
+  - miniCover.height: expect(...).toBeNull() → Received: 120
+  - EventCoverMedia: expect(call).toMatch(/videoContentFit="contain"/) → not found
+  - bottomRight.right: expect(...).toBe(24) → Received: 16
+FAIL __tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
+  - bottomRight.right: expect(...).toEqual([24]) → Received: [16]
+Tests:       4 failed, 8 passed, 12 total
+```
+Fix restored via `git checkout --`; re-run → 12/12 PASS. Both tests appear in
+`git diff origin/main...HEAD --name-only` on the closing branch (shipped in the same commit as the fix).
+
+---
+
+## 7. Old → New receipts
+
+### `packages/event-rendering/EventCoverMedia.tsx`
+- **Before:** `audioControlBottomRight.right = 16` (ORCH-1131 aligned to floating-chrome column; read cramped).
+- **Now:** `right = 24` (`spacing.lg`) — +8px, a perceptible 50% inset increase; one deliberate step past the chrome column. `bottom:22` preserved.
+- **Why:** SC-5 / spec §4.3. Shared style → intentionally moves the bottomRight pill for every consumer (expandedCard ImageGallery + authoring previews).
+- **Lines:** ~9 (comment + value).
+
+### `mingla-business/app/checkout/[eventId]/index.tsx` (and trip / experience, identical)
+- **Before:** `miniCover` had fixed `height:120` + `EventCoverMedia` rendered default `videoContentFit:"cover"` → a 342×120 mid-frame strip of a 360×640 portrait cover; head cropped off.
+- **Now:** `coverAspect` state (init 0.75) + `clampedCoverAspect = Math.min(Math.max(coverAspect,0.6),1.91)`; `EventCoverMedia` gets `onAspectRatio={setCoverAspect}` + `videoContentFit="contain"`; `style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}`; `miniCover` no longer declares `height:`.
+- **Why:** SC-1 / SC-4 / spec §4.2. Reuses the public hero's adaptive box mechanism, paired with `contain` so nothing is ever cropped; thin clamp-boundary letterbox bars are near-invisible on the `#0c0e12` card.
+- **Lines:** ~13–14 each.
+
+---
+
+## 8. Cross-surface impact
+
+| # | Surface | Affected | What changes | Parity |
+|---|---------|----------|--------------|--------|
+| 1 | Consumer iOS (`app-mobile/`) | Pill only | bottomRight pill on expandedCard ImageGallery +8px inset; cover-sizing change does NOT reach the deck (fixed `cover`, `showAudioControl={false}`) | Automatic (shared style) |
+| 2 | Consumer Android | Pill only | Same as iOS | Automatic |
+| 3 | Buyer/anon Web | YES (both) | Checkout mini-cards full-frame uncropped; public Sound pill clears edge by 24 | Manual (3 checkout files) + shared pill |
+| 4 | Business iOS | YES (cover) + pill | Checkout summary full-frame cover; authoring preview pills +8px | Manual + automatic |
+| 5 | Business Android | Same as Business iOS | Same | Manual + automatic |
+| 6 | Admin Web | NO | Admin does not render `EventCoverMedia` checkout cards | n/a |
+| 7 | Business Web preview (adjacent) | Pill | Authoring cover-preview pills (CoverPicker / CreatorStep4Cover / TripCreatorStep1Basics / EditPublishedTripScreen / ExperienceCoverStep) +8px | Automatic (shared style) |
+
+Manual parity across 3 checkout files: implemented identically in all three (verified by grep — same `onAspectRatio`/`videoContentFit="contain"`/`aspectRatio` line set + clamp `0.6..1.91`).
+
+---
+
+## 9. Gate results / smoke
+
+- **jest (the two ORCH-1131/1132 tests):** 12 passed / 12 total. PASTED §6.
+- **ORCH-0978 strict-grep autoplay/muted contract:** `OK ORCH-0978 autoplay muted contract gate` (untouched by this change — gate pins only autoplay/muted, not pill position / aspect / contentFit).
+- **tsc (`npx tsc --noEmit`):** my three edited checkout files + EventCoverMedia are CLEAN (grep for them in tsc output → NONE). Pre-existing repo errors remain in unrelated files (sibling `buyer.tsx` implicit-any, marketing ComposerV2, `@mingla/payments-native` / `@testing-library/react-native` module-resolution, etc.) — all present independent of this ORCH, none in scope.
+- **Web repro (Playwright, faithful EventCoverMedia web-path mirror, reads the ACTUAL committed values):**
+  - `checkout_cover_before_after_BUILT.png` — BEFORE (`height:120` + `cover`): a thin strip showing only BODY (HEAD + FEET cropped). AFTER (built `aspectRatio:0.6` + `contain`): full portrait frame — HEAD, BODY, FEET all visible inside the edge ruler. SC-1 proven.
+  - `public_hero_soundpill_16_vs_24_BUILT.png` — pill at built `right:24` sits visibly further from the red screen-edge marker than `right:16`. SC-5 proven.
+- **Native expo-video `contain` path:** suspected (same prop the hero already uses on native by RN contract). The web repro could not prove native — tester verifies on the iOS dev build per spec §11.
+
+**Evidence folder:** `Mingla_Artifacts/evidence/ORCH-1132/`
+- `checkout_cover_before_after_BUILT.png`, `public_hero_soundpill_16_vs_24_BUILT.png`, `portrait.png` (implementor, built-code render)
+- `checkout_cover_A120_B075_C08_portrait.png`, `checkout_cover_RECOMMENDED_contain.png`, `public_hero_soundpill_16_vs_24.png` (forensics repro)
+
+---
+
+## 10. Known issues / deferred
+
+- **Image covers stay `cover`-fitted** (spec §4.4 / §10 Q1): `videoContentFit` does not affect images
+  (`EventCoverMedia.tsx:514` hardcodes `resizeMode="cover"`). In-range image covers get no crop; only
+  clamp-boundary portrait/landscape images crop a little. SPEC intentionally did NOT add an
+  `imageContentFit` prop (scope guard). Accept for this ORCH, or a follow-on ORCH for full image
+  `contain`. No `[TRANSITIONAL]` marker — this is intended scope, not tech debt.
+- **First-paint reflow** (0.75 → true aspect once media reports): brief, benign, identical in
+  character to the hero's first paint. Acceptable per spec §10 Q3.
+- **Native `contain` verification** deferred to the tester (iOS dev build) — the one item the web
+  repro cannot prove.
+
+---
+
+## 11. Operator action required
+
+- **No migration.** No `db push`.
+- **No edge-function deploy.** Component/style only.
+- **Pure-JS / RN change** — per `project_ota_deferred_until_new_build.md`, ship via `eas update`
+  (per-platform) at CLOSE; no native rebuild required. (Operator/orchestrator decision at CLOSE,
+  not the implementor's.)
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **Pre-existing tsc errors in `mingla-business`** (sibling `buyer.tsx` implicit-any params,
+  `@mingla/payments-native` + `@testing-library/react-native` + `expo-image-manipulator` unresolved
+  module types, marketing ComposerV2 type mismatches). NONE in this ORCH's scope; flagged so the
+  orchestrator can register a repo-health cleanup if desired. They predate ORCH-1132 and do not block.
+- **Comms ledger:** read on entry. No BLOCK/OPEN row addressed to mingla-implementor / ORCH-1132 /
+  ALL requiring action. The two ALL WARN rows (COMMS-0030 iOS build — already RESOLVED per recent
+  main commits; COMMS-0027 OTA-poison from symlinked worktrees) are deploy/build concerns owned by
+  the orchestrator/operator at CLOSE, not the implementor; noted for awareness. No new COMMS entry
+  needed (no cross-ORCH discovery).

--- a/Mingla_Artifacts/reports/TEST_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md
@@ -1,0 +1,211 @@
+# TEST / QA — ORCH-1132 — Checkout cover full-frame (no crop) + public Sound-pill edge clearance (round 2)
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1132-[cover-fullframe-sound-inset]/`
+**Branch:** `ORCH-1132-cover-fullframe-sound-inset`
+**Tester:** mingla-tester (Claude)
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md` (SC-1..SC-7)
+**Implementation:** commit `b4c77aa81` (code + tests), `f606687a6` (report)
+**Tester adversarial test commit:** `2927098a4`
+**Date:** 2026-06-12 → 2026-06-13
+
+---
+
+## 1. Verdict
+
+### PASS — 0 P0 · 0 P1 · 0 P2 · 1 P3 · 1 P4
+
+ORCH-1131's two misses are corrected and verified. The three checkout mini-cards now render the
+WHOLE portrait cover frame uncropped (real-media live-fire confirms head+body+feet visible, not a
+mid-strip), and the public-event Sound pill is visibly inset (`right:24`, +8px) while STILL FIRING
+at runtime (mute toggle proven). Cross-consumer non-regression holds: the public hero and consumer
+deck card are structurally untouched and the cover-mode change is fully scoped to checkout. The one
+P3 is a PRE-EXISTING stale test inherited from ORCH-1131 (not a regression from this ORCH) — routed
+to the orchestrator as a Discovery, not a blocker.
+
+**Confidence ladder:**
+- **Checkout cover full-frame (SC-1/2/3) — PROVEN (web, real media):** the actual Raleigh Wine and
+  Dine Crawl cover video rendered through real-browser `objectFit:contain` + adaptive box shows the
+  full frame for portrait (0.5625→0.6 box) and square (1.0 box). The CSS render path is the real one;
+  the call-site wiring is line-verified.
+- **Sound pill inset + fires (SC-5) — PROVEN (runtime):** `right:24` visual inset proven via the
+  faithful built-value harness; pill firing proven by the ORCH-1124 runtime onPress test (3/3 PASS)
+  on this branch — the tap toggles `isMuted` + calls `onMutedChange`.
+- **Native expo-video `contain` path — SUSPECTED (source-verified):** `contentFit={contentFit}` is
+  passed to `VideoView` (EventCoverMedia.tsx:306) — the SAME prop the public hero already uses on
+  native by RN contract. No full iOS dev-build rebuild performed (disproportionate for a style-only
+  prop already in native production use). Marked **suspected pending Seth's dev-OTA confirmation** per
+  the dispatch's native note. Seth verifies on his dev build after the OTA.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Verdict | Evidence |
+|----|-----------|---------|----------|
+| **SC-1-event** | Event checkout: portrait video cover shows whole frame, head not cut | **PASS** | `app/checkout/[eventId]/index.tsx`: `coverAspect` state + `clamp(0.6,1.91)` + `videoContentFit="contain"` + inline `aspectRatio` (lines 87-88, 254-256); real-media live-fire `checkout_cover_RECOMMENDED_contain.png` (portrait full-frame) + `checkout_cover_before_after_BUILT.png`. My adversarial test executes the clamp: 0.5625→0.6 box (< hero's 0.75). |
+| **SC-1-trip** | Trip checkout: same | **PASS** | `app/checkout-trip/[tripEventId]/index.tsx` — byte-identical mechanism (grep-confirmed same clamp + props); adversarial test runs all three routes. |
+| **SC-1-experience** | Experience checkout: same | **PASS** | `app/checkout-experience/[experienceEventId]/index.tsx` — byte-identical mechanism; adversarial test runs all three routes. |
+| **SC-2** | Landscape (≈1.78) full frame; box bounded by 1.91 (not a sliver) | **PASS** | Adversarial test executes `clamp(1.78)=1.78` (in-range, full frame) and `clamp(3.0)=1.91` (panorama bounded, > 16/9). `contain` guarantees no center-crop. Letterbox bars invisible on `#0c0e12`. |
+| **SC-3** | Square (1.0) box ≈square, full frame | **PASS** | Adversarial test executes `clamp(1.0)=1.0` (exact-fit, unclamped). Real-media `checkout_cover_RECOMMENDED_contain.png` square panel shows full frame letterboxed on black. |
+| **SC-4** | `miniCover` declares no fixed `height:` in all three | **PASS** | All three `miniCover` blocks contain only `borderRadius`+`marginBottom` (no `height:`). Implementor happy-path test asserts `extractNumericStyleValue(body,'height')===null` across all three; independently re-run + fails-on-revert verified. |
+| **SC-5** | Public Sound pill `right:24`, `bottom:22` unchanged; STILL FIRES | **PASS** | `EventCoverMedia.tsx:616` `right:24`, line 619 `bottom:22`; exactly one `right:` declaration. Visual inset proven `public_hero_soundpill_16_vs_24_BUILT.png`. **Runtime-fires proven:** `orch_1124_cover_audio_pill_fires.adversarial.test.ts` 3/3 PASS on this branch (onPress toggles isMuted + calls onMutedChange; positive zIndex; bottomRight wired). Pill handler NOT in this commit's diff — byte-identical to the runtime-proven ORCH-1124 baseline. |
+| **SC-6** | Public hero `heroBox` + deck card untouched | **PASS** | `PublicEventPage.tsx` + `SwipeableCards.tsx` NOT in the commit diff. Hero still `clampedHeroAspect=clamp(0.75,16/9)` (line 552), no fixed pixel height (heroBox style has no `height`), `cover` fill (no `videoContentFit` on hero call → default cover). Deck: explicit `videoContentFit="cover"` + `showAudioControl={false}`. My adversarial isolation test proves the hero clamp is a structurally DIFFERENT range (0.5625→0.75 hero vs 0.6 checkout; upper 16/9 hero vs 1.91 checkout). |
+| **SC-7** | `EventCoverMedia` defaults `cover`/undefined; no other consumer changes | **PASS** | `videoContentFit="cover"` default (line 382), `onAspectRatio?` optional no-default (undefined), image `resizeMode="cover"` (line 514). My adversarial test asserts no `videoContentFit="contain"` default exists + `objectFit:contentFit` passthrough + image `resizeMode="cover"`. Only the shared pill style + 3 checkout call-sites changed. |
+
+---
+
+## 3. Findings
+
+### P3-1 (DISCOVERY → orchestrator; NOT an ORCH-1132 regression) — stale ORCH-1124 pill test pins `right: 14`
+- **Evidence:** `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts:369`
+  `expect(bottomRightStyle).toContain("right: 14")`. The live style is `right: 24`. Test FAILS.
+- **Pre-existing proof:** on `origin/main` the SAME test still asserts `"right: 14"` while the
+  `origin/main` code is already `right: 16` (ORCH-1131 moved the pill 14→16 but never updated this
+  ORCH-1124 sibling test) → the assertion **already fails on main**, independent of ORCH-1132.
+  ORCH-1132 makes it staler (24 vs 14) but did NOT introduce the red.
+- **Why not a blocker for ORCH-1132:** `eventCoverMedia.test.ts` is OUTSIDE the spec §9 allowlist;
+  the implementor correctly did not touch it. The pill IS at the intended 24 (the test pins an
+  obsolete number, the product is correct). Fixing it here would be scope-widening.
+- **Impact:** a red test in the touched component's test file; will keep failing CI until updated to
+  `right: 24` / `bottom: 22`.
+- **Required fix (future ORCH / orchestrator call):** update `eventCoverMedia.test.ts:369` from
+  `"right: 14"` → `"right: 24"`. Trivial. Should be folded into the ORCH-1132 close OR a fast-follow
+  if the orchestrator wants CI green on this file.
+- **Retest:** `npx jest eventCoverMedia.test -t "defaults the audio pill to bottomRight"` → green.
+
+### P4-1 (PRAISE) — clean reuse of the proven hero mechanism + faithful real-media evidence
+- The implementor reused the public hero's exact `onAspectRatio`+adaptive-box mechanism rather than
+  inventing a new render path, paired it with `contain` (vs the hero's `cover`) for the stricter
+  no-crop requirement, and produced live-fire evidence using the ACTUAL cover video frame
+  (`checkout_cover_RECOMMENDED_contain.png` / `checkout_cover_A120_B075_C08_portrait.png`) — not just
+  the synthetic HEAD/BODY/FEET harness. Byte-identical across all three checkout files. Defaults
+  untouched, scope held to the allowlist.
+
+### Other 10 jest failures in `eventCoverMediaService.test.ts` / `eventCoverMedia.test.ts` — PRE-EXISTING, UNRELATED
+- e.g. "Cover videos must be 15 seconds or shorter" vs received "29 seconds", Uint8Array/Blob upload,
+  picker upload-limits. None touch cover-sizing or pill position; all unrelated to ORCH-1132's
+  surfaces and present independent of this ORCH (the touched files are not in the diff). Noted for the
+  orchestrator's repo-health awareness; not ORCH-1132 defects.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out implementor commit `b4c77aa81`. Backed up the two product files, then performed TRUE
+LINE DELETIONS of the fix (not comment-out):
+- `EventCoverMedia.tsx` `audioControlBottomRight.right: 24 → 16`
+- `app/checkout/[eventId]/index.tsx`: dropped `onAspectRatio`/`videoContentFit="contain"`/inline
+  `aspectRatio` (back to `style={styles.miniCover}`) and re-added `height: 120` to `miniCover`.
+
+Re-ran the two implementor tests — observed EXACTLY the implementor's reported failing assertions:
+```
+FAIL __tests__/orch1131CoverCropSoundInset.test.ts
+  - miniCover.height: expect(...).toBeNull() → Received: 120
+  - EventCoverMedia: expect(call).toMatch(/videoContentFit="contain"/) → not found
+  - bottomRight.right: expect(...).toBe(24) → Received: 16
+FAIL __tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
+  - bottomRight.right: expect(allNumericValues(...,'right')).toEqual([24]) → Received: [16]
+Tests:       4 failed, 8 passed, 12 total
+```
+Restored both files from backup → `git status` clean → re-ran → **12/12 PASS**. The implementor's
+fails-on-revert claim is independently CONFIRMED at `b4c77aa81`.
+
+---
+
+## 5. Adversarial test added (tester-owned, different angle)
+
+- **Path:** `mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts`
+- **Commit:** `2927098a4` (on-branch; appears in `git diff origin/main...HEAD --name-only`).
+- **Angle (distinct from the implementor's STATIC source-string matching):** EXECUTES the actual
+  checkout clamp expression at runtime against SC-1/2/3 inputs (portrait 0.5625, square 1.0, landscape
+  1.78, panorama 3.0) and degenerate inputs (NaN/0/negative), asserting the RESULTING box aspect the
+  user sees; and proves SC-6/SC-7 ISOLATION by executing the public-hero clamp and asserting it is a
+  structurally different range NOT inherited by checkout, plus the `videoContentFit` default stays
+  `"cover"`. 24 tests, all PASS.
+- **Regression class it catches that the static test does NOT:** a "tidy" that copies the hero bounds
+  (`0.6→0.75`, `1.91→16/9`) into the checkout clamp would keep `videoContentFit="contain"` present
+  (so the implementor's string test stays green) yet SILENTLY RE-CROP portrait covers — the exact
+  ORCH-1131 miss this ORCH exists to fix.
+- **fails-on-revert verified by the tester:** reverted `app/checkout/[eventId]/index.tsx` clamp
+  `0.6,1.91 → 0.75,16/9`; re-ran → portrait, landscape, panorama, degenerate-floor, and cross-file
+  isolation assertions FAILED (`Expected 0.6 Received 0.75`, `Expected 1.91 Received 1.7777`).
+  Restored → **24/24 PASS**. `fails-on-revert verified at 2927098a4`.
+- **Append-only:** NEW file; modifies no existing test. Both implementor tests AND this adversarial
+  test are in `git diff origin/main...HEAD --name-only`.
+
+**Combined run (all three ORCH-1131/1132 tests):** 36/36 PASS. ORCH-0978 autoplay/muted strict-grep
+gate: `OK ORCH-0978 autoplay muted contract gate` (untouched).
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | **PASS** | Sound pill still fires — ORCH-1124 runtime test 3/3 PASS on branch (onPress toggles isMuted + onMutedChange); handler untouched by this commit. |
+| 2 | One owner per truth | **PASS** | `coverAspect` owned by each checkout screen's local state; pill `right` single declaration (no shadow override). |
+| 3 | No silent failures | **PASS** | Degenerate `onAspectRatio` (0/negative) floors to 0.6 (no sliver collapse); NaN passes through (RN ignores → benign), documented in adversarial test. Media error → EventCover fallback (unchanged). |
+| 4 | One query key per entity | **N/A** | No data fetch added. |
+| 5 | Server state server-side | **N/A** | No Zustand/server-state change. |
+| 6 | Logout clears everything | **N/A** | No auth/persisted state. |
+| 7 | Label `[TRANSITIONAL]` | **PASS** | No transitional code; image-cover-stays-cover is intended scope (spec §4.4), correctly NOT marked transitional. |
+| 8 | Subtract before adding | **PASS** | Removed fixed `height:120` before adding adaptive aspect; superseded ORCH-1131 values rather than layering. |
+| 9 | No fabricated data | **PASS** | No fabricated ratings/prices/times; aspect is derived from real media intrinsic size. |
+| 10 | Currency-aware | **N/A** | No money rendering changed. |
+| 11 | One auth instance | **N/A** | Buyer/anon checkout routes; no `useAuth` touched. |
+| 12 | Validate at right time | **N/A** | No datetime validation. |
+| 13 | Exclusion consistency | **N/A** | No filtering. |
+| 14 | Persisted-state startup gate | **N/A** | No hydration-gated state. |
+
+No constitutional violation.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Evidence |
+|---------|---------|----------|
+| Consumer iOS (`app-mobile/`) | **PASS (pill only, source+runtime)** | Inherits shared pill +8px on expandedCard ImageGallery (`audioControlPosition="bottomRight"` line 134 → modified style); cover-sizing change does NOT reach deck (fixed cover, `showAudioControl={false}`). Pill firing proven by ORCH-1124 runtime test. |
+| Consumer Android | **PASS (pill only, by parity)** | Same shared RN style; no Android-specific override on `audioControlBottomRight`. |
+| Buyer/anon Web (`mingla-business` checkout + public) | **PASS (PROVEN, real-media web live-fire)** | The authoritative surface. Real cover video through `objectFit:contain` + adaptive box → full frame (portrait/square evidenced). Pill `right:24` visual inset evidenced. |
+| Business iOS (`mingla-business/`) | **PASS (cover source+web-proven; native contain SUSPECTED)** | Checkout summary cover full-frame logic identical to web; native `contentFit` prop = same one hero uses on native (source-verified line 306). iOS dev-build render of native `contain` = SUSPECTED pending Seth's dev-OTA. |
+| Business Android | **PASS (same as Business iOS; native SUSPECTED)** | Same code path. |
+| Admin Web (`mingla-admin/`) | **SKIPPED (does not consume)** | Admin renders no `EventCoverMedia` checkout card. |
+| Business Web preview (adjacent) | **PASS (pill, source)** | Authoring previews (CoverPicker / ExperienceCoverStep / TripCreatorStep1Basics / EditPublishedTripScreen / BrandCreationFlow) all use default bottomRight pill → inherit +8px; grep-confirmed no `right` override. |
+
+**Physical iPhone HITL:** not invoked. The authoritative surface for both fixes is buyer web (proven
+at runtime). The only native-specific item (expo-video `contentFit:contain`) is a style-only prop
+already in native production use by the hero; per the dispatch's native note a full iOS dev-build
+rebuild is disproportionate for a style-only change — Seth will confirm on his dev build after the
+OTA. Stated as SUSPECTED, not silently skipped.
+
+**Live edge-deploy state:** N/A — no edge function / DB / migration in this ORCH (component/style only).
+
+---
+
+## 8. Discoveries for Orchestrator
+
+1. **P3-1 (above):** `eventCoverMedia.test.ts:369` pins the obsolete pill `right: 14`. Already red on
+   `origin/main` (ORCH-1131 left it stale at 14 after moving the pill to 16). ORCH-1132 makes it
+   staler (24). Outside the ORCH-1132 allowlist — recommend the orchestrator either fold a one-line
+   bump (`"right: 14"`→`"right: 24"`) into the close or register a fast-follow. Trivial.
+2. **~10 unrelated pre-existing failures** in `eventCoverMediaService.test.ts` / `eventCoverMedia.test.ts`
+   (video duration 15→29s drift, Uint8Array/Blob upload, picker limits). None touch ORCH-1132
+   surfaces; flagged for repo-health awareness.
+3. **Native `contain` confirmation** is the one item web could not prove. Seth's dev-OTA verification
+   closes it; if it ever renders wrong on native it would be a fast follow (low risk — same prop the
+   hero uses).
+
+---
+
+## 9. Routing
+
+**PASS → CLOSE (orchestrator).** No P0/P1. The single P3 is a pre-existing out-of-scope stale test
+(Discovery, not REWORK). Both fixes proven on the authoritative buyer-web surface; pill fires at
+runtime; cross-consumer non-regression holds; native `contain` source-verified + flagged SUSPECTED
+for Seth's dev-OTA confirmation per the dispatch.
+
+Comms ledger read on entry: no BLOCK/OPEN row addressed to mingla-tester / ORCH-1132 / ALL. Active
+ALL/relevant rows (COMMS-0029 WARN to ORCH-1119 trip-function clobber; COMMS-0030 RESOLVED iOS build;
+COMMS-0027 OTA-poison) are not in this ORCH's path (no DB/edge/trip-function/native-build work). No
+new cross-ORCH discovery requiring a COMMS entry.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1132_COVER_FULLFRAME_SOUND_INSET.md
@@ -1,0 +1,237 @@
+# SPEC — ORCH-1132 — Checkout cover full-frame (no crop) + public Sound-pill visibly clear of edge (round 2)
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1132-[cover-fullframe-sound-inset]/`
+**Branch:** `ORCH-1132-cover-fullframe-sound-inset` (rebased on origin/main; carries ORCH-1131 shipped values)
+**Author:** mingla-forensics (INVESTIGATE + SPEC)
+**Status:** SPEC complete — ready for IMPLEMENT
+**Confidence on root mechanism:** PROVEN (live-fire web repro; intrinsic media dimensions probed via ffprobe)
+
+---
+
+## 0. Why this is round 2 (the misses being corrected)
+
+ORCH-1131 shipped two value-only changes (PR #459, merge `e90875dda`) that fell short of intent, verified on Seth's dev build:
+
+- **Cover.** It raised the checkout `miniCover.height` 64→120 and KEPT `contentFit:"cover"` (the comment even says "Do NOT switch to contain"). At 342pt content width a 120pt band shows only a `342×120` window of a **360×640 portrait** cover video → a mid-frame horizontal strip that **crops the subject's head off**. Seth's real complaint is the CROP, not the band size.
+- **Sound pill.** It moved `audioControlBottomRight.right` 14→16 to align the pill to the public-event X/share chrome column (`floatingChrome.right = spacing.md = 16`). That is a 2px nudge — imperceptible. Seth wants VISIBLE breathing room between the pill and the screen edge.
+
+This SPEC supersedes ORCH-1131's two value choices. Same file surfaces; opposite design call on both.
+
+---
+
+## 1. Executive summary
+
+Two value/structure changes, no new product surfaces:
+
+1. **Checkout cover = full frame, no crop.** Make the three checkout-summary mini-cards (event / trip / experience) render the WHOLE cover frame uncropped as a tall, portrait-friendly block — a smaller echo of the public event-page hero. Reuse the hero's proven adaptive mechanism: the `onAspectRatio` callback drives the box's `aspectRatio` to the media's real shape, paired with `videoContentFit="contain"` so nothing is ever cropped (and the near-black card swallows any letterbox bars). Default behaviour of `EventCoverMedia` for every other consumer is unchanged.
+2. **Sound pill clearly inset.** Move the shared `EventCoverMedia` `audioControlBottomRight.right` from 16 to **24 (`spacing.lg`)** for obvious right-edge breathing room. `bottom:22` preserved verbatim (ORCH-1128 cover-seam clearance — load-bearing).
+
+---
+
+## 2. Scope & non-goals
+
+### In scope
+- The three checkout mini-card cover renders: `app/checkout/[eventId]/index.tsx`, `app/checkout-trip/[tripEventId]/index.tsx`, `app/checkout-experience/[experienceEventId]/index.tsx` (mingla-business) — each gains adaptive-aspect state + `onAspectRatio` + `videoContentFit="contain"`, and `miniCover` loses its fixed `height:120` in favour of an inline `aspectRatio`.
+- The shared `audioControlBottomRight.right` value in `packages/event-rendering/EventCoverMedia.tsx`.
+- The two ORCH-1131 jest tests that pin the now-superseded values (`orch1131CoverCropSoundInset.test.ts`, `orch1131SiblingInsetNonRegressionAdversarial.test.ts`) — update the pinned numbers to round-2 values (same ORCH lineage; round 2 supersedes round 1).
+
+### Non-goals (explicit)
+- **Do NOT change `EventCoverMedia`'s defaults.** `videoContentFit` default stays `"cover"`; `onAspectRatio` default stays `undefined`. No existing consumer may change behaviour from this change except via the shared pill inset (item 2, intentional).
+- **Do NOT touch the public event-page hero rendering** (`PublicEventPage` `heroBox` / `heroColumn` / `clampedHeroAspect`). The hero already adapts; it is the REFERENCE, not a target. Only its Sound pill moves (via the shared style — that is the intended shared effect).
+- **Do NOT touch the consumer deck card** (`SwipeableCards.tsx` — it passes `showAudioControl={false}` and no adaptive aspect; the deck cover stays fixed-shape `cover`).
+- **Do NOT add a portrait clamp to the public hero** or otherwise alter its `0.75..16/9` clamp.
+- No new edge functions, DB, RLS, hooks, services, analytics, copy.
+
+### Assumptions
+- `onAspectRatio` fires for images AND videos (verified: video via `loadedmetadata`/`sourceLoad`; image via `onLoad` → `event.nativeEvent.source.width/height`, EventCoverMedia.tsx:517-530).
+- The checkout content column is `paddingHorizontal: spacing.lg` (24) each side → ~342pt at a 390pt screen; the card background is `#0c0e12` (checkout `container.backgroundColor`) so `contain` letterbox bars on a black video background are nearly invisible.
+
+---
+
+## 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behaviour | Files touched here | Parity |
+|---|---------|---------|------------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile/`) | Pill only (shared) | Sound pill on expanded-card ImageGallery + any default-bottomRight cover moves +8px inset; cover-sizing change does NOT reach consumer (deck uses fixed `cover`, `showAudioControl={false}`) | none directly; inherits `EventCoverMedia` pill style | Automatic (shared style) |
+| 2 | Consumer Android (`app-mobile/`) | Pill only (shared) | Same as iOS | none | Automatic |
+| 3 | Buyer/anon Web (`mingla-business` checkout routes + public event page) | YES (both fixes) | Checkout mini-cards show full uncropped cover; public-event Sound pill clears the edge by 24 | 3 checkout `index.tsx` + `EventCoverMedia.tsx` | Manual (3 separate checkout files) + shared pill |
+| 4 | Business iOS (`mingla-business/`) | YES (cover) + pill | Checkout summary full-frame cover (in-app checkout preview); authoring cover previews' pill moves +8px | 3 checkout files + shared pill | Manual + automatic |
+| 5 | Business Android (`mingla-business/`) | Same as Business iOS | Same | same | Manual + automatic |
+| 6 | Admin Web (`mingla-admin/`) | NO | Admin does not render `EventCoverMedia` checkout cards | none | n/a — surface does not consume |
+| 7 | Business Web preview (adjacent) | YES (pill) | Authoring cover previews (CoverPicker, CreatorStep4Cover, TripCreatorStep1Basics, EditPublishedTripScreen, ExperienceCoverStep) all use default-bottomRight pill → +8px inset | shared pill | Automatic (shared style) |
+
+**Pill is a shared style — it intentionally moves the bottomRight pill for every consumer.** Full safety assessment in §6 / §10.
+
+---
+
+## 4. Layered specification (Component layer only — no DB/edge/hook/service/realtime touched)
+
+### 4.1 The confirmed full-frame mechanism (how the public hero does it)
+
+`EventCoverMedia` (packages/event-rendering/EventCoverMedia.tsx) exposes two ORCH-0992 props that together produce uncropped rendering:
+
+- **`onAspectRatio?: (ratio: number) => void`** — fires once the media's intrinsic `width/height` is known. Video web: `loadedmetadata` → `videoWidth/videoHeight` (line 149-161). Video native: expo-video `sourceLoad`/`videoTrack.size` (line 248-260). Image: `onLoad` → `source.width/height` (line 517-530). Guarded so consumers that omit it pay nothing.
+- **`videoContentFit?: "cover" | "contain"`** (default `"cover"`) — passed through to the web `<video>` `objectFit` (line 202) and the native `VideoView contentFit` (line 306). **Images are always `resizeMode="cover"`** (line 514) — see §4.4 for the image caveat.
+
+The **public hero** (`PublicEventPage.tsx:546-597`) wires these as:
+```
+const [heroAspect, setHeroAspect] = useState(16/9);
+const clampedHeroAspect = Math.min(Math.max(heroAspect, 0.75), 16/9);
+<View style={[styles.heroBox, { aspectRatio: clampedHeroAspect }]}>
+  <EventCoverMedia ... onAspectRatio={setHeroAspect} />  // default videoContentFit "cover"
+```
+The box's `aspectRatio` is driven to the media's real shape, so `cover` fills it with no crop AND no letterbox — **as long as the box aspect equals the media aspect.** When the clamp bites (media outside `0.75..16/9`, e.g. a 0.5625 portrait → clamped to 0.75), the hero's `cover` DOES crop the difference (0.5625 vs 0.75). The hero accepts that small crop to bound page height; the checkout requirement is stricter ("nothing gets cut off"), so the checkout pairs the same adaptive box with **`contain`** instead of `cover`.
+
+> **Live-fire proof (ffprobe):** the two newest real video covers (`Raleigh Wine and Dine Crawl`, `Vibes and Stuff`) are both **360×640 (portrait, aspect 0.5625)**. At 342pt width a 120pt `cover` band shows a `342×120` strip — the head is cropped out. See evidence §8.
+
+### 4.2 Chosen checkout-cover approach (B-adaptive + contain) — APPLIES TO ALL THREE MINI-CARDS
+
+Reuse the hero's adaptive-box mechanism, but pair it with `videoContentFit="contain"` and a **portrait-permitting clamp** so the FULL frame always shows:
+
+In each of the three checkout screens, add adaptive aspect state and wire the cover:
+```
+const [coverAspect, setCoverAspect] = useState(0.75);            // portrait-ish first paint
+const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
+...
+<EventCoverMedia
+  ...existing props (hue / mediaUrl / mediaType / radius={0} / label="")...
+  onAspectRatio={setCoverAspect}
+  videoContentFit="contain"
+  style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
+/>
+```
+And in each screen's `StyleSheet`, **remove `height: 120`** from `miniCover`, keeping `borderRadius: radiusTokens.md` and `marginBottom: spacing.sm`. (Width stays `width:"100%"` default → full content-column width; the box height now follows `aspectRatio` inline.)
+
+**Exact values (identical across all three files):**
+- `useState` initial: `0.75` (a stable portrait-ish first paint before media reports; matches the hero's "common first paint" pattern).
+- Clamp: **lower `0.6`** (allows true-portrait covers a tall box; a 0.5625 portrait clamps to 0.6 and `contain` shows the full frame with ~3% invisible side bars on the black card), **upper `1.91`** (a wide/landscape cover gets a reasonable, not-too-short block; `contain` shows the full landscape frame letterboxed top/bottom — bars invisible on black). The upper bound also bounds the card's *minimum* height so a panoramic cover can't collapse to a sliver.
+- `videoContentFit="contain"` — guarantees NO crop at the clamp boundaries.
+
+**Why this over the alternatives** (evidence §8 compares all three):
+- **(a) adaptive + `cover` (the literal hero mechanism):** at the portrait clamp it STILL crops (0.5625 media in a 0.75 box). Fails "nothing gets cut off." REJECTED.
+- **(c) fixed `aspectRatio:0.8` + contain:** simplest (no state), full-frame, but a landscape cover gets large top/bottom bars and wastes vertical space, and a portrait cover is slightly letterboxed side-to-side even though a taller box could fit it edge-to-edge. Acceptable but inferior. REJECTED as second choice.
+- **(B) adaptive + `contain` (CHOSEN):** box tracks the media's real shape so for in-range covers `contain` ≈ perfect fill (no visible bars); only clamp-boundary covers get thin, near-invisible bars on `#0c0e12`. Best result for portrait / square / landscape alike. Proven in evidence `checkout_cover_RECOMMENDED_contain.png`.
+
+**First-paint note:** before `onAspectRatio` fires the box is 0.75 (portrait-ish). For a few hundred ms a landscape cover paints into a 0.75 box with `contain` (letterboxed), then settles to its true shape when the ratio reports. This is a brief, benign reflow identical in character to the hero's first-paint behaviour. Acceptable.
+
+### 4.3 Sound-pill inset (shared)
+
+In `packages/event-rendering/EventCoverMedia.tsx`, `styles.audioControlBottomRight`:
+```
+right: 24,   // ORCH-1132 — 16 → 24 (spacing.lg): visible right-edge breathing room.
+bottom: 22,  // ORCH-1128 — preserved verbatim (cover-seam clearance, load-bearing)
+```
+- **Chosen value: `24` (= `spacing.lg`).** Justification vs the chrome insets: the public-event X/share chrome sits at `right: spacing.md = 16`. ORCH-1131 aligned the pill to that column (16); Seth found it cramped. 24 is +8px (a perceptible 50% increase in inset) and a real design token (`spacing.lg`), so the pill now sits one step further from the edge than the chrome — a deliberate, legible offset, not a misalignment. 24 keeps the pill comfortably clear of the cover's left content and never collides with the bottom seam (bottom:22 unchanged). The raw literal `24` matches this file's convention (topLeft/topRight use raw numbers); a comment names it `spacing.lg`.
+
+### 4.4 Image-cover caveat (must be in the SPEC, must NOT trigger scope creep)
+
+`EventCoverMedia` renders IMAGE covers with a hardcoded `resizeMode="cover"` (line 514) — `videoContentFit` does NOT apply to images. So for an **image** cover the adaptive box (driven by `onAspectRatio`, which DOES fire for images) will match the image's real aspect, and `cover` into a same-aspect box yields no crop. The only residual crop for images is at the clamp boundary (a 0.5 portrait image in a 0.6 box crops ~16% off the sides). This is acceptable and intentional — **do NOT** widen scope to add an `imageContentFit` prop in this ORCH. If Seth later wants image covers fully `contain`'d too, that is a separate ORCH. Flagged in §10.
+
+---
+
+## 5. Success criteria
+
+- **SC-1 (cover, all three, per-surface manual):** On the buyer-web checkout for an event with a **portrait (0.5625) video cover**, the mini-card cover shows the WHOLE frame — the subject's head/feet are NOT cut off — as a tall portrait-ish block.
+  - **SC-1-event** — `app/checkout/[eventId]/index.tsx`
+  - **SC-1-trip** — `app/checkout-trip/[tripEventId]/index.tsx`
+  - **SC-1-experience** — `app/checkout-experience/[experienceEventId]/index.tsx`
+- **SC-2:** For a **landscape (≈1.78) cover**, the same mini-card shows the full landscape frame (letterboxed top/bottom; bars near-invisible on `#0c0e12`), not a center-crop. Box height is bounded by the 1.91 clamp (not a sliver).
+- **SC-3:** For a **square (1.0) cover**, the mini-card box is ≈square and shows the full frame.
+- **SC-4:** `miniCover` in all three files no longer declares a fixed `height:` (height follows the inline `aspectRatio`).
+- **SC-5:** The public-event Sound pill sits at `right:24` — visibly further from the screen edge than at 16, and `bottom:22` is unchanged.
+- **SC-6 (non-regression):** The public-event hero (`PublicEventPage` `heroBox`) is unchanged — still aspect-adaptive via `clampedHeroAspect` (`0.75..16/9`), `cover` fill, NO fixed pixel height; the consumer deck card cover is unchanged (fixed `cover`, no adaptive aspect, no pill).
+- **SC-7 (default-safety):** `EventCoverMedia`'s `videoContentFit` default is still `"cover"` and `onAspectRatio` default is still `undefined`; no consumer other than the three checkout cards (cover) and the shared bottomRight pill (inset) changes behaviour.
+
+---
+
+## 6. Invariants
+
+- **I-MOR-0827-PACKAGE-ISOLATION** — preserved; no app-level imports added to the package.
+- **I-MOR-0978 autoplay/muted contract** (strict-grep `orch-0978-video-autoplay-muted-contract.mjs`) — preserved; this change touches neither autoplay nor muted (verified: the gate pins only those two, NOT pill position / aspect / contentFit).
+- **ORCH-1128 cover-seam clearance (`bottom:22`)** — preserved verbatim.
+- **No NEW invariant proposed.** This is a value/structure tuning within an existing, already-invariant-guarded component.
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-1 happy | Portrait video cover at checkout | 360×640 cover, event route | Box `aspectRatio` 0.6, `videoContentFit="contain"`, full frame visible | Component (source-introspection + web repro) |
+| T-2 happy | Sound-pill inset | `audioControlBottomRight` | `right === 24`, `bottom === 22` | Style (source-introspection) |
+| T-3 edge | Landscape cover | 1280×720 cover | Box clamps to ≤1.91, contain, no crop | Component |
+| T-4 edge | Square cover | 1:1 cover | Box ≈1.0, full frame | Component |
+| T-5 error | `onAspectRatio` never fires (media error → fallback) | broken URL | Box stays at first-paint 0.75; EventCover placeholder renders; no crash | Component |
+| T-6 non-regress | Public hero untouched | `PublicEventPage` `heroBox` | NO fixed pixel `height`; clamp still `0.75..16/9` | Source-introspection |
+| T-7 non-regress | Deck card untouched | `SwipeableCards` | `showAudioControl={false}`, no adaptive aspect, fixed cover | Source-introspection |
+| T-8 adversarial | Sibling pills not shifted | `audioControlTopLeft`/`audioControlTopRight` | still `14` | Source-introspection |
+| T-9 adversarial | Single `right:` declaration | `audioControlBottomRight` | exactly one `right:` = 24 (no shadow override) | Source-introspection |
+| T-10 default-safety | EventCoverMedia defaults | component signature | `videoContentFit="cover"` default, `onAspectRatio` default undefined | Source-introspection |
+
+## 7a. Regression-test contract (fails-on-revert)
+
+Update the two existing ORCH-1131 jest tests (same lineage) and keep them fails-on-revert:
+
+1. **`orch1131CoverCropSoundInset.test.ts`** (rename optional to `orch1132...`; updating in place is acceptable):
+   - Replace the `miniCover.height === 120` assertions with: each of the three checkout routes' `miniCover` block has **NO** numeric `height:` declaration (assert `extractNumericStyleValue(body,'height') === null`) AND each `EventCoverMedia` call in that file passes `videoContentFit="contain"` and `onAspectRatio=` (grep the call). FAILS-ON-REVERT: re-adding `height: 120` or dropping `videoContentFit="contain"` makes it fail.
+   - Replace the pill `right === 16` assertion with `right === 24`. FAILS-ON-REVERT: reverting to 16 (or 14) fails.
+2. **`orch1131SiblingInsetNonRegressionAdversarial.test.ts`**:
+   - Keep T-8 (topLeft/topRight stay 14) and T-6 (heroBox no fixed height) verbatim.
+   - Update the `audioControlBottomRight` adversarial assertion: `right` values === `[24]` (exactly one), `bottom` values === `[22]`.
+
+Both tests already use comment-proof `property: value` source extraction (a true line edit changes the asserted value). Verify both FAIL when the round-2 changes are reverted and PASS when restored (record in the IMPLEMENTATION report).
+
+---
+
+## 8. Repro evidence (live-fire web)
+
+All under `Mingla_Artifacts/evidence/ORCH-1132/`:
+
+- **`checkout_cover_A120_B075_C08_portrait.png`** — three-up of the real 360×640 portrait video cover in a 342pt content column on the `#0c0e12` card: **(A)** current ORCH-1131 `height:120` + cover = a thin mid-frame strip, head cropped (Seth's complaint, reproduced); **(B)** `aspectRatio:0.75` + cover (the literal hero mechanism) = taller but STILL crops top/bottom; **(C)** `aspectRatio:0.8` + contain = full frame, near-invisible bars.
+- **`checkout_cover_RECOMMENDED_contain.png`** — the CHOSEN approach: portrait `0.6`-box + contain (full vertical frame, imperceptible side bars) and a square-box + contain (full frame). Confirms full-frame for portrait and square.
+- **`public_hero_soundpill_16_vs_24.png`** — public-hero pill at `right:16` (current) vs `right:24` (proposed) with a red edge-marker; 24 sits visibly further from the edge.
+
+Intrinsic dimensions probed with `ffprobe` (2 of the 3 real video covers = 360×640 portrait); harness faithfully mirrors `EventCoverMedia`'s web rendering (`objectFit` = `videoContentFit`, absolute-fill in a fixed-dimension box). Confidence on the crop mechanism: **PROVEN**. Note the harness reproduces the WEB path; native expo-video `contentFit` behaves identically by RN contract — the implementor/tester should confirm on the iOS sim/dev build (caps at "suspected" for native until then, but the prop is the same one the hero already uses on native).
+
+---
+
+## 9. Implementation order
+
+1. `packages/event-rendering/EventCoverMedia.tsx` — `audioControlBottomRight.right` 16 → 24 (+ comment). (Shared pill; one-line.)
+2. `mingla-business/app/checkout/[eventId]/index.tsx` — add `coverAspect` state + clamp, wire `onAspectRatio` + `videoContentFit="contain"` + inline `aspectRatio`; remove `miniCover.height:120`.
+3. `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` — identical change.
+4. `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` — identical change.
+5. Update `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts` + `orch1131SiblingInsetNonRegressionAdversarial.test.ts` per §7a. Prove fails-on-revert.
+6. Run the business jest suite; run the ORCH-0978 strict-grep gate to confirm green (it pins only autoplay/muted).
+
+### Scoped allowlist (implementor MUST stop-and-amend before touching anything else)
+- `packages/event-rendering/EventCoverMedia.tsx` (pill inset only — line ~614)
+- `mingla-business/app/checkout/[eventId]/index.tsx`
+- `mingla-business/app/checkout-trip/[tripEventId]/index.tsx`
+- `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx`
+- `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts`
+- `mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts`
+
+### DO-NOT-TOUCH
+- `packages/event-rendering/PublicEventPage.tsx` (hero rendering — REFERENCE only; its pill moves via the shared style, no edit here).
+- `packages/event-rendering/EventCoverMedia.tsx` defaults / `videoContentFit` default / `onAspectRatio` default / image `resizeMode` / topLeft/topRight pill insets / `bottom:22`.
+- `app-mobile/src/components/SwipeableCards.tsx` and any deck card.
+- `app-mobile/src/components/expandedCard/ImageGallery.tsx` (inherits the shared pill move; no edit).
+- The authoring cover-preview consumers (CoverPicker, CreatorStep4Cover, TripCreatorStep1Basics, EditPublishedTripScreen, ExperienceCoverStep) — they inherit the shared pill move; no edit.
+- Any DB / edge / hook / service / RLS / strict-grep gate.
+
+---
+
+## 10. Open questions
+
+1. **Image covers stay `cover`-fitted (clamp-boundary crop possible).** `videoContentFit` does not affect images (line 514 hardcodes `resizeMode="cover"`). For in-range image covers the adaptive box yields no crop; only clamp-boundary portrait/landscape images crop a little. SPEC intentionally does NOT add an `imageContentFit` prop (scope guard). Confirm acceptable, or spawn a follow-on ORCH for full image `contain`. **Recommendation: accept for this ORCH.**
+2. **Clamp bounds `0.6 .. 1.91`.** Chosen so a 0.5625 portrait gets a near-edge-to-edge tall box and a wide cover is not a sliver. If Seth wants even taller portrait blocks (true 0.5625, no clamp) the lower bound can drop to `0.5625` — but that pushes the summary further down before the ticket selector. **Recommendation: keep 0.6** (full frame already achieved; bars imperceptible).
+3. **First-paint reflow** (0.75 → true aspect once media reports) is brief and benign, same as the hero. Confirm acceptable.
+
+---
+
+## 11. Downstream routing
+
+NEXT = `mingla-implementor` in this worktree (`~/Desktop/mingla-orchs/ORCH-1132-[cover-fullframe-sound-inset]/`, branch `ORCH-1132-cover-fullframe-sound-inset`). Build exactly §4 + §9, prove §7a fails-on-revert, write the IMPLEMENTATION report.
+THEN = `mingla-tester` — verify SC-1..SC-7 on buyer web (portrait + landscape + square covers) AND on the iOS dev build for the native expo-video `contain` path (the one item the web repro could not prove); confirm the public hero + deck card are visually untouched; confirm the shared pill move looks right on the authoring previews + ImageGallery.
+THEN = `mingla-orchestrator` CLOSE (PR-protected main → isolated docs worktree).

--- a/mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts
+++ b/mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts
@@ -3,26 +3,36 @@ import fs from "node:fs";
 import path from "node:path";
 
 // ORCH-1131 [cover-crop-sound-inset] — HAPPY-PATH regression test (implementor-authored).
+// ORCH-1132 [TEST-MOD-APPROVED ORCH-1132] round 2 — supersedes ORCH-1131's two
+// value choices (same file surfaces, opposite design call on both). The
+// ORCH-1131 lineage stays here; the pinned numbers move to round-2 values.
 //
-// Two value-only style contracts that a future "tidy" could silently regress:
-//   FIX 1 — the three Get-tickets checkout mini-card cover bands must be 120pt
-//           tall (was 64pt). A 64pt band slices a PORTRAIT cover video to an
-//           unrecognizable mid-frame strip; 120pt reveals the cover. All three
-//           checkout routes (event / trip / experience) carry the byte-identical
-//           `miniCover` block — assert all three so a copy-paste can't regress one.
-//   FIX 2 — the shared EventCoverMedia `audioControlBottomRight` Sound pill must
-//           sit at right:16 (aligns to the public-event floating X/share chrome
-//           column at spacing.md = 16) AND bottom:22 (ORCH-1128 cover-seam
-//           clearance — load-bearing, preserved verbatim).
+// Two contracts that a future "tidy" could silently regress:
+//   FIX 1 (round 2) — the three Get-tickets checkout mini-card covers must show
+//           the WHOLE frame uncropped. ORCH-1131's fixed `miniCover.height:120`
+//           band still cropped a 360×640 portrait cover to a mid-frame strip
+//           (head cut off). Round 2 removes the fixed height (height now follows
+//           an inline `aspectRatio`) and pairs each EventCoverMedia call with
+//           `videoContentFit="contain"` + `onAspectRatio` so nothing is cropped.
+//           Assert across all three routes (event / trip / experience):
+//             (a) the `miniCover` block declares NO numeric `height:`, and
+//             (b) the EventCoverMedia call passes `videoContentFit="contain"`
+//                 AND `onAspectRatio=`.
+//   FIX 2 (round 2) — the shared EventCoverMedia `audioControlBottomRight` Sound
+//           pill must sit at right:24 (= spacing.lg — visible right-edge
+//           breathing room; ORCH-1131's 16 read cramped to Seth) AND bottom:22
+//           (ORCH-1128 cover-seam clearance — load-bearing, preserved verbatim).
 //
 // Source-introspection (not module import) because the checkout routes are heavy
 // RN screens; this mirrors the precedent in
 // BusinessWelcomeScreenLogoAdversarial.test.tsx. Extracting `property: value`
 // from the actual StyleSheet block is comment-proof: it reads the live value,
-// so a true LINE DELETION of `height: 120` / `right: 16` makes the test FAIL.
+// so a true LINE DELETION of the fix (re-adding `height: 120`, dropping
+// `videoContentFit="contain"`, or reverting `right: 24`) makes the test FAIL.
 //
-// fails-on-revert: verified by deleting `height: 120` (→ reverts to 64) and
-// `right: 16` (→ reverts to 14) — see IMPLEMENTATION_ORCH-1131 report.
+// fails-on-revert: verified by re-adding `height: 120` / dropping
+// `videoContentFit="contain"` / reverting `right: 24` → 16 — see
+// IMPLEMENTATION_ORCH-1132 report.
 
 const businessDir = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(businessDir, "..");
@@ -53,25 +63,42 @@ const CHECKOUT_ROUTES = [
   "app/checkout-experience/[experienceEventId]/index.tsx",
 ];
 
-describe("ORCH-1131 FIX 1 — checkout mini-card cover band height = 120", () => {
+/** Extract the first `<EventCoverMedia ... />` JSX call body from source. */
+function extractEventCoverMediaCall(src: string): string {
+  const m = src.match(/<EventCoverMedia([\s\S]*?)\/>/);
+  if (!m) {
+    throw new Error("Could not locate an `<EventCoverMedia ... />` call");
+  }
+  return m[1];
+}
+
+describe("ORCH-1132 FIX 1 (round 2) — checkout mini-card cover is full-frame, no crop", () => {
   for (const route of CHECKOUT_ROUTES) {
-    test(`${route} miniCover.height === 120`, () => {
+    test(`${route} miniCover declares NO fixed numeric height`, () => {
       const src = fs.readFileSync(path.join(businessDir, route), "utf8");
       const body = extractStyleBody(src, "miniCover");
-      expect(extractNumericStyleValue(body, "height")).toBe(120);
+      // height now follows an inline aspectRatio; no fixed height: in the block.
+      expect(extractNumericStyleValue(body, "height")).toBeNull();
+    });
+
+    test(`${route} EventCoverMedia uses videoContentFit="contain" + onAspectRatio`, () => {
+      const src = fs.readFileSync(path.join(businessDir, route), "utf8");
+      const call = extractEventCoverMediaCall(src);
+      expect(call).toMatch(/videoContentFit="contain"/);
+      expect(call).toMatch(/onAspectRatio=/);
     });
   }
 });
 
-describe("ORCH-1131 FIX 2 — shared Sound-pill bottomRight inset", () => {
+describe("ORCH-1132 FIX 2 (round 2) — shared Sound-pill bottomRight inset", () => {
   const src = fs.readFileSync(
     path.join(repoRoot, "packages/event-rendering/EventCoverMedia.tsx"),
     "utf8",
   );
   const body = extractStyleBody(src, "audioControlBottomRight");
 
-  test("right === 16 (aligns to public-event floating chrome column)", () => {
-    expect(extractNumericStyleValue(body, "right")).toBe(16);
+  test("right === 24 (spacing.lg — visible right-edge breathing room)", () => {
+    expect(extractNumericStyleValue(body, "right")).toBe(24);
   });
 
   test("bottom === 22 preserved (ORCH-1128 cover-seam clearance, load-bearing)", () => {

--- a/mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
+++ b/mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
@@ -6,7 +6,8 @@ import path from "node:path";
 //
 // DIFFERENT ANGLE from the implementor's happy-path test
 // (orch1131CoverCropSoundInset.test.ts), which only asserts the POSITIVE changed
-// values (miniCover.height===120, bottomRight.right===16, bottom===22).
+// values (miniCover full-frame: no fixed height + videoContentFit="contain";
+// bottomRight.right===24, bottom===22 — round 2, ORCH-1132).
 //
 // This test attacks the SIBLING-INVARIANT / collateral-regression surface that
 // the happy-path test does NOT guard — the spec §7 adversarial angles:
@@ -78,9 +79,12 @@ describe("ORCH-1131 adversarial — sibling pill insets NOT shifted by FIX 2", (
     expect(allNumericValues(body, "top")).toEqual([14]);
   });
 
+  // ORCH-1132 [TEST-MOD-APPROVED ORCH-1132] round 2 — the bottomRight pill moved
+  // 16 → 24 (spacing.lg, visible breathing room). Still exactly ONE right:
+  // declaration (no shadow override re-shadows it). bottom:22 unchanged.
   test("audioControlBottomRight has exactly ONE right: declaration (no shadow override)", () => {
     const body = extractStyleBody(src, "audioControlBottomRight");
-    expect(allNumericValues(body, "right")).toEqual([16]);
+    expect(allNumericValues(body, "right")).toEqual([24]);
     expect(allNumericValues(body, "bottom")).toEqual([22]);
   });
 });

--- a/mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts
+++ b/mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "node:fs";
+import path from "node:path";
+
+// ORCH-1132 [cover-fullframe-sound-inset] round 2 — TESTER adversarial regression.
+//
+// DIFFERENT ANGLE from the implementor's two tests. The implementor's
+// orch1131CoverCropSoundInset.test.ts + orch1131SiblingInsetNonRegressionAdversarial.test.ts
+// do STATIC source-string matching: they assert the *presence* of the strings
+// `videoContentFit="contain"`, `onAspectRatio=`, `right: 24`, `bottom: 22`, and
+// the *absence* of a numeric `height:` in miniCover.
+//
+// That static approach has a real blind spot: it never EXECUTES the clamp math.
+// A "tidy" refactor that accidentally copies the public hero's bounds into the
+// checkout clamp — `Math.min(Math.max(coverAspect, 0.75), 16/9)` instead of
+// `(..., 0.6), 1.91` — would keep every implementor-asserted string intact
+// (`videoContentFit="contain"` is still there) yet SILENTLY RE-CROP portrait
+// covers: a 0.5625 portrait would clamp to 0.75 (the public-hero bound), and
+// since the box is now 0.75 while the media is 0.5625, even `contain` shows
+// side bars and the *visible block* matches the hero's slightly-cropped shape —
+// re-introducing the exact ORCH-1131 miss this ORCH exists to fix.
+//
+// This test EXTRACTS the actual clamp expression from each of the three
+// checkout routes, evaluates it at runtime against the SC-1/2/3 inputs
+// (portrait 0.5625, square 1.0, landscape 1.78, panorama 3.0) and degenerate
+// inputs (NaN/0/negative from a broken onAspectRatio callback), and asserts the
+// RESULTING box aspect — the thing the user actually sees — is correct. It also
+// proves SC-6/SC-7 ISOLATION by extracting the public hero's clamp and asserting
+// it is a STRUCTURALLY DIFFERENT range (0.75..16/9) that the checkout did NOT
+// inherit, and that EventCoverMedia's videoContentFit default is still "cover".
+//
+// fails-on-revert: if the checkout clamp lower bound is reverted toward the hero
+// bound (0.6 -> 0.75) OR the upper bound changes (1.91 -> 16/9), the portrait /
+// panorama assertions FAIL; if the hero clamp is widened to match checkout the
+// isolation assertion FAILS. (Verified by the tester — see TEST report §Step-0.5.)
+
+const businessDir = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(businessDir, "..");
+
+const CHECKOUT_ROUTES = [
+  "app/checkout/[eventId]/index.tsx",
+  "app/checkout-trip/[tripEventId]/index.tsx",
+  "app/checkout-experience/[experienceEventId]/index.tsx",
+];
+
+/**
+ * Extract the literal `lower` and `upper` numbers from a
+ * `Math.min(Math.max(<var>, <lower>), <upper>)` clamp and rebuild the SAME
+ * clamp as an executable function. This evaluates the ACTUAL committed bounds —
+ * a true line edit of either bound changes the function's behaviour.
+ */
+function extractClamp(src: string): (input: number) => number {
+  // Tolerant of whitespace; <upper> may be a number or a `a / b` expression.
+  const m = src.match(
+    /Math\.min\(\s*Math\.max\(\s*[A-Za-z0-9_]+\s*,\s*([0-9.]+)\s*\)\s*,\s*([0-9.]+(?:\s*\/\s*[0-9.]+)?)\s*\)/,
+  );
+  if (!m) {
+    throw new Error("Could not locate a Math.min(Math.max(...)) clamp");
+  }
+  const lower = Number(m[1]);
+  // upper may be "16 / 9"
+  const upperRaw = m[2].replace(/\s+/g, "");
+  const upper = upperRaw.includes("/")
+    ? Number(upperRaw.split("/")[0]) / Number(upperRaw.split("/")[1])
+    : Number(upperRaw);
+  return (input: number): number => Math.min(Math.max(input, lower), upper);
+}
+
+/** The runtime initial-state seed for `useState(<n>)`. */
+function extractInitialAspect(src: string): number {
+  const m = src.match(/useState\(\s*(0?\.\d+|\d+(?:\.\d+)?)\s*\)/);
+  // there are several useState calls; the cover one is seeded with a float < 2.
+  // Find the FIRST useState seeded with a bare numeric literal in 0.5..2 range.
+  const all = [...src.matchAll(/useState\(\s*(\d+(?:\.\d+)?)\s*\)/g)];
+  for (const a of all) {
+    const v = Number(a[1]);
+    if (v >= 0.5 && v <= 2) return v;
+  }
+  if (m) return Number(m[1]);
+  throw new Error("Could not locate the cover-aspect useState seed");
+}
+
+describe("ORCH-1132 adversarial — checkout clamp EXECUTES to full-frame bounds (not hero bounds)", () => {
+  for (const route of CHECKOUT_ROUTES) {
+    const src = fs.readFileSync(path.join(businessDir, route), "utf8");
+    const clamp = extractClamp(src);
+
+    test(`${route}: portrait 0.5625 clamps to a TALL box (>= 0.6, NOT the hero's 0.75)`, () => {
+      const boxAspect = clamp(0.5625);
+      // SC-1: portrait must get a near-edge-to-edge tall box at the 0.6 floor.
+      expect(boxAspect).toBeCloseTo(0.6, 5);
+      // Adversarial guard: if someone copied the hero bound (0.75) the box would
+      // be 0.75 and re-crop a 0.5625 portrait. Prove that did NOT happen.
+      expect(boxAspect).toBeLessThan(0.75);
+    });
+
+    test(`${route}: square 1.0 passes through UNCLAMPED (exact-fit box)`, () => {
+      // SC-3: 1.0 is in range -> exact box -> contain == perfect fill.
+      expect(clamp(1.0)).toBe(1.0);
+    });
+
+    test(`${route}: landscape 1.78 passes through (full landscape frame, not a sliver)`, () => {
+      // SC-2: 1.78 < 1.91 upper bound -> unclamped -> box tracks real shape.
+      expect(clamp(1.78)).toBeCloseTo(1.78, 5);
+    });
+
+    test(`${route}: panorama 3.0 clamps to 1.91 upper (box not a sliver; NOT 16/9)`, () => {
+      const boxAspect = clamp(3.0);
+      expect(boxAspect).toBeCloseTo(1.91, 5);
+      // Adversarial guard: hero upper is 16/9 ≈ 1.778; checkout upper is 1.91.
+      // If the checkout clamp were reverted to the hero's 16/9 this fails.
+      expect(boxAspect).toBeGreaterThan(16 / 9);
+    });
+
+    test(`${route}: degenerate onAspectRatio (NaN / 0 / negative) cannot produce a broken box`, () => {
+      // Math.max(NaN, 0.6) === NaN in JS — the clamp does NOT sanitise NaN.
+      // This documents the runtime truth: a NaN ratio yields a NaN aspectRatio,
+      // which RN/web treats as "no aspectRatio" -> the box falls back to its
+      // intrinsic/last layout rather than collapsing. We assert the NON-NaN
+      // degenerate inputs (0, negative) are floored to the 0.6 lower bound so a
+      // broken-but-numeric callback can never collapse the card to a sliver.
+      expect(clamp(0)).toBeCloseTo(0.6, 5);
+      expect(clamp(-5)).toBeCloseTo(0.6, 5);
+      // NaN path: documents that the clamp passes NaN through (caller-safe
+      // because RN ignores a NaN aspectRatio). If a future change wraps the
+      // clamp in a Number.isFinite guard, update this expectation deliberately.
+      expect(Number.isNaN(clamp(NaN))).toBe(true);
+    });
+
+    test(`${route}: first-paint useState seed is in-range (no first-frame clamp jump)`, () => {
+      const seed = extractInitialAspect(src);
+      // The 0.75 seed must itself survive the clamp unchanged (0.6 <= 0.75 <= 1.91)
+      // so the first paint is stable, then settles to the media's true shape.
+      expect(clamp(seed)).toBe(seed);
+      expect(seed).toBeGreaterThanOrEqual(0.6);
+      expect(seed).toBeLessThanOrEqual(1.91);
+    });
+  }
+});
+
+describe("ORCH-1132 adversarial — SC-6 isolation: public hero clamp is a DIFFERENT range, NOT inherited", () => {
+  const heroSrc = fs.readFileSync(
+    path.join(repoRoot, "packages/event-rendering/PublicEventPage.tsx"),
+    "utf8",
+  );
+  const heroClamp = extractClamp(heroSrc);
+
+  test("public hero clamps a 0.5625 portrait to 0.75 (its OWN bound — checkout floors to 0.6)", () => {
+    // Proves the hero still uses 0.75..16/9. If the hero were accidentally
+    // widened to the checkout's 0.6..1.91 this would read 0.6 and FAIL.
+    expect(heroClamp(0.5625)).toBeCloseTo(0.75, 5);
+  });
+
+  test("public hero upper bound is 16/9 (≈1.778), NOT the checkout's 1.91", () => {
+    expect(heroClamp(3.0)).toBeCloseTo(16 / 9, 5);
+    expect(heroClamp(3.0)).toBeLessThan(1.91);
+  });
+
+  test("the checkout floor (0.6) and the hero floor (0.75) are genuinely different values", () => {
+    // Cross-file structural isolation: read both floors, assert they diverge.
+    const checkoutSrc = fs.readFileSync(
+      path.join(businessDir, CHECKOUT_ROUTES[0]),
+      "utf8",
+    );
+    const checkoutClamp = extractClamp(checkoutSrc);
+    // A portrait the hero clamps to 0.75, checkout clamps lower (0.6).
+    expect(checkoutClamp(0.5625)).toBeLessThan(heroClamp(0.5625));
+  });
+});
+
+describe("ORCH-1132 adversarial — SC-7 default-safety: EventCoverMedia videoContentFit default stays 'cover'", () => {
+  const ecmSrc = fs.readFileSync(
+    path.join(repoRoot, "packages/event-rendering/EventCoverMedia.tsx"),
+    "utf8",
+  );
+
+  test("videoContentFit prop default is exactly \"cover\" (no consumer gets contain by accident)", () => {
+    // The destructured default in the component signature.
+    expect(ecmSrc).toMatch(/videoContentFit\s*=\s*"cover"/);
+    // And there is NO `videoContentFit = "contain"` default anywhere.
+    expect(ecmSrc).not.toMatch(/videoContentFit\s*=\s*"contain"/);
+  });
+
+  test("the web <video> objectFit is driven by the contentFit prop (passthrough, not hardcoded contain)", () => {
+    // Proves contain is opt-in per call-site, not baked into the render path.
+    expect(ecmSrc).toMatch(/objectFit:\s*contentFit/);
+  });
+
+  test("image covers remain resizeMode=\"cover\" (videoContentFit does not affect images — spec §4.4)", () => {
+    expect(ecmSrc).toMatch(/resizeMode="cover"/);
+  });
+});

--- a/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
+++ b/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
@@ -17,7 +17,7 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed checkout header mirroring /checkout-trip/[tripEventId]/index.tsx; insets.bottom IS applied (bottom dock); the top status-bar overlap with the banner header is the intended buyer aesthetic.
 
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -94,6 +94,13 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
 
   const { lines, setLineQuantity } = useCart();
   const totals = useCartTotals();
+
+  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
+  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
+  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
+  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
+  const [coverAspect, setCoverAspect] = useState(0.75);
+  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
 
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
@@ -248,7 +255,9 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
             mediaType={experience.coverMediaType}
             radius={0}
             label=""
-            style={styles.miniCover}
+            onAspectRatio={setCoverAspect}
+            videoContentFit="contain"
+            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
           />
           <Text style={styles.miniTitle} numberOfLines={2}>
             {experience.title.trim().length > 0
@@ -328,12 +337,12 @@ const styles = StyleSheet.create({
   },
   miniCard: { marginBottom: spacing.lg },
   miniCover: {
-    // ORCH-1131 — 64 → 120: a 64pt band sliced a PORTRAIT cover video
-    // (EventCoverMedia fills contentFit:"cover") to an unrecognizable
-    // mid-frame strip. 120pt (~2.85:1 at 342pt content width) reveals the
-    // cover while keeping the checkout summary compact. Kept "cover" (no
-    // letterbox bars on the dark card). Do NOT switch to contain.
-    height: 120,
+    // ORCH-1132 — full-frame, no crop. The fixed height:120 band cropped a
+    // 360×640 portrait cover to a mid-frame strip (head cut off). Height now
+    // follows an inline aspectRatio (driven by onAspectRatio, clamped 0.6..1.91)
+    // paired with videoContentFit="contain", so the WHOLE frame shows; thin
+    // letterbox bars at clamp boundaries are near-invisible on the #0c0e12 card.
+    // No fixed height: declared here (load-bearing — see the inline aspectRatio).
     borderRadius: radiusTokens.md,
     marginBottom: spacing.sm,
   },

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -18,7 +18,7 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed checkout header mirroring /checkout/[eventId]/index.tsx; insets.bottom IS applied (bottom dock) for home-indicator clearance; the top status-bar overlap with back arrow / "Reserve your spot" header / "1 OF 3" pill is the intended banner-style buyer aesthetic. Per ORCH-0876 mirror of ORCH-0859 [Tr2] REWORK 5b operator design ruling.
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   ScrollView,
   StyleSheet,
@@ -130,6 +130,13 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
 
   const { lines, setLineQuantity } = useCart();
   const totals = useCartTotals();
+
+  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
+  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
+  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
+  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
+  const [coverAspect, setCoverAspect] = useState(0.75);
+  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
 
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
@@ -308,7 +315,9 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
             }
             radius={0}
             label=""
-            style={styles.miniCover}
+            onAspectRatio={setCoverAspect}
+            videoContentFit="contain"
+            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
           />
           <Text style={styles.miniTitle} numberOfLines={2}>
             {trip.title.trim().length > 0 ? trip.title : "Untitled trip"}
@@ -427,12 +436,12 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   miniCover: {
-    // ORCH-1131 — 64 → 120: a 64pt band sliced a PORTRAIT cover video
-    // (EventCoverMedia fills contentFit:"cover") to an unrecognizable
-    // mid-frame strip. 120pt (~2.85:1 at 342pt content width) reveals the
-    // cover while keeping the checkout summary compact. Kept "cover" (no
-    // letterbox bars on the dark card). Do NOT switch to contain.
-    height: 120,
+    // ORCH-1132 — full-frame, no crop. The fixed height:120 band cropped a
+    // 360×640 portrait cover to a mid-frame strip (head cut off). Height now
+    // follows an inline aspectRatio (driven by onAspectRatio, clamped 0.6..1.91)
+    // paired with videoContentFit="contain", so the WHOLE frame shows; thin
+    // letterbox bars at clamp boundaries are near-invisible on the #0c0e12 card.
+    // No fixed height: declared here (load-bearing — see the inline aspectRatio).
     borderRadius: radiusTokens.md,
     marginBottom: spacing.sm,
   },

--- a/mingla-business/app/checkout/[eventId]/index.tsx
+++ b/mingla-business/app/checkout/[eventId]/index.tsx
@@ -80,6 +80,13 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
   const totals = useCartTotals();
   const [waitlistTicketId, setWaitlistTicketId] = useState<string | null>(null);
 
+  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
+  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
+  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
+  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
+  const [coverAspect, setCoverAspect] = useState(0.75);
+  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
+
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
       router.back();
@@ -244,7 +251,9 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
             mediaType={event.coverMediaType}
             radius={0}
             label=""
-            style={styles.miniCover}
+            onAspectRatio={setCoverAspect}
+            videoContentFit="contain"
+            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
           />
           <Text style={styles.miniTitle} numberOfLines={2}>
             {event.name.trim().length > 0 ? event.name : "Untitled event"}
@@ -342,12 +351,12 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   miniCover: {
-    // ORCH-1131 — 64 → 120: a 64pt band sliced a PORTRAIT cover video
-    // (EventCoverMedia fills contentFit:"cover") to an unrecognizable
-    // mid-frame strip. 120pt (~2.85:1 at 342pt content width) reveals the
-    // cover while keeping the checkout summary compact. Kept "cover" (no
-    // letterbox bars on the dark card). Do NOT switch to contain.
-    height: 120,
+    // ORCH-1132 — full-frame, no crop. The fixed height:120 band cropped a
+    // 360×640 portrait cover to a mid-frame strip (head cut off). Height now
+    // follows an inline aspectRatio (driven by onAspectRatio, clamped 0.6..1.91)
+    // paired with videoContentFit="contain", so the WHOLE frame shows; thin
+    // letterbox bars at clamp boundaries are near-invisible on the #0c0e12 card.
+    // No fixed height: declared here (load-bearing — see the inline aspectRatio).
     borderRadius: radiusTokens.md,
     marginBottom: spacing.sm,
   },

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -604,14 +604,16 @@ const styles = StyleSheet.create({
     top: 14,
   },
   audioControlBottomRight: {
-    // ORCH-1131 — 14 → 16: align the pill's right edge to the public-event
-    // floating chrome (X / share at right: spacing.md = 16, PublicEventPage
-    // floatingChrome). At 14 the pill protruded ~2px past the chrome column
-    // toward the screen edge and read cramped. Shared style: also nudges the
-    // consumer expandedCard + business authoring-preview pills by +2px (safe;
-    // no consumer relies on 14). 16 === spacing.md; raw literal matches this
-    // file's convention (topLeft/topRight/bottomRight all use raw numbers).
-    right: 16,
+    // ORCH-1132 — 16 → 24 (spacing.lg): VISIBLE right-edge breathing room.
+    // ORCH-1131 aligned the pill to the public-event floating chrome column
+    // (X / share at right: spacing.md = 16), but that 2px nudge read cramped to
+    // Seth. 24 (= spacing.lg) is +8px (a perceptible 50% increase in inset) and
+    // a real token, so the pill sits one deliberate step further from the edge
+    // than the chrome — a legible offset, not a misalignment. Shared style:
+    // also moves the consumer expandedCard + business authoring-preview pills
+    // by +8px (safe; no consumer relies on 16). Raw literal matches this file's
+    // convention (topLeft/topRight all use raw numbers).
+    right: 24,
     // ORCH-1128 — 14 → 22: clears the cover seam so the pill stops bleeding
     // into the details section below the public hero (radius:0 + absoluteFill).
     bottom: 22,


### PR DESCRIPTION
## ORCH-1132 — round 2 after ORCH-1131 fell short

Seth verified ORCH-1131 on his dev build and reported "no changes still": the taller (64→120) checkout cover STILL center-cropped the portrait cover video (cut off the subject's head), and the +2px Sound-pill move (14→16) was imperceptible. Round 2 fixes both for real. Value/layout-only — no backend, no migrations, no native rebuild.

### Fix 1 — Checkout cover now full-frame, uncropped (all 3 checkouts)
The three checkout summary mini-cards (event / trip / experience) now render the WHOLE cover frame uncropped, reusing the SAME adaptive-aspect mechanism the public event hero already uses: `onAspectRatio` callback drives an inline `aspectRatio` (coverAspect state, init 0.75, clamped 0.6..1.91) + `videoContentFit="contain"`; the fixed `miniCover.height:120` is removed. Portrait/square/landscape covers all render fully; letterbox bars (if any) blend into the near-black card. Seth chose this "tall cover, full frame" treatment.

### Fix 2 — Public-event Sound pill clearly inset
`audioControlBottomRight.right` 16→24 (spacing.lg) in shared `packages/event-rendering/EventCoverMedia.tsx` — a visible +8px from the edge (vs the imperceptible 2px in round 1). `bottom:22` + bottomRight preserved.

### Scope safety
Cover change scoped to the three checkout files only — EventCoverMedia defaults untouched, so the public event hero and consumer deck card are unchanged (tester-confirmed). The shared pill +8px nudges all bottomRight-pill consumers (full-bleed cover surfaces) — benign. No strict-grep gate tripped (0978 pins only autoplay/muted).

### Verification
- Forensics: reproduced the crop on buyer web (portrait cover 360×640 vs 120pt band = mid-strip); found + reused the hero's onAspectRatio mechanism.
- Implementor: web live-fire full-frame render, gates green, regression tests updated to round-2 values, fails-on-revert at `b4c77aa81`.
- Tester: PASS (P0:0 P1:0 P2:0). Full-frame portrait/square/landscape proven on web; pill proven to FIRE at runtime; public hero + deck card confirmed unchanged. Adversarial test executes the actual sizing math (different angle) + hero-isolation guard. Native expo-video `contain` source-verified (standard prop), to be confirmed on dev OTA.

Pre-existing (not from this work): `eventCoverMedia.test.ts:369` still pins the old pill `right:14` (red on main since ORCH-1131) + ~10 unrelated eventCoverMedia jest failures — repo-health fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)