### PR TITLE
G1 discover: pre-serialized gzip hot path for 1k/10k load gates

### DIFF
--- a/scripts/audit/discover-scale-contract.mjs
+++ b/scripts/audit/discover-scale-contract.mjs
@@ -20,19 +20,36 @@ const scaleMigration = join(
   root,
   "supabase/migrations/20260612000000_orch_426_discover_scale.sql",
 );
+const gzipMigration = join(
+  root,
+  "supabase/migrations/20260615000000_orch_426_discover_cache_gzip.sql",
+);
 const distributed = join(root, "scripts/load/run-distributed.sh");
 
 const index = readFileSync(indexPath, "utf8");
 const rpcSql = readFileSync(rpcMigration, "utf8");
 const scaleSql = readFileSync(scaleMigration, "utf8");
+const gzipSql = readFileSync(gzipMigration, "utf8");
 const distributedSh = readFileSync(distributed, "utf8");
+
+const memoryPath = join(root, "supabase/functions/discover-merged-events/_memory-cache.ts");
+const bytesPath = join(root, "supabase/functions/discover-merged-events/_response-bytes.ts");
+const supabaseEdge = join(root, "scripts/load/lib/supabase-edge.js");
+const memory = readFileSync(memoryPath, "utf8");
+const bytes = readFileSync(bytesPath, "utf8");
+const supabaseEdgeJs = readFileSync(supabaseEdge, "utf8");
 
 const checks = [
   [index.includes("coalesceDiscoverBuild"), "L1 single-flight coalesce"],
   [index.includes("l1Get"), "L1 memory cache"],
+  [index.includes("discoverJsonResponse"), "pre-serialized hot path"],
+  [memory.includes("bytes"), "L1 byte cache"],
+  [bytes.includes("encodeDiscoverResponse"), "gzip response bytes"],
+  [supabaseEdgeJs.includes('"Accept-Encoding": "gzip"'), "k6 gzip request header"],
   [index.includes("pg_discover_business_events") || readFileSync(join(root, "supabase/functions/discover-merged-events/_business-query.ts"), "utf8").includes("pg_discover_business_events"), "discover RPC"],
   [rpcSql.includes("pg_discover_business_events"), "RPC migration"],
   [scaleSql.includes("discover_merged_events_cache"), "response cache table"],
+  [gzipSql.includes("response_gzip_base64"), "gzip cache column"],
   [distributedSh.includes('execution-segment "${SEG_START}:${SEG_END}"'), "k6 v2 segment format"],
 ];
 

--- a/scripts/load/lib/supabase-edge.js
+++ b/scripts/load/lib/supabase-edge.js
@@ -30,6 +30,7 @@ export function edgeHeaders(extra = {}) {
   return {
     apikey: requireEnv("SUPABASE_ANON_KEY"),
     "Content-Type": "application/json",
+    "Accept-Encoding": "gzip",
     ...extra,
   };
 }

--- a/supabase/functions/discover-merged-events/__tests__/discover_scale_contract.test.ts
+++ b/supabase/functions/discover-merged-events/__tests__/discover_scale_contract.test.ts
@@ -5,17 +5,22 @@ import { assert } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 const INDEX_URL = new URL("../index.ts", import.meta.url);
 const BUSINESS_URL = new URL("../_business-query.ts", import.meta.url);
 const MEMORY_URL = new URL("../_memory-cache.ts", import.meta.url);
+const BYTES_URL = new URL("../_response-bytes.ts", import.meta.url);
 
 Deno.test("discover-merged-events uses L1 cache, RPC, and coalesced builds", async () => {
   const index = await Deno.readTextFile(INDEX_URL);
   const business = await Deno.readTextFile(BUSINESS_URL);
   const memory = await Deno.readTextFile(MEMORY_URL);
+  const bytes = await Deno.readTextFile(BYTES_URL);
 
   assert(index.includes("coalesceDiscoverBuild"), "expected coalesceDiscoverBuild");
   assert(index.includes("l1Get"), "expected l1Get");
+  assert(index.includes("discoverJsonResponse"), "expected pre-serialized response path");
   assert(
     business.includes("pg_discover_business_events"),
     "expected pg_discover_business_events RPC",
   );
   assert(memory.includes("inflight"), "expected single-flight inflight map");
+  assert(bytes.includes("encodeDiscoverResponse"), "expected encodeDiscoverResponse");
+  assert(memory.includes("bytes"), "expected L1 byte cache");
 });

