### PR TITLE
ORCH-1139: exempt Stripe-Connect + invite routes from sign-in redirect [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md
@@ -1,0 +1,149 @@
+# IMPLEMENTATION — ORCH-1139 [Stripe setup redirects to business sign-in]
+
+- **Phase:** IMPLEMENT (binding SPEC executed)
+- **Date:** 2026-06-15
+- **Skill:** mingla-implementor + claude
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1139-[stripe-connect-route-gate]/` on branch `ORCH-1139-stripe-connect-route-gate` (rebased onto origin/main, 0 behind)
+- **SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md`
+- **Status:** implemented and verified (gate-level). Device SC-4/SC-5 are the tester's runtime gate.
+- **Implementation commit:** `e8d091da4`
+- **Comms ledger:** read on entry. No BLOCK/WARN row addressed to ORCH-1139 / mingla-implementor / ALL requires action (COMMS-0029 is an ORCH-1119/1120 trip-migration matter; this ORCH touches no migration). COMMS-0021 (Stripe seller-copy rename) is copy-only and out of this ORCH's allowlist — no route/path impact. No new cross-ORCH discovery → no COMMS write.
+
+---
+
+## 1. Summary
+
+A logged-in business user who tapped "Set up payments" / "Connect bank" was bounced to the business sign-in screen instead of the Stripe Connect onboarding form. Root cause (investigation F-1): the native CTA opens the WEB `/connect-onboarding` page in a SESSIONLESS in-app browser; ORCH-1102's route-agnostic root-layout gate redirects every web route without a Supabase web session to `/` (sign-in), and its only escape hatch (`PUBLIC_BUYER_ROUTE_PREFIXES`, ORCH-1115) was scoped to anon buyer routes — never the self-authenticating Stripe-Connect seller routes.
+
+The fix is an allowlist extension only: two new, semantically-distinct exemption sets (`SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` = 6 connect routes; `INVITE_ACCEPT_ROUTE_PREFIXES` = 2 invite routes) plus the segment-safe matcher `isSelfAuthenticatedExemptRoute`, ANDed into both the web predicate `shouldRedirectToSignInFromRoute` and the native `nativeRedirectToSignIn` path. Plus the DRAFT closure invariant test that forces every top-level `app/` route into exactly one classified bucket. No CTA-routing, edge-function, or connect-page-body change.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence (commit `e8d091da4`) |
+|----|-----------|--------|-------------------------------|
+| SC-1 | logged-out web → no redirect on all 8 exempt routes | ✓ | `orch_1139_connect_seller_route_allowlist` T-A1/A2/A3 (bare + sub-path) |
+| SC-2 | logged-out → STILL redirect on private routes | ✓ | T-A4 (`/account`, `/(tabs)/home`, `/brand/123`, `/notifications`) |
+| SC-3 | segment-safety on near-miss/traversal | ✓ (matcher built identical to 1115; tester owns the adversarial file per SPEC) | matcher uses `normalized === base \|\| startsWith(base + "/")` |
+| SC-4-iOS / SC-4-Android | device: CTA opens Stripe form, not sign-in | UNVERIFIED (tester device gate) | parity automatic via shared `coldLoadAuthGates.ts`; tester verifies ≥1 platform |
+| SC-5 | direct sessionless web visit renders connect page | UNVERIFIED (tester runtime gate) | web predicate now returns false for `/connect-onboarding` (T-A1) |
+| SC-6 | `PUBLIC_BUYER_ROUTE_PREFIXES` byte-for-byte unchanged | ✓ | 1115 T-9 (exactly 9 prefixes) still passes |
+| SC-7 | each constant defined once; web+native consult matcher | ✓ | T-A7 (`source.match` count === 1; `_layout.tsx` contains `!isSelfAuthenticatedExemptRoute(pathname)`) |
+| SC-8 | every top-level `app/` route classified into exactly one bucket | ✓ | `orch_1139_route_gate_closure` T-C1 (live enumeration === seeded map) |
+
+UNVERIFIED items (SC-4/SC-5) are runtime/device gates the SPEC assigns to the tester (§12 downstream routing); they are not code-implementable at the gate layer.
+
+---
+
+## 3. Files changed
+
+| File | Change | Δ lines |
+|------|--------|---------|
+| `mingla-business/src/utils/coldLoadAuthGates.ts` | +2 constants + matcher + AND exemption into `shouldRedirectToSignInFromRoute` + doc-comment | +~110 |
+| `mingla-business/app/_layout.tsx` | import `isSelfAuthenticatedExemptRoute` + AND into `nativeRedirectToSignIn` + comment | +~9 |
+| `mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts` | removed `/connect-partner-onboarding` + `/stripe-onboarding-return` from `AUTHED_ONLY_ROUTE_SAMPLES` ([TEST-MOD-APPROVED ORCH-1139]) | -2 / +6 comment |
+| `mingla-business/src/utils/__tests__/orch_1139_connect_seller_route_allowlist.test.ts` | NEW implementor happy-path | +~250 |
+| `mingla-business/__tests__/orch_1139_route_gate_closure.test.ts` | NEW closure-invariant | +~210 |
+
+All committed in `e8d091da4`. Working tree clean (`git status --short` empty, `git diff HEAD` empty after fails-on-revert proofs restored).
+
+---
+
+## 4. Data-model changes applied
+
+None. Client-route-gate only. No DB / RLS / migration / edge / service / hook / realtime change.
+
+---
+
+## 5. Edge functions touched
+
+None. (`brand-stripe-onboard` already enforces auth server-side at link creation — investigation reconciliation. No deploy required for this ORCH.)
+
+---
+
+## 6. Regression tests added
+
+- **Happy-path (implementor):** `mingla-business/src/utils/__tests__/orch_1139_connect_seller_route_allowlist.test.ts` — 44 tests (T-A1..A7).
+- **Closure invariant:** `mingla-business/__tests__/orch_1139_route_gate_closure.test.ts` — 33 tests (T-C1, I-PROPOSED-1139-ROUTE-GATE-CLOSURE).
+- **Modified (approved):** `orch_1115_anon_buyer_route_allowlist.test.ts` — removed two now-exempt samples; `/accept-invite` kept as negative control. `[TEST-MOD-APPROVED ORCH-1139]` in commit body.
+
+**fails-on-revert verified at commit `e8d091da4`:**
+
+- **Gate clause (happy-path):** deleted `&& !isSelfAuthenticatedExemptRoute(pathname)` from `shouldRedirectToSignInFromRoute` → `orch_1139_connect_seller_route_allowlist`: **20 failed, 24 passed** (T-A1/A2/A3 flip redirect→true and FAIL; T-A4 private routes stay true and PASS). Restored → **44 passed**.
+- **Closure invariant:** removed `/stripe-onboarding-return` from `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` → `orch_1139_route_gate_closure`: **2 failed, 31 passed** (route reclassifies connect-exempt → gated-default, contradicting the seeded map). Restored → **33 passed**.
+
+Full restored suite: **227 passed across 6 suites** (`orch_1139` × 2, `orch_1115`, `androidWebOnlyConnectRoutes`, `orch1100ColdLoadAuthGates`).
+
+---
+
+## 7. Old → New receipts
+
+### `mingla-business/src/utils/coldLoadAuthGates.ts`
+**Before:** only `PUBLIC_BUYER_ROUTE_PREFIXES` / `isPublicBuyerRoute` exempted routes from the sign-in redirect; connect-seller + invite routes had no exemption.
+**Now:** adds `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` (6), `INVITE_ACCEPT_ROUTE_PREFIXES` (2), and `isSelfAuthenticatedExemptRoute` (segment-safe matcher over the union). `shouldRedirectToSignInFromRoute` now ANDs `&& !isSelfAuthenticatedExemptRoute(pathname)`.
+**Why:** SC-1/SC-2/SC-7 — exempt the self-authenticating routes (out-of-band URL credential, no Supabase session) without widening the buyer allowlist.
+**Lines:** +~110.
+
+### `mingla-business/app/_layout.tsx`
+**Before:** `nativeRedirectToSignIn` ANDed only `!isSignInRoute(pathname) && !isPublicBuyerRoute(pathname)`.
+**Now:** imports `isSelfAuthenticatedExemptRoute`; `nativeRedirectToSignIn` also ANDs `&& !isSelfAuthenticatedExemptRoute(pathname)` (no-op on native today; keeps the exemption in one place, hardens against a future native connect/invite route — same rationale as the ORCH-1115 note).
+**Why:** SC-7 — single source of truth; web + native lockstep.
+**Lines:** +~9.
+
+### `orch_1115_anon_buyer_route_allowlist.test.ts`
+**Before:** `AUTHED_ONLY_ROUTE_SAMPLES` asserted `/connect-partner-onboarding` + `/stripe-onboarding-return` STILL redirect.
+**Now:** both removed (now exempt → would make T-2 fail); `/accept-invite` retained as a negative control (not a real route → correctly still redirects).
+**Why:** SPEC §9 step 3.
+
+---
+
+## 8. Cross-surface impact
+
+| # | Surface | Affected | Parity |
+|---|---------|----------|--------|
+| 1 | Consumer iOS (`app-mobile`) | NO | n/a — different app |
+| 2 | Consumer Android (`app-mobile`) | NO | n/a |
+| 3 | Buyer/anon Web | NO (already 1115) | buyer allowlist untouched |
+| 4 | Business iOS | YES — CTA opens Stripe form, not sign-in | Automatic (shared gate) |
+| 5 | Business Android | YES — same web-bundle path | Automatic (shared gate) |
+| 6 | Admin Web | NO | separate app |
+| 7 | Business Web preview | YES — direct sessionless visit renders connect/invite page | Automatic (shared gate) |
+
+Single allowlist change in the shared `coldLoadAuthGates.ts` serves all three affected surfaces — parity automatic.
+
+---
+
+## 9. Smoke result
+
+Gate-layer verification only (this ORCH is a pure client-route-gate predicate change with no device-buildable UI of its own):
+- jest: 227 passed / 6 suites.
+- strict-grep `orch-1105-layout-no-self-redirect.mjs`: self-test PASS (4/4), live PASS (loop guard intact; no unguarded `/` self-redirect — my change preserves `nativeRedirectToSignIn`'s `!isSignInRoute(...)` clause).
+- `tsc --noEmit`: zero errors in any touched file.
+- fails-on-revert: proven for both the gate clause and the closure invariant (§6).
+
+Device SC-4/SC-5 deferred to tester per SPEC §12.
+
+---
+
+## 10. Known issues / deferred
+
+- None. No `[TRANSITIONAL]` code added. `/stripe-onboarding-return` is `@deprecated` (ORCH-0954) but still live for legacy TEST hosted-onboarding returns — exempted per SPEC §5 because its mount-time self-redirect would otherwise be bounced first; no change to its body.
+
+---
+
+## 11. Operator action required
+
+- None for this ORCH (no migration, no edge deploy). Route to **mingla-orchestrator REVIEW** → **mingla-tester** (writes the Step-0.5(b) adversarial `orch_1139_connect_route_segment_safety.test.ts` independently + runs device SC-4 / web SC-5) → **CLOSE** (flips `I-PROPOSED-1139-ROUTE-GATE-CLOSURE` ACTIVE, registers in `INVARIANT_REGISTRY.md`, World-Map sync).
+
+---
+
+## 12. Discoveries for orchestrator
+
+- None outside scope. The closure test reads the live `app/` directory: any NEW top-level route added later WITHOUT seeding it in the test's `EXPECTED` map will redden the closure test — that is the invariant working as designed (it forces classification of every new route).
+
+---
+
+## SPEC deviations
+
+None. The two SPEC symbol names matched the real file exactly (`shouldRedirectToSignInFromRoute`, `nativeRedirectToSignIn`, `isPublicBuyerRoute`). The matcher reuses ORCH-1115's exact segment-safe normalization (duplicated verbatim rather than factored into a shared private helper — correctness-over-DRY, which the SPEC explicitly permits in §4.1.3). All 8 exempt routes, both constant names, the matcher name, and the predicate wiring are implemented exactly as specified.

--- a/Mingla_Artifacts/reports/QA_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md
+++ b/Mingla_Artifacts/reports/QA_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md
@@ -1,0 +1,186 @@
+# QA — ORCH-1139 [Stripe setup redirects to business sign-in]
+
+- **Phase:** TEST (mingla-tester, brutal gatekeeper)
+- **Date:** 2026-06-15
+- **Skill:** mingla-tester + claude
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1139-[stripe-connect-route-gate]/` on branch `ORCH-1139-stripe-connect-route-gate`
+- **Implementation under test:** commit `e8d091da4` (+ docs `df9bfd8d4`)
+- **QA test commit:** `1bf5b43a0`
+- **Comms ledger:** read on entry. No BLOCK-OPEN row addressed to mingla-tester / ORCH-1139 / ALL. All OPEN rows are WARN→ALL for unrelated ORCHs (COMMS-0029 trip-migration; COMMS-0030 iOS-build now RESOLVED; COMMS-0003/0021 Stripe-copy/external-API-docs — this ORCH touches no Stripe payload/enum/copy, only a client route-gate predicate). No new cross-ORCH discovery → no COMMS write.
+
+---
+
+## 1. Verdict
+
+**CONDITIONAL PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 1 · P4: 2
+
+The gate-layer fix is **correct, real, and not a symptom mask** (proven by exhaustive jest + independent fails-on-revert + segment-safety adversarial test). The verdict is capped at **CONDITIONAL PASS (not full PASS)** ONLY because the two runtime success criteria SC-4 (device CTA reaches Stripe form) and SC-5 (sessionless web visit renders) could **not** be proven at runtime this turn — the runtime web environment was genuinely blocked (details §7), and SC-4 is structurally un-provable pre-deploy (the native CTA opens the *deployed production* web URL, not this branch). Source + jest reasoning on these two runtime SCs is therefore capped at **suspected** per tester discipline; they are NOT fabricated as device passes.
+
+There are no defects requiring rework. The single P3 + two P4s are observations, not blockers. If the orchestrator/Seth accepts the runtime SCs as deferred-to-deploy (the fix cannot reach a faithful runtime until the branch web is deployed), this is effectively a PASS on the implementable surface.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| SC-1 | logged-out web → no redirect on all 8 exempt routes (bare + sub-path) | **PASS** | `orch_1139_connect_seller_route_allowlist` T-A1/A2/A3 — 44/44; independently re-run green |
+| SC-2 | logged-out → STILL redirect on private routes (`/account`, `/(tabs)/home`, `/brand/123`, `/notifications`) | **PASS** | T-A4 green; my adversarial ADV-3 control cases green |
+| SC-3 | segment-safety on near-miss/traversal lookalikes | **PASS (proven)** | my `orch_1139_connect_route_segment_safety.test.ts` — 73/73; fails-on-revert (loosen→`includes`) = 43 fail |
+| SC-4-iOS / SC-4-Android | device: "Set up payments"/"Connect bank" opens Stripe form, not sign-in | **suspected (runtime BLOCKED)** | structurally un-provable pre-deploy: CTA opens the *deployed prod* web URL (`result.onboarding_url` → `business.usemingla.com/connect-onboarding?session=…`), not the branch (`BrandOnboardView.tsx:384`). Gate logic that *would* run is the same shared `coldLoadAuthGates.ts` proven by SC-1/SC-3. |
+| SC-5 | direct sessionless web visit renders connect page, not `/` | **suspected (runtime BLOCKED)** | web export SPA-fallback → "No routes found" (output:single static-serve limitation); `expo start --web` in this worktree bundled the **stock Expo template placeholder** ("Welcome to Expo", 614 modules), not the real app — neither gives a faithful runtime. Web predicate returns `false` for the 8 routes by unit proof (SC-1). |
+| SC-6 | `PUBLIC_BUYER_ROUTE_PREFIXES` byte-for-byte unchanged | **PASS** | `git diff origin/main...HEAD` shows zero change to the constant body or `isPublicBuyerRoute`; 1115 T-9 (exactly 9 prefixes) still green |
+| SC-7 | each constant defined once; web + native both consult the matcher | **PASS** | T-A7 (`source.match` count === 1) green; `_layout.tsx` ANDs `!isSelfAuthenticatedExemptRoute(pathname)` into BOTH paths (verified §4) |
+| SC-8 | every top-level `app/` route classified into exactly one bucket | **PASS** | `orch_1139_route_gate_closure` 33/33; fails-on-revert (remove a connect prefix) = 2 fail, reproduced |
+
+---
+
+## 3. Both-predicates-covered finding (mandate item 1)
+
+**CONFIRMED — the exemption is ANDed into BOTH the web predicate AND the native path. A web-only fix would have left native theoretically broken; this fix covers both.**
+
+- **Matcher is segment-safe (not a loose `includes`/`startsWith`):** `coldLoadAuthGates.ts:255-273` — normalizes (trim → strip single trailing slash for `length>1`) then `normalized === base || normalized.startsWith(\`${base}/\`)` over the union of the two sets. Identical to the proven ORCH-1115 `isPublicBuyerRoute` normalization.
+- **Constants are SEPARATE from `PUBLIC_BUYER_ROUTE_PREFIXES`:** `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` (6) + `INVITE_ACCEPT_ROUTE_PREFIXES` (2) are distinct exports (`:208`, `:232`); the buyer constant is untouched (SC-6).
+- **Web predicate (`shouldRedirectToSignInFromRoute`, `:302-318`):** ANDs `&& !isSelfAuthenticatedExemptRoute(pathname)` as the 4th conjunct (composes after `isSignInRoute` + `isPublicBuyerRoute`; can ONLY flip `true`→`false`).
+- **Native predicate (`nativeRedirectToSignIn`, `app/_layout.tsx:363-369`):** ALSO ANDs `&& !isSelfAuthenticatedExemptRoute(pathname)` (no-op on native today — business-native serves none of these — but keeps the allowlist in one place and hardens a future native connect/invite route; same rationale as the ORCH-1115 note). Import added at `:80`.
+
+Architecturally clean: one shared helper, one allowlist, consulted by both code paths. This is a real fix, not a symptom mask.
+
+---
+
+## 4. Findings (P-numbered)
+
+### P3-1 — `expo start --web` bundles the stock Expo template in this worktree (env hygiene, not a code defect)
+- **Evidence:** `npx expo start --web --port 8092` produced "Web Bundled index.js (614 modules)" and headless Chromium rendered the default Expo Router starter ("Welcome to Expo · Start by creating a file in the app directory") at `/`, `/connect-onboarding`, and `/b/some-brand` alike. The real mingla-business app is thousands of modules.
+- **Impact:** the dev-web runtime path could not faithfully exercise the gate this turn — it is the wrong bundle entirely. This is an environment/worktree Metro-entry issue, NOT a product defect (jest imports the real `coldLoadAuthGates.ts` and passes; the production app on Vercel is unaffected).
+- **Required fix:** none for the ORCH; flag for env follow-up (likely a Metro/`main` entry resolution quirk in the freshly-spawned worktree). Does not block close.
+- **Retest:** after the branch web is deployed to a preview URL, re-run the SC-5 probe (`playwright/orch1139-connect-gate-runtime-probe.mjs`) against it.
+
+### P4-1 (praise) — matcher reuses the proven ORCH-1115 normalization verbatim
+Correctness-over-DRY (SPEC §4.1.3-permitted). The duplicated segment-safe normalization is byte-identical to `isPublicBuyerRoute`, so the proven 1115 behavior carries over with zero new logic risk.
+
+### P4-2 (praise) — closure invariant test converts a latent P0 into a CI failure
+`orch_1139_route_gate_closure.test.ts` reads the live `app/` dir and forces every new top-level route into exactly one classification bucket. This is the structural root-cause fix for the *class* of bug behind both ORCH-1115 and ORCH-1139 (a new route silently inheriting "redirect to sign-in"). Excellent defense-in-depth.
+
+---
+
+## 5. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out commit `e8d091da4` (HEAD-2; the implementation commit), re-ran both proofs myself by true line-deletion:
+
+| Proof | Mutation | Implementor claimed | I observed (independent) | Match |
+|-------|----------|--------------------|--------------------------|-------|
+| Gate clause | delete `&& !isSelfAuthenticatedExemptRoute(pathname)` from `shouldRedirectToSignInFromRoute` | 20 failed, 24 passed | **20 failed, 24 passed** | ✓ exact |
+| Closure invariant | remove `/stripe-onboarding-return` from `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` | 2 failed, 31 passed | **2 failed, 31 passed** | ✓ exact |
+
+Both restored → green (44/44, 33/33). File restored byte-for-byte (`diff -q` clean). Implementor's fails-on-revert is genuine, not claimed.
+
+---
+
+## 6. Adversarial test added (tester-owned, different angle)
+
+- **Path:** `mingla-business/src/utils/__tests__/orch_1139_connect_route_segment_safety.test.ts`
+- **Commit:** `1bf5b43a0` (on-branch, in `git diff origin/main...HEAD --name-only` — verified).
+- **Angle (DIFFERENT from implementor happy-path):** the implementor proves exempt routes are NOT redirected. My suite attacks the **false-positive / boundary** failure mode — crafted near-miss/traversal/case/junk/query-smuggled paths that must STILL redirect, proving the matcher exempts ONLY the intended routes + sub-paths and never a loose substring. 73 tests across ADV-1..ADV-8.
+  - ADV-1 suffix lookalikes (`/connect-onboarding-evil`, `/connect-onboardingX`, `/stripe-onboarding-return-fake`, `/accept-brand-invitationX`)
+  - ADV-2 traversal / substring-in-the-middle (`/x/connect-onboarding`, `/foo/connect-onboarding`, `/account/connect-onboarding`, `/brand/123/connect-onboarding`)
+  - ADV-3 every MUST_NOT_MATCH path rejected
+  - ADV-4 case variants (`/Connect-Onboarding`, `/CONNECT-ONBOARDING`) do not match
+  - ADV-5 query-string smuggling cannot flip a private route exempt
+  - ADV-6 null/empty/whitespace never match (no crash)
+  - ADV-7 legitimate exempt routes (bare / trailing-slash / sub-path) DO match
+  - ADV-8 regression sentinel — re-derives loose `includes`/`startsWith` inline and proves the production matcher DIVERGES from them on exactly the dangerous boundary cases (and AGREES on the legit cases)
+- **fails-on-revert verified at commit `e8d091da4` (matcher loosened to `normalized.includes(base)`):** suite went to **43 failed, 30 passed** — the loose matcher leaks `/connect-onboarding-evil`, `/x/connect-onboarding`, `/account/connect-onboarding`, `/connect-onboardingfoo`, `/accept-brand-invitationX`, etc.; every leak caught. Restored → **73/73 passed**. Gate file restored byte-for-byte (`diff -q` clean).
+- **Both tests appear in the closing diff:** implementor `orch_1139_connect_seller_route_allowlist.test.ts` + tester `orch_1139_connect_route_segment_safety.test.ts` both in `git diff origin/main...HEAD --name-only`. Regression gate satisfied.
+
+---
+
+## 7. Runtime-evidence status (explicit — what I could and could NOT verify at runtime)
+
+**Could NOT verify at runtime this turn — both runtime SCs are capped at `suspected`:**
+
+- **SC-5 (sessionless web render):** TWO runtime attempts, both blocked by environment:
+  1. `web:export` (output:single) served by the META-ORCH-0952 static server (SPA fallback): every non-root route threw `Error: No routes found` from the Expo Router store on hard-load — a static-serve limitation of `output:single` (the production Vercel rewrites are not replicated by the simple static server). The connect-route string IS present in the bundle, so the route exists; the static server just can't hand the deep path to the router on cold load.
+  2. `expo start --web` dev server: bundled the **stock Expo template placeholder** (614 modules, "Welcome to Expo"), not the real app — wrong bundle (see P3-1). Every route uniformly bounced to `/` showing the template, INCLUDING the proven-exempt buyer route `/b/some-brand` (which is shipped-and-working in production) — confirming the uniform bounce is the wrong-bundle/dev-cold-load artifact, NOT the gate.
+
+- **SC-4 (device CTA reaches Stripe form):** **structurally un-provable pre-deploy.** `BrandOnboardView.handleStart` (`:384`) opens `WebBrowser.openAuthSessionAsync(result.onboarding_url, …)` where `result.onboarding_url` is the **deployed production** web URL (`business.usemingla.com/connect-onboarding?session=…`). The gate that runs in that in-app browser is the *deployed* web bundle (origin/main, pre-fix), NOT this branch. A logged-in sim session would exercise the OLD gate. SC-4 cannot be device-proven until this branch's web is deployed. The business app IS installed on the booted iOS sim (`com.sethogieva.minglabusiness`), but pointing it at the branch gate is impossible without a deploy.
+
+**Could verify at runtime / statically (proven):**
+- All 8 exempt routes + sub-paths exist as real `app/` files (SPEC §5 grep re-verified).
+- The connect-route string is in the production web bundle (export grep).
+- The gate predicate logic is exhaustively unit-proven (301 jest tests, 2 independent fails-on-revert).
+
+**Conclusion:** the runtime web environment is a genuine blocker requiring a branch deploy; it is NOT downgraded silently — SC-4/SC-5 are held at `suspected` and the verdict is capped at CONDITIONAL PASS accordingly. The cleanest unblock is to deploy the branch web to a Vercel preview, then re-run `playwright/orch1139-connect-gate-runtime-probe.mjs` against it (and, post-deploy, a device SC-4 tap).
+
+---
+
+## 8. Regression results (mandate item 4)
+
+| Check | Result |
+|-------|--------|
+| Buyer routes (`/e/ /t/ /b/ /exp/ /checkout/ /checkout-trip/ /checkout-experience/ /o/ /booking/`) still exempt | **PASS** — 1115 happy-path suite green; `PUBLIC_BUYER_ROUTE_PREFIXES` + `isPublicBuyerRoute` byte-for-byte unchanged (git diff); 1115 path-confusion adversarial suite green |
+| 1115 buyer behavior neither widened nor narrowed | **PASS** — only doc-comment + the `&&` append-line reference `isPublicBuyerRoute`; the constant + matcher body are untouched |
+| Genuinely-private route (`/account`, `/(tabs)/home`, `/brand/123`, `/notifications`) STILL redirects unauthenticated | **PASS** — T-A4 + my ADV-3 controls green |
+| ORCH-1103 self-redirect loop guard preserved | **PASS** — `isSignInRoute` ANDed first; strict-grep `orch-1105-layout-no-self-redirect.mjs` PASS |
+| META-ORCH-0972 Android web-SDK quarantine | **PASS** — `androidWebOnlyConnectRoutes.test.ts` green; no connect-route-file or metro change |
+| `tsc --noEmit` on touched files | **PASS** — zero errors in `coldLoadAuthGates.ts`, `_layout.tsx`, both new tests |
+| strict-grep gates (`orch-1105-layout-no-self-redirect`, `orch-1105-no-route-stub-gates`, `orch-1105-web-gesture-safe`, `orch-1056-connect-page-shared-styles`) | **PASS (4/4)** |
+
+**Full relevant jest:** 301 passed / 7 suites (`orch_1139` ×2, `orch_1139_route_gate_closure`, `orch_1115` ×2, `orch_1103_signout_redirect_loop`, `androidWebOnlyConnectRoutes`).
+
+---
+
+## 9. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | N/A | no UI added (pure predicate); the fix RESTORES a tap (CTA → form) — anti-dead-tap |
+| 2 | One owner per truth | **PASS** | exemption defined once in `coldLoadAuthGates.ts`; both paths consult the one helper (SC-7) |
+| 3 | No silent failures | **PASS** | exemption can only suppress a redirect on a known-safe route; private routes still redirect (no swallow) |
+| 4 | One query key per entity | N/A | no query |
+| 5 | Server state server-side | N/A | no state |
+| 6 | Logout clears everything | N/A | no auth-state mutation |
+| 7 | Label `[TRANSITIONAL]` | **PASS** | none added; `/stripe-onboarding-return` is pre-existing `@deprecated`, body untouched |
+| 8 | Subtract before adding | **PASS** | allowlist extension only; no parallel mechanism; reuses 1115 normalization |
+| 9 | No fabricated data | N/A | no data |
+| 10 | Currency-aware | N/A | no money |
+| 11 | One auth instance | **PASS** | reads existing `user`/`hasStoredWebSession`; no new auth |
+| 12 | Validate at right time | **PASS** | gate composes after auth resolves (`!loading`); exemption is purely path-based |
+| 13 | Exclusion consistency | **PASS** | three distinct exemption classes (buyer / connect-seller / invite), each reasoned independently; closure test enforces exactly-one-bucket |
+| 14 | Persisted-state startup | N/A | no hydration gate touched |
+
+Zero violations.
+
+---
+
+## 10. Device / parity matrix
+
+| # | Surface | Status | Note |
+|---|---------|--------|------|
+| 1 | Consumer iOS (`app-mobile`) | N/A | different app; unaffected |
+| 2 | Consumer Android (`app-mobile`) | N/A | different app |
+| 3 | Buyer/anon Web | PASS (regression) | buyer allowlist untouched; 1115 suites green |
+| 4 | Business iOS | **suspected (BLOCKED)** | SC-4 un-provable pre-deploy (CTA opens deployed prod web, not branch); sim has the app installed but cannot point at branch gate. Gate logic shared + unit-proven. |
+| 5 | Business Android | **suspected (BLOCKED)** | same shared web-bundle path; physical Samsung A72 present but same pre-deploy constraint |
+| 6 | Admin Web | N/A | separate app |
+| 7 | Business Web preview | **suspected (BLOCKED)** | SC-5 runtime env blocked (P3-1 + static-serve limit); needs branch deploy |
+
+Physical-iPhone HITL: not invoked — SC-4 is structurally un-provable pre-deploy regardless of device, so a manual tap would exercise the OLD deployed gate and prove nothing about this branch. Reserved for post-deploy retest.
+
+---
+
+## 11. Discoveries for Orchestrator
+
+- **D-1 (env):** `expo start --web` in this freshly-spawned worktree bundles the stock Expo template, not the real app (P3-1). Likely a Metro/`main`-entry resolution quirk specific to the worktree. Worth a one-line env check before any future web-runtime QA in spawned worktrees — the `web:export` path produced the real bundle, so the export pipeline is fine; only the dev-web entry is off.
+- **D-2 (process):** SC-4/SC-5 for any client-route-gate that the NATIVE app reaches via an in-app browser to the *deployed* web URL are inherently post-deploy gates. Future SPECs of this shape should mark SC-4/SC-5 as "verify on the preview/prod deploy" rather than "tester device gate," to avoid a structural BLOCKED at TEST time.
+
+---
+
+## 12. Accepted conditions (CONDITIONAL PASS)
+
+The two runtime SCs are deferred, NOT defects:
+
+- **SC-4 (device CTA reaches Stripe form)** — deferred to post-deploy device retest. Structurally un-provable pre-deploy.
+- **SC-5 (sessionless web render)** — deferred to a branch web preview deploy, then re-run `playwright/orch1139-connect-gate-runtime-probe.mjs` against the preview URL.
+
+The implementable surface (the gate predicate, both code paths, segment-safety, regression, closure invariant) is fully PROVEN. If Seth/orchestrator accepts the runtime SCs as deploy-gated, this is a clean pass to CLOSE with a post-deploy runtime confirmation step.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md
@@ -1,0 +1,373 @@
+# SPEC — ORCH-1139 [Stripe setup redirects to business sign-in]
+
+- **Phase:** SPEC (binding build contract — no product-code edits in this phase)
+- **Date:** 2026-06-15
+- **Skill:** mingla-forensics + claude (SPEC mode)
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1139-[stripe-connect-route-gate]/` on branch `ORCH-1139-stripe-connect-route-gate` (verified at parity with `origin/main`, head `1123cffb5`, 0 commits behind)
+- **Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1139_STRIPE_SETUP_REDIRECTS_TO_SIGNIN.md` (root cause `probable`, git-pinned)
+- **Comms ledger:** read on entry. **COMMS-0021** (WARN→ALL, Stripe seller-copy rename "Connect Stripe"→"Connect bank") factored — it renames user-facing COPY only; route PATHS and identifiers are unchanged, and NONE of the COMMS-0021 files are in this SPEC's allowlist. No new cross-ORCH discovery requiring a COMMS write.
+
+---
+
+## 1. Executive summary
+
+A logged-in business user who taps "Set up payments" / "Connect bank" is bounced to the business sign-in screen instead of the Stripe Connect onboarding form. Root cause (ORCH-1139 investigation, `CONFIRMED ROOT CAUSE` F-1): the native CTA opens the **web** `/connect-onboarding` page in a sessionless in-app browser (`WebBrowser.openAuthSessionAsync`); ORCH-1102's route-agnostic root-layout gate redirects EVERY web route without a Supabase web session to `/` (sign-in); its only escape hatch is `PUBLIC_BUYER_ROUTE_PREFIXES`, which ORCH-1115 scoped to anon **buyer** routes and never extended to the self-authenticating Stripe-Connect **seller** routes. The connect pages need only their Stripe `session` client_secret (F-2 / Q3) — never a Supabase session.
+
+The fix is an **allowlist extension only**: add two new, semantically-distinct exemption sets — Stripe-Connect seller routes and invite-accept routes — consumed by the same redirect predicate, mirroring exactly the ORCH-1115 segment-safe matcher. No CTA routing, edge function, or connect-page-body change. Plus a new DRAFT closure invariant (`I-PROPOSED-1139-ROUTE-GATE-CLOSURE`) that forces every top-level `app/` route into exactly one classified bucket so no future route silently inherits "redirect to sign-in."
+
+---
+
+## 2. Scope & non-goals
+
+### In scope
+1. Add a **Stripe-Connect seller** exemption set to `mingla-business/src/utils/coldLoadAuthGates.ts`.
+2. Add an **invite-accept** exemption set to the same file (D-1 from the investigation, **folded in per Seth 2026-06-15**).
+3. Wire BOTH sets into the existing redirect predicate `shouldRedirectToSignInFromRoute` AND the native `nativeRedirectToSignIn` path in `app/_layout.tsx`, via a single combined "exempt-from-sign-in-redirect" matcher.
+4. Update the existing `orch_1115_anon_buyer_route_allowlist.test.ts` where it currently asserts now-exempt routes STILL redirect (`/connect-partner-onboarding`, `/stripe-onboarding-return` at lines 84-86).
+5. Step-0.5 (a) implementor happy-path regression test (new file).
+6. Step-0.5 (b) tester adversarial near-miss/segment-safety test (new file, different angle).
+7. New DRAFT invariant `I-PROPOSED-1139-ROUTE-GATE-CLOSURE` + its fails-on-revert closure test.
+
+### Non-goals (explicitly NOT in this SPEC)
+- **Do NOT propagate the Supabase session into the in-app browser.** The pages don't need it (F-2/Q3); session propagation is higher-risk and out of scope.
+- **Do NOT change the CTA routing** (`brandStripeOnboardingRoute` → `/brand/{id}/payments/onboard`), the `BrandOnboardView.handleStart` `WebBrowser.openAuthSessionAsync` call, the `brand-stripe-onboard` edge function, or any `brand-stripe-*` / connect edge function.
+- **Do NOT modify any connect page component body** (`ConnectOnboardingBody.web.tsx` et al.) or the native fallbacks.
+- **Do NOT modify the existing buyer allowlist** `PUBLIC_BUYER_ROUTE_PREFIXES` entries or `isPublicBuyerRoute` semantics. The 9 buyer prefixes stay exactly as they are (pinned by `orch_1115...test.ts` T-9).
+- **Do NOT fold seller/invite routes into `PUBLIC_BUYER_ROUTE_PREFIXES`.** They are a different security class (self-authenticating via out-of-band credential, NOT anon-public-supply). A separate constant is mandatory (investigation Invariant-impact note + Seth-locked).
+- **Do NOT touch COMMS-0021 files** (the copy-rename set).
+- **No consumer-app (`app-mobile`) change** — different app, unaffected (investigation blast map).
+
+### Assumptions
+- The investigation's five-layer trace is accepted as the basis; no new investigation is performed inside this SPEC (SPEC hard rule).
+- Route paths verified against the worktree's actual `app/` tree this turn (see §5).
+
+---
+
+## 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behavior demanded | Files touched here | Parity |
+|---|---------|---------|--------------------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile`) | NO | n/a — different app; Stripe payouts here unrelated | none | n/a |
+| 2 | Consumer Android (`app-mobile`) | NO | n/a — different app | none | n/a |
+| 3 | Buyer/anonymous Web (`mingla-business` buyer routes) | NO (already fixed by ORCH-1115) | unchanged — buyer routes still render for anon | none (buyer allowlist untouched) | n/a |
+| 4 | Business iOS | **YES** | Tapping "Set up payments"/"Connect bank" opens the Stripe onboarding form in the in-app browser — NOT the sign-in screen. Same for tax-registrations, account-management, partner onboarding/management, and invite-accept links. | `coldLoadAuthGates.ts` (shared) — the gate runs in the WEB bundle loaded by the native in-app browser | Automatic (shared gate file; one code path serves all web-rendered connect/invite routes) |
+| 5 | Business Android | **YES** | Same as Business iOS (same `WebBrowser` → web-bundle path). | `coldLoadAuthGates.ts` (shared) | Automatic (shared) |
+| 6 | Admin Web (`mingla-admin`, adjacent) | NO | n/a — separate app, separate gate | none | n/a |
+| 7 | Business Web preview (adjacent) | **YES** | A direct sessionless visit to `/connect-*` / `/accept-*` renders the page (Stripe session / invite token in URL) instead of bouncing to `/`. | `coldLoadAuthGates.ts` + `app/_layout.tsx` (shared) | Automatic (shared gate) |
+
+**Affected Surfaces (one line):** Business iOS in-app browser + Business Android in-app browser + Business Web preview (direct). All three are served by the SAME web bundle + the SAME `coldLoadAuthGates.ts` gate, so the single allowlist change fixes all three at once (parity automatic).
+
+---
+
+## 4. Layered specification
+
+Only ONE layer is affected: the **client route gate** (`coldLoadAuthGates.ts`) and its **consumer** (`app/_layout.tsx`). No DB / RLS / edge / service / hook / realtime change. (`brand-stripe-onboard` already enforces auth server-side at link creation — investigation §reconciliation Schema/RLS row.)
+
+### 4.1 `mingla-business/src/utils/coldLoadAuthGates.ts`
+
+#### 4.1.1 New constant — Stripe-Connect seller routes
+
+Insert AFTER the `isPublicBuyerRoute` function (after line 181) and BEFORE the `shouldRedirectToSignInFromRoute` doc-comment (line 183). The new constant + its sibling (4.1.2) + the combined matcher (4.1.3) form a contiguous new block.
+
+```ts
+export const SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES = [ ... ] as const;
+```
+
+Exact entries (each verified against an `app/` file in §5):
+
+| Prefix | `app/` file that defines it |
+|--------|-----------------------------|
+| `"/connect-onboarding"` | `app/connect-onboarding.web.tsx` |
+| `"/connect-account-management"` | `app/connect-account-management.web.tsx` |
+| `"/connect-partner-onboarding"` | `app/connect-partner-onboarding.web.tsx` |
+| `"/connect-partner-account-management"` | `app/connect-partner-account-management.web.tsx` |
+| `"/connect-tax-registrations"` | `app/connect-tax-registrations/index.web.tsx` |
+| `"/stripe-onboarding-return"` | `app/stripe-onboarding-return.tsx` |
+
+> **Trailing-slash form:** these are written WITHOUT a trailing slash (unlike the buyer prefixes which carry one) because the combined matcher (4.1.3) normalizes a prefix to its no-trailing-slash `base` regardless. Writing them bare keeps the constant readable AND makes the bare route (`/connect-onboarding`, no sub-segment — the real arrival path) the literal first match. The matcher's `base + "/"` clause still makes any deeper path (`/connect-onboarding/foo`) match and a lookalike (`/connect-onboarding-evil`) NOT match. **Do NOT rely on a trailing slash being present** — the matcher must strip/normalize identically to ORCH-1115.
+
+**Mandatory inline comment (constitutional caveat — verbatim intent, implementor may reflow):**
+
+```
+/**
+ * SELF-AUTHENTICATING STRIPE-CONNECT SELLER ROUTES — ORCH-1139.
+ *
+ * Exempt from the ORCH-1102 route-agnostic sign-in redirect. These are NOT
+ * anon-public buyer routes (do NOT add them to PUBLIC_BUYER_ROUTE_PREFIXES).
+ * They are served by the WEB bundle and opened by the native "Set up payments"
+ * CTA in a SESSIONLESS in-app browser (WebBrowser.openAuthSessionAsync), so they
+ * carry NO Supabase web session and the route-agnostic gate would bounce them
+ * to `/` (business sign-in) before the page can mount.
+ *
+ * CONSTITUTIONAL CAVEAT: this exemption is valid ONLY because each page carries
+ * its OWN out-of-band credential in the URL — the Stripe AccountSession
+ * client_secret (`?session=…`), minted by the auth-checked `brand-stripe-onboard`
+ * edge function — and authenticates itself against Stripe (ConnectOnboardingBody
+ * never reads a Supabase user). The exemption does NOT make seller account data
+ * public: the page renders nothing without a valid Stripe client_secret. NEVER
+ * add a route here that would instead read account data from an implicit Supabase
+ * session — that would be a real data exposure. (See ORCH-1139 F-2 / Q3.)
+ */
+```
+
+#### 4.1.2 New constant — invite-accept routes
+
+Immediately after 4.1.1:
+
+```ts
+export const INVITE_ACCEPT_ROUTE_PREFIXES = [ ... ] as const;
+```
+
+Exact entries (each verified in §5):
+
+| Prefix | `app/` file that defines it | Covers |
+|--------|-----------------------------|--------|
+| `"/accept-brand-invitation"` | `app/accept-brand-invitation.tsx` | the bare accept page AND `app/accept-brand-invitation/success.tsx` (`/accept-brand-invitation/success`), because the segment-safe matcher's `base + "/"` clause matches the sub-route |
+| `"/accept-scanner-invitation"` | `app/accept-scanner-invitation.tsx` | the scanner-invite accept page |
+
+**Mandatory inline comment (constitutional caveat — verbatim intent, implementor may reflow):**
+
+```
+/**
+ * INVITE-ACCEPT ROUTES — ORCH-1139 (D-1, Seth-folded-in 2026-06-15).
+ *
+ * Exempt from the sign-in redirect for the SAME reason as the connect routes:
+ * a logged-OUT invitee opening an emailed invite link must reach the accept
+ * page, not the sign-in wall. CONSTITUTIONAL CAVEAT: valid ONLY because each
+ * page carries its OWN out-of-band credential — the invite TOKEN in the URL —
+ * and performs its own authorization against that token. The exemption does NOT
+ * make any brand/scanner data public; the page resolves nothing without a valid
+ * invite token. Kept DISTINCT from the connect set and the buyer set so a
+ * reviewer can reason about each class independently.
+ */
+```
+
+#### 4.1.3 New combined matcher
+
+Add a single matcher that the predicate consults, reusing the EXACT ORCH-1115 segment-safe normalization (trim → strip one trailing slash for `length > 1` → `normalized === base || normalized.startsWith(base + "/")`). It checks the union of the two new sets:
+
+```ts
+export const isSelfAuthenticatedExemptRoute = (
+  pathname: string | null | undefined,
+): boolean => { ... }
+```
+
+Behavioral contract (identical normalization to `isPublicBuyerRoute`, lines 166-181):
+- `null` / `undefined` / `""` / whitespace-only → `false`.
+- Trim; strip a single trailing slash only when `length > 1`.
+- For each prefix `P` in `[...SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES, ...INVITE_ACCEPT_ROUTE_PREFIXES]`: let `base = P` without any trailing slash; match iff `normalized === base || normalized.startsWith(`${base}/`)`.
+- Returns `true` if ANY prefix matches.
+
+> The implementor MAY factor the shared normalization into a private helper used by both `isPublicBuyerRoute` and `isSelfAuthenticatedExemptRoute` IF it does not change `isPublicBuyerRoute`'s observable behavior (T-3/T-4/T-5 of the 1115 test must still pass unchanged). Otherwise duplicate the proven matcher verbatim — correctness over DRY here.
+
+#### 4.1.4 Predicate change — `shouldRedirectToSignInFromRoute`
+
+Current (lines 214-217):
+```ts
+shouldRedirectToSignIn({ isWeb, loading, hasUser, hasStoredWebSession }) &&
+!isSignInRoute(pathname) &&
+!isPublicBuyerRoute(pathname);
+```
+
+New — AND in the new exemption (an exemption can ONLY flip `true`→`false`, never introduce a redirect):
+```ts
+shouldRedirectToSignIn({ isWeb, loading, hasUser, hasStoredWebSession }) &&
+!isSignInRoute(pathname) &&
+!isPublicBuyerRoute(pathname) &&
+!isSelfAuthenticatedExemptRoute(pathname);
+```
+
+Update the function's doc-comment to note the ORCH-1139 clause alongside the ORCH-1115 one (same "can only suppress, never cause" reasoning).
+
+### 4.2 `mingla-business/app/_layout.tsx`
+
+#### 4.2.1 Import
+
+Add `isSelfAuthenticatedExemptRoute` to the existing import block from `coldLoadAuthGates` (currently importing `isPublicBuyerRoute`, `isSignInRoute`, `isWebAuthResolving`, `shouldRedirectToSignInFromRoute` at lines 79-82).
+
+#### 4.2.2 Native path — `nativeRedirectToSignIn`
+
+Current (lines 356-361):
+```ts
+const nativeRedirectToSignIn =
+  !isWeb &&
+  !loading &&
+  user === null &&
+  !isSignInRoute(pathname) &&
+  !isPublicBuyerRoute(pathname);
+```
+
+New — AND in the same exemption so the native path stays in lockstep with the web predicate (this is a no-op on business-native today, which serves none of these routes, but it keeps the exemption set in ONE place and hardens against a future native connect/invite route — exactly the ORCH-1115 rationale at lines 350-355):
+```ts
+const nativeRedirectToSignIn =
+  !isWeb &&
+  !loading &&
+  user === null &&
+  !isSignInRoute(pathname) &&
+  !isPublicBuyerRoute(pathname) &&
+  !isSelfAuthenticatedExemptRoute(pathname);
+```
+
+Add a one-line ORCH-1139 comment above mirroring the ORCH-1115 note already there.
+
+> NOTE: The `redirectToSignIn` (web) variable at line 327 calls `shouldRedirectToSignInFromRoute`, which already gains the exemption via 4.1.4 — no further change there. Only the native inline predicate (4.2.2) needs the explicit clause.
+
+---
+
+## 5. Verified route-path list (grep proof)
+
+All routes verified against the worktree `app/` tree this turn:
+
+```
+$ ls -1 app/*.tsx app/*.web.tsx | sed 's#app/##' | sort -u
+  accept-brand-invitation.tsx
+  accept-scanner-invitation.tsx
+  connect-account-management.tsx  + .web.tsx
+  connect-onboarding.tsx          + .web.tsx
+  connect-partner-account-management.tsx + .web.tsx
+  connect-partner-onboarding.tsx  + .web.tsx
+  index.tsx
+  notifications.tsx
+  stripe-onboarding-return.tsx
+$ find app -maxdepth 1 -type d   (route segments)
+  (tabs) account ari auth b booking brand checkout checkout-experience
+  checkout-trip connect-tax-registrations e event exp experience o partner
+  support t trip venue accept-brand-invitation
+$ ls app/accept-brand-invitation/   → success.tsx   (→ /accept-brand-invitation/success)
+$ ls app/connect-tax-registrations/ → index.tsx + index.web.tsx
+$ head app/stripe-onboarding-return.tsx → "/stripe-onboarding-return — HTTPS relay for Stripe hosted onboarding"
+$ head app/connect-onboarding.web.tsx   → "/connect-onboarding — Mingla-hosted Stripe Connect Embedded Components page"
+$ head app/connect-account-management.web.tsx → "/connect-account-management — Mingla-hosted Stripe Connect management page"
+$ head app/connect-partner-onboarding.web.tsx → "/connect-partner-onboarding — Mingla-hosted Stripe Connect Embedded"
+$ head app/connect-partner-account-management.web.tsx → "/connect-partner-account-management — Mingla-hosted Stripe Connect"
+$ head app/connect-tax-registrations/index.web.tsx → "/connect-tax-registrations — embedded Stripe Tax registrations + settings page"
+$ ls app/accept-invite*  → no matches found   (the 1115 test's "/accept-invite" sample is NOT a real route)
+```
+
+**Final exempt list (all 8 confirmed to exist):**
+
+Connect-seller (6): `/connect-onboarding`, `/connect-account-management`, `/connect-partner-onboarding`, `/connect-partner-account-management`, `/connect-tax-registrations`, `/stripe-onboarding-return`.
+
+Invite-accept (2): `/accept-brand-invitation` (covers `/accept-brand-invitation/success` via segment match), `/accept-scanner-invitation`.
+
+> **Deviation from the investigation's recommendation:** none on the route list. The investigation's "Recommended fix" named exactly the 6 connect routes and flagged the 2 invite routes (D-1) for a scope decision; Seth folded D-1 in, so this SPEC exempts all 8. The `/stripe-onboarding-return` route exists and is `@deprecated` (ORCH-0954) but still live for legacy TEST hosted-onboarding returns (investigation D-2) — it is exempted because its mount-time self-redirect would otherwise be bounced first.
+
+---
+
+## 6. Success criteria
+
+- **SC-1 (web predicate):** For a logged-out web user (`isWeb:true, loading:false, hasUser:false, hasStoredWebSession:false`), `shouldRedirectToSignInFromRoute({ pathname })` returns `false` for every one of the 8 exempt routes (bare + a representative sub-path each).
+- **SC-2 (still-gated):** For the same logged-out user, `shouldRedirectToSignInFromRoute` STILL returns `true` for a representative private route (`/account`, `/(tabs)/home`, `/brand/123`, `/notifications`).
+- **SC-3 (segment-safety):** `isSelfAuthenticatedExemptRoute` returns `false` for near-miss/traversal lookalikes — `/connect-onboarding-evil`, `/connect-onboardingX`, `/x/connect-onboarding`, `/accept-brand-invitationX`, `/stripe-onboarding-return-fake` — and `shouldRedirectToSignInFromRoute` STILL returns `true` for each.
+- **SC-4-iOS / SC-4-Android (runtime — tester device gate):** On a real device, tapping "Set up payments"/"Connect bank" opens the in-app browser to the Stripe onboarding form (NOT the business sign-in screen). Parity automatic via the shared gate; tester verifies at least one platform end-to-end and the other by code-path identity.
+- **SC-5 (Web preview):** A direct sessionless browser visit to `https://business.…/connect-onboarding?session=…&brand_id=…` renders the Connect Embedded page, not `/`.
+- **SC-6 (buyer untouched):** `PUBLIC_BUYER_ROUTE_PREFIXES` is byte-for-byte unchanged (the existing 1115 T-9 assertion of exactly 9 prefixes still passes).
+- **SC-7 (single source of truth):** Each new constant is defined exactly once in `coldLoadAuthGates.ts`; both web and native redirect paths consult `isSelfAuthenticatedExemptRoute`.
+- **SC-8 (closure):** Every top-level route under `mingla-business/app/` is classified into exactly one of {gated-default, buyer-exempt, connect-seller-exempt, invite-exempt}; the closure test fails the build if any unclassified route appears.
+
+---
+
+## 7. Invariants
+
+### Preserved
+- **I-PROPOSED-1115-PUBLIC-BUYER-ROUTE-ALLOWLIST** (`coldLoadAuthGates.ts:130`): preserved — `PUBLIC_BUYER_ROUTE_PREFIXES` and `isPublicBuyerRoute` are not modified; the new set is a distinct sibling. Verified by SC-6 + the unchanged 1115 test T-9.
+- **ORCH-1103 self-redirect loop guard** (`isSignInRoute` ANDed first): preserved — the new clause composes after it and can only suppress, never add, a redirect. Verified by the 1115 test T-8 (kept) + SC carry-over.
+- **META-ORCH-0972 Sub-B Android web-SDK quarantine** (`androidWebOnlyConnectRoutes.test.ts`): preserved — this SPEC touches neither the native connect route files nor metro config. (Run that test as a regression check.)
+
+### New (DRAFT — orchestrator owns the ACTIVE flip at CLOSE)
+- **I-PROPOSED-1139-ROUTE-GATE-CLOSURE (DRAFT):** Every top-level route under `mingla-business/app/` (`*.tsx` / `*.web.tsx` directly in `app/`, plus each immediate subdirectory of `app/` as a route segment) MUST be classified into exactly one explicit set: GATED-by-default, or one of the three exemption sets (buyer / connect-seller / invite). A new route added to `app/` that is not added to a classification list FAILS the build. This converts "a new route silently inherits redirect-to-sign-in" (the exact mechanism behind both ORCH-1115 and ORCH-1139) from a latent P0 into a CI failure. **Flips ACTIVE at CLOSE.**
+
+---
+
+## 8. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-A1 | logged-out, each connect route (bare) | `/connect-onboarding`, …×6 | `shouldRedirectToSignInFromRoute` → `false` | gate |
+| T-A2 | logged-out, each connect route + sub-path | `/connect-onboarding/step2`, `/accept-brand-invitation/success` | `false` | gate |
+| T-A3 | logged-out, each invite route | `/accept-brand-invitation`, `/accept-scanner-invitation` | `false` | gate |
+| T-A4 | logged-out, private route still gated | `/account`, `/(tabs)/home`, `/brand/123`, `/notifications` | `true` | gate |
+| T-A5 | logged-IN on exempt route | any exempt + `hasUser:true` | `false` (already; pins it) | gate |
+| T-A6 | warming session on exempt route | exempt + `hasStoredWebSession:true,hasUser:false` | `false` | gate |
+| T-B1 | near-miss suffix | `/connect-onboarding-evil`, `/connect-onboardingX` | `isSelfAuthenticatedExemptRoute` → `false`; redirect → `true` | gate |
+| T-B2 | path-traversal prefix | `/x/connect-onboarding`, `/foo/accept-scanner-invitation` | `false`; redirect → `true` | gate |
+| T-B3 | invite lookalike | `/accept-brand-invitationX`, `/accept-scanner` | `false`; redirect → `true` | gate |
+| T-B4 | null/empty/whitespace | `null`, `""`, `" "` | `isSelfAuthenticatedExemptRoute` → `false` | gate |
+| T-B5 | trailing-slash + bare both match | `/connect-onboarding/`, `/connect-onboarding`, `/accept-scanner-invitation/` | `true` | gate |
+| T-C1 | closure — every app route classified | enumerate `app/` | each route in exactly one set; else FAIL | structural |
+| T-C2 | closure fails-on-revert | remove a connect prefix | closure test FAILS | structural |
+
+---
+
+## 9. Implementation order
+
+1. **`coldLoadAuthGates.ts`** — add `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` (4.1.1) + `INVITE_ACCEPT_ROUTE_PREFIXES` (4.1.2) + `isSelfAuthenticatedExemptRoute` (4.1.3), then AND the exemption into `shouldRedirectToSignInFromRoute` (4.1.4) + update its doc-comment.
+2. **`app/_layout.tsx`** — import `isSelfAuthenticatedExemptRoute` (4.2.1) + AND it into `nativeRedirectToSignIn` (4.2.2) + one-line comment.
+3. **Update `src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts`** — remove `/connect-partner-onboarding` (line 84) and `/stripe-onboarding-return` (line 86) from `AUTHED_ONLY_ROUTE_SAMPLES` (they are now exempt and would make T-2 fail). Leave `/accept-invite` (line 85) — it is NOT a real route, so it correctly STILL redirects; keep it as a negative control. Mark the edit `[TEST-MOD-APPROVED ORCH-1139]` with a one-line why.
+4. **Step-0.5 (a)** implementor happy-path test — new file (§ Regression).
+5. **Step-0.5 (b)** tester adversarial test — new file (§ Regression).
+6. **Closure invariant test** — new file (§ Regression).
+7. Run the jest suite (`coldLoadAuthGates`, the 1115 test, `androidWebOnlyConnectRoutes`, the three new files) — all green; then prove fails-on-revert per §9 regression.
+
+---
+
+## 10. Regression prevention (fails-on-revert contract)
+
+### Step-0.5 (a) — implementor happy-path test
+**File:** `mingla-business/src/utils/__tests__/orch_1139_connect_seller_route_allowlist.test.ts` (mirrors the 1115 test's location + shape).
+**Imports:** `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES`, `INVITE_ACCEPT_ROUTE_PREFIXES`, `isSelfAuthenticatedExemptRoute`, `shouldRedirectToSignInFromRoute` from `../coldLoadAuthGates`.
+**Asserts:** T-A1/A2/A3 (each exempt route + sub-path → redirect `false`), T-A4 (private routes still `true`), T-A5/A6 (logged-in + warming → `false`), plus structural: each constant defined exactly once; `_layout.tsx` consumes `isSelfAuthenticatedExemptRoute`; the web predicate ANDs `!isSelfAuthenticatedExemptRoute(pathname)`.
+**Fails-on-revert:** delete the `&& !isSelfAuthenticatedExemptRoute(pathname)` clause from `shouldRedirectToSignInFromRoute` → T-A1/A2/A3 flip to `true` and FAIL, while T-A4 stays `true` and PASSES — proving the new allowlist (not a blanket change) is what suppresses the redirect. Restore → all PASS.
+
+### Step-0.5 (b) — tester adversarial test (DIFFERENT angle: segment-safety / traversal)
+**File:** `mingla-business/src/utils/__tests__/orch_1139_connect_route_segment_safety.test.ts`.
+**Asserts:** T-B1/B2/B3 (near-miss suffix, path-traversal prefix, invite lookalike → `isSelfAuthenticatedExemptRoute` `false` AND `shouldRedirectToSignInFromRoute` STILL `true`), T-B4 (null/empty/whitespace → `false`), T-B5 (trailing-slash + bare both `true`).
+**Fails-on-revert:** if the implementor uses a loose `includes`/`startsWith` without the segment-safe `base + "/"` boundary, T-B1/B2/B3 flip to `false`-exempt (wrongly exempting `/connect-onboarding-evil` and `/x/connect-onboarding`) and FAIL — proving the match is segment-safe, not a substring match. This is the tester's independent adversarial gate; it must be a SEPARATE file from (a) and written by tester, not implementor.
+
+### Closure invariant test (I-PROPOSED-1139-ROUTE-GATE-CLOSURE)
+**File:** `mingla-business/__tests__/orch_1139_route_gate_closure.test.ts` (sits alongside `androidWebOnlyConnectRoutes.test.ts`, which is the route-enumeration precedent).
+**Mechanism:**
+1. Enumerate top-level routes: `fs.readdirSync('mingla-business/app')` → for each `*.tsx`/`*.web.tsx` directly in `app/`, derive the route name by stripping `.web.tsx`/`.tsx` (dedupe `.tsx`+`.web.tsx` pairs); for each immediate SUBDIRECTORY, the dir name IS the route segment. EXCLUDE the special files `_layout`, `+html`, `+not-found`, `__styleguide` (Expo-router internals / dev-only).
+2. Build the classification union from the actual exported constants: `GATED_DEFAULT` = the explicit gated set the test hardcodes (`(tabs)`, `account`, `ari`, `auth`, `b`*, `booking`*, `brand`, `checkout`*, `checkout-experience`*, `checkout-trip`*, `e`*, `event`, `exp`*, `experience`, `o`*, `partner`, `support`, `t`*, `trip`, `venue`, `index`, `notifications`) — where `*` routes are ALSO buyer-public but are gated-by-default at the directory level and exempted at the deeper buyer path; the test classifies by the buyer-prefix membership for those. To avoid double-counting: a route is "buyer-exempt" iff its `/segment/` is in `PUBLIC_BUYER_ROUTE_PREFIXES`, "connect-exempt" iff in `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES`, "invite-exempt" iff in `INVITE_ACCEPT_ROUTE_PREFIXES`, else "gated-default".
+3. Assert: every enumerated route maps to EXACTLY ONE bucket (no route unclassified, no route in two exemption sets). Build an explicit expected-classification map in the test and assert the live enumeration equals it.
+**Where it lives + why:** `mingla-business/__tests__/` (top-level jest dir; same place as the existing connect-route enumeration test, so the route-listing fixtures stay together).
+**Fails-on-revert:** (T-C2) removing a connect prefix from the constant moves that route from "connect-exempt" to "gated-default", which contradicts the expected map → FAIL. Adding a new file to `app/` without classifying it → the enumeration finds an unmapped route → FAIL. Restore → PASS.
+**Caveat for the implementor:** the closure test reads the live `app/` directory, so it is sensitive to new routes. That is the POINT (it forces classification), but the implementor must seed the expected-map with the CURRENT inventory in §5 so the test is green on first run. If a route in §5 is missed, the test will redden — that is the safety net working.
+
+---
+
+## 11. Open questions
+
+None. Seth locked the scope (connect-seller routes + invite routes folded in) on 2026-06-15. The only judgment calls — separate constants vs. one combined (→ two distinct constants), and whether `/stripe-onboarding-return` is exempted (→ yes, it exists and self-redirects) — are resolved above with evidence.
+
+---
+
+## 12. Downstream routing
+
+**Next = mingla-implementor (business side).** Then mingla-tester (writes the Step-0.5 (b) adversarial test independently + runs device SC-4/SC-5). Then mingla-orchestrator CLOSE (flips `I-PROPOSED-1139-ROUTE-GATE-CLOSURE` to ACTIVE, registers in `INVARIANT_REGISTRY.md`, World-Map sync).
+
+`Working tree: ~/Desktop/mingla-orchs/ORCH-1139-[stripe-connect-route-gate]/ on branch ORCH-1139-stripe-connect-route-gate` (rebased onto origin/main, 0 behind).
+
+---
+
+## Allowlist (implementor MAY change ONLY these)
+
+1. `mingla-business/src/utils/coldLoadAuthGates.ts` — add 2 constants + 1 matcher + AND the exemption into `shouldRedirectToSignInFromRoute`.
+2. `mingla-business/app/_layout.tsx` — import + AND the exemption into `nativeRedirectToSignIn`.
+3. `mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts` — remove the two now-exempt samples from `AUTHED_ONLY_ROUTE_SAMPLES` only (`[TEST-MOD-APPROVED ORCH-1139]`).
+4. **CREATE** `mingla-business/src/utils/__tests__/orch_1139_connect_seller_route_allowlist.test.ts` (implementor happy-path).
+5. **CREATE** `mingla-business/__tests__/orch_1139_route_gate_closure.test.ts` (closure invariant).
+6. (tester) **CREATE** `mingla-business/src/utils/__tests__/orch_1139_connect_route_segment_safety.test.ts` (adversarial — tester writes this independently).
+
+## DO-NOT-TOUCH
+
+- `PUBLIC_BUYER_ROUTE_PREFIXES` / `isPublicBuyerRoute` (buyer allowlist — unchanged).
+- `src/utils/paidPublishGuards.ts` `brandStripeOnboardingRoute` + all CTA routing.
+- `src/components/brand/BrandOnboardView.tsx` (the `WebBrowser.openAuthSessionAsync` call).
+- `supabase/functions/brand-stripe-onboard/` and every `brand-stripe-*` / connect edge function.
+- All connect-page component bodies (`ConnectOnboardingBody.web.tsx`, the native fallbacks, `connect-*.tsx`/`.web.tsx` route files, `connect-tax-registrations/`).
+- `metro.config.js`, `stripeConnectNativeStub.js`, `androidWebOnlyConnectRoutes.test.ts` (META-ORCH-0972 quarantine).
+- The COMMS-0021 copy-rename file set.
+- `app-mobile/` (consumer app — unaffected).
+
+Anything outside the allowlist → **stop-and-amend** (request a SPEC amendment); never silently widen.

--- a/mingla-business/__tests__/orch_1139_route_gate_closure.test.ts
+++ b/mingla-business/__tests__/orch_1139_route_gate_closure.test.ts
@@ -1,0 +1,187 @@
+/**
+ * ORCH-1139 [stripe-connect-route-gate] — ROUTE-GATE CLOSURE invariant.
+ *
+ * Carries DRAFT invariant I-PROPOSED-1139-ROUTE-GATE-CLOSURE (flips ACTIVE at
+ * CLOSE). Every top-level route under `mingla-business/app/` MUST be classified
+ * into EXACTLY ONE bucket: gated-by-default, or one of the three exemption sets
+ * (buyer / connect-seller / invite). A new route added to `app/` that is not
+ * classified FAILS the build — converting "a new route silently inherits
+ * redirect-to-sign-in" (the exact mechanism behind BOTH ORCH-1115 and ORCH-1139)
+ * from a latent P0 into a CI failure.
+ *
+ * Mechanism:
+ * 1. Enumerate top-level routes from the live `app/` dir: each `*.tsx`/`*.web.tsx`
+ *    directly in `app/` (dedupe `.tsx`+`.web.tsx` pairs), plus each immediate
+ *    SUBDIRECTORY (the dir name IS the route segment). Exclude Expo-router
+ *    internals / dev-only files (`_layout`, `+html`, `+not-found`, `__styleguide`).
+ * 2. Classify each route via membership in the actual exported constants:
+ *    connect-exempt iff `/route` in SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES,
+ *    invite-exempt iff in INVITE_ACCEPT_ROUTE_PREFIXES, buyer-exempt iff
+ *    `/route/` in PUBLIC_BUYER_ROUTE_PREFIXES, else gated-default.
+ * 3. Assert the live classification equals the SEEDED expected map (§5 inventory)
+ *    AND every route lands in exactly one bucket.
+ *
+ * FAILS ON REVERT (T-C2): removing a connect prefix from the constant reclassifies
+ * that route connect-exempt → gated-default, contradicting the expected map →
+ * FAIL. Adding a new file to `app/` without seeding it here → the live
+ * enumeration finds an unmapped route → FAIL. Restore → PASS.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  INVITE_ACCEPT_ROUTE_PREFIXES,
+  PUBLIC_BUYER_ROUTE_PREFIXES,
+  SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES,
+} from "../src/utils/coldLoadAuthGates";
+
+// __dirname = mingla-business/__tests__ → up 1 = mingla-business.
+const APP_DIR = path.resolve(__dirname, "..", "app");
+
+// Expo-router internals + dev-only files that are NOT user-facing routes.
+const NON_ROUTE_FILES = new Set([
+  "_layout",
+  "+html",
+  "+not-found",
+  "__styleguide",
+]);
+
+type Bucket =
+  | "gated-default"
+  | "buyer-exempt"
+  | "connect-seller-exempt"
+  | "invite-exempt";
+
+// Strip the no-trailing-slash form of each prefix into a Set of bare segments.
+const bareSet = (prefixes: readonly string[]): Set<string> =>
+  new Set(
+    prefixes.map((p) =>
+      p.endsWith("/") && p.length > 1 ? p.slice(0, -1) : p,
+    ),
+  );
+
+const CONNECT = bareSet(SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES);
+const INVITE = bareSet(INVITE_ACCEPT_ROUTE_PREFIXES);
+const BUYER = bareSet(PUBLIC_BUYER_ROUTE_PREFIXES);
+
+const classify = (route: string): Bucket[] => {
+  const p = `/${route}`;
+  const buckets: Bucket[] = [];
+  if (CONNECT.has(p)) buckets.push("connect-seller-exempt");
+  if (INVITE.has(p)) buckets.push("invite-exempt");
+  if (BUYER.has(p)) buckets.push("buyer-exempt");
+  if (buckets.length === 0) buckets.push("gated-default");
+  return buckets;
+};
+
+// Live enumeration of top-level routes.
+const enumerateRoutes = (): string[] => {
+  const entries = fs.readdirSync(APP_DIR, { withFileTypes: true });
+  const routes = new Set<string>();
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      routes.add(e.name);
+      continue;
+    }
+    if (!e.isFile()) continue;
+    const m = e.name.match(/^(.+?)(?:\.web)?\.tsx$/);
+    if (!m) continue;
+    const name = m[1];
+    if (NON_ROUTE_FILES.has(name)) continue;
+    routes.add(name);
+  }
+  return [...routes].sort();
+};
+
+// SEEDED expected classification — the verified §5 inventory at ORCH-1139 close.
+// Buyer prefixes here are SINGLE-LETTER / short segments that ALSO appear as
+// app/ subdirectories (e/ t/ b/ exp/ checkout/ checkout-trip/ checkout-experience/
+// o/ booking/) → those directories are the buyer-exempt routes.
+const EXPECTED: Record<string, Bucket> = {
+  // --- connect-seller-exempt (6) ---
+  "connect-onboarding": "connect-seller-exempt",
+  "connect-account-management": "connect-seller-exempt",
+  "connect-partner-onboarding": "connect-seller-exempt",
+  "connect-partner-account-management": "connect-seller-exempt",
+  "connect-tax-registrations": "connect-seller-exempt",
+  "stripe-onboarding-return": "connect-seller-exempt",
+  // --- invite-exempt (2) ---
+  "accept-brand-invitation": "invite-exempt",
+  "accept-scanner-invitation": "invite-exempt",
+  // --- buyer-exempt (9 — directory segments) ---
+  e: "buyer-exempt",
+  t: "buyer-exempt",
+  b: "buyer-exempt",
+  exp: "buyer-exempt",
+  checkout: "buyer-exempt",
+  "checkout-trip": "buyer-exempt",
+  "checkout-experience": "buyer-exempt",
+  o: "buyer-exempt",
+  booking: "buyer-exempt",
+  // --- gated-default (everything else) ---
+  "(tabs)": "gated-default",
+  account: "gated-default",
+  ari: "gated-default",
+  auth: "gated-default",
+  brand: "gated-default",
+  event: "gated-default",
+  experience: "gated-default",
+  partner: "gated-default",
+  support: "gated-default",
+  trip: "gated-default",
+  venue: "gated-default",
+  index: "gated-default",
+  notifications: "gated-default",
+};
+
+describe("ORCH-1139 T-C1 (closure) — every app/ route is classified into exactly one bucket", () => {
+  const liveRoutes = enumerateRoutes();
+
+  test("the live app/ route enumeration equals the seeded inventory (no unmapped route)", () => {
+    expect(liveRoutes.sort()).toEqual(Object.keys(EXPECTED).sort());
+  });
+
+  test.each(enumerateRoutes())(
+    "%s is classified into EXACTLY ONE bucket, matching the expected map",
+    (route) => {
+      const buckets = classify(route);
+      // Exactly one bucket — never double-counted across exemption sets.
+      expect(buckets).toHaveLength(1);
+      expect(EXPECTED[route]).toBeDefined();
+      expect(buckets[0]).toBe(EXPECTED[route]);
+    },
+  );
+
+  test("no route lives in two exemption sets simultaneously", () => {
+    for (const route of liveRoutes) {
+      const exemptHits = classify(route).filter(
+        (b) => b !== "gated-default",
+      );
+      expect(exemptHits.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("all 6 connect + 2 invite exempt routes resolve to real classifications", () => {
+    const connectRoutes = liveRoutes.filter(
+      (r) => classify(r)[0] === "connect-seller-exempt",
+    );
+    const inviteRoutes = liveRoutes.filter(
+      (r) => classify(r)[0] === "invite-exempt",
+    );
+    expect(connectRoutes.sort()).toEqual(
+      [
+        "connect-account-management",
+        "connect-onboarding",
+        "connect-partner-account-management",
+        "connect-partner-onboarding",
+        "connect-tax-registrations",
+        "stripe-onboarding-return",
+      ].sort(),
+    );
+    expect(inviteRoutes.sort()).toEqual(
+      ["accept-brand-invitation", "accept-scanner-invitation"].sort(),
+    );
+  });
+});

--- a/mingla-business/app/_layout.tsx
+++ b/mingla-business/app/_layout.tsx
@@ -77,6 +77,7 @@ import {
   AUTH_RESOLUTION_CEILING_MS,
   isAuthResolutionExpired,
   isPublicBuyerRoute,
+  isSelfAuthenticatedExemptRoute,
   isSignInRoute,
   isWebAuthResolving,
   shouldRedirectToSignInFromRoute,
@@ -353,12 +354,19 @@ function RootLayoutInner(): React.ReactElement {
   // today (business native serves none of these routes), but routing the
   // public-route exemption through the one shared helper keeps the allowlist in
   // exactly one place and hardens against a future native public route.
+  //
+  // ORCH-1139 [stripe-connect-route-gate]: ALSO exempt the SELF-AUTHENTICATING
+  // routes (`isSelfAuthenticatedExemptRoute` — Stripe-Connect seller routes +
+  // invite-accept routes). A no-op on native today (business native serves none
+  // of these), but keeping the exemption in the one shared helper hardens against
+  // a future native connect/invite route — same rationale as the ORCH-1115 note.
   const nativeRedirectToSignIn =
     !isWeb &&
     !loading &&
     user === null &&
     !isSignInRoute(pathname) &&
-    !isPublicBuyerRoute(pathname);
+    !isPublicBuyerRoute(pathname) &&
+    !isSelfAuthenticatedExemptRoute(pathname);
 
   // ORCH-1102 Wave 2 — BOUNDED-LOADING backstop at the UI gate. The AuthContext
   // hard ceiling (AUTH_RESOLUTION_HARD_CEILING_MS) releases `loading` if the

--- a/mingla-business/playwright/orch1139-connect-gate-runtime-probe.mjs
+++ b/mingla-business/playwright/orch1139-connect-gate-runtime-probe.mjs
@@ -1,0 +1,117 @@
+// ORCH-1139 SC-5 RUNTIME PROBE — sessionless connect-route gate.
+//
+// Drives a headless Chromium against the branch web export served SPA-fallback,
+// with NO auth token in storage, and observes whether each route is BOUNCED to
+// the sign-in welcome screen (the bug) or RENDERS its own route.
+//
+// Signal model:
+//   - A REDIRECTED (gated) route → the SPA navigates to `/` and mounts
+//     BusinessWelcomeScreen → the document body carries the welcome/sign-in
+//     copy AND the URL path collapses toward `/`.
+//   - An EXEMPT connect route (the fix) → the SPA stays on the connect path;
+//     the connect page mounts. With no valid Stripe `session=` it shows its OWN
+//     loading/error state — but crucially NOT the sign-in welcome screen, and
+//     the path is NOT bounced to `/`.
+//
+// The decisive, copy-independent assertion is the URL: a sessionless visit to
+// `/connect-onboarding` must NOT end up at `/` (redirected). We also capture the
+// rendered welcome-marker text as corroboration.
+import { chromium } from "playwright";
+
+const BASE = process.env.ORCH1139_BASE ?? "http://127.0.0.1:43139";
+
+// Welcome/sign-in screen markers (BusinessWelcomeScreen canonical copy).
+const SIGNIN_MARKERS = [
+  "Your Place Deserves to Be Found",
+  "Sign in",
+  "Sign In",
+  "Continue with",
+  "Log in",
+];
+
+const CASES = [
+  // EXEMPT (fix): must NOT bounce to `/`.
+  { route: "/connect-onboarding", expect: "exempt" },
+  { route: "/connect-account-management", expect: "exempt" },
+  { route: "/accept-brand-invitation", expect: "exempt" },
+  // CONTROL gated private route: MUST bounce to `/` (sign-in).
+  { route: "/account", expect: "redirected" },
+  { route: "/notifications", expect: "redirected" },
+  // CONTROL buyer route (ORCH-1115): must NOT bounce (regression guard).
+  { route: "/b/some-brand", expect: "exempt" },
+  // CONTROL near-miss lookalike: MUST bounce (segment-safety at runtime).
+  { route: "/connect-onboarding-evil", expect: "redirected" },
+];
+
+const run = async () => {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  let hardFail = false;
+
+  for (const c of CASES) {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (e) => pageErrors.push(String(e?.message ?? e)));
+
+    // Guarantee NO auth: clear storage before any app code runs.
+    await context.addInitScript(() => {
+      try { window.localStorage.clear(); } catch {}
+      try { window.sessionStorage.clear(); } catch {}
+    });
+
+    await page.goto(`${BASE}${c.route}`, { waitUntil: "networkidle", timeout: 30000 });
+    // Let the SPA hydrate + run the auth bootstrap + the redirect gate.
+    await page.waitForTimeout(3500);
+
+    const finalPath = await page.evaluate(() => window.location.pathname);
+    const bodyText = await page.evaluate(() => (document.body?.innerText ?? ""));
+    const showsSignIn = SIGNIN_MARKERS.some((m) => bodyText.includes(m));
+    const rootLen = await page.evaluate(() => {
+      const el = document.getElementById("root");
+      return el ? el.innerHTML.length : -1;
+    });
+    const hasAuthToken = await page.evaluate(() => {
+      try {
+        return Object.keys(window.localStorage).some(
+          (k) => /auth|sb-|supabase|session|access_token/i.test(k) &&
+            /access_token|refresh_token/i.test(window.localStorage.getItem(k) || ""),
+        );
+      } catch { return false; }
+    });
+
+    // "redirected" iff the final path collapsed to `/` (the welcome route).
+    const bouncedToRoot = finalPath === "/" || finalPath === "";
+    let ok;
+    if (c.expect === "redirected") {
+      ok = bouncedToRoot;
+    } else {
+      // exempt: must NOT bounce to `/`, AND must have rendered something.
+      ok = !bouncedToRoot && rootLen > 0;
+    }
+    if (!ok) hardFail = true;
+
+    results.push({
+      route: c.route,
+      expect: c.expect,
+      finalPath,
+      bouncedToRoot,
+      showsSignIn,
+      rootLen,
+      hasAuthToken,
+      pageErrors: pageErrors.length,
+      ok,
+    });
+    await context.close();
+  }
+
+  await browser.close();
+  console.log(JSON.stringify(results, null, 2));
+  console.log(hardFail ? "ORCH-1139 SC-5 PROBE: HARD FAIL" : "ORCH-1139 SC-5 PROBE: PASS");
+  process.exit(hardFail ? 1 : 0);
+};
+
+run().catch((e) => {
+  console.error("PROBE ERROR:", e);
+  process.exit(2);
+});

--- a/mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1115_anon_buyer_route_allowlist.test.ts
@@ -81,9 +81,13 @@ const AUTHED_ONLY_ROUTE_SAMPLES: string[] = [
   "/ari",
   "/support",
   "/notifications",
-  "/connect-partner-onboarding",
+  // [TEST-MOD-APPROVED ORCH-1139] /connect-partner-onboarding and
+  // /stripe-onboarding-return are now SELF-AUTHENTICATING exempt routes
+  // (ORCH-1139) → they correctly NO LONGER redirect, so removed from this
+  // authed-only sample. /accept-invite stays: it is NOT a real route (the real
+  // routes are /accept-brand-invitation + /accept-scanner-invitation), so it
+  // correctly STILL redirects — kept as a negative control.
   "/accept-invite",
-  "/stripe-onboarding-return",
 ];
 
 describe("ORCH-1115 T-1 (happy) — logged-out guest on a PUBLIC buyer route is NOT redirected", () => {

--- a/mingla-business/src/utils/__tests__/orch_1139_connect_route_segment_safety.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1139_connect_route_segment_safety.test.ts
@@ -1,0 +1,298 @@
+/**
+ * ORCH-1139 [Stripe setup redirects to business sign-in] — TESTER ADVERSARIAL
+ * (segment-safety / boundary attack). Step-0.5 (b) per SPEC §10.
+ *
+ * DIFFERENT ANGLE than the implementor's happy-path suite
+ * (`orch_1139_connect_seller_route_allowlist.test.ts`, which proves the 8 exempt
+ * routes + their sub-paths are NOT redirected and a handful of private routes
+ * STILL redirect). This suite attacks the SECURITY failure mode of the exemption
+ * matcher: the dangerous direction is a FALSE-POSITIVE — a crafted path that is
+ * NOT one of the 8 exempt routes (a near-miss lookalike, a traversal-prefixed
+ * path, a case variant, trailing junk, or a query-string-smuggled path) wrongly
+ * MATCHING `isSelfAuthenticatedExemptRoute` and thereby SUPPRESSING the sign-in
+ * redirect on a route that should have stayed gated.
+ *
+ * The exemption can only ever flip a redirect TRUE→FALSE, so a false-positive
+ * match means a genuinely-private/unknown route silently loses its sign-in gate.
+ * Every assertion below pins that:
+ *   (1) `isSelfAuthenticatedExemptRoute(x) === false` for the crafted path, and
+ *   (2) the COMPOSED predicate `shouldRedirectToSignInFromRoute` STILL returns
+ *       `true` for a logged-out web guest on that path.
+ *
+ * FAILS ON REVERT TO A LOOSE MATCHER: if the implementor had used a boundary-less
+ * `pathname.includes(prefix)` or `pathname.startsWith(prefix)` (without the
+ * `base + "/"` segment boundary), then `/connect-onboarding-evil`,
+ * `/connect-onboardingX`, `/accept-brand-invitationX`, and
+ * `/foo/connect-onboarding` (for `includes`) would wrongly match and these
+ * assertions would FLIP and FAIL. The SEGMENT_BOUNDARY block below re-derives the
+ * loose-matcher behavior inline and proves the production matcher diverges from
+ * it on exactly the boundary cases — so a regression to `includes`/bare
+ * `startsWith` reddens this suite.
+ *
+ * Tester-owned, append-only, on-branch, in the closing diff. It must PASS on the
+ * fix.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  INVITE_ACCEPT_ROUTE_PREFIXES,
+  SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES,
+  isSelfAuthenticatedExemptRoute,
+  shouldRedirectToSignInFromRoute,
+} from "../coldLoadAuthGates";
+
+const loggedOutOnWeb = {
+  isWeb: true,
+  loading: false,
+  hasUser: false,
+  hasStoredWebSession: false,
+};
+
+const ALL_EXEMPT_PREFIXES: readonly string[] = [
+  ...SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES,
+  ...INVITE_ACCEPT_ROUTE_PREFIXES,
+];
+
+/**
+ * Crafted paths that are NOT exempt routes and MUST therefore (a) NOT match the
+ * exemption matcher and (b) STILL redirect a logged-out guest to sign-in.
+ *
+ * These are the cases a loose `includes` / boundary-less `startsWith` would get
+ * WRONG.
+ */
+const MUST_NOT_MATCH: string[] = [
+  // --- near-miss SUFFIX (same start, extra chars past the segment boundary) ---
+  "/connect-onboarding-evil", // SPEC SC-3 named case
+  "/connect-onboardingX", // SPEC SC-3 named case
+  "/connect-onboarding-return-attacker", // looks like onboarding-return but isn't
+  "/connect-account-management-evil",
+  "/connect-partner-onboarding-evil",
+  "/connect-tax-registrations-evil",
+  "/stripe-onboarding-return-fake", // SPEC SC-3 named case
+  "/accept-brand-invitationX", // SPEC SC-3 named case
+  "/accept-brand-invitation-evil",
+  "/accept-scanner-invitationX",
+  "/accept-scanner", // shorter lookalike — not a real route
+
+  // --- TRAVERSAL / substring-in-the-middle (a loose `includes` would match) ---
+  "/x/connect-onboarding", // SPEC SC-3 named case
+  "/foo/connect-onboarding", // prefix-as-substring (SPEC mandate case)
+  "/foo/accept-scanner-invitation",
+  "/account/connect-onboarding", // private parent, exempt-looking tail
+  "/brand/123/connect-onboarding", // deep private path containing the token
+  "/notifications?next=/connect-onboarding", // smuggled in a query value
+  "/some-connect-onboarding-page", // token embedded mid-segment
+
+  // --- TRAILING JUNK that breaks the segment ---
+  "/connect-onboardingfoo", // no separator at all
+  "/accept-brand-invitationsuccess", // glued, no slash boundary
+
+  // --- pure unknown / private (control) ---
+  "/account",
+  "/(tabs)/home",
+  "/connect", // bare token, shorter than any prefix
+  "/accept", // bare token, shorter than any prefix
+];
+
+/**
+ * Paths that ARE the legitimate exempt routes in awkward-but-valid forms — these
+ * MUST match (proving the matcher is not over-tightened to the point of rejecting
+ * real arrivals).
+ */
+const MUST_MATCH: string[] = [
+  "/connect-onboarding", // bare
+  "/connect-onboarding/", // single trailing slash
+  "/connect-onboarding/step2", // real sub-path
+  "/accept-brand-invitation", // bare
+  "/accept-brand-invitation/", // trailing slash
+  "/accept-brand-invitation/success", // real sub-route
+  "/accept-scanner-invitation/", // trailing slash
+  "/stripe-onboarding-return", // @deprecated but live
+];
+
+describe("ORCH-1139 ADV-1 — near-miss SUFFIX lookalikes are NOT exempt and STILL redirect", () => {
+  const suffixCases = MUST_NOT_MATCH.filter(
+    (p) =>
+      p.startsWith("/connect") ||
+      p.startsWith("/stripe") ||
+      p.startsWith("/accept"),
+  );
+  test.each(suffixCases)(
+    "%s → isSelfAuthenticatedExemptRoute=false AND redirect=true",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(false);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1139 ADV-2 — traversal / substring-in-the-middle does NOT loosely match", () => {
+  const traversal = [
+    "/x/connect-onboarding",
+    "/foo/connect-onboarding",
+    "/foo/accept-scanner-invitation",
+    "/account/connect-onboarding",
+    "/brand/123/connect-onboarding",
+    "/notifications?next=/connect-onboarding",
+    "/some-connect-onboarding-page",
+  ];
+  test.each(traversal)(
+    "%s → isSelfAuthenticatedExemptRoute=false AND redirect=true",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(false);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1139 ADV-3 — every MUST_NOT_MATCH path is rejected by the matcher", () => {
+  test.each(MUST_NOT_MATCH)(
+    "%s → isSelfAuthenticatedExemptRoute === false",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1139 ADV-4 — case variants do NOT match (matcher is case-sensitive, real routes are lowercase)", () => {
+  // Expo-router route paths are lowercase; an uppercased variant is NOT a real
+  // route, so it must NOT be exempted (and must still redirect).
+  const caseVariants = [
+    "/Connect-Onboarding",
+    "/CONNECT-ONBOARDING",
+    "/Connect-Account-Management",
+    "/Accept-Brand-Invitation",
+    "/ACCEPT-SCANNER-INVITATION",
+  ];
+  test.each(caseVariants)(
+    "%s → isSelfAuthenticatedExemptRoute=false AND redirect=true",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(false);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1139 ADV-5 — query-string smuggling cannot turn a private route exempt", () => {
+  // A query string is part of the pathname string the gate could receive; an
+  // attacker appending ?session=/connect-onboarding to a private route must NOT
+  // flip it exempt. (The matcher does not strip query strings, but it also
+  // anchors on the path PREFIX — so the leading private segment governs.)
+  const smuggled = [
+    "/account?redirect=/connect-onboarding",
+    "/notifications?x=/accept-brand-invitation",
+    "/?next=/connect-onboarding",
+    "/brand/123?from=/stripe-onboarding-return",
+  ];
+  test.each(smuggled)(
+    "%s → isSelfAuthenticatedExemptRoute=false AND redirect=true",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(false);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+
+  // A LEGITIMATE exempt route WITH a trailing query string should still be
+  // exempt only if the bare path is exempt; the matcher matches the literal
+  // string, so "/connect-onboarding?session=abc" is one segment "/connect-
+  // onboarding?session=abc" which does NOT equal the base and does NOT start with
+  // base + "/". This is acceptable: at runtime usePathname() returns the path
+  // WITHOUT the query, so the gate sees "/connect-onboarding". We assert the
+  // documented behavior so a future refactor that changes query handling is
+  // caught.
+  test("query-bearing exempt path string (no path separator) is matched literally, not loosely", () => {
+    // "/connect-onboarding?session=abc": "?" is not "/", so this is NOT a
+    // sub-path of "/connect-onboarding" and must NOT match (boundary-safe).
+    expect(
+      isSelfAuthenticatedExemptRoute("/connect-onboarding?session=abc"),
+    ).toBe(false);
+  });
+});
+
+describe("ORCH-1139 ADV-6 — null/empty/whitespace inputs never match (no crash, no exemption)", () => {
+  test.each([null, undefined, "", "   ", "\t", "\n"])(
+    "%p → isSelfAuthenticatedExemptRoute === false",
+    (pathname) => {
+      expect(
+        isSelfAuthenticatedExemptRoute(pathname as unknown as string),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1139 ADV-7 — legitimate exempt routes (bare / trailing-slash / sub-path) DO match", () => {
+  test.each(MUST_MATCH)(
+    "%s → isSelfAuthenticatedExemptRoute=true AND redirect=false",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(true);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1139 ADV-8 — the production matcher DIVERGES from a loose includes/startsWith on the boundary cases (regression sentinel)", () => {
+  // Re-derive what a LOOSE matcher would do, then prove the production matcher
+  // disagrees on at least the boundary cases. If someone reverts the production
+  // matcher to a loose form, these expectations flip and FAIL.
+
+  const looseIncludes = (pathname: string): boolean =>
+    ALL_EXEMPT_PREFIXES.some((p) => pathname.includes(p));
+
+  const looseStartsWith = (pathname: string): boolean =>
+    ALL_EXEMPT_PREFIXES.some((p) => pathname.startsWith(p));
+
+  test("a loose `includes` WOULD wrongly match traversal/suffix cases that the production matcher rejects", () => {
+    // These are exactly the cases a boundary-less includes-matcher leaks.
+    const leakedByIncludes = [
+      "/x/connect-onboarding",
+      "/foo/connect-onboarding",
+      "/account/connect-onboarding",
+      "/connect-onboarding-evil", // includes "/connect-onboarding"
+      "/accept-brand-invitationX", // includes "/accept-brand-invitation"
+    ];
+    for (const p of leakedByIncludes) {
+      // The loose matcher leaks (true)...
+      expect(looseIncludes(p)).toBe(true);
+      // ...but the PRODUCTION matcher must NOT.
+      expect(isSelfAuthenticatedExemptRoute(p)).toBe(false);
+    }
+  });
+
+  test("a loose `startsWith` WOULD wrongly match suffix lookalikes that the production matcher rejects", () => {
+    const leakedByStartsWith = [
+      "/connect-onboarding-evil",
+      "/connect-onboardingX",
+      "/connect-onboardingfoo",
+      "/accept-brand-invitationX",
+      "/accept-brand-invitationsuccess",
+    ];
+    for (const p of leakedByStartsWith) {
+      expect(looseStartsWith(p)).toBe(true);
+      expect(isSelfAuthenticatedExemptRoute(p)).toBe(false);
+    }
+  });
+
+  test("on the LEGITIMATE bare + sub-path cases all three matchers agree (true) — proving divergence is only on the dangerous boundary", () => {
+    const legit = [
+      "/connect-onboarding",
+      "/connect-onboarding/step2",
+      "/accept-brand-invitation/success",
+    ];
+    for (const p of legit) {
+      expect(looseIncludes(p)).toBe(true);
+      expect(looseStartsWith(p)).toBe(true);
+      expect(isSelfAuthenticatedExemptRoute(p)).toBe(true);
+    }
+  });
+});

--- a/mingla-business/src/utils/__tests__/orch_1139_connect_seller_route_allowlist.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1139_connect_seller_route_allowlist.test.ts
@@ -1,0 +1,212 @@
+/**
+ * ORCH-1139 [Stripe setup redirects to business sign-in] — implementor happy-path.
+ *
+ * Root cause: ORCH-1102's route-agnostic root-layout sign-in redirect bounces
+ * EVERY web route without a Supabase web session to `/`. Its only escape hatch
+ * was `PUBLIC_BUYER_ROUTE_PREFIXES` (ORCH-1115), scoped to anon BUYER routes —
+ * never extended to the self-authenticating Stripe-Connect SELLER routes (opened
+ * by the native "Set up payments" CTA in a SESSIONLESS in-app browser) or the
+ * invite-accept routes. So a logged-in seller tapping "Connect bank" landed on
+ * the business sign-in wall instead of the Stripe onboarding form.
+ *
+ * The fix adds two distinct exemption sets —
+ * `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` (6 connect routes) and
+ * `INVITE_ACCEPT_ROUTE_PREFIXES` (2 invite routes) — plus the segment-safe
+ * matcher `isSelfAuthenticatedExemptRoute`, ANDed into
+ * `shouldRedirectToSignInFromRoute` (web) and `nativeRedirectToSignIn`
+ * (_layout.tsx native). Each class authenticates via an out-of-band URL
+ * credential (Stripe client_secret / invite token), NOT a Supabase session, so
+ * the exemption exposes no account data.
+ *
+ * FAILS ON REVERT: delete the `&& !isSelfAuthenticatedExemptRoute(pathname)`
+ * clause from `shouldRedirectToSignInFromRoute` → T-A1/A2/A3 flip to `true` and
+ * FAIL, while T-A4 (private routes) stays `true` and PASSES — proving the new
+ * allowlist (not a blanket change) is what suppresses the redirect. Restore →
+ * all PASS.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  INVITE_ACCEPT_ROUTE_PREFIXES,
+  SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES,
+  isSelfAuthenticatedExemptRoute,
+  shouldRedirectToSignInFromRoute,
+} from "../coldLoadAuthGates";
+
+// __dirname = mingla-business/src/utils/__tests__ → up 3 = mingla-business.
+const BUSINESS_ROOT = join(__dirname, "..", "..", "..");
+const businessFile = (relativePath: string): string =>
+  readFileSync(join(BUSINESS_ROOT, relativePath), "utf8");
+
+const loggedOutOnWeb = {
+  isWeb: true,
+  loading: false,
+  hasUser: false,
+  hasStoredWebSession: false,
+};
+
+// Every exempt route (bare), exactly as the native in-app browser / direct
+// browser visit would arrive.
+const EXEMPT_BARE_ROUTES: string[] = [
+  "/connect-onboarding",
+  "/connect-account-management",
+  "/connect-partner-onboarding",
+  "/connect-partner-account-management",
+  "/connect-tax-registrations",
+  "/stripe-onboarding-return",
+  "/accept-brand-invitation",
+  "/accept-scanner-invitation",
+];
+
+// A representative sub-path under each exempt route (Stripe / Expo may append a
+// segment); all must remain exempt via the segment-safe `base + "/"` clause.
+const EXEMPT_SUBPATH_ROUTES: string[] = [
+  "/connect-onboarding/step2",
+  "/connect-account-management/edit",
+  "/connect-partner-onboarding/return",
+  "/connect-partner-account-management/edit",
+  "/connect-tax-registrations/settings",
+  "/stripe-onboarding-return/done",
+  "/accept-brand-invitation/success", // the real sub-route
+  "/accept-scanner-invitation/done",
+];
+
+// Private routes that MUST still redirect a logged-out user (the allowlist did
+// not over-widen).
+const STILL_PRIVATE_ROUTES: string[] = [
+  "/account",
+  "/(tabs)/home",
+  "/brand/123",
+  "/notifications",
+];
+
+describe("ORCH-1139 T-A1 (happy) — logged-out on each exempt CONNECT/INVITE route (bare) is NOT redirected", () => {
+  test.each(EXEMPT_BARE_ROUTES)(
+    "%s → shouldRedirectToSignInFromRoute === false",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(true);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1139 T-A2 (happy) — logged-out on an exempt route + sub-path is NOT redirected", () => {
+  test.each(EXEMPT_SUBPATH_ROUTES)(
+    "%s → shouldRedirectToSignInFromRoute === false",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(true);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1139 T-A3 (happy) — each invite-accept route resolves exempt", () => {
+  test.each([
+    "/accept-brand-invitation",
+    "/accept-brand-invitation/success",
+    "/accept-scanner-invitation",
+  ])("%s → isSelfAuthenticatedExemptRoute === true", (pathname) => {
+    expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(true);
+    expect(
+      shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+    ).toBe(false);
+  });
+});
+
+describe("ORCH-1139 T-A4 (guard) — logged-out on a still-PRIVATE route STILL redirects", () => {
+  test.each(STILL_PRIVATE_ROUTES)(
+    "%s → shouldRedirectToSignInFromRoute === true (allowlist did NOT over-widen)",
+    (pathname) => {
+      expect(isSelfAuthenticatedExemptRoute(pathname)).toBe(false);
+      expect(
+        shouldRedirectToSignInFromRoute({ ...loggedOutOnWeb, pathname }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("ORCH-1139 T-A5 (regression) — logged-IN on an exempt route also does not redirect", () => {
+  test.each(EXEMPT_BARE_ROUTES)(
+    "%s with hasUser:true → no redirect",
+    (pathname) => {
+      expect(
+        shouldRedirectToSignInFromRoute({
+          isWeb: true,
+          loading: false,
+          hasUser: true,
+          hasStoredWebSession: true,
+          pathname,
+        }),
+      ).toBe(false);
+    },
+  );
+});
+
+describe("ORCH-1139 T-A6 (regression) — a warming session on an exempt route never redirects", () => {
+  const warming = {
+    isWeb: true,
+    loading: false,
+    hasUser: false,
+    hasStoredWebSession: true,
+  };
+  test.each(EXEMPT_BARE_ROUTES)("%s warming → no redirect", (pathname) => {
+    expect(
+      shouldRedirectToSignInFromRoute({ ...warming, pathname }),
+    ).toBe(false);
+  });
+});
+
+describe("ORCH-1139 T-A7 (single source of truth) — constants defined once; web + native consult the matcher", () => {
+  test("SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES contains exactly the 6 spec'd prefixes", () => {
+    expect([...SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES]).toEqual([
+      "/connect-onboarding",
+      "/connect-account-management",
+      "/connect-partner-onboarding",
+      "/connect-partner-account-management",
+      "/connect-tax-registrations",
+      "/stripe-onboarding-return",
+    ]);
+  });
+
+  test("INVITE_ACCEPT_ROUTE_PREFIXES contains exactly the 2 spec'd prefixes", () => {
+    expect([...INVITE_ACCEPT_ROUTE_PREFIXES]).toEqual([
+      "/accept-brand-invitation",
+      "/accept-scanner-invitation",
+    ]);
+  });
+
+  test("coldLoadAuthGates.ts defines each constant exactly once", () => {
+    const src = businessFile("src/utils/coldLoadAuthGates.ts");
+    expect(
+      (
+        src.match(
+          /export const SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES/g,
+        ) ?? []
+      ).length,
+    ).toBe(1);
+    expect(
+      (src.match(/export const INVITE_ACCEPT_ROUTE_PREFIXES/g) ?? []).length,
+    ).toBe(1);
+    expect(
+      (src.match(/export const isSelfAuthenticatedExemptRoute/g) ?? []).length,
+    ).toBe(1);
+  });
+
+  test("the web predicate ANDs in the self-authenticated exemption", () => {
+    const src = businessFile("src/utils/coldLoadAuthGates.ts");
+    expect(src).toContain("!isSelfAuthenticatedExemptRoute(pathname)");
+  });
+
+  test("the native redirect path in _layout.tsx also consults isSelfAuthenticatedExemptRoute", () => {
+    const layout = businessFile("app/_layout.tsx");
+    expect(layout).toContain("isSelfAuthenticatedExemptRoute");
+    expect(layout).toContain("!isSelfAuthenticatedExemptRoute(pathname)");
+  });
+});

--- a/mingla-business/src/utils/coldLoadAuthGates.ts
+++ b/mingla-business/src/utils/coldLoadAuthGates.ts
@@ -181,6 +181,98 @@ export const isPublicBuyerRoute = (
 };
 
 /**
+ * SELF-AUTHENTICATING STRIPE-CONNECT SELLER ROUTES — ORCH-1139.
+ *
+ * Exempt from the ORCH-1102 route-agnostic sign-in redirect. These are NOT
+ * anon-public buyer routes (do NOT add them to PUBLIC_BUYER_ROUTE_PREFIXES).
+ * They are served by the WEB bundle and opened by the native "Set up payments"
+ * CTA in a SESSIONLESS in-app browser (WebBrowser.openAuthSessionAsync), so they
+ * carry NO Supabase web session and the route-agnostic gate would bounce them
+ * to `/` (business sign-in) before the page can mount.
+ *
+ * CONSTITUTIONAL CAVEAT: this exemption is valid ONLY because each page carries
+ * its OWN out-of-band credential in the URL — the Stripe AccountSession
+ * client_secret (`?session=…`), minted by the auth-checked `brand-stripe-onboard`
+ * edge function — and authenticates itself against Stripe (ConnectOnboardingBody
+ * never reads a Supabase user). The exemption does NOT make seller account data
+ * public: the page renders nothing without a valid Stripe client_secret. NEVER
+ * add a route here that would instead read account data from an implicit Supabase
+ * session — that would be a real data exposure. (See ORCH-1139 F-2 / Q3.)
+ *
+ * Written WITHOUT a trailing slash; the matcher (`isSelfAuthenticatedExemptRoute`)
+ * normalizes each prefix to its no-trailing-slash `base` and matches segment-safe
+ * (`normalized === base || normalized.startsWith(base + "/")`), so the bare route
+ * (`/connect-onboarding`) AND any sub-path (`/connect-onboarding/foo`) match while
+ * a lookalike (`/connect-onboarding-evil`) does NOT.
+ */
+export const SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES = [
+  "/connect-onboarding", // app/connect-onboarding.web.tsx — Stripe Connect onboarding
+  "/connect-account-management", // app/connect-account-management.web.tsx
+  "/connect-partner-onboarding", // app/connect-partner-onboarding.web.tsx
+  "/connect-partner-account-management", // app/connect-partner-account-management.web.tsx
+  "/connect-tax-registrations", // app/connect-tax-registrations/index.web.tsx
+  "/stripe-onboarding-return", // app/stripe-onboarding-return.tsx — hosted-onboarding HTTPS relay
+] as const;
+
+/**
+ * INVITE-ACCEPT ROUTES — ORCH-1139 (D-1, Seth-folded-in 2026-06-15).
+ *
+ * Exempt from the sign-in redirect for the SAME reason as the connect routes:
+ * a logged-OUT invitee opening an emailed invite link must reach the accept
+ * page, not the sign-in wall. CONSTITUTIONAL CAVEAT: valid ONLY because each
+ * page carries its OWN out-of-band credential — the invite TOKEN in the URL —
+ * and performs its own authorization against that token. The exemption does NOT
+ * make any brand/scanner data public; the page resolves nothing without a valid
+ * invite token. Kept DISTINCT from the connect set and the buyer set so a
+ * reviewer can reason about each class independently.
+ *
+ * `/accept-brand-invitation` also covers `/accept-brand-invitation/success`
+ * (app/accept-brand-invitation/success.tsx) via the matcher's `base + "/"` clause.
+ */
+export const INVITE_ACCEPT_ROUTE_PREFIXES = [
+  "/accept-brand-invitation", // app/accept-brand-invitation.tsx (+ /success sub-route)
+  "/accept-scanner-invitation", // app/accept-scanner-invitation.tsx
+] as const;
+
+/**
+ * Is the current pathname a SELF-AUTHENTICATING exempt route — ORCH-1139?
+ *
+ * Pure, RN-import-free (same discipline as `isPublicBuyerRoute`). Returns true
+ * for any Stripe-Connect seller route OR invite-accept route — both classes
+ * authenticate via an out-of-band credential in the URL (Stripe client_secret /
+ * invite token), NOT via a Supabase web session, so the route-agnostic sign-in
+ * redirect must NOT bounce them. Used to EXEMPT these routes from the redirect
+ * (the exemption can only ever turn a redirect OFF — never ON).
+ *
+ * Matching is IDENTICAL to `isPublicBuyerRoute` (segment-safe prefix match on the
+ * pathname only — no query string):
+ * - null / undefined / empty / whitespace-only → false.
+ * - Trim; strip a single trailing slash for `length > 1`.
+ * - For each prefix `P`, let `base = P` without any trailing slash. Match iff
+ *   `normalized === base` OR `normalized.startsWith(base + "/")` — the `+ "/"`
+ *   keeps it SEGMENT-SAFE (`/connect-onboarding-evil` does NOT match).
+ */
+export const isSelfAuthenticatedExemptRoute = (
+  pathname: string | null | undefined,
+): boolean => {
+  if (pathname === null || pathname === undefined) return false;
+  const trimmed = pathname.trim();
+  if (trimmed === "") return false;
+  // Strip a single trailing slash (but never the root "/" itself).
+  const normalized =
+    trimmed.length > 1 && trimmed.endsWith("/")
+      ? trimmed.slice(0, -1)
+      : trimmed;
+  return [
+    ...SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES,
+    ...INVITE_ACCEPT_ROUTE_PREFIXES,
+  ].some((prefix) => {
+    const base = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+    return normalized === base || normalized.startsWith(`${base}/`);
+  });
+};
+
+/**
  * REDIRECT-TO-SIGN-IN, loop-safe + public-buyer-aware — ORCH-1103 + ORCH-1115.
  *
  * Combines the ORCH-1102 `shouldRedirectToSignIn` decision with the
@@ -198,6 +290,14 @@ export const isPublicBuyerRoute = (
  * can ONLY flip a `true` to `false` (suppress a redirect on a public route) — it
  * NEVER causes a redirect that did not already fire, so no authed-only route's
  * behavior can change.
+ *
+ * ORCH-1139: ALSO returns false when the pathname is a SELF-AUTHENTICATING
+ * exempt route (`isSelfAuthenticatedExemptRoute` — Stripe-Connect seller routes
+ * `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` + invite-accept routes
+ * `INVITE_ACCEPT_ROUTE_PREFIXES`). Same "can only suppress, never cause"
+ * reasoning as the ORCH-1115 clause: these pages authenticate via an out-of-band
+ * URL credential (Stripe client_secret / invite token), not a Supabase web
+ * session, so the route-agnostic redirect must not bounce them to sign-in.
  */
 export const shouldRedirectToSignInFromRoute = ({
   isWeb,
@@ -214,7 +314,8 @@ export const shouldRedirectToSignInFromRoute = ({
 }): boolean =>
   shouldRedirectToSignIn({ isWeb, loading, hasUser, hasStoredWebSession }) &&
   !isSignInRoute(pathname) &&
-  !isPublicBuyerRoute(pathname);
+  !isPublicBuyerRoute(pathname) &&
+  !isSelfAuthenticatedExemptRoute(pathname);
 
 /**
  * The companion LOADING gate — ORCH-1102.


### PR DESCRIPTION
## ORCH-1139 — Stripe setup redirects to business sign-in

**Symptom (Seth):** Tapping "Set up payments" / "Connect bank" as a logged-in business user bounces to the business sign-in screen instead of opening the Stripe onboarding form.

**Root cause (forensics, git-pinned):** ORCH-1102 (`7c86708c2`, 2026-06-08) flipped the `mingla-business` web root layout to a route-agnostic "redirect everything not in `PUBLIC_BUYER_ROUTE_PREFIXES` to `/` sign-in" gate. The self-authenticating Stripe `/connect-*` seller pages — opened in an in-app browser that carries a Stripe credential, NOT the business Supabase session — were never allowlisted. Same defect family as ORCH-1115 (`ca352fdc2`, 2026-06-11), which fixed only the BUYER half; the seller half has been broken since 2026-06-08.

**Fix (allowlist-extension only):** two distinct, separate-from-buyer constants — `SELF_AUTHENTICATING_CONNECT_ROUTE_PREFIXES` (6 connect routes) + `INVITE_ACCEPT_ROUTE_PREFIXES` (2 invite routes) — matched by a segment-safe `isSelfAuthenticatedExemptRoute`, ANDed into BOTH the web redirect predicate and the native `_layout.tsx` redirect path. Each constant carries a constitutional caveat: the exemption is valid only because each page self-authenticates via its own URL credential (Stripe client_secret / invite token); it does NOT make seller data public. Invite routes (`/accept-brand-invitation`, `/accept-scanner-invitation`) folded in per Seth (same defect, logged-out invitees).

**Tests / gate:**
- Step 0.5(a) implementor happy-path `orch_1139_connect_seller_route_allowlist.test.ts` — fails-on-revert verified @ `e8d091da4`.
- Step 0.5(b) tester adversarial `orch_1139_connect_route_segment_safety.test.ts` — 73 near-miss/traversal/case/query-smuggling attacks; fails when the matcher is loosened to `includes`.
- Closure invariant `orch_1139_route_gate_closure.test.ts` (`I-PROPOSED-1139-ROUTE-GATE-CLOSURE`): every top-level `app/` route is in exactly one bucket (gated vs explicitly exempt) — prevents recurrence.
- 301 jest green / 7 suites; buyer routes unchanged; private routes still redirect.

**QA verdict:** CONDITIONAL PASS (P0:0 P1:0 P2:0 P3:1 P4:2). Runtime SC-4/SC-5 deferred to deploy (the native button targets the deployed web URL — fix cannot take effect or be device-verified until the web ships).

**Affected surfaces:** business iOS + Android (in-app browser) + business web preview. No migration, no edge deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)