### PR TITLE
ORCH-1140: honest Stripe-disconnect UX — reconcile brand-stripe-detach response contract [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1140_STRIPE_DETACH_RESPONSE_CONTRACT.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1140_STRIPE_DETACH_RESPONSE_CONTRACT.md
@@ -1,0 +1,199 @@
+# IMPLEMENTATION — ORCH-1140 — Stripe detach response-contract reconciliation
+
+- **ORCH-ID:** ORCH-1140
+- **Phase:** IMPLEMENT
+- **Date:** 2026-06-15
+- **Worktree:** `~/Desktop/mingla-orchs/ORCH-1140-[stripe-detach-contract]/` on branch `ORCH-1140-stripe-detach-contract`
+- **Commit:** `5b7ebb853`
+- **SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1140_STRIPE_DETACH_RESPONSE_CONTRACT.md`
+- **Status:** implemented and verified (server source + client unit verified; UX affordance implemented, runtime device verification deferred to tester per SPEC T-9/T-10)
+
+---
+
+## 1. Summary
+
+The business-app Stripe disconnect succeeded server-side but showed a red failure banner
+("missing detached_at in response"). The edge fn computed `detached_at` and wrote it to the DB
+but omitted it from the 200 body; the client hard-required it and threw. Fixed by:
+1. **Edge fn** now emits `detached_at` + a derived `stripe_delete_status`/`rejection_reason` on
+   BOTH 200 bodies (success + not_connected), replacing the dead `stripe_delete_error` wire field.
+2. **Client** hardened to treat any 200 with `status` `detached`/`not_connected` as success even if
+   `detached_at` is missing (drift guard), while still throwing on non-2xx / null / unrecognized bodies.
+3. **Confirm sheet** gains a `"done"` step: an honest "Disconnected" confirmation, plus the real
+   Stripe rejection reason (warm, informational) when Stripe rejected the account delete.
+
+No migration / schema / RLS. Audit payload, `action` selection, notification loop, and all non-200
+paths byte-unchanged. "Always succeed locally even if Stripe rejects" preserved.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Description | Verified | How | Commit |
+|----|-------------|----------|-----|--------|
+| SC-1 | Success 200 carries `detached_at` (ISO), `status:"detached"`, `stripe_delete_status` ∈ {succeeded,rejected,skipped} | ✓ | edge source + Deno structural test T-1 | 5b7ebb853 |
+| SC-2 | not_connected 200 carries `detached_at`, `status:"not_connected"`, `stripe_delete_status:"skipped"`, `rejection_reason:null` | ✓ | edge source + Deno test T-2 + client T-8 | 5b7ebb853 |
+| SC-3 | Mapping rejected/succeeded/skipped derived from `attemptedStripeDelete` + `stripeDeleteError` | ✓ | edge source (lines 117-128) + client T-4 | 5b7ebb853 |
+| SC-4 | DB UPDATE, `writeAudit` (incl. `after.stripe_delete_error`), `action`, notification loop unchanged; still 200 on Stripe rejection | ✓ | diff inspection (lines 79-115 untouched); existing Deno audit-contract test still passes | 5b7ebb853 |
+| SC-5 | Client resolves on success body with real values | ✓ | jest T-3/T-4/T-8 | 5b7ebb853 |
+| SC-6 | Client resolves on missing `detached_at`; throws on non-2xx / null / unrecognized | ✓ | jest T-5/T-6/T-7 + null-body test | 5b7ebb853 |
+| SC-7-iOS / SC-7-Android | Success shows "Disconnected" step + "Done"; no red banner | ✓ (impl) / runtime→tester | sheet `done` step (shared RN ⇒ both platforms) | 5b7ebb853 |
+| SC-8-iOS / SC-8-Android | Rejection shows real reason as warm informational note | ✓ (impl) / runtime→tester | `done` step rejection branch | 5b7ebb853 |
+| SC-9 | No input where a server-successful detach renders the red banner | ✓ | handleSubmit advances to `done` on resolve; banner only on catch (now only a real error) | 5b7ebb853 |
+
+---
+
+## 3. Files changed (all in commit 5b7ebb853)
+
+| File | +/- | Type |
+|------|-----|------|
+| `supabase/functions/brand-stripe-detach/index.ts` | +27/-3 | edge fn |
+| `supabase/functions/brand-stripe-detach/index.test.ts` | +36 | edge test (append) |
+| `mingla-business/src/services/brandStripeDetachService.ts` | +13/-3 | service |
+| `mingla-business/src/services/__tests__/brandStripeDetachService.orch1140.test.ts` | +136 (new) | client test |
+| `mingla-business/src/components/brand/BrandStripeDetachConfirmSheet.tsx` | +71/-3 | component |
+
+Exactly the 5 allowlisted files; nothing else staged.
+
+---
+
+## 4. Data-model changes applied
+
+None. No migration, no schema, no RLS, no index. `stripe_connect_accounts.detached_at` already
+exists and is written (unchanged at index.ts:79-83).
+
+---
+
+## 5. Edge functions touched
+
+| Function | `verify_jwt` to preserve | Change |
+|----------|--------------------------|--------|
+| `brand-stripe-detach` | preserve existing (auth via `requireUserId` in-body; do not change config) | response body of the two 200 paths only |
+
+**Deploy is orchestrator/operator-owned at CLOSE, from MERGED main** (not from this worktree).
+Expected post-deploy version > 187.
+
+---
+
+## 6. Regression tests added
+
+- **Edge structural (T-1/T-2):** appended 2 Deno tests to
+  `supabase/functions/brand-stripe-detach/index.test.ts` asserting the `status:"detached"` and
+  `status:"not_connected"` return blocks each contain `detached_at:` + `stripe_delete_status:`.
+- **Client behavioral (T-3..T-8 + null):** new
+  `mingla-business/src/services/__tests__/brandStripeDetachService.orch1140.test.ts` (7 tests).
+
+**fails-on-revert verified at 5b7ebb853** (both safeguards, via true LINE DELETION):
+- Safeguard A (edge): deleting `detached_at` + status fields from the success body →
+  `success 200 body carries detached_at + stripe_delete_status` FAILED (`AssertionError: success
+  200 body must include detached_at`). Restored → 3 passed | 0 failed.
+- Safeguard B (client): restoring the old strict `typeof data.detached_at !== "string"` throw →
+  `resolves even when detached_at is missing (drift hardening)` AND `throws on an unrecognized
+  response shape` FAILED (2 failed, 5 passed). Restored → 7 passed | 7 total.
+
+Passing-run output (restored state):
+- Deno: `ok | 3 passed | 0 failed`
+- Jest (ORCH-1140 file): `Tests: 7 passed, 7 total`
+- Adjacent stripe service suites (balances + account-session + orch1140): `3 passed, 11 tests`.
+
+---
+
+## 7. Old → New receipts
+
+### supabase/functions/brand-stripe-detach/index.ts
+- **Before:** not_connected 200 returned `{ ok, status:"not_connected" }`; success 200 returned
+  `{ ok, status:"detached", stripe_delete_error }`. Neither carried `detached_at`; neither carried
+  the client-expected `stripe_delete_status`/`rejection_reason`.
+- **Now:** captures `attemptedStripeDelete = !row.detached_at` before the UPDATE; derives
+  `stripeDeleteStatus` (skipped|rejected|succeeded) + `rejectionReason`; both 200 bodies carry
+  `detached_at` (string) + `stripe_delete_status` + `rejection_reason`. not_connected uses a
+  current server ISO timestamp + `"skipped"`.
+- **Why:** SC-1/2/3/9 — the missing `detached_at` was the root cause; the dead `stripe_delete_error`
+  wire field (D-1) is replaced by the contract the client already expects.
+- **Lines:** ~+27/-3. Audit/action/notification/non-200 paths untouched.
+
+### mingla-business/src/services/brandStripeDetachService.ts
+- **Before:** threw "missing detached_at in response" whenever `data.detached_at` wasn't a string —
+  i.e. on every real (compliant-pre-fix) success body.
+- **Now:** added `status?` to `RawDetachResponse`; treats `status` `detached`/`not_connected` as
+  success (falls back to a client ISO timestamp only if `detached_at` is absent); throws
+  "unexpected response shape" on any body without a recognized success status. `error`/`null`
+  throws unchanged.
+- **Why:** SC-5/SC-6 — defense-in-depth so a future shape drift can't resurrect the false failure,
+  without weakening the genuine-error path (Const #3).
+- **Lines:** ~+13/-3.
+
+### mingla-business/src/components/brand/BrandStripeDetachConfirmSheet.tsx
+- **Before:** on `mutateAsync` resolve it called `onDetached` + `onClose` and dismissed silently
+  (and in practice never fired — the throw always won). Step union was `confirm | submitting`.
+- **Now:** `Step` adds `"done"`; `handleSubmit` captures the result, sets it in state, advances to
+  `"done"`. New `handleDone` fires `onDetached` + `onClose`. The `done` step shows a check icon +
+  "Disconnected" header + "Stripe is disconnected for {brandName}.", plus a warm informational note
+  with the real `rejectionReason` when `stripeDeleteStatus === "rejected"`, and a single "Done"
+  button. Imports the `BrandStripeDetachResult` type. Added `doneWrap` + `doneHeaderRow` styles.
+- **Why:** SC-7/SC-8 — honest success confirmation + honest rejection reason (minimal, reuses
+  existing tokens/patterns; no redesign).
+- **Lines:** ~+71/-3.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Parity |
+|---------|----------|--------|
+| Consumer iOS | No (no detach UI) | n/a |
+| Consumer Android | No | n/a |
+| Buyer/anon Web | No | n/a |
+| **Business iOS** | **Yes** — honest "Disconnected" confirmation; no false banner | — |
+| **Business Android** | **Yes** — identical | Automatic (shared RN + shared edge fn) |
+| Admin Web | No (no admin detach path) | n/a |
+| Business Web preview | Yes-if-reachable | Automatic (shared RN) |
+
+---
+
+## 9. Smoke / verification result
+
+- Deno structural tests: 3 passed | 0 failed.
+- Deno `deno check` of `index.ts`: only a PRE-EXISTING `TS2345` on `writeAudit(supabase, …)` (a
+  `@supabase/supabase-js` version-mismatch in `serviceRoleClient()` typing, present on pristine
+  origin/main — verified by stashing the ORCH-1140 edits and re-running check on the unmodified
+  file). My change introduces no new type errors.
+- Business-app `tsc --noEmit`: zero errors in any of the 3 touched business files.
+- Jest ORCH-1140 client test: 7/7 pass; adjacent stripe suites 11/11.
+- Strict-grep gates run: idempotency-key (R), audit-log (S), notification-via-shared (V),
+  api-version (Q) — all 0 violations.
+- **No sim/device live-fire run** (backend response-shape + RN component); SPEC routes T-9/T-10
+  (live detach + rejection-path UX) to the tester. Labeled implemented, runtime-unverified for the
+  UX affordance per SPEC §11.
+
+---
+
+## 10. Known issues / deferred
+
+- No `[TRANSITIONAL]` code introduced.
+- UX runtime verification (T-9 success banner-absence, T-10 rejection note) deferred to tester per
+  SPEC (live-fire on Business iOS sim + device).
+
+---
+
+## 11. Operator action required (CLOSE-time, NOT implementor)
+
+1. **Migration `db push`:** none (no migration).
+2. **Edge deploy (from MERGED main, not this worktree):** redeploy `brand-stripe-detach`. Preserve
+   its `verify_jwt` config. Expected version > 187. The edge-fn change alone clears the banner.
+3. **Business-app OTA (runtime 1.0.0, per-platform, `npx -y eas-cli@latest update`, never
+   `--platform all`):** ships the service hardening + sheet `done` affordance + live Stripe-outcome
+   reporting to devices.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **D-pre-existing-TS2345:** `deno check supabase/functions/brand-stripe-detach/index.ts` reports a
+  `TS2345` on `writeAudit(supabase, …)` — a `@supabase/supabase-js` `SupabaseClient` generic-arity
+  mismatch in `serviceRoleClient()`'s type, present on pristine origin/main (NOT introduced by
+  ORCH-1140). Likely affects other Stripe edge fns using `serviceRoleClient()` + `writeAudit`. Out
+  of ORCH-1140 scope; flag for a future deps/types alignment ORCH.
+- **COMMS:** No ledger BLOCK/OPEN row targets ORCH-1140 / implementor / ALL. Only COMMS-0029 (WARN,
+  ORCH-1119/1120 trip-migration clobber) is open — unrelated to the Stripe detach flow; no ack
+  required, no new entry written.

--- a/mingla-business/src/components/brand/BrandStripeDetachConfirmSheet.tsx
+++ b/mingla-business/src/components/brand/BrandStripeDetachConfirmSheet.tsx
@@ -34,12 +34,13 @@ import {
   typography,
 } from "../../constants/designSystem";
 import { useBrandStripeDetach } from "../../hooks/useBrandStripeDetach";
+import type { BrandStripeDetachResult } from "../../services/brandStripeDetachService";
 
 import { Button } from "../ui/Button";
 import { Icon } from "../ui/Icon";
 import { Sheet } from "../ui/Sheet";
 
-type Step = "confirm" | "submitting";
+type Step = "confirm" | "submitting" | "done";
 
 export interface BrandStripeDetachConfirmSheetProps {
   visible: boolean;
@@ -60,6 +61,10 @@ export const BrandStripeDetachConfirmSheet: React.FC<
   const [step, setStep] = useState<Step>("confirm");
   const [confirmInput, setConfirmInput] = useState<string>("");
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // ORCH-1140: hold the resolved detach result so the "done" step can show an
+  // honest Stripe-side outcome (succeeded/skipped → clean; rejected → reason).
+  const [detachResult, setDetachResult] =
+    useState<BrandStripeDetachResult | null>(null);
 
   const detachMutation = useBrandStripeDetach();
 
@@ -69,6 +74,7 @@ export const BrandStripeDetachConfirmSheet: React.FC<
       setStep("confirm");
       setConfirmInput("");
       setSubmitError(null);
+      setDetachResult(null);
     }
   }, [visible, brandId]);
 
@@ -85,9 +91,12 @@ export const BrandStripeDetachConfirmSheet: React.FC<
     setStep("submitting");
     setSubmitError(null);
     try {
-      await detachMutation.mutateAsync({ brandId });
-      onDetached?.(brandId);
-      onClose();
+      // ORCH-1140: capture the result and advance to the "done" confirmation
+      // step (was: dismiss silently). onDetached/onClose now fire from the
+      // "Done" button so the user sees the success before the sheet closes.
+      const result = await detachMutation.mutateAsync({ brandId });
+      setDetachResult(result);
+      setStep("done");
     } catch (error) {
       // Const #3: surface the error inline; do not silently retry.
       setStep("confirm");
@@ -97,7 +106,14 @@ export const BrandStripeDetachConfirmSheet: React.FC<
           : "Couldn't disconnect. Tap Disconnect Stripe to try again.",
       );
     }
-  }, [canConfirm, brandId, detachMutation, onDetached, onClose, step]);
+  }, [canConfirm, brandId, detachMutation, step]);
+
+  // ORCH-1140: fire parent coordination + dismiss only after the user
+  // acknowledges the "Disconnected" confirmation.
+  const handleDone = useCallback((): void => {
+    if (brandId !== null) onDetached?.(brandId);
+    onClose();
+  }, [brandId, onDetached, onClose]);
 
   if (brandId === null || brandName === null) return null;
 
@@ -193,6 +209,45 @@ export const BrandStripeDetachConfirmSheet: React.FC<
             <Text style={styles.confirmHelper}>
               Severing the Stripe connection for {brandName}.
             </Text>
+          </View>
+        ) : null}
+
+        {step === "done" ? (
+          <View style={styles.doneWrap}>
+            <View style={styles.doneHeaderRow}>
+              <Icon name="check" size={20} color={semantic.success} />
+              <Text style={styles.title}>Disconnected</Text>
+            </View>
+            <Text style={styles.confirmHelper}>
+              Stripe is disconnected for {brandName}.
+            </Text>
+            {detachResult?.stripeDeleteStatus === "rejected" ? (
+              <View style={[styles.warnCard, styles.warnCardWarn]}>
+                <Icon name="flag" size={18} color={accent.warm} />
+                <View style={styles.warnTextCol}>
+                  <Text style={styles.warnTitleWarn}>
+                    Stripe account not fully closed
+                  </Text>
+                  <Text style={styles.warnBody}>
+                    {detachResult.rejectionReason !== null
+                      ? `Stripe couldn't fully close the account (${detachResult.rejectionReason}). Your payouts are still disconnected.`
+                      : "Stripe couldn't fully close the account. Your payouts are still disconnected."}
+                  </Text>
+                </View>
+              </View>
+            ) : null}
+            <View style={styles.actionRow}>
+              <View style={styles.actionCell}>
+                <Button
+                  label="Done"
+                  variant="primary"
+                  size="md"
+                  onPress={handleDone}
+                  fullWidth
+                  accessibilityLabel="Done"
+                />
+              </View>
+            </View>
           </View>
         ) : null}
       </ScrollView>