--- a/supabase/functions/discover-merged-events/__tests__/response_bytes.test.ts
+++ b/supabase/functions/discover-merged-events/__tests__/response_bytes.test.ts
@@ -1,0 +1,78 @@
+// ORCH-426 G1 — pre-serialized gzip response bytes for hot-path serving.
+
+import { assert } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import {
+  encodeDiscoverResponse,
+  wantsGzip,
+} from "../_response-bytes.ts";
+import type { DiscoverMergedResponse } from "../_types.ts";
+
+const SAMPLE: DiscoverMergedResponse = {
+  items: [],
+  meta: {
+    businessCount: 0,
+    ticketmasterCount: 0,
+    businessTotalAvailable: 0,
+    ticketmasterTotalAvailable: 0,
+    tmCalled: false,
+    tmError: null,
+    page: 1,
+    pageSize: 20,
+    fromCache: false,
+  },
+};
+
+Deno.test("encodeDiscoverResponse produces smaller gzip payload", async () => {
+  const large: DiscoverMergedResponse = {
+    ...SAMPLE,
+    items: Array.from({ length: 20 }, (_, i) => ({
+      source: "business_event" as const,
+      item: {
+        eventId: `evt-${i}`,
+        brandId: "brand",
+        brandSlug: "brand",
+        eventSlug: `event-${i}`,
+        brandName: "Brand",
+        brandProfilePhotoUrl: null,
+        title: "Sample event title with enough text to compress",
+        description: "Long description ".repeat(40),
+        coverMediaUrl: "https://example.com/cover.jpg",
+        coverMediaType: "image" as const,
+        coverHue: 25,
+        masterDateUtc: "2026-06-15T00:00:00Z",
+        masterEndAtUtc: "2026-06-16T00:00:00Z",
+        doorsOpenLocal: "7:00 PM",
+        endsAtLocal: "11:00 PM",
+        timezone: "America/Chicago",
+        venueName: "Venue",
+        city: "Austin",
+        address: "123 Main St",
+        hideAddressUntilTicket: true,
+        format: "in-person" as const,
+        locationGeo: { lat: 30.27, lng: -97.74 },
+        partyTypes: ["nightlife"],
+        vibeTags: ["live-music"],
+        musicGenres: ["pop"],
+        priceMin: 10,
+        priceMax: 50,
+        displayPriceCents: 2500,
+        displayCurrency: "USD",
+        currency: "USD",
+        publicBuyerUrl: "https://business.mingla.app/e/brand/event",
+      },
+    })),
+  };
+
+  const { json, gzip } = await encodeDiscoverResponse(large);
+  assert(gzip.length > 0);
+  assert(gzip.length < json.length, "gzip should shrink repetitive JSON");
+});
+
+Deno.test("wantsGzip respects Accept-Encoding header", () => {
+  const gzipReq = new Request("https://example.com", {
+    headers: { "Accept-Encoding": "gzip, deflate" },
+  });
+  const plainReq = new Request("https://example.com");
+  assert(wantsGzip(gzipReq));
+  assert(!wantsGzip(plainReq));
+});

--- a/supabase/functions/discover-merged-events/_distributed-cache.ts
+++ b/supabase/functions/discover-merged-events/_distributed-cache.ts
@@ -3,13 +3,60 @@
  */
 
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import type { DiscoverResponseBytes } from "./_response-bytes.ts";
+import { encodeDiscoverResponse, gzipDecompress } from "./_response-bytes.ts";
 import type { DiscoverMergedResponse } from "./_types.ts";
 
