### PR TITLE
ORCH-1136: fix business-web shell bugs — brand-switcher loading wedge, Hub offset, event ⋯ dead-tap, top-bar gap [deploy]

### DIFF
--- a/.github/scripts/strict-grep/i-proposed-topsheet-web-viewport-anchor.mjs
+++ b/.github/scripts/strict-grep/i-proposed-topsheet-web-viewport-anchor.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * I-PROPOSED-TOPSHEET-WEB-VIEWPORT-ANCHOR  (ORCH-1136 Batch B / F-3)
+ *
+ * THE BUG (forensics-proven, deterministic CSS harness): TopSheet's root overlay
+ * was a bare `StyleSheet.absoluteFill` (`position:absolute; top:0`), which on web
+ * anchors to the nearest positioned ancestor — the scrollable route host. When the
+ * Hub host was document-scrolled, the panel's `top: insets.top + 76` landed ABOVE
+ * the browser viewport (panel top measured −524px scrolled-600 vs the correct 76px
+ * unscrolled), so only the bottom row peeked. Home's host is viewport-bound, so it
+ * was always correct.
+ *
+ * THE FIX: on web ONLY, the root overlay gets `position: 'fixed'` so it anchors to
+ * the browser VIEWPORT, not the scrollable host — making the anchor scroll-
+ * independent at 76px. `position:'fixed'` is a valid react-native-web value but NOT
+ * a valid RN native value, hence the Platform gate; native keeps bare
+ * `StyleSheet.absoluteFill` UNCHANGED.
+ *
+ * THE RULE: TopSheet.tsx MUST apply `position: 'fixed'` to the overlay root only
+ * behind a `Platform.OS === 'web'` guard, and the native path MUST still use
+ * `StyleSheet.absoluteFill`. FAILS on a revert to a bare `absoluteFill` root (the
+ * Hub-offset regression) or on a `position:'fixed'` that is NOT web-gated (would
+ * crash/no-op on native).
+ *
+ * Scope: the single shared primitive mingla-business/src/components/ui/TopSheet.tsx.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const REL = "mingla-business/src/components/ui/TopSheet.tsx";
+const filePath = path.join(repoRoot, REL);
+
+let src;
+try {
+  src = fs.readFileSync(filePath, "utf8");
+} catch {
+  console.error(
+    `\nFAIL [I-PROPOSED-TOPSHEET-WEB-VIEWPORT-ANCHOR]: cannot read ${REL}\n`,
+  );
+  process.exit(1);
+}
+
+const violations = [];
+
+// (1) A web-gated position:'fixed' must exist. Match `Platform.OS === "web"`
+// (single or double quotes) on the same construct that yields `position: "fixed"`.
+const hasWebGate = /Platform\.OS\s*===\s*["']web["']/.test(src);
+const hasFixed = /position:\s*["']fixed["']/.test(src);
+if (!hasWebGate) {
+  violations.push(
+    "no `Platform.OS === \"web\"` gate found — the viewport anchor must be web-gated.",
+  );
+}
+if (!hasFixed) {
+  violations.push(
+    "no `position: \"fixed\"` found — the web overlay must anchor to the viewport (reverted to bare absoluteFill = the Hub-offset regression).",
+  );
+}
+
+// (2) The position:'fixed' must be co-located with the web gate (same expression),
+// not an un-gated native crash. Isolate the rootOverlayStyle ternary region.
+if (hasFixed && hasWebGate) {
+  const rootIdx = src.indexOf("rootOverlayStyle");
+  if (rootIdx < 0) {
+    violations.push(
+      "expected a `rootOverlayStyle` web-gated style variable carrying the position:'fixed' anchor.",
+    );
+  } else {
+    // Take a window around the rootOverlayStyle definition and assert BOTH the
+    // web gate and position:'fixed' co-occur there.
+    const region = src.slice(rootIdx, rootIdx + 400);
+    const gatedFixed =
+      /Platform\.OS\s*===\s*["']web["']/.test(region) &&
+      /position:\s*["']fixed["']/.test(region);
+    if (!gatedFixed) {
+      violations.push(
+        "`rootOverlayStyle` does not co-locate the `Platform.OS === \"web\"` gate with `position: \"fixed\"` — the fixed anchor must be applied ONLY on web.",
+      );
+    }
+  }
+}
+
+// (3) Native path must still reference StyleSheet.absoluteFill (unchanged).
+if (!/StyleSheet\.absoluteFill/.test(src)) {
+  violations.push(
+    "`StyleSheet.absoluteFill` missing — the native overlay path must still use absoluteFill (no position:'fixed' on native).",
+  );
+}
+
+if (violations.length > 0) {
+  console.error("\nFAIL [I-PROPOSED-TOPSHEET-WEB-VIEWPORT-ANCHOR]:");
+  console.error(
+    "  TopSheet must anchor its web overlay to the viewport via a web-gated position:'fixed';",
+  );
+  console.error("  native must keep bare StyleSheet.absoluteFill (ORCH-1136 F-3).");
+  for (const v of violations) console.error(`  ✗ ${v}`);
+  console.error("");
+  process.exit(1);
+}
+
+console.log(
+  "OK [I-PROPOSED-TOPSHEET-WEB-VIEWPORT-ANCHOR]: TopSheet web overlay is viewport-anchored via web-gated position:'fixed'; native keeps absoluteFill.",
+);

--- a/.github/scripts/strict-grep/i-proposed-web-topbar-breathing-gap.mjs
+++ b/.github/scripts/strict-grep/i-proposed-web-topbar-breathing-gap.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * I-PROPOSED-WEB-TOPBAR-BREATHING-GAP  (ORCH-1136 Batch C / F-1)
+ *
+ * CONTEXT: on web `insets.top === 0` (no viewport-fit=cover), so the detail
+ * (event/trip/experience) and Home/Hub top bars sat glued to the browser
+ * viewport top — Seth's perceived "hug." This is a perceived-spacing polish, NOT
+ * a code defect (F-1's header-container theory is proven negative on web — the
+ * headers are byte-identical). The fix adds an ADDITIVE, WEB-ONLY `spacing.sm`
+ * (8px) top padding so the chrome isn't flush to the viewport edge; native top
+ * insets are UNTOUCHED (+0 on native).
+ *
+ * THE RULE: each of the five top-bar wrappers must add a web-only top padding
+ * gated on `Platform.OS === 'web'` and sized `spacing.sm`. FAILS if the web gap
+ * is removed from any surface, or if a NON-web-gated top padding is introduced
+ * (which would double-inset native).
+ *
+ * Scope: the five mingla-business top-bar hosts in the allowlist.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+// Each entry: the file + how many web-gated `spacing.sm` top-padding sites it
+// must carry. event/[id] has TWO header wrappers (not-found shell + main).
+const TARGETS = [
+  { rel: "mingla-business/app/event/[id]/index.tsx", min: 2 },
+  { rel: "mingla-business/app/trip/[id]/index.tsx", min: 1 },
+  { rel: "mingla-business/app/experience/[id]/index.tsx", min: 1 },
+  { rel: "mingla-business/app/(tabs)/home.tsx", min: 1 },
+  { rel: "mingla-business/app/(tabs)/hub/_layout.tsx", min: 1 },
+];
+
+const violations = [];
+
+// Two accepted web-gated spacing.sm shapes:
+//   (a) ternary added to an existing inset: `(Platform.OS === "web" ? spacing.sm : 0)`
+//   (b) conditional style object:           `Platform.OS === "web" ? { paddingTop: spacing.sm } : null`
+const PATTERN_A =
+  /Platform\.OS\s*===\s*["']web["']\s*\?\s*spacing\.sm\s*:\s*0/g;
+const PATTERN_B =
+  /Platform\.OS\s*===\s*["']web["']\s*\?\s*\{\s*paddingTop:\s*spacing\.sm\s*\}\s*:\s*null/g;
+
+for (const { rel, min } of TARGETS) {
+  let src;
+  try {
+    src = fs.readFileSync(path.join(repoRoot, rel), "utf8");
+  } catch {
+    violations.push(`cannot read ${rel}`);
+    continue;
+  }
+  const countA = (src.match(PATTERN_A) ?? []).length;
+  const countB = (src.match(PATTERN_B) ?? []).length;
+  const total = countA + countB;
+  if (total < min) {
+    violations.push(
+      `${rel}: expected >= ${min} web-gated spacing.sm top-padding site(s), found ${total} ` +
+        `(the ORCH-1136 web breathing gap was removed or not web-gated).`,
+    );
+  }
+}
+
+if (violations.length > 0) {
+  console.error("\nFAIL [I-PROPOSED-WEB-TOPBAR-BREATHING-GAP]:");
+  console.error(
+    "  Detail + Home/Hub top bars must add a WEB-ONLY `spacing.sm` top padding",
+  );
+  console.error(
+    "  (Platform.OS === 'web'); native top insets stay untouched (ORCH-1136 F-1).",
+  );
+  for (const v of violations) console.error(`  ✗ ${v}`);
+  console.error("");
+  process.exit(1);
+}
+
+console.log(
+  "OK [I-PROPOSED-WEB-TOPBAR-BREATHING-GAP]: all five top-bar hosts carry the web-gated spacing.sm breathing gap; native untouched.",
+);

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2317,6 +2317,19 @@ jobs:
       - name: Run ORCH-1130 no-buyer-tax-form gate
         run: node .github/scripts/strict-grep/orch-1130-no-buyer-tax-form.mjs
 
+  orch-1136-biz-web-shell-bugs:
+    name: "ORCH-1136: TopSheet web viewport anchor + web top-bar breathing gap (I-PROPOSED-TOPSHEET-WEB-VIEWPORT-ANCHOR / I-PROPOSED-WEB-TOPBAR-BREATHING-GAP)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run ORCH-1136 TopSheet web viewport-anchor gate
+        run: node .github/scripts/strict-grep/i-proposed-topsheet-web-viewport-anchor.mjs
+      - name: Run ORCH-1136 web top-bar breathing-gap gate
+        run: node .github/scripts/strict-grep/i-proposed-web-topbar-breathing-gap.mjs
+
   # ORCH-0962 brand-field-map-coverage gate RETIRED at META-ORCH-0972 CLOSE
   # (2026-05-26). The gate asserted that `viewRowToBrand` reads `row.brand_kind`
   # from `business_public_events_view`. META-ORCH-0972 Sub-C removed `brand_kind`

--- a/Mingla_Artifacts/IMPLEMENT_ORCH-1136_BIZ_WEB_SHELL_BUGS.md
+++ b/Mingla_Artifacts/IMPLEMENT_ORCH-1136_BIZ_WEB_SHELL_BUGS.md
@@ -1,0 +1,165 @@
+# IMPLEMENTATION — ORCH-1136 [business-web shell bugs]
+
+**Phase:** IMPLEMENT (mingla-implementor). **Built exactly the binding SPEC; no scope widening.**
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1136-[biz-web-shell-bugs]/` on branch `ORCH-1136-biz-web-shell-bugs` (rebased on origin/main `f68495ca6`).
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1136_BIZ_WEB_SHELL_BUGS.md`. **Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1136_BIZ_WEB_SHELL_BUGS.md`.
+**Commits:** Batch A `d1a1378bf` · Batch B `ee4c539cf` · Batch C + gates `dc81a6c39`.
+
+---
+
+## 1. Summary
+
+Four business-app shell bugs fixed in three web-gated batches, all in shared RN/TS so native iOS+Android are unchanged by construction:
+
+- **Batch A (proven):** the brand-list status machine no longer downgrades an already-fetched, non-empty brand list to "Loading…" during a background refetch — the brand switcher and Account brands list now render cached brands instead of wedging on "Loading your brands…". The event `⋯` menu no longer silently dead-taps when the brand is momentarily null: it shows a "Loading brand… tap again in a moment." toast (Const #1), while preserving the ORCH-0862 unmount-on-close mount gate.
+- **Batch B (probable → mechanism-proven on web):** the `TopSheet` overlay anchors to the browser viewport (`position:'fixed'`) on web only, so a scrolled Hub host can't offset the brand switcher. Native keeps `StyleSheet.absoluteFill`.
+- **Batch C (web-only polish):** an additive `spacing.sm` (8px) web-only top padding on the event/trip/experience detail headers + Home/Hub top bars so the chrome isn't glued to the browser viewport top. Native insets byte-identical (`+0`).
+
+Two new strict-grep gates (Batch B + C) added and registered in CI; both proven fails-on-revert. Batch A's predicate gains a fails-on-revert unit assertion.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Status | Evidence / commit |
+|----|--------|-------------------|
+| **SC-A1** (predicate: fetched+refetching → ready/empty; first-load/auth/disabled/signed-out preserved) | ✓ VERIFIED | unit test `brandListState.test.ts` all 4 predicate tests green; new "does not downgrade…" test asserts `{isFetching:true,isFetched:true,itemCount:3}→ready`, `itemCount:0→empty`, `isFetched:false→query_loading`. `d1a1378bf` |
+| **SC-A2-Web** (switcher shows cached rows while refetching) | ✓ IMPLEMENTED, partially verified | A.1 predicate + A.2 reorder built; web bundle compiles. Authed runtime nav-and-reopen needs login (no creds) → handed to tester. `d1a1378bf` |
+| **SC-A3-Web** (Account shows cached rows after idle refetch) | ✓ IMPLEMENTED, partially verified | A.1 + A.3 `status==='ready' || brands.length>0`. Authed runtime → tester. `d1a1378bf` |
+| **SC-A4-Web** (event `⋯`: opens w/ brand, loading toast when null, never dead tap) | ✓ IMPLEMENTED, partially verified | A.4 `handleManageOpen` shows toast on null brand; line-841 mount unchanged. Authed runtime → tester. `d1a1378bf` |
+| **SC-A5-iOS / SC-A6-Android** (native parity) | ⚠ UNVERIFIED — native device run | Shared pure-TS predicate + handler; native build untouched by construction. Human-in-the-loop device run required. |
+| **SC-B1-Web** (Hub switcher anchored at ~76px == Home, scroll-independent) | ✓ MECHANISM-PROVEN on web | Deterministic Playwright CSS harness reproducing the exact F-3 scenario: bare `absolute` → top 76px unscrolled / **−524px** scrolled-600 (the bug); `position:fixed` → **76px at both** (fix). Web bundle confirmed to emit `rootOverlayStyle` + `position:"fixed"`. FULL authed end-to-end Hub measurement blocked by no-creds (SPEC §10) → tester. `ee4c539cf` |
+| **SC-B2-Web** (both TopSheet consumers from scrolled+unscrolled) | ✓ MECHANISM-PROVEN, partially verified | Fix is in the shared `TopSheet` root, so both consumers (`fixed-70` + `compact`) inherit the viewport anchor; harness proves the anchor math. Per-consumer authed runtime → tester. `ee4c539cf` |
+| **SC-B3-iOS / SC-B4-Android** (native sheets byte-identical, rotation height correct) | ⚠ UNVERIFIED — native device run | `position:'fixed'` + live-height are `Platform.OS==='web'`-gated; native path uses `StyleSheet.absoluteFill` + `Dimensions.get('window')` UNCHANGED. Device run required. |
+| **SC-C1-Web** (event/trip/exp top bars 8px below viewport top, equal) | ✓ IMPLEMENTED, partially verified | web-only `spacing.sm` on all three `headerWrap`. Web bundle compiles. Visual authed capture → tester/Seth. `dc81a6c39` |
+| **SC-C2-Web** (Home/Hub same web gap) | ✓ IMPLEMENTED, partially verified | web-only `spacing.sm` on Home + Hub hosts. `dc81a6c39` |
+| **SC-C3-iOS / SC-C4-Android** (native insets byte-identical, `+0`) | ✓ VERIFIED by construction | `Platform.OS==='web' ? spacing.sm : 0` / `: null` — native expression resolves to the pre-fix value. `i-proposed-tr2-safearea` violation count identical (13) on HEAD vs origin/main → no SafeScreen conversion, no double-inset. `dc81a6c39` |
+
+---
+
+## 3. Files changed (13; all in allowlist)
+
+| File | Batch | ± |
+|------|-------|---|
+| `mingla-business/src/utils/brandListState.ts` | A.1 | +8/−1 |
+| `mingla-business/src/hooks/__tests__/brandListState.test.ts` | A test | +33 |
+| `mingla-business/src/components/brand/BrandSwitcherSheet.tsx` | A.2 | +9/−3 |
+| `mingla-business/app/(tabs)/account.tsx` | A.3 | +4/−1 |
+| `mingla-business/app/event/[id]/index.tsx` | A.4 + C.1 | +27/−4 |
+| `mingla-business/src/components/ui/TopSheet.tsx` | B.1 | +20/−4 |
+| `mingla-business/app/trip/[id]/index.tsx` | C.1 | +9/−1 |
+| `mingla-business/app/experience/[id]/index.tsx` | C.1 | +8/−1 |
+| `mingla-business/app/(tabs)/home.tsx` | C.1 | +9/−1 |
+| `mingla-business/app/(tabs)/hub/_layout.tsx` | C.1 | +10/−1 |
+| `.github/scripts/strict-grep/i-proposed-topsheet-web-viewport-anchor.mjs` | B gate | +110 (new) |
+| `.github/scripts/strict-grep/i-proposed-web-topbar-breathing-gap.mjs` | C gate | +84 (new) |
+| `.github/workflows/strict-grep-mingla-business.yml` | gate registration | +13 |
+
+No DO-NOT-TOUCH file modified: `SafeScreen.tsx`, `useBrandListShim.ts`, `useBrands.ts`, `EventManageMenu.tsx` prop contract, and the line-841 mount gate are all untouched.
+
+---
+
+## 4. Data-model / 5. Edge functions
+
+None. Component/util layer only — no DB, RLS, edge, service, hook, or query-key change (Const #5: brand-list state stays in React Query).
+
+---
+
+## 6. Regression tests + fails-on-revert proofs
+
+### Batch A — unit (`src/hooks/__tests__/brandListState.test.ts`)
+Added `test("does not downgrade a fetched non-empty list during a background refetch")` asserting `{isFetching:true,isFetched:true,itemCount:3}→"ready"`, `itemCount:0→"empty"`, and `{isFetched:false}→"query_loading"` (first-load preserved).
+**fails-on-revert PROVEN:** reverting the predicate line to `if (isLoading || isFetching || !isFetched) return "query_loading"` (true line deletion of the fix, via `perl` line-replacement) → the new test FAILED at `.toBe("ready")`; restoring the fix → PASSES. Proven against the working tree that became commit **`d1a1378bf`**. (The 1 pre-existing failure in this file at line 93 — `useCurrentBrand.ts` no longer contains the stale grep string `"!isError && brand === null"` — is confirmed to fail identically on origin/main and is OUTSIDE my allowlist; see Discoveries.)
+
+### Batch B — strict-grep gate (`i-proposed-topsheet-web-viewport-anchor.mjs`)
+Asserts `TopSheet.tsx` co-locates a `Platform.OS === 'web'` gate with `position:'fixed'` in `rootOverlayStyle`, and still references `StyleSheet.absoluteFill` for native.
+**fails-on-revert PROVEN:** removing the `position:'fixed'` web ternary → gate FAILED (`exit=1`, "rootOverlayStyle does not co-locate the gate with position:fixed"); restoring → OK. Tested against the tree at **`ee4c539cf`**.
+
+### Batch C — strict-grep gate (`i-proposed-web-topbar-breathing-gap.mjs`)
+Asserts all five top-bar hosts carry a web-gated `spacing.sm` top padding (event ≥2, others ≥1).
+**fails-on-revert PROVEN:** reverting the Hub host to bare `insets.top` → gate FAILED (`exit=1`, "found 0"); restoring → OK. Tested against the tree at **`dc81a6c39`**.
+
+The tester writes the second, adversarial test (authed runtime measurement of the Hub panel anchor + the cached-list-while-refetching behavior).
+
+---
+
+## 7. Old → New receipts
+
+### `src/utils/brandListState.ts` (A.1)
+- **Before:** `if (isLoading || isFetching || !isFetched) return "query_loading";` — any in-flight background refetch (`isFetching`) downgraded a populated, already-fetched list to loading.
+- **Now:** `if (isLoading || !isFetched) return "query_loading";` — `query_loading` is reserved for genuine first load (RQ `isLoading` / `!isFetched`); after first fetch, `itemCount` decides. All prior guard branches (auth_loading/error/signed_out/query_disabled/error) unchanged in order.
+- **Why:** F-4 — stop discarding cached brands during a 30s-stale background refetch.
+- **Lines:** ~8 (incl. protective comment).
+
+### `src/components/brand/BrandSwitcherSheet.tsx` (A.2)
+- **Before:** `brandList.isLoading ? <Loading> : status==='error' ? <Error> : <ScrollView>{brands}…` — any loading flag blanked a populated list.
+- **Now:** precedence reordered: error-AND-empty → error; empty-AND-loading → Loading; otherwise → the `<ScrollView>` list (renders cached brands even mid-refetch).
+- **Why:** F-4 defense-in-depth. **Lines:** ~9.
+
+### `app/(tabs)/account.tsx` (A.3)
+- **Before:** `brandList.status === "ready" ? <list> : …loading…` — a populated-but-refetching list fell into the loading branch.
+- **Now:** `brandList.status === "ready" || brands.length > 0 ? <list> : …`. The `brandList.status === "empty"` literal (asserted by an existing grep test) is preserved.
+- **Why:** F-4 defense-in-depth. **Lines:** ~4.
+
+### `app/event/[id]/index.tsx` — `handleManageOpen` (A.4)
+- **Before:** `setManageMenuVisible(true)` unconditionally → with `brand===null` the line-841 `{brand !== null && manageMenuVisible ? … : null}` mounted nothing → silent dead tap.
+- **Now:** if `brand === null`, `setToast({visible:true, message:"Loading brand… tap again in a moment."})` and return (no silent no-op); otherwise unchanged. The line-841 mount gate is UNCHANGED (ORCH-0862 unmount-on-close preserved); `EventManageMenu`'s non-null `brand` contract preserved.
+- **Why:** F-2 / Const #1. **Lines:** ~10. (Uses the in-scope `setToast` state setter, same shape as `showToast`, to avoid a use-before-declaration in the callback dep array.)
+
+### `src/components/ui/TopSheet.tsx` (B.1)
+- **Before:** root overlay `style={StyleSheet.absoluteFill}` (web → `position:absolute` anchored to the scrollable host); `screenHeight = Dimensions.get('window').height` snapshot for `fixedHeight`.
+- **Now:** `rootOverlayStyle = Platform.OS==='web' ? [absoluteFill,{position:'fixed'}] : absoluteFill` (web anchors to the viewport); `screenHeight = Platform.OS==='web' ? windowHeight(live) : Dimensions.get('window').height`. Anchor style, `panelTop`, animations, swipe, scrim, `heightMode`, glass stack UNCHANGED.
+- **Why:** F-3 Hub offset + secondary stale-height. **Lines:** ~20.
+
+### event/trip/experience/home/hub top bars (C.1)
+- **Before:** top padding = `insets.top` (= 0 on web) → bar glued to the viewport top.
+- **Now:** `insets.top + (Platform.OS==='web' ? spacing.sm : 0)` (event/home/hub) or an additive `Platform.OS==='web' ? {paddingTop: spacing.sm} : null` style entry (trip/experience headerWrap, which get their inset from the shared SafeScreen — NOT edited). `Platform` import added to home + hub `_layout`.
+- **Why:** F-1 perceived "hug" — additive, web-gated, regression-safe. **Lines:** ~9 each.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Parity |
+|---------|----------|--------|
+| Consumer iOS / Android (`app-mobile/`) | NO — different app | n/a |
+| Buyer/anonymous Web | NO — these are authed business shell screens | n/a |
+| Business iOS | YES | Automatic (shared) — A is pure TS; B+C web-gated → native unchanged by construction |
+| Business Android | YES | Same as iOS |
+| Admin Web (`mingla-admin/`) | NO | untouched |
+| Business Web preview (PRIMARY) | YES | primary surface — all fixes land here |
+
+---
+
+## 9. Smoke / runtime result
+
+- **Web build:** served the bracket-free detached worktree (`/tmp/orch1136-clean`, port 8125, the SPEC/evidence-documented workaround for the literal `[brackets]` that break expo-router's require.context) via `npx expo start --web`. Bundle compiled cleanly (2282 modules, HTTP 200, no resolve/syntax errors) WITH all batches applied — confirms `position:'fixed'`, the live-height read, and all five Batch C edits + new imports are valid in the actual RNW web build. The served `index.bundle` contains `rootOverlayStyle` + `position:"fixed"`.
+- **Batch B mechanism proof (deterministic, unauthenticated):** Playwright/Chromium harness replicating the exact F-3 DOM/CSS (a `position:relative` scrollable host scrolled down, overlay child anchored at `top: insets.top+76`):
+  - BEFORE (bare `absolute`): unscrolled top = **76px**; scrolled-600 top = **−524px** (the Hub bug — panel above viewport, only bottom row peeks).
+  - AFTER (`absolute + position:fixed`): unscrolled = **76px**; scrolled-600 = **76px** (scroll-independent — Hub == Home). VERDICT: PASS.
+- **NOT runtime-verified (named blocker):** the four symptoms on the ACTUAL authenticated event/Hub/Home/Account screens — blocked by no login credentials (SPEC §10, investigation PD-9, Seth-confirmed). The authed end-to-end SC-A2/A3/A4 + SC-B1/B2 full measurements + SC-C visual capture + all native parity SCs are handed to the tester / Seth-driven device run.
+
+---
+
+## 10. Known issues / deferred
+
+- **Batch B confidence:** mechanism-proven on web via the deterministic harness + bundle inspection, but the SPEC's authed Hub `getBoundingClientRect().top` measurement requires login. Per SPEC §10, if the authed runtime shows the offset persists after `position:'fixed'`, STOP and request a SPEC amendment — the harness strongly indicates it will NOT persist (the CSS mechanism is decisive), but the authed confirm is the tester's to lift "probable" → "proven".
+- **Batch C** is a perceived-spacing polish, not a code-defect fix (F-1 header theory proven negative on web). `spacing.sm` (8px) is the SPEC's chosen value; if Seth wants more it's a one-token bump to `spacing.md` (16), not a re-architecture.
+- No `[TRANSITIONAL]` code introduced.
+
+---
+
+## 11. Operator action required
+
+- **No migration, no edge-function deploy** (component/util only).
+- **Native parity SCs** (SC-A5/A6, SC-B3/B4, SC-C3/C4) require a human-in-the-loop run on the physical/sim business iOS+Android app — hand to tester / Seth.
+- **Authed web SCs** (SC-A2/A3/A4, SC-B1/B2, SC-C1/C2) require a logged-in web session — hand to tester (login on the dev build, scroll Hub, open switcher, measure panel `getBoundingClientRect().top` + host `scrollTop`).
+
+---
+
+## 12. Discoveries for orchestrator
+
+1. **[COMMS-0034 — read + honored, no overlap]** ORCH-1137 owns the systemic business-web lucide-icon blank-out (`metro.config.js` icon aliasing / `src/shims/lucideReactNativeWebStub.js`). ORCH-1136 touched NEITHER file; the web-icon surface is fully out of my scope (no icon-stub work in this SPEC). The COMMS-0034 anchor ledger row is dirty from a parallel session, so I did NOT entangle my ack-append into another session's in-flight COMMS_LEDGER.md edit (per the "direct-to-main ledger commits on a dirty anchor are fragile" hazard); recording the ack here instead.
+2. **[PRE-EXISTING TEST FAILURE — not mine]** `brandListState.test.ts:93` asserts `useCurrentBrand.ts` contains `"!isError && brand === null"`, but that file was refactored to `brandIsNull: brand === null` by a prior ORCH — the grep is stale and FAILS on a clean origin/main checkout. `useCurrentBrand.ts` is OUTSIDE the ORCH-1136 allowlist; I did not fix it (scope discipline). Recommend a docs-hygiene ORCH to update that stale source-grep assertion.
+3. **[PRE-EXISTING LINT DEBT — not mine]** `no-unescaped-entities` errors on `Couldn't load your brands.` in `BrandSwitcherSheet.tsx` and `account.tsx` predate ORCH-1136 (verbatim on origin/main); no eslint CI gate exists, so they don't block. Left untouched (copy-escaping is out of scope).
+4. **[Discovery #4/#6 from investigation, NOT fixed — out of scope per SPEC §2]** TopSheet's native `Dimensions.get('window')` mix and `useBrands`' `Date.now()`-keyed Realtime channel remain; SPEC explicitly excluded them.

--- a/mingla-business/app/(tabs)/account.tsx
+++ b/mingla-business/app/(tabs)/account.tsx
@@ -258,7 +258,10 @@ export default function AccountTab(): React.ReactElement {
         />
       </View>
       <ScrollView contentContainerStyle={styles.scroll}>
-        {brandList.status === "ready" ? (
+        {/* ORCH-1136 F-4 defense-in-depth: render the brands list whenever it
+           is populated, even if the status machine is transiently in a loading
+           state during a background refetch. */}
+        {brandList.status === "ready" || brands.length > 0 ? (
           <GlassCard variant="elevated" padding={spacing.lg}>
             <Text style={styles.title}>Your brands</Text>
             <Text style={styles.body}>Tap a brand to open its profile.</Text>

--- a/mingla-business/app/(tabs)/home.tsx
+++ b/mingla-business/app/(tabs)/home.tsx
@@ -22,6 +22,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
+  Platform,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -413,7 +414,14 @@ export default function HomeTab(): React.ReactElement {
   }
 
   return (
-    <View style={[styles.host, { paddingTop: insets.top }]}>
+    <View
+      style={[
+        styles.host,
+        {
+          paddingTop: insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+        },
+      ]}
+    >
       <View style={styles.barWrap}>
         <TopBar
           leftKind="brand"

--- a/mingla-business/app/(tabs)/hub/_layout.tsx
+++ b/mingla-business/app/(tabs)/hub/_layout.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { Suspense, useCallback, useEffect, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
 import { Slot, usePathname, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -191,7 +191,14 @@ export default function HubTabLayout(): React.ReactElement {
   );
 
   return (
-    <View style={[styles.host, { paddingTop: insets.top }]}>
+    <View
+      style={[
+        styles.host,
+        {
+          paddingTop: insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+        },
+      ]}
+    >
       <View style={styles.barWrap}>
         <TopBar
           leftKind="brand"

--- a/mingla-business/app/event/[id]/index.tsx
+++ b/mingla-business/app/event/[id]/index.tsx
@@ -162,8 +162,17 @@ export default function EventDetailScreen(): React.ReactElement {
   }, []);
 
   const handleManageOpen = useCallback((): void => {
+    // ORCH-1136 F-2: never a silent dead tap (Const #1). EventManageMenu
+    // requires a non-null brand and the line-841 mount gates on
+    // `brand !== null` (ORCH-0862 unmount-on-close — preserved). When the
+    // brand hasn't resolved yet, give explicit feedback instead of entering a
+    // no-op state that mounts nothing.
+    if (brand === null) {
+      setToast({ visible: true, message: "Loading brand… tap again in a moment." });
+      return;
+    }
     setManageMenuVisible(true);
-  }, []);
+  }, [brand]);
 
   const handleManageClose = useCallback((): void => {
     setManageMenuVisible(false);

--- a/mingla-business/app/event/[id]/index.tsx
+++ b/mingla-business/app/event/[id]/index.tsx
@@ -593,7 +593,15 @@ export default function EventDetailScreen(): React.ReactElement {
   ) {
     return (
       <View style={styles.host}>
-        <View style={[styles.headerWrap, { paddingTop: insets.top }]}>
+        <View
+          style={[
+            styles.headerWrap,
+            {
+              paddingTop:
+                insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+            },
+          ]}
+        >
           <TopBar leftKind="back" onBack={handleBack} title="Event" />
         </View>
         <View style={styles.emptyWrap}>
@@ -619,7 +627,15 @@ export default function EventDetailScreen(): React.ReactElement {
   return (
     <View style={styles.host}>
       {/* Header */}
-      <View style={[styles.headerWrap, { paddingTop: insets.top }]}>
+      <View
+        style={[
+          styles.headerWrap,
+          {
+            paddingTop:
+              insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+          },
+        ]}
+      >
         <TopBar
           leftKind="back"
           onBack={handleBack}

--- a/mingla-business/app/experience/[id]/index.tsx
+++ b/mingla-business/app/experience/[id]/index.tsx
@@ -260,7 +260,14 @@ export default function ExperienceDashboardRoute(): React.ReactElement {
 
   return (
     <SafeScreen style={styles.host}>
-      <View style={styles.headerWrap}>
+      {/* ORCH-1136 F-1: web-only additive breathing gap (insets.top === 0 on
+          web); native uses the SafeScreen inset only (+0 here). */}
+      <View
+        style={[
+          styles.headerWrap,
+          Platform.OS === "web" ? { paddingTop: spacing.sm } : null,
+        ]}
+      >
         <TopBar
           leftKind="back"
           onBack={() => router.back()}

--- a/mingla-business/app/trip/[id]/index.tsx
+++ b/mingla-business/app/trip/[id]/index.tsx
@@ -361,7 +361,15 @@ export default function TripDashboardRoute(): React.ReactElement {
     >
       {/* ORCH-0913-B: share the event dashboard TopBar shell so trip detail
           width/chrome tracks event/[id] instead of carrying a bespoke header. */}
-      <View style={styles.headerWrap}>
+      {/* ORCH-1136 F-1: web-only additive breathing gap so the bar isn't glued
+          to the browser viewport top (insets.top === 0 on web). Native uses the
+          SafeScreen inset only (+0 here). */}
+      <View
+        style={[
+          styles.headerWrap,
+          Platform.OS === "web" ? { paddingTop: spacing.sm } : null,
+        ]}
+      >
         <TopBar
           leftKind="back"
           onBack={() => router.back()}

--- a/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
+++ b/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
@@ -90,13 +90,17 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
             <View style={styles.header}>
               <Text style={styles.headerTitle}>Switch brand</Text>
             </View>
-            {brandList.isLoading ? (
-              <View style={styles.loadingState}>
-                <Text style={styles.emptyText}>Loading your brands…</Text>
-              </View>
-            ) : brandList.status === "error" ? (
+            {/* ORCH-1136 F-4 defense-in-depth: render the cached brand list
+               whenever brands exist, BEFORE the loading branch — a populated
+               cache must never be hidden behind a transient/background-refetch
+               loading flag even if the status machine regresses again. */}
+            {brandList.status === "error" && brands.length === 0 ? (
               <View style={styles.loadingState}>
                 <Text style={styles.emptyText}>Couldn't load your brands.</Text>
+              </View>
+            ) : brands.length === 0 && brandList.isLoading ? (
+              <View style={styles.loadingState}>
+                <Text style={styles.emptyText}>Loading your brands…</Text>
               </View>
             ) : (
               <ScrollView

--- a/mingla-business/src/components/ui/TopSheet.tsx
+++ b/mingla-business/src/components/ui/TopSheet.tsx
@@ -131,11 +131,17 @@ export const TopSheet: React.FC<TopSheetProps> = ({
   style,
 }) => {
   const insets = useSafeAreaInsets();
-  const screenHeight = Dimensions.get("window").height;
   // ORCH-1100: width-aware so the mobile-web (< 768px) blur-kill triggers the
   // opaque fallback (the brand-switcher TopSheet was the worst RC-2 offender —
   // it rendered `background-color: rgba(0,0,0,0)` on phone web).
-  const { width: windowWidth } = useWindowDimensions();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+  // ORCH-1136 F-3: on web, drive the panel height from the LIVE viewport
+  // (useWindowDimensions) rather than the Dimensions.get('window') snapshot,
+  // so a stale snapshot can't yield a short/wrong panel. Native keeps the
+  // snapshot semantics UNCHANGED (parity: native height behavior preserved on
+  // rotation).
+  const screenHeight =
+    Platform.OS === "web" ? windowHeight : Dimensions.get("window").height;
 
   // ORCH-0826: heightMode="compact" uses content-measured height via
   // onLayout. Before first measurement, panel renders invisibly (opacity 0)
@@ -311,10 +317,22 @@ export const TopSheet: React.FC<TopSheetProps> = ({
   const blurOk = shouldUseRealBlur(windowWidth);
   const blurIntensity = blurIntensityTokens.cardElevated;
 
+  // ORCH-1136 F-3: on web, anchor the overlay to the browser VIEWPORT
+  // (`position: 'fixed'`), not the scrollable page host. With bare
+  // `absoluteFill` the overlay anchors to its nearest positioned ancestor (the
+  // route host), so on a scrolled Hub host the panel's `top: insets.top + 76`
+  // landed above the viewport. `position: 'fixed'` is a valid react-native-web
+  // value but NOT a valid RN native value, hence the gate — native keeps bare
+  // `StyleSheet.absoluteFill` UNCHANGED.
+  const rootOverlayStyle =
+    Platform.OS === "web"
+      ? [StyleSheet.absoluteFill, { position: "fixed" as const }]
+      : StyleSheet.absoluteFill;
+
   return (
     <View
       pointerEvents={visible ? "auto" : "none"}
-      style={StyleSheet.absoluteFill}
+      style={rootOverlayStyle}
       testID={testID}
     >
       <Animated.View

--- a/mingla-business/src/hooks/__tests__/brandListState.test.ts
+++ b/mingla-business/src/hooks/__tests__/brandListState.test.ts
@@ -48,6 +48,39 @@ describe("brand list state honesty", () => {
     expect(resolveBrandListStatus({ ...base, itemCount: 0 })).toBe("empty");
   });
 
+  // ORCH-1136 F-4 fails-on-revert gate: a populated, already-fetched list that
+  // is merely background-refetching must resolve to "ready"/"empty" — NOT
+  // "query_loading". This FAILS if line 34's predicate is reverted to
+  // `if (isLoading || isFetching || !isFetched) return "query_loading"`.
+  test("does not downgrade a fetched non-empty list during a background refetch", () => {
+    expect(
+      resolveBrandListStatus({
+        ...base,
+        isFetching: true,
+        isFetched: true,
+        itemCount: 3,
+      }),
+    ).toBe("ready");
+    expect(
+      resolveBrandListStatus({
+        ...base,
+        isFetching: true,
+        isFetched: true,
+        itemCount: 0,
+      }),
+    ).toBe("empty");
+    // First-load (`!isFetched`) STILL loads even while fetching (cold-boot
+    // must never flash an empty "no brands" state).
+    expect(
+      resolveBrandListStatus({
+        ...base,
+        isFetching: true,
+        isFetched: false,
+        itemCount: 0,
+      }),
+    ).toBe("query_loading");
+  });
+
   test("account and current-brand surfaces use stateful brand/auth guards", () => {
     const accountSource = repoFile("app/(tabs)/account.tsx");
     const currentBrandSource = repoFile("src/hooks/useCurrentBrand.ts");

--- a/mingla-business/src/utils/__tests__/brandListState.orch1136.tester_adversarial.test.ts
+++ b/mingla-business/src/utils/__tests__/brandListState.orch1136.tester_adversarial.test.ts
@@ -1,0 +1,97 @@
+/**
+ * ORCH-1136 Batch A — TESTER adversarial regression test (append-only, NEW file).
+ *
+ * DIFFERENT ANGLE than the implementor's happy-path test (which proves
+ * `{isFetching:true,isFetched:true,itemCount:3} -> "ready"`). This file attacks
+ * the OTHER half of the predicate change — the COLD-BOOT / GUARD-PRECEDENCE
+ * BOUNDARY — to prove the fix did NOT over-reach:
+ *
+ *   1. Genuine first load (`!isFetched`) must STILL be "query_loading" EVEN when
+ *      a stale itemCount > 0 is present — so a cold boot can never flash a
+ *      populated-then-empty (or populated-then-loading) brand list. This is the
+ *      precise risk of the fix: that `itemCount` decides "too early", before the
+ *      first real fetch resolves. If `!isFetched` ever resolved to "ready"/"empty"
+ *      via the itemCount branch, this FAILS.
+ *
+ *   2. The earlier auth/sign-out/disabled/error guards must STILL win over the
+ *      new itemCount-decides tail, regardless of isFetching/isFetched/itemCount —
+ *      i.e. the fix only touched the LAST predicate line, never the precedence.
+ *
+ *   3. The exact bug boundary: with `isFetched:true` the in-flight `isFetching`
+ *      flag is IGNORED (itemCount decides), but with `isFetched:false` it is NOT
+ *      (still loading). Asserts both sides of that line.
+ *
+ * fails-on-revert: reverting line ~41 to
+ *   `if (isLoading || isFetching || !isFetched) return "query_loading"`
+ * makes assertion (3b) `{isFetching:true,isFetched:true,itemCount:2} -> "ready"`
+ * FAIL (it would return "query_loading"). The cold-boot assertions (1) remain
+ * green on revert (they are the invariant the fix must NOT break), guaranteeing
+ * the fix is correct in BOTH directions.
+ */
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  resolveBrandListStatus,
+  type BrandListStatus,
+} from "../../utils/brandListState";
+
+const base = {
+  authStatus: "signed_in_ready",
+  hasUser: true,
+  isError: false,
+  isFetched: true,
+  isFetching: false,
+  isLoading: false,
+  itemCount: 1,
+};
+
+const resolve = (over: Partial<typeof base>): BrandListStatus =>
+  resolveBrandListStatus({ ...base, ...over });
+
+describe("ORCH-1136 brand-list status — cold-boot & guard-precedence boundary", () => {
+  // (1) COLD BOOT: first load must never let a stale itemCount short-circuit the
+  // loading state, no matter how the cache looks. Empty AND populated stale cache.
+  test("genuine first load (!isFetched) stays query_loading even with stale itemCount>0", () => {
+    expect(resolve({ isFetched: false, itemCount: 0 })).toBe("query_loading");
+    expect(resolve({ isFetched: false, itemCount: 5 })).toBe("query_loading");
+    expect(resolve({ isFetched: false, isFetching: true, itemCount: 5 })).toBe(
+      "query_loading",
+    );
+    // React Query's own first-load flag must also force loading.
+    expect(resolve({ isLoading: true, isFetched: true, itemCount: 5 })).toBe(
+      "query_loading",
+    );
+  });
+
+  // (2) GUARD PRECEDENCE: the earlier branches outrank the itemCount tail in EVERY
+  // combination of the loading flags — the fix touched only the last line.
+  test("auth/signout/disabled/error guards outrank itemCount regardless of fetch flags", () => {
+    const noisy = { isFetching: true, isFetched: true, isLoading: true, itemCount: 9 };
+    expect(resolve({ ...noisy, authStatus: "bootstrapping" })).toBe("auth_loading");
+    expect(resolve({ ...noisy, authStatus: "refreshing" })).toBe("auth_loading");
+    expect(resolve({ ...noisy, authStatus: "error" })).toBe("error");
+    expect(resolve({ ...noisy, authStatus: "signed_out" })).toBe("signed_out");
+    expect(resolve({ ...noisy, hasUser: false })).toBe("query_disabled");
+    expect(resolve({ ...noisy, isError: true })).toBe("error");
+  });
+
+  // (3) THE EXACT FIX BOUNDARY: isFetching is ignored ONLY once isFetched===true.
+  test("isFetching is honored before first fetch, ignored after (the fix boundary)", () => {
+    // 3a — before first fetch: still loading (invariant; green on revert too).
+    expect(resolve({ isFetched: false, isFetching: true, itemCount: 2 })).toBe(
+      "query_loading",
+    );
+    // 3b — after first fetch + background refetch: itemCount decides (FIX).
+    //      This is the assertion that FAILS if `|| isFetching` is restored.
+    expect(resolve({ isFetched: true, isFetching: true, itemCount: 2 })).toBe(
+      "ready",
+    );
+    expect(resolve({ isFetched: true, isFetching: true, itemCount: 0 })).toBe(
+      "empty",
+    );
+    // And with no refetch in flight, unchanged.
+    expect(resolve({ isFetched: true, isFetching: false, itemCount: 2 })).toBe(
+      "ready",
+    );
+  });
+});

--- a/mingla-business/src/utils/brandListState.ts
+++ b/mingla-business/src/utils/brandListState.ts
@@ -31,6 +31,13 @@ export const resolveBrandListStatus = ({
   if (authStatus === "signed_out") return "signed_out";
   if (!hasUser) return "query_disabled";
   if (isError) return "error";
-  if (isLoading || isFetching || !isFetched) return "query_loading";
+  // ORCH-1136 F-4: a background refetch (`isFetching` with `isFetched === true`)
+  // must NOT downgrade an already-fetched list to `query_loading` — that
+  // discarded cached brands and wedged the switcher/Account on "Loading…".
+  // `query_loading` is reserved for the genuine FIRST load only: React Query's
+  // own first-load flag (`isLoading`, true only with no data) OR a query that
+  // has not yet fetched at least once (`!isFetched`). After the first successful
+  // fetch, `itemCount` decides — regardless of an in-flight background refetch.
+  if (isLoading || !isFetched) return "query_loading";
   return itemCount === 0 ? "empty" : "ready";
 };


### PR DESCRIPTION
## ORCH-1136 — business web app shell bugs

Fixes four Seth-reported business-web symptoms, all web-gated or pure-logic so native iOS/Android are unchanged by construction.

### What changed
- **Batch A (`d1a1378bf`, pure TS):** `resolveBrandListStatus` no longer downgrades a fetched non-empty brand list to "loading" on a background `isFetching` → the brand switcher + Account stop wedging on "Loading your brands…" after navigation. Genuine first-load (`!isFetched`) + auth-bootstrap stay loading (cold-boot never flashes empty). Event ⋯ no longer a silent dead-tap when brand is momentarily null (toast). ORCH-0862 mount gate + `EventManageMenu` prop contract preserved.
- **Batch B (`ee4c539cf`, web-gated):** `TopSheet` overlay anchors to the viewport via `position:'fixed'` on web → the Hub brand-switcher no longer floats above the viewport when the host is scrolled. Native (`absoluteFill` + `Dimensions.get`) unchanged. Chromium harness: panel top −524px (old, scrolled) → 76px (fixed, every scroll) == Home.
- **Batch C (`dc81a6c39`, web-gated):** additive 8px top gap on event/trip/experience/Home/Hub top bars on web only; native insets byte-identical.

### Root-cause linkage
Symptoms 2 (event ⋯ dead-tap) and 4 (loading-forever) share one root: the false-loading status helper made `brand` resolve null, which no-op'd the event menu. Fixed at the root.

### Evidence
- All 3 fails-on-revert gates proven (Batch A predicate, 2 new strict-grep gates).
- Implementor + independent tester both reproduced the Batch B mechanism in Chromium.
- Tester adversarial test (`e4e37c774`): cold-boot empty-flash + guard-precedence boundary.
- Verdict: CONDITIONAL PASS, 0 defects — pending authed-web + native-device confirmation (no credentials/device in CI).

3 DRAFT invariants staged: brand-list-cached-over-refetch, topsheet-web-viewport-anchor, web-topbar-breathing-gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)