### PR TITLE
ORCH-1133: revert checkout cover to compact band + Sound-pill clearance from details section [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
@@ -1,0 +1,135 @@
+# IMPLEMENTATION — ORCH-1133 [revert checkout cover to original compact band + give the public-event Sound pill clearance from the details section]
+
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1133-[revert-cover-pill-bottom]/` on branch `ORCH-1133-revert-cover-pill-bottom`
+**Base:** origin/main `907b2b2a0` (rebased, up to date).
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md` (binding).
+**Commit:** `2f06e8314` (single commit; HEAD body carries `[TEST-MOD-APPROVED ORCH-1133]`).
+**Status:** implemented and verified (buyer-web live-fire for both changes).
+
+---
+
+## 1. Summary
+
+Round 3 of the cover/pill saga (ORCH-1128 → 1131 → 1132 → 1133). Two tightly-scoped product changes, exactly per spec:
+
+1. **Reverted** all three Get-tickets checkout mini-card covers (event/trip/experience) to the TRUE pre-ORCH-1131 original — a fixed `miniCover { height: 64, borderRadius: radiusTokens.md, marginBottom: spacing.sm }` compact band + a plain `<EventCoverMedia hue mediaUrl mediaType radius={0} label="" style={styles.miniCover} />` call. Removed every ORCH-1131/1132 cover addition (coverAspect/setCoverAspect `useState`, `clampedCoverAspect`, `onAspectRatio`, `videoContentFit="contain"`, the inline `aspectRatio`, the bloated comments). Dropped the now-unused `useState` import from the trip + experience files; KEPT it in the event file (`waitlistTicketId` still uses it). Seth's complaint — "The cover fills the entire screen. Revert to original." — is resolved: the prod cover renders at **684px** (full-screen); my build renders at **64px** (compact band).
+2. **Moved** the shared public-event Sound pill bottom-anchor from `bottom: 22` to `bottom: 40` in `packages/event-rendering/EventCoverMedia.tsx` so it clears the blue details panel by a measured **+12px** (was −6px overlap). `right: 24` and the `bottomRight` position are untouched.
+
+Six in-scope jest files updated to round-3 values and brought GREEN (`[TEST-MOD-APPROVED ORCH-1133]` token in HEAD). The clamp-math adversarial test was INVERTED in place (not deleted — the append-only CI gate forbids test-file deletion with no token bypass; see §6 / Discoveries).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence (commit `2f06e8314`) |
+|----|-----------|--------|-------------------------------|
+| SC-1 (Web) | `/e/*` Sound pill bottom ≥10px above details panel (target +12) | ✓ PASS | Playwright runtime measure on live `…/e/leggothis/vibes-and-stuff`, 430×932@2x: prod `bottom:22` gap = **−6px**; my `bottom:40` gap = **+12.0px**. `AFTER_orch1133_pill_bottom40_vibes.png` |
+| SC-2-Web (cover) | Each checkout shows fixed 64px compact band, not full-screen; `miniCover` declares `height: 64` | ✓ PASS | Local worktree build `/checkout/09b4ece6…`: cover VIDEO measured **h=64** (top:81), 0 console errors. `AFTER_localbuild_checkout_compact64.png` vs prod `BEFORE_prod_checkout_cover_fullscreen.png` (h=684) |
+| SC-2-iOS / SC-2-Android | Same compact band (shared RN code) | ✓ PASS (parity automatic) | One RN codebase; same `miniCover.height:64` + plain JSX renders on all targets. Web export is the faithful render of the RN source. |
+| SC-3 | 3 checkout files have NO coverAspect/setCoverAspect/clampedCoverAspect/onAspectRatio/videoContentFit/inline aspectRatio; plain 6-prop EventCoverMedia call | ✓ PASS | `orch1132ClampMathHeroIsolationAdversarial.test.ts` (inverted) asserts all absent + plain call, all 3 routes; grep-clean |
+| SC-4 | trip + experience React imports drop `useState`; event keeps it; tsc/lint clean (no unused-import) | ✓ PASS | trip = `useCallback, useMemo`; experience = `useCallback`; event = `useCallback, useState`. tsc: 0 errors in the 4 edited files (package tsc exit 0). eslint: 0 errors (2 warnings pre-exist on origin/main — unrelated `useMemo`/`LiveEvent`) |
+| SC-5 | `audioControlBottomRight = { right: 24, bottom: 40 }`; right unchanged 24; topLeft/topRight unchanged 14 | ✓ PASS | `orch1131SiblingInsetNonRegressionAdversarial.test.ts` asserts right [24]/bottom [40]/topLeft [14]/topRight [14] |
+| SC-6 (cross-consumer) | Pill stays on-screen at bottom:40 on full-bleed covers | ✓ PASS | Pill at bottom:40 measured fully on-screen (pillBottom 533 < viewport 932); shared 36px pill on ≥200px boxes never clips |
+| SC-7 (tests) | 6 in-scope jest files PASS at round-3 values, token present | ✓ PASS | 5 suites 39/39 green; eventCoverMedia pill test green; append-only check 6/6 pass exit 0 |
+
+---
+
+## 3. Files changed (10; +155 / −222)
+
+**Product (4):**
+- `mingla-business/app/checkout/[eventId]/index.tsx` (~18 lines) — removed coverAspect state, plain JSX, miniCover height:64; KEPT useState import.
+- `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` (~20) — same + dropped `useState` import.
+- `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` (~20) — same + dropped `useState` import.
+- `packages/event-rendering/EventCoverMedia.tsx` (~11) — `audioControlBottomRight.bottom` 22→40 (+ explanatory comment). `right:24` untouched.
+
+**Tests (6):**
+- `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts` (~65) — happy-path: miniCover height===64 (3 routes) + plain call + right===24/bottom===40.
+- `mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts` (~9) — bottom [40] (was [22]); right/topLeft/topRight/heroBox unchanged.
+- `mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts` (~178) — INVERTED: asserts clamp/state/props are GONE + miniCover height:64; hero isolation + ECM default preserved.
+- `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` (~20) — pill test: right:24 + bottom:40, block-parse slice (DISC-1 hardening). DISC-2 cover-picker tests untouched.
+- `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts` (~18) — bottom 40 + right 24, block-parse.
+- `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts` (~18) — bottom > 14 (40) + right 24 + no top: key, exact-block parse.
+
+---
+
+## 4. Data-model changes applied
+None. Pure RN style/JSX + tests. No migration, no RLS, no schema.
+
+## 5. Edge functions touched
+None.
+
+---
+
+## 6. Regression tests added / updated
+
+**Happy-path (implementor-owned):** `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts` — source-introspection (comment-proof) pinning `miniCover.height===64` (all 3 routes), plain EventCoverMedia call (no videoContentFit/onAspectRatio), and `audioControlBottomRight` right===24 / bottom===40.
+
+**fails-on-revert verified at commit `2f06e8314`:** Hand-mutated (true LINE DELETION) the product code in File A back toward ORCH-1132 state — removed `height: 64` from miniCover, re-added `onAspectRatio={setCoverAspect}` + `videoContentFit="contain"` + inline `aspectRatio` to the JSX — and reverted the pill `bottom: 40 → 22`. Result: `orch1131CoverCropSoundInset.test.ts` → **3 failed, 5 passed** (the height:64 assertion, the plain-call assertion, and the bottom===40 assertion all RED). Restored the fix → **8 passed, 8 total** GREEN. Proves the test exercises the actual bug and is not comment-fooled.
+
+**Append-only compliance:** every modified test file deletes ≥1 line; the HEAD commit body carries `[TEST-MOD-APPROVED ORCH-1133]` with the why-cited reason. `node .github/scripts/test-append-only-check.js` → **6 passed, 0 failed, exit 0**.
+
+---
+
+## 7. Old → New receipts
+
+### checkout/[eventId]/index.tsx
+**Before:** mini-card cover was a full-frame adaptive box — `coverAspect`/`clampedCoverAspect` useState clamp (0.6..1.91) drove an inline `aspectRatio`, with `onAspectRatio={setCoverAspect}` + `videoContentFit="contain"`; `miniCover` declared NO height (ballooned to ~684px on web). **Now:** plain 6-prop EventCoverMedia call; `miniCover { height: 64, borderRadius, marginBottom }` compact band. KEPT the `useState` import (`waitlistTicketId`). **Why:** Seth round-3 reject — revert to e90875dda~1 original (SC-2/SC-3/SC-4). **Lines:** ~18.
+
+### checkout-trip/[tripEventId]/index.tsx & checkout-experience/[experienceEventId]/index.tsx
+**Before:** same adaptive-cover additions as the event file. **Now:** plain call + `height:64` band; `useState` dropped from the React import (coverAspect was its sole user). **Why:** same revert + SC-4 no-unused-import. **Lines:** ~20 each.
+
+### packages/event-rendering/EventCoverMedia.tsx
+**Before:** `audioControlBottomRight` = `{ right: 24, bottom: 22 }` (ORCH-1128) — pill overlapped the public-event details panel by 6px. **Now:** `{ right: 24, bottom: 40 }` — pill clears the panel by +12px. `right` and `bottomRight` position untouched; `audioControlTopLeft`/`TopRight` (14) untouched. **Why:** Seth — "sound button still needs some space from the details section" (SC-1/SC-5). **Lines:** ~11 (mostly the explanatory comment).
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Change | Parity |
+|---------|----------|--------|--------|
+| Consumer iOS | YES (shared pill only) | gallery Sound pill +18px up on full-bleed; benign | automatic (shared) |
+| Consumer Android | YES (shared pill only) | same | automatic |
+| Buyer/anon Web | YES | 3 checkout covers → 64px band; `/e/*` pill clears panel +12px | automatic (web export of RN) |
+| Business iOS | YES (checkout cover) | compact 64px band restored | automatic |
+| Business Android | YES (checkout cover) | same | automatic |
+| Admin Web | NO | no consumer of these files | — |
+| Business Web preview (authoring) | YES (shared pill only) | preview Sound pill +18px up; benign | automatic |
+
+All parity is automatic (single shared RN codebase). No manual per-surface paths.
+
+---
+
+## 9. Smoke / live-fire result
+
+- **Sound pill (SC-1):** Playwright on live prod `…/e/leggothis/vibes-and-stuff` (430×932@2x). Measured pill vs details-panel (`borderTopLeftRadius:28`) `getBoundingClientRect`: current prod `bottom:22` → gap **−6.0px** (overlap, the bug). Injected my committed value (bottom:40) → gap **+12.0px** (clean). Screenshot `AFTER_orch1133_pill_bottom40_vibes.png`. Matches the forensics live-fire (`candidate_bottom40_vibes.png`, `bottom:40 => gap:12`).
+- **Checkout cover (SC-2):** ran THIS worktree's Expo web build (`expo start --web :8092`) and loaded `/checkout/09b4ece6-eabc-4734-8ce3-3a25d90417e4`. Cover VIDEO measured **h=64** (top:81), page shows the compact "Vibes and Stuff" mini-card, 0 console errors. Screenshot `AFTER_localbuild_checkout_compact64.png`. Contrast: prod (old code) measured **h=684** full-screen — `BEFORE_prod_checkout_cover_fullscreen.png`.
+- **Gates:** package tsc exit 0; eslint 0 errors on the 3 checkout files; six jest files GREEN; all four ORCH-0978 strict-grep gates OK; append-only check 6/6 exit 0.
+
+**Evidence dir:** `Mingla_Artifacts/evidence/ORCH-1133/`
+- `AFTER_localbuild_checkout_compact64.png` — my build, 64px band (SC-2 AFTER).
+- `BEFORE_prod_checkout_cover_fullscreen.png` — prod, 684px full-screen (SC-2 BEFORE).
+- `AFTER_orch1133_pill_bottom40_vibes.png` — pill at bottom:40, +12px gap (SC-1 AFTER).
+- `seam_*` / `repro_*` (forensics) — pill at bottom:22, −6px overlap (SC-1 BEFORE).
+- `candidate_bottom40_vibes.png` / `candidate_bottom44_vibes.png` (forensics) — design-value live-fire.
+
+---
+
+## 10. Known issues / deferred
+- The 5 remaining failures in `eventCoverMedia.test.ts` are the pre-existing DISC-2 cover-picker-copy / media-error tests (`event creator shows upload limits`, `iOS-compatible image output`, `image/GIF picking`, `video playback gated by active surface intent`, `media render failures surfaced`). They fail identically on origin/main and are explicitly OUT OF SCOPE per spec §2/§7. My pill test in that file PASSES.
+- 2 eslint warnings (`useMemo` unused in trip, `LiveEvent` unused in event) pre-exist on origin/main (both are import-only on origin too) — NOT introduced by this ORCH; out of allowlist scope.
+- No `[TRANSITIONAL]` markers introduced.
+
+---
+
+## 11. Operator action required
+- No migration. No edge-function deploy. No native rebuild (pure-JS RN style/JSX change → OTA-eligible per the OTA policy; orchestrator/operator decides the channel).
+- Route back to **mingla-orchestrator** for REVIEW, then **mingla-tester** (buyer-web Playwright SC-1 measure + checkout-cover SC-2 render + the 6-file jest gate).
+- NOTE (env): this worktree's `node_modules` was missing `expo-image-manipulator` (declared in package.json `~14.0.8`, referenced by `src/utils/normalizeTripDayImage.ts` on origin/main — pre-existing, unrelated to ORCH-1133). I `npm install`ed it with `--no-save` to unblock the local web bundle for the live-fire; `package.json`/`package-lock.json` are unmodified (git status clean). The orchestrator/tester may need the same install to run the business web locally.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **DISC-A (spec-vs-gate conflict, RESOLVED in-lane):** The SPEC §7/§9/§Allowlist instructed DELETING `orch1132ClampMathHeroIsolationAdversarial.test.ts` and asserted the `[TEST-MOD-APPROVED ORCH-1133]` token covers the deletion. The ACTUAL CI gate (`.github/scripts/test-append-only-check.js`, ORCH-0840 policy) categorically FORBIDS test-file deletion — "No override token bypasses deletion" — so a delete would FAIL CI (verified: exit 1). I preserved the spec's INTENT without violating the gate by INVERTING the file in place (MODIFY, token-covered): it now asserts the checkout clamp/coverAspect/onAspectRatio/videoContentFit/inline-aspectRatio must STAY gone + miniCover height:64, while keeping the still-valid public-hero isolation + EventCoverMedia `videoContentFit="cover"` default checks. This is strictly a stronger durable guard than deletion. Flagging so the orchestrator/forensics knows the spec's "DELETE" instruction is incompatible with the append-only gate for future ORCHs — modify/invert, never delete.
+- **DISC-B (env gap):** `expo-image-manipulator` not installed in the ORCH-1133 worktree (see §11). Likely affects sibling worktrees too; an incomplete `npm install` on spawn.
+- No COMMS-ledger BLOCK rows addressed to ORCH-1133/this skill/ALL. The open ALL-targeted rows (COMMS-0027/0030 trip migrations, 0028 gif-cover-key, etc.) are all WARN and concern trip/cover-picker migrations — orthogonal to this RN style revert; read and factored (no action needed).

--- a/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
+++ b/Mingla_Artifacts/reports/INVESTIGATION_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
@@ -1,0 +1,206 @@
+# INVESTIGATION — ORCH-1133 [revert checkout cover to original compact band + give the public-event Sound pill clearance from the details section]
+
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1133-[revert-cover-pill-bottom]/` on branch `ORCH-1133-revert-cover-pill-bottom`
+**Base:** rebased on origin/main `907b2b2a0` (contains ORCH-1132 full-frame cover + pill `right:24` / `bottom:22`).
+**Date:** 2026-06-13
+**Confidence:** PROVEN (live-fire on buyer web: `https://business.usemingla.com/e/leggothis/vibes-and-stuff` + `/a-life-in-vegas`).
+
+This is round 3 of the cover/pill saga (ORCH-1128 → 1131 → 1132 → 1133). Seth rejected ORCH-1132's full-frame cover on his dev build ("The get tickets page now looks awful, revert. The cover fills the entire screen. Revert to original.") and separately ("The sound button still needs some space or padding from the details section.").
+
+---
+
+## Symptom summary (expected vs actual)
+
+| # | Expected | Actual (current main 907b2b2a0) |
+|---|----------|----------------------------------|
+| S1 | The three Get-tickets checkout mini-card covers show a SMALL compact band (the pre-ORCH-1131 original). | ORCH-1132 made each cover adaptive-aspect full-frame (`aspectRatio` driven by `onAspectRatio`, `videoContentFit="contain"`). A portrait cover (0.5625) clamps to 0.6 → balloons to ~screen-width-tall, "fills the entire screen". |
+| S2 | The public-event "Sound" pill sits with clear, visible separation above the blue details panel. | The pill (`bottom:22`) overlaps the details panel top edge by 6px — the panel (rounded, `marginTop:-28`) covers the pill's bottom. Pill bleeds into the details section. |
+
+---
+
+## Investigation manifest (every file read, in trace order)
+
+| # | File | Why |
+|---|------|-----|
+| 1 | `COMMS_LEDGER.md` | Mandatory entry scan. No BLOCK/WARN row targets forensics / ORCH-1133 / ALL relevant to cover/pill (active rows are trip-migration COMMS-0029 etc.). |
+| 2 | `mingla-business/app/checkout/[eventId]/index.tsx` | Event checkout cover (current ORCH-1132 state + state hooks + styles). |
+| 3 | `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | Trip checkout cover (parallel). |
+| 4 | `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | Experience checkout cover (parallel). |
+| 5 | `git show e90875dda~1:<each of the 3 files>` | The TRUE original (pre-ORCH-1131) cover code to restore. |
+| 6 | `packages/event-rendering/EventCoverMedia.tsx` | Shared `audioControlBottomRight` pill style (`right:24`, `bottom:22`). |
+| 7 | `packages/event-rendering/PublicEventPage.tsx` | Public hero (`heroBox`) + details panel (`bodyContent`, `marginTop:-28`) geometry. |
+| 8 | `app-mobile/src/components/expandedCard/ImageGallery.tsx` | Consumer cross-surface consumer of the shared `bottomRight` pill. |
+| 9 | CoverPicker / ExperienceCoverStep / TripCreatorStep1Basics / EditPublishedTripScreen / CreatorStep4Cover | Authoring-preview consumers (default `bottomRight`). |
+| 10 | 6 jest test files (1131/1132/1128/eventCoverMedia) | Regression assertions on the values being changed. |
+| 11 | `.github/scripts/test-append-only-check.js`, `tests-append-only.yml`, `regression-test-backfill-warning.mjs` | Append-only override mechanics. |
+
+---
+
+## Q-scorecard
+
+**Q1 — What was the TRUE original checkout cover (the one Seth wants back)?**
+Verdict (PROVEN): `git show e90875dda~1` shows in all three files an identical `miniCover` block —
+```
+miniCover: {
+  height: 64,
+  borderRadius: radiusTokens.md,
+  marginBottom: spacing.sm,
+},
+```
+and a plain `<EventCoverMedia hue=… mediaUrl=… mediaType=… radius={0} label="" style={styles.miniCover} />` with NO `coverAspect` state, NO `onAspectRatio`, NO `videoContentFit`, NO inline `aspectRatio`. (F-1)
+
+**Q2 — What did ORCH-1131 + ORCH-1132 add on top that must be removed?**
+Verdict (PROVEN): ORCH-1131 changed height 64→120; ORCH-1132 removed the fixed height entirely and added (a) `const [coverAspect, setCoverAspect] = useState(0.75)` + `const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91)`, (b) `onAspectRatio={setCoverAspect}` + `videoContentFit="contain"` + `style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}` on the JSX, (c) a 6-line ORCH-1132 comment block in `miniCover` and removal of `height:`. All of (a)(b)(c) revert. (F-2)
+
+**Q3 — Does removing `coverAspect` orphan the `useState` import in any file?**
+Verdict (PROVEN): YES in trip + experience. Original imports were `{ useCallback, useMemo }` (trip) and `{ useCallback }` (experience) — neither imported `useState`. The event file's original import IS `{ useCallback, useState }` because `waitlistTicketId` also uses `useState` (line 81), so the event file KEEPS `useState`. (F-3)
+
+**Q4 — How does the public details panel overlap the pill, and what is the measured gap?**
+Verdict (PROVEN, live-fire): `bodyContent` (the blue/dark rounded details panel, `borderTopLeftRadius:28`) has `marginTop:-28`, so its top edge sits 28px above the cover/hero bottom. The pill has `bottom:22` + `minHeight:36`. Measured on buyer web: pill bottom = hero_bottom − 22; panel top = hero_bottom − 28 → **gap = panelTop − pillBottom = −6.0px on BOTH rendered events**. The panel overlaps the pill's bottom 6px. (F-4)
+
+**Q5 — What `bottom` value gives clear, visible separation?**
+Verdict (PROVEN, live-fire): the CSS `bottom` value equals `28 + desiredGap`. Injecting candidates at runtime: `bottom:40` → measured gap **+12.0px** (clean); `bottom:44` → **+16.0px**. Recommend **`bottom:40`** (12px clearance — a deliberate, visible gap above the panel, without over-lifting the pill into the cover subject). (F-5)
+
+**Q6 — Cross-consumer blast radius of a larger `bottom` on the shared pill?**
+Verdict (PROVEN, source + render): benign. Consumers — PublicEventPage hero (target), app-mobile ImageGallery (full-bleed gallery slide), and 5 authoring previews (CoverPicker / ExperienceCoverStep / TripCreatorStep1Basics / EditPublishedTripScreen / CreatorStep4Cover) — all render the pill on a FULL-BLEED cover ≥ ~200px tall. A 36px-tall pill at `bottom:40` only goes off-screen if the cover box is < 76px tall; none are. No bottom-panel collision exists on those surfaces. The candidate render (430×932 viewport) showed the pill clear of top chrome (X / share) and not pushed off-screen. (F-6)
+
+**Q7 — Which jest tests assert the values being changed, and what is their CURRENT pass state?**
+Verdict (PROVEN): SIX files assert these values; THREE are ALREADY FAILING on current main (8 failed tests), pre-introduced by ORCH-1132's `right:16→24` + bloated comment block (the business app has NO full jest CI gate, so ORCH-1132 merged green). See F-7 + Discoveries. The clamp-execution test becomes structurally invalid post-revert (no clamp to extract). (F-7)
+
+---
+
+## Findings (six-field evidence)
+
+### F-1 — TRUE original cover is `height:64` compact band + plain EventCoverMedia (CONFIRMED ROOT CAUSE of S1 revert target)
+- **Symptom:** Seth wants "the original" back.
+- **Layer:** code.
+- **Probe:** `git show 'e90875dda~1:mingla-business/app/checkout/[eventId]/index.tsx'` (and trip/experience).
+- **Evidence (verbatim, all three identical):**
+  ```
+  miniCover: { height: 64, borderRadius: radiusTokens.md, marginBottom: spacing.sm },
+  ```
+  JSX (event): `<EventCoverMedia hue={event.coverHue} mediaUrl={event.coverMediaUrl} mediaType={event.coverMediaType} radius={0} label="" style={styles.miniCover} />`. Trip/experience use `hue={0}` + their own media fields, otherwise identical (no aspect props).
+- **Mechanism:** the fixed 64px band gives the component's default cover-fill (`videoContentFit` default = `"cover"`) → small compact thumbnail, never balloons.
+- **Severity:** CONFIRMED ROOT CAUSE (revert target).
+
+### F-2 — Current ORCH-1132 cover is adaptive-aspect full-frame → balloons portrait covers (CONFIRMED ROOT CAUSE of S1)
+- **Symptom:** "The cover fills the entire screen."
+- **Layer:** code.
+- **Probe:** read current files (lines: event 87-88/248-257/353-362; trip 138-139/310-321/438-447; experience 102-103/252-261/339-348).
+- **Evidence (event, verbatim):**
+  ```
+  const [coverAspect, setCoverAspect] = useState(0.75);
+  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
+  …
+  onAspectRatio={setCoverAspect}
+  videoContentFit="contain"
+  style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
+  …
+  miniCover: { /* ORCH-1132 6-line comment */ borderRadius: radiusTokens.md, marginBottom: spacing.sm },  // NO height
+  ```
+- **Mechanism:** a 360×640 (0.5625) portrait cover → clamp floors to 0.6 → the column-width mini-card box becomes ~0.6 aspect → ≈ screen-width-tall band → "fills the entire screen."
+- **Severity:** CONFIRMED ROOT CAUSE.
+
+### F-3 — Reverting `coverAspect` orphans `useState` in trip + experience ONLY (SECONDARY)
+- **Symptom:** would leave an unused import → lint/TS noise (and the original had no `useState` there).
+- **Layer:** code.
+- **Probe:** `grep -n useState` current vs `git show e90875dda~1:…`.
+- **Evidence:** current trip import `import React, { useCallback, useMemo, useState }`; original `…{ useCallback, useMemo }`. current experience import `…{ useCallback, useState }`; original `…{ useCallback }`. Event original IS `…{ useCallback, useState }` (kept — `waitlistTicketId` uses it, line 81).
+- **Mechanism:** `coverAspect`/`setCoverAspect` are the SOLE `useState` users in trip + experience; removing them must drop `useState` from those two imports (NOT the event import).
+- **Severity:** SECONDARY ROOT CAUSE (revert correctness).
+
+### F-4 — Details panel overlaps the pill by −6px (CONFIRMED ROOT CAUSE of S2)
+- **Symptom:** "The sound button still needs some space or padding from the details section."
+- **Layer:** code + runtime.
+- **Probe:** Playwright/Chrome (channel:chrome, 430×932@2x) on `…/e/leggothis/vibes-and-stuff` and `…/a-life-in-vegas`; measured `getBoundingClientRect()` of the pill (aria-label "Turn on cover video audio"), the panel (`borderTopLeftRadius:28`), and the `<video>` hero. Script: `/tmp/orch1133_measure.mjs`. Evidence: `Mingla_Artifacts/evidence/ORCH-1133/`.
+- **Evidence (verbatim):**
+  - vibes-and-stuff: `PILL.bottom = 551.3  PANEL.top = 545.3  GAP = -6.0px`; `PILL.bottom inset from HERO.bottom = 22.0px`.
+  - a-life-in-vegas: `PILL.bottom = 219.9  PANEL.top = 213.9  GAP = -6.0px`; inset `22.0px`.
+  - source: `PublicEventPage.tsx` `bodyContent { marginTop: -28 }` (line 1461); `EventCoverMedia.tsx` `audioControlBottomRight { right: 24, bottom: 22 }` (lines 616/619); pill `minHeight: 36` (line 587).
+  - screenshot `seam_leggothis__vibes-and-stuff.png` shows the "Sound" pill bottom clipped behind the rounded panel top.
+- **Mechanism:** panel top = hero_bottom − 28; pill bottom = hero_bottom − 22 → pill bottom is 6px BELOW the panel top → panel covers/touches the pill bottom = the visible bleed.
+- **Severity:** CONFIRMED ROOT CAUSE.
+
+### F-5 — `bottom:40` yields a clean +12px gap (the fix value, live-verified)
+- **Symptom:** need clear separation.
+- **Layer:** runtime.
+- **Probe:** `/tmp/orch1133_verify_bottom.mjs` — injected `pill.style.bottom` and re-measured on vibes-and-stuff.
+- **Evidence (verbatim):** `candidate bottom:40 => gap:12`; `candidate bottom:44 => gap:16`. Screenshot `candidate_bottom40_vibes.png` shows the Sound pill clearly separated above the blue details panel, clear of the top X/share chrome, not off-screen.
+- **Mechanism:** CSS `bottom = 28 (panel overlap) + desiredGap`. 40 → +12px (one perceptible step, matches the "needs some space/padding" ask without lifting the pill into the cover subject). 44 (= spacing.md gap of 16) is the more-generous alternative.
+- **Severity:** N/A (the chosen fix value).
+
+### F-6 — Shared-pill blast radius is benign across all consumers
+- **Symptom:** a larger bottom inset could push the pill off-screen / behind chrome on another surface.
+- **Layer:** code + render.
+- **Probe:** grep `showAudioControl` / `audioControlPosition` consumers; read each preview box style; the candidate render at 430×932.
+- **Evidence:** consumers = PublicEventPage hero (target), `app-mobile/.../ImageGallery.tsx:134` (`bottomRight`, full-bleed `styles.image`), and 5 authoring previews (CoverPicker:1053, ExperienceCoverStep:107, TripCreatorStep1Basics:504, EditPublishedTripScreen:1446, CreatorStep4Cover:99 — all default `bottomRight`). All preview boxes are `overflow:hidden` + aspect-driven full-bleed media (≥ ~200px tall when populated). `SwipeableCards.tsx:335` passes `showAudioControl={false}` (deck card — pill never renders; explicitly out of scope per dispatch).
+- **Mechanism:** +18px bottom on a ≥200px full-bleed cover keeps the 36px pill comfortably inside; no surface has a bottom panel at that inset except the public hero (the one we are fixing).
+- **Severity:** RULED OUT (no adverse cross-consumer effect).
+
+### F-7 — Six test files assert the changed values; three ALREADY FAIL on current main (CONFIRMED)
+- **Symptom:** ORCH-1133's reverts/round-3 values contradict pinned jest assertions.
+- **Layer:** code (tests).
+- **Probe:** `npx jest` on the 6 files at HEAD 907b2b2a0 (clean worktree).
+- **Evidence (verbatim):** `Test Suites: 3 failed, 3 passed; Tests: 8 failed, 58 passed`. Failing files: `eventCoverMedia.test.ts`, `orch1128FreeCtaMutePill.test.ts`, `orch1128FreeCtaMutePill.adversarial.test.ts`. Assertions touched:
+  - `orch1131CoverCropSoundInset.test.ts:81/87-88` — miniCover NO height + `videoContentFit="contain"` + `onAspectRatio=` → ALL INVERT under revert; `:101` `right===24` KEEP; `:105` `bottom===22` → 40.
+  - `orch1131SiblingInsetNonRegressionAdversarial.test.ts:87` `right [24]` KEEP; `:88` `bottom [22]` → `[40]`. (topLeft/topRight/heroBox assertions untouched — stay green.)
+  - `orch1132ClampMathHeroIsolationAdversarial.test.ts` — first `describe` (83-139) + the cross-file check (159-168) call `extractClamp(checkoutSrc)`, which THROWS post-revert (no `Math.min(Math.max(...))` clamp left in the checkout files) → whole file invalid. SC-7 block (171-192, EventCoverMedia `videoContentFit` default = `"cover"`) stays valid. → DELETE the file (its subject, the checkout clamp, is removed); the SC-7 assertions are already covered by the SC-7 default check and can be dropped with it.
+  - `eventCoverMedia.test.ts:369` `right: 14` (stale; current is 24) + `:371` `bottom: 22` → `right: 24` + `bottom: 40`, and WIDEN the 400-char slice (the ORCH-1132 comment block pushed `bottom:` out of the window → current failure).
+  - `orch1128FreeCtaMutePill.test.ts:97` `/bottom:\s*22/` → `/bottom:\s*40/` (+ slice/window fix).
+  - `orch1128FreeCtaMutePill.adversarial.test.ts:122-127` numeric `bottom > 14` (passes for 40) but currently NULL because the 400-char slice from `audioControlBottomRight:` no longer reaches `bottom:` (ORCH-1132 comment bloat); `:133` `right:\s*14` (stale — current is 24) → must update to 24. WIDEN the slice and update `right` to 24.
+- **Mechanism:** ORCH-1132 changed `right` + bloated the comment but did not update `eventCoverMedia` + `orch1128` tests; no full jest gate caught it. ORCH-1133 must bring all in-scope pill/cover assertions back to GREEN at the round-3 values.
+- **Severity:** CONFIRMED (regression-test update plan, not a product bug).
+
+---
+
+## Five-Truth-Layer reconciliation
+
+| Layer | Truth | Contradiction? |
+|-------|-------|----------------|
+| Docs | Seth: revert cover to original; give pill space from details. | — |
+| Schema | n/a (pure RN style). | — |
+| Code | Checkout = ORCH-1132 adaptive full-frame; pill `right:24`/`bottom:22`. | Code ≠ desired (S1+S2). |
+| Runtime | Buyer web: pill overlaps panel by −6px; portrait cover balloons. | Confirms code → symptom. |
+| Data | live events `leggothis/vibes-and-stuff`, `/a-life-in-vegas` (video covers). | — |
+
+**Flagged contradiction:** three jest files assert values that no longer match current main (ORCH-1132 drift) — see F-7 / Discoveries.
+
+---
+
+## Repro evidence
+
+Buyer web, Chrome (Playwright channel:chrome), 430×932@2x, prod `https://business.usemingla.com`:
+- `Mingla_Artifacts/evidence/ORCH-1133/repro_leggothis__vibes-and-stuff.png` + `seam_*.png` — pill bottom clipped behind details panel (−6px).
+- `…/repro_leggothis__a-life-in-vegas.png` + `seam_*.png` — same, −6px.
+- `…/candidate_bottom40_vibes.png` — pill cleanly separated (+12px) at `bottom:40`.
+- (raleigh-wine-and-dine-crawl returned null — status `scheduled`, no rendered video hero; the two live ones reproduce.)
+
+---
+
+## Blast radius / cross-surface map
+
+| Surface | In scope | Effect |
+|---------|----------|--------|
+| Buyer/anon Web (`/checkout/*`, `/e/*`) | YES | cover revert (3 checkouts) + pill `bottom:22→40` on `/e/*` hero. |
+| Business iOS/Android | YES (checkout cover only) | same 3 checkout files reverted. |
+| Consumer iOS/Android (ImageGallery pill) | YES (shared pill only, benign) | pill moves +18px up on full-bleed gallery slide; no panel collision. |
+| Authoring previews (5 mounts) | YES (shared pill only, benign) | pill +18px up on full-bleed preview; benign. |
+| Consumer deck card (`SwipeableCards`) | NO | `showAudioControl={false}` — pill never renders. |
+| Public hero cover rendering | NO (DO-NOT-TOUCH) | `right:24` + hero clamp untouched. |
+| Admin Web | NO | no consumer. |
+
+---
+
+## Invariant impact
+- `I-1128` (pill clears the cover seam) — PRESERVED and strengthened (22→40 widens clearance).
+- No new invariant required; the regression test (updated to `bottom:40`) is the durable guard.
+
+## Discoveries for Orchestrator
+1. **DISC-1 (pre-existing, P2):** 3 jest files (`eventCoverMedia.test.ts`, `orch1128FreeCtaMutePill.test.ts` + `.adversarial.test.ts`) are RED on current main (8 failed tests) — ORCH-1132 changed `right:16→24` and bloated the `audioControlBottomRight` comment (pushing `bottom:` out of the tests' 400-char slice window) without updating these files. They merged because mingla-business has NO full jest CI gate (only strict-grep + append-only + a single `featureFlags.test.ts`). ORCH-1133 fixes the pill-related assertions as part of its test update; the slice-window brittleness should be hardened (parse the style block, not a fixed 400-char slice).
+2. **DISC-2 (pre-existing, out of scope):** other `eventCoverMedia.test.ts` failures (upload-limits / iOS-image / native-trim copy) read `CreatorStep4Cover.tsx` and assert strings that moved into `CoverPickerSheet` under ORCH-0989 — unrelated cover-picker drift, NOT touched by ORCH-1133.
+
+## Confidence
+PROVEN — buyer-web live-fire measured the −6px overlap and the +12px fix on two live events; source diff against `e90875dda~1` is exact.
+
+## Recommended next phase
+SPEC (this dispatch is INVESTIGATE-THEN-SPEC). Then implementor. Scope: the exact per-file revert of the 3 checkout covers + `bottom:22→40` on the shared pill + the regression-test update with `[TEST-MOD-APPROVED ORCH-1133]`. NO product-code beyond these. DO-NOT-TOUCH: `right:24`, the public hero cover rendering / hero clamp, the consumer deck card.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
@@ -1,0 +1,143 @@
+# TEST — ORCH-1133 [revert checkout cover to original compact band + Sound-pill clearance from the details section]
+
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1133-[revert-cover-pill-bottom]/` on branch `ORCH-1133-revert-cover-pill-bottom`
+**HEAD at test:** `daeeda425` (tester adversarial commit) on top of `d2c54b23f` (implementor revert commit, carries the `[TEST-MOD-APPROVED ORCH-1133]` test-mod token; re-carried in HEAD after the tester commit — see Finding P3-1).
+**Base:** origin/main `907b2b2a0`.
+**Mode:** TARGETED + SPEC-COMPLIANCE. Buyer web is the authoritative live-fire surface.
+**Date:** 2026-06-13.
+
+---
+
+## 1. Verdict
+
+# PASS
+
+**Finding counts:** P0: 0 · P1: 0 · P2: 0 · P3: 1 (a CI-gate hazard the tester caught AND resolved in-lane on the test commit) · P4: 2 (pre-existing notes).
+
+Seth's two round-3 complaints are BOTH resolved with `proven`-level runtime evidence:
+1. "The cover fills the entire screen. Revert to original." → the three checkout covers now render a **compact 64px band** (independently measured h=64 on a live local web build), not a full-screen cover.
+2. "The sound button still needs some space or padding from the details section." → the public-event Sound pill now clears the blue details panel by **+12px** (independently measured on live prod: prod's old `bottom:22` = −6px overlap; the new `bottom:40` = +12px gap), and the pill still **FIRES** at runtime (clicking it flipped the cover `<video>` from `muted:true` → `muted:false`).
+
+Regression gate satisfied (implementor happy-path with fails-on-revert + tester adversarial on a different angle, both on-branch and in-diff). Append-only gate green 7/7. Non-regression proven by full-suite baseline diff (branch has FEWER failures than origin/main).
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Verdict | Evidence (runtime / live-fire) |
+|----|-----------|---------|--------------------------------|
+| **SC-1-Web** | `/e/*` Sound pill bottom ≥10px above details panel (target +12) | **PASS** | Tester Playwright (chromium-headless, 430×932@2x) on live `https://business.usemingla.com/e/leggothis/vibes-and-stuff`: PROD `bottom:22` → pill.bottom=551, panel.top=545, **gap=−6px** (the bug); injected `bottom:40` → pill.bottom=533, panel.top=545, **gap=+12px**. Matches implementor + forensics. Screenshot `/tmp/orch1133_tester_pill.png`. |
+| **SC-1-fire** | The pill must STILL FIRE (mute/unmute, no dead tap) | **PASS** | Same Playwright session: located `[role="button"]` "Sound", clicked. Cover `<video>` `muted:true → muted:false`; pill text "Sound" → toggled. Runtime firing proof, not source wiring. |
+| **SC-2-Web** | Each checkout shows a fixed 64px compact band (not full-screen); `miniCover` declares `height:64` | **PASS** | Tester ran THIS worktree's Expo web build (`expo start --web :8095`), loaded `/checkout/09b4ece6-eabc-4734-8ce3-3a25d90417e4`: cover VIDEO measured **w=382, h=64, top=81**, page = compact "Vibes and Stuff" mini-card, **0 console errors**. Screenshot `/tmp/orch1133_tester_checkout.png`. Contrast: prod (old code) = h=684 full-screen (`BEFORE_prod_checkout_cover_fullscreen.png`). |
+| **SC-2-iOS / SC-2-Android** | Same compact band (shared RN code) | **PASS (parity automatic)** | Single RN codebase; all 3 routes' `miniCover` = `{height:64, borderRadius:radiusTokens.md, marginBottom:spacing.sm}` + plain 6-prop `<EventCoverMedia>`. The web export is the faithful render of the RN source. No platform-specific cover code. |
+| **SC-3** | 3 checkout files have NO coverAspect/setCoverAspect/clampedCoverAspect/onAspectRatio/videoContentFit/inline aspectRatio; plain 6-prop call | **PASS** | grep across all 3 files: 0 forbidden tokens. JSX = `<EventCoverMedia hue mediaUrl mediaType radius={0} label="" style={styles.miniCover}/>`. The inverted `orch1132ClampMathHeroIsolationAdversarial.test.ts` asserts all absent on all 3 routes (green). |
+| **SC-4** | trip + experience drop `useState`; event keeps it; tsc/lint clean (no unused-import) | **PASS** | event=`useCallback, useState`; trip=`useCallback, useMemo`; experience=`useCallback`. The 3 checkout `index.tsx` files are tsc-clean (no unused-import from the `useState` drop). eslint: 0 errors on the 3 files (2 warnings — `useMemo` in trip, `LiveEvent` in event — both PRE-EXIST identically on origin/main; P4-1). |
+| **SC-5** | `audioControlBottomRight = {right:24, bottom:40}`; right unchanged 24; topLeft/topRight 14 | **PASS** | Source confirmed: `right:24` (untouched), `bottom:40` (only changed line). `minHeight:36` preserved in base `audioControl`. `orch1131SiblingInsetNonRegressionAdversarial.test.ts` asserts right[24]/bottom[40]/topLeft[14]/topRight[14] (green). |
+| **SC-6 (cross-consumer)** | Pill stays on-screen at bottom:40 on full-bleed covers, not behind chrome | **PASS** | Computed geometry (tester adversarial test): shortest real `bottomRight` consumer = expandedCard `ImageGallery` (height:300). Pill band = [300−(40+36) .. 300−40] = [224 .. 260] — top edge 224px, safely inside the box. SwipeableCards uses `showAudioControl={false}` (unaffected). PublicEventPage hero + authoring previews (CoverPicker/CreatorStep4Cover/ExperienceCoverStep/TripCreatorStep1Basics/EditPublishedTripScreen) all render ≥200px full-bleed covers with no bottom panel → benign. |
+| **SC-7 (tests)** | 6 in-scope jest files PASS at round-3 values, token present | **PASS** | 6 pinned files (5 standalone + the pill tests in eventCoverMedia) = green; full pinned set re-run with the tester adversarial = 6 suites / 45 tests green. Append-only check 7/7 (6 modified + 1 added). |
+
+---
+
+## 3. Findings (P-numbered)
+
+### P3-1 — Adding a tester commit on top of the implementor's test-mod commit broke the append-only gate; resolved in-lane.
+- **Evidence:** The append-only gate (`.github/scripts/test-append-only-check.js`) checks the `[TEST-MOD-APPROVED ORCH-####]` token in the **LATEST commit body only**. The implementor's token lived in `d2c54b23f`. When the tester committed the new adversarial test as `daeeda425` (no token), the gate flipped to **1 passed / 6 failed** for the still-present test-file deletions.
+- **Impact:** Would FAIL CI at merge time even though the deletions are legitimately approved — a closing-PR blocker.
+- **Resolution (in-lane, tester-owned commit only):** amended the tester commit body to re-carry `[TEST-MOD-APPROVED ORCH-1133]` with the same why-cited reason. Gate now **7 passed / 0 failed**. No product code touched.
+- **Retest:** `node .github/scripts/test-append-only-check.js` → `Append-only check: 7 passed, 0 failed.`
+- **Note for the orchestrator:** at CLOSE, if any further commit lands on this branch, the LATEST commit body must re-carry the token (gate is HEAD-only, not range-wide).
+
+### P4-1 (NOTE, pre-existing) — Two eslint `no-unused-vars` warnings unrelated to ORCH-1133.
+`useMemo` (trip `index.tsx`) and `LiveEvent` (event `index.tsx`) are import-only and UNUSED on origin/main too (verified via `git show origin/main:…`). NOT introduced by this ORCH; out of allowlist scope. 0 errors.
+
+### P4-2 (NOTE, pre-existing) — Wide jest/strict-grep baseline noise, identical to origin/main.
+The full business jest suite fails 79 suites / 148 tests on the branch vs **81 suites / 151 tests on origin/main** — i.e. the branch has FEWER failures (it FIXED the eventCoverMedia pill test + the 1131/1132/1128 suites). All remaining failures are pre-existing (missing `@testing-library/react-native`, `@mingla/payments-native`; source-introspection drift from unrelated ORCHs). 3 non-PASS strict-grep gates (`orch-0756a`, `orch-0770`, `orch-0776a`) all touch files NOT in the ORCH-1133 diff. The 4 ORCH-0978 cover gates + orch-0766f/0783/0805/0989 cover gates all PASS.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out the implementor's product state (HEAD `d2c54b23f` cover/pill values). Hand-mutated the product code (TRUE line edits) and ran the implementor's happy-path test `orch1131CoverCropSoundInset.test.ts`:
+
+- **Mutation:** removed `height: 64` from `checkout/[eventId]/index.tsx` `miniCover`; reverted `EventCoverMedia.tsx` pill `bottom: 40 → 22`.
+- **Result (mutated):** `Tests: 2 failed, 6 passed` — the `miniCover height:64` assertion AND the `bottom === 40` assertion both RED. (The implementor reported 3-failed because they additionally re-added onAspectRatio/videoContentFit; my narrower mutation reproduced the two core failures.)
+- **Result (restored):** `Tests: 8 passed, 8 total` — green.
+- **Conclusion:** the implementor's happy-path test genuinely exercises the fix and is not comment-fooled. **fails-on-revert verified at `d2c54b23f`.** Product tree restored clean (git status shows no product modifications).
+
+---
+
+## 5. Adversarial test added (tester-owned)
+
+- **Path:** `mingla-business/__tests__/orch1133PillClearanceGeometryAdversarial.tester.test.ts`
+- **Commit:** `daeeda425` (on-branch, in `git diff origin/main...HEAD --name-only`).
+- **Different angle:** the implementor's tests assert WHICH literals are present (source-introspection). This test parses the real `bottom`/`marginTop`/`minHeight` numbers out of the shared source and PROVES the resulting GEOMETRY — the two physical invariants Seth complained about:
+  - **(1) Clearance:** `gap = pill.bottom − |bodyContent.marginTop|` = `40 − 28 = +12` must be `≥ +10` (asserts `=== 12`), with an in-test regression proof that the old `bottom:22` would yield `−6` (overlap).
+  - **(2) On-screen safety:** for the shortest `bottomRight` consumer (ImageGallery h=300), the pill's TOP edge `300 − (40+36) = 224` must be `> 0` (never clipped off the top).
+- **fails-on-revert verified at `daeeda425`:** mutated `EventCoverMedia.tsx` `bottom: 40 → 22` → `Tests: 2 failed, 4 passed` (the (1) "round-3 contract" + "positive clearance" assertions RED). Restored → 6 passed. Recorded; product tree restored clean.
+- **Both tests in the closing diff:** `orch1131CoverCropSoundInset.test.ts` (implementor) + `orch1133PillClearanceGeometryAdversarial.tester.test.ts` (tester) both appear in `git diff origin/main...HEAD --name-only`. ✓
+
+**Inverted-test audit (spec asked to verify):** `orch1132ClampMathHeroIsolationAdversarial.test.ts` was INVERTED in place (not deleted — append-only gate forbids test-file deletion with no token bypass). I read it: it now asserts, on ALL 3 checkout routes, NO `Math.min(Math.max(...))` clamp, NO `coverAspect`/`clampedCoverAspect`, NO `onAspectRatio`/`videoContentFit`/inline `aspectRatio` in the EventCoverMedia call, AND `miniCover.height:64` — i.e. it genuinely guards the full-screen-cover code staying gone, and still guards the public-hero clamp isolation (B) + the EventCoverMedia `videoContentFit="cover"` default (C). It is a STRONGER durable guard than deletion. Confirmed valid.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | **PASS** | Sound pill FIRES at runtime (video muted:true→false on click). The bottom:40 inset is style-only; the onClick wiring is untouched. `orch_1124_cover_audio_pill_fires.adversarial.test.ts` green. |
+| 2 | One owner per truth | N/A | No state ownership change (removed redundant `coverAspect` local state). |
+| 3 | No silent failures | N/A | No error paths changed; pure style/JSX. |
+| 4 | One query key per entity | N/A | No queries. |
+| 5 | Server state stays server-side | N/A | No Zustand/server-state. |
+| 6 | Logout clears everything | N/A | No auth/session. |
+| 7 | Label `[TRANSITIONAL]` | **PASS** | None introduced. |
+| 8 | Subtract before adding | **PASS** | This ORCH IS a subtraction (removed the ORCH-1131/1132 adaptive-cover additions). |
+| 9 | No fabricated data | N/A | No data. |
+| 10 | Currency-aware | N/A | No prices. |
+| 11 | One auth instance | N/A | Anon buyer routes; no useAuth touched. |
+| 12 | Validate at the right time | N/A | No validation. |
+| 13 | Exclusion consistency | N/A | No filters. |
+| 14 | Persisted-state startup | N/A | No persisted state. |
+
+No constitutional violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Evidence |
+|---------|---------|----------|
+| Buyer/anon Web (authoritative) | **PASS (proven)** | Live prod pill measure (−6→+12, fires) + local web checkout cover measure (h=64, 0 errors). |
+| Consumer iOS | **PASS (parity automatic)** | Shared `EventCoverMedia.tsx` pill only; SwipeableCards `showAudioControl={false}` so the deck card is unaffected. No consumer cover code touched. |
+| Consumer Android | **PASS (parity automatic)** | Same shared RN pill. |
+| Business iOS | **PASS (parity automatic)** | 3 checkout `index.tsx` are shared RN; `miniCover.height:64` renders identically. |
+| Business Android | **PASS (parity automatic)** | Same. |
+| Admin Web | **N/A (skip)** | No consumer of these files. |
+| Business Web preview (authoring) | **PASS (parity automatic)** | Shared pill +18px up on ≥200px full-bleed preview covers; benign (no bottom panel). |
+
+**Physical iPhone HITL:** NOT required — buyer web is the spec-authoritative surface and was live-fired by the tester; the change is a single shared style literal + a style-only cover-band revert with no native-only code path. No native rebuild (pure-JS RN). Stated as a deliberate skip with reason, not "TBD".
+
+---
+
+## 8. Discoveries for Orchestrator
+
+- **DISC-T1 (ID collision):** `git worktree list` shows TWO `ORCH-1133` worktrees — this one (`ORCH-1133-[revert-cover-pill-bottom]`) and `ORCH-1133-[biz-root-render-loop]` (HEAD `68d9aede6`). Two different efforts share the ORCH-1133 number. Orchestrator should de-conflict the IDs at INTAKE/CLOSE (one must be renumbered) before either merges, to avoid registry/World-Map collision.
+- **DISC-T2 (append-only gate is HEAD-only):** confirms the implementor's DISC-A and adds a corollary — because the gate reads the token from the LATEST commit body only, ANY commit added on top of a token-bearing test-mod commit (incl. the tester's adversarial test, incl. a CLOSE doc commit on the same branch) must re-carry the token or the gate flips red. Already handled here (P3-1); flag for future ORCHs that the tester/closer commit AFTER the token commit.
+- **DISC-T3 (env, confirms implementor DISC-B):** the worktree needed `expo-image-manipulator` to bundle the business web; it was already present (implementor's `--no-save` install persisted). `package.json`/`lock` unmodified. A clean spawn likely needs `npm install` to run the business web locally.
+- The open COMMS-ledger rows (0027/0028/0029 trip migrations, 0024/0025 prior cover ORCHs, etc.) are all WARN and orthogonal to this RN style revert — read, no BLOCK addressed to ORCH-1133/tester/ALL.
+
+---
+
+## 9. Gate results summary
+
+- **Pinned jest (6 files):** 6 suites / 45 tests GREEN (incl. tester adversarial). eventCoverMedia 2 pill tests GREEN; its 5 DISC-2 cover-picker-copy failures fail IDENTICALLY on origin/main (verified by running origin's file against origin's source: same 5 + the pill test which the branch FIXED) → out of scope per spec §2/§7.
+- **Append-only gate:** 7 passed / 0 failed (token in HEAD `daeeda425`).
+- **fails-on-revert:** implementor `orch1131CoverCropSoundInset.test.ts` verified at `d2c54b23f` (2 failed→8 passed); tester `orch1133PillClearanceGeometryAdversarial.tester.test.ts` verified at `daeeda425` (2 failed→6 passed).
+- **Non-regression:** full business jest branch = 79 failed suites vs origin/main = 81 failed suites (branch fixed 2, added 0). 4 ORCH-0978 + cover strict-grep gates PASS.
+- **tsc:** the 3 checkout `index.tsx` files clean; EventCoverMedia.tsx pre-existing cross-package resolution noise only (single-literal change cannot introduce type errors).
+
+---
+
+## 10. Routing
+
+**PASS → CLOSE (mingla-orchestrator).** No rework. At CLOSE: keep the `[TEST-MOD-APPROVED ORCH-1133]` token in the LATEST commit body of the closing branch (DISC-T2), and de-conflict the ORCH-1133 ID collision (DISC-T1).

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md
@@ -1,0 +1,267 @@
+# SPEC — ORCH-1133 [revert checkout cover to original compact band + give the public-event Sound pill clearance from the details section]
+
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1133-[revert-cover-pill-bottom]/` on branch `ORCH-1133-revert-cover-pill-bottom`
+**Base:** origin/main `907b2b2a0`.
+**Investigation:** `Mingla_Artifacts/reports/INVESTIGATION_ORCH-1133_REVERT_COVER_PILL_BOTTOM.md` (PROVEN, buyer-web live-fire).
+**Round 3** of the cover/pill saga (ORCH-1128 → 1131 → 1132 → 1133).
+
+---
+
+## 1. Executive summary
+
+Two tightly-scoped changes:
+
+1. **REVERT** the three Get-tickets checkout mini-card covers to the TRUE pre-ORCH-1131 original — a fixed `height: 64` compact band with the component's default cover-fill — undoing ORCH-1131 (64→120) AND ORCH-1132 (adaptive full-frame). Seth: "The get tickets page now looks awful, revert. The cover fills the entire screen. Revert to original."
+2. **MOVE** the shared public-event Sound pill DOWN-anchor from `bottom: 22` to `bottom: 40` so it clears the blue details panel by a visible +12px (measured), while KEEPING `right: 24`. Seth: "The sound button still needs some space or padding from the details section."
+
+This is NOT a `git revert` of ORCH-1131/1132 — only the cover/miniCover code reverts; the pill's `right: 24` is preserved.
+
+---
+
+## 2. Scope & non-goals
+
+**In scope (product code):**
+- `miniCover` style + `<EventCoverMedia>` JSX + cover-aspect state in the 3 checkout files → restored to `e90875dda~1` original.
+- `audioControlBottomRight.bottom` in `packages/event-rendering/EventCoverMedia.tsx`: `22 → 40`.
+
+**In scope (tests):** update the 6 jest files that pin the changed values to the round-3 values, with `[TEST-MOD-APPROVED ORCH-1133]` in the LATEST commit body (see §9).
+
+**Non-goals / DO-NOT-TOUCH:**
+- `audioControlBottomRight.right` stays `24` (Seth satisfied with right-edge clearance).
+- The public-event HERO cover rendering (`PublicEventPage.tsx` `heroBox`, the hero `aspectRatio` clamp, `bodyContent.marginTop`) — UNCHANGED.
+- The consumer deck card (`SwipeableCards.tsx`, `showAudioControl={false}`) — UNCHANGED.
+- `audioControlTopLeft` / `audioControlTopRight` insets — UNCHANGED.
+- The unrelated `eventCoverMedia.test.ts` cover-picker-copy failures (DISC-2) — NOT addressed here.
+
+**Assumptions:** `radiusTokens` + `spacing` imports remain present in all 3 checkout files post-revert (verified: each still has 2 `radiusTokens` refs via `miniCover.borderRadius` + elsewhere).
+
+---
+
+## 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behavior | Files touched here | Parity |
+|---|---------|---------|------------------------|--------------------|--------|
+| 1 | Consumer iOS | YES (shared pill only) | gallery Sound pill moves +18px up on full-bleed slide; benign | `EventCoverMedia.tsx` (shared) | automatic (shared) |
+| 2 | Consumer Android | YES (shared pill only) | same | same | automatic |
+| 3 | Buyer/anon Web | YES | 3 checkout covers → compact 64px band; `/e/*` Sound pill clears details panel by +12px | 3 checkout files + `EventCoverMedia.tsx` | automatic (web export of same RN) |
+| 4 | Business iOS | YES (checkout cover) | compact 64px cover band restored | 3 checkout files | automatic |
+| 5 | Business Android | YES (checkout cover) | same | same | automatic |
+| 6 | Admin Web | NO — no consumer of these files | — | — | — |
+| 7 | Business Web preview (authoring) | YES (shared pill only) | preview Sound pill +18px up on full-bleed preview; benign | `EventCoverMedia.tsx` (shared) | automatic |
+
+Cross-consumer safety: PROVEN benign (investigation F-6). A 36px pill at `bottom:40` only clips off a cover box < 76px tall; every consumer renders a full-bleed cover ≥ ~200px tall, and only the public hero has a bottom panel (the surface being fixed).
+
+---
+
+## 4. Layered specification (Component layer only — pure RN style/JSX)
+
+### 4.1 CHANGE 1 — revert all 3 checkout covers to the `e90875dda~1` original
+
+For EACH of the three files, apply the per-file before/after below. All three end in the IDENTICAL `miniCover` block and a plain `<EventCoverMedia … style={styles.miniCover} />` (no aspect props).
+
+#### File A — `mingla-business/app/checkout/[eventId]/index.tsx`
+
+**(A1) Remove the cover-aspect state (current lines ~83–88):**
+```
+BEFORE:
+  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
+  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
+  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
+  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
+  const [coverAspect, setCoverAspect] = useState(0.75);
+  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
+
+AFTER:
+  (delete all six lines)
+```
+**(A2) KEEP the React import as-is** — `import React, { useCallback, useState } from "react";` (the event file's `waitlistTicketId` still uses `useState`, line 81). DO NOT remove `useState` here.
+
+**(A3) Restore the plain EventCoverMedia JSX (current lines ~248–257):**
+```
+BEFORE:
+          <EventCoverMedia
+            hue={event.coverHue}
+            mediaUrl={event.coverMediaUrl}
+            mediaType={event.coverMediaType}
+            radius={0}
+            label=""
+            onAspectRatio={setCoverAspect}
+            videoContentFit="contain"
+            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
+          />
+
+AFTER:
+          <EventCoverMedia
+            hue={event.coverHue}
+            mediaUrl={event.coverMediaUrl}
+            mediaType={event.coverMediaType}
+            radius={0}
+            label=""
+            style={styles.miniCover}
+          />
+```
+**(A4) Restore the miniCover style (current lines ~353–362):**
+```
+BEFORE:
+  miniCover: {
+    // ORCH-1132 — full-frame, no crop. … (6 comment lines) …
+    borderRadius: radiusTokens.md,
+    marginBottom: spacing.sm,
+  },
+
+AFTER:
+  miniCover: {
+    height: 64,
+    borderRadius: radiusTokens.md,
+    marginBottom: spacing.sm,
+  },
+```
+
+#### File B — `mingla-business/app/checkout-trip/[tripEventId]/index.tsx`
+
+**(B1)** Delete the cover-aspect state (current ~135–139, same 4-comment + 2 const lines).
+**(B2) Drop `useState` from the React import** — original was `import React, { useCallback, useMemo } from "react";`. Change current `import React, { useCallback, useMemo, useState } from "react";` → `import React, { useCallback, useMemo } from "react";` (coverAspect is the sole `useState` user here).
+**(B3)** Restore the JSX (current ~310–321) to the plain form — same as A3 but with the trip's props:
+```
+AFTER:
+          <EventCoverMedia
+            hue={0}
+            mediaUrl={trip.coverMediaUrl}
+            mediaType={
+              trip.coverMediaType as "image" | "video" | "gif" | null
+            }
+            radius={0}
+            label=""
+            style={styles.miniCover}
+          />
+```
+**(B4)** Restore `miniCover` (current ~438–447) to `{ height: 64, borderRadius: radiusTokens.md, marginBottom: spacing.sm }`.
+
+#### File C — `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx`
+
+**(C1)** Delete the cover-aspect state (current ~99–103).
+**(C2) Drop `useState` from the React import** — original was `import React, { useCallback } from "react";`. Change current `import React, { useCallback, useState } from "react";` → `import React, { useCallback } from "react";`.
+**(C3)** Restore the JSX (current ~252–261) to the plain form with the experience's props:
+```
+AFTER:
+          <EventCoverMedia
+            hue={0}
+            mediaUrl={experience.coverMediaUrl}
+            mediaType={experience.coverMediaType}
+            radius={0}
+            label=""
+            style={styles.miniCover}
+          />
+```
+**(C4)** Restore `miniCover` (current ~339–348) to `{ height: 64, borderRadius: radiusTokens.md, marginBottom: spacing.sm }`.
+
+> The implementor MAY equivalently `git show 'e90875dda~1:<file>'` and copy the exact original `miniCover` block + JSX call verbatim, then re-apply only the import deltas above. The end state MUST equal `e90875dda~1` for these regions.
+
+### 4.2 CHANGE 2 — Sound pill bottom inset `22 → 40`
+
+`packages/event-rendering/EventCoverMedia.tsx`, `audioControlBottomRight` (current lines ~606–620):
+```
+BEFORE:
+    right: 24,
+    // ORCH-1128 — 14 → 22: clears the cover seam …
+    bottom: 22,
+
+AFTER:
+    right: 24,
+    // ORCH-1133 — 22 → 40: round-3 clearance from the public-event details panel.
+    // The blue details panel (PublicEventPage `bodyContent`, marginTop:-28) sits
+    // 28px above the hero bottom; at bottom:22 the pill overlapped the panel top
+    // by 6px (measured on buyer web). bottom:40 = 28 + 12px visible gap (live-
+    // verified +12.0px on /e/leggothis/vibes-and-stuff & /a-life-in-vegas).
+    // Shared style → also lifts the consumer gallery + authoring-preview pills
+    // +18px on their full-bleed covers (benign; ≥200px boxes, no panel below).
+    bottom: 40,
+```
+KEEP `right: 24`. KEEP `minHeight: 36`. Do NOT add a `top:` key. Do NOT touch `audioControlTopLeft` / `audioControlTopRight`.
+
+---
+
+## 5. Success criteria
+
+- **SC-1 (Web):** On `/e/{brandSlug}/{eventSlug}` with a video cover, the Sound pill's bottom edge sits ≥ 10px ABOVE the blue details panel top edge (target +12px). Verify by Playwright measure on `…/e/leggothis/vibes-and-stuff`: `panelTop − pillBottom ≥ 10`.
+- **SC-2-iOS / SC-2-Android / SC-2-Web (checkout cover):** Each of `/checkout/{eventId}`, `/checkout-trip/{tripEventId}`, `/checkout-experience/{experienceEventId}` shows a fixed 64px-tall compact cover band (NOT a full-screen/ballooned cover) for a portrait video cover. The `miniCover` block declares `height: 64`.
+- **SC-3:** The 3 checkout files contain NO `coverAspect`, `setCoverAspect`, `clampedCoverAspect`, `onAspectRatio`, `videoContentFit`, or inline `aspectRatio` in the cover path; the `<EventCoverMedia>` cover call is the plain 6-prop form (`hue`, `mediaUrl`, `mediaType`, `radius`, `label`, `style`).
+- **SC-4:** `trip` + `experience` React imports no longer include `useState`; the `event` import still does. `tsc`/lint clean (no unused-import).
+- **SC-5:** `audioControlBottomRight` = `{ right: 24, bottom: 40 }`; `right` unchanged at 24; `audioControlTopLeft`/`audioControlTopRight` unchanged at 14.
+- **SC-6 (cross-consumer):** On a full-bleed consumer/authoring cover the pill remains fully on-screen, not behind top chrome (no regression). Verified by render (no off-screen pill at `bottom:40`).
+- **SC-7 (tests):** The 6 in-scope jest files PASS against the round-3 values (see §7), with the append-only override token present (§9).
+
+---
+
+## 6. Invariants
+- **I-1128 (Sound pill clears the cover seam):** PRESERVED + strengthened (22→40 widens clearance). The updated regression test (`bottom: 40`) is the durable guard.
+- No new invariant proposed.
+
+---
+
+## 7. Test cases / regression-test update plan
+
+The implementor MUST end with all 6 files GREEN. Three are RED on current main (pre-existing ORCH-1132 drift — investigation DISC-1); fixing them is part of this update.
+
+| File | Current assertion | New assertion | Action |
+|------|-------------------|---------------|--------|
+| `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts` | FIX1: miniCover NO height + `videoContentFit="contain"` + `onAspectRatio=`; FIX2 `right===24`, `bottom===22` | revert FIX1 → assert miniCover `height===64` AND the call has NO `videoContentFit`/`onAspectRatio`; FIX2 `right===24` (keep), `bottom===40` | MODIFY (deletes lines) → token required |
+| `mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts` | `bottomRight` `right [24]` / `bottom [22]`; topLeft/topRight [14]; heroBox no height | `right [24]` keep, `bottom [40]`; topLeft/topRight/heroBox UNCHANGED | MODIFY (deletes line) → token required |
+| `mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts` | extracts + executes the checkout `Math.min(Math.max(...))` clamp; SC-6 isolation; SC-7 default | subject (checkout clamp) is REMOVED → `extractClamp` throws → file invalid | **DELETE the file** → token required (deletion) |
+| `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` (pill test only, lines 362–372) | slice asserts `right: 14` + `bottom: 22` (both stale; currently RED) | assert `right: 24` + `bottom: 40`; WIDEN the slice (parse the `audioControlBottomRight` block, not a fixed 400-char window) | MODIFY (deletes lines) → token required. DO NOT touch the unrelated cover-picker-copy tests (DISC-2). |
+| `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts` (line 91–97) | `/bottom:\s*22/` (currently RED — comment bloat) | `/bottom:\s*40/`; widen the slice so `bottom:` is in window | MODIFY (deletes line) → token required |
+| `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts` (line 115–134) | numeric `bottom > 14` (currently NULL → RED) + `right:\s*14` (stale) | parse the full `audioControlBottomRight` block (widen window), assert `bottom > 14` (40 passes) + `right:\s*24`; keep "no `top:` key" | MODIFY (deletes line) → token required |
+
+**Token requirement:** because every modified test file deletes ≥1 line (and one is deleted outright), the LATEST commit body that lands these test changes MUST contain `[TEST-MOD-APPROVED ORCH-1133]` (regex `/\[TEST-MOD-APPROVED (?:META-)?ORCH-\d{4}(?:-[A-Z])?\]/`, checked by `.github/scripts/test-append-only-check.js`). One token in the final commit body covers all of them. Cite WHY in the body: "ORCH-1131/1132 cover+pill values reverted/superseded per Seth round-3 reject; the prior assertions are now wrong."
+
+**fails-on-revert (required):** the updated `orch1131CoverCropSoundInset.test.ts` MUST FAIL if a future change re-adds `height: 120` / adds back `videoContentFit="contain"` / reverts `bottom` to 22, and PASS at `height:64`/`bottom:40`. The implementor proves this by hand-mutating the product code and showing red→green (record in the implementation report).
+
+**Recommended hardening (DISC-1):** replace the brittle fixed-`400`-char slices in `eventCoverMedia.test.ts` + both `orch1128` files with a proper `audioControlBottomRight: { … }` block extraction (same helper the 1131 tests use), so future comment-length changes can't re-NULL the parse.
+
+---
+
+## 8. Implementation order
+1. CHANGE 1 — revert the 3 checkout covers (File A, B, C: state delete → import delta → JSX → miniCover).
+2. CHANGE 2 — `EventCoverMedia.tsx` `bottom: 22 → 40`.
+3. Update the 6 test files to the §7 round-3 values (incl. deleting `orch1132ClampMathHeroIsolationAdversarial.test.ts`).
+4. Run `tsc`/lint on the 3 checkout files + `npx jest` on the 6 files → all GREEN.
+5. Prove fails-on-revert; record in implementation report.
+6. Commit with `[TEST-MOD-APPROVED ORCH-1133]` in the body.
+
+---
+
+## 9. Regression prevention
+- Structural safeguard: `orch1131CoverCropSoundInset.test.ts` (source-introspection, comment-proof) pins `miniCover.height===64` + `audioControlBottomRight.bottom===40` + `right===24` — re-introducing the ORCH-1131/1132 cover or reverting the pill makes it FAIL.
+- Protective comment in `audioControlBottomRight` explains the 28px panel overlap + the 12px target gap (the "why") so a future "tidy" doesn't drop it back.
+- Append-only gate forces an explicit, ORCH-cited override for any future change to these pinned values.
+
+---
+
+## 10. Open questions
+- **OQ-1:** `bottom: 40` (+12px gap) is recommended. If Seth wants MORE air, `bottom: 44` (+16px = `spacing.md` gap) is the live-verified alternative. Default to 40 unless Seth says otherwise.
+
+---
+
+## 11. Downstream routing
+Next = **mingla-implementor** (worktree `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1133-[revert-cover-pill-bottom]/`, branch `ORCH-1133-revert-cover-pill-bottom`). Then **mingla-tester** (buyer-web Playwright measure of SC-1 + checkout-cover render SC-2 + the 6-file jest gate). Then **mingla-orchestrator** CLOSE.
+
+### Allowlist (implementor MAY change ONLY these)
+- `mingla-business/app/checkout/[eventId]/index.tsx`
+- `mingla-business/app/checkout-trip/[tripEventId]/index.tsx`
+- `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx`
+- `packages/event-rendering/EventCoverMedia.tsx` (ONLY `audioControlBottomRight.bottom`)
+- `mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts`
+- `mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts`
+- `mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts` (DELETE)
+- `mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts` (pill test only)
+- `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts`
+- `mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts`
+
+### DO-NOT-TOUCH
+- `audioControlBottomRight.right` (stays 24), `audioControlTopLeft`/`audioControlTopRight`.
+- `packages/event-rendering/PublicEventPage.tsx` (hero `heroBox`, hero clamp, `bodyContent.marginTop`).
+- `app-mobile/src/components/SwipeableCards.tsx` (consumer deck card).
+- The unrelated `eventCoverMedia.test.ts` cover-picker-copy tests (DISC-2) and any other test file.
+- Any product file outside the 4 allowlisted product files.
+
+Stop-and-amend before touching anything outside the allowlist.

--- a/mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts
+++ b/mingla-business/__tests__/orch1131CoverCropSoundInset.test.ts
@@ -3,36 +3,35 @@ import fs from "node:fs";
 import path from "node:path";
 
 // ORCH-1131 [cover-crop-sound-inset] — HAPPY-PATH regression test (implementor-authored).
-// ORCH-1132 [TEST-MOD-APPROVED ORCH-1132] round 2 — supersedes ORCH-1131's two
-// value choices (same file surfaces, opposite design call on both). The
-// ORCH-1131 lineage stays here; the pinned numbers move to round-2 values.
+// ORCH-1133 [TEST-MOD-APPROVED ORCH-1133] round 3 — supersedes ORCH-1131 (64→120)
+// AND ORCH-1132 (adaptive full-frame). Seth round-3 reject: "The get tickets page
+// now looks awful, revert. The cover fills the entire screen. Revert to original."
+// The pinned numbers move to the TRUE pre-ORCH-1131 original (`e90875dda~1`).
 //
 // Two contracts that a future "tidy" could silently regress:
-//   FIX 1 (round 2) — the three Get-tickets checkout mini-card covers must show
-//           the WHOLE frame uncropped. ORCH-1131's fixed `miniCover.height:120`
-//           band still cropped a 360×640 portrait cover to a mid-frame strip
-//           (head cut off). Round 2 removes the fixed height (height now follows
-//           an inline `aspectRatio`) and pairs each EventCoverMedia call with
-//           `videoContentFit="contain"` + `onAspectRatio` so nothing is cropped.
-//           Assert across all three routes (event / trip / experience):
-//             (a) the `miniCover` block declares NO numeric `height:`, and
-//             (b) the EventCoverMedia call passes `videoContentFit="contain"`
-//                 AND `onAspectRatio=`.
-//   FIX 2 (round 2) — the shared EventCoverMedia `audioControlBottomRight` Sound
-//           pill must sit at right:24 (= spacing.lg — visible right-edge
-//           breathing room; ORCH-1131's 16 read cramped to Seth) AND bottom:22
-//           (ORCH-1128 cover-seam clearance — load-bearing, preserved verbatim).
+//   FIX 1 (round 3) — the three Get-tickets checkout mini-card covers must show a
+//           fixed COMPACT 64px-tall band (the e90875dda~1 original), NOT a full-
+//           screen / ballooned cover. ORCH-1131 (height:120) and ORCH-1132 (no
+//           fixed height + inline aspectRatio + videoContentFit="contain") are
+//           both reverted. Assert across all three routes (event/trip/experience):
+//             (a) the `miniCover` block declares `height: 64`, and
+//             (b) the EventCoverMedia call has NO `videoContentFit`
+//                 AND NO `onAspectRatio` (the plain cover call).
+//   FIX 2 (round 3) — the shared EventCoverMedia `audioControlBottomRight` Sound
+//           pill must sit at right:24 (= spacing.lg — visible right-edge breathing
+//           room; KEPT from ORCH-1132) AND bottom:40 (round-3 clearance from the
+//           public-event details panel; supersedes ORCH-1128's bottom:22).
 //
 // Source-introspection (not module import) because the checkout routes are heavy
 // RN screens; this mirrors the precedent in
 // BusinessWelcomeScreenLogoAdversarial.test.tsx. Extracting `property: value`
 // from the actual StyleSheet block is comment-proof: it reads the live value,
-// so a true LINE DELETION of the fix (re-adding `height: 120`, dropping
-// `videoContentFit="contain"`, or reverting `right: 24`) makes the test FAIL.
+// so a true LINE DELETION of the fix (re-adding `height: 120` / no height +
+// `videoContentFit="contain"`, or reverting `bottom: 40` → 22) makes the test FAIL.
 //
-// fails-on-revert: verified by re-adding `height: 120` / dropping
-// `videoContentFit="contain"` / reverting `right: 24` → 16 — see
-// IMPLEMENTATION_ORCH-1132 report.
+// fails-on-revert: verified by re-adding `videoContentFit="contain"` /
+// `onAspectRatio=` + dropping `height: 64` / reverting `bottom: 40` → 22 — see
+// IMPLEMENTATION_ORCH-1133 report.
 
 const businessDir = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(businessDir, "..");
@@ -72,36 +71,36 @@ function extractEventCoverMediaCall(src: string): string {
   return m[1];
 }
 
-describe("ORCH-1132 FIX 1 (round 2) — checkout mini-card cover is full-frame, no crop", () => {
+describe("ORCH-1133 FIX 1 (round 3) — checkout mini-card cover is the compact 64px original band", () => {
   for (const route of CHECKOUT_ROUTES) {
-    test(`${route} miniCover declares NO fixed numeric height`, () => {
+    test(`${route} miniCover declares the fixed compact height: 64`, () => {
       const src = fs.readFileSync(path.join(businessDir, route), "utf8");
       const body = extractStyleBody(src, "miniCover");
-      // height now follows an inline aspectRatio; no fixed height: in the block.
-      expect(extractNumericStyleValue(body, "height")).toBeNull();
+      // original e90875dda~1 fixed band: height: 64 (no inline aspectRatio).
+      expect(extractNumericStyleValue(body, "height")).toBe(64);
     });
 
-    test(`${route} EventCoverMedia uses videoContentFit="contain" + onAspectRatio`, () => {
+    test(`${route} EventCoverMedia is the plain call (no videoContentFit / onAspectRatio)`, () => {
       const src = fs.readFileSync(path.join(businessDir, route), "utf8");
       const call = extractEventCoverMediaCall(src);
-      expect(call).toMatch(/videoContentFit="contain"/);
-      expect(call).toMatch(/onAspectRatio=/);
+      expect(call).not.toMatch(/videoContentFit=/);
+      expect(call).not.toMatch(/onAspectRatio=/);
     });
   }
 });
 
-describe("ORCH-1132 FIX 2 (round 2) — shared Sound-pill bottomRight inset", () => {
+describe("ORCH-1133 FIX 2 (round 3) — shared Sound-pill bottomRight inset", () => {
   const src = fs.readFileSync(
     path.join(repoRoot, "packages/event-rendering/EventCoverMedia.tsx"),
     "utf8",
   );
   const body = extractStyleBody(src, "audioControlBottomRight");
 
-  test("right === 24 (spacing.lg — visible right-edge breathing room)", () => {
+  test("right === 24 (spacing.lg — visible right-edge breathing room, kept)", () => {
     expect(extractNumericStyleValue(body, "right")).toBe(24);
   });
 
-  test("bottom === 22 preserved (ORCH-1128 cover-seam clearance, load-bearing)", () => {
-    expect(extractNumericStyleValue(body, "bottom")).toBe(22);
+  test("bottom === 40 (round-3 clearance from the public-event details panel)", () => {
+    expect(extractNumericStyleValue(body, "bottom")).toBe(40);
   });
 });

--- a/mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
+++ b/mingla-business/__tests__/orch1131SiblingInsetNonRegressionAdversarial.test.ts
@@ -79,13 +79,14 @@ describe("ORCH-1131 adversarial — sibling pill insets NOT shifted by FIX 2", (
     expect(allNumericValues(body, "top")).toEqual([14]);
   });
 
-  // ORCH-1132 [TEST-MOD-APPROVED ORCH-1132] round 2 — the bottomRight pill moved
-  // 16 → 24 (spacing.lg, visible breathing room). Still exactly ONE right:
-  // declaration (no shadow override re-shadows it). bottom:22 unchanged.
+  // ORCH-1133 [TEST-MOD-APPROVED ORCH-1133] round 3 — the bottomRight pill bottom
+  // moved 22 → 40 (round-3 clearance from the public-event details panel). right
+  // stays 24 (kept from ORCH-1132). Still exactly ONE right: and ONE bottom:
+  // declaration (no shadow override re-shadows either).
   test("audioControlBottomRight has exactly ONE right: declaration (no shadow override)", () => {
     const body = extractStyleBody(src, "audioControlBottomRight");
     expect(allNumericValues(body, "right")).toEqual([24]);
-    expect(allNumericValues(body, "bottom")).toEqual([22]);
+    expect(allNumericValues(body, "bottom")).toEqual([40]);
   });
 });
 

--- a/mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts
+++ b/mingla-business/__tests__/orch1132ClampMathHeroIsolationAdversarial.test.ts
@@ -3,36 +3,36 @@ import fs from "node:fs";
 import path from "node:path";
 
 // ORCH-1132 [cover-fullframe-sound-inset] round 2 — TESTER adversarial regression.
+// ORCH-1133 [TEST-MOD-APPROVED ORCH-1133] round 3 — INVERTED.
 //
-// DIFFERENT ANGLE from the implementor's two tests. The implementor's
-// orch1131CoverCropSoundInset.test.ts + orch1131SiblingInsetNonRegressionAdversarial.test.ts
-// do STATIC source-string matching: they assert the *presence* of the strings
-// `videoContentFit="contain"`, `onAspectRatio=`, `right: 24`, `bottom: 22`, and
-// the *absence* of a numeric `height:` in miniCover.
+// Round 2 (ORCH-1132) introduced an adaptive checkout cover whose box aspectRatio
+// was driven by an in-screen `Math.min(Math.max(coverAspect, 0.6), 1.91)` clamp.
+// This file EXECUTED that clamp and asserted its math.
 //
-// That static approach has a real blind spot: it never EXECUTES the clamp math.
-// A "tidy" refactor that accidentally copies the public hero's bounds into the
-// checkout clamp — `Math.min(Math.max(coverAspect, 0.75), 16/9)` instead of
-// `(..., 0.6), 1.91` — would keep every implementor-asserted string intact
-// (`videoContentFit="contain"` is still there) yet SILENTLY RE-CROP portrait
-// covers: a 0.5625 portrait would clamp to 0.75 (the public-hero bound), and
-// since the box is now 0.75 while the media is 0.5625, even `contain` shows
-// side bars and the *visible block* matches the hero's slightly-cropped shape —
-// re-introducing the exact ORCH-1131 miss this ORCH exists to fix.
+// ORCH-1133 REVERTS the checkout cover to the e90875dda~1 compact fixed 64px band
+// (Seth round-3 reject: "The cover fills the entire screen. Revert to original.").
+// The checkout clamp NO LONGER EXISTS — so the old `extractClamp(checkoutSrc)`
+// would throw, and asserting the clamp's math is meaningless. The append-only CI
+// gate (ORCH-0840) forbids DELETING a test file outright (no token bypasses a
+// deletion), so this file is INVERTED in place (MODIFY, token-covered) into the
+// durable guard that the clamp must STAY gone, while preserving the still-valid
+// SC-6 public-hero isolation + SC-7 EventCoverMedia default-safety checks.
 //
-// This test EXTRACTS the actual clamp expression from each of the three
-// checkout routes, evaluates it at runtime against the SC-1/2/3 inputs
-// (portrait 0.5625, square 1.0, landscape 1.78, panorama 3.0) and degenerate
-// inputs (NaN/0/negative from a broken onAspectRatio callback), and asserts the
-// RESULTING box aspect — the thing the user actually sees — is correct. It also
-// proves SC-6/SC-7 ISOLATION by extracting the public hero's clamp and asserting
-// it is a STRUCTURALLY DIFFERENT range (0.75..16/9) that the checkout did NOT
-// inherit, and that EventCoverMedia's videoContentFit default is still "cover".
+//   (A) NO checkout route may re-introduce a `Math.min(Math.max(...))` cover-
+//       aspect clamp, a `coverAspect`/`clampedCoverAspect` state, an
+//       `onAspectRatio=` cover prop, a `videoContentFit=` cover prop, or an inline
+//       cover `aspectRatio` — the exact ORCH-1131/1132 additions the revert undid.
+//       Each route's miniCover must declare the fixed `height: 64` band.
+//   (B) The public-event HERO clamp (PublicEventPage) is UNCHANGED — it still
+//       uses its OWN 0.75..16/9 range. The revert was scoped away from the hero
+//       (spec §2 DO-NOT-TOUCH); a "tidy" that drags the hero clamp out with the
+//       checkout clamp would break the public page. This stays a live guard.
+//   (C) EventCoverMedia's `videoContentFit` default stays "cover" (no consumer
+//       silently gets "contain").
 //
-// fails-on-revert: if the checkout clamp lower bound is reverted toward the hero
-// bound (0.6 -> 0.75) OR the upper bound changes (1.91 -> 16/9), the portrait /
-// panorama assertions FAIL; if the hero clamp is widened to match checkout the
-// isolation assertion FAILS. (Verified by the tester — see TEST report §Step-0.5.)
+// fails-on-revert: if any checkout route re-adds the clamp / onAspectRatio /
+// videoContentFit / inline aspectRatio (i.e. a future ORCH-1132-style change),
+// the (A) assertions FAIL; if the public hero clamp is removed/changed, (B) FAILS.
 
 const businessDir = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(businessDir, "..");
@@ -46,11 +46,10 @@ const CHECKOUT_ROUTES = [
 /**
  * Extract the literal `lower` and `upper` numbers from a
  * `Math.min(Math.max(<var>, <lower>), <upper>)` clamp and rebuild the SAME
- * clamp as an executable function. This evaluates the ACTUAL committed bounds —
- * a true line edit of either bound changes the function's behaviour.
+ * clamp as an executable function. Used ONLY for the public hero now (the
+ * checkout clamp is gone — see this file's header).
  */
 function extractClamp(src: string): (input: number) => number {
-  // Tolerant of whitespace; <upper> may be a number or a `a / b` expression.
   const m = src.match(
     /Math\.min\(\s*Math\.max\(\s*[A-Za-z0-9_]+\s*,\s*([0-9.]+)\s*\)\s*,\s*([0-9.]+(?:\s*\/\s*[0-9.]+)?)\s*\)/,
   );
@@ -58,135 +57,88 @@ function extractClamp(src: string): (input: number) => number {
     throw new Error("Could not locate a Math.min(Math.max(...)) clamp");
   }
   const lower = Number(m[1]);
-  // upper may be "16 / 9"
-  const upperRaw = m[2].replace(/\s+/g, "");
-  const upper = upperRaw.includes("/")
-    ? Number(upperRaw.split("/")[0]) / Number(upperRaw.split("/")[1])
-    : Number(upperRaw);
+  const upper = eval(m[2]) as number; // safe: regex-restricted to digits/`/`
   return (input: number): number => Math.min(Math.max(input, lower), upper);
 }
 
-/** The runtime initial-state seed for `useState(<n>)`. */
-function extractInitialAspect(src: string): number {
-  const m = src.match(/useState\(\s*(0?\.\d+|\d+(?:\.\d+)?)\s*\)/);
-  // there are several useState calls; the cover one is seeded with a float < 2.
-  // Find the FIRST useState seeded with a bare numeric literal in 0.5..2 range.
-  const all = [...src.matchAll(/useState\(\s*(\d+(?:\.\d+)?)\s*\)/g)];
-  for (const a of all) {
-    const v = Number(a[1]);
-    if (v >= 0.5 && v <= 2) return v;
+/** Extract the body of `styleKey: { ... }` from a StyleSheet.create block. */
+function extractStyleBody(src: string, styleKey: string): string {
+  const m = src.match(new RegExp(`\\n\\s*${styleKey}:\\s*\\{([\\s\\S]*?)\\n\\s*\\},`));
+  if (!m) {
+    throw new Error(`Could not locate \`${styleKey}:\` style block`);
   }
-  if (m) return Number(m[1]);
-  throw new Error("Could not locate the cover-aspect useState seed");
+  return m[1];
 }
 
-describe("ORCH-1132 adversarial — checkout clamp EXECUTES to full-frame bounds (not hero bounds)", () => {
+/** Extract the first `<EventCoverMedia ... />` JSX call body from source. */
+function extractEventCoverMediaCall(src: string): string {
+  const m = src.match(/<EventCoverMedia([\s\S]*?)\/>/);
+  if (!m) {
+    throw new Error("Could not locate an `<EventCoverMedia ... />` call");
+  }
+  return m[1];
+}
+
+describe("ORCH-1133 inverted (A) — the ORCH-1132 checkout cover-aspect clamp is GONE and stays gone", () => {
   for (const route of CHECKOUT_ROUTES) {
     const src = fs.readFileSync(path.join(businessDir, route), "utf8");
-    const clamp = extractClamp(src);
 
-    test(`${route}: portrait 0.5625 clamps to a TALL box (>= 0.6, NOT the hero's 0.75)`, () => {
-      const boxAspect = clamp(0.5625);
-      // SC-1: portrait must get a near-edge-to-edge tall box at the 0.6 floor.
-      expect(boxAspect).toBeCloseTo(0.6, 5);
-      // Adversarial guard: if someone copied the hero bound (0.75) the box would
-      // be 0.75 and re-crop a 0.5625 portrait. Prove that did NOT happen.
-      expect(boxAspect).toBeLessThan(0.75);
+    test(`${route}: NO Math.min(Math.max(...)) cover-aspect clamp`, () => {
+      expect(src).not.toMatch(/Math\.min\(\s*Math\.max\(/);
     });
 
-    test(`${route}: square 1.0 passes through UNCLAMPED (exact-fit box)`, () => {
-      // SC-3: 1.0 is in range -> exact box -> contain == perfect fill.
-      expect(clamp(1.0)).toBe(1.0);
+    test(`${route}: NO coverAspect / clampedCoverAspect state`, () => {
+      expect(src).not.toMatch(/coverAspect/);
+      expect(src).not.toMatch(/clampedCoverAspect/);
     });
 
-    test(`${route}: landscape 1.78 passes through (full landscape frame, not a sliver)`, () => {
-      // SC-2: 1.78 < 1.91 upper bound -> unclamped -> box tracks real shape.
-      expect(clamp(1.78)).toBeCloseTo(1.78, 5);
+    test(`${route}: the EventCoverMedia cover call has NO onAspectRatio / videoContentFit / inline aspectRatio`, () => {
+      const call = extractEventCoverMediaCall(src);
+      expect(call).not.toMatch(/onAspectRatio=/);
+      expect(call).not.toMatch(/videoContentFit=/);
+      expect(call).not.toMatch(/aspectRatio:/);
     });
 
-    test(`${route}: panorama 3.0 clamps to 1.91 upper (box not a sliver; NOT 16/9)`, () => {
-      const boxAspect = clamp(3.0);
-      expect(boxAspect).toBeCloseTo(1.91, 5);
-      // Adversarial guard: hero upper is 16/9 ≈ 1.778; checkout upper is 1.91.
-      // If the checkout clamp were reverted to the hero's 16/9 this fails.
-      expect(boxAspect).toBeGreaterThan(16 / 9);
-    });
-
-    test(`${route}: degenerate onAspectRatio (NaN / 0 / negative) cannot produce a broken box`, () => {
-      // Math.max(NaN, 0.6) === NaN in JS — the clamp does NOT sanitise NaN.
-      // This documents the runtime truth: a NaN ratio yields a NaN aspectRatio,
-      // which RN/web treats as "no aspectRatio" -> the box falls back to its
-      // intrinsic/last layout rather than collapsing. We assert the NON-NaN
-      // degenerate inputs (0, negative) are floored to the 0.6 lower bound so a
-      // broken-but-numeric callback can never collapse the card to a sliver.
-      expect(clamp(0)).toBeCloseTo(0.6, 5);
-      expect(clamp(-5)).toBeCloseTo(0.6, 5);
-      // NaN path: documents that the clamp passes NaN through (caller-safe
-      // because RN ignores a NaN aspectRatio). If a future change wraps the
-      // clamp in a Number.isFinite guard, update this expectation deliberately.
-      expect(Number.isNaN(clamp(NaN))).toBe(true);
-    });
-
-    test(`${route}: first-paint useState seed is in-range (no first-frame clamp jump)`, () => {
-      const seed = extractInitialAspect(src);
-      // The 0.75 seed must itself survive the clamp unchanged (0.6 <= 0.75 <= 1.91)
-      // so the first paint is stable, then settles to the media's true shape.
-      expect(clamp(seed)).toBe(seed);
-      expect(seed).toBeGreaterThanOrEqual(0.6);
-      expect(seed).toBeLessThanOrEqual(1.91);
+    test(`${route}: miniCover declares the fixed compact height: 64 band`, () => {
+      const body = extractStyleBody(src, "miniCover");
+      expect(body).toMatch(/^\s*height:\s*64,/m);
     });
   }
 });
 
-describe("ORCH-1132 adversarial — SC-6 isolation: public hero clamp is a DIFFERENT range, NOT inherited", () => {
+describe("ORCH-1133 inverted (B) — public hero clamp UNCHANGED (revert scoped away from the hero)", () => {
   const heroSrc = fs.readFileSync(
     path.join(repoRoot, "packages/event-rendering/PublicEventPage.tsx"),
     "utf8",
   );
   const heroClamp = extractClamp(heroSrc);
 
-  test("public hero clamps a 0.5625 portrait to 0.75 (its OWN bound — checkout floors to 0.6)", () => {
-    // Proves the hero still uses 0.75..16/9. If the hero were accidentally
-    // widened to the checkout's 0.6..1.91 this would read 0.6 and FAIL.
+  test("public hero still clamps a 0.5625 portrait to its OWN 0.75 bound", () => {
     expect(heroClamp(0.5625)).toBeCloseTo(0.75, 5);
   });
 
-  test("public hero upper bound is 16/9 (≈1.778), NOT the checkout's 1.91", () => {
+  test("public hero upper bound is still 16/9 (≈1.778), not the old checkout 1.91", () => {
     expect(heroClamp(3.0)).toBeCloseTo(16 / 9, 5);
     expect(heroClamp(3.0)).toBeLessThan(1.91);
   });
-
-  test("the checkout floor (0.6) and the hero floor (0.75) are genuinely different values", () => {
-    // Cross-file structural isolation: read both floors, assert they diverge.
-    const checkoutSrc = fs.readFileSync(
-      path.join(businessDir, CHECKOUT_ROUTES[0]),
-      "utf8",
-    );
-    const checkoutClamp = extractClamp(checkoutSrc);
-    // A portrait the hero clamps to 0.75, checkout clamps lower (0.6).
-    expect(checkoutClamp(0.5625)).toBeLessThan(heroClamp(0.5625));
-  });
 });
 
-describe("ORCH-1132 adversarial — SC-7 default-safety: EventCoverMedia videoContentFit default stays 'cover'", () => {
+describe("ORCH-1133 inverted (C) — EventCoverMedia videoContentFit default stays 'cover'", () => {
   const ecmSrc = fs.readFileSync(
     path.join(repoRoot, "packages/event-rendering/EventCoverMedia.tsx"),
     "utf8",
   );
 
-  test("videoContentFit prop default is exactly \"cover\" (no consumer gets contain by accident)", () => {
-    // The destructured default in the component signature.
+  test('videoContentFit prop default is exactly "cover" (no consumer gets contain by accident)', () => {
     expect(ecmSrc).toMatch(/videoContentFit\s*=\s*"cover"/);
-    // And there is NO `videoContentFit = "contain"` default anywhere.
     expect(ecmSrc).not.toMatch(/videoContentFit\s*=\s*"contain"/);
   });
 
-  test("the web <video> objectFit is driven by the contentFit prop (passthrough, not hardcoded contain)", () => {
-    // Proves contain is opt-in per call-site, not baked into the render path.
+  test("the web <video> objectFit is driven by the contentFit prop (passthrough)", () => {
     expect(ecmSrc).toMatch(/objectFit:\s*contentFit/);
   });
 
-  test("image covers remain resizeMode=\"cover\" (videoContentFit does not affect images — spec §4.4)", () => {
+  test('image covers remain resizeMode="cover"', () => {
     expect(ecmSrc).toMatch(/resizeMode="cover"/);
   });
 });

--- a/mingla-business/__tests__/orch1133PillClearanceGeometryAdversarial.tester.test.ts
+++ b/mingla-business/__tests__/orch1133PillClearanceGeometryAdversarial.tester.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "node:fs";
+import path from "node:path";
+
+// ORCH-1133 [revert-cover-pill-bottom] — TESTER adversarial regression.
+//
+// DIFFERENT ANGLE than the implementor's source-introspection happy-path and the
+// inverted orch1132 token-absence guard. Those assert WHICH literals are present.
+// This test PROVES THE GEOMETRY those literals encode — the two physical
+// invariants Seth actually complained about — by parsing the real numbers out of
+// the shared source and computing the resulting layout:
+//
+//   (1) CLEARANCE: the public-event Sound pill, anchored bottom:<B> on the hero,
+//       must clear the blue details panel whose top sits |marginTop| px above the
+//       hero bottom (PublicEventPage.bodyContent.marginTop = -28). The signed gap
+//       = B - |marginTop| MUST be a POSITIVE, visible value (Seth: "still needs
+//       some space"). Forensics measured prod (B=22) at -6px overlap; round-3
+//       (B=40) must yield ~+12px. We assert gap >= +10 AND that the OLD value
+//       (22) would have FAILED this same predicate (regression proof in-test).
+//
+//   (2) ON-SCREEN SAFETY: a bottomRight pill of minHeight <MH> at bottom:<B>
+//       occupies the band [boxH-(B+MH) .. boxH-B] inside its cover box. For the
+//       SHORTEST real bottomRight consumer (expandedCard ImageGallery, height:300)
+//       the pill's TOP edge (boxH-(B+MH)) MUST stay > 0 (fully inside the box,
+//       never clipped off the top by top chrome). This is the SC-6 cross-consumer
+//       invariant computed, not assumed.
+//
+// fails-on-revert: reverting bottom 40->22 makes (1) gap = -6 (< 10) -> FAILS.
+// Pushing bottom absurdly high (e.g. 280) on the 300px box would make the pill
+// top edge negative -> (2) FAILS. Both directions are guarded.
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const ECM = fs.readFileSync(
+  path.join(repoRoot, "packages/event-rendering/EventCoverMedia.tsx"),
+  "utf8",
+);
+const PEP = fs.readFileSync(
+  path.join(repoRoot, "packages/event-rendering/PublicEventPage.tsx"),
+  "utf8",
+);
+
+/** Pull the body of `styleKey: { ... }` from a StyleSheet.create block. */
+function styleBody(src: string, styleKey: string): string {
+  const m = src.match(new RegExp(`\\n\\s*${styleKey}:\\s*\\{([\\s\\S]*?)\\n\\s*\\},`));
+  if (!m) throw new Error(`Could not locate \`${styleKey}:\` style block`);
+  return m[1];
+}
+
+/**
+ * Read a numeric `key: <n>,` out of a style body. Matches ONLY a real
+ * declaration line (start-of-line whitespace then `key:`), so it never reads a
+ * value out of a `//` comment that happens to mention `bottom:22` etc.
+ */
+function numProp(body: string, key: string): number {
+  const lines = body.split("\n");
+  for (const line of lines) {
+    if (/^\s*\/\//.test(line)) continue; // skip comment lines
+    const m = line.match(new RegExp(`^\\s*${key}:\\s*(-?[0-9]+)`));
+    if (m) return Number(m[1]);
+  }
+  throw new Error(`Could not read numeric \`${key}\` declaration from style body`);
+}
+
+describe("ORCH-1133 (1) — Sound pill clears the public-event details panel with a positive visible gap", () => {
+  const pill = styleBody(ECM, "audioControlBottomRight");
+  const body = styleBody(PEP, "bodyContent");
+
+  const pillBottom = numProp(pill, "bottom"); // anchor inset from hero bottom
+  const panelMarginTop = numProp(body, "marginTop"); // -28: panel pulled up over hero
+  const panelOverlap = Math.abs(panelMarginTop); // 28: how far the panel top sits above hero bottom
+
+  // Signed gap between the pill's bottom anchor and the panel's top edge.
+  // Both measured from the hero bottom going up: gap = pillBottom - panelOverlap.
+  const gap = pillBottom - panelOverlap;
+
+  test("the live values are the round-3 contract (bottom=40, panelOverlap=28)", () => {
+    expect(pillBottom).toBe(40);
+    expect(panelOverlap).toBe(28);
+  });
+
+  test("gap is a POSITIVE visible clearance (>= +10px, target +12)", () => {
+    expect(gap).toBeGreaterThanOrEqual(10);
+    expect(gap).toBe(12);
+  });
+
+  test("the pre-revert value (bottom:22) would have OVERLAPPED the panel (regression proof)", () => {
+    const oldGap = 22 - panelOverlap;
+    expect(oldGap).toBeLessThan(0); // -6: the exact bug forensics measured
+  });
+});
+
+describe("ORCH-1133 (2) — pill stays fully on-screen on the SHORTEST bottomRight consumer (ImageGallery h=300)", () => {
+  const pill = styleBody(ECM, "audioControlBottomRight");
+  const base = styleBody(ECM, "audioControl"); // base style carries minHeight
+  const pillBottom = numProp(pill, "bottom"); // 40
+  const pillMinHeight = numProp(base, "minHeight"); // 36
+
+  // expandedCard/ImageGallery renders a full-bleed video cover at height:300 with
+  // audioControlPosition="bottomRight" — the shortest real bottomRight box.
+  const SHORTEST_BOTTOMRIGHT_BOX = 300;
+
+  test("ImageGallery still uses a 300px bottomRight cover (guards the assumption)", () => {
+    const gallery = fs.readFileSync(
+      path.join(repoRoot, "app-mobile/src/components/expandedCard/ImageGallery.tsx"),
+      "utf8",
+    );
+    expect(gallery).toMatch(/audioControlPosition="bottomRight"/);
+    expect(gallery).toMatch(/height:\s*300/);
+  });
+
+  test("pill TOP edge stays inside the box (not clipped off the top)", () => {
+    // band occupied: [boxH-(bottom+minHeight) .. boxH-bottom]
+    const pillTopEdge = SHORTEST_BOTTOMRIGHT_BOX - (pillBottom + pillMinHeight);
+    expect(pillTopEdge).toBeGreaterThan(0); // 300-(40+36)=224 -> safely inside
+  });
+
+  test("pill base minHeight (36) is preserved at the round-3 value", () => {
+    expect(pillMinHeight).toBe(36);
+  });
+});

--- a/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
+++ b/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
@@ -17,7 +17,7 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed checkout header mirroring /checkout-trip/[tripEventId]/index.tsx; insets.bottom IS applied (bottom dock); the top status-bar overlap with the banner header is the intended buyer aesthetic.
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -94,13 +94,6 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
 
   const { lines, setLineQuantity } = useCart();
   const totals = useCartTotals();
-
-  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
-  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
-  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
-  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
-  const [coverAspect, setCoverAspect] = useState(0.75);
-  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
 
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
@@ -255,9 +248,7 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
             mediaType={experience.coverMediaType}
             radius={0}
             label=""
-            onAspectRatio={setCoverAspect}
-            videoContentFit="contain"
-            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
+            style={styles.miniCover}
           />
           <Text style={styles.miniTitle} numberOfLines={2}>
             {experience.title.trim().length > 0
@@ -337,12 +328,7 @@ const styles = StyleSheet.create({
   },
   miniCard: { marginBottom: spacing.lg },
   miniCover: {
-    // ORCH-1132 — full-frame, no crop. The fixed height:120 band cropped a
-    // 360×640 portrait cover to a mid-frame strip (head cut off). Height now
-    // follows an inline aspectRatio (driven by onAspectRatio, clamped 0.6..1.91)
-    // paired with videoContentFit="contain", so the WHOLE frame shows; thin
-    // letterbox bars at clamp boundaries are near-invisible on the #0c0e12 card.
-    // No fixed height: declared here (load-bearing — see the inline aspectRatio).
+    height: 64,
     borderRadius: radiusTokens.md,
     marginBottom: spacing.sm,
   },

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -18,7 +18,7 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed checkout header mirroring /checkout/[eventId]/index.tsx; insets.bottom IS applied (bottom dock) for home-indicator clearance; the top status-bar overlap with back arrow / "Reserve your spot" header / "1 OF 3" pill is the intended banner-style buyer aesthetic. Per ORCH-0876 mirror of ORCH-0859 [Tr2] REWORK 5b operator design ruling.
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   ScrollView,
   StyleSheet,
@@ -130,13 +130,6 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
 
   const { lines, setLineQuantity } = useCart();
   const totals = useCartTotals();
-
-  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
-  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
-  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
-  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
-  const [coverAspect, setCoverAspect] = useState(0.75);
-  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
 
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
@@ -315,9 +308,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
             }
             radius={0}
             label=""
-            onAspectRatio={setCoverAspect}
-            videoContentFit="contain"
-            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
+            style={styles.miniCover}
           />
           <Text style={styles.miniTitle} numberOfLines={2}>
             {trip.title.trim().length > 0 ? trip.title : "Untitled trip"}
@@ -436,12 +427,7 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   miniCover: {
-    // ORCH-1132 — full-frame, no crop. The fixed height:120 band cropped a
-    // 360×640 portrait cover to a mid-frame strip (head cut off). Height now
-    // follows an inline aspectRatio (driven by onAspectRatio, clamped 0.6..1.91)
-    // paired with videoContentFit="contain", so the WHOLE frame shows; thin
-    // letterbox bars at clamp boundaries are near-invisible on the #0c0e12 card.
-    // No fixed height: declared here (load-bearing — see the inline aspectRatio).
+    height: 64,
     borderRadius: radiusTokens.md,
     marginBottom: spacing.sm,
   },

--- a/mingla-business/app/checkout/[eventId]/index.tsx
+++ b/mingla-business/app/checkout/[eventId]/index.tsx
@@ -80,13 +80,6 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
   const totals = useCartTotals();
   const [waitlistTicketId, setWaitlistTicketId] = useState<string | null>(null);
 
-  // ORCH-1132 — full-frame (no-crop) checkout cover. Drive the mini-card box's
-  // aspectRatio to the cover media's real shape via onAspectRatio, paired with
-  // videoContentFit="contain", so the WHOLE frame shows (a portrait subject's
-  // head is never cropped). 0.75 = portrait-ish first paint; clamp 0.6..1.91.
-  const [coverAspect, setCoverAspect] = useState(0.75);
-  const clampedCoverAspect = Math.min(Math.max(coverAspect, 0.6), 1.91);
-
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
       router.back();
@@ -251,9 +244,7 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
             mediaType={event.coverMediaType}
             radius={0}
             label=""
-            onAspectRatio={setCoverAspect}
-            videoContentFit="contain"
-            style={[styles.miniCover, { aspectRatio: clampedCoverAspect }]}
+            style={styles.miniCover}
           />
           <Text style={styles.miniTitle} numberOfLines={2}>
             {event.name.trim().length > 0 ? event.name : "Untitled event"}
@@ -351,12 +342,7 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   miniCover: {
-    // ORCH-1132 — full-frame, no crop. The fixed height:120 band cropped a
-    // 360×640 portrait cover to a mid-frame strip (head cut off). Height now
-    // follows an inline aspectRatio (driven by onAspectRatio, clamped 0.6..1.91)
-    // paired with videoContentFit="contain", so the WHOLE frame shows; thin
-    // letterbox bars at clamp boundaries are near-invisible on the #0c0e12 card.
-    // No fixed height: declared here (load-bearing — see the inline aspectRatio).
+    height: 64,
     borderRadius: radiusTokens.md,
     marginBottom: spacing.sm,
   },

--- a/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts
+++ b/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.adversarial.test.ts
@@ -117,20 +117,28 @@ describe("ORCH-1128 adversarial A3 — mute pill clears the seam by a strict mar
     const src = coverMedia();
     const idx = src.indexOf("audioControlBottomRight:");
     expect(idx).toBeGreaterThan(-1);
-    const block = src.slice(idx, idx + 400);
-    // Numeric parse of the actual bottom value (not a literal-22 string match):
+    // Parse the EXACT `audioControlBottomRight: { ... }` block (the comment bloat
+    // pushed `bottom:` past the old fixed 400-char window, NULLing the parse —
+    // DISC-1 hardening). Extracting the precise block also keeps the no-`top:`
+    // assertion from leaking into the next sibling style's `top:` key.
+    const blockMatch = src
+      .slice(idx)
+      .match(/audioControlBottomRight:\s*\{([\s\S]*?)\n\s*\},/);
+    expect(blockMatch).not.toBeNull();
+    const block = blockMatch ? blockMatch[1] : "";
+    // Numeric parse of the actual bottom value (not a literal string match):
     const m = block.match(/bottom:\s*(\d+)/);
     expect(m).not.toBeNull();
     const bottom = Number(m?.[1]);
     // STRICT increase over the flush ORCH-1124 baseline — a partial bump that
-    // still bleeds (<=14) fails just as a full revert to 14 does.
+    // still bleeds (<=14) fails just as a full revert to 14 does. ORCH-1133 = 40.
     expect(bottom).toBeGreaterThan(14);
     // The bottomRight style must remain a BOTTOM anchor: no `top:` key smuggled
     // in (which would silently turn it into a top-pinned pill — the exact
     // ORCH-1124 regression this position contract forbids).
     expect(block).not.toMatch(/top:\s*\d+/);
-    // And the right anchor is preserved.
-    expect(block).toMatch(/right:\s*14/);
+    // And the right anchor is preserved (24, kept from ORCH-1132).
+    expect(block).toMatch(/right:\s*24/);
   });
 
   test("the shared default position is bottomRight (no topRight regression)", () => {

--- a/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts
+++ b/mingla-business/src/components/offering/__tests__/orch1128FreeCtaMutePill.test.ts
@@ -88,17 +88,23 @@ describe("ORCH-1128 item 1 — free / waitlist CTA spans the full floating bar",
 });
 
 describe("ORCH-1128 item 2 — cover mute pill clears the details below", () => {
-  test("audioControlBottomRight bottom offset is raised to 22 (clearance from details)", () => {
+  test("audioControlBottomRight bottom offset is raised to 40 (clearance from details)", () => {
     const src = coverMedia();
     const idx = src.indexOf("audioControlBottomRight:");
     expect(idx).toBeGreaterThan(-1);
-    const block = src.slice(idx, idx + 400);
-    // The bottom offset is the bumped value, not the flush ORCH-1124 default.
-    expect(block).toMatch(/bottom:\s*22/);
+    // Parse the full block (the comment bloat pushed `bottom:` past the old
+    // fixed 400-char window — DISC-1 hardening).
+    const blockMatch = src
+      .slice(idx)
+      .match(/audioControlBottomRight:\s*\{([\s\S]*?)\n\s*\},/);
+    const block = blockMatch ? blockMatch[1] : "";
+    // ORCH-1133 round 3 — the bottom offset is the bumped value, not the flush
+    // ORCH-1124 default and not the superseded ORCH-1128 value of 22.
+    expect(block).toMatch(/bottom:\s*40/);
     expect(block).not.toMatch(/bottom:\s*14\b/);
     // ORCH-1124 position contract preserved: still bottom-right (right anchor),
-    // NOT reverted to a top position.
-    expect(block).toMatch(/right:\s*14/);
+    // NOT reverted to a top position. right kept at 24 (ORCH-1132).
+    expect(block).toMatch(/right:\s*24/);
   });
 
   test("the public page still inherits the bottomRight default (no topRight regression)", () => {

--- a/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
+++ b/mingla-business/src/components/ui/__tests__/eventCoverMedia.test.ts
@@ -355,19 +355,23 @@ describe("ORCH-1124 cover-video audio pill clears top-right floating chrome", ()
   });
 
   // The shared component's audio-pill default is "bottomRight" and is styled
-  // inside the cover container (bottom:22 / right:14) — not the page base — so
+  // inside the cover container (bottom:40 / right:24) — not the page base — so
   // it does not collide with the host-mounted floating Buy bar (ORCH-1117) and
-  // (ORCH-1128) clears the cover seam so it stops bleeding into the details
-  // section that begins immediately below the public hero.
+  // (ORCH-1133, round 3) clears the public-event blue details panel by +12px so
+  // it stops bleeding into the details section that begins below the public hero.
   test("EventCoverMedia defaults the audio pill to bottomRight, styled within the cover", () => {
     const media = coverMedia();
     expect(media).toContain('audioControlPosition = "bottomRight"');
     expect(media).toContain("audioControlBottomRight:");
-    const bottomRightStyle = media
+    // Parse the full `audioControlBottomRight: { ... }` block (the comment bloat
+    // above `bottom:` blew past the old fixed 400-char window — DISC-1 hardening).
+    const blockMatch = media
       .slice(media.indexOf("audioControlBottomRight:"))
-      .slice(0, 400);
-    expect(bottomRightStyle).toContain("right: 14");
-    // ORCH-1128 — raised from 14 → 22 for bottom clearance from the details.
-    expect(bottomRightStyle).toContain("bottom: 22");
+      .match(/audioControlBottomRight:\s*\{([\s\S]*?)\n\s*\},/);
+    const bottomRightStyle = blockMatch ? blockMatch[1] : "";
+    // ORCH-1132 — right kept at 24 (visible right-edge breathing room).
+    expect(bottomRightStyle).toContain("right: 24");
+    // ORCH-1133 — raised 22 → 40 for clearance from the public-event details panel.
+    expect(bottomRightStyle).toContain("bottom: 40");
   });
 });

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -614,9 +614,14 @@ const styles = StyleSheet.create({
     // by +8px (safe; no consumer relies on 16). Raw literal matches this file's
     // convention (topLeft/topRight all use raw numbers).
     right: 24,
-    // ORCH-1128 — 14 → 22: clears the cover seam so the pill stops bleeding
-    // into the details section below the public hero (radius:0 + absoluteFill).
-    bottom: 22,
+    // ORCH-1133 — 22 → 40: round-3 clearance from the public-event details panel.
+    // The blue details panel (PublicEventPage `bodyContent`, marginTop:-28) sits
+    // 28px above the hero bottom; at bottom:22 the pill overlapped the panel top
+    // by 6px (measured on buyer web). bottom:40 = 28 + 12px visible gap (live-
+    // verified +12.0px on /e/leggothis/vibes-and-stuff & /a-life-in-vegas).
+    // Shared style → also lifts the consumer gallery + authoring-preview pills
+    // +18px on their full-bleed covers (benign; ≥200px boxes, no panel below).
+    bottom: 40,
   },
   audioControlPressed: {
     backgroundColor: "rgba(0, 0, 0, 0.72)",


### PR DESCRIPTION
## ORCH-1133 — round 3 (revert ORCH-1132 cover + fix pill bottom clearance)

Seth verified ORCH-1132 on his dev build and rejected it: the full-frame checkout cover **ballooned a portrait cover to fill the screen** ("looks awful, revert to original"), and the Sound pill "still needs some space or padding from the details section." This reverts the cover and gives the pill real bottom clearance. Pure-JS/RN — no backend, migration, or native rebuild.

### Fix 1 — Revert checkout cover to the original compact band (all 3 checkouts)
Restored the pre-ORCH-1131 original in event/trip/experience checkouts: a fixed `miniCover: { height: 64, borderRadius, marginBottom }` band + a plain `<EventCoverMedia … style={styles.miniCover} />`. Removed all ORCH-1131 (64→120) and ORCH-1132 (adaptive aspect / onAspectRatio / contain) cover code; dropped the now-unused `useState` import from the trip + experience files. Measured: cover renders **64px** (vs prod's 684px full-screen).

### Fix 2 — Sound pill clears the details section
`audioControlBottomRight.bottom` 22→40 in shared `packages/event-rendering/EventCoverMedia.tsx` (`right:24` unchanged). Forensics measured the pill at bottom:22 **overlapping** the blue details panel by −6px; bottom:40 gives a clean **+12px** gap above it.

### Verification
- Forensics: measured the pill-vs-details-panel geometry on buyer web; diffed all 3 checkouts against the `e90875dda~1` original.
- Implementor: web live-fire (64px band + pill clearance), gates green, fails-on-revert at `d2c54b23f`. Brought 6 pinned jest files to round-3 values; the obsolete ORCH-1132 clamp test was **inverted in place** (not deleted — the append-only gate forbids test-file deletion) to guard the full-screen cover code stays gone.
- Tester: PASS (P0:0 P1:0 P2:0). Measured 64px cover band + +12px pill gap; pill still FIRES at runtime; public hero + deck card unchanged. Own adversarial geometry test (different angle), fails-on-revert verified.

### Notes
- HEAD commit carries `[TEST-MOD-APPROVED ORCH-1133]` (required by the append-only gate for the round-3 test updates).
- Spec/gate conflict registered: spec said "delete" the obsolete test; the append-only gate forbids deletion → inverted in place instead.
- ORCH-ID collision: a separate live session's worktree also used ORCH-1133 (`biz-root-render-loop`); this revert-cover work ships first and keeps the number per the shipped-first rule — the other must renumber (flagged in the comms ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)