### PR TITLE
ORCH-1146: experience-parser field completeness — plumb create_experience + widen Ve5/Ve6 + de-GBP [deploy]

### DIFF
--- a/.github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs
+++ b/.github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+/**
+ * ORCH-1146 — I-PROPOSED-1146-PARSER-NO-GBP-DEFAULT
+ *
+ * The experience-parser path MUST resolve currency from `brand.default_currency`;
+ * there is NO hardcoded "GBP" fallback in the two parsers, their two edge
+ * entries, or the shared confirm executor. When the currency is truly unknown,
+ * the field is left empty/omitted and the DB column default applies — never
+ * forced to GBP. Aligns with `[[project_orch_1034_currency_de_gbp_scope]]`.
+ *
+ * Scope (the 5 files that build/persist the snapped-experience currency):
+ *   - supabase/functions/_shared/geminiMenuParser.ts        (Ve5 normalizer/prompt)
+ *   - supabase/functions/_shared/geminiActivitiesParser.ts  (Ve6 normalizer/prompt)
+ *   - supabase/functions/parse-restaurant-menu/index.ts     (Ve5 edge entry)
+ *   - supabase/functions/parse-play-activities/index.ts     (Ve6 edge entry)
+ *   - supabase/functions/_shared/agentTools.ts              (create_experience executor)
+ *
+ * A violation = any quoted "GBP" / 'GBP' currency literal in these files.
+ *
+ * NOTE on agentTools.ts: that file holds ALL Ari tools, not just
+ * create_experience. The de-GBP rule already covered create_brand (ORCH-1103
+ * G-1) and there is no legitimate "GBP" literal anywhere in the file today, so
+ * the gate scans the whole file. If a future tool ever needs a literal currency
+ * for a non-currency-fallback reason, narrow the scan to the createExperience
+ * slice — but a hardcoded GBP fallback is never correct (use brand currency).
+ *
+ * Run: node .github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs
+ * Self-test: append --self-test (asserts the gate would catch a planted GBP).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const TARGET_FILES = [
+  "supabase/functions/_shared/geminiMenuParser.ts",
+  "supabase/functions/_shared/geminiActivitiesParser.ts",
+  "supabase/functions/parse-restaurant-menu/index.ts",
+  "supabase/functions/parse-play-activities/index.ts",
+  "supabase/functions/_shared/agentTools.ts",
+];
+
+// Matches a quoted GBP currency literal: "GBP" or 'GBP'.
+const GBP_LITERAL = /["']GBP["']/;
+
+// Strip the comment portion of a line so a "GBP" mentioned in an explanatory
+// comment is NOT a violation — only an executable GBP literal is. Handles `//`
+// line comments and `*` / `/*` block-comment bodies (the parser path uses no
+// string literals containing `//`, so this is safe here).
+function stripComments(line) {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) {
+    return "";
+  }
+  // Remove a trailing `// …` line comment (best-effort; the target files have
+  // no string literals that embed `//`).
+  const idx = line.indexOf("//");
+  return idx >= 0 ? line.slice(0, idx) : line;
+}
+
+function scanSource(rel, source) {
+  const found = [];
+  source.split(/\r?\n/).forEach((line, i) => {
+    const code = stripComments(line);
+    if (GBP_LITERAL.test(code)) {
+      found.push({ file: rel, line: i + 1, text: line.trim() });
+    }
+  });
+  return found;
+}
+
+// ── self-test ────────────────────────────────────────────────────────────────
+if (process.argv.includes("--self-test")) {
+  const planted = scanSource(
+    "fixture.ts",
+    'const c = brand.default_currency ?? "GBP";',
+  );
+  if (planted.length !== 1) {
+    console.error(
+      "ORCH-1146 gate SELF-TEST FAILED: did not catch a planted \"GBP\" literal.",
+    );
+    process.exit(1);
+  }
+  const clean = scanSource("fixture.ts", "const c = brand.default_currency;");
+  if (clean.length !== 0) {
+    console.error(
+      "ORCH-1146 gate SELF-TEST FAILED: false-positive on clean source.",
+    );
+    process.exit(1);
+  }
+  console.log("ORCH-1146 gate SELF-TEST OK.");
+  process.exit(0);
+}
+
+// ── real scan ──────────────────────────────────────────────────────────────
+const violations = [];
+let filesScanned = 0;
+
+for (const rel of TARGET_FILES) {
+  const abs = path.join(repoRoot, rel);
+  let source;
+  try {
+    source = fs.readFileSync(abs, "utf8");
+  } catch (err) {
+    console.error(
+      `ORCH-1146 no-gbp gate ERROR: could not read ${rel}: ${err.message}`,
+    );
+    process.exit(2);
+  }
+  filesScanned++;
+  violations.push(...scanSource(rel, source));
+}
+
+if (violations.length > 0) {
+  console.error(
+    "I-PROPOSED-1146-PARSER-NO-GBP-DEFAULT violation: hardcoded \"GBP\" currency fallback in the experience-parser path.",
+  );
+  console.error(
+    "Fix: resolve currency from brand.default_currency; leave empty/omit when unknown (DB default applies).",
+  );
+  console.error("");
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  ${v.text}`);
+  }
+  console.error("");
+  console.error(
+    `Scanned ${filesScanned} file(s); found ${violations.length} violation(s).`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `I-PROPOSED-1146-PARSER-NO-GBP-DEFAULT OK: scanned ${filesScanned} file(s); no hardcoded GBP currency fallback.`,
+);
+process.exit(0);

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2370,6 +2370,19 @@ jobs:
       - name: Run ORCH-1136 R3 web-sheet CSS-transition gate
         run: node .github/scripts/strict-grep/i-proposed-1136-web-sheet-css-transition.mjs
 
+  orch-1146-no-gbp-currency-default:
+    name: "ORCH-1146: no hardcoded GBP currency fallback in the experience-parser path (I-PROPOSED-1146-PARSER-NO-GBP-DEFAULT)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test the ORCH-1146 no-GBP gate
+        run: node .github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs --self-test
+      - name: Run ORCH-1146 no-GBP currency-default gate
+        run: node .github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs
+
   # ORCH-0962 brand-field-map-coverage gate RETIRED at META-ORCH-0972 CLOSE
   # (2026-05-26). The gate asserted that `viewRowToBrand` reads `row.brand_kind`
   # from `business_public_events_view`. META-ORCH-0972 Sub-C removed `brand_kind`

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1146.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1146.md
@@ -1,0 +1,236 @@
+# IMPLEMENTATION — ORCH-1146 [experience-parser field completeness]
+
+**Skill:** mingla-implementor · **Phase:** IMPLEMENT · **Date:** 2026-06-15
+**Worktree:** `~/Desktop/mingla-orchs/orch-1146-[experience-parser-field-completeness]` · branch `orch-1146-experience-parser-field-completeness`
+**Binding inputs:** `SPEC_ORCH-1146_EXPERIENCE_PARSER_FIELD_COMPLETENESS.md`, `INVESTIGATE_ORCH-1146_EXPERIENCE_PARSER_FIELD_COMPLETENESS.md`
+**Status:** implemented and verified (Deno typecheck + 35 tests green; fails-on-revert proven by true line-deletion).
+
+---
+
+## 1. Summary
+
+Snapped menu/activities photos now arrive in the experience wizard with every AI-inferable field
+already in its real typed column instead of a write-only JSON blob. The shared `create_experience`
+confirm executor now persists: the AI vibes → `events.experience_intents` (mapped to the canonical
+4-id vocabulary, or NULL when nothing maps — never an empty array), the currency →
+`events.currency`, and free/capacity/price → a single `ticket_types` row. The two Gemini parsers
+(Ve5 menu, Ve6 Play) gained an `is_free` field (+ `suggested_time_of_day` on Ve5), each "leave null
+if not in the photo." Every hardcoded `"GBP"` currency fallback in the parser path was removed —
+currency now resolves from the brand's `default_currency`. Genuinely-uninferable fields (dates,
+cover, stops, exact address, fee switches) are still left blank, and **no AI path produces a dated
+or publishable experience** — drafts stay drafts.
+
+No UI changed: the wizard already reads these columns/ticket back, so prefill is automatic. No
+migration (every target column/table already exists).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Satisfied by (commit) |
+|---|---|---|---|
+| SC-1 | Ve6 snap → canonical intents `{group-fun,romantic}` + currency + midpoint + 1 ticket (cap 8, paid) | ✓ verified (test T1) | `7f29fcf7e` |
+| SC-2 | Ve5 no-price romantic snap → `{romantic}` + free unlimited ticket | ✓ verified (test T2) | `7f29fcf7e` |
+| SC-3 | Unmappable tags → `experience_intents` NULL (omitted), insert succeeds (no CHECK fail) | ✓ verified (test T3) | `7f29fcf7e` + `7f29fcf7e` |
+| SC-4 | Wizard prefill via read-back, ZERO wizard change | ✓ source — no wizard/`experienceDetailService` edit; columns/ticket now populated (the service already reads them) | `7f29fcf7e` |
+| SC-5 | No `event_dates`/`experience_stops`/cover/`published_at` on a snapped draft | ✓ verified (test T6) | `7f29fcf7e` |
+| SC-6 | Ari minimal `{brand_id,title,narrative}` → draft + free/unlimited ticket + NULL intents, no throw | ✓ verified (test T5) | `7f29fcf7e` |
+| SC-7 | Ve5 schema has `is_free`+`suggested_time_of_day`; null when not in photo | ✓ verified (tests T8/T8b) | `7f29fcf7e` |
+| SC-8 | Ve6 schema has `is_free`; capacity/time behavior preserved | ✓ verified (tests T8c/T8d + existing Ve6 test) | `7f29fcf7e` |
+| SC-9 | Absent field → null in parser output (no fabrication) | ✓ verified (tests T8/T8c) | `7f29fcf7e`/`7f29fcf7e` |
+| SC-10 | No hardcoded `"GBP"` currency fallback across the 5 files | ✓ verified (strict-grep gate, real scan clean) | `7f29fcf7e` |
+| SC-11 | Brand NGN + unreadable currency → `currency='NGN'` end-to-end | ✓ verified (test T7; executor resolves from brand) | `7f29fcf7e` + `7f29fcf7e` |
+
+(Commit hashes filled in §11 / chat summary after commit.)
+
+---
+
+## 3. Files changed
+
+| File | Phase | Δ | Change |
+|---|---|---|---|
+| `supabase/functions/_shared/canonicalExperienceIntents.ts` (NEW) | 1 | +~190 | shared vibe-mapping helper (Play map + free-text keyword rules + already-canonical passthrough; caps 4, dedups, drops unmappable) |
+| `supabase/functions/_shared/agentTools.ts` | 1,3 | ~+90 | `createExperience` executor: currency column (de-GBP), `experience_intents` column (canonical or omitted), ONE `ticket_types` row (is_free+capacity+price), compensating orphan soft-delete; `is_free` added to the tool param schema |
+| `supabase/functions/_shared/geminiMenuParser.ts` | 2,3 | ~+25 | Ve5 schema/interface/normalizer/prompt for `is_free`+`suggested_time_of_day`; GBP default removed |
+| `supabase/functions/_shared/geminiActivitiesParser.ts` | 2,3 | ~+15 | Ve6 schema/interface/normalizer/prompt for `is_free`; GBP default removed |
+| `supabase/functions/parse-restaurant-menu/index.ts` | 2,3 | ~+5 | tool_args `is_free`+`suggested_time_of_day`; brand-currency passthrough (no GBP) |
+| `supabase/functions/parse-play-activities/index.ts` | 2,3 | ~+5 | tool_args `is_free`; brand-currency passthrough (no GBP) |
+| `mingla-business/src/constants/experienceIntents.ts` | 1 | +~10 (comment only) | cross-reference comment to the DB CHECK + the new edge helper (ids unchanged) |
+| `.github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs` (NEW) | 3 | +~130 | strict-grep gate (T10) + `--self-test` |
+| `.github/workflows/strict-grep-mingla-business.yml` | 3 | +14 | register the ORCH-1146 gate job (self-test + run) |
+| `supabase/functions/_shared/__tests__/orch_1146_create_experience_field_completeness.test.ts` (NEW) | 1 | +~310 | executor regression + adversarial tests (T1/T2/T3/T5/T6/T7/T9) |
+| `supabase/functions/_shared/__tests__/orch_1146_parser_field_completeness.test.ts` (NEW) | 1,2,3 | +~150 | helper (T4 + edge) + normalizer no-fabrication (T8) + de-GBP tests |
+
+All inside the SPEC §12 allowlist. NO existing test modified (append-only preserved). NO migration.
+NO UI / wizard / `experienceDetailService` / RPC / `agent-chat` / `agent-confirm-action` edit.
+
+---
+
+## 4. Data-model changes applied
+
+NONE. No migration. Every target already exists and is written through additively:
+- `events.currency` (`20260824…:411`) — now populated when resolvable, else omitted (DB default).
+- `events.experience_intents text[]` + CHECK `events_experience_intents_chk` (`20260828…:57-62`) —
+  now populated with the canonical 4-id array, or the key is omitted (column NULL) when empty.
+- `ticket_types` (one row, RPC default shape `20260824…:489-507`) — now inserted by the executor.
+
+Read-only schema probe NOT required (no migration, no guard/backfill). The executor writes through
+the caller's JWT (RLS is the final wall, unchanged).
+
+---
+
+## 5. Edge functions touched (deploy from MERGED main — orchestrator/operator-owned)
+
+| Function | `verify_jwt` to preserve | Why it changed |
+|---|---|---|
+| `parse-restaurant-menu` | (unchanged — preserve current) | tool_args `is_free`+`suggested_time_of_day`; brand-currency passthrough |
+| `parse-play-activities` | (unchanged — preserve current) | tool_args `is_free`; brand-currency passthrough |
+| `agent-confirm-action` | (unchanged — preserve current) | NOT edited; imports the changed `_shared/agentTools.ts` (executor) → redeploy to pick up the shared change |
+| `agent-chat` | (unchanged — preserve current) | NOT edited; imports `_shared/agentTools.ts` (AGENT_TOOLS) → redeploy to pick up the shared change |
+
+`_shared/` modules ship inside each importing function's bundle, so the four functions above must be
+redeployed from merged main for the executor + parser changes to take effect. NO new env var.
+
+---
+
+## 6. Regression tests added
+
+- `supabase/functions/_shared/__tests__/orch_1146_create_experience_field_completeness.test.ts` —
+  7 tests (T1 primary + T2/T3/T5/T6/T7/T9). PASS (7/7).
+- `supabase/functions/_shared/__tests__/orch_1146_parser_field_completeness.test.ts` — 11 tests
+  (T4 + helper edges + T8 no-fabrication + de-GBP). PASS (11/11).
+
+**fails-on-revert verified at `7f29fcf7e`** (true line-deletion, NOT comment-out): with the
+executor's three additive write blocks deleted (the `row.currency` line, the
+`row.experience_intents` line, and the entire `ticket_types` insert + orphan-delete block),
+`deno test orch_1146_create_experience_field_completeness.test.ts` → **5 of 7 FAILED**
+(T1/T2/T5/T7/T9 — the currency/intents/ticket/atomicity assertions). Restoring the fix → **7/7
+PASS**. Evidence captured in the IMPLEMENT session log.
+
+Append-only: both new test files appear in `git diff origin/main...HEAD --name-only`; no existing
+test was deleted or modified.
+
+---
+
+## 7. Old → New receipts
+
+### `_shared/agentTools.ts` — `createExperience` executor
+**Before:** wrote a 14-column `events` draft shell (no `currency`, no `experience_intents`) + a
+`theme.experience_meta` blob; wrote NO ticket; `currency` fell back to a literal `"GBP"`.
+**Now:** resolves currency from `args.currency` else `brand.default_currency` (no GBP literal; omits
+the column when unknown); maps `intent_tags` → canonical 4-id vibes via the new helper and writes
+`experience_intents` (or omits the key → NULL when empty, never `[]`); inserts ONE `ticket_types`
+row (`is_free` from explicit `args.is_free` else price-derived; `quantity_total` from Ve6
+`capacity_max`, else unlimited; `price_cents` = midpoint or 0 if free); on ticket-insert failure,
+soft-deletes the orphan `events` row and throws `WRITE_FAILED`. Blob retained for audit. Draft
+invariants unchanged.
+**Why:** SC-1/2/3/5/6/11, F-1 plumbing root cause, I-1 one-ticket, atomicity (Q4 LOCKED).
+**Lines:** ~+90.
+
+### `_shared/canonicalExperienceIntents.ts` (NEW)
+**Before:** n/a.
+**Now:** `mapToCanonicalExperienceIntents(rawTags, venueCategory)` → canonical-ordered, deduped,
+≤4 ids; Play-vocab map + free-text keyword rules + already-canonical passthrough; unmappable → drop;
+empty → `[]`.
+**Why:** F-2 vocabulary mismatch; the CHECK requires the 4 canonical ids.
+**Lines:** ~+190.
+
+### `_shared/geminiMenuParser.ts` (Ve5)
+**Before:** schema/interface had no `is_free`/`suggested_time_of_day`; prompt "Use GBP if currency
+unclear"; normalizer defaulted currency to "GBP".
+**Now:** `is_free`+`suggested_time_of_day` added (schema/interface/normalizer, null when absent);
+prompt instructs "leave currency empty if unclear" + explicit is_free/time rules; default currency
+param `""`.
+**Why:** SC-7/9/10, Phase 2+3. **Lines:** ~+25.
+
+### `_shared/geminiActivitiesParser.ts` (Ve6)
+**Before:** no `is_free`; "Use GBP" prompt; GBP normalizer default.
+**Now:** `is_free` added (null when absent); de-GBP prompt + `""` default; capacity/time-of-day
+unchanged.
+**Why:** SC-8/9/10, Phase 2+3. **Lines:** ~+15.
+
+### `parse-restaurant-menu/index.ts` / `parse-play-activities/index.ts`
+**Before:** `defaultCurrency = … || "GBP"`; tool_args lacked the new fields.
+**Now:** `… || undefined` (brand-currency passthrough, executor resolves server-side); tool_args
+carry `is_free` (+`suggested_time_of_day` on Ve5). **Why:** SC-10/11. **Lines:** ~+5 each.
+
+### `mingla-business/src/constants/experienceIntents.ts`
+**Before/Now:** ids unchanged; added a cross-reference comment to the DB CHECK + the edge helper.
+**Why:** SPEC §4.4 sync-guard. **Lines:** +~10 (comment only).
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Parity |
+|---|---|---|
+| Consumer iOS | NO | parsers have zero `app-mobile/` consumers |
+| Consumer Android | NO | same |
+| Buyer/anon Web | NO | public pages render PUBLISHED experiences; authoring prefill unaffected |
+| Business iOS | YES | wizard now prefills vibes/currency/free/capacity/price — automatic via shared edge fns + shared read-back (no iOS-specific file) |
+| Business Android | YES | same shared code |
+| Admin Web (adjacent) | NO | no admin experience authoring |
+| Business Web preview (adjacent) | YES | same shared edge fns + same wizard read-back |
+
+All three affected surfaces (Business iOS/Android/Web) are served by the SAME edge functions + the
+SAME `experienceDetailService` read-back. Parity is automatic — NO per-surface manual work.
+
+---
+
+## 9. Smoke / verification result
+
+- `deno check` clean on: `agentTools.ts`, `canonicalExperienceIntents.ts`, both Gemini parsers, both
+  edge `index.ts`.
+- `deno test` (5 files, 35 tests) → **35 passed | 0 failed**, including the pre-existing
+  `orch_1103_ari_brand_crud` (10) + adversarial (7) + both parser tests (7) — no regression.
+- Strict-grep `orch-1146-no-gbp-currency-default.mjs` `--self-test` OK + real scan clean (5 files,
+  0 violations). `i-ari-user-jwt-only.mjs` still OK (edge handlers untouched).
+- fails-on-revert proven by true line-deletion (5/7 fail on revert, 7/7 on restore).
+
+No simulator/device run performed (backend-only change; no native code; runtime behavior validated
+via the executor's mock-client tests). UNVERIFIED on device: the actual wizard prefill render — the
+tester should open a snapped draft on Business iOS/Android/web and confirm vibes/currency/free/
+capacity/price are pre-populated (the read-back path `experienceDetailService.ts:236,257-259,
+315-320,338-349` is unchanged and proven to read these columns/ticket).
+
+---
+
+## 10. Known issues / deferred
+
+- **Price RANGE** stays in `theme.experience_meta` only (no schema slot); the sellable value is the
+  midpoint (SPEC §4.5 / Q3 LOCKED). No wizard range prefill — that's ORCH-1144 UI territory.
+- **`suggested_time_of_day`** is persisted to the blob (Ve5 now extracts it too), NOT mapped to a
+  `when_draft`/date — the date stays uninferable/blank by invariant (SPEC C-3).
+- No `[TRANSITIONAL]` code introduced.
+
+---
+
+## 11. Operator action required
+
+1. **No migration** — nothing to `db push`. (Verified: every target column/table pre-exists.)
+2. **Deploy from MERGED main** (orchestrator/operator-owned, NOT from this worktree): redeploy
+   `parse-restaurant-menu`, `parse-play-activities`, `agent-confirm-action`, `agent-chat` (all four
+   bundle the changed `_shared/agentTools.ts` / parser modules). Preserve each function's current
+   `verify_jwt`. Deploy hazard: deploy from merged main, not stale worktrees
+   (`[[feedback_edge_deploy_and_migration_apply_hazards]]`).
+3. **CI**: the new gate job `orch-1146-no-gbp-currency-default` runs in
+   `strict-grep-mingla-business.yml`.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **SPEC gate-path deviation (minor, documented):** SPEC §9.4/§12 named the gate
+   `scripts/gates/orch-1146-no-gbp-currency-default.mjs`, but that directory does not exist in this
+   repo. The live convention (ORCH-1103, ORCH-1130, all 212 gates) is
+   `.github/scripts/strict-grep/<name>.mjs` registered as a job in
+   `strict-grep-mingla-business.yml`. I placed + registered the gate there so it actually runs. Gate
+   behavior is exactly per SPEC; only the location differs. No SPEC amendment requested (location is
+   not behavior-binding) — flagged for the orchestrator's awareness.
+2. **`theme.experience_meta` blob is still write-only for the structured wizard** (investigation
+   Discovery #1). This SPEC moved the high-value fields (intents/currency/free/capacity) to real
+   columns, but `suggested_time_of_day` + the price range still only live in the blob. A future ORCH
+   could wire those (or the wizard could read the blob's `when_draft`-style time hint).
+3. **`is_free` precedence (Q5 LOCKED):** explicit `args.is_free` wins over the price-derived value —
+   implemented exactly. The parser only emits `is_free=true` on an explicit free signal (else null),
+   so the price-derivation path remains the default for ordinary paid offerings.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1146.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1146.md
@@ -1,0 +1,180 @@
+# TEST — ORCH-1146 [experience-parser field completeness]
+
+**Skill:** mingla-tester · **Phase:** TEST (brutal gatekeeper) · **Date:** 2026-06-15
+**Worktree:** `~/Desktop/mingla-orchs/orch-1146-[experience-parser-field-completeness]` · branch `orch-1146-experience-parser-field-completeness`
+**Tip under test:** `3e8c0f068` (impl) + `af7714a7f` (tester adversarial test, this run)
+**Binding inputs:** `SPEC_ORCH-1146…md`, `INVESTIGATE_ORCH-1146…md`, `IMPLEMENT_ORCH-1146.md`
+**Mode:** SPEC-COMPLIANCE + TARGETED + adversarial. Backend/edge-only change → Phase 0.A live-fire sim gate is EXEMPT (no native/UI code; runtime validated via Deno mock-client executor tests + live DB CHECK read-back). Live snap→wizard render + Ari live-fire are post-deploy checks (edge fns deploy from merged main at CLOSE; current deployed versions confirmed stale).
+
+---
+
+## 1. VERDICT: **CONDITIONAL PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 2 · P4: 2
+
+Zero P0, zero P1, zero P2. Regression gate SATISFIED (implementor happy-path with independently re-proven fails-on-revert + tester adversarial different-angle test, both on-branch and in the closing diff). All 11 SCs met at the source + Deno + live-DB-CHECK level. **CHECK-safety fully proven against the live constraint.** Ari no-regression proven at the Deno/source level (17 neighbor tests + T5 green against the changed shared module).
+
+**Why CONDITIONAL, not PASS:** the product payoff (snap → wizard prefill render) and the Ari live-fire path are **source-verified + Deno-proven only** — they cannot be runtime-confirmed until the four edge functions are redeployed from merged main (currently live at stale versions: `agent-confirm-action` v162, `agent-chat` v167, `parse-restaurant-menu` v133, `parse-play-activities` v132). This is the SPEC's own documented post-deploy step (§8), not a defect. The two P3 items are doc nits. No condition requires rework.
+
+The condition to clear to full PASS: after CLOSE deploys the four edge fns from merged main, do one live snap (Ve5 menu + Ve6 activities) on the business app and confirm the wizard arrives with vibes/currency/free/capacity/price prefilled, plus one minimal Ari `create_experience` call still produces a clean draft.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Status | Evidence |
+|---|---|---|---|
+| SC-1 | Ve6 snap → `{group-fun,romantic}` + currency + midpoint 3000 + 1 ticket (cap 8, paid) | **PASS** | Deno T1 green; executor `agentTools.ts:824,820,815,860-879`. Canonical order asserted `["romantic","group-fun"]`. |
+| SC-2 | Ve5 no-price romantic → `{romantic}` + free unlimited ticket | **PASS** | Deno T2 green; helper free-text `tasting_menu/date-night`→romantic. |
+| SC-3 | Unmappable tags → `experience_intents` NULL (omitted), insert OK (no CHECK fail) | **PASS** | Deno T3 + tester ADV-4a green; executor `:824` writes key only when `length>0`. Verified against live CHECK (§4). |
+| SC-4 | Wizard prefill via read-back, ZERO wizard change | **PASS (source)** | `experienceDetailService.ts` NOT in diff; reads `currency`+`experience_intents` (`:236`), ticket (`:258-259`), maps `:315-316,344-347`. Live render = post-deploy. |
+| SC-5 | No event_dates/stops/cover/published_at on snapped draft | **PASS** | Deno T6 + tester ADV; executor writes none; `status/visibility='draft'`, `published_at=null` (`:809-811`). |
+| SC-6 | Ari minimal `{brand_id,title,narrative}` → draft + free/unlimited ticket + NULL intents, no throw | **PASS (Deno/source)** | T5 green; 17 orch_1103 neighbor tests green against changed module; callers source-traced (§ Tier 2). Live = post-deploy. |
+| SC-7 | Ve5 schema has `is_free`+`suggested_time_of_day`; null when not in photo | **PASS** | `geminiMenuParser.ts:53-54,111,68`; Deno T8/T8b green. |
+| SC-8 | Ve6 schema has `is_free`; capacity/time preserved | **PASS** | `geminiActivitiesParser.ts:59,124,57-58`; Deno T8c/T8d + existing Ve6 test green. |
+| SC-9 | Absent field → null in parser output (no fabrication) | **PASS** | Normalizers `… ? raw.is_free : null` (Ve5:111, Ve6:124); Deno T8/T8c green. |
+| SC-10 | No hardcoded `"GBP"` currency fallback across the 5 files | **PASS** | Strict-grep gate clean (5 files, 0 violations) + `--self-test` OK; independent grep: every `GBP` is a comment or an arg-description example, no quoted fallback literal. |
+| SC-11 | Brand NGN + unreadable currency → `currency='NGN'` end-to-end | **PASS** | Deno T7 green (lowercase brand `ngn`→`NGN`); edge passes `undefined`→normalizer `""`→executor brand-resolve. |
+
+All covered surfaces (Business iOS/Android/Web preview) are served by the SAME edge fns + SAME read-back service → parity automatic; no per-surface split.
+
+---
+
+## 3. CHECK-safety proof (highest-risk failure) — PASS
+
+**Live DB CHECK (read-only query, project `gqnoajqerqhnvulmnyvv`):**
+```
+CHECK ((experience_intents IS NULL) OR (
+  array_length(experience_intents,1) >= 1 AND array_length(experience_intents,1) <= 4
+  AND experience_intents <@ ARRAY['adventurous','first-date','romantic','group-fun']))
+```
+**Helper id list** `CANONICAL_EXPERIENCE_INTENTS = ['adventurous','first-date','romantic','group-fun']` is **byte-identical** to the CHECK's allowed array.
+
+**Executor guarantees (traced `agentTools.ts:735-738,824` + `canonicalExperienceIntents.ts`):**
+- `mapToCanonicalExperienceIntents` only ever returns members of the canonical set (`mapOneTag` returns a canonical id or null; non-strings/empties dropped) → **never an invalid id** (CHECK `<@` satisfied).
+- Output deduped via Set + `CANONICAL_EXPERIENCE_INTENTS.filter(...).slice(0,4)` → **length ≤ 4** (CHECK upper bound satisfied).
+- Executor writes the column ONLY when `canonicalIntents.length > 0` (`:824`) → **never `[]`** (CHECK lower bound satisfied; empty → key omitted → column NULL → CHECK `IS NULL` branch).
+
+**Adversarial inputs proven (tester ADV-4, all green):**
+- all-unmappable + case + whitespace + duplicates (`["  GLUTEN_FREE  ","Vegan","keto","halal","GLUTEN_FREE"]`) → column **OMITTED**, never `[]`.
+- mixed mappable+garbage+non-strings → ONLY canonical ids, deduped, ≤4, in canonical order `["adventurous","first-date","romantic","group-fun"]`.
+- empty array / null / non-array / `[""]` → `[]` (executor then omits → NULL).
+
+Conclusion: the snap-confirm path **cannot** produce a CHECK-violating `experience_intents` write. PROVEN.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+- Checked out HEAD `3e8c0f068`; backed up `agentTools.ts`.
+- **True line-deletion** of the three additive blocks: `row.currency` (`:820`), `row.experience_intents` (`:824`), and the entire `ticket_types` insert + orphan-soft-delete block (`:846-901`).
+- `deno test orch_1146_create_experience_field_completeness.test.ts` → **5 of 7 FAILED** (T1, T2, T5, T7, T9 — the currency/intents/ticket/atomicity assertions). T3/T6 still passed (they assert key-absence, true either way).
+- Restored from backup → `git status` clean (identical to committed HEAD) → **7/7 PASS**.
+
+Matches the implementor's claim exactly (5/7 fail on revert, 7/7 on restore). Hashes: proof commit `3e8c0f068`; restore verified at `3e8c0f068`.
+
+---
+
+## 5. Adversarial test added (tester-owned, different angle)
+
+**Path:** `supabase/functions/_shared/__tests__/orch_1146_create_experience.tester-adversarial.test.ts`
+**Commit:** `af7714a7f` (on-branch, append-only, in `git diff origin/main...HEAD --name-only`).
+**Angles (7 tests, all green):** ADV-1 explicit `is_free=false` wins over price-derivation; ADV-2 `capacity_max` on a RESTAURANT does NOT cap; ADV-3 >120-char title → INVALID_ARGS, no partial write; ADV-4a/b/c CHECK-safety; ADV-5 events-insert failure → no ticket, no orphan update.
+**fails-on-revert verified at `3e8c0f068`** — with the executor plumbing line-deleted, ADV-1 + ADV-2 FAIL (no ticket inserted: 5 passed | 2 failed); restored → 7/7 PASS.
+
+Both the implementor happy-path test (fails-on-revert) AND this tester adversarial test appear in the closing diff. Regression gate SATISFIED.
+
+---
+
+## 6. Tier 2 — Ari no-regression
+
+- **Callers enumerated (grep):** only `agent-confirm-action/index.ts:188,200` (`findTool`+`executor`) and `agent-chat/index.ts:320,357,365` (`AGENT_TOOLS`/`findTool`+`executor`). No other executor caller.
+- **Additive proof:** `create_experience.required = ["brand_id","title","narrative"]` UNCHANGED (`:659`); `currency`/`intent_tags`/`capacity_*`/`is_free` all optional (`:660-681`). Executor return shape `{ event: data }` UNCHANGED; `data` still carries `title` (selected `:829`), so `agent-confirm-action:316-318`'s `result.event.title` read still works.
+- **Deno proof:** T5 (minimal Ari call → draft + free/unlimited ticket + NULL intents + NULL currency, no throw) green; the 17 `orch_1103_ari_brand_crud` (10) + adversarial (7) neighbor tests green against the changed `agentTools.ts`.
+- **Runtime status:** SOURCE + DENO PROVEN. Live `agent-confirm-action`/`agent-chat` are deployed at v162/v167 (pre-1146) — live-fire is a post-deploy check, capped at strong-source here (stated, not claimed as runtime).
+
+---
+
+## 7. Tier 3 — invariants / no-fabrication / draft-only / schema
+
+- **Draft-only:** executor sets `status/visibility='draft'`, `published_at=null`; writes NO `event_dates`/`experience_stops`/`cover_media_*`. The one added ticket has no date → unsellable. (T6 + ADV.) I-2/I-4 preserved.
+- **I-1 ONE-TICKET:** exactly one `ticket_types` insert (T1 asserts `tickets.length === 1`).
+- **No fabrication (Constitution #9):** `is_free`/`suggested_time_of_day` → null when absent (T8/T8c); unmappable vibes dropped, never invented.
+- **No silent failures (#3):** every write failure throws `ToolError("WRITE_FAILED")`; ticket-insert failure compensates with an orphan soft-delete then throws (T9). No empty catch in the diff.
+- **Currency-aware (#10):** resolves from brand `default_currency`, no GBP literal.
+- **Schema (live, read-only):** `events.currency` ✓, `events.experience_intents` ✓, `ticket_types` ✓ all exist. **Zero migration files** in the diff (correct — targets pre-exist).
+
+---
+
+## 8. Tier 1 — Deno + static (commands + output)
+
+- `deno test orch_1146_create_experience_field_completeness.test.ts orch_1146_parser_field_completeness.test.ts` → **18 passed | 0 failed**. With tester adversarial → **25 passed | 0 failed**.
+- `deno test orch_1103_ari_brand_crud*.test.ts` → **17 passed | 0 failed** (no regression on shared module).
+- `deno check` clean on all ORCH-1146 files (`canonicalExperienceIntents.ts`, `agentTools.ts`, both parsers, both edge `index.ts`). The 20 type errors surfaced by a full `__tests__/` typecheck are all in `ticketPdf.ts` (NOT touched by ORCH-1146; pre-existing).
+- `node .github/scripts/strict-grep/orch-1146-no-gbp-currency-default.mjs --self-test` → `SELF-TEST OK` (exit 0). Real scan → `scanned 5 file(s); no hardcoded GBP currency fallback` (exit 0).
+
+---
+
+## 9. Constitution 14-rule matrix (against the diff)
+
+| # | Rule | Result |
+|---|---|---|
+| 1 | No dead taps | N/A (no UI) |
+| 2 | One owner per truth | PASS — executor is the single writer of the snap draft; helper is the single vibe-mapping source (cross-ref comments in 3 places) |
+| 3 | No silent failures | PASS — all writes throw ToolError; orphan compensation on ticket failure |
+| 4 | One query key per entity | N/A (no client query keys touched) |
+| 5 | Server state server-side | N/A |
+| 6 | Logout clears | N/A |
+| 7 | `[TRANSITIONAL]` labelled | N/A (none introduced) |
+| 8 | Subtract before adding | PASS — reused RPC's ticket-default shape + existing blob; no parallel structure |
+| 9 | No fabricated data | PASS — null-on-absent for is_free/time; unmappable vibes dropped |
+| 10 | Currency-aware | PASS — brand-resolved, no GBP literal |
+| 11 | One auth instance | N/A — executor uses the passed user-scoped client (I-ARI-USER-JWT-ONLY preserved) |
+| 12 | Validate at right time | PASS — title/narrative length validated before any write |
+| 13 | Exclusion consistency | N/A |
+| 14 | Persisted-state startup | N/A |
+
+No violations.
+
+---
+
+## 10. Device / parity matrix
+
+| Surface | Ships here? | Result |
+|---|---|---|
+| Consumer iOS | NO | N/A — zero `app-mobile/` consumers of the parsers/executor |
+| Consumer Android | NO | N/A |
+| Buyer/anon Web | NO | N/A — public pages render PUBLISHED experiences |
+| Business iOS | YES | PASS (source) — prefill via shared read-back; live render = post-deploy |
+| Business Android | YES | PASS (source) — same shared code |
+| Admin Web | NO | N/A |
+| Business Web preview | YES | PASS (source) — same shared edge fns + read-back |
+
+Live-fire sim gate EXEMPT (backend/edge-only, no native/UI code). No physical-iPhone step (nothing user-touchable changed without an edge redeploy).
+
+---
+
+## 11. Findings
+
+**P3-1 (doc nit) — migration-line citation drift in the helper comment.**
+Evidence: `canonicalExperienceIntents.ts:7` cites the CHECK at `:57-62` while `:20` and `experienceIntents.ts` cite `:62-64`. Impact: none (the live CHECK is byte-identical regardless; cosmetic). Fix: pick one line range. Retest: visual.
+
+**P3-2 (copy nit, PRE-EXISTING, out of scope) — confirm-action says "Published experience".**
+Evidence: `agent-confirm-action/index.ts:318` returns `Published experience "<title>" to your venue.` but `create_experience` produces a DRAFT (never published). Impact: misleading Ari confirmation copy. NOT introduced by ORCH-1146 (unchanged line; the file is DO-NOT-TOUCH per SPEC §12). Fix: future ORCH — change to "Created draft experience…". Routed to Discoveries.
+
+**P4-1 (praise).** Clean CHECK-safety design: the column write is gated on `length>0` and the id list is frozen + cross-referenced in 3 places (helper, biz constant, DB CHECK), making drift loud. The compensating orphan soft-delete on ticket failure is the correct non-transactional pattern.
+
+**P4-2 (praise).** De-GBP chain is single-source-of-truth end-to-end (edge `undefined` → normalizer `""` → executor brand-resolve), with a self-testing strict-grep gate.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **`agent-confirm-action:318` "Published experience" copy is wrong** — the AI path creates a DRAFT, not a published experience. Pre-existing, DO-NOT-TOUCH this ORCH. Spawn a tiny copy-fix ORCH.
+2. **`theme.experience_meta` blob is still write-only** for `suggested_time_of_day` + the price range (no schema slot; the wizard doesn't read the blob). Per SPEC Q3 LOCKED; a future ORCH could surface the range/time in the wizard.
+3. **Post-deploy verification owed at CLOSE:** redeploy `parse-restaurant-menu`, `parse-play-activities`, `agent-confirm-action`, `agent-chat` from MERGED main (they bundle the changed `_shared/`), then live-snap + live-Ari check.
+4. **COMMS-0035 (WARN, ALL, OPEN)** read + factored: `expo-image-manipulator` native-module-via-OTA risk — UNRELATED to this backend-only ORCH (no native modules, no business runtime bundle change beyond a comment). Not acked on the anchor to avoid the fragile-direct-main-commit hazard mid-QA; flagged here for the orchestrator.
+
+---
+
+## 13. Accepted conditions (CONDITIONAL PASS)
+
+The single deferral is the **live snap→wizard-prefill render + Ari live-fire**, deferred to post-deploy because the four edge functions are not yet redeployed from merged main (SPEC §8's own step). This is `probable`-level (source + Deno + live-DB-CHECK proven; blocked from runtime only by the not-yet-merged/deployed state). It is NOT a P1 and requires no rework — it is the standard CLOSE-time deploy + smoke. If you want it cleared to full PASS before CLOSE, deploy to a preview and run the two live checks in §1.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1146_EXPERIENCE_PARSER_FIELD_COMPLETENESS.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1146_EXPERIENCE_PARSER_FIELD_COMPLETENESS.md
@@ -1,0 +1,327 @@
+# SPEC — ORCH-1146 [experience-parser field completeness]
+
+**Skill:** mingla-forensics · **Phase:** SPEC · **Date:** 2026-06-15
+**Worktree:** `~/Desktop/mingla-orchs/orch-1146-[experience-parser-field-completeness]` · branch `orch-1146-experience-parser-field-completeness`
+**Binding investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1146_EXPERIENCE_PARSER_FIELD_COMPLETENESS.md` (read as ground truth; F-1/F-2/F-3 + the class A/B/C/D matrix).
+**Surface:** Mingla Business (`mingla-business/`) authoring + Supabase edge functions. **Experiences ONLY** (Ve5 `parse-restaurant-menu`, Ve6 `parse-play-activities`).
+**Decisions LOCKED by Seth** — this SPEC implements them exactly; it does NOT relitigate scope.
+
+> The implementor builds in the LOCKED phase order below. Each phase is independently shippable.
+> The implementor MUST NOT touch anything outside the allowlist (§12); to widen scope, stop and request a SPEC amendment.
+
+---
+
+## 1. Executive summary
+
+Today a snapped menu/activities photo yields an experience DRAFT that carries only **title, narrative, and a single midpoint price** into the structured wizard. Everything else the AI already extracts — vibes (`intent_tags`), currency, capacity, time-of-day, and the price range — is dumped into a write-only `theme.experience_meta` JSON blob that the structured edit wizard never reads back (`experienceDetailService.ts:236` reads typed columns, not the blob). So the brand re-enters fields the AI already knew.
+
+This SPEC makes snapped experiences arrive with **every wizard field the AI can reasonably infer already filled in its real typed column**, while leaving genuinely-uninferable fields (dates, cover, exact address/geo, stops, fee/tax switches) blank — and keeping the hard invariant that **no AI path creates a dated or publishable experience** (it stays a draft).
+
+Three phases, in LOCKED order:
+
+- **Phase 1 — plumb `create_experience`** (the `agentTools.ts` executor; the Layer-2 bottleneck). Persist `intent_tags`→`events.experience_intents` (canonical 4-id vocab), `currency`→`events.currency`, `is_free` + `capacity`→a single `ticket_types` row, and keep the price range visible. This is the highest-value change: the AI already extracts these; they're just discarded.
+- **Phase 2 — widen Ve5/Ve6 Gemini prompts + responseSchemas** for the remaining inferable class-B fields (`is_free` on both; `suggested_time_of_day` on Ve5; canonical-vibe emission on both — see §4.2). Two cores stay SEPARATE.
+- **Phase 3 — currency fix** — replace the hardcoded "Use GBP if currency unclear" parser fallback with the brand's `default_currency`; align with the de-GBP-ify direction.
+
+---
+
+## 2. Scope & non-goals
+
+### In scope
+- The `create_experience` executor in `supabase/functions/_shared/agentTools.ts` (Phase 1).
+- `supabase/functions/_shared/geminiMenuParser.ts` (Ve5 schema/prompt/normalizer) + `supabase/functions/_shared/geminiActivitiesParser.ts` (Ve6) (Phase 2 + 3).
+- `supabase/functions/parse-restaurant-menu/index.ts` + `supabase/functions/parse-play-activities/index.ts` — `tool_args` construction for any newly-extracted field + the GBP-fallback at the edge entry (Phase 2 + 3).
+- A new shared vibe-mapping helper `supabase/functions/_shared/canonicalExperienceIntents.ts` (Phase 1; used by the executor).
+- A regression-test contract (§9).
+
+### Non-goals (explicitly NOT in this SPEC)
+- **NO UI redesign.** No change to the snap sheets, the chooser, the Hub tab, `ExperienceReviewCards.tsx`, `ExperienceConfirmationCard.tsx`, or `ExperienceCreatorWizard.tsx`. The wizard already reads back every column/ticket field this SPEC fills (`experienceDetailService.ts:236,257-259,315-320,338-349`); prefill is automatic once the columns/ticket exist. (UI is ORCH-1144 territory — just closed.)
+- **NO dated/publishable experience from any AI path.** Drafts stay drafts; no `event_dates`, no `cover_media_*`, no `experience_stops`, no `published_at`. (I-1/I-2/I-4 META-ORCH-1059 — see §6.)
+- **NO stops / per-stop fields** (place_id/address/geo/images/start_time/ai_description) — class D, uninferable from a photo and invariant-safe to leave at 0 stops.
+- **NO consumer app, NO public/buyer web, NO admin** — the parsers + wizard are business-only (investigation blast-radius map).
+- **NO broad de-GBP-ify sweep** beyond the two parser modules + their two edge entries. Client-side `?? "GBP"` fallbacks elsewhere remain under `[[project_orch_1034_currency_de_gbp_scope]]` (NOT YET STARTED) — out of scope here.
+- **NO change to `biz_create_experience` / `biz_publish_experience` RPCs** — the AI confirm path does NOT call them (investigation §Layer 2); leave them untouched.
+
+### Assumptions
+- The wizard prefill reads typed `events` columns + the single `ticket_types` row + `experience_intents` (proven: `experienceDetailService.ts:236,257-259,315-320,338-349`). Filling those columns/ticket = automatic prefill. No adapter change needed.
+- `create_experience` is SHARED with the Ari AI chat (`agent-chat/index.ts` imports `AGENT_TOOLS`; `agent-confirm-action/index.ts` runs the executor). All new fields MUST be additive/optional (§4.1 HARD GUARD).
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY)
+
+| # | Surface | Covered? | User-visible behavior demanded | Files touched here | Parity |
+|---|---------|----------|-------------------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile/` iOS) | NO | — | none | n/a — parsers have zero `app-mobile/` consumers |
+| 2 | Consumer Android (`app-mobile/` Android) | NO | — | none | n/a — same |
+| 3 | Buyer/anon Web | NO | — | none | n/a — public pages render PUBLISHED experiences; authoring prefill unaffected |
+| 4 | Business iOS | YES | A snapped experience opened in the wizard arrives with vibes, currency, free/capacity, price prefilled | reads back via shared RN code; no iOS-specific file | automatic (shared edge fns + shared wizard read-back) |
+| 5 | Business Android | YES | Same as iOS | same shared RN read-back | automatic (shared) |
+| 6 | Admin Web (adjacent) | NO | — | none | n/a — no admin experience authoring |
+| 7 | Business Web preview (adjacent) | YES | Same prefill on the RN-web wizard | same shared edge fns + shared wizard | automatic (shared) |
+
+All three covered surfaces (4/5/7) are served by the SAME edge functions + the SAME `experienceDetailService` read-back; parity is automatic. The only code that changes is backend (edge functions) + one shared helper. There is NO per-surface manual parity work.
+
+---
+
+## 4. Layered specification
+
+### 4.0 Field-by-field fill-rules table (the contract spine)
+
+For every field: **source** (parser field / brand column) → **target** (DB column/table) → **transform** → **leave-blank condition**. The executor MUST apply each rule.
+
+| Field | Source (parser/brand) | Target column/table | Transform / mapping | Leave-blank condition | Phase |
+|---|---|---|---|---|---|
+| **title** | `args.title` | `events.title` | trim, ≤120 | required — error if absent | (existing) |
+| **narrative** | `args.narrative` | `events.description` | trim, ≤2000 | required — error if absent | (existing) |
+| **vibes** | `args.intent_tags[]` | `events.experience_intents text[]` | map each tag → canonical 4-id via §4.4; dedup; keep order of EXPERIENCE_INTENTS; cap 4; **unmappable → drop** | empty after mapping → write `NULL` (column stays null; publish gate handles it) | 1 |
+| **currency** | `args.currency` else `brand.default_currency` | `events.currency` | uppercase, slice(0,3) | never blank — falls back to `brand.default_currency`; if that is also null → omit the key (DB default applies). NEVER hardcode "GBP" in the executor. | 1 |
+| **is_free** | `args.is_free` (Phase 2 adds it to the schema) | `ticket_types.is_free` | boolean; if true → `price_cents=0` | if `args.is_free` absent → derive: `is_free = (resolved price <= 0)`. Never fabricate a non-free paid ticket if no price. | 1 (derive) + 2 (explicit field) |
+| **capacity** | `args.capacity_max` (Ve6 only) | `ticket_types.quantity_total` + `is_unlimited` | `quantity_total = capacity_max` (>=1); `is_unlimited = (capacity_max is null/<=0)` | Ve5 (restaurant): always `quantity_total=NULL`, `is_unlimited=true` (menus don't state party size — class D). Ve6 with no capacity → unlimited. | 1 |
+| **price (whole)** | `args.suggested_price_min_cents` / `max` | `events.whole_price_cents` + `ticket_types.price_cents` | `whole_price_cents = midpoint` (existing logic); ticket `price_cents = whole_price_cents` (or 0 if free) | both null → `whole_price_cents=NULL`, ticket free with price 0 | 1 |
+| **price RANGE (min,max)** | `args` min+max | `theme.experience_meta.suggested_price_min/max_cents` (KEEP) | preserve in blob (already done) so the range survives for audit/future prefill; the SELLABLE single value is the midpoint (schema has ONE price). | both null → both null in blob | 1 (note limitation §4.5) |
+| **suggested_time_of_day** | `args.suggested_time_of_day` | `theme.experience_meta.suggested_time_of_day` (KEEP in blob) | preserve (already done for Ve6); Phase 2 adds it to Ve5's schema | absent → null | 2 |
+| location_mode / pricing_mode | (default) | `events.location_mode='single'`/`pricing_mode='whole'` | hardcoded default (correct for one-venue snap) | n/a | (existing) |
+| dates / timezone / cover / stops / fee switches | — | — | NOT WRITTEN (class D + invariant) | always blank | (invariant) |
+
+### 4.1 Phase 1 — plumb the `create_experience` executor
+
+**File:** `supabase/functions/_shared/agentTools.ts` — the `createExperience` AgentTool (`:645-813`), executor body `:677-812`.
+
+**Current state (verbatim, investigation-confirmed):** the INSERT row (`:780-795`) writes only `brand_id, created_by, title, slug, description, event_type, status, visibility, published_at, timezone, location_mode, pricing_mode, whole_price_cents, theme`. It writes **no `currency` column, no `experience_intents`, and no `ticket_types` row at all**. `currency` is computed at `:704-706` but never written to the column. `intent_tags` go to the blob (`:736`). Capacity/time-of-day go to the blob (`:753-756`).
+
+**Required changes (additive — preserve all existing behavior):**
+
+1. **Currency → column.** Add `currency` to the INSERT row object (`:780-795`) using the already-computed `currency` local (`:704-706`). Change the `:704-706` fallback per Phase 3 (§4.3) so it resolves from `brand.default_currency` and does NOT hardcode `"GBP"` in the executor (if `args.currency` absent AND `brand.default_currency` null → omit the `currency` key so the `events` column default applies; do NOT write a literal "GBP").
+
+2. **Vibes → `experience_intents` column.** After computing `intentTags` (`:708-716`), derive the canonical 4-id array via the new shared helper (§4.4):
+   - `const canonicalIntents = mapToCanonicalExperienceIntents(args.intent_tags, venueCategory);`
+   - Add `experience_intents` to the INSERT row: write `canonicalIntents` when non-empty, else **omit the key (write NULL)** — NEVER write an empty array (the CHECK requires length 1–4 when non-null; `20260828…:57-62`).
+   - KEEP `experienceMeta.intent_tags` (the raw tags) in the blob for audit — do not remove it.
+
+3. **`is_free` + capacity → ONE `ticket_types` row.** Today the executor writes NO ticket. Add a SECOND insert (after the `events` insert returns its id), mirroring the RPC's single-ticket shape (`20260824…:489-507`, the I-1 ONE-TICKET spine):
+   - Compute `isFree`:
+     - if `args.is_free` is a boolean → use it (Phase 2 supplies this);
+     - else derive `isFree = (suggestedMidCents === null || suggestedMidCents <= 0)`.
+   - Compute capacity (Ve6 only): `quantity_total = (venueCategory === 'play' && capacityMax != null && capacityMax > 0) ? capacityMax : NULL`; `is_unlimited = (quantity_total is NULL)`. For Ve5/restaurant → always `quantity_total=NULL, is_unlimited=true`.
+   - INSERT ONE `ticket_types` row: `{ event_id: <new events.id>, name: 'Standard', description: null, price_cents: isFree ? 0 : (suggestedMidCents ?? 0), currency, quantity_total, is_unlimited, is_free: isFree, min_purchase_qty: 1, max_purchase_qty: null, is_hidden: false, is_disabled: false, requires_approval: false, allow_transfers: true, password_protected: false, available_online: true, available_in_person: true, waitlist_enabled: false, display_order: 0 }` — exactly the RPC's defaults (`20260824…:490-507`).
+   - **I-1 ONE-TICKET:** write EXACTLY ONE ticket row, never N.
+   - **Atomicity:** the executor is two client inserts (events, then ticket_types) — NOT a transaction. If the ticket insert fails after the events insert succeeds, the executor MUST throw `ToolError("WRITE_FAILED", …)` AND best-effort delete the orphan `events` row (soft-delete via `deleted_at` if a hard delete is RLS-blocked) so a snap never leaves a ticket-less draft. (See Open Question §10-Q4 if a single RPC is preferred instead — but the LOCKED decision is: keep the executor's direct-insert style, add the compensating delete.)
+
+4. **Keep `whole_price_cents` midpoint** (`:770-778,793`) unchanged. Keep the price min/max in the blob (`:737-742`).
+
+5. **Invariant preservation (unchanged):** still `status='draft'`, `visibility='draft'`, `published_at=null`, NO `event_dates`, NO `experience_stops`, NO `cover_media_*`. The added ticket row carries no date → still unsellable (matches the RPC's draft contract `20260824…:616` "Drafts … write the events row + stops + ticket but NO event_dates → unsellable until published").
+
+**HARD GUARD — Ari no-regression (MANDATORY).** `create_experience` is shared. The implementor MUST:
+- Enumerate every caller: (a) `agent-confirm-action/index.ts:187,197` (snap confirm + Ari confirm both run the same executor) and (b) `agent-chat/index.ts` (Ari tool-call path importing `AGENT_TOOLS`). No other callers exist (grep-confirmed: only `agentTools.ts`, `agent-chat`, `agent-confirm-action`, and the two `__tests__/orch_1103_ari_brand_crud*` import it).
+- Prove the Ari path is additive: when Ari calls `create_experience` with only `{brand_id, title, narrative}` (the required set, `:658`), the new code MUST produce the same observable result PLUS a free, unlimited Standard ticket and (if Ari passed no intents) a NULL `experience_intents`. No new required parameter. No throw on absent optional fields. `venue_category` for an Ari-created experience under a non-restaurant/non-play brand → no capacity, no Play-vocab filtering (the existing `:709-716` branch already handles this; preserve it).
+- Add the regression assertion in §9 (Ari-path no-regression test).
+
+### 4.2 Phase 2 — widen Ve5/Ve6 Gemini prompts + responseSchemas
+
+**Two cores stay SEPARATE** — own prompt, own schema, own normalizer, own `tool_args`. Each new schema field gets a normalizer + a "leave null if not present in the photo" rule. Keep `temperature: 0.2` + the "do not invent" clause (this is what makes blank-on-unknown safe).
+
+**Ve5 — `geminiMenuParser.ts`:**
+- Add to `RESPONSE_SCHEMA.properties.experiences.items.properties` (`:43-49`): `is_free: { type: "boolean" }`, `suggested_time_of_day: { type: "string" }`. Keep `required: ["title","narrative"]`.
+- Add to `ParsedMenuExperience` interface (`:16-24`): `is_free: boolean | null; suggested_time_of_day: string | null;`.
+- Normalizer (`normalizeExperience` `:80-111`): `is_free` → `typeof raw.is_free === "boolean" ? raw.is_free : null`; `suggested_time_of_day` → `asString(raw.suggested_time_of_day, 80) || null`.
+- Prompt (`SYSTEM_PROMPT` `:58-63`): add: *"Set is_free=true ONLY when the menu explicitly signals no charge (e.g. 'free entry', 'no cover charge'); otherwise omit it. Include suggested_time_of_day only when a serving window is stated (e.g. 'Saturday brunch', 'happy hour 4–6pm'); otherwise omit it. Do not guess."*
+- `tool_args` (`parse-restaurant-menu/index.ts:193-203`): add `is_free: exp.is_free`, `suggested_time_of_day: exp.suggested_time_of_day`.
+
+**Ve6 — `geminiActivitiesParser.ts`:**
+- `suggested_time_of_day` + `capacity_min/max` ALREADY exist (`:54-56`). Add only `is_free: { type: "boolean" }` to the schema (`:48-57`) + the interface (`:18-29`) + the normalizer (`:96-132`): `is_free` → `typeof raw.is_free === "boolean" ? raw.is_free : null`.
+- Prompt (`SYSTEM_PROMPT` `:66-74`): add the same is_free instruction.
+- `tool_args` (`parse-play-activities/index.ts:204-217`): add `is_free: exp.is_free`.
+
+**Vibes / canonical intents — schema-level decision (LOCKED):** the parsers KEEP emitting their existing `intent_tags` taxonomies (Ve5 free-text; Ve6 the Play vocab `friends_chill|group_activity|date_night_active|family_friendly|solo_exploration`). The canonical 4-id mapping happens deterministically in the **executor** (Phase 1, §4.4) — NOT in the Gemini prompt. Rationale: keeping the mapping in TypeScript (a) is deterministic + testable (no LLM variance), (b) avoids a second source of truth, (c) means the Play prompt's hard `filterPlayIntentTags` allowlist stays intact. (Optionally, the implementor MAY add a one-line prompt hint suggesting the model lean toward tags that map cleanly — but the binding mapping is code, per §4.4. This is the only acceptable prompt-side vibe change.)
+
+**Token budget:** the added fields are scalars/booleans/short strings × ≤20 experiences — cheap against `maxOutputTokens: 8192` (investigation F-4, RULED OUT as a blocker). Do NOT add long free-text fields.
+
+### 4.3 Phase 3 — currency de-GBP fix
+
+Replace every hardcoded `"GBP"` fallback in the TWO parser modules + their TWO edge entries so currency resolves from `brand.default_currency`, never a literal GBP:
+
+| Location | Current | Required |
+|---|---|---|
+| `geminiMenuParser.ts:61` (prompt) | `Use GBP if currency unclear.` | `If the printed currency is unclear, leave currency empty (do not guess a currency).` |
+| `geminiActivitiesParser.ts:69` (prompt) | `Use GBP if currency unclear.` | same as above |
+| `geminiMenuParser.ts:91,116,146` (normalizer `defaultCurrency` default + the `if (!currency) currency = defaultCurrency`) | defaults to `"GBP"` | the normalizer keeps using the passed `defaultCurrency` arg; CHANGE the exported `normalizeMenuParsePayload`'s default param from `"GBP"` to a required arg (or default to `""`) so a missing brand currency does NOT silently become GBP. Callers MUST pass the brand currency. |
+| `geminiActivitiesParser.ts:107,137,167` | same | same as Ve6 equivalent |
+| `parse-restaurant-menu/index.ts:158` | `(brand.default_currency ...)?.trim() || "GBP"` | `(brand.default_currency ...)?.trim() || null` → pass the brand currency through; if null, pass `null`/`""` so the normalizer leaves currency empty and the executor (§4.1-1) falls back to `brand.default_currency` server-side (single source of truth). |
+| `parse-play-activities/index.ts:165` | same | same |
+| `agentTools.ts:706` (executor) | `(brand.default_currency ?? "GBP")` | `brand.default_currency` (no GBP literal); if null, OMIT the `currency` key from the INSERT (DB default applies) — see §4.1-1. |
+
+**Net rule:** GBP is never a hardcoded default anywhere in the experience-parser path. The brand's `default_currency` is the single source of truth; when truly unknown, the field is left for the DB column default — not forced to GBP. Aligns with `[[project_orch_1034_currency_de_gbp_scope]]`.
+
+> NOTE: the unit-test default-param change (`normalizeMenuParsePayload(payload, defaultCurrency="GBP")`) is the only signature touch. If existing tests call it without the second arg expecting GBP, update those tests in lockstep (they're in the allowlist).
+
+### 4.4 The new shared canonical-vibe mapping helper
+
+**New file:** `supabase/functions/_shared/canonicalExperienceIntents.ts`.
+
+Exports:
+```
+export const CANONICAL_EXPERIENCE_INTENTS = ['adventurous','first-date','romantic','group-fun'] as const;
+export type CanonicalExperienceIntent = (typeof CANONICAL_EXPERIENCE_INTENTS)[number];
+export function mapToCanonicalExperienceIntents(rawTags: unknown, venueCategory: string | null): CanonicalExperienceIntent[];
+```
+
+**Behavior:** accept the raw `intent_tags` (free-text for Ve5, Play-vocab for Ve6). Lowercase + `trim` + `replace(/\s+/g,'_')` each tag, map via the table below, dedup, preserve the order of `CANONICAL_EXPERIENCE_INTENTS`, cap at 4. **Unmappable tags → DROP (never fabricate).** Return `[]` when nothing maps (executor then writes NULL).
+
+**The canonical-vibe mapping table (LOCKED).** Source = the 4 ids the DB CHECK enforces (`20260828…:57-62`) + the wizard vocab (`experienceIntents.ts:45-48`).
+
+Play-vocab tags (Ve6) → canonical:
+
+| Play tag | → canonical id |
+|---|---|
+| `group_activity` | `group-fun` |
+| `friends_chill` | `group-fun` |
+| `family_friendly` | `group-fun` |
+| `date_night_active` | `romantic` |
+| `solo_exploration` | `adventurous` |
+
+Free-text keyword mapping (Ve5 — substring/keyword match, case-insensitive, after normalization). Apply in order; first match wins per tag:
+
+| Keyword/substring in tag | → canonical id |
+|---|---|
+| `romantic`, `date_night`, `date-night`, `couple`, `intimate`, `candlelit`, `tasting_menu`, `wine_pairing`, `anniversary` | `romantic` |
+| `first_date`, `first-date`, `casual_date`, `meet`, `icebreaker` | `first-date` |
+| `adventur`, `explore`, `thrill`, `outdoor`, `active`, `solo`, `discover` | `adventurous` |
+| `group`, `friends`, `family`, `party`, `social`, `shareable`, `bottomless`, `brunch`, `happy_hour`, `crew`, `team` | `group-fun` |
+| (anything else) | DROP |
+
+> The mapping is intentionally conservative: when in doubt it drops rather than invents (Constitution #9). Ambiguous tags that match multiple rows resolve by the row order above (romantic > first-date > adventurous > group-fun). Edge-case ambiguities are flagged in §10 for the notify-list.
+
+**Why a shared `_shared/` helper (not the business-app `experienceIntents.ts`):** the executor runs in Deno edge-function land and cannot import from `mingla-business/src`. The id list MUST stay byte-identical to `experienceIntents.ts:45-48` + the DB CHECK; add a protective comment in both files cross-referencing each other and the migration.
+
+---
+
+## 5. Success criteria (numbered, observable, testable)
+
+**Phase 1:**
+- **SC-1:** Confirming a Ve6 (Play) snap whose `tool_args` carry `intent_tags:['group_activity','date_night_active']`, `currency:'NGN'`, `capacity_max:8`, `suggested_price_min_cents:2000`, `suggested_price_max_cents:4000` produces an `events` row with `experience_intents = {group-fun, romantic}`, `currency='NGN'`, `whole_price_cents=3000`, `status='draft'`, `visibility='draft'`, `published_at IS NULL`, AND exactly one `ticket_types` row with `quantity_total=8`, `is_unlimited=false`, `is_free=false`, `price_cents=3000`.
+- **SC-2:** Confirming a Ve5 (restaurant) snap with `intent_tags:['date-night tasting menu']`, no price → `experience_intents = {romantic}` (mapped) OR `{romantic}`; `ticket_types` row `is_free=true`, `price_cents=0`, `quantity_total IS NULL`, `is_unlimited=true`.
+- **SC-3:** A snap whose `intent_tags` map to NOTHING (e.g. `['gluten_free']`) writes `experience_intents = NULL` (not an empty array → no CHECK violation) and inserts successfully.
+- **SC-4:** Opening any Phase-1 snapped draft in the wizard shows the vibes pre-selected, the currency correct, the free/capacity toggle pre-set, and the price prefilled — with ZERO wizard code change (prefill is via `experienceDetailService.ts` read-back; assert the service returns the populated `experienceIntents`, `currency`, `ticket.{isFree,quantityTotal,isUnlimited}`).
+- **SC-5 (invariant):** No Phase-1 snapped draft has any `event_dates` row, any `experience_stops` row, any `cover_media_url`, or `published_at != NULL`.
+- **SC-6 (Ari no-regression):** Ari calling `create_experience` with only `{brand_id,title,narrative}` succeeds, produces a draft with `experience_intents=NULL`, a free/unlimited Standard ticket, and is otherwise identical to today's behavior (title/narrative/draft-shell).
+
+**Phase 2:**
+- **SC-7:** Ve5 Gemini schema includes `is_free` + `suggested_time_of_day`; a menu image stating "Free entry" yields `is_free=true`; one without yields `is_free=null` (NOT false-fabricated). `suggested_time_of_day` is null when no window is printed.
+- **SC-8:** Ve6 Gemini schema includes `is_free`; unchanged capacity/time-of-day behavior preserved.
+- **SC-9:** A field absent from the photo is null in the parser output (no fabrication) — verified at the normalizer for `is_free` and `suggested_time_of_day`.
+
+**Phase 3:**
+- **SC-10:** Neither `geminiMenuParser.ts` nor `geminiActivitiesParser.ts` nor the two edge entries nor the executor contains a hardcoded `"GBP"` literal as a currency fallback. (`grep -n '"GBP"'` over the 5 files returns no fallback-default occurrences.)
+- **SC-11:** A snap under a brand with `default_currency='NGN'` and an unreadable menu currency yields `currency='NGN'` end-to-end (parser leaves currency empty → executor resolves from brand).
+
+Surfaces 4/5/7 are served by identical shared code → no per-surface split needed (§3).
+
+---
+
+## 6. Invariants
+
+| Invariant | How preserved | Verifying test |
+|---|---|---|
+| **I-1 ONE-TICKET** (META-ORCH-1059; `20260824…:19,489-507`) | The executor writes EXACTLY ONE `ticket_types` row, mirroring the RPC defaults | SC-1 asserts exactly one ticket row |
+| **I-2 / I-4 — no AI path produces a published, sellable, dateless experience** (`agentTools.ts:647-653`) | Still `status/visibility='draft'`, `published_at=null`, NO `event_dates`; the added ticket has no date → unsellable | SC-5 |
+| **`events_experience_intents_chk`** (`20260828…:57-62`) — array is NULL or 1–4 of the 4 ids | The helper caps at 4 + drops unmappable; executor writes NULL (never `[]`) when empty | SC-3 |
+| **`experience_stops` 2–5 fires only at publish** (`20260824…:23`) — a draft may have 0 stops | The executor writes NO stops; draft is invariant-safe | SC-5 |
+| **I-BRAND-UNIVERSAL-AUTHORING** (META-ORCH-0972) — no kind gate | The executor keeps `assertBrandOwned` + the venue_category-driven (not kind-gated) branch | SC-6 |
+
+**New invariant (DRAFT — flips ACTIVE on CLOSE; orchestrator owns the flip):**
+- **`I-PROPOSED-1146-PARSER-CANONICAL-VIBES-OR-NULL`** — *"The experience-confirm executor MUST persist parser-extracted vibes only as the canonical 4-id vocabulary (`adventurous|first-date|romantic|group-fun`); unmappable tags are dropped; the `experience_intents` column is written as NULL (never an empty array) when nothing maps. No AI path fabricates a vibe not derivable from the source tags."*
+- **`I-PROPOSED-1146-PARSER-NO-GBP-DEFAULT`** — *"The experience-parser path MUST resolve currency from `brand.default_currency`; no hardcoded 'GBP' fallback in the parsers, edge entries, or executor."*
+- **`I-PROPOSED-1146-AI-EXPERIENCE-STAYS-DRAFT`** — *"No AI/snap path writes `event_dates`, `experience_stops`, `cover_media_*`, or `published_at` for an experience; those remain unset until the brand finishes the draft in the wizard."* (Restates I-2/I-4 for the parser surface.)
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|---|---|---|---|---|
+| T1 (happy, Ve6) | Play snap full fields | tool_args §SC-1 | events + 1 ticket as SC-1; vibes `{group-fun,romantic}` | executor |
+| T2 (happy, Ve5) | Restaurant snap, no price, romantic tag | `intent_tags:['date-night tasting menu']`, no price | `experience_intents={romantic}`, free unlimited ticket | executor + helper |
+| T3 (edge) | Unmappable tags only | `intent_tags:['gluten_free','vegan']` | `experience_intents=NULL`, insert succeeds (no CHECK fail) | executor + helper |
+| T4 (edge) | >4 mappable tags | 6 tags mapping to all 4 + dups | array capped at 4, deduped, ordered | helper |
+| T5 (Ari no-reg) | Ari minimal call | `{brand_id,title,narrative}` | draft + free/unlimited ticket; `experience_intents=NULL`; no throw | executor (Ari path) |
+| T6 (invariant) | Any snap | any | 0 event_dates, 0 stops, null cover, draft visibility | executor |
+| T7 (currency) | Brand NGN, currency arg absent | no `args.currency`, brand `default_currency='NGN'` | events.currency='NGN'; ticket currency='NGN' | executor + Phase 3 |
+| T8 (no-fabrication) | Ve5 normalizer, no is_free in raw | `{title,narrative}` only | `is_free=null`, `suggested_time_of_day=null` | normalizer |
+| T9 (atomicity) | ticket insert fails after events insert | forced ticket error | executor throws WRITE_FAILED + orphan events row soft-deleted | executor |
+| T10 (grep gate) | GBP-fallback strict-grep | the 5 files | no hardcoded `"GBP"` currency default | CI |
+
+---
+
+## 8. Implementation order (LOCKED phases)
+
+**Phase 1 (ship first):**
+1. Create `supabase/functions/_shared/canonicalExperienceIntents.ts` (§4.4) + its unit test (T2/T3/T4).
+2. Edit `agentTools.ts` executor (§4.1): currency→column, vibes→column via helper, ONE ticket_types row (is_free + capacity), compensating orphan-delete. Preserve all existing behavior + the blob.
+3. Add the agentTools experience-confirm test file (T1/T2/T3/T5/T6/T7/T9).
+
+**Phase 2:**
+4. `geminiMenuParser.ts`: schema + interface + normalizer + prompt for `is_free` + `suggested_time_of_day`; `parse-restaurant-menu/index.ts` tool_args.
+5. `geminiActivitiesParser.ts`: schema + interface + normalizer + prompt for `is_free`; `parse-play-activities/index.ts` tool_args.
+6. Normalizer unit tests (T8).
+
+**Phase 3:**
+7. Replace GBP fallbacks across the 5 files (§4.3) + the normalizer default-param signature change + lockstep test updates; add the strict-grep gate (T10).
+
+Deploy edge functions from MERGED main (clobber hazard, per memory `[[feedback_edge_deploy_and_migration_apply_hazards]]`). **No migration** is required — all target columns/tables (`events.currency`, `events.experience_intents`, `ticket_types`) already exist. Coordinate parser-file edits with the ORCH-1144 worktree if still in flight (investigation Discovery #4).
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+1. **Structural safeguard:** the canonical-vibe mapping lives in one shared TS helper with a frozen id list + a protective comment cross-referencing the DB CHECK (`20260828…:57-62`) and `experienceIntents.ts:45-48`.
+2. **Fails-on-revert test (primary):** `supabase/functions/_shared/__tests__/orch_1146_create_experience_field_completeness.test.ts` runs T1 — asserts the snapped tool_args produce a fully-populated draft (vibes canonicalized + currency column + ticket with is_free/capacity + price) and that dates/cover/stops/published_at are null. This test **FAILS when §4.1 is reverted** (the executor reverts to writing only the 14-column shell, so `experience_intents`/`currency`/the ticket assertions fail) and **PASSES when restored**. Include a protective comment: *"ORCH-1146 — snapped experiences must arrive with every inferable field in its real column; do not collapse the confirm executor back to a title/narrative shell."*
+3. **Adversarial tests (MUST also pass):**
+   - **Ari no-regression (T5):** asserts the minimal Ari call still works and adds only additive output — fails if a new required param sneaks in.
+   - **Unmappable-vibe-dropped (T3):** asserts `experience_intents=NULL` for non-matching tags and that the CHECK is NOT violated.
+   - **No-fabrication (T8):** asserts the Ve5/Ve6 normalizers leave `is_free`/`suggested_time_of_day` null when absent from the raw payload.
+4. **Strict-grep gate (T10):** a CI script (e.g. `scripts/gates/orch-1146-no-gbp-currency-default.mjs`) greps the 5 parser-path files for a hardcoded `"GBP"` currency fallback and fails the build if reintroduced.
+
+---
+
+## 10. Open questions (for the notify-list)
+
+- **Q1 — vibe-mapping ambiguities:** the Play tag `family_friendly` is mapped to `group-fun` (there is no "family" canonical id). Confirm `group-fun` is the right home, vs dropping it. Likewise `solo_exploration → adventurous` (no "solo" id). LOCKED to the table above unless Seth overrides.
+- **Q2 — free-text Ve5 keyword breadth:** the keyword list (§4.4) is a starting set. After ~5–10 real menu snaps, the mapping may need tuning (e.g. cuisine → vibe). Flag as a fast-follow, not a blocker.
+- **Q3 — price range has no real schema home:** the schema holds ONE price (`whole_price_cents` + the single ticket's `price_cents`). The SPEC keeps the midpoint as the sellable value and preserves min/max in `theme.experience_meta` only (audit/future prefill). The wizard does NOT prefill a range. If Seth wants the range surfaced, that's a wizard-UI change (out of scope — ORCH-1144 territory).
+- **Q4 — executor atomicity:** Phase 1 keeps the executor's two-direct-insert style + a compensating delete on ticket failure (§4.1-3). If Seth prefers true atomicity, an alternative is a thin `biz_create_experience_draft_shell` RPC — but that widens scope and touches the DB; NOT chosen here. Flag for decision.
+- **Q5 — `is_free` derive-vs-explicit ordering:** Phase 1 derives `is_free` from price absence; Phase 2 adds an explicit parser `is_free`. Confirm the precedence: explicit `args.is_free` (when present) wins over the price-derived value. (SPEC LOCKED to: explicit wins.)
+
+---
+
+## 11. Downstream routing
+
+**Next = `mingla-implementor` (Mingla Business + Supabase edge).** Build Phases 1→2→3 IN ORDER from this SPEC + the binding investigation, inside `~/Desktop/mingla-orchs/orch-1146-[experience-parser-field-completeness]` on branch `orch-1146-experience-parser-field-completeness` (rebase onto origin/main first). Hard constraints: additive-only on the SHARED `create_experience` executor (prove Ari no-regression), NO dated/publishable experience, NO UI change, NO migration, allowlist in §12. Output = implementation report under `Mingla_Artifacts/reports/`. Then → `mingla-tester` (verify SC-1..SC-11 + fails-on-revert + Ari no-reg, business iOS/Android/web preview) → `mingla-orchestrator` CLOSE (flip the three `I-PROPOSED-1146-*` invariants ACTIVE; reconcile any World Map scope per `[[feedback_shared_worldmap_scope_bleed]]`).
+
+---
+
+## 12. Scoped allowlist + DO-NOT-TOUCH
+
+### Allowlist — MAY add/modify
+| File | Phase | Change |
+|---|---|---|
+| `supabase/functions/_shared/canonicalExperienceIntents.ts` (NEW) | 1 | the shared vibe-mapping helper (§4.4) |
+| `supabase/functions/_shared/agentTools.ts` | 1 | `createExperience` executor: currency column, experience_intents column, ONE ticket_types row, compensating delete (§4.1) — executor ONLY |
+| `supabase/functions/_shared/geminiMenuParser.ts` | 2,3 | schema/interface/normalizer/prompt for `is_free`+`suggested_time_of_day`; GBP removal |
+| `supabase/functions/_shared/geminiActivitiesParser.ts` | 2,3 | schema/interface/normalizer/prompt for `is_free`; GBP removal |
+| `supabase/functions/parse-restaurant-menu/index.ts` | 2,3 | tool_args additions; brand-currency passthrough (no GBP literal) |
+| `supabase/functions/parse-play-activities/index.ts` | 2,3 | tool_args additions; brand-currency passthrough (no GBP literal) |
+| `supabase/functions/_shared/__tests__/orch_1146_*.test.ts` (NEW) | 1,2,3 | the regression + adversarial tests (§9) |
+| `scripts/gates/orch-1146-no-gbp-currency-default.mjs` (NEW) | 3 | strict-grep gate (T10) |
+| Existing tests that call `normalizeMenuParsePayload`/`normalizeActivitiesParsePayload` with the old GBP default | 3 | lockstep signature update only |
+
+### DO-NOT-TOUCH
+- `mingla-business/src/components/experience/ExperienceCreatorWizard.tsx`, `ExperienceReviewCards.tsx`, `ExperienceConfirmationCard.tsx`, `experienceWizardTypes.ts`, `useExperienceDraftAdapter.ts` — NO UI change; prefill is automatic via read-back.
+- `mingla-business/src/services/experienceDetailService.ts` — it ALREADY reads back every field this SPEC fills; do not modify.
+- `mingla-business/src/constants/experienceIntents.ts` — read-only reference for the id list (add only a cross-ref comment if anything; do not change the ids).
+- `supabase/functions/_shared/playIntentTags.ts` — keep the Play allowlist intact (the canonical mapping consumes its output; it does not replace it).
+- `biz_create_experience` / `biz_publish_experience` RPCs + all `supabase/migrations/**` — NO migration; the AI confirm path does not call these RPCs.
+- `agent-chat/index.ts` / `agent-confirm-action/index.ts` — do NOT modify; only PROVE they're not regressed by the executor change.
+- Any consumer app, public/buyer web, admin, marketing surface.
+
+The implementor MUST stop-and-amend (request a SPEC amendment as `SPEC_AMENDMENT_ORCH-1146_*.md` or an in-file append) before touching anything outside the allowlist.

--- a/mingla-business/src/constants/experienceIntents.ts
+++ b/mingla-business/src/constants/experienceIntents.ts
@@ -40,6 +40,14 @@ export interface ExperienceIntentOption {
 /**
  * The 4 curated intents, mirrored from `ONBOARDING_INTENTS` in the consumer app.
  * Order matches the consumer list.
+ *
+ * ⚠️ ORCH-1146: this id list is the SINGLE SOURCE OF TRUTH for experience vibes.
+ * It is mirrored byte-for-byte by the DB CHECK `events_experience_intents_chk`
+ * (migration `20260828000000_meta_orch_1059_experience_intents_multi.sql:62-64`)
+ * and by the edge-side parser mapper
+ * `supabase/functions/_shared/canonicalExperienceIntents.ts`
+ * (CANONICAL_EXPERIENCE_INTENTS). Keep all three in sync — drift produces
+ * CHECK-violating writes from the snap-confirm path.
  */
 export const EXPERIENCE_INTENTS: readonly ExperienceIntentOption[] = [
   { id: "adventurous", label: "Adventurous", description: "Explore the unexpected", icon: "compass" },

--- a/supabase/functions/_shared/__tests__/orch_1146_create_experience.tester-adversarial.test.ts
+++ b/supabase/functions/_shared/__tests__/orch_1146_create_experience.tester-adversarial.test.ts
@@ -1,0 +1,272 @@
+// ORCH-1146 [experience-parser field completeness] — TESTER ADVERSARIAL.
+//
+// Different angle than the implementor's happy-path file
+// (orch_1146_create_experience_field_completeness.test.ts). This file attacks:
+//   ADV-1  is_free PRECEDENCE — explicit args.is_free=false on a zero/absent
+//          price must NOT be forced free (explicit wins over price-derivation).
+//   ADV-2  CAPACITY LEAK — capacity_max present on a RESTAURANT (Ve5) snap must
+//          NOT cap the ticket (capacity is a Play-only signal).
+//   ADV-3  TITLE BOUNDARY — a >120-char title still errors (INVALID_ARGS), no
+//          partial event/ticket write.
+//   ADV-4  CHECK-SAFETY (the highest-risk DB failure) — experience_intents is
+//          NEVER written as [] and NEVER as an invalid id. Adversarial inputs:
+//          all-unmappable, mixed mappable+garbage, case/whitespace variants,
+//          duplicate tags. The events.experience_intents CHECK requires a NULL
+//          column OR an array of length 1-4 of the 4 canonical ids.
+//   ADV-5  ORPHAN-CLEANUP ON EVENTS-INSERT FAILURE — if the events insert
+//          itself fails, NO ticket is written and the tool throws (no orphan).
+//
+// Append-only: brand-new file; modifies no existing test. The mock client below
+// is an independent re-implementation (not imported from the implementor file).
+
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { findTool, ToolError } from "../agentTools.ts";
+import {
+  CANONICAL_EXPERIENCE_INTENTS,
+  mapToCanonicalExperienceIntents,
+} from "../canonicalExperienceIntents.ts";
+
+// deno-lint-ignore no-explicit-any
+type Row = Record<string, any>;
+
+interface TableScript {
+  single?: Row | null;
+  error?: { message: string; code?: string } | null;
+}
+interface Recorder {
+  inserts: { table: string; payload: Row }[];
+  updates: { table: string; payload: Row }[];
+}
+
+function makeClient(scripts: Record<string, TableScript>, rec: Recorder) {
+  function builder(table: string) {
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+    const script = scripts[table] ?? {};
+    const chain: Record<string, unknown> = {};
+    const passthrough = () => chain;
+    const terminal = (data: unknown) =>
+      Promise.resolve({ data, error: script.error ?? null });
+    Object.assign(chain, {
+      select: () => Object.assign(terminal(null), chain),
+      insert: (payload: Row) => {
+        pendingInsert = payload;
+        rec.inserts.push({ table, payload });
+        return chain;
+      },
+      update: (payload: Row) => {
+        pendingUpdate = payload;
+        rec.updates.push({ table, payload });
+        return chain;
+      },
+      eq: passthrough,
+      in: passthrough,
+      is: passthrough,
+      maybeSingle: () => terminal(script.single ?? null),
+      single: () => terminal(script.single ?? null),
+      then: (resolve: (v: unknown) => void) =>
+        terminal(pendingInsert ?? pendingUpdate ?? null).then(resolve),
+    });
+    return chain;
+  }
+  return { from: (t: string) => builder(t) } as unknown as Parameters<
+    NonNullable<ReturnType<typeof findTool>>["executor"]
+  >[1];
+}
+
+const BRAND = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const USER = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const EVENT = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+function scriptsFor(
+  venueCategory: string | null,
+  defaultCurrency: string | null,
+  opts: { eventError?: { message: string; code?: string } } = {},
+): Record<string, TableScript> {
+  return {
+    brands: {
+      single: {
+        id: BRAND,
+        venue_category: venueCategory,
+        default_currency: defaultCurrency,
+      },
+    },
+    events: opts.eventError
+      ? { error: opts.eventError }
+      : { single: { id: EVENT, brand_id: BRAND, status: "draft" } },
+    ticket_types: {},
+  };
+}
+function ins(rec: Recorder, table: string): Row | undefined {
+  return rec.inserts.find((i) => i.table === table)?.payload;
+}
+
+// ── ADV-1: explicit is_free=false on absent price must NOT be forced free ────
+Deno.test("ORCH-1146 ADV-1: explicit is_free=false wins over price-derivation (no zero-price 'free')", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("play", "USD"), rec);
+  const tool = findTool("create_experience")!;
+  await tool.executor(
+    {
+      brand_id: BRAND,
+      title: "Paid-but-priceless workshop",
+      narrative: "A paid workshop where the AI didn't read a price.",
+      intent_tags: ["group_activity"],
+      is_free: false, // explicit — must override the price-absent derivation
+      // NO price supplied
+    },
+    client,
+    USER,
+  );
+  const tk = ins(rec, "ticket_types");
+  assert(tk, "ticket inserted");
+  // explicit is_free=false MUST be honored (not flipped to free by price absence)
+  assertEquals(tk!.is_free, false, "explicit is_free=false must win");
+  assertEquals(tk!.price_cents, 0, "no price → 0 cents, but ticket is NOT marked free");
+});
+
+// ── ADV-2: capacity_max on a RESTAURANT must NOT cap the ticket ──────────────
+Deno.test("ORCH-1146 ADV-2: capacity_max on a Ve5 RESTAURANT snap does NOT cap (Play-only signal)", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("restaurant", "USD"), rec);
+  const tool = findTool("create_experience")!;
+  await tool.executor(
+    {
+      brand_id: BRAND,
+      title: "Tasting menu",
+      narrative: "A restaurant tasting menu.",
+      intent_tags: ["tasting_menu"],
+      capacity_max: 4, // bogus for a restaurant — must be ignored
+    },
+    client,
+    USER,
+  );
+  const tk = ins(rec, "ticket_types");
+  assert(tk, "ticket inserted");
+  assertEquals(tk!.quantity_total, null, "restaurant ticket must stay uncapped");
+  assertEquals(tk!.is_unlimited, true, "restaurant ticket must be unlimited");
+});
+
+// ── ADV-3: >120-char title still errors, no partial write ───────────────────
+Deno.test("ORCH-1146 ADV-3: >120-char title → INVALID_ARGS, no event/ticket written", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("play", "USD"), rec);
+  const tool = findTool("create_experience")!;
+  const err = await assertRejects(
+    () =>
+      tool.executor(
+        {
+          brand_id: BRAND,
+          title: "x".repeat(121),
+          narrative: "valid narrative",
+          intent_tags: ["group_activity"],
+        },
+        client,
+        USER,
+      ),
+    ToolError,
+  );
+  assertEquals((err as ToolError).code, "INVALID_ARGS");
+  assertEquals(rec.inserts.length, 0, "no inserts on validation failure");
+});
+
+// ── ADV-4: CHECK-SAFETY — experience_intents never [] and never an invalid id ─
+Deno.test("ORCH-1146 ADV-4a: all-unmappable + case/whitespace/dup → column OMITTED (never [])", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("restaurant", "USD"), rec);
+  const tool = findTool("create_experience")!;
+  await tool.executor(
+    {
+      brand_id: BRAND,
+      title: "Allergen menu",
+      narrative: "Nothing maps to a vibe.",
+      intent_tags: ["  GLUTEN_FREE  ", "Vegan", "keto", "halal", "GLUTEN_FREE"],
+    },
+    client,
+    USER,
+  );
+  const ev = ins(rec, "events");
+  assert(ev, "events insert happened");
+  assertEquals(
+    "experience_intents" in ev!,
+    false,
+    "all-unmappable (incl. case/whitespace/dup variants) → key OMITTED, never []",
+  );
+});
+
+Deno.test("ORCH-1146 ADV-4b: mixed mappable+garbage → ONLY valid canonical ids, deduped, ≤4, in canonical order", () => {
+  // Direct helper assault (the CHECK contract is: NULL or 1-4 of the 4 ids).
+  const out = mapToCanonicalExperienceIntents(
+    [
+      "  Romantic Candlelit  ", // → romantic (case + whitespace)
+      "gluten_free", // garbage → drop
+      "GROUP party", // → group-fun
+      "solo_exploration", // → adventurous
+      "first-date", // → first-date
+      "romantic", // dup of romantic
+      42, // non-string → ignored
+      null, // non-string → ignored
+    ],
+    "restaurant",
+  );
+  // Every emitted id MUST be a member of the canonical set.
+  for (const id of out) {
+    assert(
+      (CANONICAL_EXPERIENCE_INTENTS as readonly string[]).includes(id),
+      `emitted id '${id}' must be canonical`,
+    );
+  }
+  // No duplicates.
+  assertEquals(new Set(out).size, out.length, "no duplicate ids");
+  // Length within 1-4 (CHECK bound).
+  assert(out.length >= 1 && out.length <= 4, "length must be 1-4");
+  // Canonical order preserved: adventurous, first-date, romantic, group-fun.
+  assertEquals(out, ["adventurous", "first-date", "romantic", "group-fun"]);
+});
+
+Deno.test("ORCH-1146 ADV-4c: empty array / non-array inputs → [] (executor then omits → NULL)", () => {
+  assertEquals(mapToCanonicalExperienceIntents([], "play"), []);
+  assertEquals(mapToCanonicalExperienceIntents(null, "play"), []);
+  assertEquals(mapToCanonicalExperienceIntents("group_activity", "play"), []); // not an array
+  assertEquals(mapToCanonicalExperienceIntents([""], "play"), []); // empty string drops
+});
+
+// ── ADV-5: events-insert failure → no ticket, tool throws, no orphan cleanup needed ─
+Deno.test("ORCH-1146 ADV-5: events insert fails → throws, NO ticket written, NO stray update", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(
+    scriptsFor("play", "USD", { eventError: { message: "rls denied" } }),
+    rec,
+  );
+  const tool = findTool("create_experience")!;
+  await assertRejects(
+    () =>
+      tool.executor(
+        {
+          brand_id: BRAND,
+          title: "Will fail at events insert",
+          narrative: "events insert rejected.",
+          intent_tags: ["group_activity"],
+        },
+        client,
+        USER,
+      ),
+    ToolError,
+  );
+  // No ticket should be attempted when the parent insert failed.
+  assertEquals(
+    rec.inserts.some((i) => i.table === "ticket_types"),
+    false,
+    "no ticket insert after a failed events insert",
+  );
+  // No compensating soft-delete (there is no orphan to clean).
+  assertEquals(
+    rec.updates.some((u) => u.table === "events"),
+    false,
+    "no orphan soft-delete when the events insert itself failed",
+  );
+});

