### PR TITLE
G1 discover: fix cold-path stampede after gzip hot path (#426)

### DIFF
--- a/scripts/audit/discover-scale-contract.mjs
+++ b/scripts/audit/discover-scale-contract.mjs
@@ -34,18 +34,30 @@ const distributedSh = readFileSync(distributed, "utf8");
 
 const memoryPath = join(root, "supabase/functions/discover-merged-events/_memory-cache.ts");
 const bytesPath = join(root, "supabase/functions/discover-merged-events/_response-bytes.ts");
+const distributedPath = join(root, "supabase/functions/discover-merged-events/_distributed-cache.ts");
+const resolvePath = join(root, "supabase/functions/discover-merged-events/_resolve-entry.ts");
 const supabaseEdge = join(root, "scripts/load/lib/supabase-edge.js");
 const memory = readFileSync(memoryPath, "utf8");
 const bytes = readFileSync(bytesPath, "utf8");
+const distributedTs = readFileSync(distributedPath, "utf8");
+const resolveTs = readFileSync(resolvePath, "utf8");
 const supabaseEdgeJs = readFileSync(supabaseEdge, "utf8");
 
 const checks = [
   [index.includes("coalesceDiscoverBuild"), "L1 single-flight coalesce"],
   [index.includes("l1Get"), "L1 memory cache"],
-  [index.includes("discoverJsonResponse"), "pre-serialized hot path"],
+  [index.includes("resolveDiscoverEntry"), "coalesced resolve entry"],
+  [index.includes("serveDiscoverBytes"), "byte serve path"],
   [memory.includes("bytes"), "L1 byte cache"],
   [bytes.includes("encodeDiscoverResponse"), "gzip response bytes"],
+  [bytes.includes("bytesFromStoredGzip"), "gzip-only DB bytes"],
   [supabaseEdgeJs.includes('"Accept-Encoding": "gzip"'), "k6 gzip request header"],
+  [distributedTs.includes("export async function writeDbDiscoverCache"), "awaited cache write"],
+  [distributedTs.includes("return false"), "fail-closed build lock"],
+  [distributedTs.includes("waitForDbDiscoverCacheGzip"), "gzip poll waiter"],
+  [distributedTs.includes("POLL_ATTEMPTS = 200"), "20s poll cap"],
+  [resolveTs.includes("DiscoverOverloadedError"), "overload fast-fail"],
+  [resolveTs.includes("includeStale: true"), "stale DB fallback"],
   [index.includes("pg_discover_business_events") || readFileSync(join(root, "supabase/functions/discover-merged-events/_business-query.ts"), "utf8").includes("pg_discover_business_events"), "discover RPC"],
   [rpcSql.includes("pg_discover_business_events"), "RPC migration"],
   [scaleSql.includes("discover_merged_events_cache"), "response cache table"],

--- a/supabase/functions/discover-merged-events/__tests__/discover_scale_contract.test.ts
+++ b/supabase/functions/discover-merged-events/__tests__/discover_scale_contract.test.ts
@@ -1,4 +1,4 @@
-// ORCH-426 G1 — structural regression for discover scale optimizations.
+// ORCH-426 G1 — stampede-fix structural regression (P0+P1).
 
 import { assert } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 
@@ -6,21 +6,34 @@ const INDEX_URL = new URL("../index.ts", import.meta.url);
 const BUSINESS_URL = new URL("../_business-query.ts", import.meta.url);
 const MEMORY_URL = new URL("../_memory-cache.ts", import.meta.url);
 const BYTES_URL = new URL("../_response-bytes.ts", import.meta.url);
+const DISTRIBUTED_URL = new URL("../_distributed-cache.ts", import.meta.url);
+const RESOLVE_URL = new URL("../_resolve-entry.ts", import.meta.url);
 
 Deno.test("discover-merged-events uses L1 cache, RPC, and coalesced builds", async () => {
   const index = await Deno.readTextFile(INDEX_URL);
   const business = await Deno.readTextFile(BUSINESS_URL);
   const memory = await Deno.readTextFile(MEMORY_URL);
   const bytes = await Deno.readTextFile(BYTES_URL);
+  const distributed = await Deno.readTextFile(DISTRIBUTED_URL);
+  const resolve = await Deno.readTextFile(RESOLVE_URL);
 
   assert(index.includes("coalesceDiscoverBuild"), "expected coalesceDiscoverBuild");
   assert(index.includes("l1Get"), "expected l1Get");
-  assert(index.includes("discoverJsonResponse"), "expected pre-serialized response path");
+  assert(index.includes("resolveDiscoverEntry"), "expected resolveDiscoverEntry");
+  assert(index.includes("serveDiscoverBytes"), "expected serveDiscoverBytes");
   assert(
     business.includes("pg_discover_business_events"),
     "expected pg_discover_business_events RPC",
   );
   assert(memory.includes("inflight"), "expected single-flight inflight map");
   assert(bytes.includes("encodeDiscoverResponse"), "expected encodeDiscoverResponse");
+  assert(bytes.includes("bytesFromStoredGzip"), "expected bytesFromStoredGzip");
   assert(memory.includes("bytes"), "expected L1 byte cache");
+  assert(distributed.includes("export async function writeDbDiscoverCache"), "expected awaited cache write");
+  assert(distributed.includes("return false"), "expected fail-closed lock");
+  assert(distributed.includes("waitForDbDiscoverCacheGzip"), "expected gzip poll waiter");
+  assert(distributed.includes("POLL_ATTEMPTS = 200"), "expected 20s poll cap");
+  assert(resolve.includes("DiscoverOverloadedError"), "expected overload fast-fail");
+  assert(resolve.includes("includeStale: true"), "expected stale fallback");
+  assert(!resolve.includes("buildDiscoverMergedResponse") || resolve.includes("holdsLock"), "expected lock-gated origin");
 });

--- a/supabase/functions/discover-merged-events/__tests__/response_bytes.test.ts
+++ b/supabase/functions/discover-merged-events/__tests__/response_bytes.test.ts
@@ -1,7 +1,11 @@
 // ORCH-426 G1 — pre-serialized gzip response bytes for hot-path serving.
 
-import { assert } from "https://deno.land/std@0.190.0/testing/asserts.ts";
 import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import {
+  bytesFromStoredGzip,
   encodeDiscoverResponse,
   wantsGzip,
 } from "../_response-bytes.ts";
@@ -66,6 +70,13 @@ Deno.test("encodeDiscoverResponse produces smaller gzip payload", async () => {
   const { json, gzip } = await encodeDiscoverResponse(large);
   assert(gzip.length > 0);
   assert(gzip.length < json.length, "gzip should shrink repetitive JSON");
+});
+
+Deno.test("bytesFromStoredGzip avoids decompress on hot path", () => {
+  const gzip = new Uint8Array([0x1f, 0x8b, 0x08]);
+  const stored = bytesFromStoredGzip(gzip);
+  assertEquals(stored.gzip, gzip);
+  assertEquals(stored.json.length, 0);
 });
 
 Deno.test("wantsGzip respects Accept-Encoding header", () => {

--- a/supabase/functions/discover-merged-events/_distributed-cache.ts
+++ b/supabase/functions/discover-merged-events/_distributed-cache.ts
@@ -3,12 +3,17 @@
  */
 
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import type { DiscoverResponseBytes } from "./_response-bytes.ts";
-import { encodeDiscoverResponse, gzipDecompress } from "./_response-bytes.ts";
+import {
+  bytesFromStoredGzip,
+  encodeDiscoverResponse,
+  type DiscoverResponseBytes,
+} from "./_response-bytes.ts";
 import type { DiscoverMergedResponse } from "./_types.ts";
 
-const POLL_MS = 100;
-const POLL_ATTEMPTS = 450;
+export const POLL_MS = 100;
+/** 20s max wait — stays under k6 30s client timeout with headroom for encode + response. */
+export const POLL_ATTEMPTS = 200;
+export const SHORT_POLL_ATTEMPTS = 50;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -32,23 +37,25 @@ function base64ToBytes(encoded: string): Uint8Array {
   return out;
 }
 
-export async function readDbDiscoverCacheBytes(
+export async function readDbDiscoverCacheGzip(
   supabase: SupabaseClient,
   cacheKey: string,
+  options?: { includeStale?: boolean },
 ): Promise<DiscoverResponseBytes | null> {
-  const { data, error } = await supabase
+  let query = supabase
     .from("discover_merged_events_cache")
     .select("response_gzip_base64, response")
-    .eq("cache_key", cacheKey)
-    .gt("expires_at", new Date().toISOString())
-    .maybeSingle();
+    .eq("cache_key", cacheKey);
 
+  if (!options?.includeStale) {
+    query = query.gt("expires_at", new Date().toISOString());
+  }
+
+  const { data, error } = await query.maybeSingle();
   if (error || !data) return null;
 
   if (typeof data.response_gzip_base64 === "string" && data.response_gzip_base64.length > 0) {
-    const gzip = base64ToBytes(data.response_gzip_base64);
-    const json = await gzipDecompress(gzip);
-    return { json, gzip };
+    return bytesFromStoredGzip(base64ToBytes(data.response_gzip_base64));
   }
 
   if (!data.response) return null;
@@ -57,6 +64,14 @@ export async function readDbDiscoverCacheBytes(
     ...cached,
     meta: { ...cached.meta, fromCache: true },
   });
+}
+
+/** @deprecated Prefer readDbDiscoverCacheGzip — avoids jsonb parse on hot path. */
+export async function readDbDiscoverCacheBytes(
+  supabase: SupabaseClient,
+  cacheKey: string,
+): Promise<DiscoverResponseBytes | null> {
+  return readDbDiscoverCacheGzip(supabase, cacheKey);
 }
 
 export async function readDbDiscoverCache(
@@ -78,16 +93,27 @@ export async function readDbDiscoverCache(
   };
 }
 
-export async function waitForDbDiscoverCache(
+export async function waitForDbDiscoverCacheGzip(
   supabase: SupabaseClient,
   cacheKey: string,
-): Promise<DiscoverMergedResponse | null> {
-  for (let i = 0; i < POLL_ATTEMPTS; i++) {
-    const hit = await readDbDiscoverCache(supabase, cacheKey);
+  maxAttempts = POLL_ATTEMPTS,
+): Promise<DiscoverResponseBytes | null> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const hit = await readDbDiscoverCacheGzip(supabase, cacheKey);
     if (hit) return hit;
     await sleep(POLL_MS);
   }
   return null;
+}
+
+/** @deprecated Prefer waitForDbDiscoverCacheGzip. */
+export async function waitForDbDiscoverCache(
+  supabase: SupabaseClient,
+  cacheKey: string,
+): Promise<DiscoverMergedResponse | null> {
+  const bytes = await waitForDbDiscoverCacheGzip(supabase, cacheKey);
+  if (!bytes) return null;
+  return readDbDiscoverCache(supabase, cacheKey);
 }
 
 export async function tryDistributedBuildLock(
@@ -99,8 +125,8 @@ export async function tryDistributedBuildLock(
     p_ttl_seconds: 60,
   });
   if (error) {
-    console.warn("[discover-merged-events] build lock skipped:", error.message);
-    return true;
+    console.warn("[discover-merged-events] build lock denied:", error.message);
+    return false;
   }
   return data === true;
 }
@@ -114,31 +140,25 @@ export async function releaseDistributedBuildLock(
   });
 }
 
-export function writeDbDiscoverCache(
+export async function writeDbDiscoverCache(
   supabase: SupabaseClient,
   cacheKey: string,
   response: DiscoverMergedResponse,
   discoverStaleExpiresAt: () => string,
   bytes?: DiscoverResponseBytes,
-): void {
-  (async () => {
-    try {
-      await supabase.from("discover_merged_events_cache").upsert(
-        {
-          cache_key: cacheKey,
-          response,
-          response_gzip_base64: bytes ? bytesToBase64(bytes.gzip) : null,
-          fetched_at: new Date().toISOString(),
-          expires_at: discoverStaleExpiresAt(),
-        },
-        { onConflict: "cache_key" },
-      );
-      await supabase
-        .from("discover_merged_events_cache")
-        .delete()
-        .lt("expires_at", new Date().toISOString());
-    } catch (err) {
-      console.warn("[discover-merged-events] cache upsert error:", err);
-    }
-  })();
+): Promise<void> {
+  await supabase.from("discover_merged_events_cache").upsert(
+    {
+      cache_key: cacheKey,
+      response,
+      response_gzip_base64: bytes ? bytesToBase64(bytes.gzip) : null,
+      fetched_at: new Date().toISOString(),
+      expires_at: discoverStaleExpiresAt(),
+    },
+    { onConflict: "cache_key" },
+  );
+  await supabase
+    .from("discover_merged_events_cache")
+    .delete()
+    .lt("expires_at", new Date().toISOString());
 }

--- a/supabase/functions/discover-merged-events/_memory-cache.ts
+++ b/supabase/functions/discover-merged-events/_memory-cache.ts
@@ -2,11 +2,7 @@
  * ORCH-426 G1 — L1 in-memory cache + single-flight + stale-while-revalidate.
  */
 
-import {
-  encodeDiscoverResponse,
-  withCacheMeta,
-  type DiscoverResponseBytes,
-} from "./_response-bytes.ts";
+import type { DiscoverResponseBytes } from "./_response-bytes.ts";
 import type { DiscoverMergedResponse } from "./_types.ts";
 
 export const DISCOVER_L1_FRESH_MS = Number(
@@ -35,16 +31,6 @@ export function l1Get(key: string, now = Date.now()): L1Entry | null {
   return hit;
 }
 
-export async function l1Set(
-  key: string,
-  response: DiscoverMergedResponse,
-  now = Date.now(),
-): Promise<L1Entry> {
-  const cached = withCacheMeta(response);
-  const bytes = await encodeDiscoverResponse(cached);
-  return l1SetBytes(key, bytes, cached, now);
-}
-
 export function l1SetBytes(
   key: string,
   bytes: DiscoverResponseBytes,
@@ -63,16 +49,14 @@ export function l1SetBytes(
 
 export async function coalesceDiscoverBuild(
   key: string,
-  build: () => Promise<DiscoverMergedResponse>,
+  build: () => Promise<L1Entry>,
 ): Promise<L1Entry> {
   const existing = inflight.get(key);
   if (existing) return existing;
 
-  const promise = build()
-    .then((response) => l1Set(key, response))
-    .finally(() => {
-      inflight.delete(key);
-    });
+  const promise = build().finally(() => {
+    inflight.delete(key);
+  });
 
   inflight.set(key, promise);
   return promise;
@@ -80,7 +64,7 @@ export async function coalesceDiscoverBuild(
 
 export function refreshDiscoverInBackground(
   key: string,
-  build: () => Promise<DiscoverMergedResponse>,
+  build: () => Promise<L1Entry>,
 ): void {
   if (inflight.has(key)) return;
   void coalesceDiscoverBuild(key, build).catch((err) => {

--- a/supabase/functions/discover-merged-events/_resolve-entry.ts
+++ b/supabase/functions/discover-merged-events/_resolve-entry.ts
@@ -1,0 +1,104 @@
+/**
+ * ORCH-426 G1 — coalesced discover cache resolve (L1 miss / SWR refresh path).
+ */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { buildDiscoverMergedResponse, type BuildDiscoverContext } from "./_build-response.ts";
+import { discoverStaleExpiresAt } from "./_cache.ts";
+import {
+  readDbDiscoverCacheGzip,
+  releaseDistributedBuildLock,
+  SHORT_POLL_ATTEMPTS,
+  tryDistributedBuildLock,
+  waitForDbDiscoverCacheGzip,
+  writeDbDiscoverCache,
+} from "./_distributed-cache.ts";
+import { l1SetBytes, type L1Entry } from "./_memory-cache.ts";
+import { encodeDiscoverResponse, withCacheMeta } from "./_response-bytes.ts";
+import type { DiscoverMergedResponse } from "./_types.ts";
+
+export class DiscoverOverloadedError extends Error {
+  constructor() {
+    super("discover_overloaded");
+    this.name = "DiscoverOverloadedError";
+  }
+}
+
+function cachedResponseStub(): DiscoverMergedResponse {
+  return {
+    items: [],
+    meta: {
+      businessCount: 0,
+      ticketmasterCount: 0,
+      businessTotalAvailable: 0,
+      ticketmasterTotalAvailable: 0,
+      tmCalled: false,
+      tmError: null,
+      page: 1,
+      pageSize: 20,
+      fromCache: true,
+    },
+  };
+}
+
+function entryFromDbGzip(
+  cacheKey: string,
+  bytes: Awaited<ReturnType<typeof readDbDiscoverCacheGzip>>,
+  now: number,
+): L1Entry {
+  return l1SetBytes(cacheKey, bytes!, cachedResponseStub(), now);
+}
+
+export async function resolveDiscoverEntry(
+  supabase: SupabaseClient,
+  cacheKey: string,
+  buildCtx: BuildDiscoverContext,
+): Promise<L1Entry> {
+  const now = Date.now();
+
+  const dbBytes = await readDbDiscoverCacheGzip(supabase, cacheKey);
+  if (dbBytes) {
+    return entryFromDbGzip(cacheKey, dbBytes, now);
+  }
+
+  let holdsLock = await tryDistributedBuildLock(supabase, cacheKey);
+
+  if (!holdsLock) {
+    const waitedBytes = await waitForDbDiscoverCacheGzip(supabase, cacheKey);
+    if (waitedBytes) {
+      return entryFromDbGzip(cacheKey, waitedBytes, now);
+    }
+
+    const staleBytes = await readDbDiscoverCacheGzip(supabase, cacheKey, {
+      includeStale: true,
+    });
+    if (staleBytes) {
+      return entryFromDbGzip(cacheKey, staleBytes, now);
+    }
+
+    holdsLock = await tryDistributedBuildLock(supabase, cacheKey);
+    if (!holdsLock) {
+      const shortWait = await waitForDbDiscoverCacheGzip(
+        supabase,
+        cacheKey,
+        SHORT_POLL_ATTEMPTS,
+      );
+      if (shortWait) {
+        return entryFromDbGzip(cacheKey, shortWait, now);
+      }
+      throw new DiscoverOverloadedError();
+    }
+  }
+
+  try {
+    const built = await buildDiscoverMergedResponse(buildCtx);
+    const cached = withCacheMeta(built);
+    const bytes = await encodeDiscoverResponse(cached);
+    await writeDbDiscoverCache(supabase, cacheKey, built, discoverStaleExpiresAt, bytes);
+    return l1SetBytes(cacheKey, bytes, cached, now);
+  } finally {
+    if (holdsLock) {
+      await releaseDistributedBuildLock(supabase, cacheKey);
+    }
+  }
+}

--- a/supabase/functions/discover-merged-events/_response-bytes.ts
+++ b/supabase/functions/discover-merged-events/_response-bytes.ts
@@ -36,12 +36,37 @@ export function discoverJsonResponse(
   corsHeaders: Record<string, string>,
 ): Response {
   const gzip = wantsGzip(req);
-  return new Response(gzip ? bytes.gzip : bytes.json, {
+  const body = gzip && bytes.gzip.length > 0 ? bytes.gzip : bytes.json;
+  return new Response(body, {
     status: 200,
     headers: {
       ...corsHeaders,
       "Content-Type": "application/json; charset=utf-8",
-      ...(gzip ? { "Content-Encoding": "gzip" } : {}),
+      ...(gzip && bytes.gzip.length > 0 ? { "Content-Encoding": "gzip" } : {}),
+      "Cache-Control": "public, max-age=30, stale-while-revalidate=120",
+      Vary: "Accept-Encoding",
+    },
+  });
+}
+
+/** Serves cached bytes; decompresses gzip-only storage when client omits Accept-Encoding. */
+export async function serveDiscoverBytes(
+  req: Request,
+  bytes: DiscoverResponseBytes,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  if (wantsGzip(req) && bytes.gzip.length > 0) {
+    return discoverJsonResponse(req, bytes, corsHeaders);
+  }
+  if (bytes.json.length > 0) {
+    return discoverJsonResponse(req, bytes, corsHeaders);
+  }
+  const json = await gzipDecompress(bytes.gzip);
+  return new Response(json, {
+    status: 200,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json; charset=utf-8",
       "Cache-Control": "public, max-age=30, stale-while-revalidate=120",
       Vary: "Accept-Encoding",
     },
@@ -58,4 +83,9 @@ export async function gzipDecompress(input: Uint8Array): Promise<Uint8Array> {
   const stream = new Blob([input]).stream().pipeThrough(new DecompressionStream("gzip"));
   const buffer = await new Response(stream).arrayBuffer();
   return new Uint8Array(buffer);
+}
+
+/** Gzip bytes stored in DB — no decompress needed for gzip clients. */
+export function bytesFromStoredGzip(gzip: Uint8Array): DiscoverResponseBytes {
+  return { json: new Uint8Array(0), gzip };
 }

--- a/supabase/functions/discover-merged-events/index.ts
+++ b/supabase/functions/discover-merged-events/index.ts
@@ -14,28 +14,17 @@ import {
   isSubsetOf,
 } from "../_shared/eventTaxonomy.ts";
 import { parseLocalStartEndDateTime } from "../_shared/timezone.ts";
-import { buildDiscoverMergedResponse } from "./_build-response.ts";
 import {
   buildDiscoverCacheKey,
-  discoverStaleExpiresAt,
   type DiscoverCacheParams,
 } from "./_cache.ts";
 import {
-  readDbDiscoverCache,
-  readDbDiscoverCacheBytes,
-  releaseDistributedBuildLock,
-  tryDistributedBuildLock,
-  waitForDbDiscoverCache,
-  writeDbDiscoverCache,
-} from "./_distributed-cache.ts";
-import {
   coalesceDiscoverBuild,
   l1Get,
-  l1SetBytes,
   refreshDiscoverInBackground,
 } from "./_memory-cache.ts";
-import { discoverJsonResponse, encodeDiscoverResponse, withCacheMeta } from "./_response-bytes.ts";
-import type { DiscoverMergedResponse } from "./_types.ts";
+import { DiscoverOverloadedError, resolveDiscoverEntry } from "./_resolve-entry.ts";
+import { serveDiscoverBytes } from "./_response-bytes.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -69,10 +58,10 @@ interface DiscoverMergedRequest {
 const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 50;
 
-function jsonError(body: unknown, status = 200): Response {
+function jsonError(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: { ...corsHeaders, "Content-Type": "application/json", ...extraHeaders },
   });
 }
 
@@ -187,49 +176,24 @@ serve(async (req: Request): Promise<Response> => {
     sort: body.sort,
   };
 
-  const buildFresh = async (): Promise<DiscoverMergedResponse> => {
-    const dbCached = await readDbDiscoverCache(supabase, cacheKey);
-    if (dbCached) return dbCached;
-
-    const gotLock = await tryDistributedBuildLock(supabase, cacheKey);
-    if (!gotLock) {
-      const waited = await waitForDbDiscoverCache(supabase, cacheKey);
-      if (waited) return waited;
-      const lateHit = await readDbDiscoverCache(supabase, cacheKey);
-      if (lateHit) return lateHit;
-    }
-
-    try {
-      const built = await buildDiscoverMergedResponse(buildCtx);
-      const cached = withCacheMeta(built);
-      const bytes = await encodeDiscoverResponse(cached);
-      writeDbDiscoverCache(supabase, cacheKey, built, discoverStaleExpiresAt, bytes);
-      return built;
-    } finally {
-      await releaseDistributedBuildLock(supabase, cacheKey);
-    }
-  };
+  const resolveEntry = () => resolveDiscoverEntry(supabase, cacheKey, buildCtx);
 
   const now = Date.now();
   const l1Hit = l1Get(cacheKey, now);
   if (l1Hit) {
     if (now >= l1Hit.freshUntil) {
-      refreshDiscoverInBackground(cacheKey, buildFresh);
+      refreshDiscoverInBackground(cacheKey, resolveEntry);
     }
-    return discoverJsonResponse(req, l1Hit.bytes, corsHeaders);
-  }
-
-  const dbBytes = await readDbDiscoverCacheBytes(supabase, cacheKey);
-  if (dbBytes) {
-    const cached = JSON.parse(new TextDecoder().decode(dbBytes.json)) as DiscoverMergedResponse;
-    l1SetBytes(cacheKey, dbBytes, cached, now);
-    return discoverJsonResponse(req, dbBytes, corsHeaders);
+    return serveDiscoverBytes(req, l1Hit.bytes, corsHeaders);
   }
 
   try {
-    const entry = await coalesceDiscoverBuild(cacheKey, buildFresh);
-    return discoverJsonResponse(req, entry.bytes, corsHeaders);
+    const entry = await coalesceDiscoverBuild(cacheKey, resolveEntry);
+    return serveDiscoverBytes(req, entry.bytes, corsHeaders);
   } catch (e) {
+    if (e instanceof DiscoverOverloadedError) {
+      return jsonError({ error: "discover_overloaded" }, 503, { "Retry-After": "5" });
+    }
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.startsWith("db_error:")) {
       return jsonError(


### PR DESCRIPTION
## Summary
- Fix ~60% timeout regression after #475 gzip hot path by hardening the cold-path cache orchestration.
- Await DB cache writes before releasing the distributed build lock (was fire-and-forget).
- Fail-closed on lock RPC errors; cap waiter polls at 20s (under k6 30s timeout).
- After wait exhaust: serve stale gzip bytes from DB instead of stampeding parallel origin builds (RPC + TM).
- Coalesce DB reads inside `resolveDiscoverEntry`; serve gzip-only bytes without decompress on hot path.
- Fast-fail with `503` + `Retry-After` when overloaded instead of 30s hangs.

## Context
Post-#475 load tests showed 2xx p95 ~400ms (gzip hits work) but ~60% requests timed out at 30s due to async cache write + post-wait origin stampede.

## Test plan
- [ ] `node scripts/audit/discover-scale-contract.mjs`
- [ ] Deploy: `./scripts/load/deploy-discover-staging.sh`
- [ ] Phase 2: `./scripts/load/run-staging.sh discover 1000 5m` — target >99.5% checks, p95 < 2s
- [ ] Phase 3: `./scripts/load/run-distributed.sh discover 4 2500 5m` — target >99% checks, p95 < 2s