@@ -301,5 +356,14 @@ const styles = StyleSheet.create({
   },
   submittingWrap: {
     paddingVertical: spacing.xl,
+  },
+  doneWrap: {
+    paddingVertical: spacing.lg,
+  },
+  doneHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: spacing.xs,
   },
 });

--- a/mingla-business/src/services/__tests__/brandStripeDetachService.orch1140.adversarial.test.ts
+++ b/mingla-business/src/services/__tests__/brandStripeDetachService.orch1140.adversarial.test.ts
@@ -1,0 +1,142 @@
+/**
+ * ORCH-1140 — TESTER ADVERSARIAL angle (separate from the implementor's
+ * happy-path T-3..T-8 in brandStripeDetachService.orch1140.test.ts).
+ *
+ * The implementor proved: success resolves, a pre-baked rejection maps, a
+ * missing detached_at on the SUCCEEDED path resolves, not_connected resolves,
+ * and error/null/unrecognized throw.
+ *
+ * This file attacks the BOUNDARIES the implementor did NOT exercise, all of
+ * which protect the dual guarantee of this ORCH — "the false-failure is gone"
+ * AND "a real failure still surfaces honestly":
+ *
+ *  A. The Stripe-REJECTION + missing-field boundary: a 200 status:detached body
+ *     that is `rejected` but OMITS rejection_reason must STILL resolve with a
+ *     null reason (NO fabricated reason — Const #9). And a `rejected` body that
+ *     also omits detached_at must STILL resolve (hardening must not regress on
+ *     the rejection path, only the succeeded path).
+ *  B. The genuine-error-NOT-swallowed boundary: when supabase.functions.invoke
+ *     returns a non-null `error` (the real non-2xx signal) the wrapper MUST
+ *     throw EVEN IF `data` happens to carry a success-looking status:detached
+ *     body. A real failure must never be swallowed as success.
+ *  C. The not_connected drift boundary: not_connected with NO detached_at still
+ *     resolves benignly (the second latent 200 path).
+ *
+ * Fails-on-revert: restoring the old strict `typeof data.detached_at !== "string"`
+ * throw breaks A (the missing-field rejection/null cases throw), and the prior
+ * code had no status-aware branch so B's error path is the shared guard.
+ */
+import { describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    functions: {
+      invoke: jest.fn(),
+    },
+  },
+}));
+
+import { detachBrandStripe } from "../brandStripeDetachService";
+import { supabase } from "../supabase";
+
+const invoke = supabase.functions.invoke as jest.MockedFunction<
+  typeof supabase.functions.invoke
+>;
+
+describe("brandStripeDetachService — ORCH-1140 adversarial boundaries", () => {
+  // A1: rejected outcome with NO rejection_reason → resolve, reason === null.
+  // Must NOT fabricate a reason (Const #9) and must NOT false-fail (the whole
+  // point of the ORCH: a Stripe rejection is an HONEST partial success).
+  test("rejected body missing rejection_reason resolves with null reason (no fabrication)", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "detached",
+        detached_at: "2026-06-15T13:45:53.592Z",
+        stripe_delete_status: "rejected",
+        // rejection_reason intentionally ABSENT
+      },
+      error: null,
+    } as never);
+
+    const result = await detachBrandStripe("brand-1");
+    expect(result.stripeDeleteStatus).toBe("rejected");
+    expect(result.rejectionReason).toBeNull();
+    expect(result.detachedAt).toBe("2026-06-15T13:45:53.592Z");
+  });
+
+  // A2: rejected outcome that ALSO omits detached_at → still resolves (the
+  // hardening must hold on the rejection path, not only the succeeded path).
+  test("rejected body missing detached_at still resolves (hardening on rejection path)", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "detached",
+        stripe_delete_status: "rejected",
+        rejection_reason: "Your account has a positive balance.",
+        // detached_at intentionally ABSENT
+      },
+      error: null,
+    } as never);
+
+    const result = await detachBrandStripe("brand-1");
+    expect(result.stripeDeleteStatus).toBe("rejected");
+    expect(result.rejectionReason).toBe("Your account has a positive balance.");
+    expect(typeof result.detachedAt).toBe("string");
+    expect(result.detachedAt.length).toBeGreaterThan(0);
+  });
+
+  // B: a GENUINE error must win even when data looks like success. A non-2xx
+  // (error != null) carrying a status:detached body MUST still throw — never
+  // swallow a real failure as a successful detach.
+  test("non-null error throws even when data carries a success-looking body", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "detached",
+        detached_at: "2026-06-15T13:45:53.592Z",
+        stripe_delete_status: "succeeded",
+        rejection_reason: null,
+      },
+      error: new Error("FunctionsHttpError: edge function returned 500"),
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).rejects.toThrow(
+      "FunctionsHttpError",
+    );
+  });
+
+  // C: not_connected with NO detached_at (drift) still resolves benignly.
+  test("not_connected body missing detached_at still resolves benignly", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "not_connected",
+        // detached_at, stripe_delete_status both ABSENT
+      },
+      error: null,
+    } as never);
+
+    const result = await detachBrandStripe("brand-1");
+    expect(result.stripeDeleteStatus).toBe("skipped"); // ?? fallback, not thrown
+    expect(typeof result.detachedAt).toBe("string");
+  });
+
+  // D: an explicitly UNKNOWN status string (not detached/not_connected) must
+  // still throw — the success gate is exact, so a future renamed status can't
+  // silently pass as success.
+  test("an unknown status string throws (success gate is exact)", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "soft_detached_v2", // not a recognized success status
+        detached_at: "2026-06-15T13:45:53.592Z",
+      },
+      error: null,
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).rejects.toThrow(
+      "unexpected response shape",
+    );
+  });
+});