--- a/supabase/functions/_shared/__tests__/orch_1146_create_experience_field_completeness.test.ts
+++ b/supabase/functions/_shared/__tests__/orch_1146_create_experience_field_completeness.test.ts
@@ -1,0 +1,339 @@
+// ORCH-1146 [experience-parser field completeness]
+// Implementor happy-path + guard regression (mingla-implementor side).
+// The tester writes the adversarial counterpart separately.
+//
+// PRIMARY (fails-on-revert) — T1: confirming a snapped Ve6 tool_args set must
+// produce a FULLY-POPULATED draft: experience_intents canonicalized + currency
+// column + ONE ticket_types row carrying is_free/capacity/price — and dates /
+// cover / stops / published_at left null. This test FAILS if §4.1 of the spec
+// is reverted (the executor collapses back to a 14-column title/narrative shell
+// with no currency column, no experience_intents, and NO ticket row).
+//
+// Also covers:
+//   T2  (Ve5, no price, romantic tag)  → {romantic}, free unlimited ticket
+//   T3  (unmappable tags only)         → experience_intents OMITTED (NULL, no CHECK fail)
+//   T5  (Ari minimal call)             → draft + free/unlimited ticket; intents NULL; no throw
+//   T6  (invariant)                    → 0 dates/stops, null cover, draft visibility
+//   T7  (currency from brand)          → currency='NGN' on event + ticket
+//   T9  (atomicity)                    → ticket insert fails ⇒ throws WRITE_FAILED + orphan soft-deleted
+//
+// ⚠️ ORCH-1146 — snapped experiences must arrive with every inferable field in
+// its real column; do not collapse the confirm executor back to a
+// title/narrative shell.
+
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { findTool, ToolError } from "../agentTools.ts";
+
+// ── mock Supabase client (chainable query-builder) ──────────────────────────
+// deno-lint-ignore no-explicit-any
+type Row = Record<string, any>;
+
+interface TableScript {
+  // row returned by single()/maybeSingle()
+  single?: Row | null;
+  // error to surface on the terminal (insert/select)
+  error?: { message: string; code?: string } | null;
+}
+
+interface Recorder {
+  inserts: { table: string; payload: Row }[];
+  updates: { table: string; payload: Row }[];
+}
+
+function makeClient(scripts: Record<string, TableScript>, rec: Recorder) {
+  function builder(table: string) {
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+    const script = scripts[table] ?? {};
+    const chain: Record<string, unknown> = {};
+    const passthrough = () => chain;
+    const terminal = (data: unknown) =>
+      Promise.resolve({ data, error: script.error ?? null });
+
+    Object.assign(chain, {
+      select: () => Object.assign(terminal(null), chain),
+      insert: (payload: Row) => {
+        pendingInsert = payload;
+        rec.inserts.push({ table, payload });
+        return chain;
+      },
+      update: (payload: Row) => {
+        pendingUpdate = payload;
+        rec.updates.push({ table, payload });
+        return chain;
+      },
+      eq: passthrough,
+      in: passthrough,
+      is: passthrough,
+      maybeSingle: () => terminal(script.single ?? null),
+      single: () => terminal(script.single ?? null),
+      // `await chain` after an insert with no .select()/.single() (the ticket
+      // insert + the orphan-delete update both terminate this way).
+      then: (resolve: (v: unknown) => void) =>
+        terminal(pendingInsert ?? pendingUpdate ?? null).then(resolve),
+    });
+    return chain;
+  }
+  return { from: (t: string) => builder(t) } as unknown as Parameters<
+    NonNullable<ReturnType<typeof findTool>>["executor"]
+  >[1];
+}
+
+const OWNED_BRAND_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const USER_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const NEW_EVENT_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+// Build the standard scripts for a successful snap-confirm under a brand with
+// `venue_category` + `default_currency`. `assertBrandOwned` reads brands(id);
+// the executor then re-reads brands(venue_category, default_currency); the
+// events insert returns the new row id; the ticket insert succeeds.
+function scriptsFor(
+  venueCategory: string | null,
+  defaultCurrency: string | null,
+  opts: { ticketError?: { message: string } } = {},
+): Record<string, TableScript> {
+  return {
+    brands: {
+      single: {
+        id: OWNED_BRAND_ID,
+        venue_category: venueCategory,
+        default_currency: defaultCurrency,
+      },
+    },
+    events: {
+      single: { id: NEW_EVENT_ID, brand_id: OWNED_BRAND_ID, status: "draft" },
+    },
+    ticket_types: { error: opts.ticketError ?? null },
+  };
+}
+
+function getInsert(rec: Recorder, table: string): Row | undefined {
+  return rec.inserts.find((i) => i.table === table)?.payload;
+}
+
+// ── T1 (happy, Ve6) — full-field draft ──────────────────────────────────────
+Deno.test("ORCH-1146 T1: Ve6 snap → canonical intents + currency column + ONE ticket (cap/free/price)", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("play", "GBP"), rec);
+  const tool = findTool("create_experience");
+  assert(tool, "create_experience registered");
+
+  await tool!.executor(
+    {
+      brand_id: OWNED_BRAND_ID,
+      title: "Lane + pitcher for 8",
+      narrative: "Bowling lane and a pitcher, great for a crew.",
+      intent_tags: ["group_activity", "date_night_active"],
+      currency: "NGN",
+      capacity_max: 8,
+      suggested_price_min_cents: 2000,
+      suggested_price_max_cents: 4000,
+    },
+    client,
+    USER_ID,
+  );
+
+  // events row — canonical intents + currency column + draft invariants.
+  const ev = getInsert(rec, "events");
+  assert(ev, "events insert happened");
+  assertEquals(ev!.experience_intents, ["romantic", "group-fun"]); // canonical order
+  assertEquals(ev!.currency, "NGN");
+  assertEquals(ev!.whole_price_cents, 3000); // midpoint
+  assertEquals(ev!.status, "draft");
+  assertEquals(ev!.visibility, "draft");
+  assertEquals(ev!.published_at, null);
+
+  // exactly ONE ticket_types row (I-1) with capacity + paid price.
+  const tickets = rec.inserts.filter((i) => i.table === "ticket_types");
+  assertEquals(tickets.length, 1, "exactly one ticket row");
+  const tk = tickets[0].payload;
+  assertEquals(tk.quantity_total, 8);
+  assertEquals(tk.is_unlimited, false);
+  assertEquals(tk.is_free, false);
+  assertEquals(tk.price_cents, 3000);
+  assertEquals(tk.currency, "NGN");
+  assertEquals(tk.name, "Standard");
+  assertEquals(tk.event_id, NEW_EVENT_ID);
+});
+
+// ── T2 (happy, Ve5) — no price, romantic free-text tag → {romantic}, free ──
+Deno.test("ORCH-1146 T2: Ve5 snap, no price, romantic tag → {romantic}, free unlimited ticket", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("restaurant", "USD"), rec);
+  const tool = findTool("create_experience");
+
+  await tool!.executor(
+    {
+      brand_id: OWNED_BRAND_ID,
+      title: "Date-night tasting menu",
+      narrative: "A candlelit five-course tasting.",
+      intent_tags: ["date-night tasting menu"],
+      // no price → free
+    },
+    client,
+    USER_ID,
+  );
+
+  const ev = getInsert(rec, "events");
+  assertEquals(ev!.experience_intents, ["romantic"]);
+  assertEquals(ev!.whole_price_cents, null);
+
+  const tk = getInsert(rec, "ticket_types");
+  assert(tk, "ticket inserted");
+  assertEquals(tk!.is_free, true);
+  assertEquals(tk!.price_cents, 0);
+  assertEquals(tk!.quantity_total, null);
+  assertEquals(tk!.is_unlimited, true);
+});
+
+// ── T3 (edge) — unmappable tags → experience_intents OMITTED (NULL) ──────────
+Deno.test("ORCH-1146 T3: unmappable tags → experience_intents key OMITTED (column stays NULL, no CHECK fail)", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("restaurant", "USD"), rec);
+  const tool = findTool("create_experience");
+
+  await tool!.executor(
+    {
+      brand_id: OWNED_BRAND_ID,
+      title: "Gluten-free brunch",
+      narrative: "Coeliac-friendly brunch dishes.",
+      intent_tags: ["gluten_free", "vegan"],
+    },
+    client,
+    USER_ID,
+  );
+
+  const ev = getInsert(rec, "events");
+  // Key must be ABSENT (never an empty array — the CHECK rejects []).
+  assertEquals(
+    "experience_intents" in ev!,
+    false,
+    "experience_intents must be omitted, not written as []",
+  );
+});
+
+// ── T5 (Ari no-regression) — minimal call still works, additive only ─────────
+Deno.test("ORCH-1146 T5: Ari minimal {brand_id,title,narrative} → draft + free/unlimited ticket; intents NULL; no throw", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  // Ari under a brand with NO venue_category + NO default_currency.
+  const client = makeClient(scriptsFor(null, null), rec);
+  const tool = findTool("create_experience");
+
+  const result = await tool!.executor(
+    {
+      brand_id: OWNED_BRAND_ID,
+      title: "Pop-up supper club",
+      narrative: "An intimate one-off supper.",
+    },
+    client,
+    USER_ID,
+  ) as { event: unknown };
+
+  assert(result.event, "returns the event (additive output)");
+
+  const ev = getInsert(rec, "events");
+  assertEquals(ev!.status, "draft");
+  assertEquals(ev!.visibility, "draft");
+  // No intents passed → key omitted (NULL).
+  assertEquals("experience_intents" in ev!, false);
+  // No brand currency + no arg → currency key omitted (DB default applies).
+  assertEquals("currency" in ev!, false);
+
+  // Still gains a free, unlimited Standard ticket.
+  const tk = getInsert(rec, "ticket_types");
+  assert(tk, "Ari draft still gets a ticket");
+  assertEquals(tk!.is_free, true);
+  assertEquals(tk!.is_unlimited, true);
+  assertEquals(tk!.quantity_total, null);
+  assertEquals("currency" in tk!, false);
+});
+
+// ── T6 (invariant) — no dates/stops/cover/published_at written ──────────────
+Deno.test("ORCH-1146 T6: snap writes NO event_dates/experience_stops/cover/published_at", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("play", "GBP"), rec);
+  const tool = findTool("create_experience");
+
+  await tool!.executor(
+    {
+      brand_id: OWNED_BRAND_ID,
+      title: "Escape room",
+      narrative: "60-minute room, up to 6.",
+      intent_tags: ["group_activity"],
+      capacity_max: 6,
+    },
+    client,
+    USER_ID,
+  );
+
+  // No inserts into the forbidden tables.
+  assertEquals(rec.inserts.some((i) => i.table === "event_dates"), false);
+  assertEquals(rec.inserts.some((i) => i.table === "experience_stops"), false);
+
+  const ev = getInsert(rec, "events");
+  assertEquals(ev!.published_at, null);
+  assertEquals("cover_media_url" in ev!, false);
+  assertEquals(ev!.timezone, "UTC");
+});
+
+// ── T7 (currency) — currency arg absent → resolved from brand.default_currency ─
+Deno.test("ORCH-1146 T7: no currency arg + brand NGN → events.currency='NGN' + ticket currency='NGN'", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(scriptsFor("play", "ngn"), rec); // lowercase brand value
+  const tool = findTool("create_experience");
+
+  await tool!.executor(
+    {
+      brand_id: OWNED_BRAND_ID,
+      title: "Arcade tournament",
+      narrative: "Friday night arcade tournament.",
+      intent_tags: ["group_activity"],
+      suggested_price_min_cents: 5000,
+      suggested_price_max_cents: 5000,
+    },
+    client,
+    USER_ID,
+  );
+
+  const ev = getInsert(rec, "events");
+  assertEquals(ev!.currency, "NGN"); // uppercased from brand default
+  const tk = getInsert(rec, "ticket_types");
+  assertEquals(tk!.currency, "NGN");
+});
+
+// ── T9 (atomicity) — ticket insert fails ⇒ throws + orphan events soft-deleted ─
+Deno.test("ORCH-1146 T9: ticket insert failure throws WRITE_FAILED and soft-deletes the orphan events row", async () => {
+  const rec: Recorder = { inserts: [], updates: [] };
+  const client = makeClient(
+    scriptsFor("play", "GBP", { ticketError: { message: "boom" } }),
+    rec,
+  );
+  const tool = findTool("create_experience");
+
+  const err = await assertRejects(
+    () =>
+      tool!.executor(
+        {
+          brand_id: OWNED_BRAND_ID,
+          title: "Mini golf 18",
+          narrative: "Round of mini golf.",
+          intent_tags: ["group_activity"],
+          suggested_price_min_cents: 1500,
+          suggested_price_max_cents: 1500,
+        },
+        client,
+        USER_ID,
+      ),
+    ToolError,
+  );
+  assertEquals((err as ToolError).code, "WRITE_FAILED");
+
+  // Compensating soft-delete of the orphan events row happened.
+  const evUpdates = rec.updates.filter((u) => u.table === "events");
+  assertEquals(evUpdates.length, 1, "exactly one events update (the orphan soft-delete)");
+  assert("deleted_at" in evUpdates[0].payload, "deleted_at stamped on the orphan");
+});

