### PR TITLE
ORCH-1143: business Home live-card — Scan button on every live kind + collapsible accordion + multi-live carousel

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -233,3 +233,57 @@ No new test required — pure visual token change with zero behavior/store/carou
 
 ### Commit
 `97c661ca137567ccb71d544b46225966c43d8e29`
+
+---
+
+## Continuous-section fix (device feedback v2) — 2026-06-15
+
+Seth device-tested the prior (device-feedback v1) fix and reported the "Live now" header + content read as "two different sections as opposed to one continuous section with a divider." The designer revised §4.4-A (the "REVISED 2026-06-15 (continuous-section fix) — AUTHORITATIVE" block) to bind header + divider + body into ONE shared `base` GlassCard surface. This section records the v2 delta. Scope: visual/structure ONLY — zero behavior change (collapse store, carousel cardWidth math, scan button, per-kind routing, ≥44pt header target all untouched).
+
+### Files changed (v2)
+- `mingla-business/app/(tabs)/home.tsx` — `renderLiveSection` JSX restructure + 1 style edit + 3 new style keys + 1 style key augmented (~+55 lines net incl. comments).
+- `mingla-business/src/components/home/LiveOfferingCard.tsx` — `flat?: boolean` prop + content/chrome split + `flatRoot` style (~+45 lines net incl. comments).
+- `mingla-business/jest.orch1143.render.cjs` — appended the new flat render-test to `testMatch` (config, not a test; append-only).
+- `mingla-business/src/components/home/__tests__/LiveOfferingCard.flat.orch1143.render.test.tsx` — NEW happy-path regression test (3 tests).
+
+### home.tsx — exact keys/props changed (per §4.4-A AUTHORITATIVE delta tables)
+- **JSX:** enclosing card flipped `<GlassCard variant="base" padding={spacing.md}>` → `<GlassCard variant="base" padding={0}>`. The body block (single-live `LiveOfferingCard` / carousel `ScrollView`) was MOVED from being a SIBLING of the GlassCard to INSIDE it, below the header `Pressable`, with the new `liveSectionDivider` between header and body. The single-live `<LiveOfferingCard>` now passes `flat`; the carousel cards do NOT (stay elevated). Stale "stays a SIBLING below this card, NOT inside it" comment replaced with the continuous-section note. The single-live card is wrapped in `<View style={styles.liveSectionBody}>`; the carousel in `<View style={styles.liveSectionCarouselBody}>`.
+- **`liveHeaderRow`:** re-added `paddingHorizontal: spacing.md` + `paddingVertical: spacing.sm` (the GlassCard no longer pads). `minHeight: 44` preserved.
+- **`liveSectionDivider` (NEW):** `{ height: StyleSheet.hairlineWidth, backgroundColor: glass.border.profileBase, marginHorizontal: spacing.md }`. Rendered ONLY when `showLiveOpen`.
+- **`liveSectionBody` (NEW):** `{ paddingHorizontal: spacing.md, paddingTop: spacing.sm, paddingBottom: spacing.md }`.
+- **`liveSectionCarouselBody` (NEW):** `{ paddingTop: spacing.sm, paddingBottom: spacing.md }` (no h-padding; ScrollView content owns it).
+- **`liveCarouselContent`:** added `paddingLeft: spacing.md` (GlassCard `padding:0` no longer supplies the carousel's left inset).
+- **UNCHANGED:** `liveSection`, `liveHeaderRowPressed`, `liveHeaderChevron`, `liveHeaderLeft`, `liveHeaderDot`, `liveHeaderTitle`, `liveHeaderCount`.
+
+### LiveOfferingCard.tsx — the flat-prop addition (§4.4-A.6)
+- Added `flat?: boolean` (default `false`) to `LiveOfferingCardProps` with a doc comment.
+- Extracted the hero content tree into a `content` fragment. When `flat`, the card returns `<View style={styles.flatRoot} testID={testID}>{content}</View>` (chrome-less: no GlassCard, no border/shadow/radius, no air gap; `width` ignored). When unset/false, it returns the unchanged `<GlassCard variant="elevated" padding={spacing.lg} …>{content}</GlassCard>`. `testID` rides the wrapper in BOTH modes so render-test selectors still resolve.
+- `flatRoot` style: `{ padding: 0 }` — the enclosing `liveSectionBody` (16/8/16) owns the single-live inset (no double-pad), per A.6 inset reconciliation.
+
+### Token verification (zero new tokens)
+All tokens resolve against `home.tsx`'s existing import (`{ accent, glass, radius as radiusTokens, spacing, text as textTokens, typography } from "../../src/constants/designSystem"`):
+- `glass.border.profileBase` → **RESOLVED** = `rgba(255,255,255,0.08)` (`designSystem.ts:266`); same token `VARIANT_TOKENS.base.border` uses for the card perimeter (divider reads as internal seam). `glass` imported directly — no alias.
+- `spacing.md` (16) / `spacing.sm` (8) → RESOLVED, imported directly.
+- `StyleSheet.hairlineWidth` → RESOLVED (RN core; already used at `home.tsx` scanButton-era and now `liveSectionDivider`). `StyleSheet` imported at `home.tsx:30`.
+- No new import added to either file. `flat` is the ONLY new component-API surface.
+
+### Render-test selector update
+**None required.** The two pre-existing render proofs (`LiveOfferingCard.orch1143.render`, `UpcomingDedup.orch1143.render`) mount `LiveOfferingCard` WITHOUT `flat` (default elevated path), with GlassCard stubbed — the chrome split and the added prop do not touch their selectors (`home-live-card-scan-button`, "Scan QR codes", "Scanned", a11y label). Both still pass unchanged (7/7). A NEW test file was ADDED (not modified) for the v2 behavior.
+
+### Regression test (v2)
+- **New:** `LiveOfferingCard.flat.orch1143.render.test.tsx` — 3 tests: (1) `flat` renders WITHOUT a GlassCard chrome marker (the continuous-section requirement) while the wrapper testID still resolves; (2) default/elevated mode DOES wrap in a GlassCard; (3) scan button fires in BOTH modes (behavior unchanged).
+- **Fails-on-revert PROVEN by true line-deletion:** deleted the `if (flat) { return <View style={styles.flatRoot} …> }` branch in `LiveOfferingCard.tsx` → test "flat mode renders WITHOUT a GlassCard" FAILED (`expect(queryByTestId("glasscard-marker")).toBeNull()` — the card fell through to the elevated GlassCard, marker present). Restored the branch → re-ran, GREEN (10/10 across the render config). `fails-on-revert verified at 3fa9297d7` (pre-fix-restore baseline HEAD).
+- **T10/SC-7 behavioral tests:** unchanged + still passing (behavior is unchanged by a visual restructure). `home.orch_1143` (SC-7 source assertions incl. `liveItems.length === 1 ? (`, `snapToInterval`, `width={liveCardWidth}`, chevron name, scan-button testID), `home.orch_0974` (+adversarial), `liveSectionCollapseStore` (+adversarial), `UpcomingDedup` render — ALL pass.
+
+### Gate results (v2) — ALL GREEN (pre-existing-unrelated noted)
+- `npx tsc --noEmit` → **zero errors in `app/(tabs)/home.tsx` and `LiveOfferingCard.tsx`** (confirmed by file-filtered grep). The remaining repo errors (`@testing-library/react-native` type-resolution in test files, `packages/phone-input` standalone deps) are PRE-EXISTING on the rebased origin/main baseline (35 such errors present with my change stashed) — not introduced here.
+- `npx eslint app/(tabs)/home.tsx src/components/home/LiveOfferingCard.tsx` → **exit 0**, clean.
+- `npx jest --config jest.orch1143.render.cjs` → **10 passed, 3 suites** (incl. the new flat test).
+- `npx jest home.orch_1143 home.orch_0974 upcomingBuilder liveSectionCollapseStore` → **71 passed, 1 failed**. The single failure is `upcomingBuilder.adversarial.test.ts › ADV-09` in `pickHomeNextAction` (brand-switch isolation) — **NOT touched by this change** and **fails identically on the rebased origin/main baseline** (verified by stash). Pre-existing, unrelated.
+- Strict-grep gates: `i-proposed-z-home-no-fabricated-events` PASS · `orch-1105-web-glass-opaque-fallback` PASS (Android opaque-glass inherited via the single base GlassCard — no manual Platform.select introduced) · `i-proposed-tr2-livestore-addliveevent-owner` PASS.
+
+### Smoke / verification status
+**implemented, partially verified** — runtime render evidence via jest+@testing-library/react-native (the flat-vs-elevated chrome split + scan-button fire are proven at runtime). The visual continuous-section appearance on a physical device/sim is NOT machine-verifiable here and is the tester's device step (the prior fix was the one Seth eyeballed; this v2 needs a fresh device look). No native compilation needed (pure-JS/RN style change) → ships via OTA per [[project_ota_deferred_until_new_build]], orchestrator/operator-owned.
+
+### Commit (v2)
+`318461e7ecc3887a3f18f2f22bb2c9fe9c354955` (branch `ORCH-1143-live-card-scan-accordion`). The code + tests + this report ship in this single commit; `fails-on-revert verified at 3fa9297d7`.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -1,0 +1,145 @@
+# IMPLEMENTATION — ORCH-1143 [business Home live-card: scan parity + accordion + multi-live carousel]
+
+**Skill:** mingla-implementor+claude · **Phase:** IMPLEMENT · **Date:** 2026-06-15
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1143-[live-card-scan-accordion]/` on branch `ORCH-1143-live-card-scan-accordion`
+**Commit:** `9bbf98980`
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md`
+**Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1143_LIVE_CARD_SCAN_PARITY.md`
+**App:** Mingla BUSINESS (`mingla-business/`). UI-only — NO backend, NO migration, NO edge-fn, NO new scanner route.
+
+---
+
+## 1. Summary
+
+The business Home "Live now" section now: (1) shows a **Scan QR codes** button on EVERY live offering kind — event, experience, AND trip — all routing to the shared kind-agnostic `/event/{id}/scanner` (proven event-type-agnostic by the investigation; zero backend change); (2) is a **collapsible accordion** with a persisted, hydration-gated open/closed state (no flash-of-wrong-state on cold start); and (3) renders **all concurrently-live offerings** as a horizontal peek-width **carousel** (one full-width card when exactly one is live). The former inline hero was lifted into a reusable `LiveOfferingCard` (one owner per truth). The "Scanned" tile stays honest-empty (`—`); per-card revenue stays currency-aware.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence (commit `9bbf98980`) |
+|----|-----------|--------|------------------------------|
+| SC-1 | Scan button on every live kind → `/event/{id}/scanner` | ✓ | `LiveOfferingCard` emits the button unconditionally; `handleScanPress(id)` pushes `/event/${id}/scanner` with no kind gate (`home.tsx`). Test `home.orch_1143` T1/T10. |
+| SC-1-iOS / Android | native scanner mounts (kind-aware) | ✓ (source-verified; runtime = tester) | route unchanged; `/event/[id]/scanner/index.tsx` byte-untouched. |
+| SC-1-Web | routes to web EmptyState, not a dead tap | ✓ (source-verified) | button always enabled; `.web.tsx` ORCH-1099 EmptyState untouched. |
+| SC-2 | ≥2 live → ALL render, live-first start-asc | ✓ | carousel maps `liveItems` (owned by `upcomingBuilder.liveItems`). Builder test T4/T12. |
+| SC-3 | carousel ≥2; single full-width card for 1 | ✓ | `liveItems.length === 1 ? <card> : <ScrollView horizontal snapToInterval…>`. Test T-SC3. |
+| SC-4 | accordion toggle (easeInEaseOut + chevron swap + expanded state) | ✓ | `LayoutAnimation.Presets.easeInEaseOut` + `chevU/chevD` + `accessibilityState.expanded`. Test T6. |
+| SC-5 | persisted collapse + hydration gate (no flash) | ✓ | `liveSectionCollapseStore` (`hasHydrated` not persisted) + `showOpen = !hasHydrated || !collapsed`. Tests T7/T8. |
+| SC-6 | honest data (Scanned `—`) + currency-aware | ✓ | Scanned cell `—`; revenue `view.currency ?? brand.defaultCurrency`. Tests SC-6. |
+| SC-7 | live not duplicated in Upcoming list | ⚠ DEFERRED (see §10) | locked ORCH-0974 test A-05 pins `data={upcoming.items}`; de-dup would require a TEST-MOD-APPROVED ORCH. |
+| SC-8 | logout cascade resets the store | ✓ | `reset` wired into `clearAllStores`. Tests SC-8/T11. |
+| SC-9 | live TRIP renders a scannable card | ✓ | trips adapt via `tripToLiveEvent`; included in `liveEventViews`/metrics + scan. Builder test T2/T3. |
+
+---
+
+## 3. Files changed (commit `9bbf98980`; +968 / −284)
+
+| File | Δ | What |
+|------|---|------|
+| `mingla-business/src/utils/upcomingBuilder.ts` | +18/−6 | add `liveItems` to `buildUpcomingItems` return + type |
+| `mingla-business/src/hooks/useUpcomingForBrand.ts` | +7/−2 | thread `liveItems` through interface + return |
+| `mingla-business/src/store/liveSectionCollapseStore.ts` | +67 NEW | persisted, `hasHydrated`-gated collapse store |
+| `mingla-business/src/components/home/LiveOfferingCard.tsx` | +250 NEW | reusable live card (hero lifted) + contained scan button |
+| `mingla-business/app/(tabs)/home.tsx` | +~288/−284 | accordion header + carousel/single render; generalized scan handler; metrics over `liveItems`; stale comment removed; dead hero styles removed |
+| `mingla-business/src/utils/clearAllStores.ts` | +2 | wire `reset` (logout cascade) |
+| `mingla-business/src/utils/reapOrphanStorageKeys.ts` | +1 | register new persist key (I-PROPOSED-M gate sync) |
+| `mingla-business/app/(tabs)/__tests__/home.orch_1143.test.tsx` | +141 NEW | source-contract tests incl. T10 fails-on-revert |
+| `mingla-business/src/utils/__tests__/upcomingBuilder.test.ts` | +110 | append ORCH-1143 `liveItems` tests (T2/T3/T4/T5/T12) |
+| `mingla-business/src/store/__tests__/liveSectionCollapseStore.test.ts` | +84 NEW | store behaviour (T7/T8/T11) |
+
+---
+
+## 4. Data-model changes
+
+NONE. No `supabase/` file touched. No migration, no edge fn, no RLS. (Investigation F-1..F-8 proved the scan backend is already event-type-agnostic.)
+
+## 5. Edge functions touched
+
+NONE. `/event/[id]/scanner` (index.tsx + index.web.tsx), `scan-ticket`, `biz_ticket_scan`, `useManagedEventRoute`, `tripToLiveEvent` all byte-unchanged (read-only consumers). No `verify_jwt` change.
+
+---
+
+## 6. Regression tests added + fails-on-revert proof
+
+- **`mingla-business/app/(tabs)/__tests__/home.orch_1143.test.tsx`** (NEW, 10 tests) — source-contract proofs for carousel-off-`liveItems`, single-vs-carousel, accordion motion/glyph/expanded, hydration gate, scan-route-no-gate, honest data + currency, store persist/partialize, logout reset.
+- **`mingla-business/src/store/__tests__/liveSectionCollapseStore.test.ts`** (NEW, 5 tests) — T7/T8/T11 store behaviour.
+- **`mingla-business/src/utils/__tests__/upcomingBuilder.test.ts`** (APPENDED, +6 tests) — T2/T3/T4/T5/T12 `liveItems` enumeration over all kinds.
+
+**fails-on-revert verified at `9bbf98980`** (TRUE LINE DELETION, not comment-out): deleting the scan-button `Pressable` block from `LiveOfferingCard.tsx` → `home.orch_1143` T10 FAILS (`Tests: 1 failed, 9 passed`); restoring the block (working tree byte-identical to the commit) → `Tests: 10 passed`. The revert removes the scan affordance for experience/trip live cards — exactly the bug.
+
+Note on test style: the default biz-app jest config is node/ts-jest with NO RN renderer and `@testing-library/react-native` NOT installed (render proofs are segregated to dedicated configs per `jest.config.cjs`). The home proofs are therefore source-contract tests — the established repo pattern (mirrors `home.orch_0974.test.tsx`). Runtime/device live-fire of the per-kind scan happy path is the tester's job (INVESTIGATE flagged the end-to-end as "probable" pending live-fire).
+
+---
+
+## 7. Old → New receipts
+
+### `app/(tabs)/home.tsx`
+- **Before:** the live hero rendered only for `primaryLiveItem` of kind `event`/`experience` (trips excluded entirely); the "Scan QR codes" button showed ONLY when `primaryLiveItem.kind === "event"` (`showScanAction`); `handleScanPress` guarded `kind !== "event"`; static, single card; extra live offerings were demoted to Upcoming rows; stale ORCH-0965 comment claimed experiences were a stub and trips had no scanner.
+- **Now:** consumes `upcoming.liveItems`; builds a `LiveEvent[]` view (trips via `tripToLiveEvent`) + a `liveMetricsById` map; renders a `LiveSectionHeader` (live dot + "Live now" + count chip + chevron, whole-section collapse via `LayoutAnimation` easeInEaseOut, Android guard at module top, `accessibilityState.expanded`); body = one full-width `LiveOfferingCard` (1 live) or a horizontal `ScrollView` of peek-width cards (≥2); `handleScanPress(id)` routes EVERY kind to `/event/${id}/scanner`; collapse persisted + hydration-gated (`showLiveOpen = !hasHydrated || !collapsed`); stale comment deleted; the live section renders ABOVE the ORCH-0974 locked single-scroll pane so the carousel's horizontal scroller never violates that lock; dead hero styles removed (moved to the card).
+- **Why:** SC-1..SC-6, SC-9; DISC-1143-A/B.
+- **Lines:** ~288 changed.
+
+### `src/components/home/LiveOfferingCard.tsx` (NEW)
+- **Now:** reusable per-offering live card — live pill, name, date, revenue (32/36 hero number), optional progress bar (capacity-gated), sold/capacity/scanned stat row (Scanned always `—`), and a contained 44pt warm-tinted **Scan QR codes** button emitted UNCONDITIONALLY (no per-kind gate, protective comment + `I-PROPOSED-ORCH1143-LIVE-SCAN-ALL-KINDS`). Token-only; reuses `GlassCard variant="elevated"` (Android opaque-glass policy baked in), `Pill variant="live" livePulse`, `Icon`.
+- **Why:** one owner per truth (SC-2/§4.4-B/C). **Lines:** 250.
+
+### `src/store/liveSectionCollapseStore.ts` (NEW)
+- **Now:** persisted Zustand store (`mingla-business.liveSectionCollapse.v1`), `collapsed` persisted (default false=open), `hasHydrated` NOT persisted (flipped in `onRehydrateStorage`), `toggle/setCollapsed/setHasHydrated/reset`. Modeled exactly on `currentBrandStore`. **Why:** SC-5/#14. **Lines:** 67.
+
+### `src/utils/upcomingBuilder.ts` / `useUpcomingForBrand.ts`
+- **Now:** `buildUpcomingItems` returns `liveItems` (live-first sorted subset; `primaryLiveItem = liveItems[0]`); the hook threads it. **Why:** one owner per truth (SC-2). **Lines:** +18/+7.
+
+### `src/utils/clearAllStores.ts` / `reapOrphanStorageKeys.ts`
+- **Now:** `liveSectionCollapseStore.reset()` in the logout cascade; new persist key registered in `KNOWN_MINGLA_KEYS` (I-PROPOSED-M gate). **Why:** SC-8/#6 + gate sync. **Lines:** +2 / +1.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Behavior | Parity |
+|---------|----------|----------|--------|
+| Consumer iOS | NO | — | n/a |
+| Consumer Android | NO | — | n/a |
+| Buyer/anonymous Web | NO | — | n/a |
+| Business iOS | YES | accordion + carousel + per-kind scan → native camera scanner | shared RN → automatic |
+| Business Android | YES | same; new card uses `GlassCard` opaque-fallback | automatic |
+| Admin Web | NO | — | n/a |
+| Business Web preview | YES (card UI; camera N/A) | accordion + carousel + scan button render; scan → `/event/{id}/scanner` `.web.tsx` EmptyState (ORCH-1099), not a dead tap | manual but already-built |
+
+---
+
+## 9. Gate results (run inside the worktree)
+
+- **`tsc --noEmit`:** ZERO errors in any ORCH-1143 file (`home.tsx`, `LiveOfferingCard.tsx`, `liveSectionCollapseStore.ts`, `upcomingBuilder.ts`, `useUpcomingForBrand.ts`, `clearAllStores.ts`, `reapOrphanStorageKeys.ts`). Pre-existing repo-wide tsc errors in unrelated files (checkout buyer.tsx, marketing ComposerV2, payments native modules, several test modules) exist on origin/main untouched.
+- **`eslint`** (my files): 0 errors, 0 new warnings (after removing the now-unused `GlassCard` import). Remaining warnings in `useUpcomingForBrand`/`reapOrphanStorageKeys` are pre-existing.
+- **`jest`** (my touched areas + existing ORCH-0974 locks): **53/53 tests PASS** — `home.orch_1143` (10), `home.orch_0974` (6), `home.orch_0974.adversarial` (5), `liveSectionCollapseStore` (5), `upcomingBuilder` (27). The existing ORCH-0974 single-scroll-pane lock + adversarial branch digest still pass (live section sits outside the lock markers).
+- **strict-grep gates:** `i-proposed-m-persist-key-whitelist` PASS (after registering the new key); `orch-1105-web-glass-opaque-fallback` PASS; `orch-0769-app-wide-currency` PASS; `i-proposed-1137-biz-web-lucide-real` PASS.
+- **No barrel imports** introduced (per-symbol named imports only) — keeps the ORCH-1083 `__common` web budget honest.
+
+**Unrun gate (CI/operator):** `web-build-check.yml` (full `expo export` + ORCH-1083 `__common` 2.25MB budget). Not runnable as a quick local gate; my change adds only small local-module named imports + no new library, so risk is minimal. Operator/CI runs it on the PR.
+
+---
+
+## 10. Known issues / deferred
+
+- **SC-7 (no-duplication) DEFERRED — needs orchestrator/Seth attention.** The SPEC wanted live offerings to appear in the carousel ONLY, not also as Upcoming-list rows. The existing **append-only-locked** ORCH-0974 test `home.orch_0974.adversarial.test.tsx` A-05 pins the FlatList binding to the literal `data={upcoming.items}` (all items, including live). Filtering live items out of that list would change the binding and FAIL A-05, which CI `tests-append-only.yml` forbids without a `[TEST-MOD-APPROVED ORCH-NNNN]` commit (itself a new ORCH). SPEC §SC-7 explicitly anticipated this ("Confirm current Upcoming-list behavior in IMPLEMENT"). I kept A-05 green and did NOT de-duplicate. Net behavior: a live offering shows in BOTH the new live carousel (with the scan button) and as an existing Upcoming row (navigation only, no scan). If Seth wants strict de-dup, spawn a follow-up ORCH that carries the `[TEST-MOD-APPROVED]` to retarget A-05.
+- **`accessible={false}` on the chevron Icon** was specified (§4.4-A) but `IconProps` doesn't expose `accessible`; the Icon renders an inert SVG (no `accessibilityRole`) and the expanded/collapsed state lives on the parent Pressable's `accessibilityState`, so VoiceOver/TalkBack announce only the header button — the intended a11y is preserved without the prop.
+
+## 11. Operator action required
+
+- NONE for backend (no migration, no edge-fn deploy).
+- CLOSE / OTA: pure-JS business-app change → OTA the business `development`/`production` channel per the EAS gotchas memory (no native build needed). Orchestrator-owned.
+- Orchestrator to flip `I-PROPOSED-ORCH1143-LIVE-SCAN-ALL-KINDS` ACTIVE on CLOSE.
+
+## 12. Discoveries for Orchestrator
+
+- **DISC-1143-D (pre-existing, unrelated):** `liveEventStore-migrator-chain.adversarial.test.ts` + `liveEventStore-v4-v5-migrator.test.ts` FAIL on this branch AND are independent of ORCH-1143 — the tests expect `liveEventStore` persist `version: 5` but the source is `version: 6` (a prior ORCH bumped the store without updating these adversarial tests). I did not touch `liveEventStore.ts` (confirmed `git diff origin/main...HEAD`). Register as a stale-test cleanup.
+- **SC-7 / A-05 lock conflict** (see §10) — needs a decision: accept live-in-both-places, or spawn a TEST-MOD-APPROVED follow-up.
+- **DISC-1143-C (from investigation, confirmed):** no per-offering historical scanned count source exists; Scanned stays `—`. Future enhancement if a real count is wanted.
+
+---
+
+## Next handoff
+
+Working tree: `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1143-[live-card-scan-accordion]/` on branch `ORCH-1143-live-card-scan-accordion`, commit `9bbf98980`. Route back to **mingla-orchestrator** for REVIEW, then **mingla-tester** (live-fire the per-kind scan happy path on device + re-verify the T10 fails-on-revert).

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -123,7 +123,7 @@ Note on test style: the default biz-app jest config is node/ts-jest with NO RN r
 
 ## 10. Known issues / deferred
 
-- **SC-7 (no-duplication) DEFERRED — needs orchestrator/Seth attention.** The SPEC wanted live offerings to appear in the carousel ONLY, not also as Upcoming-list rows. The existing **append-only-locked** ORCH-0974 test `home.orch_0974.adversarial.test.tsx` A-05 pins the FlatList binding to the literal `data={upcoming.items}` (all items, including live). Filtering live items out of that list would change the binding and FAIL A-05, which CI `tests-append-only.yml` forbids without a `[TEST-MOD-APPROVED ORCH-NNNN]` commit (itself a new ORCH). SPEC §SC-7 explicitly anticipated this ("Confirm current Upcoming-list behavior in IMPLEMENT"). I kept A-05 green and did NOT de-duplicate. Net behavior: a live offering shows in BOTH the new live carousel (with the scan button) and as an existing Upcoming row (navigation only, no scan). If Seth wants strict de-dup, spawn a follow-up ORCH that carries the `[TEST-MOD-APPROVED]` to retarget A-05.
+- **SC-7 (no-duplication) — NOW IMPLEMENTED 2026-06-15 (commit `d0c7f0b50`).** The earlier deferral (A-05 append-only lock) was resolved with Seth's `[TEST-MOD-APPROVED ORCH-1143]` token. The Upcoming list (mobile FlatList + desktop pane) now renders `upcoming.nonLiveItems` (non-live only); live offerings are surfaced exclusively in the Live-now carousel. See §13 (SC-7) below for the full receipt.
 - **`accessible={false}` on the chevron Icon** was specified (§4.4-A) but `IconProps` doesn't expose `accessible`; the Icon renders an inert SVG (no `accessibilityRole`) and the expanded/collapsed state lives on the parent Pressable's `accessibilityState`, so VoiceOver/TalkBack announce only the header button — the intended a11y is preserved without the prop.
 
 ## 11. Operator action required
@@ -135,7 +135,7 @@ Note on test style: the default biz-app jest config is node/ts-jest with NO RN r
 ## 12. Discoveries for Orchestrator
 
 - **DISC-1143-D (pre-existing, unrelated):** `liveEventStore-migrator-chain.adversarial.test.ts` + `liveEventStore-v4-v5-migrator.test.ts` FAIL on this branch AND are independent of ORCH-1143 — the tests expect `liveEventStore` persist `version: 5` but the source is `version: 6` (a prior ORCH bumped the store without updating these adversarial tests). I did not touch `liveEventStore.ts` (confirmed `git diff origin/main...HEAD`). Register as a stale-test cleanup.
-- **SC-7 / A-05 lock conflict** (see §10) — needs a decision: accept live-in-both-places, or spawn a TEST-MOD-APPROVED follow-up.
+- **SC-7 / A-05 lock conflict — RESOLVED 2026-06-15.** Seth approved the TEST-MOD; A-05's data-source assertion was retargeted under `[TEST-MOD-APPROVED ORCH-1143]` and SC-7 is implemented (§13). No longer open.
 - **DISC-1143-C (from investigation, confirmed):** no per-offering historical scanned count source exists; Scanned stays `—`. Future enhancement if a real count is wanted.
 
 ---
@@ -143,3 +143,55 @@ Note on test style: the default biz-app jest config is node/ts-jest with NO RN r
 ## Next handoff
 
 Working tree: `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1143-[live-card-scan-accordion]/` on branch `ORCH-1143-live-card-scan-accordion`, commit `9bbf98980`. Route back to **mingla-orchestrator** for REVIEW, then **mingla-tester** (live-fire the per-kind scan happy path on device + re-verify the T10 fails-on-revert).
+
+---
+
+## 13. SC-7 — live/Upcoming de-duplication (DEFERRED criterion, completed 2026-06-15)
+
+**Status: implemented and verified.** Commit `d0c7f0b50` (TEST-MOD token `[TEST-MOD-APPROVED ORCH-1143]`, Seth-approved 2026-06-15). Rebased on origin/main `0fd6f39c4`.
+
+### 13.1 Problem
+A currently-live offering appeared in BOTH the new "Live now" carousel (with its scan button) AND as a row in the "Upcoming" list below. SC-7 requires live offerings to live ONLY in the carousel; the Upcoming list shows non-live (upcoming/draft) items only.
+
+### 13.2 Files changed (4 product/test files)
+| File | Change | ~lines |
+|------|--------|--------|
+| `mingla-business/src/utils/upcomingBuilder.ts` | Added `nonLiveItems: UpcomingItem[]` to the `buildUpcomingItems` return type + computed it as `nonPast.filter((i) => i.status !== "live")`. Does NOT mutate `items` or `liveItems`. | +9 |
+| `mingla-business/src/hooks/useUpcomingForBrand.ts` | Added `nonLiveItems` to the `UpcomingForBrand` interface; destructured it from the builder + returned it. No query-key/query change. | +6 |
+| `mingla-business/app/(tabs)/home.tsx` | Mobile FlatList `data={upcoming.items}` → `data={upcoming.nonLiveItems}`; desktop Upcoming pane `upcoming.items.map` → `upcoming.nonLiveItems.map`; `hasUpcomingItems` gated on `upcoming.nonLiveItems.length > 0`. keyExtractor, renderItem (`<UpcomingListItem>`), and the three handlers unchanged. | ~3 edits |
+| `mingla-business/app/(tabs)/__tests__/home.orch_0974.adversarial.test.tsx` | TEST-MOD: A-05 data-source assertion retargeted. | 1 line |
+
+### 13.3 New non-live field name
+**`nonLiveItems`** — owned by `upcomingBuilder.buildUpcomingItems`, threaded through `useUpcomingForBrand`. It is a strict projection of the SAME sorted `nonPast` set (live-state stays single-sourced as `liveItems`; one owner per truth, Constitution #2). `items` is never mutated — the carousel, `counts`, and KPI grid still consume the full set / live subset unchanged.
+
+### 13.4 Old → New receipt — `home.tsx`
+- **Before:** the Upcoming list (mobile FlatList + desktop pane) rendered `upcoming.items` (the full non-past set, INCLUDING live offerings). A live offering therefore rendered twice on Home — a live carousel card AND an Upcoming row.
+- **Now:** the Upcoming list renders `upcoming.nonLiveItems` (upcoming + draft only). `hasUpcomingItems` is gated on `nonLiveItems.length > 0`, so when every active item is live the Upcoming section header + list hide cleanly (no empty list). KPI counts (`upcoming.counts`, `hasActiveEvents`, `showKpiGrid`) still count the full set including live.
+- **Why:** SPEC §SC-7 — live offerings belong exclusively in the Live-now carousel.
+
+### 13.5 TEST-MOD rationale (intent preserved)
+A-05 (`home.orch_0974.adversarial.test.tsx`) is append-only-locked. The ONLY change is the FlatList data-source assertion:
+- `data: flatList.includes("data={upcoming.items}")` → `data: flatList.includes("data={upcoming.nonLiveItems}")`
+- The `data: true` expectation (~line 138) is an outcome boolean and is unchanged.
+- Inline comment added: `// ORCH-1143 SC-7 [TEST-MOD-APPROVED by Seth 2026-06-15]: Upcoming list excludes live items (now in the Live-now carousel); single-scroll + all item-kind branches still asserted.`
+
+PRESERVED unchanged (intent NOT weakened): `keyExtractor`, `renderItem` (`<UpcomingListItem>`), the three handlers (`onOpenDraft`/`onOpenTrip`/`onOpenLiveEvent`), and ALL UpcomingListItem branch-preservation checks — draft length 4, trip length 3, event length 5. The single-scroll intent (one FlatList in the locked mobile-populated pane) and the per-kind branch preservation remain fully protected. Only the data-source contract changed (`items` → `nonLiveItems`).
+
+### 13.6 New regression test + fails-on-revert
+- **Path:** `mingla-business/src/utils/__tests__/upcomingBuilder.test.ts` — describe block `"ORCH-1143 SC-7 nonLiveItems — live offerings excluded from the Upcoming list"` (3 tests, append-only, real `buildUpcomingItems` pipeline, `Date.now()` pinned to NOW):
+  - **SC7-1:** a live event is in `liveItems` but NOT in `nonLiveItems`; a future-dated (upcoming) event + a draft ARE in `nonLiveItems`; `items.length === liveItems.length + nonLiveItems.length` (projection, no mutation).
+  - **SC7-2 (all-live edge case):** all items live → `nonLiveItems` empty, `.map` over it is safe (no crash) — proves the clean Upcoming-hides behavior.
+  - **SC7-3 (no-live edge case):** none live → `nonLiveItems` equals `items` in the same order (Upcoming unchanged).
+- **Fails-on-revert verified at commit `d0c7f0b50`.** Method: TRUE line replacement of the fix — `const nonLiveItems = nonPast.filter((i) => i.status !== "live");` → `const nonLiveItems = nonPast;` (live leaks back into the Upcoming view). Re-ran the SC-7 block → **2 failed** (SC7-1: live id present in nonLiveItems; SC7-2: length 2 ≠ 0). Restored the filter → **3 passed**. Output captured during implementation.
+
+### 13.7 Edge-case handling (confirmed)
+- **ALL items live** → `nonLiveItems` is empty; `hasUpcomingItems` is false → the Upcoming header + FlatList/desktop-pane do not render (their existing `hasUpcomingItems ?` gate). No empty list, no crash (SC7-2). The live carousel still renders all live cards.
+- **NONE live** → `nonLiveItems === items` (same order); Upcoming list is identical to prior behavior (SC7-3).
+
+### 13.8 Gates (SC-7)
+- `npx jest home.orch_0974 home.orch_1143 src/utils/__tests__/upcomingBuilder.test.ts` → **4 suites, 51 tests, all PASS** (incl. the modified A-05 and the 3 new SC-7 tests).
+- `npx tsc --noEmit` → zero errors on the 5 touched files (pre-existing unrelated errors remain only in `../packages/phone-input/`).
+- `npx eslint` on the 5 touched files → 0 errors; the 2 `react-hooks/exhaustive-deps` warnings on `useUpcomingForBrand.ts` are PRE-EXISTING on origin/main (confirmed via `git stash`), not introduced here.
+
+### 13.9 Scope adherence
+Stayed within `home.tsx` + `upcomingBuilder.ts` + `useUpcomingForBrand.ts` (the hook is the established thread for builder fields, already in the SPEC §4.2 allowlist) + the two test files. Did NOT touch the scanner, the carousel render, `LiveOfferingCard`, the collapse store, or any other ORCH-1143 work. No new config files. Currency-awareness + no-fabricated-data untouched.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -195,3 +195,41 @@ PRESERVED unchanged (intent NOT weakened): `keyExtractor`, `renderItem` (`<Upcom
 
 ### 13.9 Scope adherence
 Stayed within `home.tsx` + `upcomingBuilder.ts` + `useUpcomingForBrand.ts` (the hook is the established thread for builder fields, already in the SPEC §4.2 allowlist) + the two test files. Did NOT touch the scanner, the carousel render, `LiveOfferingCard`, the collapse store, or any other ORCH-1143 work. No new config files. Currency-awareness + no-fabricated-data untouched.
+
+---
+
+## Live-now header styling fix (device feedback) — 2026-06-15
+
+**Trigger:** Seth device-tested the dev OTA and reported the "Live now" header sat too close to the screen edges and didn't read as a tappable dropdown. The designer traced both to SPEC under-spec and wrote the exact fix in SPEC §4.4-A "REVISED 2026-06-15 (device-feedback fix)". This is HEADER CHROME ONLY — zero behavior change. Edited ONLY `mingla-business/app/(tabs)/home.tsx`.
+
+### Style keys changed (per §4.4-A revised delta table)
+| Key | Before | After |
+|-----|--------|-------|
+| `liveSection` | `{ marginBottom: spacing.md }` | `{ paddingHorizontal: spacing.md, marginBottom: spacing.md }` — the gutter fix (16pt Home gutter; wrapper View now owns it). |
+| `liveHeaderRow` | `{ flexDirection:'row', alignItems:'center', justifyContent:'space-between', paddingHorizontal: spacing.xs, paddingTop: spacing.sm, paddingBottom: spacing.sm, minHeight: 44 }` | `{ flexDirection:'row', alignItems:'center', justifyContent:'space-between', minHeight: 44 }` — dropped all padding (GlassCard `padding={spacing.md}` owns the inset). |
+| `liveHeaderChevron` | (NEW) | `{ width:28, height:28, borderRadius: radiusTokens.full, alignItems:'center', justifyContent:'center', backgroundColor: glass.tint.profileBase }` — 28pt circular dropdown handle. |
+| `liveHeaderRowPressed`, `liveHeaderLeft`, `liveHeaderDot`, `liveHeaderTitle`, `liveHeaderCount` | (current) | unchanged. |
+
+**JSX deltas:** (1) added `import { GlassCard } from "../../src/components/ui/GlassCard";` (alphabetical, after `EventCoverMedia`, before `Icon`). (2) wrapped the existing header `Pressable` in `<GlassCard variant="base" padding={spacing.md}>…</GlassCard>` inside the `liveSection` View; the card body (single card / carousel) stays a sibling BELOW the GlassCard, NOT enclosed. (3) replaced the bare `<Icon … size={20} …/>` with `<View style={styles.liveHeaderChevron}><Icon name={showLiveOpen ? "chevU" : "chevD"} size={18} color={textTokens.secondary} /></View>`. The `chevU`/`chevD` conditional Icon-name string was preserved verbatim (home.orch_1143 asserts it).
+
+### Token verification — ALL RESOLVED (zero new tokens)
+Every referenced token already exists and is imported in `home.tsx`. Two name substitutions vs. the spec's literal token names, because this file imports the design-system under aliases (verified at the import block, `home.tsx:58-65`):
+- `radius.full` (spec) → **`radiusTokens.full`** (file alias; `radius as radiusTokens`). Value `999`, defined `designSystem.ts:46`. SUBSTITUTION.
+- `text.secondary` (spec) → **`textTokens.secondary`** (file alias; `text as textTokens`). `rgba(255,255,255,0.72)`, `designSystem.ts:290`. SUBSTITUTION.
+- `glass.tint.profileBase` → unchanged (`glass` imported directly); `rgba(255,255,255,0.04)`, `designSystem.ts:260`; already used at `home.tsx:1214`. RESOLVED.
+- `spacing.md` (16) — RESOLVED. `GlassCard` export — RESOLVED (`variant`/`padding` props confirmed). Icon `chevD`/`chevU` — RESOLVED (`Icon.tsx:25-26,128-129`).
+
+No invented tokens. Substitutions are alias-name only (same underlying values), forced by the file's existing import aliasing.
+
+### Gate results — ALL GREEN
+- `npx tsc --noEmit` → **zero errors in `app/(tabs)/home.tsx`** (the listed errors are all pre-existing in unrelated files: checkout buyers, marketing composer, payments modules, and `@testing-library/react-native` type-resolution in render-test files — none in home.tsx).
+- `npx eslint app/(tabs)/home.tsx` → **exit 0**, clean.
+- `npx jest home.orch_1143 home.orch_0974` (+ adversarial) → **21 passed** (3 suites).
+- `npx jest --config jest.orch1143.render.cjs` (the dedicated RN render config for the two `.orch1143.render` proofs — they are `testPathIgnore`d from the default config) → **7 passed** (2 suites).
+- Strict-grep gates: `orch-0974-home-mobile-lock-pane` PASS · `orch-0965-home-uses-upcoming-hook` PASS · `orch-1105-web-glass-opaque-fallback` PASS · `i-proposed-z-home-no-fabricated-events` PASS.
+
+### Regression test
+No new test required — pure visual token change with zero behavior/store/carousel-math/a11y change. No existing test asserts the old style keys (the only style-adjacent assertion, `home.orch_1143:63`, checks the `chevU`/`chevD` Icon-name string, which is preserved verbatim and still passes). Android opaque-glass is automatic via GlassCard's internal GlassChrome. Touch target stays ≥44pt (`liveHeaderRow.minHeight: 44`).
+
+### Commit
+`48fe3d351479d5d8ef7149a46cd40d73ca67c212`

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -232,4 +232,4 @@ No invented tokens. Substitutions are alias-name only (same underlying values), 
 No new test required — pure visual token change with zero behavior/store/carousel-math/a11y change. No existing test asserts the old style keys (the only style-adjacent assertion, `home.orch_1143:63`, checks the `chevU`/`chevD` Icon-name string, which is preserved verbatim and still passes). Android opaque-glass is automatic via GlassCard's internal GlassChrome. Touch target stays ≥44pt (`liveHeaderRow.minHeight: 44`).
 
 ### Commit
-`48fe3d351479d5d8ef7149a46cd40d73ca67c212`
+`97c661ca137567ccb71d544b46225966c43d8e29`

--- a/Mingla_Artifacts/reports/TEST_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -173,3 +173,62 @@ This verdict is CONDITIONAL pending Seth's affirmative on:
 2. **C-2 (CONDITION):** accept that the physical-device QR live-fire of a real experience/trip ticket is a post-merge device smoke owned by Seth (everything machine-verifiable is proven).
 
 With both accepted → routes to CLOSE. Without → STOP and surface to Seth (do not auto-CLOSE).
+
+---
+
+## 12. SC-7 ADDENDUM — focused adversarial pass on the live/Upcoming de-dup fix (2026-06-15)
+
+**Context:** §11 C-1 (P2) was the open condition from the prior CONDITIONAL PASS — a live offering
+appeared in BOTH the Live-now carousel and the Upcoming list. Seth authorized the `[TEST-MOD-APPROVED ORCH-1143]`
+follow-up. This addendum is the focused re-test of the resulting SC-7 fix. **The C-1 condition is now RESOLVED.**
+
+**SC-7 fix under test:** `4c6314f81` *(post-rebase onto `origin/main` @ `232dd5ea0`; pre-rebase the dispatch referenced `d0c7f0b50`)* — source change; `34c5fb0fc` — IMPLEMENT-report §13 append.
+**Re-test branch HEAD:** `34c5fb0fc`.
+
+### 12.1 SC-7 Verdict — **PASS** (P0: 0 · P1: 0 · P2: 0)
+
+The de-dup is correct, surgical, and constitutionally clean. Proven at TWO independent levels:
+the implementor's source-level array regression AND a tester-owned RENDER-level proof.
+
+### 12.2 SC-7 SC-by-SC matrix
+
+| Check | Verdict | Evidence |
+|-------|---------|----------|
+| Live offering of EACH kind absent from Upcoming, present in live set | PASS | Source: `upcomingBuilder.test.ts` SC7-1 (event); existing carousel render proof `LiveOfferingCard.orch1143.render.test.tsx` covers event/experience/trip scan render. Render: my `UpcomingDedup.orch1143.render.test.tsx` proves the live EVENT renders in the `live-carousel-host` and is ABSENT from the `upcoming-list-host` FlatList through the real `LiveOfferingCard` + `UpcomingListItem` + `buildUpcomingItems`. Trip/experience share the identical `status !== "live"` filter path (single code path; no per-kind branch in the filter). |
+| No leakage either direction (scheduled stays in Upcoming, not carousel) | PASS | Render test 2nd case: `SCHEDULED_GALA_Y` renders in `upcoming-list-host`, NULL in `live-carousel-host`. Source SC7-1: `nonLiveItems` = `["draft-x","evt-soon"]`, `liveItems` excludes them. |
+| Dedup uses a DERIVED view (`nonLiveItems`); does NOT mutate `items` or the live set (one owner per truth, Constitution #2) | PASS | `upcomingBuilder.ts:238` — `const nonLiveItems = nonPast.filter((i) => i.status !== "live")` is a fresh array; `items: nonPast` and `liveItems` unchanged. SC7-1 asserts `items.length === liveItems.length + nonLiveItems.length` and `items` still contains `evt-live`. Carousel still reads `liveItems` (home.tsx:564); live count unchanged. |
+| Edge: ALL items live → Upcoming hides cleanly (no crash, no empty-list artifact) | PASS | SC7-2: `nonLiveItems` length 0, `.map` over it safe. home.tsx:898 gates the section header on `hasUpcomingItems = upcoming.nonLiveItems.length > 0` (home.tsx:457) — header + list both suppressed, not an empty FlatList. |
+| Edge: NO items live → Upcoming identical to pre-SC-7 | PASS | SC7-3: `nonLiveItems.map(id) === items.map(id)` in the same sorted order. |
+| A-05 TEST-MOD intent-preserving; only the data-source assertion changed; `[TEST-MOD-APPROVED]` token present | PASS | `home.orch_0974.adversarial.test.tsx:106` carries `[TEST-MOD-APPROVED by Seth 2026-06-15]`; line 107 is the ONLY changed assertion (`data={upcoming.nonLiveItems}`). keyExtractor, `<UpcomingListItem`, the 3 handlers, and the draft(4)/trip(3)/event(5) branch digests (lines 148-150) are unchanged. Single-scroll + all item-kind branches still protected. Set runs GREEN (5/5). |
+
+### 12.3 Tester adversarial test (DIFFERENT ANGLE — render-level)
+
+- **Path:** `mingla-business/src/components/home/__tests__/UpcomingDedup.orch1143.render.test.tsx` (NEW, append-only).
+- **Config:** added one `testMatch` glob to the existing worktree-local `jest.orch1143.render.cjs` (RTL resolved via the `.orch1118-testdeps` overlay, same as the implementor's render proof).
+- **Angle vs implementor:** the implementor's `upcomingBuilder.test.ts` asserts on the PURE `nonLiveItems` ARRAY. This test mounts a faithful `home.tsx` slice — the Live-now carousel (`liveItems.map → <LiveOfferingCard>`) and the Upcoming `<FlatList data={nonLiveItems ?? items}> → <UpcomingListItem>` — fed by REAL `buildUpcomingItems(...)` output, and asserts on the rendered host-tree: the live row is ABSENT from the Upcoming list host and PRESENT in the carousel host; the scheduled row is the inverse. It catches a leak the user would actually see, not just an array contents mismatch.
+- **Green:** `npx jest --config jest.orch1143.render.cjs --runInBand` → 2 suites / 7 tests PASS (my 2 + the existing 5).
+- **Fails-on-revert: VERIFIED.** Deleting the `nonLiveItems = nonPast.filter((i) => i.status !== "live")` line + the return field in `upcomingBuilder.ts` makes `nonLiveItems` undefined → the FlatList's `?? items` fallback feeds the FULL set (incl. the live row) → `LIVE_CONCERT_X` LEAKS into the rendered `upcoming-list-host` → `expect(upcoming.queryByText(LIVE_NAME)).toBeNull()` FAILS (received a `Text` fiber). Restored → green. Verified at branch HEAD `34c5fb0fc` (fix commit `4c6314f81`).
+- **In closing diff:** `git diff origin/main...HEAD --name-only` includes BOTH the implementor's `upcomingBuilder.test.ts` (SC7-1/2/3) AND this new `UpcomingDedup.orch1143.render.test.tsx`.
+
+### 12.4 Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out the branch state, then deleted the SC-7 filter + interface field in `upcomingBuilder.ts` and re-ran the implementor's `upcomingBuilder.test.ts` SC7-1: the suite **fails to run** with `error TS2339: Property 'nonLiveItems' does not exist` at test lines 643/686/700 (ts-jest strict). The implementor's source test is tightly coupled to the `nonLiveItems` API surface — it cannot compile, let alone pass, without the fix. Restored → 30/30 green. Hashes run: fix `4c6314f81`, branch HEAD `34c5fb0fc`.
+
+### 12.5 SC-7 gates
+
+- `npx jest src/utils/__tests__/upcomingBuilder.test.ts` → 30/30 PASS (incl. SC7-1/2/3).
+- `npx jest home.orch_0974.adversarial` → 5/5 PASS (A-05 retargeted, intent-preserved).
+- `npx jest --config jest.orch1143.render.cjs` → 7/7 PASS (incl. the new render proof).
+- **tsc:** the ONLY error touching the new test is `TS2307 Cannot find module '@testing-library/react-native'` — RTL is NOT a project dependency (overlay-only, runtime-resolved via the jest `moduleNameMapper`); the EXISTING `LiveOfferingCard.orch1143.render.test.tsx` and `EditPublishedTripScreen.*.render.test.tsx` emit the identical TS2307. All other tsc errors (checkout buyers, marketing composer, payments, `category`-on-`DraftEvent` service tests) are in files OUTSIDE the SC-7 diff → pre-existing, not introduced here.
+- **eslint:** the new test's `import/no-unresolved` error + `require()`-style / `import/first` warnings are byte-for-byte the same profile as the shipped `LiveOfferingCard.orch1143.render.test.tsx` (eslint exits 0; not a blocking gate for these overlay-resolved render proofs). `useUpcomingForBrand.ts` exhaustive-deps warnings are pre-existing (unrelated to the threaded `nonLiveItems` field).
+- **DISC-1143-D** (`liveEventStore` v4-v5 migrator, `version:5` vs source `version:6`) confirmed pre-existing + not in any required CI gate — NOT blocked on, per §9.
+
+### 12.6 Constitution re-check (SC-7 delta)
+
+- **#2 One owner per truth:** PASS — `nonLiveItems` is a derived projection; `liveItems` remains the sole owner of live-state, `items` the full set. No competing writer.
+- **#3 No silent failure:** PASS — all-live case hides the section via an explicit `length > 0` gate, not a swallowed empty render.
+- All other rules: N/A to this delta (no auth/data/currency/cache surface touched).
+
+**SC-7 outcome:** the §11 C-1 condition is RESOLVED. Live offerings now render exclusively in the
+Live-now carousel; the Upcoming list is the non-live projection; no leakage; edges clean; A-05
+intent preserved. SC-7 = **PASS**.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md
@@ -1,0 +1,175 @@
+# TEST — ORCH-1143 [business Home live-card: scan parity + accordion + multi-live carousel]
+
+**Skill:** mingla-tester+claude · **Phase:** TEST (production gatekeeper) · **Date:** 2026-06-15
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1143-[live-card-scan-accordion]/` on branch `ORCH-1143-live-card-scan-accordion`
+**Branch HEAD at verdict:** `34102f6dc` · **Implementation commit:** `a7f1ebe5a` (report cites stale pre-rebase `9bbf98980`)
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1143_LIVE_CARD_SCAN_ACCORDION_CAROUSEL.md`
+**App:** Mingla BUSINESS (`mingla-business/`). UI-only — no backend / migration / edge-fn / scanner-route change.
+
+---
+
+## 1. Verdict
+
+### CONDITIONAL PASS — P0: 0 · P1: 0 · P2: 2 · P3: 1 · P4: 2
+
+Zero P0, zero unaccepted P1. The three asks are met and proven: (1) the scan button renders + FIRES for every live kind (event/experience/trip) via a real RN render mount — runtime evidence, above the source-grep ceiling; (2) the accordion is persisted + hydration-gated with the no-flash invariant proven across the full truth table; (3) the carousel/single boundary is correct and the live enumeration surfaces ALL live kinds. The CONDITIONAL tier (not PASS) is driven by **two documented deferrals/conditions** that need Seth's affirmative acceptance, NOT by any defect:
+
+- **C-1 (P2, accepted-deferral candidate):** SC-7 no-duplication is NOT implemented — a live offering appears in BOTH the new live carousel AND the Upcoming list. This is blocked by the append-only ORCH-0974 A-05 lock and was explicitly anticipated by SPEC §SC-7. Needs a follow-up `[TEST-MOD-APPROVED ORCH-NNNN]` to fix. Pre-existing list behavior, not a regression.
+- **C-2 (CONDITION, not a defect):** physical-device live-fire of an ACTUAL QR scan of a real experience/trip ticket is a STOP point owned by Seth (requires a seeded paid ticket + an authorized scanner). The scanner backend + screen + route kind-agnosticism is proven at the source/schema layer (forensics F-1..F-9) and the home-side scan button + routing is proven at the render layer; the end-to-end QR decode on a physical device remains the one human-in-the-loop step.
+
+If Seth accepts C-1's deferral and treats C-2 as the standard post-merge device smoke, this is a clean ship. Without that affirmative, it stays CONDITIONAL (per the tester contract, do not auto-route to CLOSE).
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Verdict | Evidence |
+|----|-----------|---------|----------|
+| SC-1 | Scan button on every live kind → `/event/{id}/scanner` | **PASS** | Render proof `LiveOfferingCard.orch1143.render.test.tsx` `test.each([event,experience,trip])` — button renders + `fireEvent.press` calls `onScanPress(id)` for all 3 kinds. `handleScanPress` (`home.tsx:411-416`) pushes `/event/${id}/scanner` with NO kind gate. |
+| SC-1-iOS / Android | native scanner mounts, kind-aware | **PASS (source-proven) / device-CONDITION** | Scanner screen `app/event/[id]/scanner/index.tsx` byte-unchanged; no `event_type` refusal (line 372+ `kind===` are scan-RESULT kinds, not type gates); `useManagedEventRoute` resolves event+experience+trip (forensics F-6). Actual camera scan = physical-device step (C-2). |
+| SC-1-Web | routes to web EmptyState, not a dead tap | **PASS (source-proven)** | `index.web.tsx` uses `offeringKindConfig` + `router` (kind-aware EmptyState + back), byte-unchanged. Button always enabled (`LiveOfferingCard` — no web disable). |
+| SC-2 | ≥2 live → ALL render, live-first start-asc | **PASS** | `upcomingBuilder.liveItems = nonPast.filter(status==="live")` after the live-first comparator sort; executable tests T2/T3/T4/T12 (`upcomingBuilder.test.ts`) prove event+experience+trip all enumerated in order. `home.tsx` maps `liveItems` (one owner). |
+| SC-3 | carousel ≥2; single full-width for 1 | **PASS (boundary proven)** | `home.tsx:540` `liveItems.length === 1 ? <card/> : <ScrollView horizontal snapToInterval…>`; single card has no `width` prop (full-width), carousel cards get `width={liveCardWidth}`. Source-contract T-SC3 + render proof of the card both green. |
+| SC-4 | accordion toggle (easeInEaseOut + chevron swap + expanded) | **PASS** | `LayoutAnimation.Presets.easeInEaseOut` + `chevU/chevD` glyph swap + `accessibilityState={{expanded:!liveCollapsed}}` + Android `setLayoutAnimationEnabledExperimental(true)` guard at module top (`home.tsx:105-111`). |
+| SC-5 | persisted collapse + hydration gate (no flash) | **PASS (runtime-proven)** | `liveSectionCollapseStore` — `hasHydrated` NOT persisted, flipped in `onRehydrateStorage`. **Tester adversarial** `liveSectionCollapseStore.orch1143.adversarial.test.ts` executes the gate truth table: pre-hydration ALWAYS open even with `collapsed=true` persisted (the flash defect); only `(hydrated,collapsed)` hides. |
+| SC-6 | honest data (Scanned `—`) + currency-aware | **PASS (runtime-proven)** | Render proof asserts the `—` Scanned cell at mount + kind-neutral copy. Revenue uses `view.currency ?? brand.defaultCurrency ?? "GBP"` — the SAME pre-existing fallback already on origin/main (`home.tsx:319`), generalized over the array; NO new GBP introduced (ORCH-1034 deferred, untouched). |
+| SC-7 | live NOT duplicated in Upcoming list | **FAIL → DEFERRED (C-1, P2)** | Mobile FlatList renders `data={upcoming.items}` (incl. live); the append-only A-05 lock (`home.orch_0974.adversarial.test.tsx:102-106`) pins that literal string. De-dup requires `[TEST-MOD-APPROVED]`. SPEC §SC-7 anticipated this. Live appears in carousel (with scan) AND list (nav-only). |
+| SC-8 | logout cascade resets the store | **PASS** | `clearAllStores` calls `useLiveSectionCollapseStore.getState().reset()`. Store test T11 + adversarial ADV-1143-04 (reset returns `collapsed=false`, LEAVES `hasHydrated` true). |
+| SC-9 | live TRIP renders a scannable card | **PASS (runtime-proven)** | Render proof's `trip` case: card renders via `tripToLiveEvent` + scan button fires with the trip id. Builder T2/T3 include the trip in `liveItems`. Fixes DISC-1143-B (trips were previously excluded from the hero entirely). |
+
+---
+
+## 3. Findings (P-ranked)
+
+### C-1 / P2 — SC-7 no-duplication NOT implemented (live offering shows in carousel AND Upcoming list)
+- **Evidence:** `home.tsx:889` mobile `<FlatList data={upcoming.items} …>` (and `:693` desktop `upcoming.items.map`) render the full set including live items; `home.orch_0974.adversarial.test.tsx:102-106` A-05 asserts `flatList.includes("data={upcoming.items}")`. Filtering live out changes that binding → A-05 fails → `tests-append-only.yml` forbids the test-mod without a `[TEST-MOD-APPROVED ORCH-NNNN]` token.
+- **Impact:** A live offering renders twice on Home — once as a live carousel card (with the scan button) and once as a navigation-only Upcoming row. Mild visual redundancy; not a functional break (the scan affordance is unique to the carousel card).
+- **Required fix:** spawn a follow-up ORCH carrying `[TEST-MOD-APPROVED]` to retarget A-05 so the Upcoming list filters `status !== "live"`. OR Seth accepts live-in-both-places.
+- **Retest:** after the follow-up, assert the FlatList data excludes live items and A-05 is updated under the approved token.
+- **Status:** DEFERRED by the implementor with operator flag; SPEC-anticipated. Pre-existing list behavior — NOT a regression introduced by ORCH-1143.
+
+### C-2 / CONDITION — physical-device QR live-fire (owned by Seth)
+- **Evidence:** No mingla-business dev build is installed on the booted iOS sim (`simctl listapps` shows only Apple system apps); a full sim build + a seeded paid experience/trip ticket + an authorized scanner are needed for a real camera decode.
+- **Impact:** the end-to-end "scan a real experience/trip ticket on a physical device" path is the one step not machine-verifiable here.
+- **Required action:** Seth (or a post-merge device smoke) scans one experience ticket and one trip ticket on a physical device against prod and confirms a `success` result + the duplicate-on-rescan path.
+- **Mitigation already in place:** the backend (`scan-ticket`/`biz_ticket_scan`), the ticket mint (`biz_ticket_checkout_finalize`), the scanner screen + `useManagedEventRoute` are all event-type-agnostic and byte-unchanged (forensics F-1..F-9); the home-side button + routing is render-proven. Risk is low.
+
+### P3 — render-proof test file emits a base-tsconfig `TS2307` for `@testing-library/react-native`
+- **Evidence:** `npx tsc --noEmit` → `LiveOfferingCard.orch1143.render.test.tsx(20): Cannot find module '@testing-library/react-native'`.
+- **Impact:** none at runtime / CI. RTL lives only in the gitignored `.orch1118-testdeps` overlay. The EXISTING ORCH-1118/1122 render tests on origin/main emit the IDENTICAL error (verified) — this is the accepted render-proof pattern, and no CI workflow runs `tsc --noEmit`.
+- **Required fix:** none (matches precedent). Optional: exclude `*.render.test.tsx` from the base tsconfig program if the noise is ever undesirable.
+- **Retest:** n/a.
+
+### P4 — IMPLEMENT report cites a stale commit hash
+- The report's `9bbf98980` / "fails-on-revert verified at 9bbf98980" no longer exists post-rebase; the real implementation commit is `a7f1ebe5a`. Independently re-verified at the real HEAD (see §4). Cosmetic; flag for the orchestrator's close record.
+
+### P4 — clean patterns worth crediting
+- Store mirrors `currentBrandStore` hydration gate exactly; `liveItems` added as a single owner on the builder (no ad-hoc re-derive in `home.tsx`); scan affordance is structurally unconditional (no kind gate) with a protective comment + invariant id; live section correctly placed ABOVE the ORCH-0974 locked single-scroll pane so the horizontal carousel never violates the one-scroll lock; per-icon named imports preserved (no barrel) for the ORCH-1083 budget.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+The implementor claimed T10 fails-on-revert at `9bbf98980` (stale). Re-verified at the REAL HEAD `ceea8ed0e`/`a7f1ebe5a` by TRUE LINE DELETION:
+
+- Deleted the scan-button `<Pressable>` block from `LiveOfferingCard.tsx` (466-byte block, not a comment-out).
+- Ran `npx jest home.orch_1143` → **T10 FAILED** (`Tests: 1 failed, 9 passed`); the failing assertion is `expect(CARD).toContain('testID="home-live-card-scan-button"')`.
+- Restored the block → working tree byte-identical to the commit (`git diff --quiet` clean) → **all 10 pass**.
+- Conclusion: the implementor's T10 fails-on-revert holds at the real HEAD. **Caveat:** T10 is a SOURCE-GREP (string presence), so its "fails-on-revert" only proves the string was deleted — it does not prove behavior. The tester render-proof (§5) supplies the behavioral fails-on-revert.
+
+---
+
+## 5. Adversarial tests added (tester-owned, different angle)
+
+Two tester files, both in the closing diff (`git diff origin/main...HEAD --name-only`), both append-only-new:
+
+### 5a. `mingla-business/src/store/__tests__/liveSectionCollapseStore.orch1143.adversarial.test.ts` (committed `e9a567970`)
+- **Angle:** the implementor only source-greps the literal `showLiveOpen` string and checks `reset` returns `collapsed=false`. This test EXECUTES the real store and evaluates the no-flash gate across the full `(hasHydrated, collapsed)` truth table, and asserts `reset()` LEAVES `hasHydrated` true (logout must not re-arm the cold-start gate).
+- **fails-on-revert verified at `e9a567970`:** injecting the bug `reset: () => set({ collapsed:false, hasHydrated:false })` → **ADV-1143-04 FAILS** (`1 failed, 4 passed`); restore → byte-identical, **5 pass**. This catches a real Constitution #14 defect invisible to the implementor's suite.
+
+### 5b. `mingla-business/src/components/home/__tests__/LiveOfferingCard.orch1143.render.test.tsx` (committed `34102f6dc`)
+- **Angle:** RUNTIME render mount (RTL via the `.orch1118-testdeps` overlay + worktree-local `jest.orch1143.render.cjs`) — proves the scan button RENDERS + FIRES `onScanPress(id)` for event, experience, AND trip; honest-empty `—` at render; kind-neutral a11y label. Lifts SC-1/SC-9 above the source-grep "suspected" ceiling.
+- **fails-on-revert (behavioral):** re-gating the card's scan button to `{item.kind === "event" ? … : null}` → the **experience + trip + a11y cases FAIL** (`3 failed, 2 passed`), event passes; restore → byte-identical, **5 pass**. Stronger than T10: catches ANY mechanism that suppresses the button for non-events, not just one string.
+- Added to the default `jest.config.cjs` `testPathIgnorePatterns` (RTL is overlay-only) — mirrors the ORCH-1118/1122 render-proof precedent; the default node/ts-jest run does NOT pick it up.
+
+Both implementor happy-path test (`home.orch_1143.test.tsx`) and tester adversarial tests appear in the closing diff. Regression gate satisfied.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | PASS | scan button fires `onScanPress(id)` (render-proven) for all kinds; web routes to a real EmptyState (byte-unchanged ORCH-1099 screen). |
+| 2 | One owner per truth | PASS | live-state owned by `upcomingBuilder.liveItems`; `home.tsx` maps it, does not re-derive. |
+| 3 | No silent failures | PASS | no new catch/swallow; metrics fall back to `EMPTY_LIVE_CARD_METRICS` (honest `—`), not a fake. |
+| 4 | One query key per entity | N/A | no new query/key — `useUpcomingForBrand` threads `liveItems` off the existing query. |
+| 5 | Server state stays server-side | PASS | `liveSectionCollapseStore` is a client UI flag only (collapsed boolean). |
+| 6 | Logout clears everything | PASS | `reset` wired into `clearAllStores`; adversarial ADV-1143-04 proves reset semantics. |
+| 7 | Label `[TRANSITIONAL]` | N/A | no transitional code. |
+| 8 | Subtract before adding | PASS | inline hero block REMOVED from `home.tsx`, lifted into `LiveOfferingCard`; dead hero styles deleted; stale ORCH-0965 comment deleted. |
+| 9 | No fabricated data | PASS | Scanned cell is `—` (render-proven); revenue currency-aware, no new hardcoded symbol. |
+| 10 | Currency-aware | PASS | `view.currency ?? brand.defaultCurrency` (pre-existing `?? "GBP"` fallback untouched — ORCH-1034 deferred). |
+| 11 | One auth instance | N/A | no auth touched (business operator surface). |
+| 12 | Validate at the right time | N/A | no datetime validation added. |
+| 13 | Exclusion consistency | PASS | `liveItems` derived from the same `nonPast` set as the rest of the builder. |
+| 14 | Persisted-state startup gate | PASS | `hasHydrated` gate; `showLiveOpen = !hasHydrated || !collapsed`; runtime no-flash proven across the truth table (adversarial). |
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Notes |
+|---------|---------|-------|
+| Consumer iOS | N/A | no business Home/scanner. |
+| Consumer Android | N/A | — |
+| Buyer/anonymous Web | N/A | buyer surface. |
+| Business iOS | PASS (render+source) / device-CONDITION | card render-proven; accordion + carousel source-proven; real QR camera scan = C-2 (physical device, Seth). No biz dev build on the booted iOS 17 Pro sim → full sim live-fire not run; component render mount substitutes for the card-layer proof. |
+| Business Android | PASS (shared RN) | shared `home.tsx`/card → automatic; `GlassCard` Android opaque-fallback intact (ORCH-1105 strict-grep gate PASS); no new translucent Android fill introduced (diff-verified). |
+| Admin Web | N/A | — |
+| Business Web preview (adjacent) | PASS (source) | accordion + carousel + scan button render on web; scan routes to the kind-aware web EmptyState (byte-unchanged), NOT a dead tap. |
+
+**Physical iPhone HITL:** NOT performed (no real ticket/scanner seeded). Captured as C-2 condition, not skipped/faked.
+
+---
+
+## 8. Gate results (run in-worktree, HEAD `34102f6dc`)
+
+- **tsc --noEmit:** ZERO errors in any ORCH-1143 PRODUCT file. One `TS2307 @testing-library/react-native` in the tester render-proof test — matches the existing ORCH-1118/1122 render-test pattern on origin/main (overlay-only RTL); not in any CI gate. Pre-existing repo-wide tsc errors in unrelated files unchanged.
+- **eslint (ORCH-1143 product files):** 0 errors. 4 warnings, ALL pre-existing on origin/main (`useUpcomingForBrand` serverEvents/trips exhaustive-deps; `reapOrphanStorageKeys` unused-disable) — not introduced here.
+- **jest (default config, ORCH-1143 surface):** `home.orch_1143` (10) + `liveSectionCollapseStore` (5) + `liveSectionCollapseStore.orch1143.adversarial` (5) + `upcomingBuilder.test` (27) = **47/47 PASS**.
+- **jest (render config `jest.orch1143.render.cjs`):** **5/5 PASS** (real RN mount).
+- **append-only check (`test-append-only-check.js`):** **5 passed, 0 failed** — 4 new test files ADDED, `upcomingBuilder.test.ts` MODIFIED additions-only (0 deletions).
+- **strict-grep gates:** `i-proposed-m-persist-key-whitelist` PASS (new key registered), `orch-1105-web-glass-opaque-fallback` PASS, `i-proposed-1137-biz-web-lucide-real` PASS.
+- **NOT run (CI/operator):** `web-build-check.yml` full `expo export` + ORCH-1083 `__common` 2.25MB budget — needs the full export; change adds only local named imports + no new library, low risk; CI runs it on the PR.
+
+---
+
+## 9. DISC-1143-D CI-blocker assessment (EXPLICIT)
+
+**DISC-1143-D is PRE-EXISTING on origin/main and does NOT block the ORCH-1143 PR.**
+
+- **Tests:** `liveEventStore-migrator-chain.adversarial.test.ts` + `liveEventStore-v4-v5-migrator.test.ts` (2 failures) assert the store persist `version: 5`, but `liveEventStore.ts` is `version: 6`.
+- **Pre-existing proof:** `liveEventStore.ts` is `version: 6` on BOTH origin/main AND this branch (identical, line 421). ORCH-1143 touches neither `liveEventStore.ts` nor the migrator test files (`git diff origin/main...HEAD --name-only` confirms).
+- **Bonus pre-existing failure found:** `upcomingBuilder.adversarial.test.ts` ADV-09 (`pickHomeNextAction` brand-switch ladder) also FAILS. PROVEN pre-existing by reverting `upcomingBuilder.ts` to origin/main and re-running — ADV-09 still fails (it tests `homeNextAction.ts`, untouched by ORCH-1143).
+- **CI-blocker verdict:** The ONLY jest invocation in ALL CI workflows is `production-readiness-audit.yml:63` → `npx jest src/config/__tests__/featureFlags.test.ts --runInBand`. There is NO CI workflow that runs the full business-app jest suite. Therefore neither DISC-1143-D nor the ADV-09 failure runs in any required CI gate, and **neither blocks the ORCH-1143 PR merge.** They are local-suite hygiene items for a future stale-test cleanup ORCH.
+
+---
+
+## 10. Discoveries for Orchestrator
+
+- **DISC-1143-D (confirmed pre-existing):** 2 `liveEventStore` migrator tests assert `version:5` vs source `version:6`. Stale-test cleanup ORCH. Not in CI; not blocking.
+- **DISC-1143-E (new, tester-found):** `upcomingBuilder.adversarial.test.ts` ADV-09 fails on origin/main (`pickHomeNextAction` brand-switch ladder rung 1 vs 2). Independent of ORCH-1143. Same stale-test cleanup. Not in CI; not blocking.
+- **SC-7 / A-05 lock conflict (C-1):** needs a decision — accept live-in-both-places, or spawn a `[TEST-MOD-APPROVED]` follow-up to filter live out of the Upcoming list.
+- **DISC-1143-C (from investigation):** no per-offering historical scanned count source; Scanned stays `—`. Future-enhancement candidate.
+- **IMPLEMENT report stale hash:** cites `9bbf98980`; real commit `a7f1ebe5a`. Fix in the close record.
+
+---
+
+## 11. Accepted conditions (CONDITIONAL PASS)
+
+This verdict is CONDITIONAL pending Seth's affirmative on:
+1. **C-1 (P2):** accept SC-7 deferral (live shows in carousel + Upcoming list) OR authorize a `[TEST-MOD-APPROVED]` follow-up ORCH.
+2. **C-2 (CONDITION):** accept that the physical-device QR live-fire of a real experience/trip ticket is a post-merge device smoke owned by Seth (everything machine-verifiable is proven).
+
+With both accepted → routes to CLOSE. Without → STOP and surface to Seth (do not auto-CLOSE).

--- a/mingla-business/app/(tabs)/__tests__/home.orch_0974.adversarial.test.tsx
+++ b/mingla-business/app/(tabs)/__tests__/home.orch_0974.adversarial.test.tsx
@@ -103,7 +103,8 @@ describe("ORCH-1038 Home adversarial contracts", () => {
     const flatList = mobileFlatListBlock();
     const branchDigest = {
       flatList: {
-        data: flatList.includes("data={upcoming.items}"),
+        // ORCH-1143 SC-7 [TEST-MOD-APPROVED by Seth 2026-06-15]: Upcoming list excludes live items (now in the Live-now carousel); single-scroll + all item-kind branches still asserted.
+        data: flatList.includes("data={upcoming.nonLiveItems}"),
         keyExtractor: flatList.includes("keyExtractor={(item) => item.key}"),
         renderItem: flatList.includes("<UpcomingListItem"),
         handlers: [

--- a/mingla-business/app/(tabs)/__tests__/home.orch_1143.test.tsx
+++ b/mingla-business/app/(tabs)/__tests__/home.orch_1143.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ORCH-1143 [business Home live-card: scan parity + accordion + carousel].
+ *
+ * Source-level contract tests (node/ts-jest — the default biz-app jest config
+ * has no RN renderer + no RTL; render proofs are segregated to dedicated
+ * configs, see jest.config.cjs). These lock the runtime behaviour by pinning
+ * the source contracts that produce it:
+ *
+ *   - the live carousel/single-card maps off `upcoming.liveItems` (all kinds),
+ *   - it renders the reusable <LiveOfferingCard> (no inline event-only hero),
+ *   - <LiveOfferingCard> emits the scan button UNCONDITIONALLY (no per-kind
+ *     gate) → experience + trip live offerings are scannable (the bug),
+ *   - the scan handler routes EVERY kind to /event/{id}/scanner with NO
+ *     `kind === "event"` guard,
+ *   - the collapse store is persisted + hasHydrated-gated (Constitution #14).
+ *
+ * The fails-on-revert contract (§9 / T10): re-introducing a `kind === "event"`
+ * gate around the scan affordance, or scoping the carousel to events, or
+ * deleting the <LiveOfferingCard> map, makes T10 / T2 / T3 FAIL.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const read = (rel: string): string => readFileSync(join(REPO_ROOT, rel), "utf8");
+
+const HOME = read("mingla-business/app/(tabs)/home.tsx");
+const CARD = read("mingla-business/src/components/home/LiveOfferingCard.tsx");
+const STORE = read(
+  "mingla-business/src/store/liveSectionCollapseStore.ts",
+);
+const CLEAR = read("mingla-business/src/utils/clearAllStores.ts");
+
+function countToken(source: string, token: string): number {
+  return source.split(token).length - 1;
+}
+
+describe("ORCH-1143 — live carousel maps off liveItems (all kinds)", () => {
+  test("T-SC2: the carousel maps off upcoming.liveItems (one-owner-per-truth), not re-derived", () => {
+    // home consumes liveItems from the hook (the builder owns live-state).
+    expect(HOME).toContain("const liveItems = upcoming.liveItems;");
+    // the carousel iterates the live set
+    expect(HOME).toContain("liveItems.map((liveItem)");
+    // both branches render the reusable card
+    expect(countToken(HOME, "<LiveOfferingCard")).toBeGreaterThanOrEqual(2);
+  });
+
+  test("T-SC3: ≥2 live → horizontal ScrollView with snap; exactly 1 live → single full-width card", () => {
+    expect(HOME).toContain("liveItems.length === 1 ? (");
+    expect(HOME).toContain("snapToInterval={liveCardWidth + spacing.md}");
+    expect(HOME).toContain('decelerationRate="fast"');
+    // single-live card has NO width prop (full-width); carousel cards do.
+    expect(HOME).toContain("width={liveCardWidth}");
+  });
+
+  test("T6/SC-4: accordion header toggles via LayoutAnimation easeInEaseOut + chevron glyph swap + expanded state", () => {
+    expect(HOME).toContain(
+      "LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)",
+    );
+    expect(HOME).toContain('name={showLiveOpen ? "chevU" : "chevD"}');
+    expect(HOME).toContain("accessibilityState={{ expanded: !liveCollapsed }}");
+    // Android guard for LayoutAnimation present (module top).
+    expect(HOME).toContain(
+      "UIManager.setLayoutAnimationEnabledExperimental(true)",
+    );
+  });
+
+  test("SC-5/#14: collapse render is hydration-gated (no flash-of-wrong-state)", () => {
+    expect(HOME).toContain(
+      "const showLiveOpen = !liveHasHydrated || !liveCollapsed;",
+    );
+  });
+});
+
+describe("ORCH-1143 — scan parity on EVERY live kind (T10 fails-on-revert)", () => {
+  test("T1/T9: scan handler routes EVERY kind to /event/{id}/scanner with NO kind gate", () => {
+    // handler takes an id and pushes the shared scanner route.
+    expect(HOME).toContain("router.push(`/event/${id}/scanner` as never)");
+    // NO event-only gate on the scan affordance anywhere in home.
+    expect(HOME).not.toContain("primaryLiveItem.kind === \"event\"");
+    expect(HOME).not.toContain("showScanAction");
+  });
+
+  test("T10 (fails-on-revert): <LiveOfferingCard> emits the scan button UNCONDITIONALLY (no per-kind gate)", () => {
+    // The scan button is present in the card.
+    expect(CARD).toContain('testID="home-live-card-scan-button"');
+    expect(CARD).toContain("Scan QR codes");
+    expect(CARD).toContain("onScanPress(item.id)");
+    // There is NO event-type gate inside the card — it renders for every kind.
+    expect(CARD).not.toContain('item.kind === "event"');
+    expect(CARD).not.toContain('event_type === "event"');
+    // The button is NOT wrapped in a conditional ternary keyed on kind: it is a
+    // direct child of the card (the structural safeguard from §9). If a future
+    // edit re-gates the carousel to events only, T-SC2's two-card map + the
+    // builder T2/T3 (experience/trip → liveItems) fail.
+  });
+
+  test("T2/T3: an experience and a trip live offering reach the carousel (no kind filter)", () => {
+    // home builds the live views over liveItems with trips adapted (NOT
+    // filtered to events). Reverting to event-only would delete this map.
+    expect(HOME).toContain("tripToLiveEvent(i.source as Trip)");
+    expect(HOME).toContain("(i.source as LiveEvent)");
+    // liveEventViews is derived from liveItems, not from an event-only filter.
+    expect(HOME).toContain("liveItems\n        .map((i)");
+  });
+});
+
+describe("ORCH-1143 — honest data + currency (SC-6)", () => {
+  test("SC-6: Scanned tile stays '—' (Constitution #9), revenue is currency-aware", () => {
+    // Scanned cell is the honest-empty dash; never a fabricated number.
+    expect(CARD).toContain("<Text style={styles.statValue}>—</Text>");
+    expect(CARD).toContain("Scanned");
+    // revenue uses the offering currency ?? brand default (no NEW hardcoded GBP
+    // introduced by this ORCH; the metricsById builder threads currency).
+    expect(HOME).toContain(
+      "view.currency ?? currentBrand?.defaultCurrency ?? \"GBP\"",
+    );
+  });
+});
+
+describe("ORCH-1143 — collapse store (SC-5/SC-8, Constitution #14/#6)", () => {
+  test("store is persisted, partialized to collapsed only, hasHydrated NOT persisted", () => {
+    expect(STORE).toContain('name: "mingla-business.liveSectionCollapse.v1"');
+    expect(STORE).toContain("partialize: (state) => ({ collapsed: state.collapsed })");
+    expect(STORE).toContain("hasHydrated: false");
+    expect(STORE).toContain(
+      "useLiveSectionCollapseStore.getState().setHasHydrated(true)",
+    );
+    // hasHydrated is NOT in the persisted partition.
+    expect(STORE).not.toContain("hasHydrated: state.hasHydrated");
+  });
+
+  test("SC-8: reset is wired into clearAllStores (logout cascade, Constitution #6)", () => {
+    expect(CLEAR).toContain(
+      "useLiveSectionCollapseStore.getState().reset()",
+    );
+  });
+});

--- a/mingla-business/app/(tabs)/home.tsx
+++ b/mingla-business/app/(tabs)/home.tsx
@@ -47,6 +47,7 @@ import {
 } from "../../src/components/home/LiveOfferingCard";
 import { UpcomingListItem } from "../../src/components/home/UpcomingListItem";
 import { EventCoverMedia } from "../../src/components/ui/EventCoverMedia";
+import { GlassCard } from "../../src/components/ui/GlassCard";
 import { Icon } from "../../src/components/ui/Icon";
 import { KpiTile } from "../../src/components/ui/KpiTile";
 import { Pill } from "../../src/components/ui/Pill";
@@ -504,42 +505,54 @@ export default function HomeTab(): React.ReactElement {
     if (!hasLiveItems) return null;
     return (
       <View style={styles.liveSection}>
-        <Pressable
-          onPress={handleToggleLiveSection}
-          accessibilityRole="button"
-          accessibilityState={{ expanded: !liveCollapsed }}
-          accessibilityLabel={
-            liveItems.length === 1
-              ? `Live now, 1 offering, ${
-                  liveCollapsed ? "tap to expand" : "tap to collapse"
-                }`
-              : `Live now, ${liveItems.length} offerings, ${
-                  liveCollapsed ? "tap to expand" : "tap to collapse"
-                }`
-          }
-          style={({ pressed }) => [
-            styles.liveHeaderRow,
-            pressed && styles.liveHeaderRowPressed,
-          ]}
-          testID="home-live-section-header"
-        >
-          <View style={styles.liveHeaderLeft}>
-            <View style={styles.liveHeaderDot} />
-            <Text style={styles.liveHeaderTitle}>Live now</Text>
-            {liveItems.length > 1 ? (
-              <Text style={styles.liveHeaderCount}>{`· ${liveItems.length}`}</Text>
-            ) : null}
-          </View>
-          {/* Chevron is decorative — the expanded/collapsed state lives on the
-              parent Pressable's accessibilityState. Icon renders an inert SVG
-              (no accessibilityRole), so VoiceOver/TalkBack announce only the
-              header button. */}
-          <Icon
-            name={showLiveOpen ? "chevU" : "chevD"}
-            size={20}
-            color={textTokens.secondary}
-          />
-        </Pressable>
+        {/* ORCH-1143 §4.4-A (device-feedback fix): the header is wrapped in a
+            GlassCard so it reads as an interactive surface (matching the
+            BusinessTodoToggle directly above it on Home) — the bare label row
+            looked like a static section title. GlassCard owns the inner
+            spacing.md inset and the Android opaque-glass fallback; the gutter
+            lives on the liveSection wrapper View. The card body (single card or
+            carousel) stays a SIBLING below this card, NOT inside it. */}
+        <GlassCard variant="base" padding={spacing.md}>
+          <Pressable
+            onPress={handleToggleLiveSection}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: !liveCollapsed }}
+            accessibilityLabel={
+              liveItems.length === 1
+                ? `Live now, 1 offering, ${
+                    liveCollapsed ? "tap to expand" : "tap to collapse"
+                  }`
+                : `Live now, ${liveItems.length} offerings, ${
+                    liveCollapsed ? "tap to expand" : "tap to collapse"
+                  }`
+            }
+            style={({ pressed }) => [
+              styles.liveHeaderRow,
+              pressed && styles.liveHeaderRowPressed,
+            ]}
+            testID="home-live-section-header"
+          >
+            <View style={styles.liveHeaderLeft}>
+              <View style={styles.liveHeaderDot} />
+              <Text style={styles.liveHeaderTitle}>Live now</Text>
+              {liveItems.length > 1 ? (
+                <Text style={styles.liveHeaderCount}>{`· ${liveItems.length}`}</Text>
+              ) : null}
+            </View>
+            {/* Chevron is decorative — the expanded/collapsed state lives on the
+                parent Pressable's accessibilityState. The contained circular
+                handle is the explicit "this is a dropdown" affordance; the Icon
+                renders an inert SVG (no accessibilityRole), so VoiceOver/TalkBack
+                announce only the header button. */}
+            <View style={styles.liveHeaderChevron}>
+              <Icon
+                name={showLiveOpen ? "chevU" : "chevD"}
+                size={18}
+                color={textTokens.secondary}
+              />
+            </View>
+          </Pressable>
+        </GlassCard>
 
         {showLiveOpen ? (
           liveItems.length === 1 ? (
@@ -1122,19 +1135,33 @@ const styles = StyleSheet.create({
   // The hero render moved into the reusable <LiveOfferingCard>; these styles
   // own only the section wrapper + the accordion header + the carousel.
   liveSection: {
+    // ORCH-1143 §4.4-A (device-feedback fix): self-supply the full Home gutter
+    // (spacing.md = 16) because renderLiveSection() is rendered OUTSIDE the
+    // padded column, so the GlassCard header + card body line up flush with the
+    // To-do toggle above and the KPI/Upcoming column below.
+    paddingHorizontal: spacing.md,
     marginBottom: spacing.md,
   },
   liveHeaderRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: spacing.xs,
-    paddingTop: spacing.sm,
-    paddingBottom: spacing.sm,
+    // No paddingHorizontal/vertical — the wrapping GlassCard's padding={spacing.md}
+    // owns the content inset (adding more would double-pad). minHeight keeps the
+    // touch target ≥44pt.
     minHeight: 44,
   },
   liveHeaderRowPressed: {
     opacity: 0.6,
+  },
+  liveHeaderChevron: {
+    // ORCH-1143 §4.4-A: contained circular "dropdown handle" affordance.
+    width: 28,
+    height: 28,
+    borderRadius: radiusTokens.full,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: glass.tint.profileBase,
   },
   liveHeaderLeft: {
     flexDirection: "row",

--- a/mingla-business/app/(tabs)/home.tsx
+++ b/mingla-business/app/(tabs)/home.tsx
@@ -22,12 +22,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
+  LayoutAnimation,
   Platform,
   Pressable,
   RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
+  UIManager,
+  useWindowDimensions,
   View,
 } from "react-native";
 import { useRouter } from "expo-router";
@@ -38,9 +41,12 @@ import { BrandDeleteSheet } from "../../src/components/brand/BrandDeleteSheet";
 import { BrandSwitcherSheet } from "../../src/components/brand/BrandSwitcherSheet";
 import { BusinessTodoToggle } from "../../src/components/home/BusinessTodoToggle";
 import { HomeTripRow } from "../../src/components/home/HomeTripRow";
+import {
+  LiveOfferingCard,
+  type LiveCardMetrics,
+} from "../../src/components/home/LiveOfferingCard";
 import { UpcomingListItem } from "../../src/components/home/UpcomingListItem";
 import { EventCoverMedia } from "../../src/components/ui/EventCoverMedia";
-import { GlassCard } from "../../src/components/ui/GlassCard";
 import { Icon } from "../../src/components/ui/Icon";
 import { KpiTile } from "../../src/components/ui/KpiTile";
 import { Pill } from "../../src/components/ui/Pill";
@@ -76,11 +82,13 @@ import {
   upcomingKeys,
   useUpcomingForBrand,
 } from "../../src/hooks/useUpcomingForBrand";
+import { useLiveSectionCollapseStore } from "../../src/store/liveSectionCollapseStore";
 import type { DraftEvent } from "../../src/store/draftEventStore";
 import type { LiveEvent } from "../../src/store/liveEventStore";
 import type { Trip } from "../../src/services/tripsService";
 // ORCH-0865 REWORK 5 — canonical routing helper, ban hardcoded /event/{id}
 import { routeForEventRowDefensive } from "../../src/utils/routeForEventRow";
+import { tripToLiveEvent } from "../../src/utils/tripToLiveEvent";
 import type { BusinessTodo } from "../../src/utils/businessTodos";
 
 import { formatCurrencyRound } from "../../src/utils/currency";
@@ -93,6 +101,32 @@ import { formatRelativeTime } from "../../src/utils/relativeTime";
 // cleanly. The full HomeTab body below is unchanged for rank>=20.
 import { ScannerHome } from "../../src/components/scanners/ScannerHome";
 import { isScannerOnlyRank } from "../../src/utils/navTabGate";
+
+// ORCH-1143 — LayoutAnimation requires this guard on Android or the live-section
+// accordion collapse won't animate (BusinessTodoToggle.tsx:38-43 precedent).
+if (
+  Platform.OS === "android" &&
+  UIManager.setLayoutAnimationEnabledExperimental !== undefined
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+// ORCH-1143 — horizontal live-carousel sizing (§4.4-D). PEEK is the visible
+// sliver of the next card that signals "swipe for more"; CARD_MAX keeps the
+// card from over-stretching on wide phones/foldables.
+const LIVE_CARD_PEEK = 40;
+const LIVE_CARD_MAX = 360;
+
+// ORCH-1143 — inert metrics for the one-frame gap before sales resolve (the
+// card renders immediately; values fill in). Revenue "—" is honest until the
+// per-id summary lands; Scanned stays "—" forever (Constitution #9).
+const EMPTY_LIVE_CARD_METRICS: LiveCardMetrics = {
+  revenueLabel: "—",
+  soldValue: "0",
+  capacityLabel: "—",
+  capacity: null,
+  progress: 0,
+};
 
 interface ToastState {
   visible: boolean;
@@ -273,62 +307,78 @@ export default function HomeTab(): React.ReactElement {
     }
   }, [brandRecovery.errorMessage]);
 
-  const primaryLiveItem = upcoming.primaryLiveItem;
-  const primaryLiveEvent: LiveEvent | null =
-    primaryLiveItem !== null &&
-    (primaryLiveItem.kind === "event" || primaryLiveItem.kind === "experience")
-      ? (primaryLiveItem.source as LiveEvent)
-      : null;
+  // ORCH-1143 — ALL concurrently-live offerings (event/experience/trip), owned
+  // by upcomingBuilder.liveItems (one-owner-per-truth, Constitution #2). The
+  // home screen does NOT re-derive live status.
+  const liveItems = upcoming.liveItems;
 
-  // Sales summary lookup for ALL event/experience items — both live AND upcoming.
-  // Upcoming (scheduled, future-dated) events are still selling tickets, so their
-  // sold count + revenue must be fetched too. Previously this filtered to
-  // status === "live", so every upcoming row fell back to a false "0 sold" / "$0"
-  // (its orders were never fetched). Trips are excluded — they carry their own
-  // ticketsSoldCount on the Trip row; drafts have no orders.
-  const summaryEvents = useMemo<LiveEvent[]>(
+  // ORCH-1143 — a LiveEvent-shaped view per live item (trips adapt via
+  // tripToLiveEvent) for per-card metrics. tripToLiveEvent never returns null
+  // for a non-null source, but we guard for type-safety.
+  const liveEventViews = useMemo<LiveEvent[]>(
     () =>
-      upcoming.items
-        .filter((i) => i.kind === "event" || i.kind === "experience")
-        .map((i) => i.source as LiveEvent),
-    [upcoming.items],
+      liveItems
+        .map((i) =>
+          i.kind === "trip"
+            ? tripToLiveEvent(i.source as Trip)
+            : (i.source as LiveEvent),
+        )
+        .filter((v): v is LiveEvent => v !== null),
+    [liveItems],
   );
+
+  // Sales summary lookup for ALL event/experience items — both live AND upcoming —
+  // PLUS the adapted live-trip views (so live trips get currency-aware revenue
+  // in the carousel). Upcoming (scheduled, future-dated) events are still selling
+  // tickets, so their sold count + revenue must be fetched too. Deduped by id.
+  const summaryEvents = useMemo<LiveEvent[]>(() => {
+    const byId = new Map<string, LiveEvent>();
+    for (const i of upcoming.items) {
+      if (i.kind === "event" || i.kind === "experience") {
+        byId.set(i.id, i.source as LiveEvent);
+      }
+    }
+    for (const view of liveEventViews) {
+      if (!byId.has(view.id)) byId.set(view.id, view);
+    }
+    return Array.from(byId.values());
+  }, [upcoming.items, liveEventViews]);
   const eventSalesSummaries = useEventSalesSummaries(
     summaryEvents,
     currentBrand?.defaultCurrency,
   );
 
-  const liveHeroMetrics = useMemo(() => {
-    if (primaryLiveEvent === null) {
-      return {
-        revenueLabel: "—",
-        soldValue: "0",
-        capacity: null as number | null,
-        progress: 0,
+  // ORCH-1143 — per-live-card display metrics, keyed by offering id. Generalizes
+  // the former single-item `liveHeroMetrics` over the live array. Currency stays
+  // venue/brand-sourced (do NOT introduce a new `?? "GBP"` here — ORCH-1034
+  // deferred work owns the existing fallback).
+  const liveMetricsById = useMemo<Record<string, LiveCardMetrics>>(() => {
+    const map: Record<string, LiveCardMetrics> = {};
+    for (const view of liveEventViews) {
+      const capacity = finiteTicketCapacity(view);
+      const salesSummary = eventSalesSummaries[view.id];
+      const soldCount = salesSummary?.soldCount ?? 0;
+      map[view.id] = {
+        revenueLabel:
+          salesSummary?.revenueLabel ??
+          formatCurrencyRound(
+            0,
+            view.currency ?? currentBrand?.defaultCurrency ?? "GBP",
+          ),
+        soldValue:
+          salesSummary?.hasError === true
+            ? "Unable"
+            : soldCount.toLocaleString("en-GB"),
+        capacityLabel: formatCapacityLabel(view),
+        capacity,
+        progress:
+          capacity !== null && capacity > 0
+            ? Math.min(1, soldCount / capacity)
+            : 0,
       };
     }
-
-    const capacity = finiteTicketCapacity(primaryLiveEvent);
-    const salesSummary = eventSalesSummaries[primaryLiveEvent.id];
-    const soldCount = salesSummary?.soldCount ?? 0;
-    return {
-      revenueLabel:
-        salesSummary?.revenueLabel ??
-        formatCurrencyRound(
-          0,
-          primaryLiveEvent.currency ?? currentBrand?.defaultCurrency ?? "GBP",
-        ),
-      soldValue:
-        salesSummary?.hasError === true
-          ? "Unable"
-          : soldCount.toLocaleString("en-GB"),
-      capacity,
-      progress:
-        capacity !== null && capacity > 0
-          ? Math.min(1, soldCount / capacity)
-          : 0,
-    };
-  }, [primaryLiveEvent, currentBrand?.defaultCurrency, eventSalesSummaries]);
+    return map;
+  }, [liveEventViews, currentBrand?.defaultCurrency, eventSalesSummaries]);
 
   // ORCH-0965 — counts shape for the existing getActiveEventsKpiSub helper.
   // The helper consumes BrandEventSummaryCounts which has `all` + status
@@ -351,23 +401,56 @@ export default function HomeTab(): React.ReactElement {
   // rule-ladder / offering-chooser logic now lives in the shared useBusinessTodos
   // hook + handleTodoAction below.
 
-  // ORCH-0965 — scan-QR action visible ONLY when the primary live hero is
-  // an `event`-kind offering. Experiences route to a coming-soon stub
-  // (Ve series not shipped) and trips have no scanner today.
-  const showScanAction =
-    primaryLiveItem !== null && primaryLiveItem.kind === "event";
+  // ORCH-1143 — scan on EVERY live kind (event/experience/trip). The scan
+  // backend (biz_ticket_scan) + /event/[id]/scanner are event-type-agnostic
+  // (INVESTIGATE_ORCH-1143 verdict A/A/A) — /event/[id]/scanner is the SHARED
+  // scanner route for all kinds (no /experience or /trip scanner route). On web
+  // it routes to the ORCH-1099 kind-aware "Scan tickets in the app" EmptyState,
+  // NOT a dead tap. Do NOT re-add a `kind === "event"` gate here.
+  // I-PROPOSED-ORCH1143-LIVE-SCAN-ALL-KINDS.
+  const handleScanPress = useCallback(
+    (id: string): void => {
+      router.push(`/event/${id}/scanner` as never);
+    },
+    [router],
+  );
 
-  const handleScanPress = useCallback((): void => {
-    if (primaryLiveItem === null || primaryLiveItem.kind !== "event") return;
-    router.push(`/event/${primaryLiveItem.id}/scanner` as never);
-  }, [primaryLiveItem, router]);
+  // ORCH-1143 — live-section accordion collapse, persisted + hydration-gated
+  // (Constitution #14). Until `hasHydrated`, render the default (open) state and
+  // do NOT read `collapsed` for layout — prevents a flash-of-wrong-state on cold
+  // start. The toggle wraps the LayoutAnimation per the BusinessTodoToggle
+  // precedent (easeInEaseOut, ~300ms default, Android guard at module top).
+  const liveCollapsed = useLiveSectionCollapseStore((s) => s.collapsed);
+  const liveHasHydrated = useLiveSectionCollapseStore((s) => s.hasHydrated);
+  const toggleLiveCollapsed = useLiveSectionCollapseStore((s) => s.toggle);
+  const showLiveOpen = !liveHasHydrated || !liveCollapsed;
+  const handleToggleLiveSection = useCallback((): void => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    toggleLiveCollapsed();
+  }, [toggleLiveCollapsed]);
+
+  const windowDimensions = useWindowDimensions();
+  const liveCardWidth = useMemo(
+    () =>
+      Math.min(
+        Math.round(
+          windowDimensions.width - spacing.md * 2 - LIVE_CARD_PEEK,
+        ),
+        LIVE_CARD_MAX,
+      ),
+    [windowDimensions.width],
+  );
 
   // ORCH-1038 — analytics tiles render ONLY when there is real data to show
   // (no zero/empty placeholders); the to-do toggle carries guidance instead.
   const hasRevenueData =
     currentBrand?.defaultCurrency !== undefined &&
     (currentBrand?.stats.rev7d ?? 0) > 0;
-  const showRevenueTile = primaryLiveEvent !== null || hasRevenueData;
+  // ORCH-1143 — the live cards moved OUT of the KPI grid into their own
+  // accordion section above the locked pane; the "Last 7 days" KPI fallback now
+  // shows only when there is rev7d data (it no longer doubles as the live slot).
+  const hasLiveItems = liveItems.length > 0;
+  const showRevenueTile = hasRevenueData;
   const hasActiveEvents = upcoming.counts.total > 0;
   const hasUpcomingItems = upcoming.items.length > 0;
   const showKpiGrid = showRevenueTile || hasActiveEvents;
@@ -403,6 +486,93 @@ export default function HomeTab(): React.ReactElement {
     },
     [router],
   );
+
+  // ORCH-1143 — the "Live now" accordion section (header + body). Renders only
+  // when ≥1 offering is live. Header toggles whole-section collapse. Body:
+  // exactly 1 live → one full-width LiveOfferingCard (no carousel chrome);
+  // ≥2 live → a horizontal ScrollView of peek-width cards, each independently
+  // scannable, live-first start-ascending (ExperienceStopsGalleryTile house
+  // style). Hidden when collapsed (after hydration). Shared across the desktop
+  // pane and the mobile pane (above the locked zone, so the carousel's
+  // horizontal scroller stays outside the ORCH-0974 single-scroll lock).
+  const renderLiveSection = (): React.ReactElement | null => {
+    if (!hasLiveItems) return null;
+    return (
+      <View style={styles.liveSection}>
+        <Pressable
+          onPress={handleToggleLiveSection}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: !liveCollapsed }}
+          accessibilityLabel={
+            liveItems.length === 1
+              ? `Live now, 1 offering, ${
+                  liveCollapsed ? "tap to expand" : "tap to collapse"
+                }`
+              : `Live now, ${liveItems.length} offerings, ${
+                  liveCollapsed ? "tap to expand" : "tap to collapse"
+                }`
+          }
+          style={({ pressed }) => [
+            styles.liveHeaderRow,
+            pressed && styles.liveHeaderRowPressed,
+          ]}
+          testID="home-live-section-header"
+        >
+          <View style={styles.liveHeaderLeft}>
+            <View style={styles.liveHeaderDot} />
+            <Text style={styles.liveHeaderTitle}>Live now</Text>
+            {liveItems.length > 1 ? (
+              <Text style={styles.liveHeaderCount}>{`· ${liveItems.length}`}</Text>
+            ) : null}
+          </View>
+          {/* Chevron is decorative — the expanded/collapsed state lives on the
+              parent Pressable's accessibilityState. Icon renders an inert SVG
+              (no accessibilityRole), so VoiceOver/TalkBack announce only the
+              header button. */}
+          <Icon
+            name={showLiveOpen ? "chevU" : "chevD"}
+            size={20}
+            color={textTokens.secondary}
+          />
+        </Pressable>
+
+        {showLiveOpen ? (
+          liveItems.length === 1 ? (
+            <LiveOfferingCard
+              item={liveItems[0]}
+              metrics={
+                liveMetricsById[liveItems[0].id] ?? EMPTY_LIVE_CARD_METRICS
+              }
+              onScanPress={handleScanPress}
+              testID="home-live-card"
+            />
+          ) : (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              snapToInterval={liveCardWidth + spacing.md}
+              snapToAlignment="start"
+              decelerationRate="fast"
+              contentContainerStyle={styles.liveCarouselContent}
+              accessibilityLabel="Live offerings, swipe horizontally to see more"
+            >
+              {liveItems.map((liveItem) => (
+                <LiveOfferingCard
+                  key={liveItem.key}
+                  item={liveItem}
+                  metrics={
+                    liveMetricsById[liveItem.id] ?? EMPTY_LIVE_CARD_METRICS
+                  }
+                  onScanPress={handleScanPress}
+                  width={liveCardWidth}
+                />
+              ))}
+            </ScrollView>
+          )
+        ) : null}
+      </View>
+    );
+  };
 
   // ORCH-1055: rank-10 scanner — render the door-only surface. All hooks
   // above have run unconditionally; this is a render-time branch, safe
@@ -460,94 +630,29 @@ export default function HomeTab(): React.ReactElement {
         >
           {currentBrand === null ? null : (
             <>
+              {/* ORCH-1143 — the "Live now" accordion + carousel sits at the top
+                  of the dashboard, above the analytics grid. */}
+              {renderLiveSection()}
+
               {/* ORCH-1038 — analytics only when there's real data; the to-do
                   toggle above carries all guidance/empty-state actions. */}
               {showKpiGrid ? (
               <View style={styles.desktopKpiGrid}>
                 {showRevenueTile ? (
                 <View style={styles.desktopKpiCell}>
-                  {primaryLiveEvent !== null ? (
-                    <GlassCard variant="elevated" padding={spacing.lg}>
-                      <View style={styles.heroLiveTagRow}>
-                        <Pill variant="live" livePulse>
-                          Live now
-                        </Pill>
-                      </View>
-                      <Text style={styles.heroEventName}>
-                        {getEventName(primaryLiveEvent.name, "Untitled event")}
-                      </Text>
-                      <Text style={styles.heroEventDate}>
-                        {formatDraftDateLine(primaryLiveEvent)}
-                      </Text>
-                      <View style={styles.heroAmountRow}>
-                        <Text style={styles.heroAmountSold}>
-                          {liveHeroMetrics.revenueLabel}
-                        </Text>
-                        <Text style={styles.heroAmountGoal}> revenue</Text>
-                      </View>
-                      {liveHeroMetrics.capacity !== null ? (
-                        <View style={styles.progressBarTrack}>
-                          <View
-                            style={[
-                              styles.progressBarFill,
-                              {
-                                width: `${Math.round(
-                                  liveHeroMetrics.progress * 100,
-                                )}%`,
-                              },
-                            ]}
-                          />
-                        </View>
-                      ) : null}
-                      <View style={styles.heroStatRow}>
-                        <View style={styles.heroStatCell}>
-                          <Text style={styles.heroStatValue}>
-                            {liveHeroMetrics.soldValue}
-                          </Text>
-                          <Text style={styles.heroStatLabel}>Tickets sold</Text>
-                        </View>
-                        <View style={styles.heroStatCell}>
-                          <Text style={styles.heroStatValue}>
-                            {formatCapacityLabel(primaryLiveEvent)}
-                          </Text>
-                          <Text style={styles.heroStatLabel}>Capacity</Text>
-                        </View>
-                        <View style={styles.heroStatCell}>
-                          <Text style={styles.heroStatValue}>—</Text>
-                          <Text style={styles.heroStatLabel}>Scanned</Text>
-                        </View>
-                      </View>
-                      {/* ORCH-0965 — scan-QR action. Event-kind hero only. */}
-                      {showScanAction ? (
-                        <Pressable
-                          onPress={handleScanPress}
-                          accessibilityRole="button"
-                          accessibilityLabel={`Scan tickets for ${getEventName(primaryLiveEvent.name, "Untitled event")}`}
-                          style={styles.heroScanAction}
-                          testID="home-live-hero-scan-button"
-                        >
-                          <Icon name="qr" size={16} color={accent.warm} />
-                          <Text style={styles.heroScanActionText}>
-                            Scan QR codes
-                          </Text>
-                        </Pressable>
-                      ) : null}
-                    </GlassCard>
-                  ) : (
-                    <KpiTile
-                      label="Last 7 days"
-                      value={
-                        currentBrand.defaultCurrency !== undefined
-                          ? formatCurrencyRound(
-                              // ORCH-0816 — windowed 7-day GMV. Lifetime stays on
-                              // BrandProfileView's "GMV / all time" tile.
-                              currentBrand.stats.rev7d,
-                              currentBrand.defaultCurrency,
-                            )
-                          : "—"
-                      }
-                    />
-                  )}
+                  <KpiTile
+                    label="Last 7 days"
+                    value={
+                      currentBrand.defaultCurrency !== undefined
+                        ? formatCurrencyRound(
+                            // ORCH-0816 — windowed 7-day GMV. Lifetime stays on
+                            // BrandProfileView's "GMV / all time" tile.
+                            currentBrand.stats.rev7d,
+                            currentBrand.defaultCurrency,
+                          )
+                        : "—"
+                    }
+                  />
                 </View>
                 ) : null}
 
@@ -725,82 +830,21 @@ export default function HomeTab(): React.ReactElement {
           )}
         </ScrollView>
       ) : currentBrand === null ? null : (
-        // orch-0974-lock-pane:begin-mobile-populated; ORCH-1038 — the to-do
-        // toggle above carries no-brand / no-venue / deck-readiness / offering
-        // guidance; this pane is now analytics-only (gated on real data).
-        <View style={styles.mobileBody}>
+        <>
+          {/* ORCH-1143 — the "Live now" accordion + carousel sits ABOVE the
+              ORCH-0974 locked single-scroll pane, so the carousel's horizontal
+              ScrollView never violates that pane's one-scroll-surface lock. */}
+          {renderLiveSection()}
+          {
+            // orch-0974-lock-pane:begin-mobile-populated; ORCH-1038 — the to-do
+            // toggle above carries no-brand / no-venue / deck-readiness / offering
+            // guidance; this pane is now analytics-only (gated on real data).
+          }
+          <View style={styles.mobileBody}>
           <View style={styles.lockedZone}>
             {showKpiGrid ? (
             <View style={styles.mobileKpiStack}>
               {showRevenueTile ? (
-              primaryLiveEvent !== null ? (
-                <GlassCard variant="elevated" padding={spacing.lg}>
-                  <View style={styles.heroLiveTagRow}>
-                    <Pill variant="live" livePulse>
-                      Live now
-                    </Pill>
-                  </View>
-                  <Text style={styles.heroEventName}>
-                    {getEventName(primaryLiveEvent.name, "Untitled event")}
-                  </Text>
-                  <Text style={styles.heroEventDate}>
-                    {formatDraftDateLine(primaryLiveEvent)}
-                  </Text>
-                  <View style={styles.heroAmountRow}>
-                    <Text style={styles.heroAmountSold}>
-                      {liveHeroMetrics.revenueLabel}
-                    </Text>
-                    <Text style={styles.heroAmountGoal}> revenue</Text>
-                  </View>
-                  {liveHeroMetrics.capacity !== null ? (
-                    <View style={styles.progressBarTrack}>
-                      <View
-                        style={[
-                          styles.progressBarFill,
-                          {
-                            width: `${Math.round(
-                              liveHeroMetrics.progress * 100,
-                            )}%`,
-                          },
-                        ]}
-                      />
-                    </View>
-                  ) : null}
-                  <View style={styles.heroStatRow}>
-                    <View style={styles.heroStatCell}>
-                      <Text style={styles.heroStatValue}>
-                        {liveHeroMetrics.soldValue}
-                      </Text>
-                      <Text style={styles.heroStatLabel}>Tickets sold</Text>
-                    </View>
-                    <View style={styles.heroStatCell}>
-                      <Text style={styles.heroStatValue}>
-                        {formatCapacityLabel(primaryLiveEvent)}
-                      </Text>
-                      <Text style={styles.heroStatLabel}>Capacity</Text>
-                    </View>
-                    <View style={styles.heroStatCell}>
-                      <Text style={styles.heroStatValue}>—</Text>
-                      <Text style={styles.heroStatLabel}>Scanned</Text>
-                    </View>
-                  </View>
-                  {/* ORCH-0965 — scan-QR action. Event-kind hero only. */}
-                  {showScanAction ? (
-                    <Pressable
-                      onPress={handleScanPress}
-                      accessibilityRole="button"
-                      accessibilityLabel={`Scan tickets for ${getEventName(primaryLiveEvent.name, "Untitled event")}`}
-                      style={styles.heroScanAction}
-                      testID="home-live-hero-scan-button"
-                    >
-                      <Icon name="qr" size={16} color={accent.warm} />
-                      <Text style={styles.heroScanActionText}>
-                        Scan QR codes
-                      </Text>
-                    </Pressable>
-                  ) : null}
-                </GlassCard>
-              ) : (
                 <KpiTile
                   label="Last 7 days"
                   value={
@@ -814,7 +858,6 @@ export default function HomeTab(): React.ReactElement {
                       : "—"
                   }
                 />
-              )
               ) : null}
 
               {hasActiveEvents ? (
@@ -864,8 +907,11 @@ export default function HomeTab(): React.ReactElement {
             }
             showsVerticalScrollIndicator={false}
           />
-        </View>
-        // orch-0974-lock-pane:end-mobile-populated
+          </View>
+          {
+            // orch-0974-lock-pane:end-mobile-populated
+          }
+        </>
       )}
 
       <BrandSwitcherSheet
@@ -1063,85 +1109,51 @@ const styles = StyleSheet.create({
     textTransform: "uppercase",
   },
 
-  // Hero — live event ---------------------------------------------------
-  heroLiveTagRow: {
-    flexDirection: "row",
-    marginBottom: spacing.sm,
-  },
-  heroEventName: {
-    fontSize: typography.bodySm.fontSize,
-    lineHeight: typography.bodySm.lineHeight,
-    color: textTokens.secondary,
-    marginBottom: 2,
-  },
-  heroEventDate: {
-    fontSize: typography.caption.fontSize,
-    lineHeight: typography.caption.lineHeight,
-    color: textTokens.tertiary,
-    marginBottom: 4,
-  },
-  heroAmountRow: {
-    flexDirection: "row",
-    alignItems: "baseline",
+  // ORCH-1143 — "Live now" accordion section -------------------------------
+  // The hero render moved into the reusable <LiveOfferingCard>; these styles
+  // own only the section wrapper + the accordion header + the carousel.
+  liveSection: {
     marginBottom: spacing.md,
   },
-  heroAmountSold: {
-    fontSize: 32,
-    lineHeight: 36,
-    fontWeight: "700",
-    letterSpacing: -0.4,
-    color: textTokens.primary,
-  },
-  heroAmountGoal: {
-    fontSize: 18,
-    lineHeight: 22,
-    fontWeight: "500",
-    color: textTokens.tertiary,
-  },
-  progressBarTrack: {
-    height: 4,
-    borderRadius: 999,
-    backgroundColor: glass.tint.profileBase,
-    overflow: "hidden",
-    marginBottom: spacing.md,
-  },
-  progressBarFill: {
-    height: "100%",
-    backgroundColor: accent.warm,
-    borderRadius: 999,
-  },
-  heroStatRow: {
+  liveHeaderRow: {
     flexDirection: "row",
+    alignItems: "center",
     justifyContent: "space-between",
+    paddingHorizontal: spacing.xs,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.sm,
+    minHeight: 44,
   },
-  heroStatCell: {
-    flex: 1,
+  liveHeaderRowPressed: {
+    opacity: 0.6,
   },
-  heroStatValue: {
-    fontSize: typography.body.fontSize,
-    lineHeight: typography.body.lineHeight,
-    fontWeight: "700",
-    color: textTokens.primary,
-  },
-  heroStatLabel: {
-    fontSize: typography.caption.fontSize,
-    lineHeight: typography.caption.lineHeight,
-    color: textTokens.tertiary,
-    marginTop: 2,
-  },
-  // ORCH-0965 — scan-QR action inside live hero (event-kind only).
-  heroScanAction: {
+  liveHeaderLeft: {
     flexDirection: "row",
     alignItems: "center",
     gap: spacing.xs,
-    alignSelf: "flex-start",
-    marginTop: spacing.md,
   },
-  heroScanActionText: {
+  liveHeaderDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 999,
+    backgroundColor: accent.warm,
+  },
+  liveHeaderTitle: {
     fontSize: typography.bodySm.fontSize,
     lineHeight: typography.bodySm.lineHeight,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  liveHeaderCount: {
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight,
     fontWeight: "600",
-    color: accent.warm,
+    color: textTokens.secondary,
+    marginLeft: 2,
+  },
+  liveCarouselContent: {
+    gap: spacing.md,
+    paddingRight: spacing.md,
   },
 
   // Section header ------------------------------------------------------

--- a/mingla-business/app/(tabs)/home.tsx
+++ b/mingla-business/app/(tabs)/home.tsx
@@ -505,14 +505,20 @@ export default function HomeTab(): React.ReactElement {
     if (!hasLiveItems) return null;
     return (
       <View style={styles.liveSection}>
-        {/* ORCH-1143 §4.4-A (device-feedback fix): the header is wrapped in a
-            GlassCard so it reads as an interactive surface (matching the
-            BusinessTodoToggle directly above it on Home) — the bare label row
-            looked like a static section title. GlassCard owns the inner
-            spacing.md inset and the Android opaque-glass fallback; the gutter
-            lives on the liveSection wrapper View. The card body (single card or
-            carousel) stays a SIBLING below this card, NOT inside it. */}
-        <GlassCard variant="base" padding={spacing.md}>
+        {/* ORCH-1143 §4.4-A (continuous-section fix, AUTHORITATIVE): ONE shared
+            `base` GlassCard surface wraps the WHOLE section — header row →
+            hairline divider → body — so the header and content read as one
+            continuous section parted by a divider, not two stacked cards (the
+            device-feedback fix's separate header GlassCard + separate elevated
+            body card read as "two different sections"; Seth rejected it). The
+            card uses padding={0} so each region controls its own inset and the
+            divider can run full-width inside the surface. Single-live content
+            renders FLAT (no own glass chrome) directly on this surface; the
+            carousel (≥2 live) parks discrete `elevated` cards under the divider
+            inside the same surface. The 16pt gutter still lives on the
+            liveSection wrapper View; Android opaque-glass is inherited from this
+            single base GlassCard. */}
+        <GlassCard variant="base" padding={0}>
           <Pressable
             onPress={handleToggleLiveSection}
             accessibilityRole="button"
@@ -552,42 +558,59 @@ export default function HomeTab(): React.ReactElement {
               />
             </View>
           </Pressable>
-        </GlassCard>
 
-        {showLiveOpen ? (
-          liveItems.length === 1 ? (
-            <LiveOfferingCard
-              item={liveItems[0]}
-              metrics={
-                liveMetricsById[liveItems[0].id] ?? EMPTY_LIVE_CARD_METRICS
-              }
-              onScanPress={handleScanPress}
-              testID="home-live-card"
-            />
-          ) : (
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              snapToInterval={liveCardWidth + spacing.md}
-              snapToAlignment="start"
-              decelerationRate="fast"
-              contentContainerStyle={styles.liveCarouselContent}
-              accessibilityLabel="Live offerings, swipe horizontally to see more"
-            >
-              {liveItems.map((liveItem) => (
+          {/* §4.4-A.3 — hairline divider (the seam that replaces the
+              inter-card gap), using the card's OWN border token so it reads as
+              an internal continuation of the card edge. Inset 16/16 so it does
+              not collide with the rounded corners. Rendered ONLY when open, so
+              a collapsed header sits alone as a clean rounded bar. */}
+          {showLiveOpen ? (
+            <View style={styles.liveSectionDivider} />
+          ) : null}
+
+          {/* §4.4-A.4/A.5 — body INSIDE the same surface, under the divider.
+              Single-live = flat content laid on the shared surface; carousel =
+              discrete elevated cards parked beneath the divider. */}
+          {showLiveOpen ? (
+            liveItems.length === 1 ? (
+              <View style={styles.liveSectionBody}>
                 <LiveOfferingCard
-                  key={liveItem.key}
-                  item={liveItem}
+                  flat
+                  item={liveItems[0]}
                   metrics={
-                    liveMetricsById[liveItem.id] ?? EMPTY_LIVE_CARD_METRICS
+                    liveMetricsById[liveItems[0].id] ?? EMPTY_LIVE_CARD_METRICS
                   }
                   onScanPress={handleScanPress}
-                  width={liveCardWidth}
+                  testID="home-live-card"
                 />
-              ))}
-            </ScrollView>
-          )
-        ) : null}
+              </View>
+            ) : (
+              <View style={styles.liveSectionCarouselBody}>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  snapToInterval={liveCardWidth + spacing.md}
+                  snapToAlignment="start"
+                  decelerationRate="fast"
+                  contentContainerStyle={styles.liveCarouselContent}
+                  accessibilityLabel="Live offerings, swipe horizontally to see more"
+                >
+                  {liveItems.map((liveItem) => (
+                    <LiveOfferingCard
+                      key={liveItem.key}
+                      item={liveItem}
+                      metrics={
+                        liveMetricsById[liveItem.id] ?? EMPTY_LIVE_CARD_METRICS
+                      }
+                      onScanPress={handleScanPress}
+                      width={liveCardWidth}
+                    />
+                  ))}
+                </ScrollView>
+              </View>
+            )
+          ) : null}
+        </GlassCard>
       </View>
     );
   };
@@ -1146,13 +1169,43 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    // No paddingHorizontal/vertical — the wrapping GlassCard's padding={spacing.md}
-    // owns the content inset (adding more would double-pad). minHeight keeps the
-    // touch target ≥44pt.
+    // ORCH-1143 §4.4-A.2 (continuous-section fix): re-add the header inset
+    // because the enclosing GlassCard is now padding={0}. paddingHorizontal:16
+    // reinstates the gutter the card used to supply; paddingVertical:8 +
+    // minHeight:44 keeps the ≥44pt touch target while sitting tight to the
+    // divider.
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
     minHeight: 44,
   },
   liveHeaderRowPressed: {
     opacity: 0.6,
+  },
+  // ORCH-1143 §4.4-A.3 — hairline seam between header and body, INSIDE the
+  // shared base surface. Uses glass.border.profileBase — the EXACT token the
+  // base GlassCard draws its own perimeter with — so it reads as an internal
+  // continuation of the card edge, not a foreign line. Inset 16/16 so it does
+  // not collide with the 16-radius corners.
+  liveSectionDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: glass.border.profileBase,
+    marginHorizontal: spacing.md,
+  },
+  // ORCH-1143 §4.4-A.4 — single-live body region inside the shared surface.
+  // Owns the flat card's inset (the flat LiveOfferingCard renders padding:0):
+  // 16 horizontal, 8 top (tight under the divider so content reads as belonging
+  // to the header), 16 bottom (comfortable base inset).
+  liveSectionBody: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+  },
+  // ORCH-1143 §4.4-A.5 — carousel body region: NO horizontal padding (the
+  // ScrollView contentContainerStyle owns the 16 left/right via
+  // liveCarouselContent); 8 top under the divider, 16 bottom.
+  liveSectionCarouselBody: {
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
   },
   liveHeaderChevron: {
     // ORCH-1143 §4.4-A: contained circular "dropdown handle" affordance.
@@ -1189,6 +1242,10 @@ const styles = StyleSheet.create({
   },
   liveCarouselContent: {
     gap: spacing.md,
+    // ORCH-1143 §4.4-A.5 — add left inset: the enclosing GlassCard is now
+    // padding={0}, so the carousel must self-supply its 16pt left inset to
+    // align the first card's left edge with the divider's 16pt inset.
+    paddingLeft: spacing.md,
     paddingRight: spacing.md,
   },
 

--- a/mingla-business/app/(tabs)/home.tsx
+++ b/mingla-business/app/(tabs)/home.tsx
@@ -452,7 +452,12 @@ export default function HomeTab(): React.ReactElement {
   const hasLiveItems = liveItems.length > 0;
   const showRevenueTile = hasRevenueData;
   const hasActiveEvents = upcoming.counts.total > 0;
-  const hasUpcomingItems = upcoming.items.length > 0;
+  // ORCH-1143 SC-7 — the "Upcoming" section header + list render the non-live
+  // items only (live offerings are surfaced exclusively in the live carousel
+  // above). When every active item is live, the Upcoming section hides cleanly
+  // instead of showing an empty list. `counts`/`hasActiveEvents` still count the
+  // full set (live included) so the KPI grid is unchanged.
+  const hasUpcomingItems = upcoming.nonLiveItems.length > 0;
   const showKpiGrid = showRevenueTile || hasActiveEvents;
 
   // ORCH-1038 — unified smart to-do list: derived from live state, ordered by
@@ -690,7 +695,9 @@ export default function HomeTab(): React.ReactElement {
                     styles.desktopEventsGrid,
                   ]}
                 >
-                {upcoming.items.map((item) => {
+                {/* ORCH-1143 SC-7 — non-live items only; live offerings are in
+                    the live carousel above, never duplicated in this list. */}
+                {upcoming.nonLiveItems.map((item) => {
                     if (item.kind === "draft") {
                       const draft = item.source as DraftEvent;
                       return (
@@ -886,7 +893,9 @@ export default function HomeTab(): React.ReactElement {
 
           <FlatList
             style={styles.mobileUpcomingList}
-            data={upcoming.items}
+            // ORCH-1143 SC-7 — non-live items only; live offerings are in the
+            // live carousel above (with the scan button), never duplicated here.
+            data={upcoming.nonLiveItems}
             keyExtractor={(item) => item.key}
             renderItem={({ item }) => (
               <UpcomingListItem

--- a/mingla-business/jest.config.cjs
+++ b/mingla-business/jest.config.cjs
@@ -14,6 +14,10 @@ module.exports = {
     "EditPublishedTripScreen\\.coverDeadTap\\.render\\.test\\.tsx$",
     // ORCH-1122 tester-owned adversarial render-proof (two-way close binding).
     "EditPublishedTripScreen\\.coverClose\\.adversarial\\.render\\.test\\.tsx$",
+    // ORCH-1143 tester runtime render-proof — runs under jest.orch1143.render.cjs
+    // (RN preset + RTL via the .orch1118-testdeps overlay); MUST NOT run under
+    // this default node/ts-jest config (no RTL).
+    "LiveOfferingCard\\.orch1143\\.render\\.test\\.tsx$",
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   transform: {

--- a/mingla-business/jest.orch1143.render.cjs
+++ b/mingla-business/jest.orch1143.render.cjs
@@ -1,0 +1,56 @@
+// ORCH-1143 LiveOfferingCard render-proof — worktree-local jest config (tester).
+//
+// Stands up a REAL @testing-library/react-native mount of the production
+// LiveOfferingCard so the per-kind scan button + single-vs-carousel sizing are
+// proven to RENDER + FIRE at runtime (not just source-grepped). Mirrors
+// jest.orch1122.render.cjs (RN preset + babel-jest of the RN tree) and resolves
+// RTL + react-test-renderer from the worktree-local .orch1118-testdeps overlay
+// (gitignored; provisioned per worktree), with react/react-native pinned to the
+// business install (single copy).
+//
+// Run:
+//   npx jest --config jest.orch1143.render.cjs --runInBand
+
+const fs = require("fs");
+const path = require("path");
+
+const businessRoot = __dirname;
+const overlay = path.join(businessRoot, ".orch1118-testdeps", "node_modules");
+const bizModules = path.join(businessRoot, "node_modules");
+
+const rtlRoot = path.join(overlay, "@testing-library", "react-native");
+const matchersBuild = path.join(rtlRoot, "build", "matchers", "extend-expect.js");
+const matchersDist = path.join(rtlRoot, "dist", "matchers", "extend-expect.js");
+const extendExpect = fs.existsSync(matchersBuild) ? matchersBuild : matchersDist;
+
+module.exports = {
+  rootDir: businessRoot,
+  preset: "react-native",
+  transform: {
+    "^.+\\.(js|jsx|ts|tsx)$": [
+      "babel-jest",
+      { configFile: path.join(businessRoot, "jest.orch1118.babel.cjs") },
+    ],
+  },
+  testMatch: [
+    "**/__tests__/LiveOfferingCard.orch1143.render.test.tsx",
+  ],
+  transformIgnorePatterns: [
+    "node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|@testing-library|test-renderer|react-clone-referenced-element|@react-native-async-storage|expo|@expo|react-native-safe-area-context|@gorhom)",
+  ],
+  moduleNameMapper: {
+    "^react$": path.join(bizModules, "react"),
+    "^react/(.*)$": path.join(bizModules, "react", "$1"),
+    "^react-native$": path.join(bizModules, "react-native"),
+    "^react-test-renderer$": path.join(overlay, "react-test-renderer"),
+    "^react-test-renderer/(.*)$": path.join(overlay, "react-test-renderer", "$1"),
+    "^@testing-library/react-native$": path.join(overlay, "@testing-library", "react-native"),
+    "^@testing-library/react-native/(.*)$": path.join(overlay, "@testing-library", "react-native", "$1"),
+  },
+  modulePaths: [overlay, bizModules],
+  setupFilesAfterEnv: [extendExpect],
+  haste: {
+    defaultPlatform: "ios",
+    platforms: ["ios", "android", "native"],
+  },
+};

--- a/mingla-business/jest.orch1143.render.cjs
+++ b/mingla-business/jest.orch1143.render.cjs
@@ -34,6 +34,8 @@ module.exports = {
   },
   testMatch: [
     "**/__tests__/LiveOfferingCard.orch1143.render.test.tsx",
+    // ORCH-1143 SC-7 (tester adversarial) — Upcoming/Live de-dup render proof.
+    "**/__tests__/UpcomingDedup.orch1143.render.test.tsx",
   ],
   transformIgnorePatterns: [
     "node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|@testing-library|test-renderer|react-clone-referenced-element|@react-native-async-storage|expo|@expo|react-native-safe-area-context|@gorhom)",

--- a/mingla-business/jest.orch1143.render.cjs
+++ b/mingla-business/jest.orch1143.render.cjs
@@ -36,6 +36,8 @@ module.exports = {
     "**/__tests__/LiveOfferingCard.orch1143.render.test.tsx",
     // ORCH-1143 SC-7 (tester adversarial) — Upcoming/Live de-dup render proof.
     "**/__tests__/UpcomingDedup.orch1143.render.test.tsx",
+    // ORCH-1143 §4.4-A continuous-section fix v2 — flat-vs-elevated chrome proof.
+    "**/__tests__/LiveOfferingCard.flat.orch1143.render.test.tsx",
   ],
   transformIgnorePatterns: [
     "node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|@testing-library|test-renderer|react-clone-referenced-element|@react-native-async-storage|expo|@expo|react-native-safe-area-context|@gorhom)",

--- a/mingla-business/src/components/home/LiveOfferingCard.tsx
+++ b/mingla-business/src/components/home/LiveOfferingCard.tsx
@@ -1,0 +1,250 @@
+/**
+ * LiveOfferingCard — ORCH-1143 [business Home live-card: scan parity + carousel].
+ *
+ * The reusable per-offering "live now" card, lifted token-for-token from the
+ * former inline hero block in `app/(tabs)/home.tsx`. It renders for ANY live
+ * offering kind (event / experience / trip): the live pill, name, date,
+ * revenue (the hero number), an optional sold-vs-capacity progress bar, the
+ * sold / capacity / scanned stat row, and a single primary action — the
+ * "Scan QR codes" button.
+ *
+ * The parent (`home.tsx`) owns metric computation (revenue/sold/capacity/
+ * progress) via `useEventSalesSummaries`; this component is presentational and
+ * normalizes only `name` + `dateLine` for display (trips adapt via
+ * `tripToLiveEvent`).
+ *
+ * ORCH-1143 — scan button on EVERY live kind (event/experience/trip). The scan
+ * backend (biz_ticket_scan) + /event/[id]/scanner are event-type-agnostic —
+ * INVESTIGATE_ORCH-1143 verdict A/A/A. Do NOT re-gate to kind==="event"
+ * (regresses experience/trip scan). I-PROPOSED-ORCH1143-LIVE-SCAN-ALL-KINDS.
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  glass,
+  radius,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { LiveEvent } from "../../store/liveEventStore";
+import type { Trip } from "../../services/tripsService";
+import type { UpcomingItem } from "../../utils/upcomingBuilder";
+import { formatDraftDateLine } from "../../utils/eventDateDisplay";
+import { tripToLiveEvent } from "../../utils/tripToLiveEvent";
+import { GlassCard } from "../ui/GlassCard";
+import { Icon } from "../ui/Icon";
+import { Pill } from "../ui/Pill";
+
+/** Display metrics computed by the parent (one-owner-per-truth for sales). */
+export interface LiveCardMetrics {
+  /** Currency-aware revenue string (e.g. "$0" / "₦1,200" / "£40"). */
+  revenueLabel: string;
+  /** Tickets-sold value, already formatted (or "Unable" on a summary error). */
+  soldValue: string;
+  /** Capacity label, already formatted ("—" / "Unlimited" / a number). */
+  capacityLabel: string;
+  /** Finite capacity (null ⇒ no progress bar rendered). */
+  capacity: number | null;
+  /** 0..1 sold-vs-capacity fraction. */
+  progress: number;
+}
+
+export interface LiveOfferingCardProps {
+  item: UpcomingItem;
+  metrics: LiveCardMetrics;
+  onScanPress: (id: string) => void;
+  /** Set by the carousel parent. Undefined ⇒ full-width (single-live). */
+  width?: number;
+  testID?: string;
+}
+
+const getEventName = (name: string, fallback: string): string =>
+  name.trim().length > 0 ? name : fallback;
+
+export const LiveOfferingCard: React.FC<LiveOfferingCardProps> = ({
+  item,
+  metrics,
+  onScanPress,
+  width,
+  testID,
+}) => {
+  // Display-only normalization. Trips adapt to a LiveEvent-shaped view for the
+  // name + date line; events/experiences are already LiveEvent.
+  const displayEvent: LiveEvent | null =
+    item.kind === "trip"
+      ? tripToLiveEvent(item.source as Trip)
+      : (item.source as LiveEvent);
+
+  const name = getEventName(displayEvent?.name ?? "", "Untitled");
+  const dateLine =
+    displayEvent !== null ? formatDraftDateLine(displayEvent) : "";
+
+  return (
+    <GlassCard
+      variant="elevated"
+      padding={spacing.lg}
+      style={width !== undefined ? { width } : undefined}
+      testID={testID}
+    >
+      <View style={styles.liveTagRow}>
+        <Pill variant="live" livePulse>
+          Live now
+        </Pill>
+      </View>
+      <Text style={styles.offeringName}>{name}</Text>
+      <Text style={styles.offeringDate}>{dateLine}</Text>
+
+      <View style={styles.amountRow}>
+        <Text style={styles.amountValue}>{metrics.revenueLabel}</Text>
+        <Text style={styles.amountSuffix}> revenue</Text>
+      </View>
+
+      {metrics.capacity !== null ? (
+        <View style={styles.progressTrack}>
+          <View
+            style={[
+              styles.progressFill,
+              { width: `${Math.round(metrics.progress * 100)}%` },
+            ]}
+          />
+        </View>
+      ) : null}
+
+      <View style={styles.statRow}>
+        <View style={styles.statCell}>
+          <Text style={styles.statValue}>{metrics.soldValue}</Text>
+          <Text style={styles.statLabel}>Tickets sold</Text>
+        </View>
+        <View style={styles.statCell}>
+          <Text style={styles.statValue}>{metrics.capacityLabel}</Text>
+          <Text style={styles.statLabel}>Capacity</Text>
+        </View>
+        <View style={styles.statCell}>
+          {/* ORCH-1143 — honest-empty (Constitution #9): no per-offering
+              scanned-count source exists. NEVER fabricate a number. */}
+          <Text style={styles.statValue}>—</Text>
+          <Text style={styles.statLabel}>Scanned</Text>
+        </View>
+      </View>
+
+      {/* ORCH-1143 — scan button on EVERY live kind (event/experience/trip).
+          The scan backend (biz_ticket_scan) + /event/[id]/scanner are
+          event-type-agnostic — INVESTIGATE_ORCH-1143 verdict A/A/A. Do NOT
+          re-gate to kind==="event" (regresses experience/trip scan).
+          I-PROPOSED-ORCH1143-LIVE-SCAN-ALL-KINDS. */}
+      <Pressable
+        onPress={() => onScanPress(item.id)}
+        accessibilityRole="button"
+        accessibilityLabel={`Scan tickets for ${name}`}
+        style={({ pressed }) => [
+          styles.scanButton,
+          pressed && styles.scanButtonPressed,
+        ]}
+        testID="home-live-card-scan-button"
+      >
+        <Icon name="qr" size={18} color={accent.warm} />
+        <Text style={styles.scanButtonText}>Scan QR codes</Text>
+      </Pressable>
+    </GlassCard>
+  );
+};
+
+const styles = StyleSheet.create({
+  liveTagRow: {
+    flexDirection: "row",
+    marginBottom: spacing.sm,
+  },
+  offeringName: {
+    fontSize: typography.bodySm.fontSize,
+    lineHeight: typography.bodySm.lineHeight,
+    color: textTokens.secondary,
+    marginBottom: 2,
+  },
+  offeringDate: {
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight,
+    color: textTokens.tertiary,
+    marginBottom: 4,
+  },
+  amountRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    marginBottom: spacing.md,
+  },
+  amountValue: {
+    fontSize: 32,
+    lineHeight: 36,
+    fontWeight: "700",
+    letterSpacing: -0.4,
+    color: textTokens.primary,
+  },
+  amountSuffix: {
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: "500",
+    color: textTokens.tertiary,
+  },
+  progressTrack: {
+    height: 4,
+    borderRadius: 999,
+    backgroundColor: glass.tint.profileBase,
+    overflow: "hidden",
+    marginBottom: spacing.md,
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: accent.warm,
+    borderRadius: 999,
+  },
+  statRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  statCell: {
+    flex: 1,
+  },
+  statValue: {
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  statLabel: {
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight,
+    color: textTokens.tertiary,
+    marginTop: 2,
+  },
+  // ORCH-1143 — contained, full-width warm-tinted primary action. Replaces the
+  // bare orange text link (heroScanAction) so the scan affordance reads as a
+  // clear ≥44pt button on every card, incl. inside the horizontal carousel.
+  scanButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.xs,
+    marginTop: spacing.lg,
+    height: 44,
+    borderRadius: radius.md,
+    backgroundColor: accent.tint,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: accent.border,
+    paddingHorizontal: spacing.md,
+  },
+  scanButtonPressed: {
+    opacity: 0.7,
+  },
+  scanButtonText: {
+    fontSize: typography.buttonMd.fontSize,
+    lineHeight: typography.buttonMd.lineHeight,
+    fontWeight: typography.buttonMd.fontWeight,
+    letterSpacing: typography.buttonMd.letterSpacing,
+    color: accent.warm,
+  },
+});
+
+export default LiveOfferingCard;

--- a/mingla-business/src/components/home/LiveOfferingCard.tsx
+++ b/mingla-business/src/components/home/LiveOfferingCard.tsx
@@ -59,6 +59,16 @@ export interface LiveOfferingCardProps {
   onScanPress: (id: string) => void;
   /** Set by the carousel parent. Undefined ⇒ full-width (single-live). */
   width?: number;
+  /**
+   * ORCH-1143 §4.4-A (continuous-section fix): when true, the card renders
+   * FLAT — without its own `GlassCard` chrome (no border/shadow/radius/air
+   * gap) — so the single-live content sits directly on the shared `base`
+   * section surface in home.tsx (header → hairline divider → flat body = ONE
+   * continuous section). The carousel (≥2 live) leaves `flat` unset so each
+   * card keeps its discrete `variant="elevated"` chrome. `width` is ignored in
+   * flat mode (single-live is full-width of the body region).
+   */
+  flat?: boolean;
   testID?: string;
 }
 
@@ -70,6 +80,7 @@ export const LiveOfferingCard: React.FC<LiveOfferingCardProps> = ({
   metrics,
   onScanPress,
   width,
+  flat = false,
   testID,
 }) => {
   // Display-only normalization. Trips adapt to a LiveEvent-shaped view for the
@@ -83,13 +94,13 @@ export const LiveOfferingCard: React.FC<LiveOfferingCardProps> = ({
   const dateLine =
     displayEvent !== null ? formatDraftDateLine(displayEvent) : "";
 
-  return (
-    <GlassCard
-      variant="elevated"
-      padding={spacing.lg}
-      style={width !== undefined ? { width } : undefined}
-      testID={testID}
-    >
+  // ORCH-1143 §4.4-A (continuous-section fix): the hero content tree is the
+  // same in both modes. In FLAT mode (single-live) it renders chrome-less so
+  // it sits directly on the shared `base` section surface in home.tsx (the
+  // surrounding `liveSectionBody` owns the inset — see A.4/A.6); in elevated
+  // mode (carousel cards) it keeps its own `GlassCard variant="elevated"`.
+  const content = (
+    <>
       <View style={styles.liveTagRow}>
         <Pill variant="live" livePulse>
           Live now
@@ -149,11 +160,42 @@ export const LiveOfferingCard: React.FC<LiveOfferingCardProps> = ({
         <Icon name="qr" size={18} color={accent.warm} />
         <Text style={styles.scanButtonText}>Scan QR codes</Text>
       </Pressable>
+    </>
+  );
+
+  // FLAT (single-live): no own glass surface / elevation / air gap. The
+  // content is laid directly on the shared section surface; `width` is ignored
+  // (single-live is full-width of liveSectionBody). The testID rides the
+  // wrapper View so render-test selectors still resolve.
+  if (flat) {
+    return (
+      <View style={styles.flatRoot} testID={testID}>
+        {content}
+      </View>
+    );
+  }
+
+  // ELEVATED (carousel, ≥2 live): each card keeps discrete chrome.
+  return (
+    <GlassCard
+      variant="elevated"
+      padding={spacing.lg}
+      style={width !== undefined ? { width } : undefined}
+      testID={testID}
+    >
+      {content}
     </GlassCard>
   );
 };
 
 const styles = StyleSheet.create({
+  // ORCH-1143 §4.4-A.6 — flat (single-live) wrapper: NO outer padding. The
+  // enclosing `liveSectionBody` in home.tsx supplies the 16/8/16 inset, so the
+  // flat content must not double-pad. No border/shadow/radius — it is laid
+  // directly on the shared `base` section surface.
+  flatRoot: {
+    padding: 0,
+  },
   liveTagRow: {
     flexDirection: "row",
     marginBottom: spacing.sm,

--- a/mingla-business/src/components/home/__tests__/LiveOfferingCard.flat.orch1143.render.test.tsx
+++ b/mingla-business/src/components/home/__tests__/LiveOfferingCard.flat.orch1143.render.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * ORCH-1143 §4.4-A (continuous-section fix v2) — LiveOfferingCard `flat` prop
+ * RENDER proof.
+ *
+ * Seth device-tested the prior fix and said the "Live now" header + content read
+ * as "two different sections as opposed to one continuous section with a
+ * divider." The fix makes them ONE continuous surface: the single-live card is
+ * rendered FLAT (chrome-less) directly on the shared `base` section surface in
+ * home.tsx, while the carousel (≥2 live) keeps each card's own elevated glass.
+ *
+ * This is the runtime evidence that:
+ *   - `flat` mode renders the content WITHOUT its own GlassCard chrome (no
+ *     glass-on-glass / no air gap = the continuous-section requirement), while
+ *   - default/elevated mode (carousel) DOES wrap in a GlassCard, AND
+ *   - in BOTH modes the scan button still renders + fires (behavior unchanged).
+ *
+ * The GlassCard stub emits a `glasscard` marker testID so its presence/absence
+ * is directly assertable.
+ *
+ * Run: npx jest --config jest.orch1143.render.cjs --runInBand
+ */
+
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+// GlassCard stub emits a marker so we can assert presence/absence of the chrome.
+jest.mock("../../ui/GlassCard", () => {
+  const { View: V } = require("react-native");
+  return {
+    GlassCard: ({ children, testID }: any) => (
+      <V testID={testID}>
+        <V testID="glasscard-marker" />
+        {children}
+      </V>
+    ),
+  };
+});
+jest.mock("../../ui/Pill", () => {
+  const { Text: T } = require("react-native");
+  return { Pill: ({ children }: any) => <T>{children}</T> };
+});
+jest.mock("../../ui/Icon", () => {
+  const { View: V } = require("react-native");
+  return { Icon: ({ name }: any) => <V testID={`icon-${name}`} /> };
+});
+jest.mock("../../../utils/tripToLiveEvent", () => ({
+  tripToLiveEvent: (t: any) => ({ id: t.id, name: t.name, event_type: "trip" }),
+}));
+jest.mock("../../../utils/eventDateDisplay", () => ({
+  formatDraftDateLine: () => "Today · 7:00 PM",
+}));
+
+import { LiveOfferingCard, type LiveCardMetrics } from "../LiveOfferingCard";
+
+const metrics: LiveCardMetrics = {
+  revenueLabel: "$120",
+  soldValue: "6",
+  capacityLabel: "20",
+  capacity: 20,
+  progress: 0.3,
+};
+
+const item = {
+  key: "k-e1",
+  id: "e1",
+  kind: "event" as const,
+  status: "live" as const,
+  startAtUtc: new Date(),
+  endAtUtc: new Date(),
+  source: { id: "e1", name: "event name", event_type: "event" } as any,
+};
+
+describe("ORCH-1143 §4.4-A v2 — flat (single-live) renders chrome-less, elevated (carousel) keeps glass", () => {
+  test("flat mode renders WITHOUT a GlassCard (continuous-section: no glass-on-glass / no air gap)", () => {
+    const { queryByTestId } = render(
+      <LiveOfferingCard flat item={item as any} metrics={metrics} onScanPress={jest.fn()} testID="home-live-card" />,
+    );
+    // The shared section surface lives in home.tsx; the flat card must NOT add
+    // its own GlassCard chrome.
+    expect(queryByTestId("glasscard-marker")).toBeNull();
+    // The flat wrapper still carries the testID so render-test selectors resolve.
+    expect(queryByTestId("home-live-card")).toBeTruthy();
+  });
+
+  test("default/elevated mode (carousel card) DOES wrap in a GlassCard", () => {
+    const { queryByTestId } = render(
+      <LiveOfferingCard item={item as any} metrics={metrics} onScanPress={jest.fn()} width={320} />,
+    );
+    expect(queryByTestId("glasscard-marker")).toBeTruthy();
+  });
+
+  test("scan button renders + fires in BOTH modes (behavior unchanged by the chrome split)", () => {
+    const onScanFlat = jest.fn();
+    const flatView = render(
+      <LiveOfferingCard flat item={item as any} metrics={metrics} onScanPress={onScanFlat} />,
+    );
+    fireEvent.press(flatView.getByTestId("home-live-card-scan-button"));
+    expect(onScanFlat).toHaveBeenCalledWith("e1");
+
+    const onScanElevated = jest.fn();
+    const elevatedView = render(
+      <LiveOfferingCard item={item as any} metrics={metrics} onScanPress={onScanElevated} width={320} />,
+    );
+    fireEvent.press(elevatedView.getByTestId("home-live-card-scan-button"));
+    expect(onScanElevated).toHaveBeenCalledWith("e1");
+  });
+});

--- a/mingla-business/src/components/home/__tests__/LiveOfferingCard.orch1143.render.test.tsx
+++ b/mingla-business/src/components/home/__tests__/LiveOfferingCard.orch1143.render.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * ORCH-1143 — LiveOfferingCard RENDER proof (tester runtime evidence).
+ *
+ * A REAL @testing-library/react-native mount of the production LiveOfferingCard.
+ * Source-grep tests are capped at "suspected"; this is the runtime evidence that
+ * the scan button actually RENDERS and FIRES for EVERY live kind (event /
+ * experience / trip) and routes the correct id to onScanPress, plus that the
+ * Scanned tile is honest-empty ("—") at runtime.
+ *
+ * Heavy presentational deps (GlassCard / Pill / Icon) are stubbed to lightweight
+ * hosts so the mount is fast + deterministic; the component's OWN logic (the
+ * unconditional scan Pressable, the per-kind display normalization, the honest
+ * Scanned cell) runs for real.
+ *
+ * Run: npx jest --config jest.orch1143.render.cjs --runInBand
+ */
+
+import React from "react";
+import { Text, View } from "react-native";
+import { fireEvent, render } from "@testing-library/react-native";
+
+// Lightweight stubs for the visual primitives (not under test here).
+jest.mock("../../ui/GlassCard", () => {
+  const { View: V } = require("react-native");
+  return { GlassCard: ({ children, testID }: any) => <V testID={testID}>{children}</V> };
+});
+jest.mock("../../ui/Pill", () => {
+  const { Text: T } = require("react-native");
+  return { Pill: ({ children }: any) => <T>{children}</T> };
+});
+jest.mock("../../ui/Icon", () => {
+  const { View: V } = require("react-native");
+  return { Icon: ({ name }: any) => <V testID={`icon-${name}`} /> };
+});
+// Trip adapter: return a LiveEvent-shaped object so the card's trip branch runs.
+// The card imports `../../utils/tripToLiveEvent`; from this test that resolves
+// at `../../../utils/tripToLiveEvent`.
+jest.mock("../../../utils/tripToLiveEvent", () => ({
+  tripToLiveEvent: (t: any) => ({ id: t.id, name: t.name, event_type: "trip" }),
+}));
+jest.mock("../../../utils/eventDateDisplay", () => ({
+  formatDraftDateLine: () => "Today · 7:00 PM",
+}));
+
+import { LiveOfferingCard, type LiveCardMetrics } from "../LiveOfferingCard";
+
+const metrics: LiveCardMetrics = {
+  revenueLabel: "$120",
+  soldValue: "6",
+  capacityLabel: "20",
+  capacity: 20,
+  progress: 0.3,
+};
+
+const makeItem = (kind: "event" | "experience" | "trip", id: string) => ({
+  key: `k-${id}`,
+  id,
+  kind,
+  status: "live" as const,
+  startAtUtc: new Date(),
+  endAtUtc: new Date(),
+  source: { id, name: `${kind} name`, event_type: kind } as any,
+});
+
+describe("ORCH-1143 RENDER — scan button fires for EVERY live kind", () => {
+  test.each(["event", "experience", "trip"] as const)(
+    "a live %s renders a scan button that fires onScanPress with the offering id",
+    (kind) => {
+      const onScan = jest.fn();
+      const id = `id-${kind}`;
+      const { getByTestId, getByText } = render(
+        <LiveOfferingCard item={makeItem(kind, id) as any} metrics={metrics} onScanPress={onScan} />,
+      );
+      // The button RENDERS (not gated by kind).
+      const btn = getByTestId("home-live-card-scan-button");
+      expect(btn).toBeTruthy();
+      // Kind-neutral copy.
+      expect(getByText("Scan QR codes")).toBeTruthy();
+      // It FIRES with the correct id (proves not a dead tap).
+      fireEvent.press(btn);
+      expect(onScan).toHaveBeenCalledTimes(1);
+      expect(onScan).toHaveBeenCalledWith(id);
+    },
+  );
+
+  test("Scanned tile is honest-empty '—' at runtime (Constitution #9, no fabrication)", () => {
+    const { getByText, queryAllByText } = render(
+      <LiveOfferingCard item={makeItem("event", "e1") as any} metrics={metrics} onScanPress={jest.fn()} />,
+    );
+    expect(getByText("Scanned")).toBeTruthy();
+    // The dash is present as a stat value (the Scanned cell).
+    expect(queryAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("a11y label is kind-neutral + disambiguated by offering name", () => {
+    const { getByLabelText } = render(
+      <LiveOfferingCard item={makeItem("trip", "t9") as any} metrics={metrics} onScanPress={jest.fn()} />,
+    );
+    // Trip name comes via the mocked tripToLiveEvent → "trip name".
+    expect(getByLabelText("Scan tickets for trip name")).toBeTruthy();
+  });
+});

--- a/mingla-business/src/components/home/__tests__/UpcomingDedup.orch1143.render.test.tsx
+++ b/mingla-business/src/components/home/__tests__/UpcomingDedup.orch1143.render.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * ORCH-1143 SC-7 — Upcoming/Live de-duplication RENDER proof (TESTER adversarial).
+ *
+ * Attacks SC-7 at a DIFFERENT ANGLE than the implementor's source-level
+ * `upcomingBuilder.test.ts` regression (which asserts on the PURE
+ * `buildUpcomingItems().nonLiveItems` array). This test mounts a faithful
+ * @testing-library/react-native render slice that mirrors `home.tsx`'s actual
+ * wiring:
+ *   - the "Live now" carousel: `liveItems.map(...)` -> <LiveOfferingCard>
+ *   - the "Upcoming" FlatList:  `data={upcoming.nonLiveItems ?? upcoming.items}`
+ *     -> <UpcomingListItem>  (home.tsx binds `data={upcoming.nonLiveItems}`)
+ *
+ * The data feeding both surfaces is the REAL `buildUpcomingItems(...)` output —
+ * no hand-built arrays — so the dedup runs through production code end to end.
+ *
+ * INVARIANT PROVEN AT THE RENDER LEVEL:
+ *   A currently-live offering RENDERS in the Live-now carousel and does NOT
+ *   render anywhere in the Upcoming FlatList; a scheduled (future) offering
+ *   renders in the Upcoming FlatList and NOT in the carousel. No leakage either
+ *   direction.
+ *
+ * FAILS-ON-REVERT: the FlatList is fed `nonLiveItems ?? items` — the exact
+ * fallback semantics of reverting the fix. Delete the
+ * `nonLiveItems = nonPast.filter((i) => i.status !== "live")` line in
+ * upcomingBuilder.ts (and `nonLiveItems` from the return) and `nonLiveItems`
+ * becomes `undefined` -> the FlatList renders from `items` (which INCLUDES the
+ * live offering) -> the live offering LEAKS into the rendered Upcoming list ->
+ * `queryByText(LIVE_NAME)` inside the upcoming host is non-null -> this test
+ * FAILS. Restore -> green. (Tester-verified; see TEST report §SC-7.)
+ *
+ * Different angle vs implementor: implementor asserts the array; THIS asserts
+ * the actual DOM/host-tree the user sees — a live row is absent from the
+ * Upcoming list host AND present in the carousel host, through the real
+ * UpcomingListItem + LiveOfferingCard components.
+ *
+ * Run: npx jest --config jest.orch1143.render.cjs --runInBand
+ */
+
+import React from "react";
+import { FlatList, View } from "react-native";
+import { render, within } from "@testing-library/react-native";
+
+// Lightweight stubs for purely-presentational deps so the mount is fast +
+// deterministic. The component's OWN routing logic (kind branch, name render,
+// live-vs-upcoming) runs for real.
+jest.mock("../../ui/GlassCard", () => {
+  const { View: V } = require("react-native");
+  return { GlassCard: ({ children, testID }: any) => <V testID={testID}>{children}</V> };
+});
+jest.mock("../../ui/Pill", () => {
+  const { Text: T } = require("react-native");
+  return { Pill: ({ children }: any) => <T>{children}</T> };
+});
+jest.mock("../../ui/Icon", () => {
+  const { View: V } = require("react-native");
+  return { Icon: ({ name }: any) => <V testID={`icon-${name}`} /> };
+});
+jest.mock("../../ui/EventCoverMedia", () => {
+  const { View: V } = require("react-native");
+  return { EventCoverMedia: () => <V /> };
+});
+jest.mock("../HomeTripRow", () => {
+  const { Text: T } = require("react-native");
+  return { HomeTripRow: ({ trip }: any) => <T>{trip?.name ?? "trip"}</T> };
+});
+jest.mock("../../../utils/eventDateDisplay", () => ({
+  formatDraftDateLine: () => "Today · 7:00 PM",
+}));
+
+import { LiveOfferingCard, type LiveCardMetrics } from "../LiveOfferingCard";
+import { UpcomingListItem } from "../UpcomingListItem";
+import { buildUpcomingItems } from "../../../utils/upcomingBuilder";
+import type { LiveEvent } from "../../../store/liveEventStore";
+
+// Fixed "now" — 2026-06-01 12:00 UTC. deriveLiveStatus reads Date.now(); pin it
+// so the date fixtures below resolve live/upcoming deterministically.
+const NOW = new Date("2026-06-01T12:00:00.000Z").getTime();
+
+const LIVE_NAME = "LIVE_CONCERT_X";
+const SCHEDULED_NAME = "SCHEDULED_GALA_Y";
+
+// Minimal LiveEvent shape sufficient for buildUpcomingItems + both render
+// components. status:"live" is the persisted publish state; the *derived*
+// live/upcoming classification comes from the date vs NOW.
+const ev = (patch: Partial<LiveEvent>): LiveEvent =>
+  ({
+    id: "evt",
+    serverEventId: null,
+    brandId: "brand-1",
+    brandSlug: "brand-one",
+    eventSlug: "evt-one",
+    status: "live",
+    publishedAt: "2026-05-01T09:00:00.000Z",
+    cancelledAt: null,
+    endedAt: null,
+    name: "Event",
+    description: "",
+    format: "in_person",
+    whenMode: "single",
+    date: "2026-06-15",
+    doorsOpen: "19:00",
+    endsAt: "23:00",
+    timezone: "UTC",
+    recurrenceRule: null,
+    multiDates: null,
+    venueName: "Venue",
+    address: "1 Main St",
+    onlineUrl: null,
+    hideAddressUntilTicket: true,
+    coverHue: 25,
+    coverMediaUrl: null,
+    coverMediaType: null,
+    tickets: [],
+    visibility: "public",
+    requireApproval: false,
+    allowTransfers: true,
+    hideRemainingCount: false,
+    passwordProtected: false,
+    privateGuestList: false,
+    inPersonPaymentsEnabled: false,
+    currency: "USD",
+    ...patch,
+  }) as LiveEvent;
+
+const metrics: LiveCardMetrics = {
+  revenueLabel: "$120",
+  soldValue: "6",
+  capacityLabel: "20",
+  capacity: 20,
+  progress: 0.3,
+};
+
+const noopHandlers = {
+  onOpenDraft: jest.fn(),
+  onOpenTrip: jest.fn(),
+  onOpenLiveEvent: jest.fn(),
+};
+
+/**
+ * Faithful render of home.tsx's two offering surfaces from REAL builder output.
+ * The FlatList data binding uses `nonLiveItems ?? items` to reproduce both the
+ * fixed state (nonLiveItems present -> live excluded) AND the reverted state
+ * (nonLiveItems undefined -> falls back to items -> live LEAKS).
+ */
+function HomeOfferingSlice(): React.ReactElement {
+  const live = ev({
+    id: "evt-live",
+    name: LIVE_NAME,
+    status: "live",
+    date: "2026-06-01",
+    doorsOpen: "08:00",
+    endsAt: "23:00",
+  });
+  const scheduled = ev({
+    id: "evt-soon",
+    name: SCHEDULED_NAME,
+    status: "live",
+    date: "2026-06-20",
+    doorsOpen: "19:00",
+    endsAt: "23:00",
+  });
+
+  const built = buildUpcomingItems([live, scheduled], [], [], [], NOW);
+  // Mirror home.tsx: live carousel reads liveItems; Upcoming list reads
+  // nonLiveItems. The `?? items` is the revert-equivalent fallback.
+  const liveItems = built.liveItems;
+  const upcomingData =
+    (built as { nonLiveItems?: typeof built.items }).nonLiveItems ?? built.items;
+
+  return (
+    <View>
+      <View testID="live-carousel-host">
+        {liveItems.map((liveItem) => (
+          <LiveOfferingCard
+            key={liveItem.key}
+            item={liveItem}
+            metrics={metrics}
+            onScanPress={jest.fn()}
+          />
+        ))}
+      </View>
+      <View testID="upcoming-list-host">
+        <FlatList
+          data={upcomingData}
+          keyExtractor={(item) => item.key}
+          renderItem={({ item }) => (
+            <UpcomingListItem
+              item={item}
+              currentBrandCurrency="USD"
+              eventSalesSummaries={{}}
+              onOpenDraft={noopHandlers.onOpenDraft}
+              onOpenTrip={noopHandlers.onOpenTrip}
+              onOpenLiveEvent={noopHandlers.onOpenLiveEvent}
+            />
+          )}
+        />
+      </View>
+    </View>
+  );
+}
+
+describe("ORCH-1143 SC-7 RENDER — live offering excluded from the Upcoming list, present in the carousel", () => {
+  // deriveLiveStatus reads the REAL Date.now(); pin it so the date fixtures
+  // resolve live/upcoming deterministically (mirrors the SC-7 source block).
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(NOW);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("a live event RENDERS in the Live-now carousel and does NOT render in the Upcoming FlatList", () => {
+    const { getByTestId } = render(<HomeOfferingSlice />);
+
+    const carousel = within(getByTestId("live-carousel-host"));
+    const upcoming = within(getByTestId("upcoming-list-host"));
+
+    // The live offering is surfaced in the carousel...
+    expect(carousel.queryByText(LIVE_NAME)).toBeTruthy();
+    // ...and is NOT duplicated into the Upcoming list (the SC-7 invariant; fails
+    // on revert because the FlatList then falls back to `items`, which includes
+    // the live row).
+    expect(upcoming.queryByText(LIVE_NAME)).toBeNull();
+  });
+
+  test("a scheduled (future) event RENDERS in the Upcoming FlatList and NOT in the carousel — no leakage either direction", () => {
+    const { getByTestId } = render(<HomeOfferingSlice />);
+
+    const carousel = within(getByTestId("live-carousel-host"));
+    const upcoming = within(getByTestId("upcoming-list-host"));
+
+    // The scheduled offering stays in the Upcoming list...
+    expect(upcoming.queryByText(SCHEDULED_NAME)).toBeTruthy();
+    // ...and never leaks into the live carousel.
+    expect(carousel.queryByText(SCHEDULED_NAME)).toBeNull();
+  });
+});

--- a/mingla-business/src/hooks/useUpcomingForBrand.ts
+++ b/mingla-business/src/hooks/useUpcomingForBrand.ts
@@ -48,6 +48,9 @@ export interface UpcomingForBrand {
   // already sorted live-first start-ascending. Owner of live-state truth for
   // the home live carousel (Constitution #2).
   liveItems: UpcomingItem[];
+  // ORCH-1143 SC-7 — `items` minus the live items (which live in the carousel).
+  // The Upcoming list renders from this so a live offering is never duplicated.
+  nonLiveItems: UpcomingItem[];
   isLoading: boolean;
   isError: boolean;
   errors: { events?: unknown; trips?: unknown };
@@ -64,7 +67,7 @@ export const useUpcomingForBrand = (
   const serverEvents = eventsQuery.data ?? [];
   const trips = tripsQuery.data ?? [];
 
-  const { items, counts, primaryLiveItem, liveItems } = useMemo(
+  const { items, counts, primaryLiveItem, liveItems, nonLiveItems } = useMemo(
     () => buildUpcomingItems(serverEvents, legacyLiveEvents, trips, drafts),
     [serverEvents, legacyLiveEvents, trips, drafts],
   );
@@ -74,6 +77,7 @@ export const useUpcomingForBrand = (
     counts,
     primaryLiveItem,
     liveItems,
+    nonLiveItems,
     isLoading: eventsQuery.isLoading || tripsQuery.isLoading,
     isError: eventsQuery.isError || tripsQuery.isError,
     errors: {

--- a/mingla-business/src/hooks/useUpcomingForBrand.ts
+++ b/mingla-business/src/hooks/useUpcomingForBrand.ts
@@ -44,6 +44,10 @@ export interface UpcomingForBrand {
   items: UpcomingItem[];
   counts: UpcomingCounts;
   primaryLiveItem: UpcomingItem | null;
+  // ORCH-1143 — ALL concurrently-live offerings (event/experience/trip),
+  // already sorted live-first start-ascending. Owner of live-state truth for
+  // the home live carousel (Constitution #2).
+  liveItems: UpcomingItem[];
   isLoading: boolean;
   isError: boolean;
   errors: { events?: unknown; trips?: unknown };
@@ -60,7 +64,7 @@ export const useUpcomingForBrand = (
   const serverEvents = eventsQuery.data ?? [];
   const trips = tripsQuery.data ?? [];
 
-  const { items, counts, primaryLiveItem } = useMemo(
+  const { items, counts, primaryLiveItem, liveItems } = useMemo(
     () => buildUpcomingItems(serverEvents, legacyLiveEvents, trips, drafts),
     [serverEvents, legacyLiveEvents, trips, drafts],
   );
@@ -69,6 +73,7 @@ export const useUpcomingForBrand = (
     items,
     counts,
     primaryLiveItem,
+    liveItems,
     isLoading: eventsQuery.isLoading || tripsQuery.isLoading,
     isError: eventsQuery.isError || tripsQuery.isError,
     errors: {

--- a/mingla-business/src/store/__tests__/liveSectionCollapseStore.orch1143.adversarial.test.ts
+++ b/mingla-business/src/store/__tests__/liveSectionCollapseStore.orch1143.adversarial.test.ts
@@ -1,0 +1,116 @@
+/**
+ * ORCH-1143 — liveSectionCollapseStore ADVERSARIAL (tester-owned).
+ *
+ * Different angle than the implementor's happy-path coverage:
+ *   - The implementor's `home.orch_1143.test.tsx` only SOURCE-GREPS the literal
+ *     string `const showLiveOpen = !liveHasHydrated || !liveCollapsed;` — that
+ *     proves the characters exist, NOT that the boolean SEMANTICS produce a
+ *     no-flash-of-wrong-state on cold start (Constitution #14). A grep passes
+ *     even if the runtime logic is wrong as long as the string is byte-present.
+ *   - The implementor's store test asserts `reset` returns `collapsed` to the
+ *     default, but does NOT assert `reset` LEAVES `hasHydrated` untouched. If a
+ *     careless edit made `reset` also clear `hasHydrated` back to false, a logout
+ *     mid-session would re-arm the cold-start gate and the NEXT render (before a
+ *     fresh rehydrate) would flash the default-open state over a user who had it
+ *     collapsed — the exact #14 defect, invisible to the implementor's suite.
+ *
+ * This file EXECUTES the real store + evaluates the gate's boolean across the
+ * full truth table (the runtime invariant), instead of matching source text.
+ *
+ * APPEND-ONLY. New file. Never modifies an existing test.
+ */
+
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => undefined),
+    removeItem: jest.fn(async () => undefined),
+  },
+}));
+
+import { useLiveSectionCollapseStore } from "../liveSectionCollapseStore";
+
+/**
+ * The EXACT gate `home.tsx` computes:
+ *   const showLiveOpen = !liveHasHydrated || !liveCollapsed;
+ * Mirrored here so we test the SEMANTICS (truth table), not the source string.
+ */
+const computeShowLiveOpen = (
+  hasHydrated: boolean,
+  collapsed: boolean,
+): boolean => !hasHydrated || !collapsed;
+
+afterEach(() => {
+  useLiveSectionCollapseStore.getState().setCollapsed(false);
+  useLiveSectionCollapseStore.getState().setHasHydrated(false);
+});
+
+describe("ORCH-1143 ADVERSARIAL — hydration gate produces NO flash (Constitution #14)", () => {
+  test("ADV-1143-01: a user who persisted collapsed=true sees OPEN before rehydration completes (the flash defect)", () => {
+    // Cold start: persisted value is collapsed=true, but hasHydrated has NOT yet
+    // flipped (the first frame). The gate MUST resolve to OPEN so the section
+    // does not momentarily render collapsed-then-snap-open (or vice versa).
+    expect(computeShowLiveOpen(/*hasHydrated*/ false, /*collapsed*/ true)).toBe(
+      true,
+    );
+    // And a user who persisted collapsed=false also sees OPEN pre-hydration
+    // (consistent default — never collapsed before we know the truth).
+    expect(computeShowLiveOpen(false, false)).toBe(true);
+  });
+
+  test("ADV-1143-02: AFTER hydration the gate honors the persisted choice exactly", () => {
+    // hasHydrated true + collapsed true  → COLLAPSED (showOpen=false)
+    expect(computeShowLiveOpen(true, true)).toBe(false);
+    // hasHydrated true + collapsed false → OPEN
+    expect(computeShowLiveOpen(true, false)).toBe(true);
+  });
+
+  test("ADV-1143-03: the gate is collapsed for EXACTLY ONE state — the post-hydration collapsed state", () => {
+    // Full truth table: the ONLY (hasHydrated, collapsed) pair that hides the
+    // section is (true, true). This is the load-bearing #14 invariant: pre-
+    // hydration is ALWAYS open. If someone inverted the OR to AND, (false,true)
+    // would flip to false (flash) and this asserts against that.
+    const table: Array<[boolean, boolean, boolean]> = [
+      [false, false, true],
+      [false, true, true], // pre-hydration collapsed persisted → STILL OPEN
+      [true, false, true],
+      [true, true, false], // the only collapsed state
+    ];
+    for (const [hasHydrated, collapsed, expected] of table) {
+      expect(computeShowLiveOpen(hasHydrated, collapsed)).toBe(expected);
+    }
+  });
+});
+
+describe("ORCH-1143 ADVERSARIAL — reset must NOT re-arm the cold-start gate (logout safety)", () => {
+  test("ADV-1143-04: reset() returns collapsed to default but LEAVES hasHydrated true (no re-flash on next render)", () => {
+    // Simulate a live, hydrated session where the user collapsed the section.
+    useLiveSectionCollapseStore.getState().setHasHydrated(true);
+    useLiveSectionCollapseStore.getState().setCollapsed(true);
+    expect(useLiveSectionCollapseStore.getState().hasHydrated).toBe(true);
+
+    // Logout cascade calls reset().
+    useLiveSectionCollapseStore.getState().reset();
+
+    const s = useLiveSectionCollapseStore.getState();
+    // collapsed back to the open default (Constitution #6 — logout clears UI state).
+    expect(s.collapsed).toBe(false);
+    // CRITICAL: reset must NOT clear hasHydrated. The store is already hydrated
+    // for this app session; clearing it would re-arm the cold-start gate and the
+    // next render would treat a known state as unknown (a spurious open-flash).
+    expect(s.hasHydrated).toBe(true);
+  });
+
+  test("ADV-1143-05: the gate after reset (collapsed=false, still hydrated) is OPEN — not a flash, an honest default", () => {
+    useLiveSectionCollapseStore.getState().setHasHydrated(true);
+    useLiveSectionCollapseStore.getState().setCollapsed(true);
+    useLiveSectionCollapseStore.getState().reset();
+    const s = useLiveSectionCollapseStore.getState();
+    // Post-reset, the computed gate is a deterministic OPEN driven by the real
+    // (collapsed=false, hasHydrated=true) state — NOT the pre-hydration fallback.
+    expect(computeShowLiveOpen(s.hasHydrated, s.collapsed)).toBe(true);
+  });
+});

--- a/mingla-business/src/store/__tests__/liveSectionCollapseStore.test.ts
+++ b/mingla-business/src/store/__tests__/liveSectionCollapseStore.test.ts
@@ -1,0 +1,84 @@
+/**
+ * ORCH-1143 — liveSectionCollapseStore behavioural tests (T7/T8/T11).
+ *
+ * Exercises the persisted accordion-collapse store's actions + the hydration
+ * gate contract (Constitution #14) + the logout reset (Constitution #6).
+ * AsyncStorage is mocked so the persist middleware is inert under node/ts-jest.
+ */
+
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => undefined),
+    removeItem: jest.fn(async () => undefined),
+  },
+}));
+
+import { useLiveSectionCollapseStore } from "../liveSectionCollapseStore";
+
+afterEach(() => {
+  // Reset to clean defaults between tests (collapsed=false). hasHydrated is a
+  // separate flag — set it back to false explicitly.
+  useLiveSectionCollapseStore.getState().reset();
+  useLiveSectionCollapseStore.getState().setHasHydrated(false);
+});
+
+describe("liveSectionCollapseStore", () => {
+  test("defaults: collapsed=false (open); hasHydrated flips true once rehydration completes", () => {
+    const s = useLiveSectionCollapseStore.getState();
+    // collapsed defaults to false → the live section is OPEN on first load.
+    expect(s.collapsed).toBe(false);
+    // The persist middleware fired onRehydrateStorage at store creation
+    // (AsyncStorage mocked → empty → rehydrate completes immediately), so by now
+    // the cold-start gate has flipped true. This proves onRehydrateStorage wires
+    // setHasHydrated(true). (The in-memory initializer default is false — asserted
+    // via the partialize/initializer contract below + the setHasHydrated test.)
+    expect(s.hasHydrated).toBe(true);
+  });
+
+  test("T6/SC-4: toggle flips collapsed; setCollapsed sets it explicitly", () => {
+    useLiveSectionCollapseStore.getState().toggle();
+    expect(useLiveSectionCollapseStore.getState().collapsed).toBe(true);
+    useLiveSectionCollapseStore.getState().toggle();
+    expect(useLiveSectionCollapseStore.getState().collapsed).toBe(false);
+    useLiveSectionCollapseStore.getState().setCollapsed(true);
+    expect(useLiveSectionCollapseStore.getState().collapsed).toBe(true);
+  });
+
+  test("T8/#14: hasHydrated is NOT in the persisted partition (collapsed only)", () => {
+    // The persist partialize must include ONLY `collapsed` — assert via the
+    // store options surfaced on the persist API.
+    const persistApi = (
+      useLiveSectionCollapseStore as unknown as {
+        persist: {
+          getOptions: () => {
+            partialize?: (s: Record<string, unknown>) => Record<string, unknown>;
+          };
+        };
+      }
+    ).persist;
+    const partialized = persistApi.getOptions().partialize?.({
+      collapsed: true,
+      hasHydrated: true,
+    });
+    expect(partialized).toEqual({ collapsed: true });
+    expect(Object.keys(partialized ?? {})).not.toContain("hasHydrated");
+  });
+
+  test("T7/SC-5: setHasHydrated(true) flips the gate without touching collapsed", () => {
+    useLiveSectionCollapseStore.getState().setCollapsed(true);
+    useLiveSectionCollapseStore.getState().setHasHydrated(true);
+    const s = useLiveSectionCollapseStore.getState();
+    expect(s.hasHydrated).toBe(true);
+    expect(s.collapsed).toBe(true);
+  });
+
+  test("T11/SC-8: reset returns collapsed to the default (open) — logout cascade", () => {
+    useLiveSectionCollapseStore.getState().setCollapsed(true);
+    useLiveSectionCollapseStore.getState().reset();
+    expect(useLiveSectionCollapseStore.getState().collapsed).toBe(false);
+  });
+});

--- a/mingla-business/src/store/liveSectionCollapseStore.ts
+++ b/mingla-business/src/store/liveSectionCollapseStore.ts
@@ -1,0 +1,67 @@
+/**
+ * liveSectionCollapseStore — ORCH-1143 [business Home live-card accordion].
+ *
+ * Persisted Zustand store for the Home "Live now" section's open/closed
+ * (accordion) state. Modeled EXACTLY on `currentBrandStore`'s hydration gate
+ * (Constitution #14): the `collapsed` flag is persisted; `hasHydrated` is NOT
+ * persisted and flips true only in `onRehydrateStorage`, so a first-frame read
+ * of `collapsed` during rehydration is AMBIGUOUS and consumers must treat
+ * `!hasHydrated` as "render the default (open) state, do not animate" to avoid a
+ * flash-of-wrong-state on cold start.
+ *
+ * Client state only (a UI flag) — never server data, per Constitution #5.
+ * `reset` is wired into `clearAllStores` (logout cascade, Constitution #6).
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import {
+  createJSONStorage,
+  persist,
+  type PersistOptions,
+} from "zustand/middleware";
+
+export type LiveSectionCollapseState = {
+  /** Persisted. Default false → the live section is OPEN on first load. */
+  collapsed: boolean;
+  /**
+   * NOT persisted. False until the store has rehydrated from AsyncStorage
+   * (or rehydration errored — nothing left to wait for). Until true, consumers
+   * MUST render the default (open) state and skip the collapse animation.
+   */
+  hasHydrated: boolean;
+  setCollapsed: (value: boolean) => void;
+  toggle: () => void;
+  setHasHydrated: (value: boolean) => void;
+  reset: () => void;
+};
+
+type PersistedState = Pick<LiveSectionCollapseState, "collapsed">;
+
+const persistOptions: PersistOptions<
+  LiveSectionCollapseState,
+  PersistedState
+> = {
+  name: "mingla-business.liveSectionCollapse.v1",
+  storage: createJSONStorage(() => AsyncStorage),
+  // Only `collapsed` is persisted — `hasHydrated` always starts false on a
+  // fresh load so the cold-start gate is honest (Constitution #14).
+  partialize: (state) => ({ collapsed: state.collapsed }),
+  version: 1,
+  onRehydrateStorage: () => () =>
+    useLiveSectionCollapseStore.getState().setHasHydrated(true),
+};
+
+export const useLiveSectionCollapseStore = create<LiveSectionCollapseState>()(
+  persist(
+    (set) => ({
+      collapsed: false,
+      hasHydrated: false,
+      setCollapsed: (value) => set({ collapsed: value }),
+      toggle: () => set((state) => ({ collapsed: !state.collapsed })),
+      setHasHydrated: (value) => set({ hasHydrated: value }),
+      reset: () => set({ collapsed: false }),
+    }),
+    persistOptions,
+  ),
+);

--- a/mingla-business/src/utils/__tests__/upcomingBuilder.test.ts
+++ b/mingla-business/src/utils/__tests__/upcomingBuilder.test.ts
@@ -508,3 +508,113 @@ describe("ORCH-0965 compareUpcomingItems — comparator unit tests", () => {
     expect(compareUpcomingItems(ev("a", "upcoming", 100), ev("b", "upcoming", 50))).toBeGreaterThan(0);
   });
 });
+
+describe("ORCH-1143 liveItems — enumerate ALL live offerings (T2/T3/T4/T12)", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(NOW);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("T12 — liveItems = only status==='live', sorted live-first start-ascending", () => {
+    const earlier = liveEvent({
+      id: "evt-earlier",
+      date: "2026-06-01",
+      doorsOpen: "06:00",
+      endsAt: "23:00",
+    });
+    const later = liveEvent({
+      id: "evt-later",
+      date: "2026-06-01",
+      doorsOpen: "11:00",
+      endsAt: "23:00",
+    });
+    const futureTrip = trip({ id: "trip-future", status: "scheduled" });
+    const localDraft = draft({ id: "draft-1" });
+    const { liveItems } = buildUpcomingItems(
+      [earlier, later],
+      [],
+      [futureTrip],
+      [localDraft],
+      NOW,
+    );
+    // only the two live events, older start first; trip(scheduled)/draft excluded.
+    expect(liveItems.map((i) => i.id)).toEqual(["evt-earlier", "evt-later"]);
+    expect(liveItems.every((i) => i.status === "live")).toBe(true);
+  });
+
+  test("T2/T3 — a live experience AND a live trip both appear in liveItems (all kinds)", () => {
+    const experience = liveEvent({
+      id: "exp-live",
+      date: "2026-06-01",
+      doorsOpen: "06:00",
+      endsAt: "23:00",
+    });
+    (experience as LiveEvent & { event_type?: string }).event_type = "experience";
+    const liveTrip = trip({
+      id: "trip-live",
+      status: "live",
+      businessTrip: {
+        startAt: "2026-05-30T09:00:00.000Z",
+        endAt: "2026-06-05T17:00:00.000Z",
+        destinationLocationText: null,
+        destinationPlaceId: null,
+        destinationLat: null,
+        destinationLng: null,
+        departurePlaceId: null,
+        departureLocationText: null,
+        departureLat: null,
+        departureLng: null,
+        capacity: null,
+      },
+    });
+    const { liveItems } = buildUpcomingItems([experience], [], [liveTrip], [], NOW);
+    const kinds = liveItems.map((i) => i.kind).sort();
+    expect(kinds).toEqual(["experience", "trip"]);
+    // every live kind is present — the scan affordance is no longer event-only.
+    expect(liveItems.find((i) => i.kind === "experience")).toBeDefined();
+    expect(liveItems.find((i) => i.kind === "trip")).toBeDefined();
+  });
+
+  test("T4 — event + experience + trip simultaneously live → all three enumerated, live-first order", () => {
+    const event = liveEvent({ id: "evt", date: "2026-06-01", doorsOpen: "08:00", endsAt: "23:00" });
+    const experience = liveEvent({ id: "exp", date: "2026-06-01", doorsOpen: "10:00", endsAt: "23:00" });
+    (experience as LiveEvent & { event_type?: string }).event_type = "experience";
+    const liveTrip = trip({
+      id: "trip",
+      status: "live",
+      businessTrip: {
+        startAt: "2026-05-29T09:00:00.000Z",
+        endAt: "2026-06-05T17:00:00.000Z",
+        destinationLocationText: null,
+        destinationPlaceId: null,
+        destinationLat: null,
+        destinationLng: null,
+        departurePlaceId: null,
+        departureLocationText: null,
+        departureLat: null,
+        departureLng: null,
+        capacity: null,
+      },
+    });
+    const { liveItems } = buildUpcomingItems([event, experience], [], [liveTrip], [], NOW);
+    expect(liveItems).toHaveLength(3);
+    // live-first start-ascending: trip(05-29) < event(06-01 08:00) < experience(06-01 10:00)
+    expect(liveItems.map((i) => i.id)).toEqual(["trip", "evt", "exp"]);
+  });
+
+  test("T5 — no live offerings → liveItems empty + primaryLiveItem null", () => {
+    const futureTrip = trip({ id: "trip-future", status: "scheduled" });
+    const { liveItems, primaryLiveItem } = buildUpcomingItems([], [], [futureTrip], [], NOW);
+    expect(liveItems).toHaveLength(0);
+    expect(primaryLiveItem).toBeNull();
+  });
+
+  test("liveItems[0] === primaryLiveItem (back-compat equivalence)", () => {
+    const earlier = liveEvent({ id: "evt-earlier", date: "2026-06-01", doorsOpen: "06:00", endsAt: "23:00" });
+    const later = liveEvent({ id: "evt-later", date: "2026-06-01", doorsOpen: "11:00", endsAt: "23:00" });
+    const { liveItems, primaryLiveItem } = buildUpcomingItems([earlier, later], [], [], [], NOW);
+    expect(liveItems[0]).toBe(primaryLiveItem);
+  });
+});

--- a/mingla-business/src/utils/__tests__/upcomingBuilder.test.ts
+++ b/mingla-business/src/utils/__tests__/upcomingBuilder.test.ts
@@ -618,3 +618,96 @@ describe("ORCH-1143 liveItems — enumerate ALL live offerings (T2/T3/T4/T12)", 
     expect(liveItems[0]).toBe(primaryLiveItem);
   });
 });
+
+describe("ORCH-1143 SC-7 nonLiveItems — live offerings excluded from the Upcoming list", () => {
+  // SC-7: a live offering belongs ONLY in the Live-now carousel; the Upcoming
+  // list (FlatList + desktop pane) renders the non-live items. These tests
+  // exercise the real buildUpcomingItems pipeline (no source-grep) and FAIL on
+  // revert (deleting the `nonLiveItems = nonPast.filter(status !== "live")`
+  // line in upcomingBuilder.ts makes `nonLiveItems` `undefined` → the `.map`
+  // expectations throw / the exclusion assertions fail).
+
+  // deriveLiveStatus reads the REAL Date.now(); pin it so the date fixtures
+  // below resolve live/upcoming deterministically (mirrors the T2/T3/T4 block).
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(NOW);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("SC7-1 — a live event is in liveItems but NOT in nonLiveItems; a scheduled event + draft ARE in nonLiveItems", () => {
+    const live = liveEvent({ id: "evt-live", status: "live", date: "2026-06-01", doorsOpen: "08:00", endsAt: "23:00" });
+    const scheduled = liveEvent({ id: "evt-soon", status: "live", date: "2026-06-20", doorsOpen: "19:00", endsAt: "23:00" });
+    const draftRow = draft({ id: "draft-x" });
+    const { items, liveItems, nonLiveItems } = buildUpcomingItems(
+      [live, scheduled],
+      [],
+      [],
+      [draftRow],
+      NOW,
+    );
+
+    // the live event is surfaced exclusively in the carousel set...
+    expect(liveItems.map((i) => i.id)).toContain("evt-live");
+    // ...and is NOT duplicated into the Upcoming list view.
+    expect(nonLiveItems.map((i) => i.id)).not.toContain("evt-live");
+    expect(nonLiveItems.every((i) => i.status !== "live")).toBe(true);
+
+    // the non-live items (a future-dated event surfaces as "upcoming", + draft)
+    // remain in the Upcoming list.
+    expect(nonLiveItems.map((i) => i.id).sort()).toEqual(["draft-x", "evt-soon"].sort());
+
+    // nonLiveItems is a strict projection of items (never mutates items): items
+    // still carries the full set (live + non-live).
+    expect(items.map((i) => i.id)).toContain("evt-live");
+    expect(items.length).toBe(liveItems.length + nonLiveItems.length);
+  });
+
+  test("SC7-2 — ALL items live → nonLiveItems empty (Upcoming section hides, no crash)", () => {
+    const liveA = liveEvent({ id: "evt-a", status: "live", date: "2026-06-01", doorsOpen: "08:00", endsAt: "23:00" });
+    const liveTrip = trip({
+      id: "trip-live",
+      status: "live",
+      businessTrip: {
+        startAt: "2026-05-30T09:00:00.000Z",
+        endAt: "2026-06-05T17:00:00.000Z",
+        destinationLocationText: null,
+        destinationPlaceId: null,
+        destinationLat: null,
+        destinationLng: null,
+        departurePlaceId: null,
+        departureLocationText: null,
+        departureLat: null,
+        departureLng: null,
+        capacity: null,
+      },
+    });
+    const { liveItems, nonLiveItems } = buildUpcomingItems([liveA], [], [liveTrip], [], NOW);
+
+    expect(liveItems).toHaveLength(2);
+    // the Upcoming list is empty — home gates `hasUpcomingItems` on this length,
+    // so the section hides cleanly rather than rendering an empty list.
+    expect(nonLiveItems).toHaveLength(0);
+    // `.map` over the empty projection is safe (proves no crash in the consumer).
+    expect(nonLiveItems.map((i) => i.id)).toEqual([]);
+  });
+
+  test("SC7-3 — NONE live → nonLiveItems equals items (Upcoming unchanged)", () => {
+    const scheduled = liveEvent({ id: "evt-soon", status: "live", date: "2026-06-20", doorsOpen: "19:00", endsAt: "23:00" });
+    const futureTrip = trip({ id: "trip-future", status: "scheduled" });
+    const draftRow = draft({ id: "draft-y" });
+    const { items, liveItems, nonLiveItems } = buildUpcomingItems(
+      [scheduled],
+      [],
+      [futureTrip],
+      [draftRow],
+      NOW,
+    );
+
+    expect(liveItems).toHaveLength(0);
+    // with nothing live, the Upcoming list is identical to the full set, in the
+    // same (sorted) order.
+    expect(nonLiveItems.map((i) => i.id)).toEqual(items.map((i) => i.id));
+  });
+});

--- a/mingla-business/src/utils/clearAllStores.ts
+++ b/mingla-business/src/utils/clearAllStores.ts
@@ -27,6 +27,7 @@ import { useScannerInvitationsStore } from "../store/scannerInvitationsStore";
 import { useDoorSalesStore } from "../store/doorSalesStore";
 import { useBrandTeamStore } from "../store/brandTeamStore";
 import { useNotificationPrefsStore } from "../store/notificationPrefsStore";
+import { useLiveSectionCollapseStore } from "../store/liveSectionCollapseStore";
 
 export const clearAllStores = (): void => {
   useCurrentBrandStore.getState().reset();
@@ -41,4 +42,5 @@ export const clearAllStores = (): void => {
   useDoorSalesStore.getState().reset(); // NEW Cycle 12 — Constitution #6
   useBrandTeamStore.getState().reset(); // NEW Cycle 13a — Constitution #6
   useNotificationPrefsStore.getState().reset(); // NEW Cycle 14 — Constitution #6
+  useLiveSectionCollapseStore.getState().reset(); // NEW ORCH-1143 — Constitution #6 (live-section accordion collapse)
 };

--- a/mingla-business/src/utils/reapOrphanStorageKeys.ts
+++ b/mingla-business/src/utils/reapOrphanStorageKeys.ts
@@ -31,6 +31,7 @@ const KNOWN_MINGLA_KEYS = new Set<string>([
   "mingla-business.notificationPrefsStore.v1",
   "mingla-business.doorSalesStore.v1",
   "mingla-business.scanStore.v1",
+  "mingla-business.liveSectionCollapse.v1", // ORCH-1143: home live-section accordion collapse
   // ORCH-1050: brandTeamStore.v1 was removed from the persist allowlist.
   // The store is now in-memory optimistic only (canonical state lives in
   // public.brand_invitations via React Query). The reaper now sweeps any

--- a/mingla-business/src/utils/upcomingBuilder.ts
+++ b/mingla-business/src/utils/upcomingBuilder.ts
@@ -187,7 +187,15 @@ export function buildUpcomingItems(
   trips: Trip[],
   drafts: DraftEvent[],
   now: number = Date.now(),
-): { items: UpcomingItem[]; counts: UpcomingCounts; primaryLiveItem: UpcomingItem | null } {
+): {
+  items: UpcomingItem[];
+  counts: UpcomingCounts;
+  primaryLiveItem: UpcomingItem | null;
+  // ORCH-1143 — one-owner-per-truth for live-state (Constitution #2). The
+  // home live carousel reads this; it must NOT re-derive "live" at the call
+  // site. Already-sorted (live-first, start-ascending) subset of `items`.
+  liveItems: UpcomingItem[];
+} {
   const mergedEvents = mergeServerAndLegacyLive(serverEvents, legacyLiveEvents);
 
   const items: UpcomingItem[] = [];
@@ -214,6 +222,10 @@ export function buildUpcomingItems(
     draft: nonPast.filter((i) => i.status === "draft").length,
   };
 
-  const primaryLiveItem = nonPast.find((i) => i.status === "live") ?? null;
-  return { items: nonPast, counts, primaryLiveItem };
+  // ORCH-1143 — `liveItems` inherits the live-first start-ascending order from
+  // the comparator sort above. `primaryLiveItem` stays `liveItems[0]` (the
+  // existing `find` is equivalent) and is kept for back-compat consumers.
+  const liveItems = nonPast.filter((i) => i.status === "live");
+  const primaryLiveItem = liveItems[0] ?? null;
+  return { items: nonPast, counts, primaryLiveItem, liveItems };
 }

--- a/mingla-business/src/utils/upcomingBuilder.ts
+++ b/mingla-business/src/utils/upcomingBuilder.ts
@@ -195,6 +195,12 @@ export function buildUpcomingItems(
   // home live carousel reads this; it must NOT re-derive "live" at the call
   // site. Already-sorted (live-first, start-ascending) subset of `items`.
   liveItems: UpcomingItem[];
+  // ORCH-1143 SC-7 — the Upcoming-list view: `items` MINUS the currently-live
+  // items (which are surfaced exclusively in the live carousel). Derived, not a
+  // mutation of `items` (the carousel + counts still need the full set / the
+  // live subset). One owner per truth: live-state stays single-sourced above;
+  // this is just the complementary non-live projection of the SAME sorted list.
+  nonLiveItems: UpcomingItem[];
 } {
   const mergedEvents = mergeServerAndLegacyLive(serverEvents, legacyLiveEvents);
 
@@ -227,5 +233,8 @@ export function buildUpcomingItems(
   // existing `find` is equivalent) and is kept for back-compat consumers.
   const liveItems = nonPast.filter((i) => i.status === "live");
   const primaryLiveItem = liveItems[0] ?? null;
-  return { items: nonPast, counts, primaryLiveItem, liveItems };
+  // ORCH-1143 SC-7 — non-live projection of the same sorted set (upcoming +
+  // draft). Preserves `nonPast`'s order; never mutates `items`/`liveItems`.
+  const nonLiveItems = nonPast.filter((i) => i.status !== "live");
+  return { items: nonPast, counts, primaryLiveItem, liveItems, nonLiveItems };
 }


### PR DESCRIPTION
## ORCH-1143 — business Home "Live now" section

Closes the live-card feature requested by Seth: scan-ticket parity across all offering kinds, a collapsible section, and a multi-live carousel.

### What changed (business app, native — OTA delivery, no Vercel/buyer-web surface)
1. **Scan-Ticket on every live offering** — events, experiences AND trips (was event-only). The scanner edge fn + screen + route were already kind-agnostic (META-ORCH-1059); only the stale `kind === "event"` Home gate blocked it. No dead taps — on web the button routes to the ORCH-1099 kind-aware web scanner screen.
2. **Collapsible accordion** — one "Live now · N" header collapses the whole section; open/closed state persisted in a Zustand store, `hasHydrated`-gated (no flash-of-wrong-state on cold start).
3. **Horizontal multi-live carousel** — all concurrently-live offerings surface (not just the primary); single full-width card when exactly one is live.
4. **SC-7 de-dup** — live offerings no longer appear in BOTH the carousel and the Upcoming list; the Upcoming list (`nonLiveItems`) shows only upcoming/draft items. ORCH-0974 A-05 retargeted under `[TEST-MOD-APPROVED ORCH-1143]` (Seth-approved 2026-06-15) — single-scroll + all item-kind branch-preservation assertions intact; only the data-source assertion changed.

### Evidence
- Implementor happy-path T10 (scan button per kind) + SC-7 regression (`upcomingBuilder.test.ts`) — fails-on-revert verified.
- Tester adversarial: hydration-gate no-flash, LiveOfferingCard render proof, and `UpcomingDedup.orch1143.render.test.tsx` (live absent from Upcoming, present in carousel) — all fails-on-revert verified.
- No backend / migration / edge-fn / config changes. No new palette; Android opaque-glass fallback preserved.

Verdict: tester PASS (P0:0 P1:0 P2:0). Remaining: physical-device QR live-fire (operator smoke, post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)