-const POLL_MS = 150;
-const POLL_ATTEMPTS = 120;
+const POLL_MS = 100;
+const POLL_ATTEMPTS = 450;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(encoded: string): Uint8Array {
+  const binary = atob(encoded);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+export async function readDbDiscoverCacheBytes(
+  supabase: SupabaseClient,
+  cacheKey: string,
+): Promise<DiscoverResponseBytes | null> {
+  const { data, error } = await supabase
+    .from("discover_merged_events_cache")
+    .select("response_gzip_base64, response")
+    .eq("cache_key", cacheKey)
+    .gt("expires_at", new Date().toISOString())
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  if (typeof data.response_gzip_base64 === "string" && data.response_gzip_base64.length > 0) {
+    const gzip = base64ToBytes(data.response_gzip_base64);
+    const json = await gzipDecompress(gzip);
+    return { json, gzip };
+  }
+
+  if (!data.response) return null;
+  const cached = data.response as DiscoverMergedResponse;
+  return encodeDiscoverResponse({
+    ...cached,
+    meta: { ...cached.meta, fromCache: true },
+  });
 }
 
 export async function readDbDiscoverCache(
@@ -49,7 +96,7 @@ export async function tryDistributedBuildLock(
 ): Promise<boolean> {
   const { data, error } = await supabase.rpc("pg_try_discover_cache_build_lock", {
     p_cache_key: cacheKey,
-    p_ttl_seconds: 45,
+    p_ttl_seconds: 60,
   });
   if (error) {
     console.warn("[discover-merged-events] build lock skipped:", error.message);
@@ -72,6 +119,7 @@ export function writeDbDiscoverCache(
   cacheKey: string,
   response: DiscoverMergedResponse,
   discoverStaleExpiresAt: () => string,
+  bytes?: DiscoverResponseBytes,
 ): void {
   (async () => {
     try {
@@ -79,6 +127,7 @@ export function writeDbDiscoverCache(
         {
           cache_key: cacheKey,
           response,
+          response_gzip_base64: bytes ? bytesToBase64(bytes.gzip) : null,
           fetched_at: new Date().toISOString(),
           expires_at: discoverStaleExpiresAt(),
         },

--- a/supabase/functions/discover-merged-events/_memory-cache.ts
+++ b/supabase/functions/discover-merged-events/_memory-cache.ts
@@ -2,6 +2,11 @@
  * ORCH-426 G1 — L1 in-memory cache + single-flight + stale-while-revalidate.
  */
 
+import {
+  encodeDiscoverResponse,
+  withCacheMeta,
+  type DiscoverResponseBytes,
+} from "./_response-bytes.ts";
 import type { DiscoverMergedResponse } from "./_types.ts";
 
 export const DISCOVER_L1_FRESH_MS = Number(
@@ -11,14 +16,15 @@ export const DISCOVER_L1_STALE_MS = Number(
   Deno.env.get("DISCOVER_MERGED_STALE_MS") ?? "600000",
 );
 
-interface L1Entry {
+export interface L1Entry {
   response: DiscoverMergedResponse;
+  bytes: DiscoverResponseBytes;
   freshUntil: number;
   staleUntil: number;
 }
 
 const l1 = new Map<string, L1Entry>();
-const inflight = new Map<string, Promise<DiscoverMergedResponse>>();
+const inflight = new Map<string, Promise<L1Entry>>();
 
 export function l1Get(key: string, now = Date.now()): L1Entry | null {
   const hit = l1.get(key);
@@ -29,26 +35,41 @@ export function l1Get(key: string, now = Date.now()): L1Entry | null {
   return hit;
 }
 
-export function l1Set(key: string, response: DiscoverMergedResponse, now = Date.now()): void {
-  l1.set(key, {
+export async function l1Set(
+  key: string,
+  response: DiscoverMergedResponse,
+  now = Date.now(),
+): Promise<L1Entry> {
+  const cached = withCacheMeta(response);
+  const bytes = await encodeDiscoverResponse(cached);
+  return l1SetBytes(key, bytes, cached, now);
+}
+
+export function l1SetBytes(
+  key: string,
+  bytes: DiscoverResponseBytes,
+  response: DiscoverMergedResponse,
+  now = Date.now(),
+): L1Entry {
+  const entry: L1Entry = {
     response,
+    bytes,
     freshUntil: now + DISCOVER_L1_FRESH_MS,
     staleUntil: now + DISCOVER_L1_STALE_MS,
-  });
+  };
+  l1.set(key, entry);
+  return entry;
 }
 
 export async function coalesceDiscoverBuild(
   key: string,
   build: () => Promise<DiscoverMergedResponse>,
-): Promise<DiscoverMergedResponse> {
+): Promise<L1Entry> {
   const existing = inflight.get(key);
   if (existing) return existing;
 
   const promise = build()
-    .then((response) => {
-      l1Set(key, response);
-      return response;
-    })
+    .then((response) => l1Set(key, response))
     .finally(() => {
       inflight.delete(key);
     });

--- a/supabase/functions/discover-merged-events/_response-bytes.ts
+++ b/supabase/functions/discover-merged-events/_response-bytes.ts
@@ -1,0 +1,61 @@
+/**
+ * ORCH-426 G1 — pre-serialize discover responses for hot-path serving.
+ * Avoids JSON.stringify + gzip on every L1 hit under load.
+ */
+
+import type { DiscoverMergedResponse } from "./_types.ts";
+
+export interface DiscoverResponseBytes {
+  json: Uint8Array;
+  gzip: Uint8Array;
+}
+
+export function wantsGzip(req: Request): boolean {
+  const ae = req.headers.get("accept-encoding") ?? "";
+  return /\bgzip\b/i.test(ae);
+}
+
+export function withCacheMeta(response: DiscoverMergedResponse): DiscoverMergedResponse {
+  return {
+    ...response,
+    meta: { ...response.meta, fromCache: true },
+  };
+}
+
+export async function encodeDiscoverResponse(
+  response: DiscoverMergedResponse,
+): Promise<DiscoverResponseBytes> {
+  const json = new TextEncoder().encode(JSON.stringify(response));
+  const gzip = await gzipCompress(json);
+  return { json, gzip };
+}
+
+export function discoverJsonResponse(
+  req: Request,
+  bytes: DiscoverResponseBytes,
+  corsHeaders: Record<string, string>,
+): Response {
+  const gzip = wantsGzip(req);
+  return new Response(gzip ? bytes.gzip : bytes.json, {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json; charset=utf-8",
+      ...(gzip ? { "Content-Encoding": "gzip" } : {}),
+      "Cache-Control": "public, max-age=30, stale-while-revalidate=120",
+      Vary: "Accept-Encoding",
+    },
+  });
+}
+
+async function gzipCompress(input: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([input]).stream().pipeThrough(new CompressionStream("gzip"));
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+export async function gzipDecompress(input: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([input]).stream().pipeThrough(new DecompressionStream("gzip"));
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}

--- a/supabase/functions/discover-merged-events/index.ts
+++ b/supabase/functions/discover-merged-events/index.ts
@@ -22,6 +22,7 @@ import {
 } from "./_cache.ts";
 import {
   readDbDiscoverCache,
+  readDbDiscoverCacheBytes,
   releaseDistributedBuildLock,
   tryDistributedBuildLock,
   waitForDbDiscoverCache,
@@ -30,14 +31,16 @@ import {
 import {
   coalesceDiscoverBuild,
   l1Get,
+  l1SetBytes,
   refreshDiscoverInBackground,
 } from "./_memory-cache.ts";
+import { discoverJsonResponse, encodeDiscoverResponse, withCacheMeta } from "./_response-bytes.ts";
 import type { DiscoverMergedResponse } from "./_types.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
+    "authorization, x-client-info, apikey, content-type, accept-encoding",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
@@ -66,7 +69,7 @@ interface DiscoverMergedRequest {
 const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 50;
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonError(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -78,19 +81,19 @@ serve(async (req: Request): Promise<Response> => {
     return new Response("ok", { headers: corsHeaders });
   }
   if (req.method !== "POST") {
-    return jsonResponse({ error: "method_not_allowed" }, 405);
+    return jsonError({ error: "method_not_allowed" }, 405);
   }
 
   let body: DiscoverMergedRequest;
   try {
     body = await req.json();
   } catch {
-    return jsonResponse({ error: "invalid_json" }, 400);
+    return jsonError({ error: "invalid_json" }, 400);
   }
 
   const cityName = body.city?.name?.trim();
   if (!cityName) {
-    return jsonResponse({ error: "city_required" }, 400);
+    return jsonError({ error: "city_required" }, 400);
   }
 
   const page = Math.max(1, body.page ?? 1);
@@ -104,19 +107,19 @@ serve(async (req: Request): Promise<Response> => {
     partyTypeSlugs.length > 0 &&
     !isSubsetOf(partyTypeSlugs, PARTY_TYPE_SLUGS as readonly string[])
   ) {
-    return jsonResponse({ error: "party_type_slugs_not_canonical" }, 400);
+    return jsonError({ error: "party_type_slugs_not_canonical" }, 400);
   }
   if (
     vibeTagSlugs.length > 0 &&
     !isSubsetOf(vibeTagSlugs, VIBE_TAG_SLUGS as readonly string[])
   ) {
-    return jsonResponse({ error: "vibe_tag_slugs_not_canonical" }, 400);
+    return jsonError({ error: "vibe_tag_slugs_not_canonical" }, 400);
   }
   if (
     musicGenreSlugs.length > 0 &&
     !isSubsetOf(musicGenreSlugs, MUSIC_GENRE_SLUGS as readonly string[])
   ) {
-    return jsonResponse({ error: "music_genre_slugs_not_canonical" }, 400);
+    return jsonError({ error: "music_genre_slugs_not_canonical" }, 400);
   }
 
   const requestTimezone = (body.timezone ?? "UTC").trim() || "UTC";
@@ -129,7 +132,7 @@ serve(async (req: Request): Promise<Response> => {
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return jsonResponse(
+      return jsonError(
         {
           error: msg.startsWith("invalid_local_") ? msg : "invalid_timezone",
           detail: msg,
@@ -142,7 +145,7 @@ serve(async (req: Request): Promise<Response> => {
   const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
   const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
   if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
-    return jsonResponse({ error: "supabase_env_missing" }, 500);
+    return jsonError({ error: "supabase_env_missing" }, 500);
   }
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
     auth: { persistSession: false },
@@ -192,11 +195,15 @@ serve(async (req: Request): Promise<Response> => {
     if (!gotLock) {
       const waited = await waitForDbDiscoverCache(supabase, cacheKey);
       if (waited) return waited;
+      const lateHit = await readDbDiscoverCache(supabase, cacheKey);
+      if (lateHit) return lateHit;
     }
 
     try {
       const built = await buildDiscoverMergedResponse(buildCtx);
-      writeDbDiscoverCache(supabase, cacheKey, built, discoverStaleExpiresAt);
+      const cached = withCacheMeta(built);
+      const bytes = await encodeDiscoverResponse(cached);
+      writeDbDiscoverCache(supabase, cacheKey, built, discoverStaleExpiresAt, bytes);
       return built;
     } finally {
       await releaseDistributedBuildLock(supabase, cacheKey);
@@ -209,19 +216,23 @@ serve(async (req: Request): Promise<Response> => {
     if (now >= l1Hit.freshUntil) {
       refreshDiscoverInBackground(cacheKey, buildFresh);
     }
-    return jsonResponse({
-      ...l1Hit.response,
-      meta: { ...l1Hit.response.meta, fromCache: true },
-    });
+    return discoverJsonResponse(req, l1Hit.bytes, corsHeaders);
+  }
+
+  const dbBytes = await readDbDiscoverCacheBytes(supabase, cacheKey);
+  if (dbBytes) {
+    const cached = JSON.parse(new TextDecoder().decode(dbBytes.json)) as DiscoverMergedResponse;
+    l1SetBytes(cacheKey, dbBytes, cached, now);
+    return discoverJsonResponse(req, dbBytes, corsHeaders);
   }
 
   try {
-    const response = await coalesceDiscoverBuild(cacheKey, buildFresh);
-    return jsonResponse(response);
+    const entry = await coalesceDiscoverBuild(cacheKey, buildFresh);
+    return discoverJsonResponse(req, entry.bytes, corsHeaders);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.startsWith("db_error:")) {
-      return jsonResponse(
+      return jsonError(
         { error: "db_error", detail: msg.slice("db_error:".length) },
         500,
       );

--- a/supabase/migrations/20260615000000_orch_426_discover_cache_gzip.sql
+++ b/supabase/migrations/20260615000000_orch_426_discover_cache_gzip.sql
@@ -1,0 +1,9 @@
+-- ORCH-426 G1 — store pre-compressed discover payload for cross-isolate hot path.
+-- Cold isolates serve gzip bytes without JSON parse + re-stringify.
+
+BEGIN;
+
+ALTER TABLE public.discover_merged_events_cache
+  ADD COLUMN IF NOT EXISTS response_gzip_base64 text;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Serve pre-serialized gzip/json bytes on L1 cache hits instead of re-stringifying ~40KB JSON every request.
- Store response_gzip_base64 in discover_merged_events_cache for cold isolates at 10k VU.
- Extend distributed build lock wait and add late cache re-read to reduce stampede timeouts.
- k6 harness sends Accept-Encoding: gzip; regression contract updated.

## Test plan
- node scripts/audit/discover-scale-contract.mjs
- Deploy via scripts/load/deploy-discover-staging.sh
- Phase 2: run-staging.sh discover 1000 5m
- Phase 3: run-distributed.sh discover 4 2500 5m