--- a/supabase/functions/_shared/__tests__/orch_1146_parser_field_completeness.test.ts
+++ b/supabase/functions/_shared/__tests__/orch_1146_parser_field_completeness.test.ts
@@ -1,0 +1,141 @@
+// ORCH-1146 [experience-parser field completeness]
+// Helper + normalizer unit tests (mingla-implementor side).
+//
+// Covers:
+//   T4  (helper) — >4 mappable tags: capped at 4, deduped, canonical order
+//   T8  (no-fabrication) — Ve5/Ve6 normalizers leave is_free / suggested_time_of_day
+//        null when absent from the raw payload
+//   helper edge — Play-vocab + free-text + already-canonical id passthrough
+//   de-GBP — normalizers do NOT inject "GBP" when no defaultCurrency is passed
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  CANONICAL_EXPERIENCE_INTENTS,
+  mapToCanonicalExperienceIntents,
+} from "../canonicalExperienceIntents.ts";
+import { normalizeMenuParsePayload } from "../geminiMenuParser.ts";
+import { normalizeActivitiesParsePayload } from "../geminiActivitiesParser.ts";
+
+// ── helper: the canonical id list is exactly the 4 the DB CHECK enforces ─────
+Deno.test("ORCH-1146 helper: canonical list is exactly the 4 CHECK ids in order", () => {
+  assertEquals(
+    [...CANONICAL_EXPERIENCE_INTENTS],
+    ["adventurous", "first-date", "romantic", "group-fun"],
+  );
+});
+
+// ── T4: >4 mappable tags → capped at 4, deduped, canonical order ─────────────
+Deno.test("ORCH-1146 T4: >4 mappable tags capped/deduped/ordered", () => {
+  const out = mapToCanonicalExperienceIntents(
+    [
+      "group_activity", // group-fun
+      "friends_chill", // group-fun (dup)
+      "date_night_active", // romantic
+      "solo_exploration", // adventurous
+      "first_date", // first-date
+      "family_friendly", // group-fun (dup)
+    ],
+    "play",
+  );
+  // All 4 ids present, deduped, in canonical order, capped at 4.
+  assertEquals(out, ["adventurous", "first-date", "romantic", "group-fun"]);
+});
+
+// ── helper: Play LOCKED mappings (Q1) ────────────────────────────────────────
+Deno.test("ORCH-1146 helper: family_friendly→group-fun, solo_exploration→adventurous", () => {
+  assertEquals(mapToCanonicalExperienceIntents(["family_friendly"], "play"), [
+    "group-fun",
+  ]);
+  assertEquals(mapToCanonicalExperienceIntents(["solo_exploration"], "play"), [
+    "adventurous",
+  ]);
+});
+
+// ── helper: free-text keyword mapping (Ve5), first-match by rule order ────────
+Deno.test("ORCH-1146 helper: free-text keywords map by rule order (romantic wins over group)", () => {
+  // 'tasting_menu' matches romantic; 'bottomless brunch' matches group-fun.
+  assertEquals(
+    mapToCanonicalExperienceIntents(["tasting menu", "bottomless brunch"], "restaurant"),
+    ["romantic", "group-fun"],
+  );
+  // 'explore the city' → adventurous.
+  assertEquals(
+    mapToCanonicalExperienceIntents(["explore the city"], "restaurant"),
+    ["adventurous"],
+  );
+});
+
+// ── helper: unmappable → [] (caller writes NULL) ─────────────────────────────
+Deno.test("ORCH-1146 helper: unmappable tags → empty array", () => {
+  assertEquals(mapToCanonicalExperienceIntents(["gluten_free", "vegan"], "restaurant"), []);
+  assertEquals(mapToCanonicalExperienceIntents(null, null), []);
+  assertEquals(mapToCanonicalExperienceIntents("not-an-array", null), []);
+});
+
+// ── helper: an already-canonical id passes through ───────────────────────────
+Deno.test("ORCH-1146 helper: already-canonical ids pass through (Ari direct)", () => {
+  assertEquals(
+    mapToCanonicalExperienceIntents(["group-fun", "romantic"], null),
+    ["romantic", "group-fun"], // re-ordered to canonical order
+  );
+});
+
+// ── T8: Ve5 normalizer leaves is_free / time-of-day null when absent ─────────
+Deno.test("ORCH-1146 T8: Ve5 normalizer — no is_free/time → null (no fabrication)", () => {
+  const out = normalizeMenuParsePayload({
+    experiences: [{ title: "Brunch", narrative: "Eggs and toast." }],
+  }, "USD");
+  assertEquals(out.length, 1);
+  assertEquals(out[0].is_free, null);
+  assertEquals(out[0].suggested_time_of_day, null);
+});
+
+// ── T8: Ve5 normalizer keeps explicit is_free / time-of-day ─────────────────
+Deno.test("ORCH-1146 T8b: Ve5 normalizer keeps explicit is_free=true + serving window", () => {
+  const out = normalizeMenuParsePayload({
+    experiences: [{
+      title: "Free entry happy hour",
+      narrative: "No cover charge.",
+      is_free: true,
+      suggested_time_of_day: "happy hour 4-6pm",
+    }],
+  }, "USD");
+  assertEquals(out[0].is_free, true);
+  assertEquals(out[0].suggested_time_of_day, "happy hour 4-6pm");
+});
+
+// ── T8: Ve6 normalizer leaves is_free null when absent ──────────────────────
+Deno.test("ORCH-1146 T8c: Ve6 normalizer — no is_free → null (no fabrication)", () => {
+  const out = normalizeActivitiesParsePayload({
+    experiences: [{
+      title: "Lane for 4",
+      narrative: "Bowling lane.",
+      intent_tags: ["group_activity"],
+    }],
+  }, "USD");
+  assertEquals(out[0].is_free, null);
+});
+
+Deno.test("ORCH-1146 T8d: Ve6 normalizer keeps explicit is_free=true", () => {
+  const out = normalizeActivitiesParsePayload({
+    experiences: [{
+      title: "Free play hour",
+      narrative: "Free arcade hour.",
+      intent_tags: ["group_activity"],
+      is_free: true,
+    }],
+  }, "USD");
+  assertEquals(out[0].is_free, true);
+});
+
+// ── de-GBP: no default arg → empty currency (NOT 'GBP') ──────────────────────
+Deno.test("ORCH-1146 de-GBP: normalizers never inject 'GBP' when defaultCurrency unset", () => {
+  const menu = normalizeMenuParsePayload({
+    experiences: [{ title: "X", narrative: "Y" }],
+  });
+  assertEquals(menu[0].currency, ""); // empty, not 'GBP'
+  const play = normalizeActivitiesParsePayload({
+    experiences: [{ title: "X", narrative: "Y", intent_tags: ["group_activity"] }],
+  });
+  assertEquals(play[0].currency, "");
+});