--- a/mingla-business/src/services/__tests__/brandStripeDetachService.orch1140.test.ts
+++ b/mingla-business/src/services/__tests__/brandStripeDetachService.orch1140.test.ts
@@ -1,0 +1,136 @@
+/**
+ * ORCH-1140 — brandStripeDetachService response-contract regression.
+ *
+ * Binds the §9 fails-on-revert contract: a 200 success body resolves (never
+ * false-fails a completed detach), and the client hardening tolerates a
+ * missing detached_at (future shape drift) while still throwing on genuine
+ * errors / unrecognized bodies.
+ */
+import { describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    functions: {
+      invoke: jest.fn(),
+    },
+  },
+}));
+
+import { detachBrandStripe } from "../brandStripeDetachService";
+import { supabase } from "../supabase";
+
+const invoke = supabase.functions.invoke as jest.MockedFunction<
+  typeof supabase.functions.invoke
+>;
+
+describe("brandStripeDetachService (ORCH-1140)", () => {
+  // T-3: client RESOLVES on a compliant success 200 body, returning real values.
+  test("resolves on a status:detached success body with detached_at", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "detached",
+        detached_at: "2026-06-15T13:45:53.592Z",
+        stripe_delete_status: "succeeded",
+        rejection_reason: null,
+      },
+      error: null,
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).resolves.toEqual({
+      detachedAt: "2026-06-15T13:45:53.592Z",
+      stripeDeleteStatus: "succeeded",
+      rejectionReason: null,
+    });
+  });
+
+  // T-4: a genuine Stripe rejection maps through to the client.
+  test("maps a Stripe rejection (status + reason)", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "detached",
+        detached_at: "2026-06-15T13:45:53.592Z",
+        stripe_delete_status: "rejected",
+        rejection_reason: "balance_remaining",
+      },
+      error: null,
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).resolves.toMatchObject({
+      stripeDeleteStatus: "rejected",
+      rejectionReason: "balance_remaining",
+    });
+  });
+
+  // T-5 (HARDENING — fails on revert): a status:detached 200 body that OMITS
+  // detached_at must still RESOLVE (client timestamp fallback). Reverting to
+  // the old strict `typeof data.detached_at !== "string"` throw breaks this.
+  test("resolves even when detached_at is missing (drift hardening)", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "detached",
+        stripe_delete_status: "succeeded",
+      },
+      error: null,
+    } as never);
+
+    const result = await detachBrandStripe("brand-1");
+    expect(typeof result.detachedAt).toBe("string");
+    expect(result.detachedAt.length).toBeGreaterThan(0);
+    expect(result.stripeDeleteStatus).toBe("succeeded");
+  });
+
+  // T-8: not_connected is benign success.
+  test("resolves benignly on a not_connected body", async () => {
+    invoke.mockResolvedValueOnce({
+      data: {
+        ok: true,
+        status: "not_connected",
+        detached_at: "2026-06-15T13:45:53.592Z",
+        stripe_delete_status: "skipped",
+        rejection_reason: null,
+      },
+      error: null,
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).resolves.toMatchObject({
+      stripeDeleteStatus: "skipped",
+    });
+  });
+
+  // T-6: a true edge-fn error still throws.
+  test("throws on a non-2xx edge-fn error", async () => {
+    invoke.mockResolvedValueOnce({
+      data: null,
+      error: new Error("boom"),
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).rejects.toThrow("boom");
+  });
+
+  // T-7: an unrecognized body (no success status) still throws.
+  test("throws on an unrecognized response shape", async () => {
+    invoke.mockResolvedValueOnce({
+      data: { ok: false },
+      error: null,
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).rejects.toThrow(
+      "unexpected response shape",
+    );
+  });
+
+  // null body still throws.
+  test("throws on a null body", async () => {
+    invoke.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    } as never);
+
+    await expect(detachBrandStripe("brand-1")).rejects.toThrow(
+      "returned null",
+    );
+  });
+});

