### PR TITLE
ORCH-1142: business notifications full-read (tap-to-expand) + soft-delete [deploy]

### DIFF
--- a/Mingla_Artifacts/design/ORCH-1142/DESIGN_ORCH-1142_NOTIF_READ_AND_DELETE.md
+++ b/Mingla_Artifacts/design/ORCH-1142/DESIGN_ORCH-1142_NOTIF_READ_AND_DELETE.md
@@ -1,0 +1,269 @@
+# DESIGN — ORCH-1142 — Business notifications: tap-to-expand full-read + swipe/clear soft-delete
+
+- **ORCH-ID:** ORCH-1142 [notif-read-delete]
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1142-[notif-read-delete]` on `ORCH-1142-notif-read-delete`.
+- **Surfaces:** Mingla **Business** iOS + Android + web preview (one shared route). NOT consumer, NOT admin.
+- **Author:** mingla-designer · **Date:** 2026-06-15 · **Mode:** SCREEN (extends an existing screen — does NOT redesign it).
+- **Binds to:** `SPEC_ORCH-1142_NOTIF_READ_AND_DELETE.md` §4.C / §4.D / §12; embed this before IMPLEMENT.
+- **Files this design governs (allowlist only):**
+  - `mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx`
+  - `mingla-business/app/notifications.tsx`
+  - (reuse, do NOT modify) `mingla-business/src/components/ui/ConfirmDialog.tsx`
+- **Token source of truth:** `mingla-business/src/constants/designSystem.ts`. Every value below resolves to a named token there. No raw values are introduced except the three deliberate sub-grid accents the existing screen already established (`UNREAD_RAIL_WIDTH=3`, `UNREAD_DOT=8`, `ICON_CIRCLE=40`) plus the swipe-panel geometry constants called out explicitly in §2.
+
+---
+
+## 0. Design stance (read first)
+
+The collapsed row is the contract. **It stays pixel-identical to today** — same `styles.card`, same 40×40 family-tinted icon circle, same 1-line title / 2-line body, same unread rail (3pt) + dot (8pt), same chevron, same family accents, same date buckets, same severity float. This work is **purely additive**: it layers (1) an expanded state revealed on tap, (2) a delete gesture/affordance, and (3) one header sibling action. Nothing in the resting list changes. If a diff alters the collapsed row's measured geometry, it is wrong.
+
+Three locked product decisions drive every choice below and must not be reversed:
+1. Tap = expand in place + mark-read; the deep-link demotes to a secondary "Open" button inside the expanded body.
+2. Per-row swipe-to-delete (right→left) + a header "Clear read" bulk sibling to "Mark all read"; both are recoverable soft-deletes.
+3. "Clear read" gets a lightweight confirm (`Clear N read notifications?`); per-row swipe-delete is immediate (no confirm).
+
+---
+
+## 1. THE EXPANDED CARD
+
+### 1.1 IA & moment
+The operator tapped a row whose title/body was truncated. Their intent is "tell me the whole thing, and let me act if I want." The expanded state answers both: it reveals the **full text first** (the primary job — read), and only then offers the **secondary "Open"** route off-screen (the optional job — act). Reading must never require leaving the inbox; acting is opt-in. Mark-read fires on the same first tap regardless of which they do.
+
+Multiple rows may be expanded at once (SPEC §10 Q1 default — accepted; no surprise auto-collapse of siblings). Expansion state is ephemeral component state.
+
+### 1.2 What changes between collapsed and expanded (and ONLY these)
+
+| Element | Collapsed (today, unchanged) | Expanded (new) |
+|---|---|---|
+| Title `<Text>` | `numberOfLines={1}` | **no `numberOfLines`** (full wrap). Same `styles.title` size/weight/color. Bold-token span + blocking-risk 700 variant keep their styling, just uncapped. |
+| Body `<Text>` | `numberOfLines={2}` | **no `numberOfLines`** (full wrap). Same `styles.body` (14 / lh 19 / 400 / `text.secondary`). |
+| Trailing chevron | `chevR`, 16, `text.quaternary`, vertically centered | **rotates to point down** (see §1.5). Same icon, size, color. |
+| "Open" button | absent | **present** when `n.deep_link !== null` (see §1.3). |
+| Card height | `minHeight: 72`, hugs 1+2 lines | grows to fit full content (see §1.4). |
+| `respondRow` (blocking-risk) | rendered as today | unchanged — "Respond" stays; "Open" is additive and sits as a SECOND button in the same action row (see §1.3). |
+| `backgroundColor` / `borderColor` / rail / dot / icon circle | per family + read state | **unchanged** — expansion does not restyle the surface. (Mark-read on first tap will flip an unread row to its read surface via the existing path; that is the existing behavior, not new.) |
+
+### 1.3 The "Open" secondary button — anatomy & placement
+
+A text-button affordance that mirrors the existing `respondBtn` grammar (the screen already has a labelled-CTA pattern — do not invent a filled button).
+
+- **Container:** a new `expandedActionRow` — `flexDirection:"row"`, `justifyContent:"flex-end"`, `gap: spacing.sm`, `marginTop: spacing.sm`. This is the same shape as `respondRow`. When a row is BOTH blocking-risk AND has a deep_link, "Respond" and "Open" share this one row, right-aligned, "Respond" leftmost, "Open" rightmost (Respond is the more urgent verb → it reads first L→R).
+- **Button label:** `Open`.
+- **Type:** `typography.buttonMd` (14 / lh 20 / 600 / ls 0.2).
+- **Color:** `accent.warm` (#eb7825) — the canonical brand action color. (Blocking-risk "Respond" keeps `semantic.warning`; the two colors intentionally differ — Open is a neutral navigate, Respond is a risk verb.)
+- **Leading glyph:** none required; if the implementor wants a glyph, reuse `chevR` 14 `accent.warm` to the RIGHT of the label (signals "goes somewhere"). Optional.
+- **Hit target:** `paddingVertical: spacing.sm` (8) + `paddingHorizontal: spacing.sm` (8) with the text's own 20pt line-height yields ≥36pt; add `hitSlop={{top:6,bottom:6,left:6,right:6}}` to clear ≥44pt. REQUIRED.
+- **Press feedback:** `opacity: 0.7` on `pressed` (matches `markAllPressed`).
+- **Action:** calls `onOpenDeepLink(n.deep_link, n)` — the SAME prop the route already passes. Plain tap on the card no longer navigates.
+- **Absent** when `n.deep_link === null` (SC-2): the expanded card then shows full text only, no action row (unless blocking-risk, which keeps "Respond").
+
+### 1.4 Height growth behavior
+- The card has no fixed height — `minHeight: 72` stays as the floor; the expanded card's height is **content-driven** (RN auto-layout). Do NOT animate `height` to a measured pixel value (jank + measurement cost).
+- Growth animates via the layout transition in §1.5, NOT via a manual `Animated.Value` on height. The body/title simply re-measure when `numberOfLines` is removed; `LayoutAnimation` (iOS/Android) / Reanimated `Layout` transition carries the resize.
+- Horizontal metrics are **untouched**: same `paddingVertical: spacing.md`, `paddingLeft: spacing.md + 3`, `paddingRight: spacing.md`, `gap: spacing.md`, `borderRadius: radius.lg`. The icon circle stays top-aligned (`alignItems:"flex-start"` is already set) so it pins to the first title line as the body grows — correct; do not center it.
+
+### 1.5 EXPAND / COLLAPSE MOTION (the spec the implementor builds to)
+
+Two coordinated animations on tap. Both are already-available primitives (Reanimated v4 is present and used by `IconChrome`/`ConfirmDialog`; `LayoutAnimation` is RN core). **Pick ONE of the two equivalent implementations below — do not mix:**
+
+**Animation A — the height/reveal (card grows):**
+- **Trigger:** row `onPress` toggles `expanded`.
+- **Property:** the card's intrinsic layout (height + the title/body text reflow).
+- **Implementation (preferred):** Reanimated `LinearTransition` (a.k.a. `Layout`) on the card container, OR RN `LayoutAnimation.configureNext` fired immediately before the `setState` toggle.
+- **Curve:** map to the token `easings.out` = `cubic-bezier(0.33, 1, 0.68, 1)` (decelerate — content settles into place, no overshoot). With Reanimated `LinearTransition.easing(Easing.bezier(0.33,1,0.68,1))`. With `LayoutAnimation`, use `type: 'easeInEaseOut'` (closest core analog) — acceptable since `LayoutAnimation` cannot take a custom bezier.
+- **Duration:** `durations.entry` = **260ms** on expand; `durations.exit` = **180ms** on collapse (collapse is faster — getting out of the way should feel snappier than revealing). If `LayoutAnimation`, use a single `duration: 220` (`(260+180)/2` rounded — core cannot key per-direction); the Reanimated path SHOULD honor the per-direction split.
+
+**Animation B — the chevron rotation (state signal):**
+- **Trigger:** same `expanded` toggle.
+- **Property:** `transform: [{ rotate }]` on the trailing chevron. Collapsed `chevR` (points right, "more →") rotates to point DOWN ("expanded ▾"). Rotate the existing `chevR` glyph **+90°** (0deg → 90deg) — do NOT swap to a different icon; rotation IS the continuity cue.
+- **Curve:** `easings.out` (`cubic-bezier(0.33,1,0.68,1)`).
+- **Duration:** `durations.normal` = **200ms** (slightly leads the 260ms reveal so the chevron "commits" to the new state just before the body finishes opening — reads as cause→effect).
+- **Driver:** Reanimated `useSharedValue` + `withTiming(expanded ? 90 : 0, { duration: 200, easing })` + `useAnimatedStyle`.
+
+**Reduced-motion fallback (`useReducedMotion()`, REQUIRED):**
+- Animation A: skip the layout transition entirely — the card snaps to expanded/collapsed (RN renders the new layout on the next frame; no `LayoutAnimation.configureNext`, no Reanimated layout). Instantaneous, no motion.
+- Animation B: snap the chevron rotation (set the shared value with no `withTiming` → `rotate` jumps 0↔90deg). The state is still conveyed by the static rotated glyph, so meaning survives.
+- Mark-read, full-text reveal, and "Open" all function identically with motion off.
+
+### 1.6 Expanded-state interaction edge cases
+- Tapping the expanded card body (anywhere not on "Open"/"Respond") collapses it (toggle). The card stays a single `Pressable`; "Open"/"Respond" are nested `Pressable`s that `stopPropagation` is NOT needed for in RN — they consume their own press, and a tap landing on them must NOT also collapse the card. Implementor: render the action buttons as siblings inside `content`; a press on a child Pressable does not bubble to the parent Pressable's `onPress` in RN, so this is automatic. Verify on device (T1/T2/T3).
+- A blocking-risk row already shows "Respond" while collapsed; tapping it to expand reveals full text + keeps "Respond" + adds "Open" if `deep_link`. No regression to the float-to-top behavior.
+
+---
+
+## 2. SWIPE-TO-DELETE (native) + WEB DELETE FALLBACK
+
+### 2.1 IA & moment
+The operator wants a read/handled notification gone. The gesture is the iOS-native mail idiom: **drag the row left to reveal a red destructive panel.** Because the delete is a recoverable soft-delete (row persists server-side), the destructive *styling* is honest (red, trash) but the action is **immediate, no confirm** — the cost of a mistap is near-zero and the optimistic revert covers transient failures. This is the deliberate asymmetry vs. "Clear read" (which CAN nuke many rows → it gets a confirm).
+
+### 2.2 Native swipe panel — anatomy & geometry
+Wrap each `NotificationRow` in `ReanimatedSwipeable` (named import from `react-native-gesture-handler` — NOT the legacy `Swipeable`; `GestureHandlerRootView` is already mounted at app root per SPEC §2).
+
+- **Direction:** right→left (left-swipe). `renderRightActions` only. No left-action (right-swipe) panel.
+- **Panel width (revealed, rest threshold):** **80pt**. Deliberate constant `SWIPE_ACTION_WIDTH = 80` (one trash glyph + label-less square ≥44pt target with breathing room; matches iOS mail action width). This is a called-out sub-grid accent.
+- **Panel fill:** `semantic.error` (#ef4444). Solid, fully opaque, on EVERY platform (a destructive action surface is never glass — it must read as a hard stop). This satisfies the Android opaque policy trivially (no rgba).
+- **Panel corner:** the panel sits BEHIND the row's right edge; because the card has `borderRadius: radius.lg` (16) + `overflow:'hidden'`, the revealed red must clip to the card's rounded right corners. Render the action panel inside the same rounded clip OR give the panel `borderTopRightRadius / borderBottomRightRadius: radius.lg`. The card's existing `overflow:'hidden'` already clips; ensure the swipeable wrapper does not defeat it (wrap the swipeable in a `View` with `borderRadius: radius.lg` + `overflow:'hidden'`, `marginBottom: spacing.sm` moved to that wrapper so row spacing is preserved).
+- **Trash glyph:** `Icon name="trash"` size **22**, color `text.inverse` (#ffffff) — white-on-red, contrast ≈ 4.0:1 against #ef4444 for the 22pt glyph (large-graphic threshold 3:1 → PASS). Centered in the panel (`alignItems:"center"`, `justifyContent:"center"`).
+- **No text label** in the panel (the trash glyph + red is unambiguous and keeps the panel to 80pt). The a11y label carries the words (§4).
+
+### 2.3 Full-swipe-commit vs reveal-then-tap (threshold)
+Support BOTH, like iOS Mail:
+- **Reveal-then-tap:** dragging past ~50% of the panel width (≈40pt drag) and releasing **snaps open** to the 80pt rest position; the operator then taps the red panel to delete. `ReanimatedSwipeable` `rightThreshold={40}`.
+- **Full-swipe-commit:** dragging past **40% of the row width** auto-commits the delete on release without requiring a second tap. Configure via `overshootRight={false}` + an `onSwipeableWillOpen`/`onSwipeableOpen` that, when the drag distance exceeded the full-commit threshold, fires the delete directly. Concretely: set the full-commit trigger at `dragX < -(ROW_WIDTH * 0.4)`. Implementor measures `ROW_WIDTH` via the swipeable's `onLayout`.
+- On commit, the row animates out via the optimistic cache removal (§2.5).
+
+### 2.4 Haptic timing (native only)
+Two distinct haptics, both via the existing `HapticFeedback` util (no new dep):
+1. **Threshold-cross haptic** — fire `HapticFeedback.selection()` (or `.light()` if `selection` is unavailable in the util) **once**, the moment the drag crosses the full-swipe-commit threshold (the 40%-row-width line), to tell the thumb "release now = delete." Fire exactly once per drag (debounce on a `hasCrossed` ref; reset on drag back under threshold).
+2. **Commit haptic** — fire `HapticFeedback.success()` at the instant `softDelete(n.id)` is called (whether via full-swipe or tap-the-panel). This is the "done" confirmation. (Mirror the route's `handleMarkAll` which uses `HapticFeedback.success()`.)
+- No haptic on plain reveal-then-rest (the threshold-cross already covered it if they dragged far; a short reveal that doesn't cross gets no haptic — correct, nothing committed).
+
+### 2.5 Optimistic removal motion
+On `softDelete`, the hook removes the row from cache immediately (SPEC §4.B). Visually:
+- The row collapses out of the list. Use the SAME `LinearTransition` / `LayoutAnimation` already on the list container so siblings slide up to fill the gap over `durations.exit` = **180ms**, `easings.out`. (Reuse Animation A's transition config — one transition serves both expand-resize and delete-removal.)
+- **Revert on error:** the cache restore re-inserts the row in prior order; the same 180ms layout transition slides it back in. No toast, no banner, no alarm — silent (matches mark-read grammar; SPEC §4.B item 3, SC-5). Reduced-motion: snap in/out, no slide.
+
+### 2.6 WEB delete fallback (`Platform.OS === "web"` — `isWeb` constant already at line 116)
+Swipe gestures are unreliable on web → degrade to a **visible button**, never a hidden gesture.
+- **Affordance:** a trailing trash `Pressable` rendered INSIDE the row, after the chevron, in the row's trailing cluster. `Icon name="trash"` size **16**, color `text.tertiary` at rest.
+- **Visibility model:** **always visible** on web (not hover-only). Rationale: hover-reveal fails touch-capable laptops/tablets hitting the web preview and is a discoverability trap; an always-visible low-contrast trash is the honest web pattern and the inbox is operator-dense, not marketing. (Resolves SPEC §10 Q2 → always-visible.)
+- **Hover (web pointer):** on hover, trash color animates `text.tertiary → semantic.error` over `durations.fast` (120ms); on press, `semantic.error` at full. CSS/RN-web hover via `Pressable` `onHoverIn/Out`. No layout shift (color-only).
+- **Placement:** in the trailing column, with `marginLeft: spacing.sm` from the chevron, vertically centered. Target ≥44pt via `hitSlop`.
+- **Action:** `softDelete(n.id)` directly — **no confirm** (parity with native immediacy; recoverable soft-delete).
+- On web, `ReanimatedSwipeable` is NOT mounted (branch on `isWeb`): render the plain row + trailing trash. No gesture handler on the web path.
+- Web has no haptics; the only feedback is the row sliding out (same 180ms layout transition, gated off under `prefers-reduced-motion`).
+
+---
+
+## 3. HEADER ACTION CLUSTER + "CLEAR READ" CONFIRM (`app/notifications.tsx`)
+
+### 3.1 IA & moment
+The header right slot today holds ONE action: "Mark all read" (only when `unreadCount > 0`). ORCH-1142 adds a sibling: "Clear read" (only when `hasRead`). The two can co-exist, be mutually exclusive, or both be absent. The header must read calmly in all four states and never reflow the centered title.
+
+### 3.2 The four states (the state machine)
+
+| `unreadCount` | `hasRead` | Right slot renders |
+|---|---|---|
+| `> 0` | `false` | "Mark all read" only (today's behavior, unchanged) |
+| `0` | `true` | "Clear read" only |
+| `> 0` | `true` | BOTH, as a horizontal cluster (see §3.3) |
+| `0` | `false` | empty — render `chromeRightSlot` spacer (width 36) so the title stays centered (today's empty-state behavior, unchanged) |
+
+### 3.3 Layout when BOTH appear
+The current right slot is a single `Pressable`. Replace with a `headerActions` row:
+- **Container:** `flexDirection:"row"`, `alignItems:"center"`, `gap: spacing.md` (16 between the two actions — enough that the two icon+label pairs do not read as one control), `justifyContent:"flex-end"`.
+- **Ordering (L → R):** **"Mark all read"** then **"Clear read"**. Rationale: reading (clearing unread) precedes pruning (clearing read); the more-common/less-destructive action sits first, the mildly-destructive one is the rightmost, slightly-harder reach (thumb-zone friction for the lossier action — matches the design principle that destructive actions earn a reach).
+- **Each action** keeps the existing `markAll` grammar: `flexDirection:"row"`, `gap: spacing.xs`, icon 16 + label `typography`-ish 14/600, `accent.warm`, `pressed → opacity 0.7`, `hitSlop {8,8,8,8}`.
+  - "Mark all read": `Icon name="check"` 16 `accent.warm` + label `Mark all read` (UNCHANGED).
+  - "Clear read": `Icon name="trash"` 16 `accent.warm` + label `Clear read`.
+- **Color discipline:** "Clear read" uses `accent.warm` in the header (NOT `semantic.error`) — the header action is the *trigger*, not the destruction itself; the red lives in the confirm's Confirm button. This keeps both header actions visually peers (same accent) and prevents a permanent red shouting in the chrome.
+- **Width guard:** with both labels visible, the cluster can be wide. The centered title uses `flex:1` + `textAlign:"center"` already; on a narrow device the title truncates before the actions wrap. Acceptable — the title is "Notifications" (short). If the implementor sees wrap on small Androids, drop the "Clear read" LABEL to icon-only at `< 360pt` width (keep the 44pt target + a11y label); the "Mark all read" label is the one that must always read. (Progressive disclosure under width pressure.)
+
+### 3.4 "Clear read" CONFIRM — reuse `ConfirmDialog`, do NOT build new
+The screen already ships `mingla-business/src/components/ui/ConfirmDialog.tsx` (a 3-variant dialog over `Modal`, web-safe, token-driven). Use it. NO new component, NO `Alert.alert` (Alert is inconsistent web-side and unstyled).
+
+- **Variant:** `"simple"` (title + description + Cancel + Confirm). NOT `holdToConfirm` (overkill — this is recoverable) and NOT `typeToConfirm`.
+- **`destructive`:** `true` → routes the Confirm button to the destructive (red) `Button` variant. THIS is where the red lives.
+- **`title`:** `Clear read notifications?`
+- **`description`:** `This removes N read notifications from your inbox. Unread ones stay. You can’t undo this here.` — where **N is the live count** of read business rows (`notifications.filter(n => n.read_at !== null).length`). If N is unknown/zero the action is hidden (so N ≥ 1 always at render). Use the singular `1 read notification` when N === 1 (Mingla voice: never show "1 notifications").
+  - Mingla voice note: honest and plain. "You can’t undo this here" is true (the row is hidden from the inbox; recovery is server-side only). Do NOT promise an undo we don't surface.
+- **`confirmLabel`:** `Clear read` · **`cancelLabel`:** `Cancel`.
+- **`onConfirm`:** `clearRead()` (the hook bulk soft-delete) + `HapticFeedback.success()` on native.
+- **`onClose`:** dismiss, no-op.
+- **Trigger:** tapping the header "Clear read" opens the dialog (sets `confirmVisible=true`); it does NOT call `clearRead()` directly. (This is the §3 difference from "Mark all read", which fires immediately with no confirm — mark-read is non-destructive, clear-read removes rows.)
+- **Title-count copy precision:** compute N at open time and freeze it in the description for the dialog's lifetime (don't let a background realtime insert change the sentence mid-read).
+
+### 3.5 "Clear read" hidden/empty states
+- `hasRead === false` → the "Clear read" action is **not rendered** at all (not disabled-greyed — absent). After a successful clear with no read rows left, `hasRead` flips false → the action vanishes; if `unreadCount` is also 0 the whole right slot returns to the 36pt spacer and the screen shows the existing "You're all caught up" empty state (SC-9 / T14).
+- The confirm dialog auto-dismisses on `onConfirm` (the optimistic removal empties the read rows); ensure `confirmVisible` is reset to false in the confirm handler.
+
+---
+
+## 4. PER-PLATFORM DELTAS + ACCESSIBILITY
+
+### 4.1 Android glass — opaque fallback on the EXPANDED card (standing policy)
+The collapsed row already complies: `styles.card` carries `overflow:'hidden'` (line 562) and Android shadows are zeroed via `androidSafeElevation` in the shadow tokens. The expanded card MUST NOT regress this:
+- **Surface fill unchanged:** expansion does not introduce a new translucent layer. The card keeps its existing read/unread fill (`glass.tint.profileBase` rgba .04 read, or the family `unreadFill` rgba .08). These are the SAME fills the collapsed card uses today and were already accepted under the Sub-C design; expansion adds height, not a new glass plane, so no new Android translucency is introduced. Do **not** add a fresh blur/translucent panel behind the expanded body.
+- **`overflow:'hidden'` is load-bearing now for two reasons:** (a) the Android glass clip (existing), and (b) clipping the swipe action panel's red to the rounded corners (§2.2). Keep it on the card AND on the new swipeable wrapper `View`.
+- **No Android shadow under the expanded rounded fill** — `shadows.glassCardBase` is already `Platform.select`-zeroed on Android; the expanded card keeps using it (read rows only, as today via `!isWeb && !unread`). Do not add `elevation` to any new expanded/swipe element.
+- **Swipe panel (§2.2)** is `semantic.error` solid — opaque by construction on Android; compliant.
+- **Web preview:** glass renders fine (real blur); no opaque substitution needed. The always-visible trash (§2.6) is the web delta.
+
+### 4.2 iOS vs Android swipe
+- **iOS:** `ReanimatedSwipeable` left-swipe is the native mail idiom — ships as specced (§2).
+- **Android:** same `ReanimatedSwipeable` gesture works; Android users also expect swipe-to-dismiss in lists, so the idiom transfers. Keep the SAME 80pt panel + red + trash. The full-swipe-commit threshold + threshold-cross haptic apply identically (`HapticFeedback` abstracts the platform).
+- **Web:** no swipe — always-visible trash button (§2.6). This is the only behavioral fork.
+
+### 4.3 Accessibility (WCAG AA + RN traits)
+
+**Touch targets — all ≥44pt:**
+- Row Pressable: already ≥72pt tall — PASS.
+- "Open" button: text + `paddingVertical: spacing.sm` + `hitSlop` 6 → ≥44pt. REQUIRED hitSlop.
+- Web trash: 16pt glyph + `hitSlop` to ≥44pt. REQUIRED.
+- Swipe action panel: 80pt wide × full row height — PASS.
+- Header "Mark all read" / "Clear read": keep `hitSlop {8,8,8,8}` (existing) → ≥44pt.
+
+**State announcement (expand):**
+- The row's `accessibilityLabel` (today: `"{title}. {body}. {Unread|Read}. {time} ago."`) appends the expand state: append `" Collapsed."` when collapsed, `" Expanded."` when expanded.
+- Add `accessibilityState={{ expanded }}` to the row Pressable so screen readers announce the disclosure state natively (VoiceOver/TalkBack read "expanded/collapsed").
+- When expanded, the full (now-untruncated) title + body are the visible text; the a11y label should still summarize — but because the full text is now on screen, the label may keep using `title`/`body` (which are the full strings already; truncation was visual-only). No change needed beyond the Collapsed/Expanded suffix and `accessibilityState`.
+
+**"Open" button a11y:**
+- `accessibilityRole="button"`, `accessibilityLabel="Open notification target"`, `accessibilityHint="Opens the related screen for this notification"`.
+
+**Swipe / web-delete a11y:**
+- Native: `ReanimatedSwipeable`'s right action `Pressable` (the red panel) gets `accessibilityRole="button"` + `accessibilityLabel="Delete notification"`. Because swipe is not reachable by VoiceOver/TalkBack gesture, ALSO expose delete as an **accessibility action** on the row: `accessibilityActions={[{ name: 'delete', label: 'Delete notification' }]}` + `onAccessibilityAction` → `softDelete(n.id)`. This is REQUIRED — a swipe-only delete with no a11y action is an accessibility failure on native. (Implementor: add the magic-tap / custom action.)
+- Web: the trash `Pressable` gets `accessibilityRole="button"` + `accessibilityLabel="Delete notification"`.
+
+**Header a11y:**
+- "Mark all read": unchanged (`accessibilityLabel="Mark all notifications as read"` + hint).
+- "Clear read": `accessibilityRole="button"`, `accessibilityLabel="Clear read notifications"`, `accessibilityHint="Removes read notifications from your inbox; unread stay"`.
+- Confirm dialog: `ConfirmDialog` already wires `Modal` focus + the Cancel/Confirm `Button`s carry roles. Ensure the destructive Confirm's label "Clear read" is announced; the dialog `title` is read on present.
+
+**Contrast (text-on-surface, AA):**
+- Title `text.primary` (white .96) on `canvas.discover` (#0c0e12) / family unreadFill → ≫ 7:1. PASS.
+- Body `text.secondary` (white .72) on same → ≈ 7:1. PASS.
+- "Open" `accent.warm` (#eb7825) on the dark card → ≈ 3.6:1 (large-ish 14/600 text). This matches the app-wide accepted accent-action pairing (memory: white-on-#eb7825 ~2.9:1 is the established action pairing; accent-on-dark here is BETTER). Accepted, consistent with `markAllLabel` which already uses `accent.warm` at 14pt.
+- Trash white on `semantic.error` red (panel): 22pt graphic, 3:1 threshold → PASS.
+- Web trash `text.tertiary` (white .52) at rest on dark: ~4.4:1 for the 16pt glyph — borderline but it's an icon with a clear shape; on hover it goes to full `semantic.error`. Acceptable; if the implementor wants margin, rest at `text.secondary` (.72).
+
+**Reduced motion:** every animation in §1.5 / §2.5 has a snap fallback specced above. `ConfirmDialog`'s simple variant has no animation. Honor `useReducedMotion()`.
+
+### 4.4 Dynamic Type
+- Title/body use fixed sizes today (15/14) — when expanded they wrap and grow, so larger system text sizes are accommodated by the content-driven height (§1.4). No `numberOfLines` cap in the expanded state means no clipping at large text sizes. PASS — expansion actually IMPROVES large-text behavior over the truncated collapsed row.
+
+---
+
+## 5. BUILD-READY HANDOFF
+
+**Tokens used (all exist in `designSystem.ts`):** `spacing.xs/sm/md`, `radius.lg`, `typography.buttonMd`, `accent.warm`, `accent.border`, `semantic.error`, `glass.tint.profileBase`, `text.primary/secondary/tertiary/quaternary/inverse`, `durations.normal/entry/exit/fast`, `easings.out`, `shadows.glassCardBase` (Android-zeroed).
+
+**Icons (all exist in `Icon.tsx`):** `chevR` (rotated +90° when expanded), `trash` (swipe panel + web fallback + header "Clear read"), `check` (existing "Mark all read").
+
+**Primitives / components:**
+- `ReanimatedSwipeable` from `react-native-gesture-handler` (present; `GestureHandlerRootView` mounted at root — SPEC §2). Native only.
+- Reanimated v4 (`useSharedValue` / `withTiming` / `useAnimatedStyle` / `LinearTransition` / `useReducedMotion`) — present (used by `IconChrome`, `ConfirmDialog`).
+- `LayoutAnimation` (RN core) — acceptable alternative for Animation A.
+- `HapticFeedback` util (`.selection()`/`.light()` threshold-cross, `.success()` commit + clear-read) — present.
+- `ConfirmDialog` (`variant="simple"`, `destructive`) — REUSE, do not modify.
+
+**New constants to add (deliberate sub-grid accents, declared at the top of the screen file alongside the existing `ICON_CIRCLE`/`UNREAD_RAIL_WIDTH`/`UNREAD_DOT`):**
+- `SWIPE_ACTION_WIDTH = 80`
+- `SWIPE_FULL_COMMIT_RATIO = 0.4` (fraction of row width for full-swipe auto-commit)
+- `SWIPE_REVEAL_THRESHOLD = 40` (`rightThreshold`)
+- `CHEVRON_EXPAND_DEG = 90`
+
+**No new dependency. No new component file. No new migration concern at the design layer.** The expand state is ephemeral component state (`Set<string>` of expanded ids on the screen, or per-row `useState` — implementor's choice per SPEC §4.C item 1; siblings do NOT auto-collapse).
+
+**State coverage checklist (every state designed):** collapsed (unchanged) · expanded (full text + Open) · expanded no-deep_link (no Open) · expanded blocking-risk (Respond + Open) · swipe-revealed · swipe-committed (optimistic out) · delete-revert (slides back, silent) · web always-visible trash · web hover · clear-read confirm open · clear-read N==1 singular copy · empty after clear (existing EmptyState + Clear-read hidden) · reduced-motion snap for all of the above. Skeleton / error+retry / offline-banner unchanged.
+
+---
+
+## 6. What this design explicitly does NOT do (guard against scope/regression)
+- Does NOT restyle the collapsed row (pixel-identical to today).
+- Does NOT introduce a detail screen (full-read is in-place).
+- Does NOT hard-delete or add an `Alert.alert` confirm (soft-delete + `ConfirmDialog`).
+- Does NOT add a translucent Android layer (opaque policy held; no new glass plane).
+- Does NOT change mark-read / mark-all / date-bucket / severity-float / family-accent grammar.
+- Does NOT add a new dependency or a new component file.
+- Does NOT surface an in-app "undo" (recovery is server-side; copy is honest about this).

--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1142_NOTIF_READ_AND_DELETE.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1142_NOTIF_READ_AND_DELETE.md
@@ -1,0 +1,216 @@
+# INVESTIGATE — ORCH-1142 — Business notifications: no full-read + no delete
+
+- **ORCH-ID:** ORCH-1142
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1142-[notif-read-delete]` on `ORCH-1142-notif-read-delete` (HEAD `2bcf4e847`, 0 behind / 0 ahead of `origin/main` — verified `git rev-list --left-right --count`).
+- **Date:** 2026-06-15
+- **Author:** mingla-forensics+claude
+- **Phase:** INVESTIGATE (no fix proposed; root causes proven with evidence)
+- **Affected surfaces:** business iOS, business Android, business web preview (same `app/notifications.tsx` route). NOT consumer, NOT buyer-web, NOT admin-web.
+
+---
+
+## Symptom summary (Seth, verbatim)
+
+> "Right now notifications show and there is no way to read the full thing or delete read notifications from the business app. why? When we find out why I want to know how we can fix this."
+
+**Two distinct symptoms:**
+1. **No full-read** — a notification's title/body are truncated in the inbox and there is no way to see the untruncated text; tapping navigates away instead of revealing the full content.
+2. **No delete** — read notifications cannot be removed from the inbox; only mark-read / mark-all-read exist.
+
+**Expected (per Seth's locked decisions):** tap a row to expand it in place (full title + body, deep-link demoted to a secondary "Open" action); swipe a row to delete it; a "Clear read" header action to bulk-remove read rows — all via DB **soft-delete** so financial-record reference value is preserved server-side.
+
+---
+
+## Investigation manifest (every file read, in trace order)
+
+| # | File | Layer | Why |
+|---|------|-------|-----|
+| 1 | `COMMS_LEDGER.md` (anchor) | docs | Mandatory entry read; COMMS-0029/0030 are trip-migration coordination, unrelated; none BLOCK/directed to ORCH-1142 |
+| 2 | `mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx` | code (component) | The inbox render — truncation + tap behavior |
+| 3 | `mingla-business/src/hooks/useBusinessNotifications.ts` | code (hook) | Fetch + mutations (mark-read), realtime patch, the I-PROPOSED-W filter |
+| 4 | `mingla-business/app/notifications.tsx` | code (route) | Header chrome ("Mark all read"), deep-link routing |
+| 5 | `supabase/migrations/20260511000003_b2a_v3_notifications.sql` | schema | Latest migration touching `notifications`; confirms columns added |
+| 6 | live `public.notifications` columns (Management API SQL) | schema/data | Confirm `deleted_at` does NOT exist yet |
+| 7 | live `public.notifications` RLS policies (`pg_policy`) | schema | Prove the calling business user can UPDATE own rows to set a soft-delete column |
+| 8 | `.github/scripts/strict-grep/i-proposed-w-notifications-app-type-prefix.mjs` | code (CI gate) | The I-PROPOSED-W enforcement — how soft-delete fetch must keep the filter |
+| 9 | `mingla-business/package.json` | deps | Gesture library availability (no new dep) |
+| 10 | `mingla-business/app/_layout.tsx`, `Icon.tsx`, gesture-handler node_modules | code/deps | `GestureHandlerRootView` mounted; `trash` icon present; `ReanimatedSwipeable` ships |
+| 11 | grep sweep across `mingla-business/{app,src}` | code | Prove NO existing detail route + NO existing notifications-delete path anywhere |
+
+---
+
+## Q-scorecard
+
+### Q1 — WHY is there no way to read the full notification text?
+
+**Verdict: CONFIRMED — by design (META-ORCH-1074 Sub-C), proven in source.** Title is rendered `numberOfLines={1}`, body `numberOfLines={2}`; a tap fires `markAsRead` + (if a deep-link exists) navigates *away* via `resolveBusinessNavTarget`. There is no detail screen, no inline expand, and a row with a NULL `deep_link` taps to nothing visible. Confidence: **proven** (source-only is acceptable here — this is a deterministic render/handler contract, not a reproducer-bound runtime/keyboard bug; the truncation props and the navigate-away handler are unambiguous in code).
+
+### Q2 — WHY can read notifications not be deleted?
+
+**Verdict: CONFIRMED — by design (SUB-C_DESIGN §4.4 "NO swipe-to-dismiss — financial records have reference value"), proven in source.** The hook exposes ONLY `markAsRead` / `markAllAsRead`; no delete mutation exists. The screen header offers only "Mark all read". A repo-wide grep finds NO notifications-delete path anywhere in `mingla-business`. Confidence: **proven** (source + grep + absence proof).
+
+### Q3 — Does any detail route or delete path already exist anywhere in mingla-business?
+
+**Verdict: NO — neither exists (grep absence proof).** No `notifications/[id]` dynamic route, no `notificationDetail`, no `.from("notifications").delete(`. The only `deleted_at` references in `mingla-business/src` are for `creator_accounts` (account deletion) and draft *events* (`serverDraftEventMapper` / `orch_1123_batch_rpc`) — soft-delete is an **established pattern** in the codebase, but never on `notifications`.
+
+### Q4 — Does `public.notifications` already have a `deleted_at` column?
+
+**Verdict: NO.** Live column introspection (Management API, project `gqnoajqerqhnvulmnyvv`) returns 20 columns; `deleted_at` is absent. The most recent migration touching the table (`20260511000003_b2a_v3_notifications.sql`) only ADDed `brand_id` + `deep_link` and the type-prefix index — no soft-delete column.
+
+### Q5 — Does RLS allow the calling business user to UPDATE their own rows to set a soft-delete column (precedent = the existing `read_at` update)?
+
+**Verdict: YES — proven against live policies.** The UPDATE policy on `public.notifications` is **column-agnostic** (`USING auth.uid() = user_id` + `WITH CHECK auth.uid() = user_id`). The existing `markAsRead` already does `.update({ read_at })` `.eq("id", id)` through this exact policy, so an `.update({ deleted_at })` on the same rows is permitted with **NO new RLS**. (A DELETE policy `USING auth.uid() = user_id` also exists, but the locked decision is soft-delete, not hard delete.)
+
+### Q6 — How must the soft-delete fetch preserve the I-PROPOSED-W strict-grep gate?
+
+**Verdict: Keep `.or('type.like.stripe.%,type.like.business.%')` on the SELECT and ADD `.is('deleted_at', null)`.** The gate scans forward 25 lines from each `.from('notifications')`; SELECT chains MUST contain a business-inclusion pattern (the `.or(...)` clause is one). Adding `.is('deleted_at', null)` does not remove the inclusion clause, so the gate stays green. `.update(...)` chains (the new `softDelete` and `clearRead`) are **exempt** from the gate (modify-op exemption), so they will not trip it — but the locked decision still requires `clearRead` to internally scope to `read_at IS NOT NULL` AND the business-type `.or(...)` for correctness, not for the gate.
+
+---
+
+## Findings (six-field evidence)
+
+### F-1 — Inbox truncates title to 1 line + body to 2 lines, with no expand affordance (answers Q1)
+
+1. **Symptom:** Long notification titles/bodies are clipped with no way to see the full text in the inbox.
+2. **Layer:** code (component).
+3. **Probe:** Read `BusinessNotificationsScreen.tsx` lines 246–309 verbatim.
+4. **Evidence:**
+   - Line 264–266: `<Text style={styles.title} numberOfLines={1}>{notification.title}</Text>`
+   - Line 246–248 (blocking-risk branch): `<Text ... numberOfLines={1}>{notification.title}</Text>`
+   - Line 256 (bold-token branch): `<Text style={styles.title} numberOfLines={1}>`
+   - Line 307–309: `<Text style={styles.body} numberOfLines={2}>{notification.body}</Text>`
+   - There is NO per-row `expanded` state; the `NotificationRow` component (lines 226–342) has no toggle.
+5. **Mechanism:** Hard `numberOfLines` caps + zero expand state → the full text is structurally unreachable inside the inbox.
+6. **Severity:** `CONFIRMED ROOT CAUSE` (symptom #1).
+
+### F-2 — Row tap navigates AWAY (deep-link) or does nothing; it never reveals content (answers Q1)
+
+1. **Symptom:** Tapping a row leaves the inbox (deep-link) or, with a NULL `deep_link`, visibly does nothing.
+2. **Layer:** code (component + route).
+3. **Probe:** Read `BusinessNotificationsScreen.tsx` lines 429–437 and `app/notifications.tsx` lines 63–75.
+4. **Evidence:**
+   - Screen `handlePress` (429–437): `void markAsRead(n.id); if (n.deep_link && onOpenDeepLink) { onOpenDeepLink(n.deep_link, n); }` — the ONLY tap behaviors are mark-read + navigate.
+   - Route `handleOpenDeepLink` (63–75): `const target = resolveBusinessNavTarget(data); router.push(target as never);` — navigates away.
+   - When `n.deep_link` is NULL, the `if` is skipped → tap marks read but produces no visible change.
+5. **Mechanism:** The tap is a doorway, not an opener; combined with F-1 there is no in-place full-read path.
+6. **Severity:** `CONFIRMED ROOT CAUSE` (symptom #1).
+
+### F-3 — Hook exposes only mark-read mutations; no delete mutation exists (answers Q2)
+
+1. **Symptom:** No delete capability anywhere in the inbox.
+2. **Layer:** code (hook).
+3. **Probe:** Read `useBusinessNotifications.ts` full file (1–285); grep for any delete on `notifications`.
+4. **Evidence:**
+   - The `BusinessNotificationsInbox` interface (169–178) exports exactly: `query`, `notifications`, `unreadCount`, `markAsRead`, `markAllAsRead`. No delete member.
+   - `fetchBusinessNotifications` (126–144) selects with NO `deleted_at` exclusion (the column does not exist yet — F-5).
+   - The realtime UPDATE handler (101–117) patches rows in place; it never removes a row from cache.
+   - grep: `.from("notifications").delete(` → **0 hits** in `mingla-business`.
+5. **Mechanism:** With no delete mutation and no soft-delete column, a read notification can never leave the inbox.
+6. **Severity:** `CONFIRMED ROOT CAUSE` (symptom #2).
+
+### F-4 — Screen + route offer no delete or "Clear read" affordance (answers Q2)
+
+1. **Symptom:** The only header action is "Mark all read"; no per-row swipe, no "Clear read".
+2. **Layer:** code (component + route).
+3. **Probe:** Read `BusinessNotificationsScreen.tsx` (component grammar comment §4.4 line 15) + `app/notifications.tsx` lines 92–109.
+4. **Evidence:**
+   - Screen doc comment line 15: "NO swipe-to-dismiss (§4.4 — financial records have reference value)." The `Pressable` row (271–340) has no swipe wrapper.
+   - Route header (92–109) renders only the "Mark all read" `Pressable`; the right slot is otherwise an empty spacer (`chromeRightSlot`).
+5. **Mechanism:** Deliberate SUB-C design choice; the absence is intentional, not a bug — which answers Seth's "why".
+6. **Severity:** `CONFIRMED ROOT CAUSE` (symptom #2).
+
+### F-5 — `public.notifications` has no `deleted_at` column (enables the fix path)
+
+1. **Symptom:** N/A (enabling fact for the fix).
+2. **Layer:** schema/data.
+3. **Probe:** `select column_name ... from information_schema.columns where table_name='notifications'` (Management API, live prod).
+4. **Evidence:** 20 columns returned (`id, user_id, type, title, body, data, actor_id, related_id, related_type, is_read, read_at, push_sent, push_sent_at, push_clicked, push_clicked_at, idempotency_key, created_at, expires_at, brand_id, deep_link`). `deleted_at` ABSENT.
+5. **Mechanism:** A soft-delete column must be added by migration (SPEC defines; implementor writes).
+6. **Severity:** N/A (enabling finding — informs the SPEC migration).
+
+### F-6 — RLS UPDATE policy is column-agnostic → soft-delete is permitted with no new RLS (enables the fix path)
+
+1. **Symptom:** N/A (security/enabling fact).
+2. **Layer:** schema (RLS).
+3. **Probe:** `pg_policy` introspection on `public.notifications` (live prod).
+4. **Evidence:**
+   - UPDATE (`polcmd = w`) "Users can update own notifications (mark read)": `USING (auth.uid() = user_id)`, `WITH CHECK (auth.uid() = user_id)` — no column restriction.
+   - SELECT (`r`): `USING (auth.uid() = user_id)`.
+   - DELETE (`d`): `USING (auth.uid() = user_id)` (present but unused by the soft-delete plan).
+   - INSERT (`a`): `WITH CHECK false` (service-role only).
+   - Precedent: `markAsRead` (hook lines 204–208) already updates `read_at` through the UPDATE policy.
+5. **Mechanism:** Because the UPDATE policy gates on row ownership (not column), `.update({ deleted_at })` on the user's own rows passes RLS identically to the existing `read_at` write. No policy change needed.
+6. **Severity:** N/A (enabling finding — confirms the SPEC needs no RLS migration, only a column + index).
+
+### F-7 — I-PROPOSED-W gate exempts modify-ops and requires the inclusion clause on SELECT (constrains the fix)
+
+1. **Symptom:** N/A (CI invariant the fix must preserve).
+2. **Layer:** code (CI strict-grep gate, DRAFT status per the file header).
+3. **Probe:** Read `.github/scripts/strict-grep/i-proposed-w-notifications-app-type-prefix.mjs` (1–268).
+4. **Evidence:**
+   - Lines 89–90: `.update(`/`.delete(`/`.insert(`/`.upsert(` chains are SAFE (modify-op exemption).
+   - Lines 102–109 + 232–240: business-side SELECT chains must contain a business-inclusion pattern (`.or('...type.like.stripe.%...')` or `.like('type','stripe.%')` etc.) within 25 forward lines, else a violation.
+   - Line 199: whole-file allowlist tag `orch-strict-grep-allow notifications-cross-app-read` (do NOT use — keep the real filter).
+5. **Mechanism:** The soft-delete fetch keeps `.or('type.like.stripe.%,type.like.business.%')` and ADDs `.is('deleted_at', null)` → still passes. New `softDelete`/`clearRead` use `.update(...)` → exempt. Gate stays green.
+6. **Severity:** N/A (constraint — the SPEC's regression contract must verify the gate still passes post-fix).
+
+---
+
+## Five-Truth-Layer reconciliation
+
+| Layer | Finding | Contradiction? |
+|-------|---------|----------------|
+| **Docs** | SUB-C_DESIGN §4.4 explicitly says NO swipe-to-dismiss; the screen comment block documents 1-line title / 2-line body and tap=doorway. Memory `feedback_public_trip_page_all_surface_parity` is unrelated. | None — docs MATCH code: both behaviors are intentional design, not regressions. |
+| **Schema** | `notifications` has `read_at` but no `deleted_at`; UPDATE RLS is column-agnostic; DELETE RLS exists. | None — schema is internally consistent; it simply lacks the soft-delete column. |
+| **Code** | Truncation props (F-1), navigate-away tap (F-2), no delete mutation (F-3), header has only mark-all (F-4). | None — code matches docs. |
+| **Runtime** | Not separately live-fired — see "Repro evidence". Render/handler contract is deterministic from source. | None. |
+| **Data** | Live introspection confirms 20 columns (no `deleted_at`) + the 4 RLS policies. | None — data confirms schema. |
+
+**No cross-layer contradiction.** The "bug" is the *absence* of two capabilities that were deliberately scoped out by META-ORCH-1074 Sub-C. This is the answer to Seth's "why": both are by-design Sub-C decisions, NOT hidden defects. The fix adds the two capabilities per Seth's locked decisions.
+
+---
+
+## Repro evidence
+
+This investigation is a **render/handler-contract + schema/RLS** investigation, not a reproducer-bound runtime/keyboard/gesture bug. Per Prime Directive 7's exemption ("pure backend / SQL / migration / RLS investigations, and investigations explicitly scoped 'code audit only'"), and because the two root causes are deterministic from unambiguous source (`numberOfLines={1/2}`, the tap handler, the absent delete mutation, the absent column), no simulator repro is required to *prove* the causes. The orchestrator INTAKE lead (both behaviors are deliberate Sub-C design) was independently CONFIRMED with file:line evidence (F-1..F-4) plus live schema/RLS introspection (F-5..F-6). Live-fire of the *new* behavior belongs to the TEST phase after IMPLEMENT.
+
+**Negative-verdict note:** there is genuinely no hidden detail route or delete path masked elsewhere — the grep absence proof (Q3) is exhaustive across `mingla-business/{app,src}`.
+
+---
+
+## Blast radius / cross-surface map
+
+- **In-scope:** business iOS, business Android, business web preview — all three render the SAME `app/notifications.tsx` → `BusinessNotificationsScreen.tsx` → `useBusinessNotifications.ts`. Parity is **automatic** for the hook + DB layer (shared code); **manual** for the swipe gesture (native `ReanimatedSwipeable` vs a web button fallback — see SPEC §3 web variant).
+- **Out-of-scope (do NOT touch):**
+  - Consumer iOS/Android (`app-mobile/`) — different inbox; the I-PROPOSED-W gate forces the consumer side to EXCLUDE `stripe.%`/`business.%`. A soft-delete column on the shared table is harmless to consumer reads only if the consumer fetch is left untouched (it is — out of scope). *Reason: not Seth's ask; consumer inbox unchanged.*
+  - Buyer/anonymous web — no notifications surface. *Reason: anon route, no inbox.*
+  - Admin web (`mingla-admin/`) — exempt from I-PROPOSED-W by design (cross-app support reads); adding `deleted_at` does not change admin reads unless admin opts to filter (out of scope). *Reason: not Seth's ask.*
+- **Shared-table caution:** the new `deleted_at` column lives on the shared `public.notifications`. The migration is additive (NULL-by-default), so consumer + admin reads are unaffected unless they choose to filter. The SPEC must NOT modify the consumer fetch.
+
+---
+
+## Invariant impact
+
+- **I-PROPOSED-W (DRAFT)** — MUST be preserved. The soft-delete SELECT keeps the `.or('type.like.stripe.%,type.like.business.%')` inclusion clause; modify-ops are gate-exempt. No change to the gate file. (See F-7.)
+- **New invariant proposed (DRAFT) — `I-PROPOSED-BH-NOTIF-SOFTDELETE-EXCLUDED-AND-SCOPED`:** the business notifications SELECT MUST exclude soft-deleted rows (`deleted_at IS NULL`) AND the "Clear read" bulk soft-delete MUST be scoped to `read_at IS NOT NULL` AND the business-type prefix — never unread rows, never consumer rows. (Letters BH/BI/BJ/BK are free in the registry; BH chosen.) The orchestrator owns the ACTIVE flip at CLOSE.
+- No DECISION_LOG conflict. SUB-C_DESIGN §4.4 ("NO swipe-to-dismiss — financial records have reference value") is **superseded for the operator inbox view only** by Seth's locked decision; reference value is preserved because the delete is a soft-delete (the row persists server-side, just hidden from the inbox). The SPEC must record this supersession explicitly so a future session does not "restore" the §4.4 no-delete rule as a regression.
+
+---
+
+## Discoveries for Orchestrator
+
+- **DISC-1142-A:** `notifications` carries BOTH a legacy boolean `is_read` (default false, NOT NULL) AND `read_at` (nullable timestamp). The business hook reads/writes ONLY `read_at`; `is_read` is never updated by the business app. Not in scope for ORCH-1142, but flagged: any future consumer/admin code that keys off `is_read` will diverge from the business app's `read_at`-based unread count. No action this ORCH.
+- **DISC-1142-B:** SUB-C_DESIGN §4.4's "NO swipe-to-dismiss" rule is now partially superseded (operator inbox view) by ORCH-1142. The orchestrator should annotate the SUB-C design doc / World Map so the rule is not treated as still-binding.
+- **COMMS factored:** COMMS-0029 + COMMS-0030 (trip-migration coordination, iOS build) read and confirmed unrelated to notifications; factored only for migration-version hygiene (chose `20261002000000`, clear of all prod-applied-but-unmerged trip migrations at/below `20260930000000`).
+
+---
+
+## Confidence level
+
+**proven** — both root causes (no full-read; no delete) are proven from unambiguous source with file:line evidence; the schema absence of `deleted_at` and the column-agnostic UPDATE RLS are proven from live prod introspection; the I-PROPOSED-W gate logic is read verbatim. No environment blocker. Live-fire of the *new* capability is a TEST-phase concern, not a prerequisite to proving the *current* (absent) behavior.
+
+---
+
+## Recommended next phase + scope
+
+**SPEC (same dispatch, IA mode).** Scope is fixed by Seth's two locked decisions: (1) tap-to-expand inline full-read with the deep-link demoted to a secondary "Open" action; (2) per-row swipe-to-delete + a "Clear read" header bulk action, both implemented as DB soft-delete (`deleted_at`) with fetch + realtime excluding soft-deleted rows and "Clear read" scoped to read+business-type only. Do NOT widen beyond these two. DESIGN runs after SPEC (this touches UI — expand interaction, swipe affordance, "Clear read" placement, all states).

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1142_NOTIF_READ_AND_DELETE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1142_NOTIF_READ_AND_DELETE.md
@@ -1,0 +1,153 @@
+# IMPLEMENTATION — ORCH-1142 — Business notifications: full-read (tap-to-expand) + delete (soft-delete)
+
+- **ORCH-ID:** ORCH-1142 [notif-read-delete]
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1142-[notif-read-delete]` on `ORCH-1142-notif-read-delete`
+- **Built from:** `SPEC_ORCH-1142_NOTIF_READ_AND_DELETE.md` + `DESIGN_ORCH-1142_NOTIF_READ_AND_DELETE.md` (both in worktree)
+- **Author:** mingla-implementor+claude · **Date:** 2026-06-15 · **Status:** implemented and verified (source/type/gate/test); native swipe + on-device UX **unverified — needs tester live-fire**
+- **Comms ledger:** read on entry. No BLOCK/OPEN row targets ORCH-1142, this skill, or ALL that blocks this work. Active WARNs are unrelated trip-migration coordination (factored, no action). No new COMMS entry needed (no cross-ORCH discovery).
+
+---
+
+## 1. Summary (plain English)
+
+Business operators can now (1) tap any notification to expand it in place and read the full untruncated title + body — with the deep-link demoted to a secondary "Open" button inside the expanded card — and (2) remove read/handled notifications via per-row left-swipe (native) or an always-visible trash button (web), plus a header "Clear read" bulk action behind a confirm dialog. Delete is a **soft-delete**: the row is hidden from the inbox but preserved server-side (financial-record reference value intact). Nothing in the resting/collapsed row changed.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Satisfied by (commit) |
+|----|-----------|--------|------------------------|
+| SC-1 | Tap expands in place → full title+body, marks read first tap, tap again collapses | ✓ implemented | `488ffca8b` screen |
+| SC-2 | Deep-link demoted to "Open" in expanded state; plain tap no longer navigates; no Open when deep_link null | ✓ implemented | `488ffca8b` screen + route |
+| SC-3-iOS / SC-3-Android | Left-swipe reveals destructive trash; full-swipe / tap-panel removes optimistically + sets `deleted_at`; no reappear on refetch | ✓ implemented · **swipe gesture UNVERIFIED (needs device)** | `488ffca8b` screen + hook + migration |
+| SC-3-Web | Visible per-row "Delete" affordance removes the row (no swipe) | ✓ implemented | `488ffca8b` screen (`WebTrashButton`) |
+| SC-4 | "Clear read" soft-deletes read + `stripe.%`/`business.%` rows only; unread + consumer untouched | ✓ implemented + gated by test | `488ffca8b` hook + route |
+| SC-5 | Revert on error: optimistically-removed rows reappear in prior order; silent `__DEV__` warn | ✓ implemented | `488ffca8b` hook |
+| SC-6 | Realtime multi-device: a soft-delete UPDATE drops the row from another device's cache | ✓ implemented · **multi-device UNVERIFIED (needs 2 devices)** | `488ffca8b` hook (realtime) |
+| SC-7 | Reference value preserved: row persists with `deleted_at` set (no hard delete) | ✓ implemented (soft-delete only; DELETE policy untouched) | `488ffca8b` migration + hook |
+| SC-8 | I-PROPOSED-W gate passes (SELECT keeps inclusion clause; modify-ops exempt) | ✓ verified — gate exit 0, 0 violations | gate run |
+| SC-9 | After clearing all read with no unread: empty state renders, "Clear read" hides | ✓ implemented (hasRead gate + existing EmptyState) | `488ffca8b` route + screen |
+
+`488ffca8b` = the single implementation commit (see §3 / chat handoff).
+
+---
+
+## 3. Files changed
+
+| File | Type | Δ lines (approx) |
+|------|------|-------------------|
+| `supabase/migrations/20261002000000_orch_1142_notifications_soft_delete.sql` | new | +33 |
+| `mingla-business/src/hooks/useBusinessNotifications.ts` | modified | +95 / -3 |
+| `mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx` | modified | +240 / -40 |
+| `mingla-business/app/notifications.tsx` | modified | +85 / -12 |
+| `mingla-business/src/hooks/__tests__/orch_1142_notif_softdelete_scope.test.ts` | new (test) | +115 |
+
+---
+
+## 4. Data-model changes applied (WRITTEN, not applied — operator/orchestrator owns apply)
+
+- **Migration:** `20261002000000_orch_1142_notifications_soft_delete.sql`
+- **Column:** `ALTER TABLE public.notifications ADD COLUMN IF NOT EXISTS deleted_at timestamptz;` (nullable, NO default → NULL = active). `COMMENT ON COLUMN` documents soft-delete + reference-value preservation + ORCH-1142 + GDPR-erasure separation.
+- **Index:** `CREATE INDEX IF NOT EXISTS idx_notifications_user_active ON public.notifications (user_id, created_at DESC) WHERE deleted_at IS NULL;` (partial — keeps the hot "active rows newest-first" path lean).
+- **RLS:** NONE added/altered. Read-only prod probe (MCP `execute_sql`, SELECT only) confirmed: `notifications` has `read_at` but no `deleted_at` yet; the column-agnostic UPDATE policy `"Users can update own notifications (mark read)"` (cmd `w`) exists → owners can set `deleted_at` exactly as `read_at` today (F-6); `idx_notifications_user_active` does not exist yet. Additive migration, no guards → zero `db push` failure risk.
+- **GRANT:** none (`authenticated` already has UPDATE — precedent: mark-read writes).
+- **Migration SQL safety:** ALTER TABLE + CREATE INDEX only — no functions, no `RETURNS TABLE` widening → no `$function$;`/`DROP FUNCTION` needed.
+- **Version monotonicity:** `20261002000000` verified free locally, across sibling worktrees, and `> ` the linked remote head `20261001000000` (`list_migrations`). **Re-verify the prod head at deploy time** and bump the prefix if a newer migration landed first (per `feedback_edge_deploy_and_migration_apply_hazards` — apply via Management API; CLI drift-wedged).
+
+---
+
+## 5. Edge functions touched
+
+NONE. `deleted_at` is operator-writable via the existing RLS UPDATE policy; no `notify-dispatch` / edge change (SPEC §2 non-goal). Nothing to deploy server-side except the migration.
+
+---
+
+## 6. Regression tests added
+
+- **Path:** `mingla-business/src/hooks/__tests__/orch_1142_notif_softdelete_scope.test.ts` (5 source-assertion cases — SPEC §9).
+- **Passing run:** `Test Suites: 1 passed · Tests: 5 passed`.
+- **Existing inbox test:** `useBusinessNotificationsInbox.test.ts` still `4 passed` (markAllAsRead semantics unchanged).
+- **fails-on-revert verified at `2bcf4e847`** (worktree HEAD at IMPLEMENT): TRUE LINE DELETION of `.is("deleted_at", null)` from `fetchBusinessNotifications` → case 1 went RED (`1 failed, 4 passed`); restoring the line → `5 passed`. The test strips `//` line-comments before code assertions, so the protective-comment that also mentions `.is("deleted_at", null)` cannot produce a false pass.
+- **I-PROPOSED-W gate:** `node .github/scripts/strict-grep/i-proposed-w-notifications-app-type-prefix.mjs` → exit 0, 0 violations, 1559 files scanned (SC-8).
+- **I-PROPOSED-BH (new DRAFT, SPEC §6):** enforced by this jest source-assertion (the SPEC-required minimum; no strict-grep extension added — jest suffices). Orchestrator flips ACTIVE at CLOSE + appends the registry entry.
+
+---
+
+## 7. Old → New receipts
+
+### `supabase/migrations/20261002000000_...sql` (new)
+- **Before:** `notifications` had no soft-delete; the only way to remove a row was hard DELETE (and the SUB-C design forbade swipe-to-dismiss to protect reference value).
+- **Now:** additive nullable `deleted_at` + partial active-rows index; no RLS/GRANT change.
+- **Why:** SC-7 (preserve reference value) + the hot-path exclusion filter.
+
+### `useBusinessNotifications.ts`
+- **Before:** `BusinessNotification` had no `deleted_at`; fetch returned all business rows; inbox exposed only `markAsRead`/`markAllAsRead`; realtime UPDATE patched in place.
+- **Now:** `deleted_at` on the interface + `SELECT_COLUMNS`; fetch adds `.is("deleted_at", null)` (I-PROPOSED-W `.or` kept verbatim); new optimistic `softDelete(id)` (by PK) + `clearRead()` (scoped to `user_id` + `read_at IS NOT NULL` + not-already-deleted + business-type `.or`) + derived `hasRead`; realtime UPDATE drops a row when `deleted_at` is set (before the in-place patch). Both new mutations silent-revert on error (mark-read grammar) + recompute the iOS badge.
+- **Why:** SC-3/4/5/6/7 + the soft-delete exclusion (I-PROPOSED-BH).
+- **Lines:** ~+95/-3.
+
+### `BusinessNotificationsScreen.tsx`
+- **Before:** row was a single `Pressable`; tap fired mark-read + navigate; title 1-line / body 2-line always; static chevron; no delete affordance.
+- **Now:** per-row ephemeral expand (`Set<string>` on the screen, multiple may be expanded); expanded drops the title/body `numberOfLines` cap and reveals a secondary "Open" button (gated on `deep_link`); tap = mark-read + toggle expand (NO navigate); chevron rotates +90° (200ms, `easings.out`, reduced-motion snap); rows wrapped in a `rowWrapper` carrying `borderRadius`+`overflow:'hidden'`+`marginBottom` and a Reanimated `LinearTransition` (260/180-grade) for expand-resize + delete-slide; native rows wrap `ReanimatedSwipeable` (80pt solid-red trash panel, `rightThreshold=40`, `overshootRight=false`, full-swipe-commit at 40% row width via a `useAnimatedReaction` on `translation`, light threshold-cross haptic + success commit haptic); web rows render an always-visible `WebTrashButton` (typed `onHoverIn/Out` color change). a11y: `accessibilityState={{expanded}}`, "Collapsed/Expanded" suffix, REQUIRED row `accessibilityAction` "delete", Open/trash labels.
+- **Why:** SC-1/2/3/3-Web/5/9 + DESIGN §1/§2/§4.
+- **Lines:** ~+240/-40.
+
+### `app/notifications.tsx`
+- **Before:** header right slot held only "Mark all read" (when `unreadCount>0`), else a 36pt spacer.
+- **Now:** four-state header cluster — "Mark all read" (unread>0) and/or "Clear read" (hasRead), Mark-all leftmost / Clear-read rightmost, `gap: spacing.md`; "Clear read" opens a reused `ConfirmDialog` (`variant="simple"`, `destructive`, title "Clear read notifications?", live frozen-count description with `1 read notification` singular, Confirm "Clear read"); confirm fires `clearRead()` + success haptic + dismiss; count frozen at open so a background realtime insert can't change the copy mid-read. NO `Alert.alert`, no new component.
+- **Why:** SC-4/9 + DESIGN §3.
+- **Lines:** ~+85/-12.
+
+---
+
+## 8. Cross-surface impact
+
+| # | Surface | Affected | Behavior | Parity |
+|---|---------|----------|----------|--------|
+| 1 | Consumer iOS | NO | unchanged (additive NULL column; consumer fetch untouched) | n/a |
+| 2 | Consumer Android | NO | unchanged | n/a |
+| 3 | Buyer/anon Web | NO | unchanged (no notifications surface) | n/a |
+| 4 | Business iOS | YES | tap-expand + Open + swipe-delete + Clear read | automatic (shared hook/DB) + manual (native swipe) |
+| 5 | Business Android | YES | same as iOS; Android opaque-glass policy preserved (no new translucent layer; `overflow:'hidden'` clips card + red panel; shadows stay zeroed) | automatic + manual |
+| 6 | Admin Web | NO | unchanged (exempt from I-PROPOSED-W; not in ask) | n/a |
+| 7 | Business Web preview | YES | tap-expand + Open + always-visible trash + Clear read; swipe degrades to the trash button | manual (web button instead of swipe) |
+
+---
+
+## 9. Smoke / verification result
+
+- **Source/type:** `tsc --noEmit` → 0 errors in any of the 4 changed files (project has 263 pre-existing baseline errors, none touching this ORCH).
+- **Tests:** new test 5/5 green; existing inbox test 4/4 green; fails-on-revert proven at `2bcf4e847`.
+- **Gate:** I-PROPOSED-W exit 0.
+- **DB probe:** read-only prod SELECT confirmed the migration's assumptions (table/columns/policy/index) — see §4.
+- **NOT run (label honestly):** native swipe gesture, full-swipe-commit threshold + dual haptics, multi-device realtime drop, and the expand/collapse + slide-out motion are **UNVERIFIED** — they need sim/device live-fire (the tester owns this). No `eas build` needed (pure-JS/RN; OTA-eligible) — but native runtime behavior of `ReanimatedSwipeable` + the `useAnimatedReaction` full-swipe path must be device-confirmed before CLOSE.
+
+---
+
+## 10. Known issues / deferred
+
+- **Full-swipe-commit tuning:** the auto-commit fires when `translation <= -(rowWidth * 0.4)` via a worklet reaction; the exact "feel" (vs `rightThreshold` rest-open) should be eyeballed on device and the ratio/threshold nudged if it commits too eagerly or too late. No `[TRANSITIONAL]` marker — it is the intended final mechanism, just needs device tuning.
+- No undo surface (by design — recovery is server-side; the confirm copy is honest: "You can't undo this here"). SPEC §10 Q3 default (immediate clear, no undo) accepted.
+
+---
+
+## 11. Operator action required
+
+1. **Apply the migration** (re-verify prod head first; apply via Supabase Management API per the migration-apply hazard memo — CLI is drift-wedged). If applying via CLI from the worktree:
+   ```bash
+   cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1142-[notif-read-delete]" && /Users/sethogieva/bin/supabase db push --linked
+   ```
+   The migration is additive + idempotent (`IF NOT EXISTS`), no guards — safe.
+2. **Edge functions:** none to deploy.
+3. **OTA:** after merge to main + tester PASS, OTA the business app dev channel (pure-JS/RN change; runtime biz 1.0.0) per the EAS OTA gotchas memo (`npx -y eas-cli@latest update`, per-platform).
+4. **CLOSE:** flip `I-PROPOSED-BH` ACTIVE + append the registry entry; annotate META-ORCH-1074 SUB-C_DESIGN §4.4 supersession so a future session doesn't "restore" the no-swipe rule as a regression.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **SPEC vs reality — `ReanimatedSwipeable` import mechanics (minor deviation, behavior identical):** SPEC §4.C.5 / DESIGN §5 say "named import from `react-native-gesture-handler`". The installed gesture-handler 2.28.0 does NOT re-export `ReanimatedSwipeable` from the top-level barrel (only the legacy `Swipeable`). It is the **default export of the subpath** `react-native-gesture-handler/ReanimatedSwipeable`. I imported it as `import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable"` (+ `type { SwipeableMethods }`). Same component, NO new dependency. Flagging for REVIEW so it isn't mistaken for a wrong-component substitution.
+- **Threshold-cross haptic:** the `HapticFeedback` util has no `.selection()`/`.light()`; per DESIGN §2.4's stated fallback I used `HapticFeedback.buttonPress()` (Light impact) for the threshold-cross and `HapticFeedback.success()` for the commit. No util change (DO-NOT-TOUCH respected).
+- **Web hover:** the `hovered` Pressable style-callback arg is react-native-web-only and untyped (tsc error on native types). Implemented the DESIGN §2.6 hover color change via the typed `onHoverIn/onHoverOut` + local state in a small `WebTrashButton` (same file, no new dependency/component file beyond an in-file sub-component, consistent with the existing in-file `SkeletonRow`/`EmptyState` pattern).
+- No unrelated bugs found.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1142_NOTIF_READ_AND_DELETE.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1142_NOTIF_READ_AND_DELETE.md
@@ -1,0 +1,242 @@
+# SPEC — ORCH-1142 — Business notifications: full-read (tap-to-expand) + delete (soft-delete)
+
+- **ORCH-ID:** ORCH-1142
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1142-[notif-read-delete]` on `ORCH-1142-notif-read-delete` (HEAD `2bcf4e847`).
+- **Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1142_NOTIF_READ_AND_DELETE.md` (this worktree).
+- **Date:** 2026-06-15 · **Author:** mingla-forensics+claude · **Mode:** SPEC (binding contract; ≤2–3-line snippets only).
+- **Pipeline note:** DESIGN runs AFTER this SPEC (UI-touching). §4-Component + §12-Design carry the design intent the implementor must NOT improvise on; the finished pixel spec from `mingla-designer` is appended/embedded before IMPLEMENT.
+
+---
+
+## 1. Executive summary
+
+Business operators can see notifications but can neither read the full (untruncated) text nor remove read notifications — both are deliberate META-ORCH-1074 Sub-C scope-outs (proven: F-1..F-4). This SPEC adds two capabilities, exactly to Seth's locked decisions:
+
+1. **Full-read = tap-to-expand in place.** Tapping a row toggles an inline expanded state that shows the untruncated title + body. The deep-link becomes a SECONDARY action: an "Open" button revealed only in the expanded state. Mark-as-read still fires on the first interaction.
+2. **Delete = per-row swipe-to-delete + a "Clear read" header bulk action**, both implemented as a **DB soft-delete** (`deleted_at timestamptz` on `public.notifications`, NULL by default). The inbox fetch + realtime patch exclude soft-deleted rows. "Clear read" soft-deletes only rows where `read_at IS NOT NULL` AND the business-type prefix — never unread, never consumer rows. Financial-record reference value is preserved server-side (the row persists; it is only hidden from the operator inbox).
+
+---
+
+## 2. Scope & non-goals
+
+**In scope:** business iOS + business Android + business web preview (one shared route). The migration (additive soft-delete column + index), the hook (`useBusinessNotifications.ts`), the screen (`BusinessNotificationsScreen.tsx`), the route header (`app/notifications.tsx`).
+
+**Non-goals (explicit):**
+- NO consumer (`app-mobile/`) changes — the consumer inbox fetch is untouched (its I-PROPOSED-W exclusion already holds). The new column is additive/NULL-default, so consumer reads are unaffected.
+- NO admin (`mingla-admin/`) changes.
+- NO hard delete — soft-delete only (preserves reference value). Do NOT use the existing DELETE RLS policy.
+- NO push/OneSignal change; NO notify-dispatch / edge-function change (the column is operator-writable via RLS — F-6).
+- NO new dependency — `react-native-gesture-handler` (~2.28.0) + `react-native-reanimated` (~4.1.1) are already present and `GestureHandlerRootView` is mounted at the app root (`mingla-business/app/_layout.tsx:665`).
+- NO change to mark-read / mark-all-read semantics, the date bucketing, severity float, or the family-accent grammar.
+- NO removal of the I-PROPOSED-W filter clause.
+
+**Assumptions:** the soft-delete is a UI-inbox hide, not a GDPR erasure (erasure has its own path, `b2a_v3_gdpr_erasure`). The expand state is ephemeral (component state, not persisted).
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY)
+
+| # | Surface | Covered | User-visible behavior | Files touched here | Parity |
+|---|---------|---------|------------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile/` iOS) | NO | unchanged | none | n/a — *not Seth's ask; consumer inbox separate* |
+| 2 | Consumer Android (`app-mobile/` Android) | NO | unchanged | none | n/a — *same reason* |
+| 3 | Buyer/anonymous Web | NO | unchanged | none | n/a — *no notifications surface* |
+| 4 | Business iOS | YES | tap-to-expand full text + "Open" secondary; swipe-to-delete; "Clear read" header | screen, hook, route, migration | automatic (shared hook/DB); manual (native swipe) |
+| 5 | Business Android | YES | same as iOS | same | automatic (shared); manual (native swipe + Android glass opaque fill on expanded card) |
+| 6 | Admin Web (`mingla-admin/`, adjacent) | NO | unchanged | none | n/a — *exempt from I-PROPOSED-W; not in ask* |
+| 7 | Business Web preview (adjacent) | YES | tap-to-expand full text + "Open"; swipe DEGRADES to a visible "Delete" button on the row; "Clear read" header | screen (`.web` branch via `Platform.OS === "web"`), hook, route | manual (web button instead of swipe) |
+
+**Hard gate:** the implementor must satisfy surfaces 4, 5, AND 7. Shipping native expand/swipe without the web delete-button fallback (or vice versa) is incomplete.
+
+---
+
+## 4. Layered specification
+
+### 4.A Database (migration — implementor writes; SPEC defines exactly)
+
+- **Migration file:** `supabase/migrations/20261002000000_orch_1142_notifications_soft_delete.sql`
+  - **Version rationale:** live migration head is `20261001000000` (verified via `list_migrations`) and the worktree's last file is the same. `20261002000000` is the next free monotonic slot, clear of all COMMS-0029/0030 prod-applied-but-unmerged trip migrations (all at/below `20260930000000`). **At deploy time, re-verify the prod head with `list_migrations`** and bump the date prefix if a newer migration landed first (per `feedback_edge_deploy_and_migration_apply_hazards` — apply via Management API; CLI is drift-wedged).
+- **Column:** `ALTER TABLE "public"."notifications" ADD COLUMN IF NOT EXISTS "deleted_at" timestamptz;` (nullable, NO default → NULL = not deleted). `COMMENT ON COLUMN` explaining soft-delete + reference-value preservation + ORCH-1142.
+- **Index (partial, for the exclusion filter):**
+  `CREATE INDEX IF NOT EXISTS "idx_notifications_user_active" ON "public"."notifications" ("user_id", "created_at" DESC) WHERE "deleted_at" IS NULL;`
+  Rationale: the hot path is "this user's non-deleted business rows, newest first". Partial index keeps it lean (most rows stay NULL).
+- **RLS:** **NO new policy.** Proven (F-6): the UPDATE policy "Users can update own notifications (mark read)" is column-agnostic (`USING auth.uid()=user_id` + `WITH CHECK auth.uid()=user_id`), so the user can set `deleted_at` on their own rows exactly as `read_at` is set today. Do NOT add or alter any policy. Do NOT use the DELETE policy.
+- **No GRANT change** — `authenticated` already has UPDATE on the table (precedent: existing mark-read writes).
+
+### 4.B Hook (`mingla-business/src/hooks/useBusinessNotifications.ts`)
+
+1. **`BusinessNotification` interface:** add `deleted_at: string | null;` and add `deleted_at` to `SELECT_COLUMNS`.
+2. **`fetchBusinessNotifications` (the SELECT):** keep the existing `.or("type.like.stripe.%,type.like.business.%")` clause **verbatim** (I-PROPOSED-W) and ADD `.is("deleted_at", null)` to the chain. Order/limit unchanged. (Gate stays green — F-7: inclusion clause still present on the SELECT.)
+3. **New `softDelete(id: string): Promise<void>`** — optimistic single-row soft-delete:
+   - Snapshot prev cache for `businessNotificationKeys.all(userId)`.
+   - Optimistically REMOVE the row from cache: `old.filter((n) => n.id !== id)`.
+   - `await supabase.from("notifications").update({ deleted_at: new Date().toISOString() }).eq("id", id)` (targets by PK; gate-exempt modify-op).
+   - On error: restore prev cache (or invalidate if prev undefined); `__DEV__` warn. Same silent-revert grammar as `markAsRead` (no operator alarm for a transient blip).
+   - Recompute the iOS badge after removal (mirror `markAsRead`'s `clearNotificationBadge` when no unread remain).
+4. **New `clearRead(): Promise<void>`** — optimistic bulk soft-delete scoped to read + business-type:
+   - Snapshot prev cache.
+   - Optimistically REMOVE all rows where `read_at !== null` from cache.
+   - `await supabase.from("notifications").update({ deleted_at: nowIso }).eq("user_id", userId).is("read_at", null === false ...)` — **EXACT scope:** `.eq("user_id", userId)`, `.not("read_at", "is", null)` (read rows only), `.is("deleted_at", null)` (don't re-stamp), AND `.or("type.like.stripe.%,type.like.business.%")` (business-type only — never consumer). NEVER soft-delete unread or consumer rows.
+   - On error: restore prev cache; `__DEV__` warn.
+5. **Realtime UPDATE patch (lines 101–117):** when an UPDATE arrives with `deleted_at !== null` for a business row, DROP it from cache instead of patching it in place:
+   `if (updated.deleted_at !== null) { setQueryData(key, (old=[]) => old.filter((n) => n.id !== updated.id)); return; }` — placed before the existing `.map` patch. This keeps multi-device inboxes consistent (delete on phone A removes it on phone B). The INSERT handler is unchanged.
+6. **`BusinessNotificationsInbox` interface:** add `readonly softDelete: (id: string) => Promise<void>;` and `readonly clearRead: () => Promise<void>;`. Return them from the hook. `notifications` and `unreadCount` derivations unchanged (deleted rows are already absent from cache).
+7. **Optional `hasRead` derived boolean** (`notifications.some((n) => n.read_at !== null)`) for the route to gate the "Clear read" header action. Add to the interface as `readonly hasRead: boolean;`.
+
+### 4.C Component (`mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx`)
+
+1. **Per-row expand state:** `NotificationRow` gains an `expanded` boolean (lifted to the screen as a `Set<string>` of expanded ids, OR local `useState` per row — implementor's choice, but expansion MUST collapse other rows is NOT required; multiple rows may be expanded). On row press: toggle expanded for this row AND fire `markAsRead(n.id)` on first interaction (mark-read must still happen even when only expanding).
+2. **Expanded render:** when `expanded`, the title renders with NO `numberOfLines` cap (full text) and the body with NO `numberOfLines` cap. When collapsed, keep `numberOfLines={1}` (title) / `numberOfLines={2}` (body) exactly as today. The bold-token and blocking-risk title variants must also drop their cap when expanded.
+3. **Secondary "Open" action:** when `expanded` AND `n.deep_link !== null`, render an "Open" button (revealed in the expanded state) that calls a new `onOpenDeepLink(n.deep_link, n)` — the SAME prop the route already passes. The deep-link is NO LONGER fired on plain tap (tap now = expand). Blocking-risk rows keep their existing "Respond" affordance; "Open" is additive and may co-exist.
+4. **Tap contract change:** `handlePress` (screen, lines 429–437) no longer navigates on tap. New contract: tap → `markAsRead(n.id)` + toggle expand. Navigation happens ONLY via the expanded "Open" button (or the "Respond" CTA for blocking-risk). The `onOpenDeepLink` prop is still consumed, just from the "Open"/"Respond" buttons.
+5. **Swipe-to-delete (native):** wrap each `NotificationRow` in `ReanimatedSwipeable` (named import from `react-native-gesture-handler` — NOT the legacy `Swipeable`; reanimated v4 is present). `renderRightActions` renders a destructive red panel with the `trash` icon (icon key `trash` confirmed present). On full swipe / action tap → `HapticFeedback` + `softDelete(n.id)`. Use `semantic.error` for the destructive panel; respect the Android glass opaque-fallback policy on the row card.
+6. **Web variant (`Platform.OS === "web"`):** `ReanimatedSwipeable` swipe does not apply; instead render a visible trailing "Delete" affordance on each row (e.g. a small trash `Pressable` revealed on hover/focus or always-visible per DESIGN) that calls `softDelete(n.id)`. The `isWeb` constant already exists at line 116.
+7. **States (all must be handled):**
+   - **Collapsed (default):** as today (1-line title / 2-line body, chevron, unread rail/dot).
+   - **Expanded:** full title + body, "Open" button if `deep_link`, chevron rotates or hides (DESIGN decides), card may grow height.
+   - **Optimistic-delete in flight:** row removed immediately from the list.
+   - **Delete revert on error:** row reappears in its prior position (cache restore); a non-alarming `__DEV__` warn only (matches mark-read grammar).
+   - **Empty after clear-all:** the existing `EmptyState` ("You're all caught up") renders. The "Clear read" header action must hide (or disable) when no read rows remain.
+   - Existing skeleton / error+retry / offline-banner states are unchanged.
+8. **a11y:** the row `accessibilityLabel` should append "Expanded" / "Collapsed"; the "Open" button gets `accessibilityRole="button"` + label "Open notification target"; the swipe/web delete gets label "Delete notification". Maintain ≥44pt touch targets.
+
+### 4.D Route header (`mingla-business/app/notifications.tsx`)
+
+1. Add a **"Clear read"** action as a SIBLING to "Mark all read" in the chrome header right region. Render it only when `hasRead` is true (from the hook). It calls `clearRead()` (+ `HapticFeedback` on native).
+2. Both actions may co-exist: "Mark all read" shows when `unreadCount > 0`; "Clear read" shows when `hasRead`. When both show, lay them out per DESIGN (likely a small action cluster; the current right slot is a single `Pressable`). Use the `trash` icon + accent for "Clear read", mirroring the `check` + accent for "Mark all read".
+3. Pull `softDelete`, `clearRead`, `hasRead` from `useBusinessNotificationsInbox`. Pass `onOpenDeepLink` to the screen unchanged (now consumed by the expanded "Open" button).
+4. Web: the header renders the same "Clear read" action; the route already has a web `close` affordance.
+
+### 4.E Realtime
+
+Channel + filter unchanged (`user_id=eq.${userId}`). The UPDATE handler gains the soft-delete drop branch (§4.B item 5). No new channel.
+
+---
+
+## 5. Success criteria (per-surface where parity is manual)
+
+- **SC-1 (full-read):** Tapping a collapsed row expands it in place to show the COMPLETE title + body (no truncation), and marks it read on first tap. Tapping again collapses it.
+- **SC-2 (deep-link demoted):** In the expanded state, a row with a non-NULL `deep_link` shows an "Open" button that navigates to the resolved target; plain tap NO LONGER navigates. A row with NULL `deep_link` shows no "Open" button and tap only expands/marks-read.
+- **SC-3-iOS / SC-3-Android (swipe delete):** Swiping a row left reveals a destructive trash action; completing it removes the row immediately (optimistic) and soft-deletes it server-side (`deleted_at` set). The row does not reappear on refetch.
+- **SC-3-Web:** A visible "Delete" affordance on each row removes it (no swipe gesture required).
+- **SC-4 (Clear read):** The header "Clear read" action soft-deletes every row where `read_at IS NOT NULL` AND type matches `stripe.%`/`business.%`; unread rows and any consumer rows are untouched. The inbox updates immediately; refetch confirms only unread/business rows remain.
+- **SC-5 (revert on error):** When `softDelete` or `clearRead`'s UPDATE returns an error, the optimistically-removed row(s) reappear in prior order; no crash, no alarming UI (silent `__DEV__` warn only).
+- **SC-6 (realtime multi-device):** A soft-delete performed on device A removes the row from device B's inbox within the realtime UPDATE patch (no manual refetch).
+- **SC-7 (reference value preserved):** After soft-delete, the row still exists in `public.notifications` with `deleted_at` set (NOT physically deleted) — confirmable by a service-role/admin SELECT.
+- **SC-8 (I-PROPOSED-W intact):** The strict-grep gate `i-proposed-w-notifications-app-type-prefix.mjs` passes after the change (the SELECT keeps the inclusion clause; modify-ops exempt).
+- **SC-9 (empty state):** After clearing all read rows with no unread remaining, the "You're all caught up" empty state renders and "Clear read" hides.
+
+---
+
+## 6. Invariants
+
+**Preserved:**
+- **I-PROPOSED-W (DRAFT)** — soft-delete SELECT keeps `.or('type.like.stripe.%,type.like.business.%')`; modify-ops gate-exempt. Verified by SC-8 + the existing gate run.
+
+**New (propose as DRAFT — orchestrator flips ACTIVE at CLOSE):**
+- **`I-PROPOSED-BH-NOTIF-SOFTDELETE-EXCLUDED-AND-SCOPED` (DRAFT):** the business notifications SELECT MUST exclude soft-deleted rows (`.is("deleted_at", null)`), AND the "Clear read" bulk soft-delete MUST be scoped to `read_at IS NOT NULL` AND the business-type prefix `.or("type.like.stripe.%,type.like.business.%")` — never unread rows, never consumer rows. (Letter BH is free in the registry; BI/BJ/BK also free as fallbacks.)
+  - **Why a gate:** without the `deleted_at IS NULL` filter, soft-deleted rows resurface in the inbox (defeats the feature); without the read+business scope on "Clear read", the bulk action could nuke unread or consumer notifications (data-loss + cross-app leak).
+  - **Enforcement option (DRAFT, implementor to add):** extend the existing strict-grep gate OR add a small jest source-assertion (see §9) — the SPEC requires the jest source-assertion at minimum; a strict-grep extension is optional.
+
+**Superseded (record explicitly):** SUB-C_DESIGN §4.4 "NO swipe-to-dismiss — financial records have reference value" is superseded for the operator inbox VIEW only. Reference value is preserved via soft-delete (row persists server-side). The implementor must add a protective comment at the new delete code AND the orchestrator should annotate the SUB-C design doc, so a future session does not "restore" §4.4 as a regression.
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T1 | Expand happy path | Tap a collapsed row with long title/body | Full text shown, row marked read | component |
+| T2 | Collapse | Tap an expanded row | Collapses to 1-line/2-line | component |
+| T3 | Open secondary | Expanded row, `deep_link` non-null, tap "Open" | Navigates to resolved target | component+route |
+| T4 | No deep-link | Expanded row, `deep_link` null | No "Open" button; tap only expands/marks-read | component |
+| T5 | Swipe delete (native) | Swipe + confirm | Row removed; `update({deleted_at})` by id fired | component+hook+db |
+| T6 | Web delete | Click row "Delete" affordance on web | Row removed (no swipe) | component (web) |
+| T7 | Clear read scope | 2 read business + 1 unread business + (simulated) 1 read consumer row in DB | Only the 2 read business rows get `deleted_at`; unread + consumer untouched | hook+db |
+| T8 | softDelete revert | UPDATE returns error | Removed row reappears in prior order; `__DEV__` warn | hook |
+| T9 | clearRead revert | UPDATE returns error | All removed rows reappear; warn | hook |
+| T10 | Realtime drop | Inbound UPDATE payload with `deleted_at != null`, business type | Row dropped from cache | hook (realtime) |
+| T11 | Fetch excludes deleted | Row with `deleted_at` set | Absent from inbox after refetch | hook+db |
+| T12 | I-PROPOSED-W gate | Run the strict-grep gate post-change | Exit 0 (passes) | CI |
+| T13 | Reference value | Soft-deleted row | Still present in table with `deleted_at` set (service-role SELECT) | db |
+| T14 | Empty after clear | Clear all read, no unread | "You're all caught up"; "Clear read" hidden | component+route |
+
+---
+
+## 8. Implementation order
+
+1. **DB:** write + apply (via Management API, after re-checking prod head) `20261002000000_orch_1142_notifications_soft_delete.sql` (column + partial index; NO RLS change).
+2. **Hook:** add `deleted_at` to interface + `SELECT_COLUMNS`; add `.is("deleted_at", null)` to fetch; add `softDelete` + `clearRead` + `hasRead`; add the realtime soft-delete drop branch; export the new members.
+3. **Component:** add expand state + full-text expanded render + "Open" secondary button; change tap contract (expand+mark-read, no navigate); wrap rows in `ReanimatedSwipeable` (native) with a web "Delete" fallback; handle all states; a11y.
+4. **Route:** add "Clear read" header action gated on `hasRead`; lay out alongside "Mark all read"; wire `softDelete`/`clearRead`.
+5. **Tests:** add the jest source-assertion for `I-PROPOSED-BH` + the regression test (§9); run the I-PROPOSED-W gate.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+- **Structural safeguard:** the soft-delete exclusion + the read/business scope on "Clear read".
+- **Test (jest source-assertion, REQUIRED):** add `mingla-business/src/hooks/__tests__/orch_1142_notif_softdelete_scope.test.ts` that reads `useBusinessNotifications.ts` source and asserts:
+  1. `fetchBusinessNotifications` contains BOTH `type.like.stripe.%` AND `.is("deleted_at", null)`.
+  2. `clearRead` contains `.is("read_at", null)` is NOT present as a delete-all (i.e. it targets `read_at` IS NOT NULL) AND contains the business-type `.or(...)`.
+  3. `softDelete` updates `deleted_at` and targets by `.eq("id"`.
+  - **Fails-on-revert:** removing the `.is("deleted_at", null)` filter, or widening `clearRead` to drop the read/business scope, MUST fail this test; restoring it MUST pass. The implementor proves the fail-on-revert.
+- **I-PROPOSED-W:** the existing `i-proposed-w-notifications-app-type-prefix.mjs` gate already fails-on-revert if the inclusion clause is removed — re-confirm it passes (SC-8/T12).
+- **Protective comment:** at the new delete code, add a comment citing ORCH-1142 + the SUB-C §4.4 supersession + "soft-delete preserves reference value; do NOT convert to hard delete or remove the deleted_at filter."
+
+---
+
+## 10. Open questions
+
+1. **Expand multiplicity:** may multiple rows be expanded at once, or should opening one collapse others? SPEC default: allow multiple (simpler, no surprise collapse). DESIGN may override.
+2. **Web delete affordance visibility:** always-visible trash vs hover/focus-revealed? Deferred to DESIGN.
+3. **"Clear read" confirmation:** does Seth want a confirm step (could be many rows) or immediate-with-undo? SPEC default: immediate (matches "Mark all read" which has no confirm); the optimistic revert covers transient errors but NOT user mistake-undo. Flag for Seth — if undo is wanted, that is a scope addition.
+4. **Swipe direction + threshold:** left-swipe to delete (iOS convention) — confirm with DESIGN; full-swipe auto-deletes vs reveal-then-tap.
+
+(None of these block IMPLEMENT structurally except #3 if Seth wants undo; the rest are DESIGN refinements.)
+
+---
+
+## 11. Allowlist + DO-NOT-TOUCH
+
+**Allowlist (implementor may modify/create ONLY these):**
+- `supabase/migrations/20261002000000_orch_1142_notifications_soft_delete.sql` (new)
+- `mingla-business/src/hooks/useBusinessNotifications.ts`
+- `mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx`
+- `mingla-business/app/notifications.tsx`
+- `mingla-business/src/hooks/__tests__/orch_1142_notif_softdelete_scope.test.ts` (new)
+- (optional) `.github/scripts/strict-grep/` — ONLY if adding an `I-PROPOSED-BH` strict-grep gate (not required; jest assertion suffices)
+- `Mingla_Artifacts/INVARIANT_REGISTRY.md` — append the `I-PROPOSED-BH` DRAFT entry (orchestrator may instead own this at CLOSE; coordinate).
+
+**DO-NOT-TOUCH:**
+- Any `app-mobile/` (consumer) file — consumer fetch + I-PROPOSED-W exclusion stay as-is.
+- Any `mingla-admin/` file.
+- The I-PROPOSED-W gate's inclusion logic (do not weaken; do not add the file allowlist tag).
+- `notify-dispatch` / any edge function / the `notification_preferences` table / `is_read` column.
+- RLS policies on `public.notifications` (none needed — F-6).
+- `businessNotificationRouting.ts` / `resolveBusinessNavTarget` (the "Open" button reuses the existing route map unchanged).
+- Date bucketing, severity float, family-accent grammar, mark-read/mark-all semantics.
+
+The implementor must STOP-and-amend (SPEC amendment) before touching anything outside the allowlist.
+
+---
+
+## 12. Design phase (mingla-designer — runs after this SPEC, before IMPLEMENT)
+
+This change is UI-touching. DESIGN must produce the pixel-precise spec for:
+- The **expanded card** state (height growth, full-text type/line-height, "Open" button placement/style, chevron rotate-or-hide, motion of the expand — trigger→curve→duration→property).
+- The **swipe-to-delete** affordance (right-action panel width, destructive red token, trash icon size, full-swipe threshold vs reveal, haptic timing) + the **web "Delete"** fallback (visibility model).
+- The **header action cluster** when both "Mark all read" and "Clear read" are present (layout, spacing, icon+label, the empty/hidden states).
+- Per-platform deltas incl. Android glass opaque-fallback on the expanded card; a11y (≥44pt, labels, expanded/collapsed announcement).
+
+The finished design contract is embedded here (or referenced) before the IMPLEMENT dispatch. The implementor builds from SPEC + embedded design; design questions during IMPLEMENT route back through the orchestrator to forensics, not to the designer directly.
+
+---
+
+## 13. Downstream routing
+
+- **Next:** DESIGN (`mingla-designer`, business iOS/Android/web) → produce the pixel spec for §12; embed into this SPEC.
+- **Then:** IMPLEMENT (`mingla-implementor`, business side) in this worktree — build §4 in §8 order, prove the §9 fails-on-revert.
+- **Then:** TEST (`mingla-tester`, business iOS + Android + web) — live-fire SC-1..SC-9 on sim/device.
+- **Then:** orchestrator CLOSE — flip `I-PROPOSED-BH` ACTIVE, annotate SUB-C §4.4 supersession, OTA the business app (pure-JS/RN changes are OTA-eligible; the migration deploys server-side independently).
+- **Working tree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1142-[notif-read-delete]` on branch `ORCH-1142-notif-read-delete`.

--- a/mingla-business/app/notifications.tsx
+++ b/mingla-business/app/notifications.tsx
@@ -14,7 +14,7 @@
  * I-21: operator-side route. Never imported by anon-tolerant buyer routes.
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -27,6 +27,7 @@ import {
 } from "../src/constants/designSystem";
 import { Icon } from "../src/components/ui/Icon";
 import { IconChrome } from "../src/components/ui/IconChrome";
+import { ConfirmDialog } from "../src/components/ui/ConfirmDialog";
 import { BusinessNotificationsScreen } from "../src/components/notifications/BusinessNotificationsScreen";
 import { useBusinessNotificationsInbox } from "../src/hooks/useBusinessNotifications";
 import { useAuth } from "../src/context/AuthContext";
@@ -42,7 +43,14 @@ export default function NotificationsRoute(): React.ReactElement {
   const router = useRouter();
   const { user } = useAuth();
   const userId = user?.id ?? null;
-  const { unreadCount, markAllAsRead } = useBusinessNotificationsInbox(userId);
+  const { unreadCount, markAllAsRead, notifications, clearRead, hasRead } =
+    useBusinessNotificationsInbox(userId);
+
+  // ORCH-1142: "Clear read" opens a confirm (unlike "Mark all read", which is
+  // non-destructive + immediate). The read count is FROZEN at open time so a
+  // background realtime insert can't change the dialog copy mid-read.
+  const [confirmVisible, setConfirmVisible] = useState(false);
+  const [frozenReadCount, setFrozenReadCount] = useState(0);
 
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
@@ -56,6 +64,23 @@ export default function NotificationsRoute(): React.ReactElement {
     if (Platform.OS !== "web") HapticFeedback.success();
     void markAllAsRead();
   }, [markAllAsRead]);
+
+  const handleClearReadPress = useCallback((): void => {
+    if (Platform.OS !== "web") HapticFeedback.buttonPress();
+    setFrozenReadCount(notifications.filter((n) => n.read_at !== null).length);
+    setConfirmVisible(true);
+  }, [notifications]);
+
+  const handleClearReadConfirm = useCallback((): void => {
+    if (Platform.OS !== "web") HapticFeedback.success();
+    void clearRead();
+    setConfirmVisible(false);
+  }, [clearRead]);
+
+  const clearReadDescription =
+    frozenReadCount === 1
+      ? "This removes 1 read notification from your inbox. Unread ones stay. You can’t undo this here."
+      : `This removes ${frozenReadCount} read notifications from your inbox. Unread ones stay. You can’t undo this here.`;
 
   // Tap on a row → resolve the row's deep link / type to an expo-router path
   // and navigate (the same routing map Sub-B's push tap uses). The screen
@@ -89,21 +114,45 @@ export default function NotificationsRoute(): React.ReactElement {
           accessibilityLabel="Back"
         />
         <Text style={styles.chromeTitle}>Notifications</Text>
-        {unreadCount > 0 ? (
-          <Pressable
-            onPress={handleMarkAll}
-            accessibilityRole="button"
-            accessibilityLabel="Mark all notifications as read"
-            accessibilityHint="Marks every unread notification as read"
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            style={({ pressed }) => [
-              styles.markAll,
-              pressed ? styles.markAllPressed : null,
-            ]}
-          >
-            <Icon name="check" size={16} color={accent.warm} />
-            <Text style={styles.markAllLabel}>Mark all read</Text>
-          </Pressable>
+        {/* ORCH-1142 four-state header cluster (DESIGN §3.2): "Mark all read"
+            shows when unreadCount>0; "Clear read" shows when hasRead; both may
+            co-exist (Mark all read first, Clear read rightmost); when neither,
+            the 36pt spacer keeps the title centered. */}
+        {unreadCount > 0 || hasRead ? (
+          <View style={styles.headerActions}>
+            {unreadCount > 0 ? (
+              <Pressable
+                onPress={handleMarkAll}
+                accessibilityRole="button"
+                accessibilityLabel="Mark all notifications as read"
+                accessibilityHint="Marks every unread notification as read"
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                style={({ pressed }) => [
+                  styles.markAll,
+                  pressed ? styles.markAllPressed : null,
+                ]}
+              >
+                <Icon name="check" size={16} color={accent.warm} />
+                <Text style={styles.markAllLabel}>Mark all read</Text>
+              </Pressable>
+            ) : null}
+            {hasRead ? (
+              <Pressable
+                onPress={handleClearReadPress}
+                accessibilityRole="button"
+                accessibilityLabel="Clear read notifications"
+                accessibilityHint="Removes read notifications from your inbox; unread stay"
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                style={({ pressed }) => [
+                  styles.markAll,
+                  pressed ? styles.markAllPressed : null,
+                ]}
+              >
+                <Icon name="trash" size={16} color={accent.warm} />
+                <Text style={styles.markAllLabel}>Clear read</Text>
+              </Pressable>
+            ) : null}
+          </View>
         ) : (
           <View style={styles.chromeRightSlot} />
         )}
@@ -112,6 +161,18 @@ export default function NotificationsRoute(): React.ReactElement {
       <BusinessNotificationsScreen
         userId={userId}
         onOpenDeepLink={handleOpenDeepLink}
+      />
+
+      <ConfirmDialog
+        visible={confirmVisible}
+        onClose={(): void => setConfirmVisible(false)}
+        onConfirm={handleClearReadConfirm}
+        variant="simple"
+        destructive
+        title="Clear read notifications?"
+        description={clearReadDescription}
+        confirmLabel="Clear read"
+        cancelLabel="Cancel"
       />
     </View>
   );
@@ -140,6 +201,14 @@ const styles = StyleSheet.create({
   },
   chromeRightSlot: {
     width: 36,
+  },
+  // ORCH-1142 — header action cluster when both "Mark all read" and "Clear
+  // read" are present (DESIGN §3.3). Mark-all first, Clear-read rightmost.
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: spacing.md,
   },
   markAll: {
     flexDirection: "row",

--- a/mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx
+++ b/mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx
@@ -25,7 +25,7 @@
  * are the deliberate sub-grid accents the design calls out.
  */
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   Animated,
   Platform,
@@ -36,6 +36,22 @@ import {
   Text,
   View,
 } from "react-native";
+import Reanimated, {
+  Easing,
+  LinearTransition,
+  runOnJS,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+// ReanimatedSwipeable is exposed by react-native-gesture-handler ONLY as a
+// subpath default export (the top-level barrel exports the legacy `Swipeable`).
+// gesture-handler is already installed + GestureHandlerRootView is mounted at
+// the app root — this is NOT a new dependency. Native only (web branches off).
+import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
 
 import { Icon } from "../ui/Icon";
 import {
@@ -48,6 +64,7 @@ import {
   glass,
   shadows,
   canvas,
+  durations,
 } from "../../constants/designSystem";
 import { useShimmer } from "../../hooks/useShimmer";
 import { HapticFeedback } from "../../utils/hapticFeedback";
@@ -113,7 +130,19 @@ const UNREAD_RAIL_WIDTH = 3;
 const UNREAD_DOT = 8;
 const WEB_MAX_WIDTH = 640;
 
+// ORCH-1142 deliberate sub-grid accents (DESIGN §5), declared alongside the
+// existing ICON_CIRCLE/UNREAD_RAIL_WIDTH/UNREAD_DOT.
+const SWIPE_ACTION_WIDTH = 80; // revealed red panel width (iOS-mail idiom)
+const SWIPE_FULL_COMMIT_RATIO = 0.4; // fraction of row width → full-swipe auto-commit
+const SWIPE_REVEAL_THRESHOLD = 40; // rightThreshold (snap-open distance)
+const CHEVRON_EXPAND_DEG = 90; // chevron rotation when expanded
+
 const isWeb = Platform.OS === "web";
+
+// `easings.out` token = cubic-bezier(0.33, 1, 0.68, 1) (decelerate). Reanimated
+// equivalent for the expand/collapse + chevron motion.
+const EASE_OUT = Easing.bezier(0.33, 1, 0.68, 1);
+const EXPAND_TRANSITION = LinearTransition.duration(durations.entry).easing(EASE_OUT);
 
 // ── Date bucketing (SUB-C_DESIGN §4.1) ───────────────────────────────────────
 
@@ -220,30 +249,104 @@ function boldTokenFor(n: BusinessNotification): string | null {
 
 interface RowProps {
   notification: BusinessNotification;
+  /** Toggle expand + mark-read on the row (tap contract — no longer navigates). */
   onPress: (n: BusinessNotification) => void;
+  /** Navigate to the row's deep-link target (fired from the expanded "Open" button). */
+  onOpenDeepLink: (n: BusinessNotification) => void;
+  /** Soft-delete the row (swipe-commit on native, trash tap on web). */
+  onDelete: (n: BusinessNotification) => void;
+  expanded: boolean;
 }
 
-const NotificationRow: React.FC<RowProps> = ({ notification, onPress }) => {
+/**
+ * Web delete fallback (DESIGN §2.6): always-visible trailing trash; color goes
+ * to semantic.error on hover/press via the typed onHoverIn/onHoverOut API (the
+ * `hovered` style-callback arg is react-native-web only and untyped). Color-only
+ * change → no layout shift. Native never mounts this (the swipe is the path).
+ */
+const WebTrashButton: React.FC<{ onPress: () => void }> = ({ onPress }) => {
+  const [active, setActive] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onHoverIn={(): void => setActive(true)}
+      onHoverOut={(): void => setActive(false)}
+      onPressIn={(): void => setActive(true)}
+      onPressOut={(): void => setActive(false)}
+      accessibilityRole="button"
+      accessibilityLabel="Delete notification"
+      hitSlop={{ top: 14, bottom: 14, left: 14, right: 14 }}
+      style={styles.webTrash}
+    >
+      <Icon
+        name="trash"
+        size={16}
+        color={active ? semantic.error : textTokens.tertiary}
+      />
+    </Pressable>
+  );
+};
+
+const NotificationRowInner: React.FC<RowProps> = ({
+  notification,
+  onPress,
+  onOpenDeepLink,
+  onDelete,
+  expanded,
+}) => {
   const visual = resolveNotificationVisual(notification.type);
   const fam = FAMILY_STYLE[visual.family];
   const unread = notification.read_at === null;
   const blockingRisk = isBlockingRisk(visual.family, visual.severity);
   const bold = boldTokenFor(notification);
+  const hasDeepLink = notification.deep_link !== null;
+
+  const reducedMotion = useReducedMotion();
+  const chevronDeg = useSharedValue(expanded ? CHEVRON_EXPAND_DEG : 0);
+
+  // ORCH-1142 chevron rotation (DESIGN §1.5 Animation B): +90° over
+  // durations.normal (200ms), easings.out. Reduced-motion → snap (no timing).
+  React.useEffect(() => {
+    const target = expanded ? CHEVRON_EXPAND_DEG : 0;
+    if (reducedMotion) {
+      chevronDeg.value = target;
+    } else {
+      chevronDeg.value = withTiming(target, {
+        duration: durations.normal,
+        easing: EASE_OUT,
+      });
+    }
+  }, [expanded, reducedMotion, chevronDeg]);
+
+  const chevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${chevronDeg.value}deg` }],
+  }));
 
   const handlePress = useCallback(() => {
     if (Platform.OS !== "web") HapticFeedback.buttonPress();
     onPress(notification);
   }, [notification, onPress]);
 
-  const a11yLabel = `${notification.title}. ${notification.body}. ${unread ? "Unread" : "Read"}. ${formatRelative(notification.created_at)} ago.`;
+  const handleOpen = useCallback(() => {
+    if (Platform.OS !== "web") HapticFeedback.buttonPress();
+    onOpenDeepLink(notification);
+  }, [notification, onOpenDeepLink]);
+
+  const handleWebDelete = useCallback(() => {
+    onDelete(notification);
+  }, [notification, onDelete]);
+
+  const a11yLabel = `${notification.title}. ${notification.body}. ${unread ? "Unread" : "Read"}. ${formatRelative(notification.created_at)} ago. ${expanded ? "Expanded." : "Collapsed."}`;
 
   // Title with the bold entity span emboldened (port of consumer
-  // renderTitleWithBoldActor, generalised to data.boldToken).
+  // renderTitleWithBoldActor, generalised to data.boldToken). When expanded,
+  // the title drops its numberOfLines cap so the full text wraps (DESIGN §1.2).
+  const titleLines = expanded ? undefined : 1;
   const renderTitle = (): React.ReactNode => {
     if (blockingRisk) {
       // Risk blocking rows render the whole title at 700 (§3.3).
       return (
-        <Text style={[styles.title, styles.titleBold]} numberOfLines={1}>
+        <Text style={[styles.title, styles.titleBold]} numberOfLines={titleLines}>
           {notification.title}
         </Text>
       );
@@ -253,7 +356,7 @@ const NotificationRow: React.FC<RowProps> = ({ notification, onPress }) => {
       const before = notification.title.slice(0, idx);
       const after = notification.title.slice(idx + bold.length);
       return (
-        <Text style={styles.title} numberOfLines={1}>
+        <Text style={styles.title} numberOfLines={titleLines}>
           {before}
           <Text style={styles.titleBold}>{bold}</Text>
           {after}
@@ -261,7 +364,7 @@ const NotificationRow: React.FC<RowProps> = ({ notification, onPress }) => {
       );
     }
     return (
-      <Text style={styles.title} numberOfLines={1}>
+      <Text style={styles.title} numberOfLines={titleLines}>
         {notification.title}
       </Text>
     );
@@ -272,6 +375,11 @@ const NotificationRow: React.FC<RowProps> = ({ notification, onPress }) => {
       onPress={handlePress}
       accessibilityRole="button"
       accessibilityLabel={a11yLabel}
+      accessibilityState={{ expanded }}
+      accessibilityActions={[{ name: "delete", label: "Delete notification" }]}
+      onAccessibilityAction={(e): void => {
+        if (e.nativeEvent.actionName === "delete") onDelete(notification);
+      }}
       style={({ pressed }) => [
         styles.card,
         {
@@ -304,32 +412,49 @@ const NotificationRow: React.FC<RowProps> = ({ notification, onPress }) => {
             {formatRelative(notification.created_at)}
           </Text>
         </View>
-        <Text style={styles.body} numberOfLines={2}>
+        <Text style={styles.body} numberOfLines={expanded ? undefined : 2}>
           {notification.body}
         </Text>
 
-        {blockingRisk ? (
+        {/* expanded / blocking-risk action row (DESIGN §1.3) */}
+        {blockingRisk || (expanded && hasDeepLink) ? (
           <View style={styles.respondRow}>
-            <Text
-              style={[styles.respondBtn, { color: semantic.warning }]}
-              accessibilityRole="button"
-              accessibilityLabel="Respond to dispute"
-            >
-              Respond
-            </Text>
+            {blockingRisk ? (
+              <Text
+                style={[styles.respondBtn, { color: semantic.warning }]}
+                accessibilityRole="button"
+                accessibilityLabel="Respond to dispute"
+              >
+                Respond
+              </Text>
+            ) : null}
+            {expanded && hasDeepLink ? (
+              <Pressable
+                onPress={handleOpen}
+                accessibilityRole="button"
+                accessibilityLabel="Open notification target"
+                accessibilityHint="Opens the related screen for this notification"
+                hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+                style={({ pressed }) => [
+                  styles.openBtn,
+                  pressed ? styles.openBtnPressed : null,
+                ]}
+              >
+                <Text style={styles.openLabel}>Open</Text>
+              </Pressable>
+            ) : null}
           </View>
         ) : null}
       </View>
 
       {/* trailing affordance + unread dot */}
       {!blockingRisk ? (
-        <Icon
-          name="chevR"
-          size={16}
-          color={textTokens.quaternary}
-          style={styles.chev}
-        />
+        <Reanimated.View style={[styles.chev, chevronStyle]}>
+          <Icon name="chevR" size={16} color={textTokens.quaternary} />
+        </Reanimated.View>
       ) : null}
+      {/* Web delete fallback: always-visible trailing trash (DESIGN §2.6). */}
+      {isWeb ? <WebTrashButton onPress={handleWebDelete} /> : null}
       {unread ? (
         <View
           style={[styles.dot, { backgroundColor: fam.rail }]}
@@ -337,6 +462,162 @@ const NotificationRow: React.FC<RowProps> = ({ notification, onPress }) => {
           importantForAccessibility="no-hide-descendants"
         />
       ) : null}
+    </Pressable>
+  );
+};
+
+/**
+ * Row shell — on native wraps the row in ReanimatedSwipeable (right→left
+ * swipe reveals a red trash panel; full-swipe auto-commits). On web renders
+ * the row directly (the always-visible trash inside the row is the delete
+ * affordance). The card spacing (marginBottom) moves to this wrapper so the
+ * card's overflow:'hidden' clips both the glass AND the red panel (DESIGN
+ * §2.2 / §4.1). ORCH-1142 — soft-delete preserves reference value; do NOT
+ * convert to hard delete or remove the deleted_at fetch filter.
+ */
+const NotificationRow: React.FC<RowProps> = (props) => {
+  const { notification, onDelete } = props;
+  const reducedMotion = useReducedMotion();
+  const swipeableRef = React.useRef<SwipeableMethods | null>(null);
+  // Set once the row knows its width (full-swipe-commit threshold is a fraction
+  // of it). Shared value so the worklet reaction can read it. `committed` guards
+  // against firing delete twice (reaction + rest-open tap).
+  const rowWidthSv = useSharedValue(0);
+  const committed = useSharedValue(false);
+  const crossedHaptic = useSharedValue(false);
+
+  const fireDelete = useCallback((): void => {
+    HapticFeedback.success();
+    swipeableRef.current?.close();
+    onDelete(notification);
+  }, [notification, onDelete]);
+
+  const fireThresholdHaptic = useCallback((): void => {
+    // Light threshold-cross tap (DESIGN §2.4 — selection/light; `selection`
+    // isn't in the util, so the light buttonPress stands in per the design).
+    HapticFeedback.buttonPress();
+  }, []);
+
+  // renderRightActions receives the live translation; a full left-swipe past
+  // SWIPE_FULL_COMMIT_RATIO of the row width auto-commits the delete without a
+  // second tap, and crossing it fires the one-shot threshold haptic. Short
+  // drags rest open at 80pt for the tap-to-delete path. (DESIGN §2.3/§2.4)
+  const renderRightActions = useCallback(
+    (
+      _progress: ReturnType<typeof useSharedValue<number>>,
+      translation: ReturnType<typeof useSharedValue<number>>,
+    ): React.ReactElement => {
+      return (
+        <SwipeRightAction
+          translation={translation}
+          rowWidthSv={rowWidthSv}
+          committed={committed}
+          crossedHaptic={crossedHaptic}
+          reducedMotion={reducedMotion}
+          onCommit={fireDelete}
+          onThresholdHaptic={fireThresholdHaptic}
+          onTapDelete={fireDelete}
+        />
+      );
+    },
+    [rowWidthSv, committed, crossedHaptic, reducedMotion, fireDelete, fireThresholdHaptic],
+  );
+
+  if (isWeb) {
+    return (
+      <Reanimated.View
+        layout={reducedMotion ? undefined : EXPAND_TRANSITION}
+        style={styles.rowWrapper}
+      >
+        <NotificationRowInner {...props} />
+      </Reanimated.View>
+    );
+  }
+
+  return (
+    <Reanimated.View
+      layout={reducedMotion ? undefined : EXPAND_TRANSITION}
+      style={styles.rowWrapper}
+      onLayout={(e): void => {
+        rowWidthSv.value = e.nativeEvent.layout.width;
+      }}
+    >
+      <ReanimatedSwipeable
+        ref={swipeableRef}
+        friction={2}
+        rightThreshold={SWIPE_REVEAL_THRESHOLD}
+        overshootRight={false}
+        renderRightActions={renderRightActions}
+        onSwipeableClose={(): void => {
+          committed.value = false;
+          crossedHaptic.value = false;
+        }}
+      >
+        <NotificationRowInner {...props} />
+      </ReanimatedSwipeable>
+    </Reanimated.View>
+  );
+};
+
+/**
+ * The red destructive swipe panel (native). Renders the trash glyph and runs a
+ * worklet reaction on the live `translation`: past SWIPE_FULL_COMMIT_RATIO of
+ * the row width → auto-commit the delete (full-swipe); a short reveal rests at
+ * SWIPE_ACTION_WIDTH for the tap-to-delete path. One-shot haptics via shared
+ * flags. DESIGN §2.2–§2.4.
+ */
+interface SwipeRightActionProps {
+  translation: ReturnType<typeof useSharedValue<number>>;
+  rowWidthSv: ReturnType<typeof useSharedValue<number>>;
+  committed: ReturnType<typeof useSharedValue<boolean>>;
+  crossedHaptic: ReturnType<typeof useSharedValue<boolean>>;
+  reducedMotion: boolean;
+  onCommit: () => void;
+  onThresholdHaptic: () => void;
+  onTapDelete: () => void;
+}
+
+const SwipeRightAction: React.FC<SwipeRightActionProps> = ({
+  translation,
+  rowWidthSv,
+  committed,
+  crossedHaptic,
+  onCommit,
+  onThresholdHaptic,
+  onTapDelete,
+}) => {
+  useAnimatedReaction(
+    () => translation.value,
+    (current) => {
+      "worklet";
+      const width = rowWidthSv.value;
+      if (width <= 0) return;
+      const commitPx = -(width * SWIPE_FULL_COMMIT_RATIO);
+      // current is negative for a left (right-action) swipe.
+      if (current <= commitPx) {
+        if (!crossedHaptic.value) {
+          crossedHaptic.value = true;
+          runOnJS(onThresholdHaptic)();
+        }
+        if (!committed.value) {
+          committed.value = true;
+          runOnJS(onCommit)();
+        }
+      } else if (current > commitPx && crossedHaptic.value && !committed.value) {
+        // dragged back under the threshold before committing — re-arm haptic.
+        crossedHaptic.value = false;
+      }
+    },
+  );
+
+  return (
+    <Pressable
+      onPress={onTapDelete}
+      accessibilityRole="button"
+      accessibilityLabel="Delete notification"
+      style={styles.swipeAction}
+    >
+      <Icon name="trash" size={22} color={textTokens.inverse} />
     </Pressable>
   );
 };
@@ -423,17 +704,45 @@ export function BusinessNotificationsScreen({
   userId,
   onOpenDeepLink,
 }: BusinessNotificationsScreenProps): React.ReactElement {
-  const { query, notifications, markAsRead } =
+  const { query, notifications, markAsRead, softDelete } =
     useBusinessNotificationsInbox(userId);
 
+  // ORCH-1142: per-row expand state (ephemeral). Multiple rows may be expanded
+  // at once (SPEC §10 Q1 / DESIGN §1.1 — no surprise auto-collapse of siblings).
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+
+  // Tap contract (SPEC §4.C.4): mark-read on first interaction + toggle expand.
+  // Tapping NO LONGER navigates — navigation is via the expanded "Open" button.
   const handlePress = useCallback(
     (n: BusinessNotification): void => {
       void markAsRead(n.id);
+      setExpandedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(n.id)) next.delete(n.id);
+        else next.add(n.id);
+        return next;
+      });
+    },
+    [markAsRead],
+  );
+
+  // Secondary "Open" action (from the expanded card) — the only navigate path.
+  const handleOpen = useCallback(
+    (n: BusinessNotification): void => {
       if (n.deep_link && onOpenDeepLink) {
         onOpenDeepLink(n.deep_link, n);
       }
     },
-    [markAsRead, onOpenDeepLink],
+    [onOpenDeepLink],
+  );
+
+  const handleDelete = useCallback(
+    (n: BusinessNotification): void => {
+      void softDelete(n.id);
+    },
+    [softDelete],
   );
 
   const sections = useMemo(() => groupByDate(notifications), [notifications]);
@@ -507,7 +816,14 @@ export function BusinessNotificationsScreen({
             {section.label.toUpperCase()}
           </Text>
           {section.rows.map((n) => (
-            <NotificationRow key={n.id} notification={n} onPress={handlePress} />
+            <NotificationRow
+              key={n.id}
+              notification={n}
+              onPress={handlePress}
+              onOpenDeepLink={handleOpen}
+              onDelete={handleDelete}
+              expanded={expandedIds.has(n.id)}
+            />
           ))}
         </View>
       ))}
@@ -559,8 +875,18 @@ const styles = StyleSheet.create({
     paddingRight: spacing.md,
     borderRadius: radius.lg,
     borderWidth: 1,
-    overflow: "hidden", // Android glass clip — mandatory (SUB-C_DESIGN §7)
+    // overflow:'hidden' is load-bearing TWICE (ORCH-1142 §4.1): (a) Android
+    // glass clip (existing, SUB-C_DESIGN §7) and (b) clipping the swipe red
+    // panel to the rounded corners. Keep on BOTH the card and the wrapper.
+    overflow: "hidden",
     minHeight: 72,
+  },
+  // ORCH-1142: row spacing moved here from `card` so the swipeable wrapper owns
+  // layout + clips the red action panel to the rounded corners. marginBottom
+  // preserves the exact list rhythm the collapsed row had.
+  rowWrapper: {
+    borderRadius: radius.lg,
+    overflow: "hidden",
     marginBottom: spacing.sm,
   },
   cardPressed: {
@@ -624,6 +950,39 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     paddingVertical: spacing.xs,
     paddingHorizontal: spacing.sm,
+  },
+  // ORCH-1142 — expanded "Open" secondary button (DESIGN §1.3). Text affordance
+  // mirroring `respondBtn` grammar; accent.warm; ≥44pt via padding + hitSlop.
+  openBtn: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  openBtnPressed: {
+    opacity: 0.7,
+  },
+  openLabel: {
+    fontSize: typography.buttonMd.fontSize,
+    lineHeight: typography.buttonMd.lineHeight,
+    fontWeight: typography.buttonMd.fontWeight,
+    letterSpacing: typography.buttonMd.letterSpacing,
+    color: accent.warm,
+  },
+  // ORCH-1142 — native swipe destructive panel (DESIGN §2.2). 80pt, solid red
+  // (opaque by construction — satisfies the Android opaque-glass policy), white
+  // trash glyph centered, no text label.
+  swipeAction: {
+    width: SWIPE_ACTION_WIDTH,
+    backgroundColor: semantic.error,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // ORCH-1142 — web delete fallback (DESIGN §2.6). Always-visible trailing
+  // trash; color goes to semantic.error on hover/press (color-only, no layout
+  // shift).
+  webTrash: {
+    alignSelf: "center",
+    marginLeft: spacing.sm,
+    padding: spacing.xs,
   },
   chev: {
     alignSelf: "center",

--- a/mingla-business/src/hooks/__tests__/orch_1142_notif_softdelete_scope.test.ts
+++ b/mingla-business/src/hooks/__tests__/orch_1142_notif_softdelete_scope.test.ts
@@ -1,0 +1,114 @@
+/**
+ * ORCH-1142 — IMPLEMENTOR happy-path regression (source-assertion) for the
+ * notifications soft-delete scope contract (SPEC §9, invariant I-PROPOSED-BH).
+ *
+ * Reads the real hook + screen source and asserts the load-bearing invariants:
+ *   1. fetchBusinessNotifications EXCLUDES soft-deleted rows AND keeps the
+ *      I-PROPOSED-W inclusion clause (`type.like.stripe.%` + `.is("deleted_at"`).
+ *   2. clearRead is scoped to READ rows (`.not("read_at", "is", null)`) + the
+ *      business-type `.or(...)` + not-already-deleted — it must NOT be a
+ *      delete-all and must NOT touch consumer rows.
+ *   3. softDelete updates `deleted_at` and targets by `.eq("id"`.
+ *   4. The realtime UPDATE handler DROPS soft-deleted rows from cache.
+ *   5. The screen reveals full text when expanded (drops the numberOfLines cap)
+ *      and demotes the deep-link to an expanded "Open" button.
+ *
+ * # Fails-on-revert (proven by the implementor via true LINE DELETION):
+ *   - Remove `.is("deleted_at", null)` from the fetch        → case 1 RED.
+ *   - Widen clearRead to drop the read/business scope        → case 2 RED.
+ *   - Drop `deleted_at` from the softDelete update           → case 3 RED.
+ *   - Remove the realtime soft-delete drop branch            → case 4 RED.
+ *   - Keep numberOfLines={1} when expanded / drop "Open"     → case 5 RED.
+ *
+ * Append-only post-merge per `.github/workflows/tests-append-only.yml`.
+ */
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const HOOK_SRC = readFileSync(
+  join(__dirname, "..", "useBusinessNotifications.ts"),
+  "utf8",
+);
+const SCREEN_SRC = readFileSync(
+  join(
+    __dirname,
+    "..",
+    "..",
+    "components",
+    "notifications",
+    "BusinessNotificationsScreen.tsx",
+  ),
+  "utf8",
+);
+
+/** Strip `//` line-comments so a comment mentioning a clause can't satisfy a
+ *  code assertion (otherwise fails-on-revert is a false pass). */
+function stripLineComments(src: string): string {
+  return src
+    .split("\n")
+    .map((l) => {
+      const i = l.indexOf("//");
+      return i >= 0 ? l.slice(0, i) : l;
+    })
+    .join("\n");
+}
+
+/** Slice a named function/arrow body (CODE ONLY) so assertions are scoped. */
+function sliceFrom(src: string, anchor: string, span = 60): string {
+  const idx = src.indexOf(anchor);
+  if (idx < 0) throw new Error(`anchor not found: ${anchor}`);
+  return stripLineComments(src.slice(idx).split("\n").slice(0, span).join("\n"));
+}
+
+describe("ORCH-1142 — notifications soft-delete scope (I-PROPOSED-BH)", () => {
+  test("1. fetch excludes soft-deleted rows AND keeps the I-PROPOSED-W clause", () => {
+    const fetch = sliceFrom(HOOK_SRC, "async function fetchBusinessNotifications");
+    // I-PROPOSED-W inclusion clause intact (verbatim).
+    expect(fetch).toContain("type.like.stripe.%");
+    expect(fetch).toContain("type.like.business.%");
+    // Soft-delete exclusion present.
+    expect(fetch).toMatch(/\.is\(\s*["']deleted_at["']\s*,\s*null\s*\)/);
+  });
+
+  test("2. clearRead targets READ + business-type rows only (never delete-all, never consumer)", () => {
+    const clearRead = sliceFrom(HOOK_SRC, "const clearRead = useCallback");
+    // It sets deleted_at (soft-delete) ...
+    expect(clearRead).toMatch(/\.update\(\s*\{\s*deleted_at/);
+    // ... scoped to READ rows (read_at IS NOT NULL) ...
+    expect(clearRead).toMatch(/\.not\(\s*["']read_at["']\s*,\s*["']is["']\s*,\s*null\s*\)/);
+    // ... and business-type only (the .or inclusion clause) ...
+    expect(clearRead).toContain("type.like.stripe.%");
+    expect(clearRead).toContain("type.like.business.%");
+    // ... and pinned to this user.
+    expect(clearRead).toMatch(/\.eq\(\s*["']user_id["']/);
+    // It must NOT be a blanket "all read_at" delete-all without the type scope:
+    // the .or(...) above guarantees the scope. Guard against an accidental
+    // `.is("read_at", null)` (which would target UNREAD rows).
+    expect(clearRead).not.toMatch(/\.is\(\s*["']read_at["']\s*,\s*null\s*\)/);
+  });
+
+  test("3. softDelete sets deleted_at and targets by primary key", () => {
+    const softDelete = sliceFrom(HOOK_SRC, "const softDelete = useCallback");
+    expect(softDelete).toMatch(/\.update\(\s*\{\s*deleted_at/);
+    expect(softDelete).toMatch(/\.eq\(\s*["']id["']/);
+  });
+
+  test("4. realtime UPDATE drops soft-deleted rows from cache", () => {
+    // The drop branch filters the row out when deleted_at is set (code only).
+    const code = stripLineComments(HOOK_SRC);
+    expect(code).toMatch(/updated\.deleted_at !== null/);
+    expect(code).toMatch(/old = \[\]\) =>\s*old\.filter\(\(n\) => n\.id !== updated\.id\)/);
+  });
+
+  test("5. screen reveals full text when expanded + demotes deep-link to an Open button", () => {
+    // Title/body drop their numberOfLines cap when expanded.
+    expect(SCREEN_SRC).toMatch(/numberOfLines=\{expanded \? undefined : 2\}/);
+    expect(SCREEN_SRC).toContain("const titleLines = expanded ? undefined : 1;");
+    // The expanded "Open" secondary button exists and is gated on deep_link.
+    expect(SCREEN_SRC).toContain("expanded && hasDeepLink");
+    expect(SCREEN_SRC).toMatch(/accessibilityLabel="Open notification target"/);
+    // Tap no longer navigates from the row (Open is the navigate path).
+    expect(SCREEN_SRC).toContain("onOpenDeepLink(notification)");
+  });
+});

--- a/mingla-business/src/hooks/useBusinessNotifications.ts
+++ b/mingla-business/src/hooks/useBusinessNotifications.ts
@@ -43,6 +43,12 @@ export interface BusinessNotification {
   body: string;
   deep_link: string | null;
   read_at: string | null;
+  /**
+   * ORCH-1142 soft-delete timestamp. NULL = active (visible); non-NULL = hidden
+   * from the operator inbox but PRESERVED server-side (reference value). The
+   * fetch + realtime patch EXCLUDE soft-deleted rows; never hard-delete.
+   */
+  deleted_at: string | null;
   created_at: string;
   /** JSONB payload from notify-dispatch (entity ids, bold token, etc.). */
   data?: Record<string, unknown> | null;
@@ -59,7 +65,7 @@ export const businessNotificationKeys = {
 const DISABLED_KEY = ["business-notifications-disabled"] as const;
 
 const SELECT_COLUMNS =
-  "id, user_id, brand_id, type, title, body, deep_link, read_at, created_at, data";
+  "id, user_id, brand_id, type, title, body, deep_link, read_at, deleted_at, created_at, data";
 
 function isBusinessType(type: string | undefined | null): boolean {
   const t = type ?? "";
@@ -109,6 +115,16 @@ function useBusinessNotificationsRealtime(userId: string | null): void {
         (payload) => {
           const updated = payload.new as BusinessNotification | null;
           if (updated === null || !isBusinessType(updated.type)) return;
+          // ORCH-1142: a soft-delete that arrives over realtime (e.g. the
+          // operator deleted on another device) must DROP the row from cache,
+          // not patch it in place — keeps multi-device inboxes consistent.
+          if (updated.deleted_at !== null && updated.deleted_at !== undefined) {
+            queryClient.setQueryData<readonly BusinessNotification[]>(
+              businessNotificationKeys.all(userId),
+              (old = []) => old.filter((n) => n.id !== updated.id),
+            );
+            return;
+          }
           queryClient.setQueryData<readonly BusinessNotification[]>(
             businessNotificationKeys.all(userId),
             (old = []) => old.map((n) => (n.id === updated.id ? updated : n)),
@@ -130,11 +146,16 @@ async function fetchBusinessNotifications(
   // business.% prefix filter. The `.or()` clause uses Postgrest syntax to
   // express the disjunction. Strict-grep gate W will fail if this clause is
   // removed or altered.
+  // ORCH-1142: exclude soft-deleted rows. The row persists server-side
+  // (reference value) but is hidden from the operator inbox. Do NOT remove
+  // this `.is("deleted_at", null)` filter — without it, swiped/cleared rows
+  // resurface on refetch (defeats the feature). I-PROPOSED-BH.
   const { data, error } = await supabase
     .from("notifications")
     .select(SELECT_COLUMNS)
     .eq("user_id", userId)
     .or("type.like.stripe.%,type.like.business.%")
+    .is("deleted_at", null)
     .order("created_at", { ascending: false })
     .limit(FETCH_LIMIT)
     .returns<BusinessNotification[]>();
@@ -175,6 +196,19 @@ export interface BusinessNotificationsInbox {
   readonly markAsRead: (id: string) => Promise<void>;
   /** Optimistically mark every unread business row read; reverts on error. */
   readonly markAllAsRead: () => Promise<void>;
+  /**
+   * ORCH-1142: optimistically soft-delete a single row (hide from inbox);
+   * reverts on error. Targets by primary key.
+   */
+  readonly softDelete: (id: string) => Promise<void>;
+  /**
+   * ORCH-1142: optimistically soft-delete every READ business row (the
+   * "Clear read" bulk action). Scoped to read + business-type ONLY — never
+   * unread, never consumer rows. Reverts on error.
+   */
+  readonly clearRead: () => Promise<void>;
+  /** True when at least one business row is read (gates the "Clear read" action). */
+  readonly hasRead: boolean;
 }
 
 /**
@@ -193,6 +227,12 @@ export function useBusinessNotificationsInbox(
 
   const unreadCount = useMemo(
     () => notifications.filter((n) => n.read_at === null).length,
+    [notifications],
+  );
+
+  // ORCH-1142: gates the header "Clear read" action — true when ≥1 read row.
+  const hasRead = useMemo(
+    () => notifications.some((n) => n.read_at !== null),
     [notifications],
   );
 
@@ -274,11 +314,92 @@ export function useBusinessNotificationsInbox(
     }
   }, [userId, queryClient]);
 
+  // ORCH-1142 — per-row soft-delete (swipe-to-delete native / web trash).
+  // Supersedes META-ORCH-1074 SUB-C_DESIGN §4.4 "NO swipe-to-dismiss" for the
+  // operator inbox VIEW only: soft-delete PRESERVES the row server-side (sets
+  // `deleted_at`), so reference value is intact. Do NOT convert to a hard
+  // delete and do NOT drop the `deleted_at IS NULL` fetch filter. I-PROPOSED-BH.
+  const softDelete = useCallback(
+    async (id: string): Promise<void> => {
+      if (userId === null) return;
+      const key = businessNotificationKeys.all(userId);
+      const prev = queryClient.getQueryData<readonly BusinessNotification[]>(key);
+      // Optimistically remove the row from cache (it disappears immediately).
+      queryClient.setQueryData<readonly BusinessNotification[]>(key, (old = []) =>
+        old.filter((n) => n.id !== id),
+      );
+      // Reset the iOS app-icon badge if no unread remain after removal.
+      const after = queryClient.getQueryData<readonly BusinessNotification[]>(key);
+      if ((after ?? []).every((n) => n.read_at !== null)) {
+        clearNotificationBadge();
+      }
+      // The strict-grep I-PROPOSED-W gate exempts `.update(` chains; this
+      // targets by primary key `id`, so it cannot cross-contaminate app types.
+      const { error } = await supabase
+        .from("notifications")
+        .update({ deleted_at: new Date().toISOString() })
+        .eq("id", id);
+      if (error) {
+        // Silent revert (transient blip isn't worth alarming an operator —
+        // same grammar as markAsRead). Restore the prior cache + order.
+        if (prev !== undefined) {
+          queryClient.setQueryData(key, prev);
+        } else {
+          void queryClient.invalidateQueries({ queryKey: key });
+        }
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn("[useBusinessNotifications] softDelete failed:", error.message);
+        }
+      }
+    },
+    [userId, queryClient],
+  );
+
+  // ORCH-1142 — bulk soft-delete of READ business rows ("Clear read").
+  // EXACT scope: this user's rows that are read (read_at IS NOT NULL), not
+  // already soft-deleted, AND business-type only (stripe.%/business.%). NEVER
+  // touches unread rows; NEVER touches consumer rows. Same supersession +
+  // soft-delete-preserves-reference-value contract as softDelete. I-PROPOSED-BH.
+  const clearRead = useCallback(async (): Promise<void> => {
+    if (userId === null) return;
+    const key = businessNotificationKeys.all(userId);
+    const prev = queryClient.getQueryData<readonly BusinessNotification[]>(key);
+    const nowIso = new Date().toISOString();
+    // Optimistically remove all READ rows from cache (unread stay).
+    queryClient.setQueryData<readonly BusinessNotification[]>(key, (old = []) =>
+      old.filter((n) => n.read_at === null),
+    );
+    // Bulk update scoped to read + business-type. `.update(` is gate-exempt
+    // (I-PROPOSED-W); the `.or(...)` keeps it from ever hitting consumer rows.
+    const { error } = await supabase
+      .from("notifications")
+      .update({ deleted_at: nowIso })
+      .eq("user_id", userId)
+      .not("read_at", "is", null)
+      .is("deleted_at", null)
+      .or("type.like.stripe.%,type.like.business.%");
+    if (error) {
+      if (prev !== undefined) {
+        queryClient.setQueryData(key, prev);
+      } else {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+      if (__DEV__) {
+        // eslint-disable-next-line no-console
+        console.warn("[useBusinessNotifications] clearRead failed:", error.message);
+      }
+    }
+  }, [userId, queryClient]);
+
   return {
     query,
     notifications,
     unreadCount,
     markAsRead,
     markAllAsRead,
+    softDelete,
+    clearRead,
+    hasRead,
   };
 }

--- a/supabase/migrations/20261002000000_orch_1142_notifications_soft_delete.sql
+++ b/supabase/migrations/20261002000000_orch_1142_notifications_soft_delete.sql
@@ -1,0 +1,35 @@
+-- ORCH-1142 — Business notifications: soft-delete (full-read + delete feature).
+--
+-- Adds an additive, nullable `deleted_at` column to `public.notifications` so
+-- the business operator inbox can HIDE read/handled notifications (per-row
+-- swipe-to-delete + "Clear read" header bulk action) WITHOUT physically
+-- removing the row. Financial-record reference value is preserved server-side:
+-- the row persists with `deleted_at` set; it is only excluded from the operator
+-- inbox fetch + realtime patch.
+--
+-- This supersedes META-ORCH-1074 SUB-C_DESIGN §4.4 ("NO swipe-to-dismiss —
+-- financial records have reference value") for the operator inbox VIEW ONLY.
+-- The reference value is preserved via this soft-delete (the row is never
+-- hard-deleted). Do NOT convert this to a hard delete and do NOT remove the
+-- `deleted_at IS NULL` exclusion filter in the client fetch.
+--
+-- RLS: NO new policy. The existing column-agnostic UPDATE policy
+-- ("Users can update own notifications (mark read)", USING auth.uid()=user_id
+-- + WITH CHECK auth.uid()=user_id) already lets a user set `deleted_at` on
+-- their OWN rows, exactly as it lets them set `read_at` today. The DELETE
+-- policy is intentionally NOT used (soft-delete only).
+--
+-- GRANT: none. `authenticated` already has UPDATE on the table (precedent:
+-- the existing mark-read writes).
+
+ALTER TABLE "public"."notifications"
+  ADD COLUMN IF NOT EXISTS "deleted_at" timestamptz;
+
+COMMENT ON COLUMN "public"."notifications"."deleted_at" IS
+  'ORCH-1142 soft-delete timestamp. NULL = active (visible in inbox); non-NULL = hidden from the operator inbox but PRESERVED server-side for financial-record reference value. Set by the owner via the existing column-agnostic UPDATE RLS policy (same path as read_at). Never hard-delete to satisfy an inbox-hide; GDPR erasure has its own path (b2a_v3_gdpr_erasure).';
+
+-- Partial index for the hot path: "this user''s active (non-deleted) rows,
+-- newest first". Most rows stay NULL, so the partial index stays lean.
+CREATE INDEX IF NOT EXISTS "idx_notifications_user_active"
+  ON "public"."notifications" ("user_id", "created_at" DESC)
+  WHERE "deleted_at" IS NULL;


### PR DESCRIPTION
## ORCH-1142 — business notification inbox: full-read + delete

**What changed for operators:** the business notification inbox now lets you tap a row to **expand it in place** and read the full untruncated text (the deep-link becomes a secondary "Open" button), **swipe a row to delete** it (a trash button on web preview), and **"Clear read"** in the header to bulk-clear handled notifications. Deletes are **soft** — rows leave the inbox but persist in the DB, preserving financial-record reference value (supersedes META-ORCH-1074 Sub-C §4.4 for the operator inbox VIEW only).

**Why:** both gaps were deliberate Sub-C design scope-outs (truncated body + navigate-away tap; no delete mutation), confirmed by forensics. Seth approved amending them: tap-to-expand + swipe/clear-read soft-delete.

### Changes
- `supabase/migrations/20261002000000_orch_1142_notifications_soft_delete.sql` — additive nullable `deleted_at timestamptz` + partial index on active rows. No RLS change (existing column-agnostic owner UPDATE policy covers it, same path as `read_at`).
- `mingla-business/src/hooks/useBusinessNotifications.ts` — fetch excludes soft-deleted; optimistic `softDelete(id)` (+ revert) ; `clearRead()` scoped to read + business-type rows only; realtime UPDATE drops soft-deleted rows. I-PROPOSED-W type filter preserved.
- `mingla-business/src/components/notifications/BusinessNotificationsScreen.tsx` — tap-to-expand-in-place + swipe-to-delete (`ReanimatedSwipeable`) + web trash fallback. Collapsed row pixel-identical to today.
- `mingla-business/app/notifications.tsx` — header "Clear read" + reused `ConfirmDialog`.

### QA
- REVIEW: APPROVED (commit-hash verified; no config-layer touch).
- TEST: CONDITIONAL PASS — P0:0 P1:0 P2:0 P3:1 P4:2. Bulk-delete safety proven (clearRead never touches unread/consumer rows; softDelete reverts on error; multi-device realtime drop verified). On-device tap/swipe deferred to post-merge OTA.
- Step 0.5: implementor happy-path `orch_1142_notif_softdelete_scope.test.ts` (5/5, fails-on-revert) + tester adversarial `orch_1142_clearRead_scope.tester_adversarial.test.ts` (fails-on-revert @ e7fd81560).

🤖 Generated with [Claude Code](https://claude.com/claude-code)