--- a/supabase/functions/_shared/agentTools.ts
+++ b/supabase/functions/_shared/agentTools.ts
@@ -12,6 +12,7 @@
 // deno-lint-ignore-file no-explicit-any
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
 import { filterPlayIntentTags } from "./playIntentTags.ts";
+import { mapToCanonicalExperienceIntents } from "./canonicalExperienceIntents.ts";
 
 export interface AgentTool {
   name: string;
@@ -671,6 +672,11 @@ const createExperience: AgentTool = {
       capacity_min: { type: "integer", description: "Play: minimum group size" },
       capacity_max: { type: "integer", description: "Play: maximum group size" },
       suggested_time_of_day: { type: "string", description: "Play: e.g. Friday evening" },
+      is_free: {
+        type: "boolean",
+        description:
+          "Optional: true when the offering is explicitly free (no charge). Omit to derive from price.",
+      },
       confidence: { type: "number", description: "AI confidence 0-1" },
     },
   },
@@ -701,9 +707,15 @@ const createExperience: AgentTool = {
       default_currency: string | null;
     };
     const venueCategory = brand.venue_category;
-    const currency = isString(args.currency)
+    // ORCH-1146 (Phase 3 — de-GBP): resolve currency from the explicit arg else
+    // the brand's default_currency. NEVER hardcode "GBP". When both are absent,
+    // `currency` is null and the `events`/`ticket_types` INSERTs OMIT the column
+    // so the DB default applies (single source of truth = brand currency).
+    const currency: string | null = isString(args.currency)
       ? args.currency.toUpperCase().slice(0, 3)
