### PR TITLE
ORCH-1141: re-scope ORCH-0863 C7 backend-files gate to ORCH-0863 PRs only

### DIFF
--- a/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
+++ b/.github/scripts/strict-grep/orch-0863-marketing-hub-phase-b.mjs
@@ -217,6 +217,32 @@ function checkOverviewServiceExists() {
 //          introduced by this ORCH (diff-aware against origin/main when available)
 // ---------------------------------------------------------------------------
 function checkNoNewBackendFiles() {
+  // C7 SCOPE GUARD (ORCH-1141, 2026-06-15). C7 exists solely to keep the
+  // ORCH-0863 Marketing Hub Phase B change frontend-only. ORCH-0863 merged
+  // 2026-05-17 (PR #126); since then this gate — which diffs the WHOLE
+  // origin/main...HEAD range against a hard-coded allowlist — has produced
+  // only FALSE POSITIVES, forcing ~50 unrelated backend ORCHs to register
+  // their files in the allowlist below (this file's own standing TODO calls
+  // for exactly this re-scope: "fire ONLY against PRs that cite ORCH-0863").
+  // Re-scope: run C7 ONLY when the PR actually carries ORCH-0863 work (its
+  // commit messages cite ORCH-0863). Any other PR skips C7 entirely. If commit
+  // scope is unknowable (no git / no origin/main), fall through to the legacy
+  // allowlist behavior so protection is never silently lost.
+  try {
+    const commitLog = execSync("git log origin/main..HEAD --format=%B", {
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    if (!/ORCH-0863/i.test(commitLog)) {
+      ok(
+        "C7: no-new-backend-files",
+        "skipped — PR does not carry ORCH-0863 marketing work (C7 is scoped to ORCH-0863 PRs only; ORCH-1141 re-scope)",
+      );
+      return;
+    }
+  } catch (_scopeErr) {
+    // Scope undeterminable — fall through to the legacy allowlist check.
+  }
   let diffOutput = "";
   try {
     diffOutput = execSync("git diff --name-only origin/main...HEAD", {


### PR DESCRIPTION
## ORCH-1141 — over-broad ORCH-0863 C7 gate blocks every backend PR

**Problem (architecture-flaw / CI-debt).** The `ORCH-0863: Marketing Hub Phase B invariants` strict-grep gate has a check `C7: no-new-backend-files` that diffs the **whole** `origin/main...HEAD` range and fails on **any** `supabase/functions/` or `supabase/migrations/` path not in a hard-coded allowlist. ORCH-0863 merged on 2026-05-17 (PR #126), so C7 now only ever produces **false positives** — every unrelated backend-touching ORCH since has been forced to append its files to the allowlist (~50 ORCH blocks and counting). This surfaced when ORCH-1140 (Stripe-disconnect response-contract fix) tripped C7 purely for touching `supabase/functions/brand-stripe-detach/`.

**Fix (the file's own standing TODO).** Re-scope C7 to fire **only when the PR actually carries ORCH-0863 work** — i.e. its commit messages cite `ORCH-0863`. Every other PR skips C7. If commit scope is undeterminable (no git / no `origin/main`), it falls through to the legacy allowlist behavior so protection is never silently lost. C1–C6 (the real marketing-content invariants) are unchanged and still run on every PR.

**Verification.** Gate self-test PASSES; live run on this PR (no backend files) is green. A genuine future ORCH-0863 PR still gets the full C7 check.

This unblocks ORCH-1140 and all future backend PRs without weakening any real invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)