--- a/mingla-business/src/services/brandStripeDetachService.ts
+++ b/mingla-business/src/services/brandStripeDetachService.ts
@@ -25,6 +25,7 @@ export interface BrandStripeDetachResult {
 }
 
 interface RawDetachResponse {
+  status?: "detached" | "not_connected" | string;
   detached_at?: string;
   stripe_delete_status?: StripeDeleteStatus;
   rejection_reason?: string | null;
@@ -41,11 +42,20 @@ export async function detachBrandStripe(
   if (data === null) {
     throw new Error("detachBrandStripe: edge fn returned null");
   }
-  if (typeof data.detached_at !== "string") {
-    throw new Error("detachBrandStripe: missing detached_at in response");
+  // ORCH-1140: a 200 with a recognized success status is SUCCESS even if a
+  // field is missing (defense-in-depth against future response-shape drift —
+  // the edge fn now always sends detached_at, but a missing field must never
+  // again read a completed, destructive detach as a failure). A genuinely
+  // malformed/failure body (no recognized success status) still throws;
+  // non-2xx / null bodies still throw above.
+  if (data.status !== "detached" && data.status !== "not_connected") {
+    throw new Error("detachBrandStripe: unexpected response shape");
   }
   return {
-    detachedAt: data.detached_at,
+    detachedAt:
+      typeof data.detached_at === "string"
+        ? data.detached_at
+        : new Date().toISOString(),
     stripeDeleteStatus: data.stripe_delete_status ?? "skipped",
     rejectionReason: data.rejection_reason ?? null,
   };

--- a/supabase/functions/brand-stripe-detach/index.test.ts
+++ b/supabase/functions/brand-stripe-detach/index.test.ts
@@ -9,3 +9,39 @@ Deno.test('brand-stripe-detach keeps V3 soft-delete and audit contract', async (
   assert(source.includes('dispatchNotification'));
   assertEquals(source.includes('.delete().eq("brand_id"'), false);
 });
+
+// ORCH-1140: every 200 body MUST carry detached_at (client guard) +
+// stripe_delete_status (honest Stripe outcome). Do not remove.
+Deno.test('brand-stripe-detach success 200 body carries detached_at + stripe_delete_status', async () => {
+  const source = await Deno.readTextFile(new URL('./index.ts', import.meta.url));
+
+  // Isolate the success return body (status: "detached") and assert the
+  // client-required fields are present inside it.
+  const successIdx = source.indexOf('status: "detached"');
+  assert(successIdx !== -1, 'success return (status: "detached") not found');
+  const successBlock = source.slice(successIdx, successIdx + 200);
+  assert(
+    successBlock.includes('detached_at:'),
+    'success 200 body must include detached_at (else the client false-fails a completed detach)',
+  );
+  assert(
+    successBlock.includes('stripe_delete_status:'),
+    'success 200 body must include stripe_delete_status (honest Stripe outcome)',
+  );
+});
+
+Deno.test('brand-stripe-detach not_connected 200 body carries detached_at', async () => {
+  const source = await Deno.readTextFile(new URL('./index.ts', import.meta.url));
+
+  const notConnectedIdx = source.indexOf('status: "not_connected"');
+  assert(notConnectedIdx !== -1, 'not_connected return not found');
+  const notConnectedBlock = source.slice(notConnectedIdx, notConnectedIdx + 200);
+  assert(
+    notConnectedBlock.includes('detached_at:'),
+    'not_connected 200 body must include detached_at',
+  );
+  assert(
+    notConnectedBlock.includes('stripe_delete_status:'),
+    'not_connected 200 body must include stripe_delete_status',
+  );
+});

--- a/supabase/functions/brand-stripe-detach/index.ts
+++ b/supabase/functions/brand-stripe-detach/index.ts
@@ -46,10 +46,21 @@ serve(async (req) => {
     return jsonResponse({ error: "internal_error" }, 500);
   }
   if (!row) {
-    return jsonResponse({ ok: true, status: "not_connected" });
+    // ORCH-1140: every 200 body MUST carry detached_at (client guard) +
+    // stripe_delete_status (honest Stripe outcome). Do not remove.
+    return jsonResponse({
+      ok: true,
+      status: "not_connected",
+      detached_at: new Date().toISOString(),
+      stripe_delete_status: "skipped",
+      rejection_reason: null,
+    });
   }
 
   const stripeAccountId = row.stripe_account_id as string;
+  // ORCH-1140: capture whether the Stripe-delete block runs BEFORE the UPDATE
+  // re-stamps detached_at, so the derived status is revert-proof.
+  const attemptedStripeDelete = !row.detached_at;
   let stripeDeleteError: string | null = null;
   if (!row.detached_at) {
     try {
@@ -103,9 +114,26 @@ serve(async (req) => {
     });
   }
 
+  // ORCH-1140: derive the honest Stripe-side outcome for the client.
+  // skipped  → the Stripe-delete block never ran (already detached / idempotent retry).
+  // rejected → the block ran and threw (stripeDeleteError holds the message).
+  // succeeded→ the block ran and the delete succeeded.
+  const stripeDeleteStatus: "succeeded" | "rejected" | "skipped" =
+    !attemptedStripeDelete
+      ? "skipped"
+      : stripeDeleteError
+      ? "rejected"
+      : "succeeded";
+  const rejectionReason =
+    stripeDeleteStatus === "rejected" ? stripeDeleteError : null;
+
+  // ORCH-1140: every 200 body MUST carry detached_at (client guard) +
+  // stripe_delete_status (honest Stripe outcome). Do not remove.
   return jsonResponse({
     ok: true,
     status: "detached",
-    stripe_delete_error: stripeDeleteError,
+    detached_at: detachedAt,
+    stripe_delete_status: stripeDeleteStatus,
+    rejection_reason: rejectionReason,
   });
 });


### PR DESCRIPTION
## ORCH-1140 — Stripe disconnect false-failure

**Symptom (Seth, business app):** "Disconnect Stripe from Night Market 2?" → typed brand name → tapped Disconnect → red banner **"Couldn't disconnect: detachBrandStripe: missing detached_at in response"**. The disconnect actually SUCCEEDED server-side; the error was a lie.

**Root cause (forensics, proven via live DB read):** the `brand-stripe-detach` edge fn fully detaches (severs the Stripe account, writes `detached_at`, audits, notifies) but its 200 success body and `not_connected` body OMIT the `detached_at` string the client requires, so `brandStripeDetachService.ts:44` throws and the UI paints red on a completed, hard-to-reverse action. Not a regression — mismatch existed since the feature was first written; only became reachable when the disconnect UI shipped. Second latent mismatch (Discovery D-1): server emitted `stripe_delete_error` but the client expected `stripe_delete_status`/`rejection_reason`, so a real Stripe rejection could never surface.

## Fix (no migration, no schema, no RLS)
- **`supabase/functions/brand-stripe-detach/index.ts`** — both 200 bodies carry string `detached_at`; emit `stripe_delete_status` ("succeeded"|"rejected"|"skipped") + `rejection_reason` per the SPEC mapping table (replaces dead `stripe_delete_error` on the wire; audit payload preserved). Non-200 paths unchanged.
- **`mingla-business/src/services/brandStripeDetachService.ts`** — client hardening: a 200 with status `detached`/`not_connected` resolves as success even if a field is missing, without weakening the genuine-error path.
- **`BrandStripeDetachConfirmSheet.tsx`** — minimal "Disconnected" success step + the real Stripe reason on rejection (no redesign).

## Evidence
- Forensics: `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1140_STRIPE_DETACH_MISSING_DETACHED_AT.md`
- SPEC: `Mingla_Artifacts/specs/SPEC_ORCH-1140_STRIPE_DETACH_RESPONSE_CONTRACT.md`
- TEST (CONDITIONAL PASS, 0 P0/P1/P2): `Mingla_Artifacts/reports/TEST_ORCH-1140_STRIPE_DETACH_RESPONSE_CONTRACT.md`
- Step 0.5: implementor happy-path (edge structural + client) fails-on-revert @ `5b7ebb853`; tester adversarial `brandStripeDetachService.orch1140.adversarial.test.ts` (rejection-mapping + missing-field-hardening) fails-on-revert @ `1b4c1379c`.

## CLOSE-time (post-merge)
1. Redeploy `brand-stripe-detach` edge fn from MERGED main (prod runs old body — clobber risk).
2. Business-app OTA (service + sheet), per-platform.
3. Flip I-PROPOSED-1140 DRAFT→ACTIVE.

Note: Night Market 2 is ALREADY disconnected server-side — no data cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)