### PR TITLE
ORCH-1149: in-app browser slides up + covers the consumer tab bar (no chrome change)

### DIFF
--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1149_INAPP_BROWSER_BOTTOM_GAP.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1149_INAPP_BROWSER_BOTTOM_GAP.md
@@ -1,0 +1,211 @@
+# INVESTIGATE — ORCH-1149 — in-app browser sheet leaves a bottom gap exposing the consumer tab nav
+
+**Phase:** INVESTIGATE (forensics sub-agent, Conductor dispatch)
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1149-[inapp-browser-bottom-anchor]/` on branch `ORCH-1149-inapp-browser-bottom-anchor` (rebased clean onto `origin/main`)
+**Date:** 2026-06-15
+**Confidence:** `proven` (static-layout root cause; orchestrator-reproduced on device; mechanism is a deterministic CSS fact, not a runtime/timing bug)
+**Comms ledger:** read on entry. No OPEN BLOCK entry targets forensics / ORCH-1149 / ALL. Open ALL-targeted entries are WARN-level (COMMS-0027 EAS OTA gotchas, COMMS-0035 expo-image-manipulator native drift) and do not bear on a pure-layout change. Nothing to ack as BLOCK.
+
+---
+
+## 1. Symptom summary (expected vs actual)
+
+**Reproducer (Seth-confirmed, orchestrator-reproduced):** Open a curated place card → tap the **"Policies & Reservations"** button on a stop (e.g. "Dram And Draught") → the in-app browser opens with title "Dram And Draught".
+
+- **Expected:** the in-app browser opens like every other Mingla sheet — bottom-anchored, flush to the bottom of the screen, covering the consumer in-tree tab bar (Explore / Discover / Friends / Likes / Profile). No nav bleed-through.
+- **Actual:** the browser renders as a **centered floating card** (`justifyContent:'center'`, fixed `height: SCREEN_HEIGHT * 0.85`, `width:'95%'`, all-four-corners `borderRadius: 20`, `animationType="fade"`). Because it floats mid-screen it leaves a **GAP at the bottom** through which the consumer tab bar is visible. It also opens with a fade, not a slide-up, so it does not feel like a Mingla sheet.
+
+This is a layout/animation defect only. WebView behavior, the dark title header, and the back/forward + lock/URL nav bar all function correctly.
+
+---
+
+## 2. Investigation manifest (every file read, in trace order)
+
+| # | File | Why |
+|---|------|-----|
+| 1 | `app-mobile/src/components/InAppBrowserModal.tsx` | The shared component under investigation — full verbatim read (262 lines). |
+| 2 | `app-mobile/src/components/ExpandedCardModal.tsx` (L1118-1140, L2265-2295, import L50) | Reproducer call site: curated "Policies & Reservations" button → `onOpenBrowser`; the two parent-owned `<InAppBrowserModal>` mounts (ticket L2273, policies L2282). |
+| 3 | `app-mobile/src/utils/normalizeWebsiteUrl.ts` (full) | Confirm I-WEBVIEW-URL-NORMALIZED lives in the call sites, not in the modal. |
+| 4 | `app-mobile/src/components/expandedCard/ActionButtons.tsx` (L35, L634) | Second normalizeWebsiteUrl consumer (single-place flow). |
+| 5 | `app-mobile/scripts/ci/orch-1022-expanded-card-modal-gating-check.mjs` (G-01…G-06, L40-78) | Confirm exactly what the gate asserts about `<InAppBrowserModal`. |
+| 6 | `app-mobile/src/components/ui/BaseBottomSheet.tsx` (header L1-80) | API + architecture invariants; decide in-place-raw-Modal vs route-through-BaseBottomSheet. |
+| 7 | `app-mobile/src/components/{ProfilePage,CustomPaywallScreen,OnboardingFlow}.tsx` (mount lines + imports) | Enumerate the other 3 consumers; confirm shared-component parity is automatic. |
+| 8 | `mingla-business/src/**` (grep) | Confirm the business app does NOT use `InAppBrowserModal` (different browser path) → out of scope. |
+| 9 | `Mingla_Artifacts/INVARIANT_REGISTRY.md` (gorhom-sole / NotificationsSheet sections) | Establish the RN-Modal-vs-gorhom precedent for sheets. |
+
+---
+
+## 3. Q-scorecard
+
+**Q1 — Is the centered-floating-card layout the root cause of the bottom gap?**
+Verdict: **YES — CONFIRMED ROOT CAUSE** (`proven`). See F-1.
+
+**Q2 — Does the fade animation (vs slide-up) make it not feel like a Mingla sheet?**
+Verdict: **YES — confirmed contributory layout fact** (`proven`). `animationType="fade"` at L73. See F-2.
+
+**Q3 — How many mount sites consume this shared component, and is parity automatic?**
+Verdict: **5 mount sites across 4 files; parity is AUTOMATIC** (single shared default export). See F-3.
+
+**Q4 — Does the orch-1022 gate require `<InAppBrowserModal` to be present, or absent?**
+Verdict: **NUANCED.** G-04 (line 74) requires `<InAppBrowserModal` to be **ABSENT from the curated sub-component body** (`curatedBody`) — it must delegate to the parent. The component is mounted in the parent `ExpandedCardModal` overlay block. The component NAME, file, default-export signature, and the parent mounts must all be preserved. A layout-only edit inside `InAppBrowserModal.tsx` does not touch any string the gate scans. See F-4. (The dispatch's "asserts present" framing was inverted; the binding fact is "preserve the component + its parent mounts; do not reintroduce it into curatedBody.")
+
+**Q5 — Is I-WEBVIEW-URL-NORMALIZED affected by a layout change?**
+Verdict: **NO.** Normalization happens in the call sites (`normalizeWebsiteUrl` at ExpandedCardModal L1128 / ActionButtons L634) before `url` is passed in; the modal renders `url` verbatim. A style/animation change cannot regress it. See F-5.
+
+**Q6 — In-place raw-Modal refactor vs route through BaseBottomSheet?**
+Verdict: **IN-PLACE RAW-MODAL REFACTOR** (`animationType="slide"`, bottom-anchored full-bleed). See F-6 for the full justification.
+
+**Q7 — Will un-centering create a new safe-area regression at the bottom edge?**
+Verdict: **YES if unhandled** — the WebView/footer would sit under the iOS home indicator / Android nav bar. Must add `useSafeAreaInsets().bottom`. See F-7.
+
+**Q8 — Is the business app in scope?**
+Verdict: **NO.** Zero `InAppBrowserModal` references in `mingla-business/src`; the business app uses a different browser path (expo WebBrowser / Stripe Connect embedded). Out of scope. See F-8.
+
+---
+
+## 4. Findings (six-field evidence)
+
+### F-1 — Centered floating card with fixed 0.85 height is the bottom-gap root cause — CONFIRMED ROOT CAUSE
+- **Symptom:** Browser floats mid-screen; consumer tab bar visible in the gap below it.
+- **Layer:** Code (component styles).
+- **Probe:** `Read InAppBrowserModal.tsx` lines 70-180 verbatim.
+- **Evidence:**
+  - L71-77: `<Modal visible animationType="fade" transparent onRequestClose onShow>`.
+  - L154-159 `overlay`: `{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' }`.
+  - L167-180 `modalContainer`: `{ width: '95%', maxWidth: 600, height: SCREEN_HEIGHT * 0.85, maxHeight: SCREEN_HEIGHT * 0.85, borderRadius: 20, overflow: 'hidden', shadow…, elevation: 10 }`.
+  - L181-190 `header`: `borderTopLeftRadius: 20`, `borderTopRightRadius: 20` (rounded top because the card floats).
+- **Mechanism:** `overlay` centers the `modalContainer` vertically; the container is fixed at 85% of screen height and 95% width with rounded bottom corners → ~7.5% of screen height remains uncovered at the bottom (plus the side insets), exposing the in-tree tab bar that every bottom-anchored Mingla sheet otherwise covers.
+- **Severity:** **CONFIRMED ROOT CAUSE.**
+
+### F-2 — `animationType="fade"` makes the open feel un-Mingla — confirmed contributory layout fact
+- **Symptom:** Browser fades in centered rather than sliding up from the bottom.
+- **Layer:** Code.
+- **Probe:** `Read InAppBrowserModal.tsx` L73.
+- **Evidence:** `animationType="fade"` on the RN `<Modal>`. Every other Mingla sheet slides up (BaseBottomSheet gorhom spring; legacy RN sheets used `animationType="slide"` per the NotificationsSheet invariant note).
+- **Mechanism:** fade + center = a dialog presentation, not a sheet presentation. Seth's locked decision item 2 requires switching to slide-up.
+- **Severity:** **SECONDARY ROOT CAUSE** (part of the same one-component fix; not independently shippable from F-1).
+
+### F-3 — 5 mount sites across 4 files; parity automatic — informational
+- **Symptom:** N/A (scope mapping).
+- **Layer:** Code.
+- **Probe:** `grep -rn "<InAppBrowserModal" src` and `grep -rn "import.*InAppBrowserModal" src`.
+- **Evidence (5 JSX mounts):**
+  - `ExpandedCardModal.tsx:2273` — ticket browser (`Tickets – <eventName>`), parent-owned.
+  - `ExpandedCardModal.tsx:2282` — policies/reservations browser, parent-owned (reproducer).
+  - `ProfilePage.tsx:602`.
+  - `CustomPaywallScreen.tsx:442`.
+  - `OnboardingFlow.tsx:3298`.
+  - Imports: ExpandedCardModal L50, CustomPaywallScreen L13, ProfilePage L48, OnboardingFlow L62 (ExpandedCardModal hosts both mounts). All are `import InAppBrowserModal from './InAppBrowserModal'` (single default export).
+- **Mechanism:** all 5 render the SAME default export. A style/animation change inside the component propagates to all 5 automatically — parity is automatic, no per-site edits required.
+- **Severity:** RULED OUT (not a defect; scope fact).
+
+### F-4 — orch-1022 gate G-04 requires `<InAppBrowserModal` ABSENT from curatedBody; component + parent mounts must be preserved — guard
+- **Symptom:** N/A (CI guard).
+- **Layer:** Code (CI gate).
+- **Probe:** `grep -n "InAppBrowserModal" scripts/ci/orch-1022-expanded-card-modal-gating-check.mjs` + read L40-78.
+- **Evidence:** Single hit at L74: `!curatedBody.includes("<InAppBrowserModal")` inside the **G-04** check ("curated policies no longer mount a nested browser modal"). The gate also requires (G-04) `onOpenBrowser: (url: string, title: string) => void` and `onOpenBrowser(normalized, stop.placeName)` in curatedBody, and (G-01/G-03) that `browserUrl`/`ticketBrowserUrl` drive the parent overlay. The component is mounted only in the parent overlay block.
+- **Mechanism:** The gate enforces the ORCH-1022 architecture (browser is parent-owned, not nested under the sheet). Editing only the *styles/animation inside* `InAppBrowserModal.tsx` changes none of the strings the gate scans (the gate reads `ExpandedCardModal.tsx`, not `InAppBrowserModal.tsx`). The fix must NOT: rename/delete the component, change the default export, change the `{ visible, url, title, onClose }` prop contract, or move any mount into curatedBody.
+- **Severity:** SUSPECTED CONTRIBUTOR (constraint, not defect) — must be enumerated as a hard guard in the SPEC.
+
+### F-5 — I-WEBVIEW-URL-NORMALIZED is call-site-owned; unaffected by layout change — RULED OUT as risk
+- **Symptom:** N/A.
+- **Layer:** Code.
+- **Probe:** `Read normalizeWebsiteUrl.ts` + ExpandedCardModal L1124-1135 + ActionButtons L634.
+- **Evidence:** `normalizeWebsiteUrl` is called at the button handlers (`const normalized = normalizeWebsiteUrl(stop.website); … onOpenBrowser(normalized, …)`) BEFORE the URL reaches the modal. `InAppBrowserModal` renders `source={{ uri: url }}` at L132 verbatim — it neither normalizes nor mutates the URL.
+- **Mechanism:** A change to `overlay`/`modalContainer`/`animationType` cannot affect URL normalization. Invariant preserved by construction. The SPEC must list `source={{ uri: url }}` and all WebView props as DO-NOT-TOUCH.
+- **Severity:** RULED OUT (as a risk introduced by this fix).
+
+### F-6 — In-place raw-Modal refactor is correct; routing through BaseBottomSheet is wrong — DECISION
+- **Symptom:** N/A (architecture decision).
+- **Layer:** Code / architecture.
+- **Probe:** `Read BaseBottomSheet.tsx` L1-80 + INVARIANT_REGISTRY.md (gorhom-sole + NotificationsSheet rule L259-263).
+- **Evidence:**
+  - BaseBottomSheet header L21-24: it is the **SOLE permitted importer of `@gorhom/bottom-sheet`** under `app-mobile/src/` (gate `meta-orch-0991-base-bottom-sheet-sole-consumer.mjs`). InAppBrowserModal must NOT import gorhom.
+  - BaseBottomSheet is built on the gorhom inline `<BottomSheet>` with snap points, `BOTTOM_NAV_CONTENT_HEIGHT` clearance, pan-down-to-dismiss `PanGestureHandler`, and `GestureHandlerRootView` inside an RN `<Modal>` — designed for *scrollable sheet content that clears the visible nav*, not a full-bleed, edge-to-edge, nav-COVERING WebView host. Adopting it would (a) violate the sole-consumer gate unless routed through the primitive, (b) fight gorhom's snap-point/pan-down model against a WebView that itself handles scroll, and (c) require the primitive to support a no-handle, full-screen, nav-covering mode it does not expose.
+  - ORCH-0908 precedent (BaseBottomSheet header L13-15): z-stacking over the in-tree tab bar is achieved by wrapping in an RN `<Modal transparent … statusBarTranslucent>`. The RN `<Modal>` mounts in its own native OS overlay window that renders over the in-tree tab bar regardless of tree position. InAppBrowserModal ALREADY uses a raw RN `<Modal transparent>` (L71-77) — it already layers over the tab bar; the ONLY problem is the centered, fixed-height, fade layout. The minimal correct fix is to keep the raw `<Modal>`, switch `animationType` to `"slide"`, and bottom-anchor a full-bleed container.
+  - NotificationsSheet invariant precedent (registry L261): RN `<Modal animationType="slide" transparent>` was the *legacy sheet pattern*; gorhom replaced it ONLY where a pan-down-to-close gesture over scrollable sheet content was required. A WebView host has no pan-down requirement (the WebView owns its scroll), so the raw-Modal slide pattern is appropriate here and does not regress any gesture.
+- **Mechanism:** In-place raw-Modal refactor is the smallest, gate-compliant, invariant-preserving change that satisfies all three locked decisions. Routing through BaseBottomSheet would widen scope, fight the gorhom model, and risk the sole-consumer gate.
+- **Severity:** RULED OUT (BaseBottomSheet route) / CONFIRMED (in-place raw-Modal route).
+
+### F-7 — Un-centering introduces a bottom safe-area regression if unhandled — SUSPECTED CONTRIBUTOR (pre-emptive)
+- **Symptom:** After bottom-anchoring, content would sit under the iOS home indicator / Android nav bar.
+- **Layer:** Code.
+- **Probe:** `grep -rn "useSafeAreaInsets" src/components/InAppBrowserModal.tsx` (none) + `useSafeAreaInsets` usage count across `src` (46 files).
+- **Evidence:** InAppBrowserModal currently does NOT use `useSafeAreaInsets` (it doesn't need to while centered with a 7.5% bottom margin). `react-native-safe-area-context` is used in 46 src files (widely available; `SafeAreaProvider` is mounted at the app root). Once the container is flush to the bottom, the rounded card no longer provides the implicit inset.
+- **Mechanism:** A bottom-anchored full-bleed sheet must pad its bottom edge by `useSafeAreaInsets().bottom` (applied to the WebView container / sheet footer) or content will be occluded by the home indicator. This is the single most likely regression of the un-centering operation — the SPEC must mandate it as a numbered success criterion on both platforms.
+- **Severity:** SUSPECTED CONTRIBUTOR (regression risk this fix must pre-empt).
+
+### F-8 — Business app uses a different browser path — out of scope — RULED OUT
+- **Symptom:** N/A (scope boundary).
+- **Layer:** Code.
+- **Probe:** `grep -rln "InAppBrowserModal" mingla-business/src` (0 hits) + `grep -rln "react-native-webview|openBrowserAsync" mingla-business/src`.
+- **Evidence:** Zero `InAppBrowserModal` references in `mingla-business/src`. The business app's WebView/browser usage is in `nativeCheckoutFlow.native.ts`, Stripe Connect / payments views (`BrandPaymentsView`, `BrandOnboardView`, `usePartnerStripe`, `useBrandStripeTaxAccountSession`) — a different surface and component. The consumer `app-mobile` `InAppBrowserModal` is consumer-only.
+- **Mechanism:** Business surfaces (#4 Business iOS, #5 Business Android) do not render this component → no parity work there.
+- **Severity:** RULED OUT (out of scope).
+
+---
+
+## 5. Five-Truth-Layer reconciliation
+
+| Layer | Finding | Contradiction? |
+|-------|---------|----------------|
+| **Docs** | No spec mandates the in-app browser be centered; every other Mingla sheet is bottom-anchored (BaseBottomSheet doctrine, NotificationsSheet invariant). | **YES** — Code (centered card) contradicts the product convention (bottom-anchored sheets). The Code layer holds the defect; the doctrine holds the truth. |
+| **Schema** | N/A — pure client layout; no DB/RLS/migration touched. | None. |
+| **Code** | `overlay justifyContent:'center'` + `modalContainer height: SCREEN_HEIGHT*0.85` + all-corner radius + `animationType="fade"` (F-1, F-2). | This is the defect. |
+| **Runtime** | Orchestrator reproduced on device: centered card, visible tab bar in the bottom gap, fade-in. Forensics confirms the static mechanism deterministically produces this (no timing/state dependence). | None — runtime matches the static prediction. |
+| **Data** | N/A — no data dependence; the bug reproduces for any URL. | None. |
+
+**Single contradiction:** Docs/convention (bottom-anchored sheet, covers nav) vs Code (centered floating card, exposes nav). Truth = the convention; Code is wrong. This is the entire bug.
+
+---
+
+## 6. Repro evidence
+
+- **Orchestrator light-scoping (cited in dispatch):** reproduced on device via curated place card "Dram And Draught" → "Policies & Reservations" → centered browser with the tab bar visible below.
+- **Forensics static confirmation:** the mechanism is a deterministic CSS layout fact (F-1) — `justifyContent:'center'` + fixed `SCREEN_HEIGHT*0.85` height with rounded bottom corners mathematically leaves an uncovered bottom strip on every device, for every URL, every time. There is no runtime/state/timing branch that could make it bottom-anchored. A booted sim is present (`iPhone 17 Pro` UDID `17091E60-…`); a Maestro live-fire was not run because (a) the bug is a static layout invariant already device-reproduced by the orchestrator, and (b) driving it requires building this worktree's dev build (symlinked `node_modules`), which is disproportionate for a deterministic style fact. **Confidence: `proven`** on the static-layout root cause; the device repro corroborates.
+
+---
+
+## 7. Blast radius / cross-surface map
+
+| # | Surface | In scope? | Behavior | Reason |
+|---|---------|-----------|----------|--------|
+| 1 | Consumer iOS (`app-mobile` iOS) | **YES** | Browser bottom-anchors, slides up, covers tab bar, respects bottom safe-area (home indicator). | Primary surface; renders `InAppBrowserModal`. |
+| 2 | Consumer Android (`app-mobile` Android) | **YES** | Same; respects Android nav-bar inset; `statusBarTranslucent` z-stacking over the in-tree tab bar. | Primary surface; renders `InAppBrowserModal`. |
+| 3 | Buyer/anon Web | NO | Unchanged. | `InAppBrowserModal` is a native RN-Modal component; not used on web buyer routes. |
+| 4 | Business iOS | NO | Unchanged. | F-8 — business app does not import `InAppBrowserModal`. |
+| 5 | Business Android | NO | Unchanged. | F-8. |
+| 6 | Admin Web (adjacent) | NO | Unchanged. | Different stack; no usage. |
+| 7 | Business Web preview (adjacent) | NO | Unchanged. | No usage. |
+
+**Within consumer app, all 5 mount sites change together (shared component, automatic parity):** ExpandedCardModal ticket browser, ExpandedCardModal policies browser, ProfilePage, CustomPaywallScreen, OnboardingFlow.
+
+---
+
+## 8. Invariant impact
+
+- **I-WEBVIEW-URL-NORMALIZED (ORCH-0649):** PRESERVED by construction (call-site owned; modal renders `url` verbatim). F-5.
+- **Sole-gorhom-consumer (`meta-orch-0991-base-bottom-sheet-sole-consumer.mjs`):** PRESERVED — the fix must NOT import `@gorhom/bottom-sheet` into `InAppBrowserModal`; it keeps the raw RN `<Modal>`. F-6.
+- **orch-1022 gate G-01…G-06 (`orch-1022-expanded-card-modal-gating-check.mjs`):** PRESERVED — the fix does not rename/delete the component, change its default export or prop contract, or move a mount into curatedBody. F-4.
+- **ORCH-0908 z-stacking (`<Modal transparent statusBarTranslucent>`):** already in use; the fix keeps `transparent` and should add/confirm `statusBarTranslucent` so the slide-up layers over the in-tree tab bar on Android. F-6.
+- **Keep-all-nav-inside-WebView (no eject to external browser):** PRESERVED — `onShouldStartLoadWithRequest` returns true; `onError`/`onHttpError` → error state. Not touched. (L46-53, L137-139.)
+- **No NEW invariant strictly required**, but a DRAFT is warranted to lock the bottom-anchored layout against a future "simplifying" re-center (see SPEC §6: `I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED`).
+
+---
+
+## 9. Discoveries for orchestrator (side issues)
+
+- **D-1 (FYI):** `InAppBrowserModal` does not pass `i18n` keys for the error state (there is no rendered error UI — `handleError` only flips `loading=false`, leaving a blank WebView on hard error). This is pre-existing and OUT OF SCOPE for ORCH-1149 (locked "no other visual change"); flagged for a future polish ORCH only.
+- **D-2 (FYI):** the header title bar (`#1C1C1E`) and nav bar are not safe-area-padded at the TOP either (they rely on the centered card's top margin today). Once bottom-anchored at 85%+ height it still won't reach the status bar, so a top inset is NOT required for this fix — but if a future ORCH makes it full-height, the top inset will become necessary. OUT OF SCOPE now; noted.
+
+Neither discovery should widen ORCH-1149. Both are append-only notes.
+
+---
+
+## 10. Confidence + recommended next phase
+
+**Confidence: `proven`** — the root cause is a deterministic static-layout fact (F-1/F-2) with all six evidence fields, corroborated by the orchestrator's device repro and consistent across all five truth layers.
+
+**Recommended next phase:** SPEC (this dispatch is IA — SPEC follows immediately below as `SPEC_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md`).
+
+**Recommended scope (direction only, not a fix):** surgical, single-file layout/animation change to `app-mobile/src/components/InAppBrowserModal.tsx` — un-center (`overlay` → bottom-anchored), full-bleed container (drop fixed `0.85` height, full width, top-only border radius), `animationType` "fade" → "slide", add `useSafeAreaInsets().bottom` padding, confirm `statusBarTranslucent`. Keep the header, nav/URL bar, all WebView props, normalizeWebsiteUrl flow, and error handling EXACTLY as-is. No call-site edits beyond confirming the 5 mounts still compile. Business app untouched.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md
@@ -1,0 +1,142 @@
+# IMPLEMENT — ORCH-1149 — in-app browser bottom-anchor
+
+**Phase:** IMPLEMENT (mingla-implementor, consumer side)
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1149-[inapp-browser-bottom-anchor]/` on branch `ORCH-1149-inapp-browser-bottom-anchor`
+**Date:** 2026-06-15
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md`
+**Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1149_INAPP_BROWSER_BOTTOM_GAP.md`
+**Status:** implemented and verified (source-static + gate + tsc + eslint; sim/device verification is the tester's runtime step)
+
+---
+
+## 1. Summary
+
+The shared consumer in-app browser (`app-mobile/src/components/InAppBrowserModal.tsx`) was a centered floating card at a fixed 85% screen height that left a ~7.5% gap at the base, through which the consumer tab bar (Explore/Discover/Friends/Likes/Profile) bled through, and it faded in instead of sliding up. This change bottom-anchors the sheet flush to the screen bottom (covering the tab bar), makes it full-width with top-only corner rounding, opens it with a slide-up animation, and pads the WebView container by the bottom safe-area inset so content clears the iOS home indicator / Android nav bar. Zero chrome change: the dark title header, close button, back/forward buttons, lock-icon + URL bar, every WebView prop, URL normalization, and error handling are byte-identical. It is a single product-file layout/animation change that propagates automatically to all 5 mount sites (shared default export). A new CI gate + an implementor happy-path regression test lock the bottom-anchored shape against a future re-centering refactor.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Satisfied by |
+|----|-----------|--------|--------------|
+| SC-1-iOS / SC-1-Android | Sheet flush to bottom, tab bar covered | ✓ implemented | `overlay.justifyContent:'flex-end'` + `modalContainer { width:'100%', height:'92%' }` + `statusBarTranslucent` — commit `30f70a9` |
+| SC-2-iOS / SC-2-Android | Slides up on open / down on close | ✓ implemented | `<Modal animationType="slide">` — commit `30f70a9` |
+| SC-3-iOS | WebView content clears the iOS home indicator | ✓ implemented | `style={[styles.webviewContainer, { paddingBottom: insets.bottom }]}` via `useSafeAreaInsets()` — commit `30f70a9` |
+| SC-3-Android | WebView content clears the Android nav bar | ✓ implemented | same inset — commit `30f70a9` |
+| SC-4 | Header/close/back-forward/lock+URL byte-identical (no chrome change) | ✓ preserved | JSX + `header`/`navBar`/`navButton`/`navUrlContainer`/`navUrlText` styles untouched; `git diff` shows no chrome edits |
+| SC-5 | Scrim tap still closes (overlayBackground) | ✓ preserved | `overlayBackground` style + `<TouchableOpacity onPress={onClose}>` untouched |
+| SC-6 | All nav stays in WebView; error shows in-app, no external eject | ✓ preserved | `handleShouldStartLoad`/`handleError`/`onError`/`onHttpError`/WebView props untouched |
+| SC-7 | URL stays normalized https:// (call-site owned) | ✓ preserved | `source={{ uri: url }}` verbatim; no normalization touched |
+| SC-8 | All 5 mount sites still open + bottom-anchor | ✓ verified (compile) | shared default export + prop contract unchanged; tsc clean on all 5 call sites (§ below) |
+| SC-9 | orch-1022 + sole-gorhom gates still pass | ✓ sole-gorhom PASS; orch-1022 see note | sole-gorhom PASS (real + self-test); orch-1022 has a **pre-existing** failure independent of this change (Discoveries) |
+
+> `30f70a9` = the commit hash recorded in the chat handoff and Section 6 below (filled after commit).
+
+---
+
+## 3. Files changed
+
+| File | Change | Δ |
+|------|--------|---|
+| `app-mobile/src/components/InAppBrowserModal.tsx` | modify — bottom-anchor layout + slide animation + bottom inset + protective comment; removed unused `Dimensions`/`SCREEN_HEIGHT` | +33 / −12 |
+| `app-mobile/package.json` | add `test:orch-1149` npm script registering the new gate | +1 / −1 (trailing comma) |
+| `app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs` | create — new strict-grep CI gate (7 checks + `--self-test`) | new (~180 lines) |
+| `app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor.test.tsx` | create — implementor happy-path regression test (T-01..T-08) | new (~150 lines) |
+
+No edits to the 5 call sites (`ExpandedCardModal.tsx`, `ProfilePage.tsx`, `CustomPaywallScreen.tsx`, `OnboardingFlow.tsx`), `normalizeWebsiteUrl.ts`, `BaseBottomSheet.tsx`, or the two existing gates — all DO-NOT-TOUCH, all untouched.
+
+---
+
+## 4. Data-model / edge-function changes
+
+None. Component-layer (UI) change only. No DB, migration, RLS, edge function, service, or hook touched.
+
+---
+
+## 5. Old → New receipt
+
+### `app-mobile/src/components/InAppBrowserModal.tsx`
+**What it did before:** Rendered as a centered floating card — `overlay` used `justifyContent:'center' / alignItems:'center'`; `modalContainer` was `width:'95%', maxWidth:600, height/maxHeight: SCREEN_HEIGHT*0.85, borderRadius:20` (all four corners). The `<Modal>` opened with `animationType="fade"`. No safe-area handling. Result: ~7.5% gap at the base exposing the consumer tab bar, and a fade-in that didn't read as a Mingla sheet.
+**What it does now:** `overlay` uses `justifyContent:'flex-end'` (bottom-anchored; `alignItems` dropped). `modalContainer` is `width:'100%', height:'92%'`, top-only rounded (`borderTopLeftRadius/borderTopRightRadius:20`, bottom corners 0), flush to the screen bottom — covers the tab bar. The `<Modal>` opens with `animationType="slide"` + `statusBarTranslucent={true}` (layers over the in-tree tab bar, ORCH-0908 pattern). `useSafeAreaInsets()` is read and `{ paddingBottom: insets.bottom }` is applied inline to the WebView container so web content clears the home indicator / nav bar. Unused `Dimensions` import + `SCREEN_HEIGHT` constant removed. A protective comment block cites ORCH-1149 / I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED explaining WHY it's bottom-anchored and WHY the inset exists.
+**Why:** SPEC §4 (4.1–4.8), SC-1/SC-2/SC-3; investigation root cause (centered fixed-height card + fade).
+**Lines changed:** ~33 insertions / ~12 deletions.
+
+The dark header (`#1C1C1E`), close button, back/forward nav, lock+URL bar, the WebView element and ALL its props, `handleNavigationStateChange`, `handleShouldStartLoad`, `handleError`, `goBack`, `goForward`, `handleShow`, and the `{ visible, url, title, onClose }` prop contract are UNCHANGED.
+
+---
+
+## 6. Regression tests added
+
+**Implementor happy-path test:** `app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor.test.tsx` (T-01..T-08; node-runnable source-static-analysis, the app-mobile convention — no jest in app-mobile).
+
+- Passing run (restored fix):
+  ```
+  PASS T-01..T-08 ORCH-1149 in-app browser bottom-anchor: slide animation, statusBarTranslucent,
+  bottom-anchored overlay, full-width flush sheet (no 0.85 card), top-only rounding,
+  bottom safe-area inset on webview, prop contract preserved, no gorhom import
+  ```
+
+**New CI gate:** `app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs` (G-01..G-07 + `--self-test`), registered as `npm run test:orch-1149` in `app-mobile/package.json` — same runner (the `app-mobile/package.json` `test:orch-*` scripts block) as orch-1022 / orch-1054 / orch-1072 / orch-1125. (Note: app-mobile `scripts/ci/orch-*` gates are wired as npm scripts in `app-mobile/package.json`, NOT as individual jobs in the GitHub strict-grep workflow — that workflow runs only `.github/scripts/strict-grep/*` gates. This matches all existing app-mobile orch gates.)
+
+- Gate passing run (restored fix): all 7 PASS, `ORCH-1149 in-app browser bottom-anchor regression passed.`
+- Gate self-test: `ORCH-1149 self-test passed: gate correctly FAILS the reverted shape (5/7 checks failed as expected).`
+
+**Fails-on-revert proof (TRUE line deletion — `git checkout origin/main -- InAppBrowserModal.tsx`, NOT a comment-out):**
+- On the reverted origin/main shape (centered, `fade`, `SCREEN_HEIGHT*0.85`, no inset): the happy-path test FAILED (exit 1, `AssertionError: T-01 <Modal> must use animationType="slide"`) AND the CI gate FAILED (exit 1, 5/7 checks failed).
+- After restoring the fix (`cp` back; verified byte-identical to the fix via `diff`): both PASS again (exit 0).
+- **fails-on-revert verified at `30f70a9`** (the commit recorded below).
+
+---
+
+## 7. Cross-surface impact table
+
+| # | Surface | Affected | What changes / why not | Parity |
+|---|---------|----------|------------------------|--------|
+| 1 | Consumer iOS | YES | In-app browser slides up, sits flush, covers tab bar; content clears home indicator | Shared component → automatic across all 5 mounts |
+| 2 | Consumer Android | YES | Same; clears Android nav bar; `statusBarTranslucent` layers over the in-tree tab bar | Automatic |
+| 3 | Buyer/anon Web | NO | Native-only component; not on web buyer routes | — |
+| 4 | Business iOS | NO | Business app does not import `InAppBrowserModal` (F-8) | — |
+| 5 | Business Android | NO | F-8 | — |
+| 6 | Admin Web (adjacent) | NO | No usage | — |
+| 7 | Business Web preview (adjacent) | NO | No usage | — |
+
+Parity is automatic (single shared default export). No manual parity work required.
+
+---
+
+## 8. Smoke / verification result
+
+- **Gate (orch-1149):** real PASS (7/7), self-test PASS (fails the reverted shape as designed).
+- **Gate (orch-1022, sole-gorhom):** sole-gorhom PASS (real + self-test). orch-1022 has a **pre-existing** 2/8 failure unrelated to this change — see Discoveries.
+- **Happy-path test:** PASS; fails-on-revert proven by true line deletion.
+- **tsc (`npx tsc --noEmit`):** ZERO errors mention `InAppBrowserModal` or any of the 5 call sites. All ~410 remaining errors are pre-existing and confined to `../packages/phone-input/*` (missing react types) and Deno/react-dom test files (run by deno/jest, not tsc) — none in product source I touched.
+- **eslint (`npx eslint src/components/InAppBrowserModal.tsx`):** exit 0, clean (no unused-import warning after removing `Dimensions`/`SCREEN_HEIGHT`).
+- **Per-mount-site compile confirmation:** `ExpandedCardModal.tsx` (ticket browser L2273 + policies browser L2282), `ProfilePage.tsx` (L602), `CustomPaywallScreen.tsx` (L442), `OnboardingFlow.tsx` (L3298) — all typecheck clean (prop contract `{ visible, url, title, onClose }` unchanged; no call-site edits).
+
+**UNVERIFIED (tester's runtime step):** on-device/sim visual confirmation that the tab bar is fully covered, the slide animation plays, and the home-indicator/nav-bar clearance holds on a device WITH a home indicator AND one without (inset=0 edge). This requires iOS sim + Android emulator and is the tester's adversarial angle (SPEC §9).
+
+---
+
+## 9. Known issues / deferred
+
+- No `[TRANSITIONAL]` code introduced.
+- Sheet height set to `92%` per SPEC §10 OQ-1 default (tall sheet, thin top scrim). If Seth wants a shorter sheet, it remains acceptable so long as bottom-flush + tab-bar-covered — the gate/test only enforce "not centered / not 0.85-fixed / bottom-inset", not a specific height %.
+
+---
+
+## 10. Operator action required
+
+- **No migration. No edge-function deploy.** Component-layer change only.
+- **OTA (orchestrator/operator, after merge to main + tester PASS):** consumer channels per the EAS OTA gotchas (per-platform, `npx -y eas-cli@latest update`, runtime app 1.1.0). Not the implementor's step.
+
+---
+
+## 11. Discoveries for Orchestrator
+
+- **Pre-existing failure: `orch-1022-expanded-card-modal-gating-check.mjs` fails 2/8 (G-01, G-03) on origin/main — NOT caused by ORCH-1149.** `ExpandedCardModal.tsx` is byte-identical to origin/main here (I never touched it; `git diff origin/main` is empty). The gate's G-01/G-03 regexes were written before ORCH-1072 inserted `selectedVenueExperience !== null` into the `anyChildModalOpen` chain (`ExpandedCardModal.tsx:1425-1441`); the strict regex expects the expression to terminate at `curatedLightbox.visible;` but the source now appends `|| selectedVenueExperience !== null;`. This is a stale-gate drift (gate not updated when ORCH-1072 extended the child-overlay aggregate), independent of and orthogonal to this layout change. The orch-1022 gate is DO-NOT-TOUCH for ORCH-1149, so I left it untouched. **Recommend a small follow-up ORCH** to update the orch-1022 G-01/G-03 regexes to include `selectedVenueExperience` (the architecture is still correct — the aggregate DOES cover the venue-experience surface; only the gate's pattern is stale). Note: SC-9's intent ("orch-1022 still PASS") is "do not regress it" — this change cannot affect the orch-1022 result because that gate reads only `ExpandedCardModal.tsx`, which is unchanged.
+
+---
+
+## 12. Comms ledger
+
+Read `/Users/sethogieva/Desktop/mingla-main/COMMS_LEDGER.md` on entry. No OPEN+BLOCK row targets `mingla-implementor`, `ORCH-1149`, or `ALL`. COMMS-0033 (WARN, ORCH-1133 ID-collision) is already ACKNOWLEDGED and concerns unrelated ORCHs — no action. No new cross-ORCH discovery requiring a COMMS write (the orch-1022 stale-gate is a same-repo follow-up, captured in Discoveries for the orchestrator, not a cross-in-flight-ORCH blocker).

--- a/Mingla_Artifacts/reports/TEST_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md
@@ -1,0 +1,152 @@
+# TEST — ORCH-1149 — in-app browser bottom-anchor (adversarial QA)
+
+**Phase:** TEST (mingla-tester, adversarial)
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1149-[inapp-browser-bottom-anchor]/` on branch `ORCH-1149-inapp-browser-bottom-anchor`
+**Impl commit:** `a684169b1` (rebased from the dispatch's intermediate `30f70a9fe` — component content byte-identical between the two; reconciled below)
+**Tester adversarial commit:** `8a4c74d9a`
+**Date:** 2026-06-15
+**SPEC:** `Mingla_Artifacts/specs/SPEC_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md`
+**Mode:** TARGETED (single-file deterministic StyleSheet/animation change)
+
+---
+
+## 1. Verdict
+
+**CONDITIONAL PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 1 · P4: 2.
+
+The implementation matches the SPEC exactly: the shared consumer in-app browser is re-laid-out from a centered 85%-height floating card to a bottom-anchored, full-width, slide-up sheet with a top-only radius and a `useSafeAreaInsets().bottom` pad on the WebView container. Chrome is **byte-identical**. All 5 mount sites inherit the change via the shared default export. The new gate + both regression tests are green and fail-on-revert is proven for both. The orch-1022 gate fails 2/8 but is a **pre-existing stale-gate drift unrelated to and unaffected by ORCH-1149** (proven below) — it does NOT block this change's pre-merge gate.
+
+**Why CONDITIONAL, not PASS:** this is a UI/runtime layout change, and per the tester confidence ladder a full PASS on a UI change requires `proven`-level live-fire visual confirmation. I could NOT drive the in-app browser to a visible state in this environment (the booted sim's app landed on a deep-link intercept screen and would not cleanly bind to the worktree Metro bundle; reaching the browser requires authenticated multi-screen navigation through the Discover deck). The runtime claims are therefore capped at **`suspected (source-conclusive)`**. Because the change is a deterministic, data-independent, branch-free StyleSheet swap whose visual outcome is fully determined by the verified style values, source-level layout reasoning carries the bulk of the verdict with high confidence — but the live-fire visual (tab-bar coverage, slide animation playing, home-indicator clearance) remains **un-run** and is the one open condition. **Seth's call** whether to accept the deferred live-fire or require a sim/device pass before merge.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| SC-1-iOS / SC-1-Android | Sheet flush to bottom, tab bar covered | PASS (source-conclusive; live-fire NOT run) | `overlay.justifyContent:'flex-end'` (L174) + `modalContainer { width:'100%', height:'92%' }` (L186-187) + `statusBarTranslucent={true}` (L91). RN `<Modal transparent statusBarTranslucent>` mounts in its own OS overlay over the in-tree tab bar (ORCH-0908). Visual confirmation of coverage NOT performed — capped `suspected`. |
+| SC-2-iOS / SC-2-Android | Slides up on open / down on close | PASS (source-conclusive) | `<Modal animationType="slide">` (L89); `fade` absent. Animation play NOT visually confirmed. |
+| SC-3-iOS | WebView content clears the iOS home indicator | PASS (source-conclusive) | `style={[styles.webviewContainer, { paddingBottom: insets.bottom }]}` (L141) via `const insets = useSafeAreaInsets()` (L46). Inset value is dynamic + runtime-correct by construction; not visually measured. |
+| SC-3-Android | WebView content clears the Android nav bar | PASS (source-conclusive) | same inset (L141). |
+| SC-4 | Header/close/back-forward/lock+URL byte-identical | **PASS (verified)** | `git diff origin/main -- InAppBrowserModal.tsx` shows ZERO chrome edits — header `#1C1C1E` (L206), closeButton, navBar/navButton/navUrlContainer/navUrlText, lock-closed icon (L135), chevron-back/forward (L122/L132) all untouched. Only the webviewContainer inline `paddingBottom` + comments changed. |
+| SC-5 | Scrim tap still closes (overlayBackground) | **PASS (verified)** | `overlayBackground` style (L177-183) + `<TouchableOpacity ... onPress={onClose}>` (L96-100) byte-identical to origin/main. |
+| SC-6 | All nav stays in WebView; error in-app, no external eject | **PASS (verified)** | `handleShouldStartLoad` returns `true` (L62-64); `onError={handleError}` + `onHttpError={handleError}` (L155-156); `setSupportMultipleWindows={false}` + `javaScriptCanOpenWindowsAutomatically={false}` (L157-158) all untouched. |
+| SC-7 | URL stays normalized https:// (call-site owned) | **PASS (verified)** | `source={{ uri: url }}` verbatim (L149); zero `normalize` refs inside the modal. Normalization owned by `ExpandedCardModal.tsx` + `ActionButtons.tsx` (I-WEBVIEW-URL-NORMALIZED preserved). |
+| SC-8 | All 5 mount sites still open + bottom-anchor | **PASS (verified)** | Exactly 5 mounts app-wide: `ExpandedCardModal.tsx:2273` (ticket) + `:2282` (policies), `ProfilePage.tsx:602`, `CustomPaywallScreen.tsx:442`, `OnboardingFlow.tsx:3298`. All import the default export → all inherit the bottom-anchor. Each passes precisely `{visible,url,title,onClose}` (no extra props). tsc clean on all 5. Live-open of each NOT run. |
+| SC-9 | orch-1022 + sole-gorhom gates still pass | **PARTIAL — sole-gorhom PASS; orch-1022 pre-existing 2/8 fail (NOT caused by 1149)** | sole-gorhom: `node .github/scripts/strict-grep/meta-orch-0991-...mjs` → OK (BaseBottomSheet sole importer, exit 0). orch-1022: 2/8 fail (G-01/G-03) — pre-existing on origin/main, reads only `ExpandedCardModal.tsx` which 1149 never touches (see §3 P3 + §11). |
+
+---
+
+## 3. Findings
+
+### P3-1 — orch-1022 gate is stale (pre-existing; NOT caused by ORCH-1149) — recommend a small follow-up ORCH
+
+- **Evidence:** `npm run test:orch-1022` → `FAIL G-01`, `FAIL G-03`, `2/8 failed` (exit 1). `git diff origin/main -- app-mobile/src/components/ExpandedCardModal.tsx` is **empty** (byte-identical) and `git diff origin/main -- .../orch-1022-...mjs` is **empty**. ORCH-1149's commit `a684169b1` touches NEITHER file. The gate reads only `ExpandedCardModal.tsx` + `expandedCard/ActionButtons.tsx` (gate L23-24) — neither changed by 1149 — so it is mathematically impossible for 1149 to have caused or affected this result. Root cause: ORCH-1072 inserted `|| selectedVenueExperience !== null` into the `anyChildModalOpen` chain (`ExpandedCardModal.tsx:1431` + the close-effect L1437) but the gate's G-01/G-03 regexes still expect the chain to terminate at `curatedLightbox.visible`. The architecture is correct (the aggregate DOES cover the venue-experience surface); only the gate's pattern is stale.
+- **Impact:** If a CI pre-merge job runs `npm run test:orch-1022`, it will RED on this branch — but it is equally RED on origin/main today, so it is not a *regression* introduced by 1149 and must not be charged against this change. SPEC §11 pre-declared this as a known stale gate from ORCH-1072.
+- **Required fix (NOT for this ORCH — orch-1022 is DO-NOT-TOUCH here):** a follow-up ORCH updates the orch-1022 G-01/G-03 regexes to include `selectedVenueExperience` in the expected `anyChildModalOpen` aggregate.
+- **Retest:** after the follow-up, `npm run test:orch-1022` → 8/8 PASS.
+- **Pre-merge-gate assessment:** does NOT block ORCH-1149. It is a pre-existing red unrelated to this diff; gate it on its own follow-up.
+
+### P4-1 — clean, surgical, spec-faithful implementation (praise)
+
+Single product file, exact spec match, protective comment block cites `I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED` with the WHY (tab-bar bleed / home-indicator occlusion), unused `Dimensions`/`SCREEN_HEIGHT` cleanly removed, the one dynamic inline style correctly scoped. Subtract-before-add honored.
+
+### P4-2 — dispatch hash reconciliation (informational, no defect)
+
+The dispatch cited "impl commit `a684169b1`, in-branch fix `30f70a9`". `30f70a9fe` exists in the object store (reflog) as the pre-rebase impl commit; it is NOT an ancestor of `a684169b1`, but `git diff 30f70a9 a684169b1 -- InAppBrowserModal.tsx` is **empty** (component byte-identical). The branch was rebased onto current origin/main, producing `a684169b1` with identical component content. No fix was lost; the code under test is exactly what was implemented. The IMPLEMENT report's "commit `30f70a9`" references are the pre-rebase hash.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out the implementor's component shape and the origin/main shape myself; ran their happy-path test + the gate against each.
+
+- **Reverted to origin/main** (`cp $(git show origin/main:.../InAppBrowserModal.tsx)` — TRUE line replacement, not comment-out):
+  - Implementor happy-path test → **FAIL**, exact assertion: `AssertionError [ERR_ASSERTION]: T-01 <Modal> must use animationType="slide"` (exit 1).
+  - orch-1149 gate → **FAIL 5/7** (G-01..G-05 fail; G-06/G-07 pass), exit 1.
+- **Restored fix** (`git checkout -- InAppBrowserModal.tsx`; confirmed empty diff = byte-identical):
+  - Implementor happy-path test → **PASS** (exit 0).
+  - orch-1149 gate → **PASS 7/7** (exit 0); gate `--self-test` → PASS (correctly fails the reverted shape 5/7).
+- **Verified at impl commit `a684169b1`.** The implementor's fails-on-revert claim is independently confirmed.
+
+---
+
+## 5. Adversarial test added (tester, different angle)
+
+- **Path:** `app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor-tester-adv.test.tsx`
+- **Commit:** `8a4c74d9a` (on branch, in `git diff origin/main...HEAD --name-status` as `A`).
+- **Different angle vs the implementor's test** (implementor asserts the NEW shape is PRESENT — slide/flex-end/100%/top-radius/inset). This test attacks what the happy-path test does NOT cover:
+  - **Angle A — NO leftover centered-card markers:** asserts `width:'95%'`, `maxWidth:600`, `maxHeight: SCREEN_HEIGHT`, `Dimensions`, `SCREEN_HEIGHT` are GONE, and `alignItems:'center'` is absent **scoped to the `overlay` block specifically** (it legitimately survives in chrome styles — closeButton/navBar/navButton/navUrlContainer/loadingOverlay — which a coarse file-wide grep would get wrong; the implementor test never checks these markers at all).
+  - **Angle B — chrome/WebView/error-path byte-PRESERVED:** asserts header `#1C1C1E`, lock+URL bar, back/forward chrome, `source={{ uri: url }}` verbatim, no in-modal `normalizeWebsiteUrl`, `setSupportMultipleWindows={false}` + `javaScriptCanOpenWindowsAutomatically={false}`, `onError`+`onHttpError`→`handleError`, and `handleShouldStartLoad` returns `true` (no external eject). The implementor test never verifies chrome preservation.
+  - **Angle C — all 5 mount sites still import + mount the shared default export** (and ExpandedCardModal hosts exactly 2). The implementor test only reads InAppBrowserModal.tsx.
+- **fails-on-revert verified at `a684169b1`:** on the origin/main centered shape the test FAILS with `AssertionError: A-1 the centered-card width:'95%' must be GONE` (exit 1); on the fix it PASSES (exit 0). Restore confirmed byte-identical.
+- **Both tests appear in the closing diff** (`git diff origin/main...HEAD --name-status`): implementor `orch-1149-inapp-browser-bottom-anchor.test.tsx` (A) + tester `orch-1149-inapp-browser-bottom-anchor-tester-adv.test.tsx` (A) + the gate (A). Append-only respected (the implementor's test was not modified).
+- **Lint:** tester test = 0 errors, 3 `no-require-imports` warnings — identical count/kind to the implementor's test (the app-mobile node-runnable test convention). No new error class.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Result | Evidence |
+|---|------|--------|----------|
+| 1 | No dead taps | PASS | scrim tap-to-close, close button, back/forward all untouched + wired. |
+| 2 | One owner per truth | PASS | layout owned solely by `InAppBrowserModal` styles; URL normalization owned by call sites (unchanged). |
+| 3 | No silent failures | PASS | error path unchanged (`handleError` clears loading; no swallow added). |
+| 4 | One query key per entity | N/A | no data layer touched. |
+| 5 | Server state server-side | N/A | no Zustand/React-Query touched. |
+| 6 | Logout clears everything | N/A | no auth/persistence touched. |
+| 7 | Label `[TRANSITIONAL]` | N/A | none introduced. |
+| 8 | Subtract before adding | PASS | removed `Dimensions`/`SCREEN_HEIGHT`/`width:95%`/`maxWidth`/`maxHeight`/`borderRadius:20`/`alignItems` before adding the sheet shape. |
+| 9 | No fabricated data | N/A | no data. |
+| 10 | Currency-aware | N/A | no money. |
+| 11 | One auth instance | N/A | no auth. |
+| 12 | Validate at right time | N/A | no validation. |
+| 13 | Exclusion consistency | N/A | no filtering. |
+| 14 | Persisted-state startup | N/A | no persisted state. |
+
+No constitutional violation.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Result | Notes |
+|---------|--------|-------|
+| Consumer iOS | **suspected (source-conclusive); live-fire NOT run** | iPhone 17 Pro sim booted + `com.mingla.app.v2` dev build installed + worktree Metro started, but the app landed on a deep-link "Open this event from the app" intercept with an uncaught-promise toast and would not cleanly bind to the worktree bundle (Metro stayed "Waiting on http://localhost:8081"). Reaching the in-app browser needs authenticated Discover-deck navigation to a curated card's "Policies & Reservations". Did NOT fabricate a visual. Evidence: `Mingla_Artifacts/evidence/ORCH-1149/ios_sim_deeplink_intercept_could_not_reach_browser.png`. |
+| Consumer Android | **suspected (source-conclusive); live-fire NOT run** | Android device attached (`R58R54YV7JT`) but not driven (same reachability blocker; deterministic shared style change). |
+| Buyer/anon Web | N/A (skip) | native-only component; not on web buyer routes (SPEC §3). |
+| Business iOS | N/A (skip) | business app does not import `InAppBrowserModal` (SPEC F-8). |
+| Business Android | N/A (skip) | F-8. |
+| Admin Web | N/A (skip) | no usage. |
+| Business Web preview | N/A (skip) | no usage. |
+| Physical iPhone (HITL) | NOT requested in dispatch | no physical-device step required by the dispatch; available if Seth wants the live-fire visual. |
+
+**Live deploy state:** N/A — no edge function / migration. Component-layer change; ships via OTA after merge (orchestrator/operator, per EAS OTA gotchas / COMMS-0027).
+
+---
+
+## 8. Source-verified vs live-fire (explicit)
+
+**Source-verified (high confidence — deterministic style change):** the exact style values, the `<Modal>` props, the inset application, byte-identical chrome/WebView/error-path vs origin/main, the 5 mount sites + their props, URL-normalization ownership, the gate + both tests green, both fails-on-revert proofs, sole-gorhom green, orch-1022 pre-existing-and-unaffected.
+
+**NOT live-fire (capped `suspected`):** the on-screen visual that (a) the sheet slides up, (b) the tab bar is fully covered with no nav-menu bleed at the base, (c) content clears the home indicator on an inset>0 device AND behaves correctly on an inset=0 edge. These are the SPEC §9(b)/(c) angles and remain un-run in this environment.
+
+---
+
+## 9. Discoveries for Orchestrator
+
+- **DISC-1149-1:** orch-1022 gate is stale (2/8) on origin/main due to ORCH-1072's `selectedVenueExperience` extension of `anyChildModalOpen` — recommend a small follow-up ORCH to update the G-01/G-03 regexes (architecture is correct; gate pattern lags). NOT caused by 1149; do NOT block 1149 on it.
+- **DISC-1149-2:** the consumer dev build on the booted iPhone 17 Pro sim opened to a deep-link intercept + uncaught-promise toast and would not bind to a freshly-started worktree Metro — an environment/dev-build state issue worth noting for future runtime QA (possibly stale-bundle / dev-launcher state, cf. COMMS-0027 dev-OTA cache poisoning).
+
+---
+
+## 10. Accepted conditions (CONDITIONAL PASS)
+
+One open condition, requiring Seth's decision:
+- **AC-1:** Live-fire visual confirmation (slide-up + tab-bar coverage + home-indicator clearance on inset>0 and inset=0) was NOT performed; runtime claims capped at `suspected (source-conclusive)`. **Accept the deferred live-fire** (merge on the strength of the deterministic source proof) **OR require a sim/device pass first.** No follow-up ORCH-ID assigned yet — Seth's call.
+
+---
+
+## 11. orch-1022 pre-merge-gate assessment (explicit, per dispatch)
+
+`npm run test:orch-1022` is RED (2/8) on this branch AND identically RED on origin/main. ORCH-1149 touches neither `ExpandedCardModal.tsx` nor the gate, and the gate does not read `InAppBrowserModal.tsx` for its failing checks — so 1149 cannot have caused it and it is **not a regression attributable to this change**. It is a stale gate from ORCH-1072, pre-declared in SPEC §11. **It does NOT block ORCH-1149's pre-merge gate** and should be resolved on its own follow-up ORCH, not charged here. The ORCH-1149-relevant gates — `test:orch-1149` (7/7), the sole-gorhom gate (OK), both regression tests, tsc, eslint — are all green.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1149_INAPP_BROWSER_BOTTOM_ANCHOR.md
@@ -1,0 +1,198 @@
+# SPEC — ORCH-1149 — in-app browser bottom-anchor (cover the consumer tab bar, slide up)
+
+**Phase:** SPEC (forensics, IA mode — follows `INVESTIGATE_ORCH-1149_INAPP_BROWSER_BOTTOM_GAP.md`)
+**Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/ORCH-1149-[inapp-browser-bottom-anchor]/` on branch `ORCH-1149-inapp-browser-bottom-anchor`
+**Date:** 2026-06-15
+**Investigation confidence:** `proven`
+**Approach (decided in investigation F-6):** **In-place raw-RN-`<Modal>` refactor** — keep the existing `<Modal transparent>`, switch `animationType` to `"slide"`, bottom-anchor a full-bleed container, add bottom safe-area inset. **Do NOT** route through `BaseBottomSheet` and **do NOT** import `@gorhom/bottom-sheet`.
+
+---
+
+## 1. Executive summary
+
+The shared consumer in-app browser (`app-mobile/src/components/InAppBrowserModal.tsx`) renders as a centered floating card at a fixed 85% screen height, so it leaves a ~7.5% gap at the bottom through which the consumer tab bar (Explore/Discover/Friends/Likes/Profile) shows. It also fades in instead of sliding up, so it doesn't feel like a Mingla sheet. This SPEC bottom-anchors the sheet flush to the bottom (covering the tab bar) and switches the open animation to slide-up — with **zero** change to the dark title header, the back/forward + lock/URL nav bar, any WebView prop/behavior, the URL-normalization flow, or error handling. It is a surgical, single-file layout/animation fix that propagates to all 5 mount sites automatically (shared default export).
+
+---
+
+## 2. Scope & non-goals
+
+**In scope (the only changes permitted):**
+- `InAppBrowserModal.tsx` `<Modal>` prop: `animationType="fade"` → `animationType="slide"`; add `statusBarTranslucent` (confirm/keep `transparent`).
+- `InAppBrowserModal.tsx` `styles.overlay`: remove vertical centering so the container can sit flush at the bottom.
+- `InAppBrowserModal.tsx` `styles.modalContainer`: remove the fixed `height: SCREEN_HEIGHT * 0.85` / `maxHeight`, the `width:'95%'`/`maxWidth`, and the all-corner `borderRadius: 20`; make it a full-width, bottom-anchored sheet with **top-only** corner radius and a height that covers the tab bar at the base.
+- `InAppBrowserModal.tsx`: add `useSafeAreaInsets` and apply `insets.bottom` padding at the new bottom edge (WebView container).
+
+**Non-goals (explicitly NOT in scope):**
+- No chrome redesign. The dark header (`#1C1C1E`), the close button, the back/forward buttons, the lock icon + URL text bar stay byte-identical in look and behavior.
+- No removal of the URL bar.
+- No change to any WebView prop or callback.
+- No `@gorhom/bottom-sheet` import; no routing through `BaseBottomSheet`.
+- No edits to the 5 call sites beyond confirming they still compile (props contract unchanged).
+- No business-app work (different browser path — investigation F-8).
+- No new error-state UI, no i18n additions (investigation D-1 — deferred).
+- No top safe-area inset change (investigation D-2 — not needed at current sheet height).
+
+**Assumptions:** `react-native-safe-area-context` is available app-wide (`SafeAreaProvider` mounted at root; 46 src files already use `useSafeAreaInsets`). The RN `<Modal>` continues to mount in its own OS overlay window that renders over the in-tree tab bar (ORCH-0908 pattern).
+
+---
+
+## 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behavior demanded | Files touched | Parity |
+|---|---------|---------|-------------------------------|---------------|--------|
+| 1 | Consumer iOS (`app-mobile` iOS) | **YES** | In-app browser slides up from the bottom, sits flush, covers the tab bar; content clears the home indicator (bottom inset). | `app-mobile/src/components/InAppBrowserModal.tsx` | Shared component → automatic across all 5 mounts. |
+| 2 | Consumer Android (`app-mobile` Android) | **YES** | Same; clears the Android nav bar (bottom inset); `statusBarTranslucent` keeps it layered over the in-tree tab bar. | same | Automatic. |
+| 3 | Buyer/anon Web | NO | Unchanged | none | Native-only component; not on web buyer routes. |
+| 4 | Business iOS | NO | Unchanged | none | Business app does not import `InAppBrowserModal` (F-8). |
+| 5 | Business Android | NO | Unchanged | none | F-8. |
+| 6 | Admin Web (adjacent) | NO | Unchanged | none | No usage. |
+| 7 | Business Web preview (adjacent) | NO | Unchanged | none | No usage. |
+
+---
+
+## 4. Layered specification
+
+Only the **Component** layer is touched. No DB / edge / service / hook / realtime changes.
+
+### Component — `app-mobile/src/components/InAppBrowserModal.tsx`
+
+**4.1 Imports**
+- Add: `import { useSafeAreaInsets } from 'react-native-safe-area-context';`
+- `Dimensions` / `SCREEN_HEIGHT` (L9, L15) become unnecessary for the container height once it's flex/anchored. The implementor MAY remove the `Dimensions` import and the `SCREEN_HEIGHT` constant if no longer referenced (lint will flag an unused import). Keep them only if still used.
+
+**4.2 Component body**
+- Add at top of the component: `const insets = useSafeAreaInsets();`
+
+**4.3 `<Modal>` props (currently L71-77)**
+- `animationType="fade"` → `animationType="slide"`.
+- Keep `transparent={true}`, `visible`, `onRequestClose={onClose}`, `onShow={handleShow}`.
+- Add `statusBarTranslucent={true}` (so the slide-up overlay layers over the in-tree tab bar consistently on Android — matches the ORCH-0908 pattern).
+
+**4.4 `styles.overlay` (currently L154-159)**
+- Change `justifyContent: 'center'` → `justifyContent: 'flex-end'` (anchor children to the bottom).
+- Remove `alignItems: 'center'` (the sheet is full-width now).
+- Keep `flex: 1` and `backgroundColor: 'rgba(0,0,0,0.5)'` (the dim scrim above the sheet is retained — it covers the upper portion of the screen and the `overlayBackground` tap-to-close still works).
+
+**4.5 `styles.overlayBackground` (currently L160-166)** — UNCHANGED (absolute-fill tap-to-close behind the sheet).
+
+**4.6 `styles.modalContainer` (currently L167-180)** — bottom-anchored full-bleed sheet:
+- REMOVE: `width: '95%'`, `maxWidth: 600`, `height: SCREEN_HEIGHT * 0.85`, `maxHeight: SCREEN_HEIGHT * 0.85`.
+- ADD/SET: `width: '100%'`.
+- Height: the sheet must cover the tab bar at the base. Use a tall sheet that reaches near the top but leaves the upper scrim visible (so it reads as a sheet, not a full-screen takeover). Recommended: `height: '92%'` (or `flex` within an `overlay` that has top padding). The container's bottom is flush to the screen bottom because `overlay` is `flex-end`. The exact top gap is a design value — `92%` keeps a thin scrim strip at the top consistent with other tall Mingla sheets; the implementor MUST NOT reintroduce a centered or `0.85` fixed-with-bottom-margin layout.
+- Border radius: `borderRadius: 20` → **top-only**: `borderTopLeftRadius: 20`, `borderTopRightRadius: 20`, `borderBottomLeftRadius: 0`, `borderBottomRightRadius: 0` (flush bottom = no bottom rounding).
+- Keep `backgroundColor: '#ffffff'`, `overflow: 'hidden'`.
+- Shadow/elevation: keep the top shadow (`shadowOffset: { width: 0, height: 10 }` casts upward-ish); acceptable to retain as-is. (Optional: `shadowOffset` height to a small negative for an upward shadow — purely optional, not required.)
+
+**4.7 Header `styles.header` (currently L181-190)** — UNCHANGED. It already has `borderTopLeftRadius: 20` / `borderTopRightRadius: 20`, which now correctly matches the sheet's top corners.
+
+**4.8 Bottom safe-area inset (the critical un-centering regression guard, F-7)**
+- Apply `paddingBottom: insets.bottom` to the **WebView container** (`styles.webviewContainer`, currently L243-246) so the WebView content does not sit under the iOS home indicator / Android nav bar.
+- Implementation note for the implementor: `insets.bottom` is dynamic, so apply it inline as an array style on the `webviewContainer` `<View>` (L124): `style={[styles.webviewContainer, { paddingBottom: insets.bottom }]}`. This is the ONE allowed inline style (a dynamic runtime value); do not move static styles inline.
+
+**4.9 Everything else** — UNCHANGED: `navBar`, `navButton`, `navUrlContainer`, `navUrlText`, `loadingOverlay`, `webview`, the WebView element and ALL its props (L130-145), `handleNavigationStateChange`, `handleShouldStartLoad`, `handleError`, `goBack`, `goForward`, `handleShow`, and the `{ visible, url, title, onClose }` prop contract.
+
+---
+
+## 5. Success criteria (numbered, per-surface where parity is manual; here parity is automatic so iOS+Android share each criterion unless split)
+
+- **SC-1-iOS / SC-1-Android:** Opening the in-app browser (via curated card "Policies & Reservations") shows the sheet **flush to the bottom of the screen** with **no visible tab bar** below it (Explore/Discover/Friends/Likes/Profile fully covered).
+- **SC-2-iOS / SC-2-Android:** The sheet **slides up from the bottom** on open (not a fade), and slides down on close.
+- **SC-3-iOS:** The WebView content's bottom edge clears the iOS home indicator (no content under the indicator) — `insets.bottom` padding applied.
+- **SC-3-Android:** The WebView content's bottom edge clears the Android nav bar — `insets.bottom` padding applied.
+- **SC-4:** The dark title header (`#1C1C1E`), the close (×) button, the back/forward buttons, and the lock-icon + URL text bar are **visually and behaviorally identical** to before (no chrome change).
+- **SC-5:** Tapping the dimmed scrim above the sheet still closes the browser (`overlayBackground` tap-to-close preserved).
+- **SC-6:** All in-page navigation stays inside the WebView; an error shows the existing (blank/loading-cleared) state and never ejects to an external browser (`onShouldStartLoadWithRequest`/`onError`/`onHttpError` unchanged).
+- **SC-7:** The URL passed to the WebView is still the normalized `https://` URL (I-WEBVIEW-URL-NORMALIZED) — unchanged because normalization is call-site owned.
+- **SC-8 (all 5 mount sites):** ExpandedCardModal ticket browser, ExpandedCardModal policies browser, ProfilePage, CustomPaywallScreen, OnboardingFlow each still open the browser and each now bottom-anchors + slides up (verify each compiles and opens).
+- **SC-9 (CI):** `orch-1022-expanded-card-modal-gating-check.mjs` and `meta-orch-0991-base-bottom-sheet-sole-consumer.mjs` both still PASS (component name/export/contract preserved; no gorhom import added).
+
+---
+
+## 6. Invariants
+
+**Preserved:**
+- **I-WEBVIEW-URL-NORMALIZED (ORCH-0649):** modal renders `source={{ uri: url }}` verbatim; normalization is at the call sites. Verified by SC-7 + the orch-0649 / call-site tests (unchanged).
+- **Sole-gorhom-consumer (`meta-orch-0991-base-bottom-sheet-sole-consumer.mjs`):** no `@gorhom/bottom-sheet` import added to `InAppBrowserModal`. Verified by SC-9 (that gate).
+- **orch-1022 gate (G-01…G-06):** component name, default export, `{ visible, url, title, onClose }` prop contract, and the parent-owned mount architecture all unchanged; `<InAppBrowserModal` stays ABSENT from `curatedBody`. Verified by SC-9 (that gate).
+- **ORCH-0908 z-stacking (`<Modal transparent statusBarTranslucent>`):** kept `transparent`, added `statusBarTranslucent` — the sheet continues to render over the in-tree tab bar. Verified by SC-1.
+- **Keep-all-nav-inside-WebView:** `onShouldStartLoadWithRequest` returns true; errors → error state. Unchanged. Verified by SC-6.
+
+**New (DRAFT — flips ACTIVE on CLOSE; orchestrator owns the flip):**
+- **`I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED`** — `app-mobile/src/components/InAppBrowserModal.tsx` MUST render as a bottom-anchored, full-width sheet that covers the in-tree tab bar, opened with `animationType="slide"`. The `overlay` style MUST NOT use `justifyContent:'center'`; the `modalContainer` MUST NOT use a fixed `SCREEN_HEIGHT * 0.85` height nor all-four-corner `borderRadius`; the WebView container MUST pad `useSafeAreaInsets().bottom`. *Why:* a future "simplifying" refactor could re-center the dialog and silently reopen the tab-bar bleed-through and the home-indicator occlusion.
+  - **Enforcement gate (to add):** `app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs` — see §9.
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T1 (happy, iOS) | Open browser from curated "Policies & Reservations" | Tap button | Sheet bottom-anchored, slides up, tab bar covered | Component / sim |
+| T2 (happy, Android) | Same | Tap button | Same; Android nav-bar cleared by inset | Component / emulator |
+| T3 (regression-structural) | Grep the component styles | source | `overlay` has no `justifyContent:'center'`; `modalContainer` has no `SCREEN_HEIGHT * 0.85`; no all-corner `borderRadius: 20` on the container; `animationType="slide"` present; `useSafeAreaInsets` imported & `paddingBottom` applied to webview container | CI gate (orch-1149) |
+| T4 (error path) | WebView hard error | Bad URL load | Loading clears, no external-browser eject, sheet stays bottom-anchored | Component / sim |
+| T5 (edge — small device) | Open on a device with no home indicator (older) | Open | Bottom inset = 0, sheet still flush, no gap | Component / sim |
+| T6 (gate non-regression) | Run orch-1022 + sole-gorhom gates | CI | Both PASS | CI |
+| T7 (all mounts) | Open browser from Profile, Paywall, Onboarding, ticket CTA | Each | Each bottom-anchors + slides up | Component / sim |
+| T8 (invariant) | Confirm URL normalization | http:// stop website | WebView loads https:// (normalized at call site) | Source + sim |
+
+---
+
+## 8. Implementation order
+
+1. `InAppBrowserModal.tsx`: add `useSafeAreaInsets` import + `const insets = useSafeAreaInsets();`.
+2. `<Modal>`: `animationType` → `"slide"`; add `statusBarTranslucent`.
+3. `styles.overlay`: `justifyContent: 'flex-end'`, drop `alignItems:'center'`.
+4. `styles.modalContainer`: full-width, drop fixed height/maxHeight/width/maxWidth, top-only radius, set sheet height (~92%).
+5. WebView container `<View>` (L124): `style={[styles.webviewContainer, { paddingBottom: insets.bottom }]}`.
+6. Remove now-unused `Dimensions`/`SCREEN_HEIGHT` if lint flags them.
+7. Add CI gate `orch-1149-inapp-browser-bottom-anchored.mjs` (§9) and register it in the strict-grep CI workflow.
+8. Run gates (orch-1022, sole-gorhom, orch-1149) + typecheck + the consumer test suite.
+
+---
+
+## 9. Regression prevention (fails-on-revert contract)
+
+**Structural safeguard:** a new strict-grep gate `app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs` that reads `InAppBrowserModal.tsx` and asserts ALL of:
+1. `animationType="slide"` is present AND `animationType="fade"` is ABSENT.
+2. The `overlay` style block does NOT contain `justifyContent: 'center'`.
+3. The `modalContainer` style block does NOT contain `SCREEN_HEIGHT * 0.85` (or any `height: SCREEN_HEIGHT *`).
+4. `useSafeAreaInsets` is imported AND `paddingBottom` is applied to the webview container (e.g. asserts both `useSafeAreaInsets` and `insets.bottom` appear).
+5. The component still exports default `InAppBrowserModal` and the `{ visible, url, title, onClose }` prop names are present (so the fix can't accidentally break the contract the other gates depend on).
+
+**Fails-on-revert proof requirement (for the tester):** reverting the fix (restoring `justifyContent:'center'`, `height: SCREEN_HEIGHT*0.85`, `animationType="fade"`, dropping the inset) MUST make this gate FAIL; restoring the fix MUST make it PASS. The implementor includes a protective comment block in `InAppBrowserModal.tsx` citing ORCH-1149 and `I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED` explaining WHY the sheet is bottom-anchored (tab-bar bleed-through) and WHY the bottom inset exists (home-indicator occlusion).
+
+**Tester's adversarial angle (for mingla-tester):** (a) assert no `0.85` fixed height / centered `justify` remains anywhere in the file; (b) snapshot/visually verify the bottom-anchored layout on BOTH iOS sim and Android emulator with the tab bar covered; (c) verify the home-indicator/nav-bar clearance on a device WITH a home indicator AND one without (inset=0 edge); (d) prove all 5 mount sites still open and bottom-anchor; (e) confirm the orch-1022 + sole-gorhom gates still pass (no architectural regression); (f) confirm the URL bar, header, and back/forward chrome are byte-identical; (g) confirm error path still shows in-app (no external eject).
+
+---
+
+## 10. Open questions
+
+- **OQ-1 (design value):** sheet height — SPEC recommends `~92%` (tall sheet, thin top scrim) consistent with other tall Mingla sheets. If Seth wants a SHORTER sheet that still covers the tab bar (e.g. `~80%` but bottom-flush), that is acceptable so long as it is bottom-anchored and covers the nav — the only hard constraint is "flush bottom, tab bar covered." Implementor should default to `92%` unless Seth directs otherwise. (Not a blocker.)
+- No other open questions — the fix is fully specified.
+
+---
+
+## 11. Downstream routing
+
+**Next = mingla-implementor (consumer side).** Build per §4/§8 in the worktree `~/Desktop/mingla-orchs/ORCH-1149-[inapp-browser-bottom-anchor]/` on branch `ORCH-1149-inapp-browser-bottom-anchor`. Inputs: this SPEC + `INVESTIGATE_ORCH-1149_INAPP_BROWSER_BOTTOM_GAP.md`. Hard constraints: single-file change to `InAppBrowserModal.tsx` + the one new CI gate; allowlist below; no gorhom import; no chrome change; preserve the prop contract. Output: implementation report under `Mingla_Artifacts/reports/`. Then → **mingla-tester** (adversarial, both platforms, §9 angle) → **orchestrator CLOSE** (flip `I-PROPOSED-1149-…` ACTIVE, register the gate, World Map, OTA the consumer channels per the EAS OTA gotchas / COMMS-0027).
+
+---
+
+## Scoped allowlist + DO-NOT-TOUCH
+
+**ALLOWLIST (implementor may modify/create ONLY these):**
+- `app-mobile/src/components/InAppBrowserModal.tsx` (modify — layout/animation/inset only).
+- `app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs` (create — new gate).
+- The strict-grep CI workflow file that registers app-mobile gates (add the new gate to the run list).
+- `Mingla_Artifacts/reports/IMPLEMENT_ORCH-1149_*.md` (implementor's report).
+
+**DO-NOT-TOUCH:**
+- The 5 call sites — `ExpandedCardModal.tsx`, `ProfilePage.tsx`, `CustomPaywallScreen.tsx`, `OnboardingFlow.tsx` (confirm-compiles only; no edits).
+- `normalizeWebsiteUrl.ts`, `ActionButtons.tsx`.
+- `BaseBottomSheet.tsx` and anything `@gorhom/bottom-sheet`.
+- `orch-1022-expanded-card-modal-gating-check.mjs`, `meta-orch-0991-base-bottom-sheet-sole-consumer.mjs` (must keep passing — do not edit to "make it pass").
+- The WebView element and ALL its props; the header and nav/URL bar JSX and styles.
+- Anything in `mingla-business/` (out of scope).
+
+The implementor must stop-and-amend (request a SPEC amendment) before touching anything outside the allowlist.

--- a/app-mobile/package.json
+++ b/app-mobile/package.json
@@ -71,7 +71,8 @@
     "test:orch-1049": "node ./scripts/ci/orch-1049-matches-sheet-bottom-inset-check.mjs",
     "test:orch-1054": "node ./scripts/ci/orch-1054-matches-expanded-card-parity-check.mjs",
     "test:orch-1072": "node ./scripts/ci/orch-1072-venue-experiences-check.mjs",
-    "test:orch-1125": "node ./scripts/ci/orch-1125-regression-check.mjs && node --experimental-strip-types --test app/__tests__/coldRouteQueryProvider.orch1125.test.ts"
+    "test:orch-1125": "node ./scripts/ci/orch-1125-regression-check.mjs && node --experimental-strip-types --test app/__tests__/coldRouteQueryProvider.orch1125.test.ts",
+    "test:orch-1149": "node ./scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs
+++ b/app-mobile/scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * ORCH-1149 [in-app browser bottom-anchor] structural regression gate.
+ *
+ * Locks I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED: the shared consumer
+ * in-app browser (app-mobile/src/components/InAppBrowserModal.tsx) MUST render
+ * as a bottom-anchored, full-width sheet that covers the in-tree consumer tab
+ * bar, opened with animationType="slide", with the WebView container padding the
+ * bottom safe-area inset.
+ *
+ * WHY this gate exists: a future "simplifying" refactor could re-center the
+ * dialog (reopening the ~7.5% tab-bar bleed-through at the base) or drop the
+ * bottom inset (occluding web content behind the iOS home indicator / Android
+ * nav bar). Both regressions are invisible in a diff review but caught here.
+ *
+ * Run: node ./scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs
+ * Self-test: node ./scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs --self-test
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const TARGET = "app-mobile/src/components/InAppBrowserModal.tsx";
+
+const read = (relativePath) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+/**
+ * Extract a StyleSheet.create object's named style block (best-effort, brace-
+ * balanced) so assertions are scoped to the right style and not the whole file.
+ */
+function extractStyleBlock(source, styleName) {
+  const startKey = `${styleName}: {`;
+  const start = source.indexOf(startKey);
+  if (start < 0) return "";
+  let depth = 0;
+  let i = source.indexOf("{", start);
+  const blockStart = i;
+  for (; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return source.slice(blockStart, i + 1);
+    }
+  }
+  return "";
+}
+
+function runChecks(source) {
+  const checks = [];
+  const check = (name, pass, detail) => checks.push({ name, pass, detail });
+
+  const overlayBlock = extractStyleBlock(source, "overlay");
+  const modalContainerBlock = extractStyleBlock(source, "modalContainer");
+
+  // 1. Slide animation present; fade absent.
+  check(
+    "G-01 opens with slide animation (no fade)",
+    /animationType=["']slide["']/.test(source) &&
+      !/animationType=["']fade["']/.test(source),
+    'The <Modal> must use animationType="slide" and must NOT use animationType="fade".',
+  );
+
+  // 2. overlay is bottom-anchored, not centered.
+  check(
+    "G-02 overlay is bottom-anchored (not centered)",
+    overlayBlock.length > 0 &&
+      !/justifyContent:\s*["']center["']/.test(overlayBlock) &&
+      /justifyContent:\s*["']flex-end["']/.test(overlayBlock),
+    "styles.overlay must use justifyContent: 'flex-end' and must NOT use justifyContent: 'center'.",
+  );
+
+  // 3. modalContainer drops the fixed centered-card height.
+  check(
+    "G-03 modalContainer has no fixed SCREEN_HEIGHT card height",
+    modalContainerBlock.length > 0 &&
+      !/height:\s*SCREEN_HEIGHT\s*\*/.test(modalContainerBlock) &&
+      !/SCREEN_HEIGHT\s*\*\s*0\.85/.test(source) &&
+      /width:\s*["']100%["']/.test(modalContainerBlock),
+    "styles.modalContainer must be full-width (width: '100%') and must NOT pin height to SCREEN_HEIGHT * 0.85.",
+  );
+
+  // 4. modalContainer is top-only rounded (flush bottom), not all-corner.
+  check(
+    "G-04 modalContainer is top-only rounded (flush bottom)",
+    modalContainerBlock.length > 0 &&
+      /borderTopLeftRadius:\s*20/.test(modalContainerBlock) &&
+      /borderTopRightRadius:\s*20/.test(modalContainerBlock) &&
+      !/(^|[^a-zA-Z])borderRadius:\s*20/.test(modalContainerBlock),
+    "styles.modalContainer must use borderTopLeftRadius/borderTopRightRadius (top-only) and must NOT use all-corner borderRadius: 20.",
+  );
+
+  // 5. Bottom safe-area inset is imported and applied to the webview container.
+  check(
+    "G-05 bottom safe-area inset applied to the WebView container",
+    /useSafeAreaInsets/.test(source) &&
+      /const\s+insets\s*=\s*useSafeAreaInsets\(\)/.test(source) &&
+      /webviewContainer,\s*\{\s*paddingBottom:\s*insets\.bottom\s*\}/.test(source),
+    "Must import useSafeAreaInsets, read insets, and apply { paddingBottom: insets.bottom } to the webviewContainer view.",
+  );
+
+  // 6. Component name / export / prop contract preserved (other gates depend on it).
+  check(
+    "G-06 default export + prop contract preserved",
+    /export default function InAppBrowserModal/.test(source) &&
+      /visible[\s\S]{0,40}url[\s\S]{0,40}title[\s\S]{0,40}onClose/.test(source),
+    "Must keep `export default function InAppBrowserModal` and the { visible, url, title, onClose } prop contract.",
+  );
+
+  // 7. No gorhom import sneaked in (sole-consumer invariant belt-and-braces).
+  check(
+    "G-07 no @gorhom/bottom-sheet import",
+    !/@gorhom\/bottom-sheet/.test(source),
+    "InAppBrowserModal must NOT import @gorhom/bottom-sheet (meta-orch-0991 sole-consumer invariant).",
+  );
+
+  return checks;
+}
+
+function report(checks, label) {
+  const failures = checks.filter((item) => !item.pass);
+  for (const item of checks) {
+    console.log(`${item.pass ? "PASS" : "FAIL"} ${item.name}`);
+    if (!item.pass) console.log(`  ${item.detail}`);
+  }
+  return failures;
+}
+
+if (process.argv.includes("--self-test")) {
+  // Prove the gate FAILS on the pre-ORCH-1149 (reverted) shape.
+  const reverted = `
+import { Modal, View, StyleSheet, Dimensions } from 'react-native';
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+export default function InAppBrowserModal({ visible, url, title, onClose }) {
+  return (
+    <Modal visible={visible} animationType="fade" transparent={true}>
+      <View style={styles.overlay}>
+        <View style={styles.modalContainer}>
+          <View style={styles.webviewContainer} />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+const styles = StyleSheet.create({
+  overlay: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' },
+  modalContainer: { width: '95%', maxWidth: 600, height: SCREEN_HEIGHT * 0.85, maxHeight: SCREEN_HEIGHT * 0.85, borderRadius: 20 },
+  webviewContainer: { flex: 1 },
+});
+`;
+  const checks = runChecks(reverted);
+  const failures = report(checks, "self-test (reverted shape)");
+  if (failures.length === 0) {
+    console.error(
+      "ORCH-1149 self-test ERROR: the gate PASSED on the reverted (centered/fade/0.85) shape — the gate does not actually guard the fix.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `ORCH-1149 self-test passed: gate correctly FAILS the reverted shape (${failures.length}/${checks.length} checks failed as expected).`,
+  );
+  process.exit(0);
+}
+
+const source = read(TARGET);
+const checks = runChecks(source);
+const failures = report(checks);
+
+if (failures.length > 0) {
+  console.error(
+    `ORCH-1149 in-app browser bottom-anchor regression failed: ${failures.length}/${checks.length}`,
+  );
+  process.exit(1);
+}
+
+console.log("ORCH-1149 in-app browser bottom-anchor regression passed.");

--- a/app-mobile/src/components/InAppBrowserModal.tsx
+++ b/app-mobile/src/components/InAppBrowserModal.tsx
@@ -6,13 +6,28 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   StyleSheet,
-  Dimensions,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { WebView, WebViewNavigation } from 'react-native-webview';
 import { Icon } from './ui/Icon';
 import { useTranslation } from 'react-i18next';
 
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+/**
+ * ORCH-1149 [in-app browser bottom-anchor] — I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED.
+ *
+ * This sheet is BOTTOM-ANCHORED on purpose. The RN <Modal> mounts in its own OS
+ * overlay window that renders over the in-tree consumer tab bar (ORCH-0908). It
+ * MUST stay full-width, flush to the bottom, and tall enough to cover the tab bar
+ * — otherwise the Explore/Discover/Friends/Likes/Profile tab bar bleeds through at
+ * the base (the original ~7.5% gap from a centered 85%-height card). It opens with
+ * animationType="slide" so it reads as a Mingla sheet, not a fade-in dialog.
+ *
+ * The `paddingBottom: insets.bottom` on the WebView container is REQUIRED so the
+ * web content clears the iOS home indicator / Android nav bar now that the sheet
+ * reaches the screen edge. Do NOT re-center this dialog and do NOT drop the inset —
+ * both silently reopen the tab-bar bleed-through / home-indicator occlusion the
+ * orch-1149 CI gate guards against.
+ */
 
 interface InAppBrowserModalProps {
   visible: boolean;
@@ -28,6 +43,7 @@ export default function InAppBrowserModal({
   onClose,
 }: InAppBrowserModalProps) {
   const { t } = useTranslation(['modals', 'common']);
+  const insets = useSafeAreaInsets();
   const webViewRef = useRef<WebView>(null);
   const [loading, setLoading] = useState(true);
   const [canGoBack, setCanGoBack] = useState(false);
@@ -70,8 +86,9 @@ export default function InAppBrowserModal({
   return (
     <Modal
       visible={visible}
-      animationType="fade"
+      animationType="slide"
       transparent={true}
+      statusBarTranslucent={true}
       onRequestClose={onClose}
       onShow={handleShow}
     >
@@ -121,7 +138,7 @@ export default function InAppBrowserModal({
           </View>
 
           {/* WebView */}
-          <View style={styles.webviewContainer}>
+          <View style={[styles.webviewContainer, { paddingBottom: insets.bottom }]}>
             {loading && (
               <View style={styles.loadingOverlay}>
                 <ActivityIndicator size="large" color="#eb7825" />
@@ -153,8 +170,8 @@ export default function InAppBrowserModal({
 const styles = StyleSheet.create({
   overlay: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    // ORCH-1149: anchor the sheet to the bottom so it sits flush and covers the tab bar.
+    justifyContent: 'flex-end',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   overlayBackground: {
@@ -165,12 +182,15 @@ const styles = StyleSheet.create({
     bottom: 0,
   },
   modalContainer: {
-    width: '95%',
-    maxWidth: 600,
-    height: SCREEN_HEIGHT * 0.85,
-    maxHeight: SCREEN_HEIGHT * 0.85,
+    // ORCH-1149: full-width, bottom-flush sheet (no centered fixed-height card).
+    width: '100%',
+    height: '92%',
     backgroundColor: '#ffffff',
-    borderRadius: 20,
+    // Top-only rounding — the sheet meets the screen edge at the base.
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
     overflow: 'hidden',
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 10 },

--- a/app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor-tester-adv.test.tsx
+++ b/app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor-tester-adv.test.tsx
@@ -1,0 +1,209 @@
+// @ts-nocheck
+// ORCH-1149 [in-app browser bottom-anchor] — TESTER adversarial regression test.
+//
+// DIFFERENT ANGLE than the implementor's happy-path test
+// (orch-1149-inapp-browser-bottom-anchor.test.tsx). The implementor asserts the
+// NEW shape is PRESENT (slide / flex-end / 100% / top-radius / inset). This
+// adversarial test attacks the two regression risks the happy-path test does NOT
+// cover:
+//
+//   ANGLE A — NO LEFTOVER CENTERED-CARD MARKERS. The happy-path test only checks
+//     `SCREEN_HEIGHT*0.85` and `justifyContent:'center'`. A sloppy re-center could
+//     leave the OTHER centered-card markers behind (`width:'95%'`, `maxWidth:600`,
+//     `maxHeight: SCREEN_HEIGHT*...`, `alignItems:'center'` INSIDE the overlay, a
+//     resurrected `Dimensions`/`SCREEN_HEIGHT`) — every one of which silently
+//     reopens the tab-bar bleed-through. We assert ALL of them are gone, and we
+//     scope the `alignItems:'center'` check to the OVERLAY block specifically (it
+//     legitimately remains in chrome styles: closeButton/navBar/etc.), which a
+//     coarse file-wide grep would get wrong.
+//
+//   ANGLE B — CHROME / WEBVIEW / ERROR-PATH BYTE-PRESERVED. SPEC SC-4/SC-6/SC-7 +
+//     the tester mandate #2 demand the header/close/nav/URL chrome and every
+//     WebView prop be byte-identical and the error path NOT eject to an external
+//     browser. The happy-path test never verifies chrome preservation. We assert
+//     the dark header color, the lock+URL bar, `source={{ uri: url }}` verbatim
+//     (I-WEBVIEW-URL-NORMALIZED — no normalization inside the modal), the
+//     external-window-suppression props, and the in-app error handlers are all
+//     present and that `onShouldStartLoadWithRequest` returns true (keep-all-nav-
+//     inside-WebView, never eject).
+//
+//   ANGLE C — ALL 5 MOUNT SITES STILL OPEN THE SHARED DEFAULT EXPORT. The
+//     happy-path test only reads InAppBrowserModal.tsx. We assert the 5 mount
+//     sites (ExpandedCardModal ticket + policies, ProfilePage, CustomPaywallScreen,
+//     OnboardingFlow) still `import` + `<InAppBrowserModal` so the bottom-anchor
+//     fix actually propagates everywhere (SC-8).
+//
+// Source-static-analysis (the app-mobile convention — no jest in app-mobile);
+// node-runnable via require.main === module. Append-only; does not modify the
+// implementor's test.
+//
+// FAILS-ON-REVERT lever: ANGLE A. On the origin/main (centered) shape the overlay
+// still has `alignItems:'center'`, the modalContainer still has `width:'95%'` /
+// `maxWidth:600` / `maxHeight: SCREEN_HEIGHT*...`, and `Dimensions`/`SCREEN_HEIGHT`
+// are re-imported — so the absence assertions throw. ANGLE B passes on both shapes
+// (chrome is preserved by design) and is a pure non-regression guard.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../../..'); // app-mobile/
+const SRC = path.join(ROOT, 'src/components/InAppBrowserModal.tsx');
+
+// Best-effort brace-balanced extraction of a named StyleSheet.create block.
+function styleBlock(source, name) {
+  const start = source.indexOf(`${name}: {`);
+  if (start < 0) return '';
+  let depth = 0;
+  let i = source.indexOf('{', start);
+  const blockStart = i;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(blockStart, i + 1);
+    }
+  }
+  return '';
+}
+
+function runOrch1149TesterAdversarial() {
+  const source = fs.readFileSync(SRC, 'utf8');
+  const overlay = styleBlock(source, 'overlay');
+  const modalContainer = styleBlock(source, 'modalContainer');
+
+  assert.ok(overlay.length > 0, 'precondition: styles.overlay block must exist');
+  assert.ok(modalContainer.length > 0, 'precondition: styles.modalContainer block must exist');
+
+  // ===== ANGLE A — NO leftover centered-card markers =====
+
+  // A-1 the floating-card width is gone (full-width sheet now).
+  assert.ok(
+    !/width:\s*['"]95%['"]/.test(modalContainer) && !/width:\s*['"]95%['"]/.test(source),
+    "A-1 the centered-card width:'95%' must be GONE (sheet is full-width)"
+  );
+
+  // A-2 the maxWidth cap of the floating card is gone.
+  assert.ok(
+    !/maxWidth:\s*600/.test(modalContainer) && !/maxWidth:\s*600/.test(source),
+    'A-2 the centered-card maxWidth: 600 must be GONE (full-bleed sheet)'
+  );
+
+  // A-3 the fixed maxHeight (the other half of the 0.85 fixed card) is gone.
+  assert.ok(
+    !/maxHeight:\s*SCREEN_HEIGHT/.test(modalContainer) && !/maxHeight:\s*SCREEN_HEIGHT/.test(source),
+    'A-3 the fixed maxHeight: SCREEN_HEIGHT * 0.85 must be GONE'
+  );
+
+  // A-4 the overlay no longer centers horizontally. CRITICAL: scope to the overlay
+  //     block — alignItems:'center' legitimately survives in chrome styles
+  //     (closeButton / navBar / navButton / navUrlContainer / loadingOverlay).
+  assert.ok(
+    !/alignItems:\s*['"]center['"]/.test(overlay),
+    "A-4 styles.overlay must NOT keep alignItems:'center' (full-width sheet; a leftover would re-cage the sheet to a centered column)"
+  );
+
+  // A-5 Dimensions / SCREEN_HEIGHT are fully gone (no resurrected screen-fraction sizing).
+  assert.ok(
+    !/\bDimensions\b/.test(source),
+    'A-5 the Dimensions import must be GONE (no screen-fraction card sizing)'
+  );
+  assert.ok(
+    !/\bSCREEN_HEIGHT\b/.test(source),
+    'A-5 the SCREEN_HEIGHT constant must be GONE everywhere in the file'
+  );
+
+  // ===== ANGLE B — chrome / WebView / error-path byte-preserved (SC-4/6/7) =====
+
+  // B-1 dark title header color preserved (no chrome recolor).
+  assert.ok(
+    /backgroundColor:\s*['"]#1C1C1E['"]/.test(source),
+    'B-1 the dark title header (#1C1C1E) must be preserved (no chrome change)'
+  );
+
+  // B-2 lock-icon + URL bar preserved.
+  assert.ok(
+    /name=["']lock-closed["']/.test(source) && /navUrlText/.test(source),
+    'B-2 the lock icon + URL text bar (navUrlText) must be preserved'
+  );
+
+  // B-3 back / forward chrome preserved.
+  assert.ok(
+    /name=["']chevron-back["']/.test(source) && /name=["']chevron-forward["']/.test(source),
+    'B-3 the back/forward nav chrome must be preserved'
+  );
+
+  // B-4 URL passed to WebView verbatim — normalization stays call-site owned
+  //     (I-WEBVIEW-URL-NORMALIZED). The modal must NOT normalize internally.
+  assert.ok(
+    /source=\{\{\s*uri:\s*url\s*\}\}/.test(source),
+    'B-4 WebView must render source={{ uri: url }} verbatim (call-site-owned normalization)'
+  );
+  assert.ok(
+    !/normalizeWebsiteUrl/.test(source),
+    'B-4 InAppBrowserModal must NOT normalize the URL itself (I-WEBVIEW-URL-NORMALIZED is call-site owned)'
+  );
+
+  // B-5 external-window suppression props preserved (no popup/external eject).
+  assert.ok(
+    /setSupportMultipleWindows=\{false\}/.test(source) &&
+      /javaScriptCanOpenWindowsAutomatically=\{false\}/.test(source),
+    'B-5 the external-window-suppression WebView props must be preserved'
+  );
+
+  // B-6 error path stays IN-APP — both error handlers wired, and the
+  //     shouldStartLoad handler returns true (keep-all-nav-inside-WebView), never
+  //     ejecting to an external browser (SC-6).
+  assert.ok(
+    /onError=\{handleError\}/.test(source) && /onHttpError=\{handleError\}/.test(source),
+    'B-6 onError + onHttpError must both route to the in-app handleError (no external eject)'
+  );
+  assert.ok(
+    /handleShouldStartLoad\s*=\s*useCallback\(\(\)\s*=>\s*\{\s*return true;/.test(
+      source.replace(/\s+/g, ' ')
+    ) || /const handleShouldStartLoad = useCallback\(\(\) => \{\s*return true;/.test(source),
+    'B-6 handleShouldStartLoad must return true (keep all navigation inside the WebView; never eject)'
+  );
+
+  // ===== ANGLE C — all 5 mount sites still open the shared default export =====
+
+  const mountSites = [
+    'src/components/ExpandedCardModal.tsx',
+    'src/components/ProfilePage.tsx',
+    'src/components/CustomPaywallScreen.tsx',
+    'src/components/OnboardingFlow.tsx',
+  ];
+  for (const rel of mountSites) {
+    const text = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+    assert.ok(
+      /import\s+InAppBrowserModal\s+from\s+['"][^'"]*InAppBrowserModal['"]/.test(text),
+      `C-1 ${rel} must import the default InAppBrowserModal (shared bottom-anchored sheet)`
+    );
+    assert.ok(
+      /<InAppBrowserModal/.test(text),
+      `C-1 ${rel} must mount <InAppBrowserModal (inherits the bottom-anchor)`
+    );
+  }
+  // ExpandedCardModal hosts TWO mounts (ticket + policies) → 5 total.
+  const ecm = fs.readFileSync(path.join(ROOT, 'src/components/ExpandedCardModal.tsx'), 'utf8');
+  const ecmMounts = (ecm.match(/<InAppBrowserModal/g) || []).length;
+  assert.equal(
+    ecmMounts,
+    2,
+    `C-2 ExpandedCardModal must host exactly 2 InAppBrowserModal mounts (ticket + policies); found ${ecmMounts}`
+  );
+}
+
+if (require.main === module) {
+  try {
+    runOrch1149TesterAdversarial();
+    console.log(
+      'PASS ORCH-1149 tester-adversarial: no leftover centered-card markers (95%/maxWidth/maxHeight/overlay-alignItems/Dimensions/SCREEN_HEIGHT gone), chrome+WebView+error-path byte-preserved (header/lock+URL/back-forward/verbatim-uri/window-suppression/in-app-error/no-eject), all 5 mount sites still open the shared default export'
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = { runOrch1149TesterAdversarial };

--- a/app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor.test.tsx
+++ b/app-mobile/src/components/__tests__/orch-1149-inapp-browser-bottom-anchor.test.tsx
@@ -1,0 +1,144 @@
+// @ts-nocheck
+// ORCH-1149 [in-app browser bottom-anchor] — IMPLEMENTOR happy-path regression test.
+//
+// Source-static-analysis test (the app-mobile component-test convention — see
+// orch-0995-bottom-nav-spotlight-ui-thread.test.tsx / orch-1029-coach-mark-fixes.test.tsx):
+// reads InAppBrowserModal.tsx as a string and asserts the bottom-anchored sheet shape.
+// node-runnable (no jest in app-mobile); self-runs via require.main === module.
+//
+// Guards I-PROPOSED-1149-INAPP-BROWSER-BOTTOM-ANCHORED. Covers SPEC §5/§9:
+//   T-01  <Modal> opens with animationType="slide" (not "fade")  — SC-2
+//   T-02  <Modal> sets statusBarTranslucent (layers over in-tree tab bar) — SC-1
+//   T-03  styles.overlay is bottom-anchored (justifyContent:'flex-end', no 'center') — SC-1
+//   T-04  styles.modalContainer is full-width + has NO fixed SCREEN_HEIGHT*0.85 height — SC-1
+//   T-05  styles.modalContainer is top-only rounded (flush bottom, no all-corner borderRadius:20) — SC-1
+//   T-06  useSafeAreaInsets imported + { paddingBottom: insets.bottom } applied to webview container — SC-3
+//   T-07  component name / default export / { visible,url,title,onClose } prop contract preserved — SC-8
+//   T-08  no @gorhom/bottom-sheet import (sole-consumer invariant) — SC-9
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SRC = path.resolve(__dirname, '../InAppBrowserModal.tsx');
+
+// Best-effort brace-balanced extraction of a named StyleSheet.create block.
+function styleBlock(source, name) {
+  const start = source.indexOf(`${name}: {`);
+  if (start < 0) return '';
+  let depth = 0;
+  let i = source.indexOf('{', start);
+  const blockStart = i;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(blockStart, i + 1);
+    }
+  }
+  return '';
+}
+
+function runOrch1149BottomAnchorTest() {
+  const source = fs.readFileSync(SRC, 'utf8');
+  const overlay = styleBlock(source, 'overlay');
+  const modalContainer = styleBlock(source, 'modalContainer');
+
+  // T-01 slide animation, no fade
+  assert.ok(
+    /animationType=["']slide["']/.test(source),
+    'T-01 <Modal> must use animationType="slide"'
+  );
+  assert.ok(
+    !/animationType=["']fade["']/.test(source),
+    'T-01 <Modal> must NOT use animationType="fade"'
+  );
+
+  // T-02 statusBarTranslucent
+  assert.ok(
+    /statusBarTranslucent/.test(source),
+    'T-02 <Modal> must set statusBarTranslucent so the sheet layers over the in-tree tab bar'
+  );
+
+  // T-03 overlay bottom-anchored
+  assert.ok(overlay.length > 0, 'T-03 styles.overlay block must exist');
+  assert.ok(
+    /justifyContent:\s*["']flex-end["']/.test(overlay),
+    "T-03 styles.overlay must use justifyContent: 'flex-end'"
+  );
+  assert.ok(
+    !/justifyContent:\s*["']center["']/.test(overlay),
+    "T-03 styles.overlay must NOT use justifyContent: 'center' (would re-center the dialog and reopen tab-bar bleed-through)"
+  );
+
+  // T-04 modalContainer full-width, no fixed SCREEN_HEIGHT*0.85
+  assert.ok(modalContainer.length > 0, 'T-04 styles.modalContainer block must exist');
+  assert.ok(
+    /width:\s*["']100%["']/.test(modalContainer),
+    "T-04 styles.modalContainer must be full-width (width: '100%')"
+  );
+  assert.ok(
+    !/height:\s*SCREEN_HEIGHT\s*\*/.test(modalContainer),
+    'T-04 styles.modalContainer must NOT pin height to SCREEN_HEIGHT * <n>'
+  );
+  assert.ok(
+    !/SCREEN_HEIGHT\s*\*\s*0\.85/.test(source),
+    'T-04 the SCREEN_HEIGHT * 0.85 centered-card height must be gone everywhere in the file'
+  );
+
+  // T-05 top-only rounding (flush bottom)
+  assert.ok(
+    /borderTopLeftRadius:\s*20/.test(modalContainer) &&
+      /borderTopRightRadius:\s*20/.test(modalContainer),
+    'T-05 styles.modalContainer must use top-only rounding (borderTopLeftRadius/borderTopRightRadius: 20)'
+  );
+  assert.ok(
+    !/(^|[^a-zA-Z])borderRadius:\s*20/.test(modalContainer),
+    'T-05 styles.modalContainer must NOT use all-corner borderRadius: 20 (flush bottom = no bottom rounding)'
+  );
+
+  // T-06 bottom safe-area inset applied to webview container
+  assert.ok(
+    /useSafeAreaInsets/.test(source),
+    'T-06 must import/use useSafeAreaInsets'
+  );
+  assert.ok(
+    /const\s+insets\s*=\s*useSafeAreaInsets\(\)/.test(source),
+    'T-06 must read const insets = useSafeAreaInsets()'
+  );
+  assert.ok(
+    /webviewContainer,\s*\{\s*paddingBottom:\s*insets\.bottom\s*\}/.test(source),
+    'T-06 the WebView container must apply { paddingBottom: insets.bottom } so content clears the home indicator / nav bar'
+  );
+
+  // T-07 component contract preserved
+  assert.ok(
+    /export default function InAppBrowserModal/.test(source),
+    'T-07 default export `InAppBrowserModal` must be preserved'
+  );
+  for (const prop of ['visible', 'url', 'title', 'onClose']) {
+    assert.ok(
+      new RegExp(`\\b${prop}\\b`).test(source),
+      `T-07 prop "${prop}" must remain in the { visible, url, title, onClose } contract`
+    );
+  }
+
+  // T-08 no gorhom import
+  assert.ok(
+    !/@gorhom\/bottom-sheet/.test(source),
+    'T-08 InAppBrowserModal must NOT import @gorhom/bottom-sheet (meta-orch-0991 sole-consumer)'
+  );
+}
+
+if (require.main === module) {
+  try {
+    runOrch1149BottomAnchorTest();
+    console.log(
+      'PASS T-01..T-08 ORCH-1149 in-app browser bottom-anchor: slide animation, statusBarTranslucent, bottom-anchored overlay, full-width flush sheet (no 0.85 card), top-only rounding, bottom safe-area inset on webview, prop contract preserved, no gorhom import'
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+module.exports = { runOrch1149BottomAnchorTest };


### PR DESCRIPTION
## ORCH-1149 — in-app browser bottom gap

**Problem (Seth-reported):** The shared consumer in-app browser opened as a centered floating card (85% height, fade-in), leaving a gap at the base through which the tab bar (Explore/Discover/Friends/Likes/Profile) bled through.

**Fix:** Bottom-anchor the sheet so it slides up from the bottom and sits flush — fully covering the tab bar — with a safe-area bottom inset so web content clears the home indicator / Android nav. **No chrome change** (header, back/forward, lock+URL bar, WebView behavior all byte-identical). Single product file: `app-mobile/src/components/InAppBrowserModal.tsx`. Shared component → applies to all 5 mount sites (curated card policies + ticket browser, profile, paywall, onboarding).

**Scope:** consumer iOS + Android (shared RN). No business app, no web, no migration, no edge fn.

## Evidence
- Forensics INVESTIGATE+SPEC + IMPLEMENT + TEST reports under `Mingla_Artifacts/`.
- Tester verdict: CONDITIONAL PASS, 0 P0/P1/P2 (live-fire visual deferred to dev-channel OTA eyeball).
- Step 0.5 gate satisfied: implementor happy-path test + tester adversarial test, both fails-on-revert proven (at `a684169b1`).
- New CI gate `orch-1149-inapp-browser-bottom-anchored.mjs` (7/7) guards against re-centering / inset drop.
- Sole-gorhom gate green; chrome preserved; all 5 call sites typecheck.

Note: the pre-existing orch-1022 gate is red on `main` (stale from ORCH-1072) and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)