-      : (brand.default_currency ?? "GBP");
+      : (isString(brand.default_currency)
+        ? brand.default_currency.toUpperCase().slice(0, 3)
+        : null);
 
     let intentTags: string[] = [];
     if (venueCategory === "play") {
@@ -714,6 +726,16 @@ const createExperience: AgentTool = {
       }
       intentTags = intentTags.slice(0, 12);
     }
+
+    // ORCH-1146 (Phase 1): map the raw parser tags → the canonical 4-id vocab
+    // the `events.experience_intents` CHECK enforces. Unmappable tags are
+    // dropped; an empty result means we write NULL to the column (NEVER an
+    // empty array — the CHECK requires length 1–4 when non-null). The RAW tags
+    // stay in the blob (experienceMeta.intent_tags) for audit.
+    const canonicalIntents = mapToCanonicalExperienceIntents(
+      args.intent_tags,
+      venueCategory,
+    );
 
     let capacityMin: number | null = null;
     let capacityMax: number | null = null;
@@ -777,7 +799,7 @@ const createExperience: AgentTool = {
           )
         : null;
 
-    const row = {
+    const row: Record<string, unknown> = {
       brand_id: args.brand_id,
       created_by: userId,
       title: args.title.trim(),
@@ -793,6 +815,13 @@ const createExperience: AgentTool = {
       whole_price_cents: suggestedMidCents,
       theme,
     };
+    // ORCH-1146: write currency into its real column when resolved (else OMIT
+    // so the DB default applies — never a literal "GBP").
+    if (currency) row.currency = currency;
+    // ORCH-1146: write the canonical vibes into experience_intents ONLY when at
+    // least one tag mapped. When empty → OMIT the key (column stays NULL) — the
+    // CHECK forbids an empty array. The wizard prefills from this column.
+    if (canonicalIntents.length > 0) row.experience_intents = canonicalIntents;
 
     const { data, error } = await client
       .from("events")
@@ -808,6 +837,69 @@ const createExperience: AgentTool = {
       }
       throw new ToolError("WRITE_FAILED", error.message);
     }
+
+    const eventId = (data as { id?: string } | null)?.id;
+    if (!isString(eventId)) {
+      throw new ToolError("WRITE_FAILED", "Experience insert returned no id");
+    }
+
+    // ORCH-1146 (Phase 1): write the ONE ticket_types row the wizard reads back
+    // for the free/capacity/price prefill (I-1 ONE-TICKET — never N). Mirrors
+    // the RPC's single-ticket defaults (`20260824…:489-507`). The draft has no
+    // date → still unsellable (I-2/I-4 preserved). is_free precedence: explicit
+    // args.is_free wins (Phase-2 parser field); else derive from price absence.
+    const isFree = typeof args.is_free === "boolean"
+      ? args.is_free
+      : (suggestedMidCents === null || suggestedMidCents <= 0);
+    // Capacity is a Play-only signal (Ve6). Restaurants (Ve5) never state party
+    // size → always unlimited. quantity_total NULL ⇒ is_unlimited true.
+    const quantityTotal =
+      venueCategory === "play" && capacityMax !== null && capacityMax > 0
+        ? capacityMax
+        : null;
+    const ticketRow: Record<string, unknown> = {
+      event_id: eventId,
+      name: "Standard",
+      description: null,
+      price_cents: isFree ? 0 : (suggestedMidCents ?? 0),
+      quantity_total: quantityTotal,
+      is_unlimited: quantityTotal === null,
+      is_free: isFree,
+      min_purchase_qty: 1,
+      max_purchase_qty: null,
+      is_hidden: false,
+      is_disabled: false,
+      requires_approval: false,
+      allow_transfers: true,
+      password_protected: false,
+      available_online: true,
+      available_in_person: true,
+      waitlist_enabled: false,
+      display_order: 0,
+    };
+    // Currency on the ticket too — OMIT when unresolved (DB default applies).
+    if (currency) ticketRow.currency = currency;
+
+    const { error: ticketErr } = await client
+      .from("ticket_types")
+      .insert(ticketRow);
+    if (ticketErr) {
+      // ORCH-1146 atomicity (SPEC §4.1-3, Q4 LOCKED): the executor is two
+      // direct inserts, not a transaction. If the ticket insert fails after the
+      // events insert succeeded, COMPENSATE so a snap never leaves a
+      // ticket-less draft: soft-delete the orphan events row (deleted_at), then
+      // throw. Soft-delete (not hard) because RLS may block a hard delete; the
+      // event is a draft so a stamp is sufficient to hide it.
+      await client
+        .from("events")
+        .update({ deleted_at: new Date().toISOString() })
+        .eq("id", eventId);
+      throw new ToolError(
+        "WRITE_FAILED",
+        `Experience draft created but pricing setup failed: ${ticketErr.message}`,
+      );
+    }
+
     return { event: data };
   },
 };

--- a/supabase/functions/_shared/canonicalExperienceIntents.ts
+++ b/supabase/functions/_shared/canonicalExperienceIntents.ts
@@ -1,0 +1,173 @@
+// ORCH-1146 — canonical experience-intent mapping (Ve5 menu + Ve6 Play).
+//
+// The experience parsers emit their own tag taxonomies (Ve5: free-text;
+// Ve6: the Play allowlist `friends_chill|group_activity|date_night_active|
+// family_friendly|solo_exploration`). The `events.experience_intents` column,
+// however, accepts ONLY the canonical 4-id vocabulary enforced by the DB CHECK
+// `events_experience_intents_chk` (migration
+// `20260828000000_meta_orch_1059_experience_intents_multi.sql:57-62`) and
+// mirrored by the business-app wizard vocab
+// (`mingla-business/src/constants/experienceIntents.ts:44-49`).
+//
+// This helper maps the parser tags → the canonical ids DETERMINISTICALLY in the
+// confirm executor (NOT in the Gemini prompt — keeps a single, testable source
+// of truth, no LLM variance, and leaves the Play allowlist intact). Unmappable
+// tags are DROPPED (Constitution #9 — never fabricate a vibe). When nothing
+// maps, an empty array is returned and the executor writes NULL to the column
+// (NEVER an empty array — the CHECK requires length 1–4 when non-null).
+//
+// ⚠️ KEEP THE ID LIST BYTE-IDENTICAL to:
+//   - the DB CHECK (`20260828000000…:62-64`), and
+//   - `mingla-business/src/constants/experienceIntents.ts:44-49` (EXPERIENCE_INTENTS).
+// Any drift here will produce CHECK-violating writes.
+
+export const CANONICAL_EXPERIENCE_INTENTS = [
+  "adventurous",
+  "first-date",
+  "romantic",
+  "group-fun",
+] as const;
+
+export type CanonicalExperienceIntent =
+  (typeof CANONICAL_EXPERIENCE_INTENTS)[number];
+
+const CANONICAL_SET = new Set<string>(CANONICAL_EXPERIENCE_INTENTS);
+
+// Play-vocab tags (Ve6) → canonical id. LOCKED by Seth (SPEC §4.4 / Q1):
+//   family_friendly → group-fun (no "family" canonical id)
+//   solo_exploration → adventurous (no "solo" canonical id)
+const PLAY_TAG_MAP: Record<string, CanonicalExperienceIntent> = {
+  group_activity: "group-fun",
+  friends_chill: "group-fun",
+  family_friendly: "group-fun",
+  date_night_active: "romantic",
+  solo_exploration: "adventurous",
+};
+
+// Free-text keyword mapping (Ve5). Each rule is a substring match against the
+// normalized tag (lowercased, trimmed, spaces→underscores). Rules are applied
+// IN ORDER; the first matching rule wins for a given tag (romantic > first-date
+// > adventurous > group-fun). Intentionally conservative: anything matching no
+// rule is DROPPED (never invented). SPEC §4.4 table.
+const KEYWORD_RULES: Array<
+  { id: CanonicalExperienceIntent; substrings: string[] }
+> = [
+  {
+    id: "romantic",
+    substrings: [
+      "romantic",
+      "date_night",
+      "date-night",
+      "couple",
+      "intimate",
+      "candlelit",
+      "tasting_menu",
+      "wine_pairing",
+      "anniversary",
+    ],
+  },
+  {
+    id: "first-date",
+    substrings: [
+      "first_date",
+      "first-date",
+      "casual_date",
+      "meet",
+      "icebreaker",
+    ],
+  },
+  {
+    id: "adventurous",
+    substrings: [
+      "adventur",
+      "explore",
+      "thrill",
+      "outdoor",
+      "active",
+      "solo",
+      "discover",
+    ],
+  },
+  {
+    id: "group-fun",
+    substrings: [
+      "group",
+      "friends",
+      "family",
+      "party",
+      "social",
+      "shareable",
+      "bottomless",
+      "brunch",
+      "happy_hour",
+      "crew",
+      "team",
+    ],
+  },
+];
+
+function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+/** Map ONE raw tag → a canonical id, or null if it maps to nothing. */
+function mapOneTag(tag: string): CanonicalExperienceIntent | null {
+  const norm = normalizeTag(tag);
+  if (!norm) return null;
+
+  // 1. If the tag is ALREADY a canonical id (e.g. an Ari caller passing
+  //    'group-fun' directly), keep it. (Underscore-normalization turns the
+  //    hyphenated ids into 'group_fun'/'first_date', so check both forms.)
+  if (CANONICAL_SET.has(tag.trim().toLowerCase())) {
+    return tag.trim().toLowerCase() as CanonicalExperienceIntent;
+  }
+  const hyphenated = norm.replace(/_/g, "-");
+  if (CANONICAL_SET.has(hyphenated)) {
+    return hyphenated as CanonicalExperienceIntent;
+  }
+
+  // 2. Play allowlist exact-tag map (Ve6).
+  const play = PLAY_TAG_MAP[norm];
+  if (play) return play;
+
+  // 3. Free-text keyword rules (Ve5), first-match-wins by rule order.
+  for (const rule of KEYWORD_RULES) {
+    for (const sub of rule.substrings) {
+      if (norm.includes(sub)) return rule.id;
+    }
+  }
+
+  // 4. Unmappable → DROP.
+  return null;
+}
+
+/**
+ * Map an arbitrary `intent_tags` value (free-text Ve5 or Play-vocab Ve6) to the
+ * canonical 4-id vocabulary. Dedups, preserves the order of
+ * CANONICAL_EXPERIENCE_INTENTS, caps at 4, drops unmappable tags. Returns `[]`
+ * when nothing maps (caller writes NULL — never an empty array).
+ *
+ * @param rawTags  the parser's `intent_tags` (any shape; non-arrays → []).
+ * @param _venueCategory  reserved for future per-category mapping; unused today
+ *   (the mapping is taxonomy-driven, not category-gated). Accepted so the
+ *   executor can pass it without a future signature change.
+ */
+export function mapToCanonicalExperienceIntents(
+  rawTags: unknown,
+  _venueCategory: string | null,
+): CanonicalExperienceIntent[] {
+  if (!Array.isArray(rawTags)) return [];
+
+  const matched = new Set<CanonicalExperienceIntent>();
+  for (const tag of rawTags) {
+    if (typeof tag !== "string") continue;
+    const id = mapOneTag(tag);
+    if (id) matched.add(id);
+  }
+
+  // Preserve canonical order; cap at 4 (the full set is exactly 4).
+  return CANONICAL_EXPERIENCE_INTENTS.filter((id) => matched.has(id)).slice(
+    0,
+    4,
+  );
+}

--- a/supabase/functions/_shared/geminiActivitiesParser.ts
+++ b/supabase/functions/_shared/geminiActivitiesParser.ts
@@ -25,6 +25,8 @@ export interface ParsedPlayExperience {
   capacity_min: number | null;
   capacity_max: number | null;
   suggested_time_of_day: string | null;
+  // ORCH-1146 (Phase 2): null unless explicitly present in the photo.
+  is_free: boolean | null;
   confidence: number;
 }
 
@@ -54,6 +56,7 @@ const RESPONSE_SCHEMA = {
           capacity_min: { type: "integer" },
           capacity_max: { type: "integer" },
           suggested_time_of_day: { type: "string" },
+          is_free: { type: "boolean" },
           confidence: { type: "number" },
         },
         required: ["title", "narrative"],
@@ -66,12 +69,13 @@ const RESPONSE_SCHEMA = {
 const SYSTEM_PROMPT = `You are a Play-venue activities analyst for Mingla (bowling, arcade, escape room, mini-golf, etc.).
 Given photos or PDFs of an activities/packages/pricing list, extract single-intent experience offerings.
 Each experience is ONE clear bookable or walk-in offering (e.g. "Lane + pitcher for 4", "Friday night arcade tournament").
-Return JSON only. Cap at ${MAX_EXPERIENCES} experiences. Use GBP if currency unclear.
+Return JSON only. Cap at ${MAX_EXPERIENCES} experiences. If the printed currency is unclear, leave currency empty (do not guess a currency).
 If the upload is not an activities/packages list, return {"experiences":[]}.
 Do not invent offerings not supported by the source text.
 For intent_tags use ONLY: friends_chill, group_activity, date_night_active, family_friendly, solo_exploration.
 Include capacity_min and capacity_max when the source implies group size (e.g. lanes seat 6, escape room max 8).
-Include suggested_time_of_day when timing is implied (e.g. "Friday evening", "weekday afternoon").`;
+Include suggested_time_of_day when timing is implied (e.g. "Friday evening", "weekday afternoon").
+Set is_free=true ONLY when the source explicitly signals no charge (e.g. "free entry", "free play hour"); otherwise omit it. Do not guess.`;
 
 function clampConfidence(v: unknown): number {
   if (typeof v !== "number" || Number.isNaN(v)) return 0.5;
@@ -116,6 +120,8 @@ function normalizeExperience(
 
   const timeOfDay = asString(raw.suggested_time_of_day, 80) || null;
   const intentTags = filterPlayIntentTags(raw.intent_tags);
+  // ORCH-1146 (Phase 2): null unless explicitly present (no fabrication).
+  const isFree = typeof raw.is_free === "boolean" ? raw.is_free : null;
 
   return {
     title,
@@ -127,14 +133,21 @@ function normalizeExperience(
     capacity_min: capacityMin,
     capacity_max: capacityMax,
     suggested_time_of_day: timeOfDay,
+    is_free: isFree,
     confidence: clampConfidence(raw.confidence),
   };
 }
 
-/** Exported for unit tests — normalizes raw Gemini JSON. */
+/**
+ * Exported for unit tests — normalizes raw Gemini JSON.
+ *
+ * ORCH-1146 (Phase 3 — de-GBP): `defaultCurrency` defaults to "" (NOT "GBP").
+ * Callers MUST pass the brand currency; absent → "" flows through and the
+ * confirm executor resolves from `brand.default_currency` server-side.
+ */
 export function normalizeActivitiesParsePayload(
   payload: unknown,
-  defaultCurrency = "GBP",
+  defaultCurrency = "",
 ): ParsedPlayExperience[] {
   if (payload === null || typeof payload !== "object") return [];
   const experiences = (payload as { experiences?: unknown }).experiences;
@@ -164,7 +177,9 @@ export async function parseActivitiesWithGemini(args: {
     throw new Error("GEMINI_API_KEY_ARI is not configured");
   }
 
-  const defaultCurrency = args.defaultCurrency ?? "GBP";
+  // ORCH-1146 (Phase 3 — de-GBP): no GBP literal; edge entry passes brand
+  // currency, absent → "" (executor resolves from brand.default_currency).
+  const defaultCurrency = args.defaultCurrency ?? "";
   const temporaryCategory = args.temporaryCategory ?? "play";
   const parts: Array<{ text: string } | { inline_data: { mime_type: string; data: string } }> = [];
 

--- a/supabase/functions/_shared/geminiMenuParser.ts
+++ b/supabase/functions/_shared/geminiMenuParser.ts
@@ -20,6 +20,10 @@ export interface ParsedMenuExperience {
   suggested_price_max_cents: number | null;
   currency: string;
   intent_tags: string[];
+  // ORCH-1146 (Phase 2): null unless the field is explicitly present in the
+  // photo (no fabrication).
+  is_free: boolean | null;
+  suggested_time_of_day: string | null;
   confidence: number;
 }
 
@@ -46,6 +50,8 @@ const RESPONSE_SCHEMA = {
           suggested_price_max_cents: { type: "integer" },
           currency: { type: "string" },
           intent_tags: { type: "array", items: { type: "string" } },
+          is_free: { type: "boolean" },
+          suggested_time_of_day: { type: "string" },
           confidence: { type: "number" },
         },
         required: ["title", "narrative"],
@@ -58,7 +64,8 @@ const RESPONSE_SCHEMA = {
 const SYSTEM_PROMPT = `You are a restaurant menu analyst for Mingla, a social experiences platform.
 Given menu images or PDF pages, extract single-intent experience offerings a venue could promote.
 Each experience is ONE clear intent (e.g. "Bottomless brunch Saturdays", "Date-night tasting menu").
-Return JSON only. Cap at ${MAX_EXPERIENCES} experiences. Use GBP if currency unclear.
+Return JSON only. Cap at ${MAX_EXPERIENCES} experiences. If the printed currency is unclear, leave currency empty (do not guess a currency).
+Set is_free=true ONLY when the menu explicitly signals no charge (e.g. "free entry", "no cover charge"); otherwise omit it. Include suggested_time_of_day only when a serving window is stated (e.g. "Saturday brunch", "happy hour 4-6pm"); otherwise omit it. Do not guess.
 If the upload is not a menu, return {"experiences":[]}.
 Do not invent items not supported by the menu text.`;
 
@@ -99,6 +106,11 @@ function normalizeExperience(
     }
   }
 
+  // ORCH-1146 (Phase 2): only persist these when present in the raw payload —
+  // a missing field stays null (no fabrication).
+  const isFree = typeof raw.is_free === "boolean" ? raw.is_free : null;
+  const timeOfDay = asString(raw.suggested_time_of_day, 80) || null;
+
   return {
     title,
     narrative,
@@ -106,14 +118,23 @@ function normalizeExperience(
     suggested_price_max_cents: maxCents,
     currency,
     intent_tags: intentTags.slice(0, 12),
+    is_free: isFree,
+    suggested_time_of_day: timeOfDay,
     confidence: clampConfidence(raw.confidence),
   };
 }
 
-/** Exported for unit tests — normalizes raw Gemini JSON. */
+/**
+ * Exported for unit tests — normalizes raw Gemini JSON.
+ *
+ * ORCH-1146 (Phase 3 — de-GBP): `defaultCurrency` defaults to "" (NOT "GBP").
+ * Callers MUST pass the brand's currency; when truly unknown, an empty currency
+ * flows through and the confirm executor resolves it from `brand.default_currency`
+ * server-side (single source of truth). No hardcoded GBP anywhere in this path.
+ */
 export function normalizeMenuParsePayload(
   payload: unknown,
-  defaultCurrency = "GBP",
+  defaultCurrency = "",
 ): ParsedMenuExperience[] {
   if (payload === null || typeof payload !== "object") return [];
   const experiences = (payload as { experiences?: unknown }).experiences;
@@ -143,7 +164,9 @@ export async function parseMenuWithGemini(args: {
     throw new Error("GEMINI_API_KEY_ARI is not configured");
   }
 
-  const defaultCurrency = args.defaultCurrency ?? "GBP";
+  // ORCH-1146 (Phase 3 — de-GBP): no GBP literal. The edge entry passes the
+  // brand currency; absent → "" (executor resolves from brand.default_currency).
+  const defaultCurrency = args.defaultCurrency ?? "";
   const temporaryCategory = args.temporaryCategory ?? "restaurant";
   const parts: Array<{ text: string } | { inline_data: { mime_type: string; data: string } }> = [];
 

--- a/supabase/functions/parse-play-activities/index.ts
+++ b/supabase/functions/parse-play-activities/index.ts
@@ -162,7 +162,10 @@ Deno.serve(async (req) => {
   if (brand.account_id !== userId) {
     return errorResponse(403, "FORBIDDEN", "Brand not owned by caller");
   }
-  const defaultCurrency = (brand.default_currency as string | null)?.trim() || "GBP";
+  // ORCH-1146 (Phase 3 — de-GBP): pass the brand currency through; when absent
+  // pass undefined (not "GBP"). The parser leaves currency empty and the confirm
+  // executor resolves it from brand.default_currency server-side.
+  const defaultCurrency = (brand.default_currency as string | null)?.trim() || undefined;
   const temporaryCategory = "play" as const;
   const sourceCategory = (brand.venue_category as string | null)?.trim() || "unknown";
 
@@ -213,6 +216,7 @@ Deno.serve(async (req) => {
       capacity_min: exp.capacity_min,
       capacity_max: exp.capacity_max,
       suggested_time_of_day: exp.suggested_time_of_day,
+      is_free: exp.is_free,
       confidence: exp.confidence,
     };
 

--- a/supabase/functions/parse-restaurant-menu/index.ts
+++ b/supabase/functions/parse-restaurant-menu/index.ts
@@ -155,7 +155,10 @@ Deno.serve(async (req) => {
   if (brand.account_id !== userId) {
     return errorResponse(403, "FORBIDDEN", "Brand not owned by caller");
   }
-  const defaultCurrency = (brand.default_currency as string | null)?.trim() || "GBP";
+  // ORCH-1146 (Phase 3 — de-GBP): pass the brand currency through; when absent
+  // pass null (not "GBP"). The parser leaves currency empty and the confirm
+  // executor resolves it from brand.default_currency server-side.
+  const defaultCurrency = (brand.default_currency as string | null)?.trim() || undefined;
   const temporaryCategory = "restaurant" as const;
   const sourceCategory = (brand.venue_category as string | null)?.trim() || "unknown";
 
@@ -199,6 +202,8 @@ Deno.serve(async (req) => {
       currency: exp.currency,
       temporaryCategory,
       intent_tags: exp.intent_tags,
+      is_free: exp.is_free,
+      suggested_time_of_day: exp.suggested_time_of_day,
       confidence: exp.confidence,
     };
 


### PR DESCRIPTION
## ORCH-1146 — snapped experiences arrive with every inferable field filled

Fixes the Layer-2 bottleneck: the `create_experience` executor (shared `_shared/agentTools.ts`) was discarding most of what the Gemini parsers already extract. Now it persists into real columns:
- **vibes** → `events.experience_intents` (canonicalized to the 4 enforced ids via new `_shared/canonicalExperienceIntents.ts`; unmappable dropped; empty→NULL, never `[]`)
- **currency** → `events.currency` from brand `default_currency`
- **is_free + capacity** → a new `ticket_types` row (two inserts + compensating soft-delete on failure)

Plus Phase 2 (Ve5/Ve6 schemas widened for is_free + time-of-day) and Phase 3 (GBP fallback removed everywhere; new strict-grep gate).

### Guards
- **Ari no-regression:** `create_experience` is shared with the Ari chat — all fields additive/optional; minimal `{brand_id,title,narrative}` call still works (proven, 17 neighbor tests green).
- **No AI-published/dated experience** (drafts only); **no fabrication** (absent field → NULL); **no migration** (every column already exists).

### Evidence
- SPEC + investigation under `Mingla_Artifacts/`; IMPLEMENT + TEST reports in `reports/`.
- Tester verdict CONDITIONAL PASS (0 P0/P1/P2); CHECK-safety proven vs live DB constraint; 42 Deno tests green; implementor happy-path + tester adversarial both fails-on-revert.
- Sole condition: post-deploy smoke (edge fns deploy from merged main at close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)