### PR TITLE
ORCH-1147: cart reflects the TRUE all-in price (event/trip/experience) + web charge fix [deploy]

### DIFF
--- a/.github/scripts/strict-grep/orch-1147-allin-single-owner.mjs
+++ b/.github/scripts/strict-grep/orch-1147-allin-single-owner.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1147 (SC-11) — the per-tier server all-in
+ * (`pg_public_event_tier_allin`) has exactly ONE owner of the RPC call:
+ * `fetchTierAllInCents` in `mingla-business/src/services/publicEventsService.ts`.
+ *
+ * The trip producer (`getPublicTripById`, same file) and the experience
+ * service (`publicExperienceService.ts`) MUST reuse that single helper — they
+ * IMPORT/CALL it, they do NOT call the RPC themselves and do NOT recompute
+ * fees in TS. This catches a future duplicate-RPC / re-derived-fee regression
+ * that would re-introduce the two-source drift ORCH-1147 eliminated.
+ *
+ * The gate fails if:
+ *   (a) `pg_public_event_tier_allin` is referenced anywhere OTHER than
+ *       publicEventsService.ts (the single owner), OR
+ *   (b) the trip-tier / experience source services contain the RPC string at
+ *       all (`tripsService.ts`, `publicExperienceService.ts`).
+ *
+ * Comments are stripped so explanatory ORCH-1147 prose never trips the gate.
+ * Mirrors the modular gate pattern (sibling: orch-1147-cart-total-is-allin.mjs).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+const failures = [];
+
+const RPC = "pg_public_event_tier_allin";
+
+// The ONLY file allowed to call the RPC (single owner = fetchTierAllInCents).
+const OWNER = "mingla-business/src/services/publicEventsService.ts";
+
+// Files that MUST reuse the helper, never the RPC directly.
+const REUSERS = [
+  "mingla-business/src/services/tripsService.ts",
+  "mingla-business/src/services/publicExperienceService.ts",
+];
+
+// Strip line + block comments so prose mentioning the RPC never trips.
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+// --- self-test fixtures (run with --self-test) ----------------------------
+const SELF_TEST = process.argv.includes("--self-test");
+
+const evaluateReuser = (rel, rawCode) => {
+  const code = stripComments(rawCode);
+  if (code.includes(RPC)) {
+    return [
+      `${rel}: references ${RPC} directly. The single owner is fetchTierAllInCents in publicEventsService.ts — import + reuse it, do NOT duplicate the RPC or recompute fees. ORCH-1147 SC-11.`,
+    ];
+  }
+  return [];
+};
+
+const evaluateOwner = (rel, rawCode) => {
+  const code = stripComments(rawCode);
+  // The owner must actually own the RPC (the single call site).
+  if (!code.includes(RPC)) {
+    return [
+      `${rel}: the single-owner helper fetchTierAllInCents must call ${RPC}, but the RPC string is missing. ORCH-1147 SC-11.`,
+    ];
+  }
+  // …and must export the helper so reusers can call it.
+  if (!/export\s+const\s+fetchTierAllInCents\b/.test(code)) {
+    return [
+      `${rel}: fetchTierAllInCents must be EXPORTED so the experience service reuses the single owner. ORCH-1147 SC-11.`,
+    ];
+  }
+  return [];
+};
+
+if (SELF_TEST) {
+  const GOOD_OWNER = `
+    export const fetchTierAllInCents = async (eventId) => {
+      const { data } = await supabase.rpc("pg_public_event_tier_allin", { p_event_id: eventId });
+      return data;
+    };
+  `;
+  const BAD_OWNER_NOEXPORT = `
+    const fetchTierAllInCents = async (eventId) => {
+      const { data } = await supabase.rpc("pg_public_event_tier_allin", { p_event_id: eventId });
+      return data;
+    };
+  `;
+  const GOOD_REUSER = `
+    import { fetchTierAllInCents } from "./publicEventsService";
+    const m = await fetchTierAllInCents(eventId);
+  `;
+  const BAD_REUSER = `
+    const { data } = await supabase.rpc("pg_public_event_tier_allin", { p_event_id: eventId });
+  `;
+  const ok =
+    evaluateOwner("owner.ts", GOOD_OWNER).length === 0 &&
+    evaluateOwner("owner-noexport.ts", BAD_OWNER_NOEXPORT).length >= 1 &&
+    evaluateReuser("reuser-good.ts", GOOD_REUSER).length === 0 &&
+    evaluateReuser("reuser-bad.ts", BAD_REUSER).length >= 1;
+  if (!ok) {
+    console.error("ORCH-1147 allin-single-owner SELF-TEST failed.");
+    process.exit(1);
+  }
+  console.log("ORCH-1147 allin-single-owner gate self-test passed.");
+  process.exit(0);
+}
+
+const ownerAbs = join(root, OWNER);
+if (!existsSync(ownerAbs)) {
+  failures.push(`${OWNER}: single-owner service not found.`);
+} else {
+  failures.push(
+    ...evaluateOwner(relative(root, ownerAbs), readFileSync(ownerAbs, "utf8")),
+  );
+}
+
+for (const rel of REUSERS) {
+  const abs = join(root, rel);
+  if (!existsSync(abs)) {
+    failures.push(`${rel}: expected reuser service not found.`);
+    continue;
+  }
+  failures.push(
+    ...evaluateReuser(relative(root, abs), readFileSync(abs, "utf8")),
+  );
+}
+
+if (failures.length > 0) {
+  console.error("ORCH-1147 allin-single-owner gate failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("ORCH-1147 allin-single-owner gate passed.");

--- a/.github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs
+++ b/.github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1147 — the business checkout headline "Total" is the server fee-grossed
+ * all-in, NOT the bare base subtotal.
+ *
+ * Invariant I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT): the three
+ * mingla-business checkout payment screens (event / trip / experience) MUST
+ * source the headline Total (`displayAllIn`) from the server fee-grossed all-in
+ * (`totals.allInTotal` → `allInFloorCents`, optionally refined by
+ * `allInPreviewCents`), and MUST NOT bind the headline directly to the bare
+ * base subtotal (`totals.total` / `totals.subtotal`). The base subtotal stays
+ * the per-line "Tickets" recap basis only.
+ *
+ * This catches the F-1/F-2 regression where the headline Total re-derived the
+ * bare ticket subtotal and omitted the passed Mingla/service fee (and tax).
+ *
+ * The gate fails if any payment.tsx:
+ *   (a) does NOT reference `totals.allInTotal` (the server all-in basis), OR
+ *   (b) defines `displayAllIn` directly from the bare base
+ *       (`displayAllIn = formatCurrency(... totals.total ...)` /
+ *        `... totals.subtotal ...`) without the all-in floor path.
+ *
+ * Comments are stripped so the explanatory ORCH-1147 notes never trip the gate.
+ * Mirrors the modular gate pattern (sibling: orch-1130-no-buyer-tax-form.mjs).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+const failures = [];
+
+const paymentScreens = [
+  "mingla-business/app/checkout/[eventId]/payment.tsx",
+  "mingla-business/app/checkout-trip/[tripEventId]/payment.tsx",
+  "mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx",
+];
+
+// Strip line + block comments so prose like "// ...totals.total..." never trips.
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+// --- self-test fixtures (run with --self-test) ----------------------------
+const SELF_TEST = process.argv.includes("--self-test");
+
+const evaluate = (rel, rawCode) => {
+  const code = stripComments(rawCode);
+  const fileFailures = [];
+
+  // (a) the all-in basis must be referenced.
+  if (!/\btotals\.allInTotal\b/.test(code)) {
+    fileFailures.push(
+      `${rel}: headline Total must read the server fee-grossed all-in (totals.allInTotal). The bare base subtotal omits the passed Mingla/service fee. I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN.`,
+    );
+  }
+
+  // (b) displayAllIn must NOT be defined directly off the bare base subtotal.
+  // Catch e.g. `const displayAllIn = formatCurrency(totals.total, ...)` or
+  // `... totals.subtotal ...` on the SAME statement.
+  const badHeadline =
+    /const\s+displayAllIn\s*=\s*formatCurrency\([^;]*\btotals\.(total|subtotal)\b[^;]*\)\s*;/;
+  if (badHeadline.test(code)) {
+    fileFailures.push(
+      `${rel}: displayAllIn binds the headline directly to the bare base (totals.total/totals.subtotal). Source it from the all-in floor (allInFloorCents) instead. I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN.`,
+    );
+  }
+
+  return fileFailures;
+};
+
+if (SELF_TEST) {
+  const GOOD = `
+    const allInFloorCents = Math.round(totals.allInTotal * 100);
+    const headlineCents = allInFloorCents;
+    const displayAllIn = formatCurrency(headlineCents, totals.currency, true);
+  `;
+  const BAD_BASE = `
+    const displayTotalCents = totals.total;
+    const displayAllIn = formatCurrency(displayTotalCents, totals.currency);
+  `;
+  const BAD_INLINE = `
+    const displayAllIn = formatCurrency(totals.total, totals.currency);
+  `;
+  const goodFails = evaluate("good.tsx", GOOD);
+  const badBaseFails = evaluate("bad-base.tsx", BAD_BASE);
+  const badInlineFails = evaluate("bad-inline.tsx", BAD_INLINE);
+  const ok =
+    goodFails.length === 0 &&
+    badBaseFails.length >= 1 &&
+    badInlineFails.length >= 1;
+  if (!ok) {
+    console.error("ORCH-1147 cart-total-is-allin SELF-TEST failed:", {
+      goodFails,
+      badBaseFails,
+      badInlineFails,
+    });
+    process.exit(1);
+  }
+  console.log("ORCH-1147 cart-total-is-allin gate self-test passed.");
+  process.exit(0);
+}
+
+for (const rel of paymentScreens) {
+  const abs = join(root, rel);
+  if (!existsSync(abs)) {
+    failures.push(`${rel}: expected checkout payment screen not found.`);
+    continue;
+  }
+  failures.push(...evaluate(relative(root, abs), readFileSync(abs, "utf8")));
+}
+
+if (failures.length > 0) {
+  console.error("ORCH-1147 cart-total-is-allin gate failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("ORCH-1147 cart-total-is-allin gate passed.");

--- a/.github/scripts/strict-grep/orch-1147-web-charge-allin.mjs
+++ b/.github/scripts/strict-grep/orch-1147-web-charge-allin.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1147 — the buyer-web hosted Stripe Checkout Session bills the fee-grossed
+ * pre-tax subtotal, not the bare base.
+ *
+ * Invariant I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL (DRAFT): in
+ * `supabase/functions/ticket-checkout-create/index.ts`, the web/mobile-web
+ * `checkout.sessions.create` line item `price_data.unit_amount` MUST be
+ * `buyerSubtotal.buyerSubtotalCents` (base + passed Mingla fee + passed service
+ * fee, PRE-TAX), so the web charge equals the native fee gross-up. The session
+ * has `automatic_tax: { enabled: true }` — Stripe adds tax ON TOP, so billing
+ * the bare base `totalCents` (D-1) under-charges the passed fee, and billing the
+ * tax-inclusive `buyer_total_cents` would DOUBLE-tax.
+ *
+ * The gate fails if the web Checkout line item reverts to `unit_amount: totalCents`
+ * or `unit_amount: ...buyer_total_cents`, or if the fee-grossed binding is gone.
+ *
+ * Comment-anchored fails-on-revert: comments are stripped so the explanatory
+ * ORCH-1147 note never satisfies (or trips) the gate — only LIVE code counts.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+const failures = [];
+
+const target = "supabase/functions/ticket-checkout-create/index.ts";
+
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+const SELF_TEST = process.argv.includes("--self-test");
+
+// Evaluate the `line_items: [ { price_data: { ... unit_amount: X ... } } ]`
+// block of the web Checkout Session. We isolate the price_data object that sits
+// inside a `checkout.sessions.create`/`line_items` region.
+const evaluate = (rel, rawCode) => {
+  const code = stripComments(rawCode);
+  const fileFailures = [];
+
+  // Find the web Checkout Session line-item unit_amount. The web branch is the
+  // ONLY place that builds `line_items: [{ price_data: { ... unit_amount: ... }}]`.
+  const lineItemMatch = code.match(
+    /line_items\s*:\s*\[\s*\{\s*price_data\s*:\s*\{[\s\S]*?unit_amount\s*:\s*([A-Za-z0-9_.]+)/,
+  );
+
+  if (lineItemMatch === null) {
+    fileFailures.push(
+      `${rel}: could not locate the web Checkout Session line_items[].price_data.unit_amount. The web charge binding must stay greppable. I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL.`,
+    );
+    return fileFailures;
+  }
+
+  const unitAmount = lineItemMatch[1];
+  if (unitAmount !== "buyerSubtotal.buyerSubtotalCents") {
+    fileFailures.push(
+      `${rel}: web Checkout Session bills \`unit_amount: ${unitAmount}\` — it MUST bill \`buyerSubtotal.buyerSubtotalCents\` (fee-grossed PRE-TAX subtotal). Billing the bare base (totalCents) under-charges the passed fee (D-1); billing buyer_total_cents double-taxes (automatic_tax is on). I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL.`,
+    );
+  }
+
+  return fileFailures;
+};
+
+if (SELF_TEST) {
+  const GOOD = `
+    checkoutSession = await stripeWeb.checkout.sessions.create({
+      mode: "payment",
+      line_items: [ { price_data: { currency, unit_amount: buyerSubtotal.buyerSubtotalCents, product_data: { name } }, quantity: 1 } ],
+      automatic_tax: { enabled: true },
+    });
+  `;
+  const BAD_BASE = `
+    line_items: [ { price_data: { currency, unit_amount: totalCents, product_data: { name } }, quantity: 1 } ],
+  `;
+  const BAD_TOTAL = `
+    line_items: [ { price_data: { currency, unit_amount: pricingBreakdown.buyer_total_cents }, quantity: 1 } ],
+  `;
+  const goodFails = evaluate("good.ts", GOOD);
+  const badBaseFails = evaluate("bad-base.ts", BAD_BASE);
+  const badTotalFails = evaluate("bad-total.ts", BAD_TOTAL);
+  const ok =
+    goodFails.length === 0 &&
+    badBaseFails.length >= 1 &&
+    badTotalFails.length >= 1;
+  if (!ok) {
+    console.error("ORCH-1147 web-charge-allin SELF-TEST failed:", {
+      goodFails,
+      badBaseFails,
+      badTotalFails,
+    });
+    process.exit(1);
+  }
+  console.log("ORCH-1147 web-charge-allin gate self-test passed.");
+  process.exit(0);
+}
+
+const abs = join(root, target);
+if (!existsSync(abs)) {
+  failures.push(`${target}: ticket-checkout-create edge function not found.`);
+} else {
+  failures.push(...evaluate(relative(root, abs), readFileSync(abs, "utf8")));
+}
+
+if (failures.length > 0) {
+  console.error("ORCH-1147 web-charge-allin gate failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("ORCH-1147 web-charge-allin gate passed.");

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2346,6 +2346,19 @@ jobs:
       - name: Run ORCH-1147 web-charge-allin gate
         run: node .github/scripts/strict-grep/orch-1147-web-charge-allin.mjs
 
+  orch-1147-allin-single-owner:
+    name: "ORCH-1147: pg_public_event_tier_allin has ONE owner; trip/experience reuse the helper (SC-11)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test the gate (owner vs duplicate-RPC fixtures)
+        run: node .github/scripts/strict-grep/orch-1147-allin-single-owner.mjs --self-test
+      - name: Run ORCH-1147 allin-single-owner gate
+        run: node .github/scripts/strict-grep/orch-1147-allin-single-owner.mjs
+
   orch-1138-trip-reserve-straight-to-cart:
     name: "ORCH-1138: trip Reserve opens the cart directly, never EBES (I-PROPOSED-1138-TRIP-RESERVE-STRAIGHT-TO-CART)"
     runs-on: ubuntu-latest

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2320,6 +2320,32 @@ jobs:
       - name: Run ORCH-1130 no-buyer-tax-form gate
         run: node .github/scripts/strict-grep/orch-1130-no-buyer-tax-form.mjs
 
+  orch-1147-cart-total-is-allin:
+    name: "ORCH-1147: checkout headline Total is the server fee-grossed all-in (I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test the gate (good vs base-bound fixtures)
+        run: node .github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs --self-test
+      - name: Run ORCH-1147 cart-total-is-allin gate
+        run: node .github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs
+
+  orch-1147-web-charge-allin:
+    name: "ORCH-1147: web Checkout bills the fee-grossed pre-tax subtotal (I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test the gate (good vs base/total-bound fixtures)
+        run: node .github/scripts/strict-grep/orch-1147-web-charge-allin.mjs --self-test
+      - name: Run ORCH-1147 web-charge-allin gate
+        run: node .github/scripts/strict-grep/orch-1147-web-charge-allin.mjs
+
   orch-1138-trip-reserve-straight-to-cart:
     name: "ORCH-1138: trip Reserve opens the cart directly, never EBES (I-PROPOSED-1138-TRIP-RESERVE-STRAIGHT-TO-CART)"
     runs-on: ubuntu-latest

--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1147_CART_TRUE_PRICE_FEE_TAX_OMISSION.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1147_CART_TRUE_PRICE_FEE_TAX_OMISSION.md
@@ -1,0 +1,263 @@
+# INVESTIGATE — ORCH-1147 [cart does not reflect the TRUE price of a trip/event/experience]
+
+**Phase:** INVESTIGATE ONLY (no product code, no SPEC).
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]` on branch `ORCH-1147-cart-true-price` (rebased on origin/main @ `61156a6e5`, up to date).
+**Project ref:** `gqnoajqerqhnvulmnyvv`.
+**Skill:** mingla-forensics. **COMMS ledger:** read on entry; no OPEN entry addressed to forensics / ORCH-1147 / ALL — no ack required.
+
+---
+
+## Symptom summary (expected vs actual)
+
+- **Expected (Mingla all-in / WYSIWYP, ORCH-1025/1130):** the cart/checkout summary the buyer sees BEFORE paying equals the amount the server actually charges — base + any passed-through Mingla fee + service fee + tax, shown as one all-in Total with a single combined "Fees & tax" line.
+- **Actual:** on the business app and buyer-web, the displayed Total is the **bare ticket subtotal** (base price × qty), with **fees and tax NOT folded in**, so the buyer can be charged MORE than the quoted Total. Confirmed repro anchor: business app own checkout, across trip / event / experience.
+
+---
+
+## Investigation manifest (files read, in trace order)
+
+1. `COMMS_LEDGER.md` — entry scan (no forensics/1147/ALL OPEN row).
+2. `.github/scripts/strict-grep/orch-1130-no-buyer-tax-form.mjs` — the 3 native checkout payment-screen roots.
+3. `mingla-business/app/checkout/[eventId]/index.tsx` — event ticket-select cart (subtotal).
+4. `mingla-business/src/components/checkout/CartContext.tsx` — `useCartTotals` (the client total math).
+5. `mingla-business/app/checkout/[eventId]/payment.tsx` — event payment screen `displayAllIn`.
+6. `mingla-business/app/checkout-trip/[tripEventId]/payment.tsx` — trip payment `displayAllIn`.
+7. `mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx` — experience payment `displayAllIn`.
+8. `mingla-business/app/checkout-trip/.../index.tsx`, `checkout-experience/.../index.tsx` — cart seed (`unitPrice`).
+9. `supabase/functions/ticket-checkout-create/index.ts` (1705 lines) — the charge authority (web Checkout Session + native PI + preview).
+10. `supabase/functions/_shared/allInPricingEngine.ts` — `computeBuyerSubtotal`, `buildPricingBreakdown`, `buyer_total_cents`.
+11. `mingla-business/src/services/publicEventsService.ts` — `fetchTierAllInCents` / `pg_public_event_tier_allin` (per-tier all-in IS fetched).
+12. `mingla-business/src/hooks/usePublicEvents.ts` — query wrapper.
+13. `app-mobile/src/components/expandedCard/TicketCartSheet.tsx` — consumer cart (per-tier `priceAllInGbp` client all-in).
+14. `app-mobile/src/payments/nativeCheckoutFlow.ts` — consumer native charge path (surface:"native").
+15. DB (read-only): `resolve_event_pricing_inputs`, `compute_all_in_cents`, `pg_public_event_tier_allin` defs; brand pass-toggle + region distribution; the one pass-fee brand's tier numbers.
+
+---
+
+## Q-scorecard
+
+**Q1 — Does the business-app cart/payment display equal the server charge?**
+Verdict: **NO — display omits the passed-fee gross-up (and tax). PROBABLE (source-strong + DB numeric proof), masked in current prod data.** See F-1, F-2, F-7.
+
+**Q2 — Do display and charge share ONE pricing engine, or does display re-derive independently?**
+Verdict: **They DIVERGE. The charge uses the server engine (`buyer_total_cents`); the business display re-derives the total client-side from the bare base subtotal (`useCartTotals.total`), ignoring the per-tier all-in it already fetched.** PROBABLE. See F-1, F-3.
+
+**Q3 — Same bug on web buyer funnel as on native?**
+Verdict: **WORSE on web. Web never even attempts the all-in: `displayAllIn` is forced to the base subtotal (`Platform.OS === "web"` branch), and the hosted Stripe Checkout line item is `unit_amount: totalCents` (base only) — the passed Mingla/service-fee gross-up is silently dropped from the WEB CHARGE itself, not just the display.** PROBABLE. See F-2, F-4.
+
+**Q4 — Trip vs event vs experience — same behavior?**
+Verdict: **IDENTICAL across all three. All route through `ticket-checkout-create`; all three checkout indexes seed `unitPrice: priceGbp` (base); all three payment screens use the same `displayAllIn` fallback pattern.** PROBABLE. See F-3.
+
+**Q5 — Does the consumer app (app-mobile) have the same bug?**
+Verdict: **PARTIAL. Consumer displays a correct FEE-grossed all-in (`priceAllInGbp` from `pg_public_event_tier_allin`) — so it matches the charge when tax is inclusive (GB/EU/CH) or pass_tax=false. But the all-in RPC EXCLUDES tax, so consumer UNDERSTATES by the tax amount when pass_tax=true AND the region adds tax on top (exclusive / US sales tax).** PROBABLE. See F-5, F-6.
+
+**Q6 — Is the discrepancy brand-toggle dependent, and is it masked today?**
+Verdict: **YES on both. The gross-up only appears when a brand PASSES a fee/tax. In current prod, 0 of 8 charges-enabled brands pass any toggle → the discrepancy is invisible in any live checkout today. The lone pass-fee brand is NGN/Paystack, charges-disabled.** PROBABLE→numeric-PROVEN at DB layer. See F-7.
+
+---
+
+## Findings (six-field evidence)
+
+### F-1 — `useCartTotals.total` is the bare subtotal: NO fees, NO tax (business client total math)
+- **Symptom:** business cart/payment "Total" = base × qty; fees/tax absent.
+- **Layer:** code (client).
+- **Probe:** read `mingla-business/src/components/checkout/CartContext.tsx:402-426`.
+- **Evidence:**
+  ```ts
+  // CartContext.tsx:404-423
+  let subtotal = 0;
+  for (const line of lines) { subtotal += line.unitPrice * line.quantity; ... }
+  return { ...subtotal, total: subtotal, ... }; // total === subtotal, no fee/tax term
+  ```
+  And the cart is seeded with the BASE, not the all-in:
+  ```ts
+  // checkout/[eventId]/index.tsx:274   unitPrice: ticket.priceGbp ?? 0,
+  // checkout-trip/.../index.tsx:246    unitPrice: sole.priceGbp ?? 0,
+  // checkout-experience/.../index.tsx:277 unitPrice: stub.priceGbp ?? 0,
+  ```
+- **Mechanism:** `total` is defined as the raw base subtotal → every business surface that renders `totals.total` shows a number with no fee/tax gross-up.
+- **Severity:** **CONFIRMED ROOT CAUSE** (the display total computation site).
+
+### F-2 — Business payment screen `displayAllIn` falls back to the bare subtotal; web ALWAYS shows it
+- **Symptom:** buyer sees the base Total on web always, and on native whenever the async preview hasn't resolved/failed.
+- **Layer:** code (client).
+- **Probe:** read `checkout/[eventId]/payment.tsx:558-561` (event); identical at trip `payment.tsx:573-576` and experience `payment.tsx:476-480`.
+- **Evidence:**
+  ```ts
+  // payment.tsx:558-561
+  const displayTotalCents = totals.total;                       // bare subtotal
+  const displayAllIn = Platform.OS !== "web" && allInPreviewCents !== null
+    ? formatCurrency(allInPreviewCents, totals.currency, true)  // server all-in (native only)
+    : formatCurrency(displayTotalCents, totals.currency);       // FALLBACK = bare subtotal
+  ```
+  `allInPreviewCents` is set only by a NON-BLOCKING `mode:"preview"` round-trip that requires buyer name+email and silently no-ops on any error (`payment.tsx:272-313`). On web the `Platform.OS !== "web"` guard forces the base-subtotal branch unconditionally.
+- **Mechanism:** the "all-in" display depends on a fragile native-only async fetch; web and any native fast-path / preview-failure show the base subtotal as the headline `Total` and on the `Pay {displayAllIn}` button.
+- **Severity:** **CONFIRMED ROOT CAUSE** (the divergent display computation site; web is unconditional).
+
+### F-3 — Charge authority: server engine charges `buyer_total_cents` = base + passed fees + tax
+- **Symptom:** the amount the buyer is actually billed.
+- **Layer:** code (edge) + schema.
+- **Probe:** read `supabase/functions/ticket-checkout-create/index.ts:899-927, 1488-1559` + `_shared/allInPricingEngine.ts:173-267`.
+- **Evidence:**
+  ```ts
+  // allInPricingEngine.ts:182-189
+  let buyerSubtotal = input.baseCents;
+  if (input.switches.pass_mingla_fee)  buyerSubtotal += miglaFeeCents;
+  if (input.switches.pass_service_fee) buyerSubtotal += serviceFeeCents;
+  // ticket-checkout-create.ts:1361  taxAmountCents = buyerSubtotal.buyerSubtotalCents (tax computed ON the grossed-up subtotal)
+  // ticket-checkout-create.ts:1559  amount: pricingBreakdown.buyer_total_cents  (NATIVE PI amount = all-in incl. tax)
+  // allInPricingEngine.ts:254       buyer_total_cents: amountTotalCents  (= Stripe tax calc amount_total)
+  ```
+- **Mechanism:** the server is the single charge authority and bills the full all-in; the business display (F-1/F-2) re-derives the total from the base subtotal independently → divergence whenever any pass-toggle is on (and, on the exclusive-tax path, whenever tax is added on top).
+- **Severity:** **CONFIRMED ROOT CAUSE** (ground-truth charge site; the divergence counterpart to F-1/F-2).
+
+### F-4 — WEB charge itself drops the passed fee gross-up (not just the display)
+- **Symptom:** on the buyer-web hosted Stripe page the buyer is charged base + Stripe-auto-tax, with the passed Mingla/service fee gross-up MISSING from the line item.
+- **Layer:** code (edge).
+- **Probe:** read `ticket-checkout-create/index.ts:1078-1092`.
+- **Evidence:**
+  ```ts
+  // ticket-checkout-create.ts:1082-1091  (web / mobile-web Checkout Session)
+  line_items: [{ price_data: { currency, unit_amount: totalCents, ... }, quantity: 1 }],
+  // unit_amount = totalCents = BASE subtotal (NOT buyerSubtotal.buyerSubtotalCents / buyer_total_cents)
+  automatic_tax: { enabled: true },          // Stripe adds tax on top
+  // application_fee_amount = Mingla's skim — comes OUT of the merchant cut, NOT added to the buyer
+  ```
+  Contrast with the native PI which uses `amount: pricingBreakdown.buyer_total_cents` (F-3). The web Checkout Session is built from `totalCents` (base) only.
+- **Mechanism:** on web the passed fee gross-up never reaches Stripe at all → the buyer is UNDER-charged the fee on web (revenue/economic mismatch) while the native buyer is charged the full all-in. The web display and the web charge agree with each other on base+tax, but BOTH disagree with the native charge and with the intended all-in.
+- **Severity:** **SECONDARY ROOT CAUSE** — a second, distinct divergence on web: the charge omits the passed fee. (Note: this is a charge-side bug, not only a display bug; flag for SPEC scope.)
+
+### F-5 — Consumer cart shows a FEE-grossed all-in (correct mechanism) — proves the right pattern exists
+- **Symptom:** consumer "Total" + "Fees & tax" line reflect base + passed fees.
+- **Layer:** code (client) + schema.
+- **Probe:** read `app-mobile/.../TicketCartSheet.tsx:286-330, 434, 706-722` + `pg_public_event_tier_allin` def.
+- **Evidence:**
+  ```ts
+  // TicketCartSheet.tsx:314-323
+  const allInMajor = ticket?.priceAllInGbp != null ? ticket.priceAllInGbp : null; // server all-in per tier
+  const lineAllInCents = allInMajor != null ? Math.round(allInMajor*100)*qty : lineBaseCents;
+  const feesTaxCents = Math.max(0, allInCents - baseCents);   // ONE combined "Fees & tax" line
+  // :434  totalCents: pricing.allInCents  (display total = server all-in)
+  ```
+- **Mechanism:** consumer reads a server-computed per-tier `all_in_cents` (`pg_public_event_tier_allin`) and displays the all-in client-side with zero local fee math → display matches the FEE portion of the charge. This is the contract the business app is missing.
+- **Severity:** **RULED OUT** as a fee-omission root cause on consumer; **reference pattern** for the fix.
+
+### F-6 — The all-in RPC (`compute_all_in_cents`) folds FEES but EXCLUDES tax → consumer (and any all-in display) understates by tax on exclusive-tax regions
+- **Symptom:** consumer/business all-in display can still be below the charge by the tax amount.
+- **Layer:** schema (DB function).
+- **Probe:** `pg_get_functiondef('compute_all_in_cents')`, `pg_get_functiondef('pg_public_event_tier_allin')` (live prod introspection).
+- **Evidence:**
+  ```sql
+  -- compute_all_in_cents(base, pass_mingla, pass_service, take_rate_bps, service_fee_bps=300):
+  --   base + (pass_mingla ? mingla_fee : 0) + (pass_service ? service_fee : 0)
+  --   NO TAX TERM.
+  -- pg_public_event_tier_allin → calls compute_all_in_cents; all_in_cents excludes tax.
+  ```
+  The server CHARGE (F-3) computes Stripe Tax on the grossed-up subtotal: for inclusive regions (GB/EU/CH) tax is inside the base (so `all_in_cents` matches `buyer_total_cents`); for **exclusive** regions (US sales tax) the charge ADDS tax on top → `buyer_total_cents > all_in_cents` by the tax amount when `pass_tax=true`.
+- **Mechanism:** even a "correct" all-in display sourced from this RPC will understate the charge by the tax when pass_tax + exclusive region. The combined "Fees & tax" line currently captures only the fee delta, never the tax delta, on this path.
+- **Severity:** **SECONDARY ROOT CAUSE** (latent; bites the moment a US/exclusive brand sets pass_tax=true). Distinct from F-1/F-2/F-4 — the RPC needs a tax-aware all-in or the display needs the server preview's tax-inclusive `buyer_total_cents`.
+
+### F-7 — DB numeric proof + masking condition (brand-toggle dependency)
+- **Symptom:** the discrepancy is invisible in current prod because no charges-enabled brand passes a fee/tax.
+- **Layer:** data (read-only prod).
+- **Probe:** SQL against prod `gqnoajqerqhnvulmnyvv`:
+  ```sql
+  select count(*) total, count(*) filter (where stripe_charges_enabled) charges_enabled,
+    count(*) filter (where default_pass_tax or default_pass_mingla_fee or default_pass_service_fee) any_pass
+  from brands;
+  -- → total=59, charges_enabled=8, any_pass=1  (and the 1 pass-brand is NOT charges-enabled)
+
+  select pg_public_event_tier_allin('a0000000-0000-4000-8000-000000002076');
+  -- Paystack NG Test Brand, base=500000 → all_in_cents=522500 (+22500 = 4.5% passed fees), pass_tax=true, NGN
+  ```
+- **Evidence:** region split — GB 40 (3 charges-enabled, 0 pass_tax), US 15 (2 ce, 0 pass_tax), EU 2 (2 ce), CH 1 (1 ce), NG 1 (0 ce, pass_tax=1). The single fee-grossed example (base 500000 → all-in 522500) shows the +₦225 fee delta the business cart would drop; that brand also passes tax, which `all_in_cents` does NOT add.
+- **Mechanism:** the bug requires `pass_mingla_fee` / `pass_service_fee` / `pass_tax = true` to be observable. Today every sellable brand absorbs all three → "absorb-brands look fine, masking it." The discrepancy is a live launch-time landmine the instant any charges-enabled brand flips a toggle on.
+- **Severity:** **CONFIRMED CONTRIBUTOR / masking condition** (numeric-proven at DB layer).
+
+---
+
+## Five-truth-layer reconciliation
+
+| Layer | Finding | Contradiction |
+|---|---|---|
+| **Docs** | MEMORY + ORCH-1025/1130: all-in/WYSIWYP, one "Fees & tax" line, tax venue-sourced server-side, ALL surfaces. | Business + web display contradict the doc: they show base subtotal. |
+| **Schema** | `compute_all_in_cents` folds fees, NOT tax; `resolve_event_pricing_inputs` resolves per-event pass = COALESCE(event, brand default). | The all-in RPC's no-tax term contradicts the "all-in incl. tax" promise on exclusive regions (F-6). |
+| **Code** | Charge = `buyer_total_cents` (base+fees+tax) native; web Checkout line item = base only (F-4). Business display = base subtotal (F-1/F-2); consumer display = fee-grossed all-in (F-5). | Web charge ≠ native charge for the fee gross-up (F-4). Display ≠ charge on business everywhere (F-1/F-2). |
+| **Runtime** | Not live-fired to a real charge (see Repro). DB numeric proof stands in. | Masked: no charges-enabled pass-brand exists to drive a live divergence (F-7). |
+| **Data** | 0/8 sellable brands pass any toggle; 1 NGN test brand passes all three. | The bug is currently dormant in prod data. |
+
+---
+
+## Repro evidence
+
+- **Source trace:** complete, with verbatim file:line evidence (F-1…F-6) and the live-prod function defs (F-3 engine, F-6 RPC).
+- **DB numeric proof (read-only, prod):** `pg_public_event_tier_allin` returns `522500` for a `500000` base (the +4.5% passed-fee gross-up the business cart drops); the same brand passes tax which the RPC excludes (F-6/F-7).
+- **Live-fire to a real charge: NOT performed — and not reachable without creating test data or triggering a real charge.** No charges-enabled brand passes any fee/tax (F-7), so no existing public buyer-web checkout demonstrates the divergence live; standing up such a brand/offering or forcing a toggle is a write + a real Stripe charge, both barred under the INVESTIGATE hard guards. Per Prime Directive 7, source-only + DB-numeric evidence caps the surface×offering verdicts at **PROBABLE** (not CONFIRMED). The masking condition is itself the reason a live repro is blocked, and is reported as such.
+
+---
+
+## Per-surface × per-offering-type matrix
+
+Legend: cell = displayed-Total-vs-charged-Total verdict. **BROKEN** = display < charge possible. Confidence in parens. Divergent computation sites named.
+
+| Offering → / Surface ↓ | trip | event | experience |
+|---|---|---|---|
+| **Business iOS** | BROKEN (PROBABLE) | BROKEN (PROBABLE) | BROKEN (PROBABLE) |
+| **Business Android** | BROKEN (PROBABLE) | BROKEN (PROBABLE) | BROKEN (PROBABLE) |
+| **Buyer Web** | BROKEN×2 (PROBABLE) | BROKEN×2 (PROBABLE) | BROKEN×2 (PROBABLE) |
+| **Consumer iOS** | PARTIAL — tax-gap only (PROBABLE) | PARTIAL — tax-gap only (PROBABLE) | PARTIAL — tax-gap only (PROBABLE) |
+| **Consumer Android** | PARTIAL — tax-gap only (PROBABLE) | PARTIAL — tax-gap only (PROBABLE) | PARTIAL — tax-gap only (PROBABLE) |
+
+Divergent computation sites per cell:
+
+- **Business iOS/Android (all 3 offerings):** DISPLAY = `mingla-business/src/components/checkout/CartContext.tsx:415-423` (`total = subtotal`, base only) seeded by `checkout*/.../index.tsx` `unitPrice: priceGbp`, surfaced via `checkout*/.../payment.tsx` `displayAllIn` fallback (event `:558-561`, trip `:573-576`, exp `:476-480`). CHARGE = `ticket-checkout-create/index.ts:1559` (`amount: buyer_total_cents`). Native preview (`payment.tsx:272-313`) papers over it only when it resolves; the base subtotal shows otherwise.
+- **Buyer Web (all 3): two divergences.** (1) DISPLAY forced to base subtotal — `payment.tsx` `Platform.OS !== "web"` guard (same lines as above). (2) CHARGE itself drops the fee gross-up — `ticket-checkout-create/index.ts:1086` (`unit_amount: totalCents`) vs the intended `buyer_total_cents`.
+- **Consumer iOS/Android (all 3):** DISPLAY = `TicketCartSheet.tsx:314-323,434` (fee-grossed all-in, correct for fees). CHARGE = `ticket-checkout-create/index.ts:1559` (all-in incl. tax). Gap = TAX only, on exclusive regions with `pass_tax=true`, because `compute_all_in_cents` has no tax term (F-6).
+
+---
+
+## Do display and charge share one engine?
+
+**No — they diverge.** The CHARGE has one authority: the server `allInPricingEngine` (`buyer_total_cents`). The DISPLAY:
+- **Business app/web:** re-derives independently from the bare base subtotal (`useCartTotals`), ignoring the per-tier `priceAllInGbp` it already fetches in `publicEventsService.fetchTickets`. Classic divergence root cause.
+- **Consumer app:** derives from the server `pg_public_event_tier_allin` RPC — same fee math as the engine, but that RPC OMITS tax, so it is a *partial* shared source (fees shared, tax not).
+
+Single minimal set of computation sites that must change (for the SPEC to scope — not decided here):
+1. Business cart/display total — stop using the base subtotal as the headline Total; consume a server all-in (the `priceAllInGbp` already fetched, or the preview's `buyer_total_cents`). Sites: `CartContext.tsx:415-423`, the three `index.tsx` cart seeds, the three `payment.tsx` `displayAllIn` blocks.
+2. Web CHARGE — the hosted Checkout line item must bill the grossed-up `buyer_total_cents`, not `totalCents`. Site: `ticket-checkout-create/index.ts:1086`.
+3. The all-in source's TAX term — `compute_all_in_cents` / `pg_public_event_tier_allin` exclude tax; either make the all-in tax-aware or drive the display off the tax-inclusive server preview/`buyer_total_cents`. Sites: the two DB functions and/or the display's reliance on the no-tax RPC.
+
+---
+
+## Blast radius / cross-surface map
+
+- **In scope (broken):** business iOS, business Android, buyer-web — all three offering types (event/trip/experience), all sharing `CartContext` + `ticket-checkout-create`.
+- **In scope (partial — tax gap):** consumer iOS/Android — all three offering types, on exclusive-tax regions with pass_tax.
+- **Adjacent / out of scope:** Admin Web (`mingla-admin`) — no buyer checkout. Business Web preview — non-buyer. Paystack/NGN arm shares the same `pg_public_event_tier_allin` (so the business cart bug applies to NGN too) but the Paystack charge path uses `computeConfigVat` (`ticket-checkout-create.ts:686`) — note for SPEC, not re-investigated here.
+- **Recurring pattern:** display re-deriving money instead of consuming the server's single authority — the exact class ORCH-1025/1130 set out to kill; it was killed on consumer (`all_in_cents`) and on the native business *preview*, but never on the business *cart total* or the *web charge*.
+
+---
+
+## Invariant impact (flagged, not resolved)
+
+- **I-PROPOSED-1130-NO-BUYER-TAX-FORM (DRAFT):** preserved — this investigation proposes no buyer tax form; the gate still passes. The fix direction (consume server all-in) does not reintroduce a form.
+- **WYSIWYP / all-in (ORCH-1025/1006/1130):** currently VIOLATED on business + web (display) and on web (charge). The combined single "Fees & tax" line contract (memory `feedback_cart_combined_fees_tax_line.md`) is only honored on consumer.
+- **ORCH-1034 de-GBP:** the cart still seeds `currency: ticket.currency ?? event.currency ?? "GBP"` (`index.tsx:275`) and field names carry `Gbp`. This is the SEPARATE, not-yet-started ORCH-1034 fallback — NOT the fee/tax-omission root cause. Flagged distinct per dispatch.
+
+## Discoveries for Orchestrator (side issues)
+
+- **D-1 (web charge under-bills the passed fee, F-4):** distinct from the display bug — it is a real revenue/economic mismatch (web buyers pay less than native buyers for the same passed-fee offering). The SPEC should explicitly cover the web CHARGE, not only the display.
+- **D-2 (all-in RPC has no tax term, F-6):** affects the *consumer* (which otherwise looks correct) and any business fix that reuses `pg_public_event_tier_allin` — the tax delta will still be dropped on US/exclusive regions. Decide at SPEC whether to make the all-in tax-aware or drive display off the tax-inclusive preview.
+- **D-3 (masking, F-7):** because 0/8 sellable brands pass a toggle, any TEST of the fix MUST stand up (or temporarily toggle) a charges-enabled pass-fee brand/offering — otherwise a green test proves nothing. Flag for the tester.
+- **D-4 (Paystack/NGN arm):** shares the business cart display bug; its charge path is `computeConfigVat`, not the Stripe engine — confirm parity when the SPEC lands.
+
+---
+
+## Confidence level
+
+**PROBABLE** (source-strong + DB-numeric-proven), capped below CONFIRMED only because a live-fire charge is unreachable without creating test data / triggering a real charge (both barred), and that unreachability is itself the masking condition (F-7). Every divergent computation site is named with verbatim file:line; the charge authority and the display derivations are both read in full; the brand-toggle dependency is numerically demonstrated against prod.
+
+## Recommended next phase + scope (direction only — no fix proposed)
+
+- **Next:** SPEC. Scope = make the business cart + buyer-web display the server all-in (consume the already-fetched `priceAllInGbp` and/or the tax-inclusive `buyer_total_cents` preview) across event/trip/experience on business iOS/Android/web; fix the web CHARGE line item to bill `buyer_total_cents` (D-1); decide tax-inclusivity of the all-in source for exclusive regions (D-2, also closes the consumer tax gap). Honor the single combined "Fees & tax" line. Keep ORCH-1034 GBP fallbacks OUT of scope.
+- **Do NOT** re-introduce a buyer tax form (I-1130). **Do NOT** widen into ORCH-1034 currency work.

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1147_CART_TRUE_PRICE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1147_CART_TRUE_PRICE.md
@@ -1,0 +1,208 @@
+# IMPLEMENTATION — ORCH-1147 [cart does not reflect the TRUE price of a trip/event/experience]
+
+**Phase:** IMPLEMENT (single pass). **Skill:** mingla-implementor.
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]` on branch `ORCH-1147-cart-true-price` (rebased on origin/main @ `61156a6e5`, 0 behind).
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1147_CART_TRUE_PRICE.md` (binding contract — followed §8 order).
+**Implementation commit:** `a622e9494`.
+**Status:** implemented and verified (gates + jest + deno check + fails-on-revert). Trip/experience SOURCE all-in plumbing is a documented STOP-AND-AMEND (OQ-3) — see §AMENDMENT REQUEST.
+
+---
+
+## 1. Summary (plain English)
+
+The business cart/checkout headline **Total** now equals the price the server actually charges — base ticket price **plus** the passed Mingla fee and service fee — instead of the bare ticket subtotal that omitted them. A single combined **"Fees & tax"** line is shown when there's a real delta. This holds on business iOS, business Android, and the buyer-web checkout, for events, trips, and experiences. Separately, the buyer-web hosted Stripe charge now bills the fee-grossed subtotal (so web buyers no longer under-pay the passed fee vs native), with Stripe `automatic_tax` adding tax on top.
+
+The structural fix is **one owner of the money**: the client reads the server's per-tier all-in (`priceAllInGbp` from `pg_public_event_tier_allin`) as the display basis and performs zero fee/tax math beyond summing it and subtracting the base. The server engine stays the charge authority.
+
+**Event is end-to-end live today** (its tickets already carry `priceAllInGbp`). **Trip/experience display is wired and falls back gracefully to base** until their SOURCE services are amended to attach the per-tier all-in (the two source files are outside the spec allowlist — STOP-AND-AMEND per §4.3/OQ-3).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence (commit `a622e9494`) |
+|----|-----------|--------|-------------------------------|
+| SC-1-Web | Web Total = fee-grossed all-in (not base) | ✓ (event live; trip/exp pending source) | `payment.tsx` headline = `allInFloorCents` from `totals.allInTotal`; web takes the floor branch synchronously |
+| SC-1-iOS / SC-1-Android | Native Total = fee-grossed all-in synchronously, refined to tax-inclusive preview | ✓ | `headlineCents` = floor, upgraded to `allInPreviewCents` when `>= floor` |
+| SC-2 (iOS/Android/Web) | Single combined "Fees & tax" line, never split | ✓ | `summaryFeesTaxRow` rendered iff `showFeesTaxLine`; label exactly `Fees & tax` |
+| SC-3 (event) | Event satisfies SC-1/SC-2 | ✓ live | event index seeds `unitPriceAllIn`; `getPublicEventById→fetchTickets` attaches `priceAllInGbp` |
+| SC-4 (trip) | Trip satisfies SC-1/SC-2 | ◑ display-wired; source pending amendment | trip seeds + payment wired; `TripPricingTier.priceAllInGbp` source plumbing = AMENDMENT |
+| SC-5 (experience) | Experience satisfies SC-1/SC-2 | ◑ display-wired; source pending amendment | experience seed + payment wired; `PublicExperienceTicket.priceAllInGbp` source = AMENDMENT |
+| SC-6-Web (D-1) | Web Checkout line item bills `buyerSubtotal.buyerSubtotalCents` | ✓ | `ticket-checkout-create/index.ts` web Session `unit_amount: buyerSubtotal.buyerSubtotalCents` |
+| SC-7 (NGN parity) | NGN cart shows all-in (shared CartContext); charge unchanged | ✓ (display via shared CartContext); charge-path untouched (parity confirm = tester) | NGN charges via `computeConfigVat` (DO-NOT-TOUCH), display inherits shared cart |
+| SC-8 (invariant) | No buyer tax form; `orch-1130-no-buyer-tax-form.mjs` passes | ✓ | gate GREEN (run output below) |
+| SC-9 (absorb no-regression) | absorb-all → `feesTaxCents=0`, no line, Total == base | ✓ | jest T-4 PASS; `showFeesTaxLine=false` when delta 0 |
+| SC-10 (free) | Free tier → Total "Free"/0, no fees line | ✓ | jest T-5 PASS; existing free-path guards unchanged |
+
+`◑` = display layer complete + correct; the per-tier all-in SOURCE for trip/experience is the named OQ-3 stop-and-amend (display falls back to base, no fabrication, no regression). Event SC-3 proves the full pattern works end-to-end today.
+
+---
+
+## 3. Files changed (13; +line deltas approximate)
+
+| File | Δ | Allowlisted |
+|------|---|-------------|
+| `mingla-business/src/components/checkout/CartContext.tsx` | +~55 | yes |
+| `mingla-business/app/checkout/[eventId]/index.tsx` | +~8 | yes |
+| `mingla-business/app/checkout/[eventId]/payment.tsx` | +~45 | yes |
+| `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | +~14 | yes |
+| `mingla-business/app/checkout-trip/[tripEventId]/payment.tsx` | +~45 | yes |
+| `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | +~8 | yes |
+| `mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx` | +~40 | yes |
+| `supabase/functions/ticket-checkout-create/index.ts` | ~1 line (`:1086`) + comment | yes (`:1086` only) |
+| `.github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs` | NEW | yes (NEW) |
+| `.github/scripts/strict-grep/orch-1147-web-charge-allin.mjs` | NEW | yes (NEW) |
+| `.github/workflows/strict-grep-mingla-business.yml` | +27 (2 jobs) | gate-registration (implied by NEW gates) |
+| `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts` | NEW (10 tests) | yes (NEW) |
+| `mingla-business/jest.config.cjs` | 1 line (jsx mode) | DEVIATION — see §10 |
+
+No file outside the allowlist (notably NOT `tripsService.ts` / `publicExperienceService.ts`) was touched.
+
+---
+
+## 4. Data-model changes applied
+
+**None.** No migration. `compute_all_in_cents` / `pg_public_event_tier_allin` unchanged (non-goal §2; OQ-2 parked). The DO-NOT-TOUCH SQL stayed untouched.
+
+---
+
+## 5. Edge functions touched
+
+- `supabase/functions/ticket-checkout-create/index.ts` — web/mobile-web hosted Checkout Session line item only (`:1086`): `unit_amount: totalCents` → `unit_amount: buyerSubtotal.buyerSubtotalCents`. **`verify_jwt` value to preserve: unchanged** (no auth/validation/response-shape change). Native PI amount (`buyer_total_cents`, ~`:1559`) and preview return (~`:1519`) untouched (already correct — F-3). `application_fee_amount` untouched.
+- `deno check supabase/functions/ticket-checkout-create/index.ts` → **PASS** (`/Users/sethogieva/.deno/bin/deno`).
+
+---
+
+## 6. Regression tests added — fails-on-revert proof
+
+**Implementor happy-path test:** `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts` (10 tests; T-1, T-1b, T-4, missing-all-in fallback, T-5, empty, T-2 web/native, native-preview-upgrade, T-3 stale-preview-guard).
+
+Run (committed state):
+```
+PASS src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts
+Tests: 10 passed, 10 total
+```
+
+**fails-on-revert verified at `a622e9494`** by TRUE LINE DELETION (not comment-out):
+
+1. **Hook revert** — replaced the `useCartTotals` all-in accumulation with `allInTotal = subtotal; const feesTaxCents = 0;` (deleting `allInTotal += (line.unitPriceAllIn ?? line.unitPrice) * line.quantity;` and the real `feesTaxCents`):
+   ```
+   ✕ T-1: a pass-fee line yields allInTotal ≠ subtotal + a fees/tax delta
+   ✕ T-1b: multi-qty grosses the all-in per unit
+   Tests: 2 failed, 8 passed, 10 total
+   ```
+   Restored → `Tests: 10 passed, 10 total`.
+
+2. **Web-charge gate revert** — `unit_amount: buyerSubtotal.buyerSubtotalCents` → `unit_amount: totalCents` at `:1086`:
+   ```
+   ORCH-1147 web-charge-allin gate failed:
+   - supabase/functions/ticket-checkout-create/index.ts: web Checkout Session bills `unit_amount: totalCents` — it MUST bill `buyerSubtotal.buyerSubtotalCents` ...
+   EXIT=1
+   ```
+   Restored → `gate passed. EXIT=0`.
+
+3. **Cart-total gate revert** — rebound the event payment headline to the bare base (`allInFloorCents` from `totals.subtotal`; `displayAllIn = formatCurrency(totals.total, ...)`):
+   ```
+   ORCH-1147 cart-total-is-allin gate failed:
+   - .../checkout/[eventId]/payment.tsx: headline Total must read the server fee-grossed all-in (totals.allInTotal) ...
+   - .../checkout/[eventId]/payment.tsx: displayAllIn binds the headline directly to the bare base ...
+   EXIT=1
+   ```
+   Restored → `gate passed. EXIT=0`.
+
+**Strict-grep gates (committed state):**
+```
+ORCH-1147 cart-total-is-allin gate self-test passed.   /  gate passed.
+ORCH-1147 web-charge-allin gate self-test passed.      /  gate passed.
+ORCH-1130 no-buyer-tax-form gate passed.   (SC-8 preserved)
+```
+
+Both new test + the tester's future adversarial test ship in this branch; `git diff origin/main...HEAD --name-only` shows `orch_1147_cart_allin_total.test.ts`.
+
+---
+
+## 7. Old → New receipts
+
+### CartContext.tsx
+- **Before:** `CartLine` had only `unitPrice` (base). `useCartTotals` returned `total = subtotal` (base only) — the headline was re-derived from the bare base.
+- **Now:** `CartLine.unitPriceAllIn?` (server fee-grossed all-in) threaded through action/reducer (new-line + existing-line branches)/setter. `useCartTotals` accumulates `allInTotal = Σ(unitPriceAllIn ?? unitPrice)×qty` and returns `allInTotal`, `feesTaxCents = max(0, round((allInTotal−subtotal)×100))`, `hasFeesTaxDelta`. `subtotal`/`total` keep their BASE meaning (not repurposed).
+- **Why:** F-1/F-2 — the client must consume the server all-in, not re-derive from base. ~55 lines.
+
+### checkout/[eventId]/index.tsx · checkout-trip/.../index.tsx · checkout-experience/.../index.tsx
+- **Before:** seeds passed `unitPrice: …priceGbp ?? 0` only.
+- **Now:** also pass `unitPriceAllIn: ticket.priceAllInGbp ?? ticket.priceGbp ?? 0` (event live; trip/exp read the `TicketStub.priceAllInGbp` field, base fallback until source plumbed).
+- **Why:** seed the all-in as the headline basis (never fabricate). ~8–14 lines each.
+
+### checkout/[eventId]/payment.tsx · checkout-trip/.../payment.tsx · checkout-experience/.../payment.tsx
+- **Before:** `displayTotalCents = totals.total` (base); `displayAllIn` = base on web and on native preview-miss; no "Fees & tax" line.
+- **Now:** `allInFloorCents = round(totals.allInTotal×100)`; `headlineCents` = floor, upgraded to `allInPreviewCents` when `Platform.OS!=="web" && preview !== null && preview >= floor`; `displayAllIn = formatCurrency(headlineCents, currency, true)`. Combined "Fees & tax" line `= max(0, headline − base)` rendered iff `> 0`. OQ-2 exclusive-tax caveat commented at each site. Bottom-bar Total + Pay button inherit `displayAllIn`.
+- **Why:** F-1/F-2 display fix + SC-2 combined line. ~40–45 lines each.
+
+### ticket-checkout-create/index.ts (`:1086`)
+- **Before:** web Checkout line item `unit_amount: totalCents` (bare base) — under-billed the passed fee (D-1/F-4).
+- **Now:** `unit_amount: buyerSubtotal.buyerSubtotalCents` (fee-grossed PRE-TAX); `automatic_tax: { enabled: true }` adds tax on top. (OQ-1: NOT `buyer_total_cents`, which would double-tax.)
+- **Why:** SC-6-Web / D-1. ~1 line + protective comment.
+
+### Gates + workflow + jest config
+- 2 NEW strict-grep gates (self-tested) + 2 workflow jobs; jest `jsx` mode flip (test-only). See §10.
+
+---
+
+## 8. Cross-surface impact table
+
+| Surface | Affected | What changes | Parity |
+|---------|----------|--------------|--------|
+| Consumer iOS | NO | already correct (F-5); OQ-2 tax-gap OUT | — |
+| Consumer Android | NO | same | — |
+| Buyer / anon Web | YES | Total = fee-grossed all-in; "Fees & tax" line; CHARGE bills fee-grossed subtotal | Manual (web display + web charge branches distinct) |
+| Business iOS | YES | Total = fee-grossed all-in synchronously; "Fees & tax" line; native preview refines to tax-inclusive | Auto across 3 offerings via shared CartContext |
+| Business Android | YES | same as iOS | Auto (shared RN) |
+| Admin Web | NO | no buyer checkout surface | — |
+| Business Web preview | NO | non-buyer surface | — |
+
+Manual-parity note: web display branch + web charge branch are distinct from native — covered explicitly here. Trip/experience all-in SOURCE is manual per-service (AMENDMENT).
+
+---
+
+## 9. Smoke result
+
+- **Static/unit:** `npx tsc --noEmit` on the 8 touched product files → **0 errors** (pre-existing errors in untouched `buyer.tsx`, missing test deps, and unrelated modules confirmed present on origin/main too). `npx jest` checkout suite → **42 real tests PASS** (the 2 "failed" suites are Playwright specs that throw `throwIfRunningInsideJest` — pre-existing on origin/main, unrelated). `deno check` edge fn → PASS. All gates GREEN (above).
+- **Device/sim:** NOT run this pass (display-only RN + edge body change). Tester must device-verify business iOS + Android + web buyer route across event/trip/experience with a synthetic pass-fee fixture (spec D-3). Labeled **implemented, partially verified** for the runtime display; the math + charge binding + invariants are verified.
+
+---
+
+## 10. Known issues / deferred / deviations
+
+- **DEVIATION (test infra): `mingla-business/jest.config.cjs` `jsx: "react-native"` → `"react-jsx"`.** The node/ts-jest default config preserves JSX (`react-native` mode), so any runtime import of a JSX-bearing `.tsx` (here `useCartTotals` from `CartContext.tsx`) throws `SyntaxError: Unexpected token '<'`. `react-jsx` transpiles JSX to `_jsx(...)` so node-env unit tests can import hook logic. **Jest-only** (the app build is Metro/babel — unaffected). Existing carousel `.tsx` tests read source as TEXT (`readFileSync`) — unaffected; RTL render tests run under their own configs (ignored here). Verified: full checkout jest suite still passes (42/42). This file is not in the explicit allowlist but is the minimal test-enablement change required to ship the Step-0.5 test the spec mandates. Flagged for orchestrator awareness.
+- **OQ-2 exclusive-tax residual (PARKED by Seth):** `priceAllInGbp` folds fees but excludes tax, so in exclusive-tax regions (US `pass_tax=true`) the display floor understates by tax. Blast radius ZERO today (all charges-enabled brands inclusive GB/EU/CH). Commented at each `displayAllIn` site. NOT fixed (per dispatch hard-guard).
+- **`[TRANSITIONAL]`:** none introduced.
+
+---
+
+## 11. AMENDMENT REQUEST (OQ-3 — STOP-AND-AMEND; do NOT widen silently)
+
+The spec's §4.3 stop-and-amend trigger fired: **trip and experience do NOT route through `publicEventsService.fetchTickets`** (which already attaches `priceAllInGbp`). They use separate hooks/services. Plumbing the per-tier all-in into them touches **two files outside the allowlist**, so I stopped rather than widening:
+
+1. **Trip — `mingla-business/src/services/tripsService.ts` (NOT allowlisted):** add `priceAllInGbp?: number | null` to `interface TripPricingTier` (~`:73`). Then in **`publicEventsService.getPublicTripById` (ALLOWLISTED, `:1244`)** — which already calls `fetchTicketTypesRemaining(tripEventId)` (`:1326`) — also call the existing private `fetchTierAllInCents(tripEventId)` (`:840`) and map each tier's `all_in_cents/100` onto `TripPricingTier.priceAllInGbp` in the `pricingTiers.map` (`:1402`). The trip index `tierToTicketStub` (`index.tsx:66`) then sets `priceAllInGbp: tier.priceAllInGbp` on the stub; the seed already reads `stub.priceAllInGbp`.
+2. **Experience — `mingla-business/src/services/publicExperienceService.ts` (NOT allowlisted):** add `priceAllInGbp?: number | null` to `interface PublicExperienceTicket` (`:40`); in `getPublicExperienceById` (`:348`) / `loadExperienceSidecars` call the all-in RPC (`pg_public_event_tier_allin`) and set it on the ticket in `mapExperience` (`:194`). The experience index `ticketToStub` then sets `priceAllInGbp` on the stub; the seed already reads `stub.priceAllInGbp`.
+3. **Export `fetchTierAllInCents`** from `publicEventsService.ts` (allowlisted) so the experience service can reuse the SAME RPC helper (no duplicate fee math; one owner).
+
+All three use the EXISTING `pg_public_event_tier_allin` RPC — no new SQL, no migration, no fabrication. The display layer is already wired to consume `priceAllInGbp` the moment these source fields are populated. Until then trip/experience fall back to base (graceful, no regression, no fabricated number).
+
+**Routing:** orchestrator → forensics for a `SPEC_AMENDMENT_ORCH-1147_TRIP_EXPERIENCE_ALLIN_SOURCE` adding those two source files (+ the `fetchTierAllInCents` export) to the allowlist → re-dispatch implementor for the ~30-line source plumbing → tester proves SC-4/SC-5 on a pass-fee trip + experience.
+
+---
+
+## 12. Operator action required
+
+- **No migration. No edge deploy from the implementor.** When this branch MERGES to main, the orchestrator/operator deploys `ticket-checkout-create` **from merged main** (clobber-safe), preserving its existing `verify_jwt`. The display changes are pure RN/JS → ship via OTA on close (business runtime 1.0.0) per `project_ota_deferred_until_new_build`.
+- **CLOSE:** flip `I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN` + `I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL` to ACTIVE; commit the tester's adversarial test before merge; reconcile against COMMS-0013/0014/0016.
+
+---
+
+## 13. Discoveries for Orchestrator
+
+- **OQ-3 amendment (above)** — trip/experience all-in source plumbing needs 2 non-allowlisted files added to scope. Not started; documented precisely.
+- **jest.config jsx mode** — the node/ts-jest config could not run ANY runtime-import test of a JSX-bearing `.tsx` before this fix; future hook unit tests benefit. Minor latent test-infra gap, now closed.
+- **Tester D-3 (mandatory):** a green run on current prod data proves nothing (0/8 charges-enabled brands pass any fee → `feesTaxCents=0` everywhere). Tester MUST stand up a synthetic/temporary pass-fee charges-enabled fixture and prove display Total > base by the fee gross-up + the web Checkout Session bills the grossed-up subtotal + NGN parity (SC-7).
+- **Comms:** read COMMS_LEDGER on entry — no BLOCK rows for this skill/ORCH/ALL. Recent WARN-to-ALL entries (COMMS-0035/0032/0028/0027) concern HEIC/expo-image-manipulator and OTA hygiene — unrelated to cart pricing; read, no action this turn.

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1147_CART_TRUE_PRICE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1147_CART_TRUE_PRICE.md
@@ -206,3 +206,123 @@ All three use the EXISTING `pg_public_event_tier_allin` RPC — no new SQL, no m
 - **jest.config jsx mode** — the node/ts-jest config could not run ANY runtime-import test of a JSX-bearing `.tsx` before this fix; future hook unit tests benefit. Minor latent test-infra gap, now closed.
 - **Tester D-3 (mandatory):** a green run on current prod data proves nothing (0/8 charges-enabled brands pass any fee → `feesTaxCents=0` everywhere). Tester MUST stand up a synthetic/temporary pass-fee charges-enabled fixture and prove display Total > base by the fee gross-up + the web Checkout Session bills the grossed-up subtotal + NGN parity (SC-7).
 - **Comms:** read COMMS_LEDGER on entry — no BLOCK rows for this skill/ORCH/ALL. Recent WARN-to-ALL entries (COMMS-0035/0032/0028/0027) concern HEIC/expo-image-manipulator and OTA hygiene — unrelated to cart pricing; read, no action this turn.
+
+---
+
+# AMENDMENT IMPLEMENTATION — TRIP + EXPERIENCE all-in SOURCE plumbing (2026-06-15)
+
+**Amends:** `SPEC_AMENDMENT_ORCH-1147_TRIP_EXPERIENCE_ALLIN_SOURCE.md` (§B allowlist, §C per-file spec, §D SC-4/5/11, §E test extension).
+**Status:** implemented and verified (static + unit + gate). Device-verify (tester) still required per §E2.
+**Commit:** `e968e00b3` (all 8 files: 5 product + test + new gate + workflow).
+**Comms:** COMMS_LEDGER read on entry — no OPEN BLOCK rows for mingla-implementor / ORCH-1147 / ALL. COMMS-0003 (external-API docs, WARN/ALL) and COMMS-0031 (consumer iOS native pods, WARN/ALL) are N/A — this is a pure-client cart-plumbing change with no external-API integration and no iOS native build.
+
+## A-amend. Summary (plain English)
+
+Before this amendment, the **event** cart Total already showed the true fee-grossed all-in, but **trip** and **experience** carts fell back to the bare base price — because their two source services never attached the per-tier all-in. This amendment feeds the trip + experience source services the SAME server number the event path already uses (one shared helper, no new SQL), so all three offering types now show an identical true Total + "Fees & tax" line.
+
+## B-amend. SPEC-amendment success-criteria coverage
+
+| SC | Description | Status | Commit |
+|----|-------------|--------|--------|
+| SC-4 (trip) | trip cart Total == Σ priceAllInGbp × qty on a pass-fee brand; "Fees & tax" line = Total − base | ✓ source wired (T-7a) | `e968e00b3` |
+| SC-5 (experience) | experience cart Total == server all-in on a pass-fee brand | ✓ source wired (T-7b) | `e968e00b3` |
+| SC-4b/SC-5b | absorb / free → priceAllInGbp null → seed base fallback → feesTaxCents 0, no fees line (no regression) | ✓ (T-7c) | `e968e00b3` |
+| SC-11 | pg_public_event_tier_allin has ONE owner (fetchTierAllInCents); trip/experience reuse it, no duplicated RPC/fee math | ✓ new strict-grep gate | `e968e00b3` |
+
+## C-amend. Files changed (5 product + test + gate + workflow)
+
+| File | Change | ~lines |
+|------|--------|--------|
+| `mingla-business/src/services/publicEventsService.ts` | `export` `fetchTierAllInCents` (single owner); parallel `fetchTierAllInCents(tripEventId)` in `getPublicTripById`; populate `TripPricingTier.priceAllInGbp` (`allInById.get(t.ticket_type_id)/100`, free/miss → null) | +14 |
+| `mingla-business/src/services/tripsService.ts` | `TripPricingTier.priceAllInGbp?: number \| null` (type-only) | +9 |
+| `mingla-business/src/services/publicExperienceService.ts` | `PublicExperienceTicket.priceAllInGbp`; `import { fetchTierAllInCents }`; thread `allInById` through `loadExperienceSidecars` → `MapInput` → `mapExperience` (set on ticket, free/miss → null) | +24 |
+| `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | `tierToTicketStub`: `priceAllInGbp: tier.priceAllInGbp ?? null` | +3 |
+| `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | `ticketToStub`: `priceAllInGbp: ticket.priceAllInGbp ?? null` | +3 |
+| `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts` | +T-7a/T-7b/T-7c (8 new assertions; mapping math + source-text fails-on-revert) | +180 |
+| `.github/scripts/strict-grep/orch-1147-allin-single-owner.mjs` | NEW SC-11 gate (single owner of the RPC; reusers must not call it) | +150 new file |
+| `.github/workflows/strict-grep-mingla-business.yml` | register `orch-1147-allin-single-owner` job | +12 |
+
+## D-amend. Single-owner confirmation (no duplicated RPC)
+
+`pg_public_event_tier_allin` is called from EXACTLY ONE place: the body of `fetchTierAllInCents` in `publicEventsService.ts`.
+- The trip producer `getPublicTripById` (same file) calls `fetchTierAllInCents(tripEventId)` inline.
+- `publicExperienceService.ts` `import { fetchTierAllInCents } from "./publicEventsService"` and calls it inside `loadExperienceSidecars`.
+- No `supabase.rpc("pg_public_event_tier_allin"…)` exists in `tripsService.ts` or `publicExperienceService.ts`. No fee math recomputed in TS anywhere. The SC-11 strict-grep gate enforces this on every CI run.
+- No new SQL, no migration, no edge-fn change. OQ-2 (tax-awareness) PARKED — the RPC is unchanged. No buyer tax form (`orch-1130-no-buyer-tax-form.mjs` GREEN). ORCH-1034 GBP fallbacks untouched.
+
+## E-amend. Regression tests + fails-on-revert proof
+
+**Extended Step-0.5 test:** `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts` — now **18 tests, 18 passed** (10 original + T-7a/T-7a-source×3 + T-7b/T-7b-source×2 + T-7c). Run output:
+```
+PASS src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts
+Tests:       18 passed, 18 total
+```
+
+**fails-on-revert verified at `e968e00b3`** by TRUE LINE DELETION (not comment-out), each restored to GREEN:
+
+1. **Trip stub pass-through** — deleted `priceAllInGbp: tier.priceAllInGbp ?? null` from `tierToTicketStub` (`checkout-trip/.../index.tsx`):
+   `✕ T-7a source: tierToTicketStub passes priceAllInGbp through` → `1 failed`. Restored → pass.
+2. **Trip populate** — deleted the `priceAllInGbp: (() => { allInById.get(t.ticket_type_id) … })()` block from `getPublicTripById` (`publicEventsService.ts`):
+   `✕ T-7a source: getPublicTripById populates priceAllInGbp from the single owner` → `1 failed`. Restored → pass.
+3. **Experience populate** — deleted the `priceAllInGbp: … allInCents / 100 …` block from `mapExperience` (`publicExperienceService.ts`):
+   `✕ T-7b source: PublicExperienceTicket carries priceAllInGbp + reuses the single owner` → `1 failed`. Restored → pass.
+4. **Helper export** — reverted `export const fetchTierAllInCents` → `const fetchTierAllInCents` (`publicEventsService.ts`):
+   SC-11 gate `failed … fetchTierAllInCents must be EXPORTED …` EXIT=1. Restored → gate passed.
+5. **Duplicate-RPC negative (SC-11)** — injected `supabase.rpc("pg_public_event_tier_allin"…)` into `tripsService.ts`:
+   SC-11 gate `failed … references pg_public_event_tier_allin directly …` EXIT=1. Removed → gate passed.
+
+All five reverts confirm the test/gate exercises the actual fix lines (true line-deletion, not comment-out). The T-7a/T-7b/T-7c mapping-math assertions independently prove `source.priceAllInGbp → stub → seed.unitPriceAllIn → useCartTotals.allInTotal` grosses the cart Total above base with `feesTaxCents > 0`, and the absent/null path falls back to base with `feesTaxCents == 0`.
+
+## F-amend. Gate + typecheck results (committed state)
+
+```
+ORCH-1147 allin-single-owner gate self-test passed.  /  gate passed.     (SC-11, NEW)
+ORCH-1147 cart-total-is-allin gate passed.                                (regression)
+ORCH-1147 web-charge-allin gate passed.                                   (regression)
+ORCH-1130 no-buyer-tax-form gate passed.                                  (SC-8 preserved)
+```
+`npx tsc --noEmit` (mingla-business): the 5 touched files introduce ZERO new type errors. The only errors under the touched directories are 5 pre-existing `TS7006` in `checkout-trip/[tripEventId]/buyer.tsx` (NOT a touched file; present on origin/main — confirmed in §9). Total repo baseline 325 errors unchanged.
+
+## G-amend. Old → New receipts (amendment)
+
+### publicEventsService.ts
+- **Before:** `fetchTierAllInCents` module-private; `getPublicTripById` fetched only `fetchTicketTypesRemaining`; `TripPricingTier` rows had no `priceAllInGbp`.
+- **Now:** helper `export`ed; `getPublicTripById` runs `Promise.all([fetchTicketTypesRemaining, fetchTierAllInCents])`; each tier sets `priceAllInGbp = allInById.get(t.ticket_type_id)/100` (free/miss → null; seed owns base fallback).
+- **Why:** SC-4 source — feed the existing trip cart-seed wiring the real server all-in. ~14 lines.
+
+### tripsService.ts
+- **Before:** `TripPricingTier` had no all-in field → `tier.priceAllInGbp` was `undefined` → stub carried nothing → seed read base.
+- **Now:** optional `priceAllInGbp?: number | null` (type-only; only the public buyer-read path populates it; admin draft loads leave it unset → base).
+- **Why:** SC-4 type contract. ~9 lines.
+
+### publicExperienceService.ts
+- **Before:** `PublicExperienceTicket` had no all-in; `loadExperienceSidecars` loaded only stops/tickets/dates; `mapExperience` set no all-in.
+- **Now:** `priceAllInGbp?: number | null` on the ticket; `import { fetchTierAllInCents }`; folded into the existing `Promise.all` (never throws → no new guard); `allInById` threaded through `MapInput`; `mapExperience` sets `priceAllInGbp` (free/miss → null, else `allInCents/100`).
+- **Why:** SC-5 source. ~24 lines.
+
+### checkout-trip/.../index.tsx · checkout-experience/.../index.tsx
+- **Before:** `tierToTicketStub` / `ticketToStub` mapped base price only → the seed's `stub.priceAllInGbp ?? stub.priceGbp` always hit the base branch.
+- **Now:** each passes `priceAllInGbp: <source>.priceAllInGbp ?? null` → seed reads the real all-in.
+- **Why:** the missing pass-through that completes the chain. ~3 lines each.
+
+## H-amend. Cross-surface impact (amendment delta)
+
+| Surface | Affected | What changes | Parity |
+|---------|----------|--------------|--------|
+| Consumer iOS / Android | NO | app-mobile untouched | — |
+| Buyer / anon Web | YES | trip + experience checkout Total = fee-grossed all-in + "Fees & tax" line (was base) | Auto (shared CartContext display) |
+| Business iOS / Android | YES | same, all three offering types now uniform | Auto (shared RN) |
+| Admin Web / Business Web preview | NO | non-buyer surfaces | — |
+
+Trip + experience all-in SOURCE is manual per-service (two distinct services), now both wired to the single owner. Display parity across the three types is automatic via the shared cart seed → CartContext → payment-screen chain (unchanged by this amendment).
+
+## I-amend. Operator action required (amendment)
+
+- **No migration, no edge deploy from this amendment** (the core impl's `ticket-checkout-create` deploy note still stands; this amendment touched only client services + a CI gate). Pure RN/JS → ships via business-app OTA on close (runtime 1.0.0).
+- **CLOSE:** the amendment satisfies SC-4/SC-5 source contracts + adds SC-11; flip `I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN` + `I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL` ACTIVE once the tester device-verifies all three types on a pass-fee fixture.
+
+## J-amend. Discoveries for Orchestrator (amendment)
+
+- **Tester per-type gate (§E2) is mandatory and still pending:** event (regression) + trip + experience, each on business iOS + Android + buyer-web, on a SYNTHETIC pass-fee charges-enabled fixture (0/8 prod brands pass a fee → a green prod run proves nothing). A single-type or single-platform pass must be rejected.
+- **No new open questions.** OQ-2 (exclusive-tax residual) stays PARKED — unchanged by this amendment; the existing `displayAllIn`-site comments already cover trip + experience payment screens.
+- **The untracked ORCH-1147 artifacts** (`INVESTIGATE_…`, `SPEC_…`, `SPEC_AMENDMENT_…` under `Mingla_Artifacts/`) are committed alongside the report so the closing PR diff carries the full evidence trail.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1147_CART_TRUE_PRICE.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1147_CART_TRUE_PRICE.md
@@ -1,0 +1,191 @@
+# TEST — ORCH-1147 [cart does not reflect the TRUE price of a trip/event/experience]
+
+**Phase:** TEST (mingla-tester). **Worktree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]` on branch `ORCH-1147-cart-true-price` (rebased on origin/main, 0 behind).
+**Project ref:** `gqnoajqerqhnvulmnyvv`.
+**Inputs verified:** SPEC + amendment (§E2 test contract), investigation, implementation report (core `96120f458` + amendment `e968e00b3`, post-rebase hashes).
+**Comms:** COMMS_LEDGER read on entry — no OPEN BLOCK rows for mingla-tester / ORCH-1147 / ALL. The tester-targeted OPEN rows (COMMS-0028 GIPHY, 0032 HEIC) are WARN/FYI on unrelated upload/OTA surfaces — read, no action.
+
+---
+
+## 1. VERDICT
+
+**CONDITIONAL PASS** — P0: 0 · P1: 0 · P2: 1 · P3: 0 · P4: 2.
+
+The implementation is **source-correct and math-correct across all three offering types and the web charge**, proven by live DB/RPC evidence, the real shared pricing engine, and fails-on-revert. Two conditions cap it below an unconditional PASS, both **CLOSE-gated and operator-owned** (not code defects):
+
+1. **The web-charge fix is NOT live in prod.** Deployed `ticket-checkout-create` is **v206**, which still bills `unit_amount: totalCents` (the bug). SC-6-Web is correct in source but inert until the operator deploys from merged main at CLOSE. (Expected per the implementor note + `feedback_edge_deploy_and_migration_apply_hazards`.)
+2. **The display fix ships via OTA** and was NOT pixel-rendered at runtime: the local buyer-web dev server crashes on a **pre-existing, unrelated** motion-token error (`durations.duration` in `BusinessNotificationsScreen.tsx` — a file ORCH-1147 never touched), and the business-app native checkout requires a logged-in account + multi-step navigation not reachable autonomously this pass. Display cells are **SUSPECTED** (source + data + engine-math proven), not runtime-PASS.
+
+No P0/P1. The math that the buyer is QUOTED equals what the server CHARGES (proven against the live RPC and the real engine). The fixture exercised the pass-fee path for all three types. Fixture fully cleaned up.
+
+---
+
+## 2. SC-by-SC matrix
+
+Pass-fee fixture (D-3): temporarily toggled `default_pass_mingla_fee=true` + `default_pass_service_fee=true` on 3 charges-enabled brands (Leggo This / Travel Brand / Lantern & Vine; take 150bps, service 300bps → 4.5% gross-up), proved the RPC gross-up, **restored all 3 to absorb** (verified). 0/8 prod brands pass a fee normally, so this fixture is mandatory.
+
+| SC | Criterion | Verdict | Evidence |
+|----|-----------|---------|----------|
+| SC-1-iOS | native event Total = fee-grossed all-in sync | SUSPECTED | source: `payment.tsx` headline=`allInFloorCents` from `totals.allInTotal`; hook math proven (jest T-1/T-2); native sim leg not driven (login+nav) |
+| SC-1-Android | same, Android | SUSPECTED | shared RN code (auto-parity); not driven on device |
+| SC-1-Web | web event Total = fee-grossed all-in (not base) | SUSPECTED | source-correct (web takes the floor branch, no Platform hide); buyer-web dev render blocked by pre-existing unrelated crash (§7) |
+| SC-2 (iOS/And/Web) | single combined "Fees & tax" line, never split | SUSPECTED→PASS(math) | `summaryFeesTaxRow` rendered iff `showFeesTaxLine`; label exactly `Fees & tax`; line=`headline−base`; jest proves the value; render not pixel-verified |
+| SC-3 (event) | event satisfies SC-1/SC-2 | PASS (data+math) | live RPC `a3f71d85`: base 5000 → all_in **5225**, fees 225; cart math `feesTaxCents=225` (jest A); display source-correct |
+| SC-4 (trip) | trip satisfies SC-1/SC-2 | PASS (data+math) | live RPC `060d0483`: 50000 → **52250**, fees 2250; source `getPublicTripById` populates `priceAllInGbp`; jest T-7a + fails-on-revert |
+| SC-5 (experience) | experience satisfies SC-1/SC-2 | PASS (data+math) | live RPC `b8bd995b`: 7000 → **7315**, fees 315; source `mapExperience` via `loadExperienceSidecars`; jest T-7b + fails-on-revert |
+| SC-6-Web (D-1) | web Checkout line item bills `buyerSubtotalCents` | PASS (source) / **NOT LIVE** | source `:1096 unit_amount: buyerSubtotal.buyerSubtotalCents`; gate green + fails-on-revert (EXIT=1). **Deployed v206 still bills `totalCents` — deploy required at CLOSE.** |
+| SC-7 (NGN parity) | NGN cart shows all-in; charge bills all-in | PASS (source+data) w/ caveat | NGN RPC `…2076`: 500000 → **522500** (fee gross-up; shared CartContext display). Charge: `computeConfigVat(psSubtotal.buyerSubtotalCents)` → all-in incl. VAT (DO-NOT-TOUCH, unchanged). **P2: NGN is exclusive-tax → display floor understates by VAT (OQ-2; non-zero on this fixture, unlike GB/EU/CH).** |
+| SC-8 (invariant) | no buyer tax form; `orch-1130-no-buyer-tax-form.mjs` green | PASS | gate EXIT=0 (run §6) |
+| SC-9 (absorb no-regression) | absorb → feesTax=0, no line, Total==base | PASS (data+math) | baseline RPC all_in==base for all 3 types; jest T-4; `showFeesTaxLine=false` |
+| SC-10 (free) | free → Total Free/0, no fees line | PASS (math) | jest T-5; seed null→0 base fallback |
+| SC-11 (single owner) | `pg_public_event_tier_allin` called from one place | PASS | only caller = `fetchTierAllInCents` (`publicEventsService.ts:846`); trip+exp reuse it; new gate green + fails-on-revert |
+
+**"data+math PASS"** = proven via live prod RPC output (the exact number the cart reads) + the cart's pure reduce math (jest, fails-on-revert) + the real shared engine. This is runtime-grade for the MONEY CORRECTNESS, short of a pixel screenshot of the rendered string (capped SUSPECTED for the on-screen render).
+
+---
+
+## 3. Findings
+
+### P2-1 — NGN (exclusive-tax) cart display understates by VAT on a pass-tax brand (OQ-2 residual, non-zero on the NG fixture)
+- **Evidence:** NGN brand `a0000000-…-001076` passes tax; its event `…2076` base 500000 → RPC all_in **522500** (fee-only). The NGN CHARGE adds 7.5% exclusive VAT on `buyerSubtotalCents=522500` → buyer total ≈ **561688**. The cart DISPLAY floor (`priceAllInGbp`=522500) omits the 39188 VAT.
+- **Impact:** On the Paystack/NGN arm the displayed Total is below the charged Total by the VAT (WYSIWYP gap), exactly the OQ-2 exclusive-tax residual. The SPEC's "blast radius ZERO today" holds for the Stripe arm (GB/EU/CH inclusive) but the **NG test brand is exclusive-tax and DOES exercise the gap**.
+- **Required fix:** None in ORCH-1147 (OQ-2 is operator-PARKED). **Discovery for orchestrator:** OQ-2's scope statement names "US pass_tax=true"; it must also name **NG** (also exclusive). Track the exclusive-tax display understatement as the named follow-on ORCH; confirm NG is in-scope of the parked decision.
+- **Retest:** when OQ-2 is taken up, assert NGN display == NGN charge (incl. VAT).
+
+### P4-1 (praise) — clean one-owner structural fix
+`fetchTierAllInCents` is the single caller of `pg_public_event_tier_allin`; trip + experience reuse it (no duplicated RPC/fee math); the cart performs only Σ and subtract. Constitution #2 honored and gate-enforced (SC-11).
+
+### P4-2 (praise) — display == charge proven against the REAL engine
+The DB RPC `compute_all_in_cents` and the TS `computeBuyerSubtotal` use byte-identical fee math (`base + round(base*take/10000) + round(base*svc/10000)`), so the quoted Total equals the web charge basis to the cent. My adversarial test asserts this against the genuine `_shared/allInPricingEngine.ts` — no mock.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert
+
+Re-run at the merged branch HEAD (post-rebase). True line-deletion, not comment-out:
+
+1. **Hook revert** — deleted `allInTotal += (line.unitPriceAllIn ?? line.unitPrice)*qty` and forced `feesTaxCents=0` in `useCartTotals` (`CartContext.tsx`):
+   `✕ T-1, ✕ T-1b, ✕ T-4, ✕ missing-fallback, ✕ T-7a, ✕ T-7b, ✕ T-7c` → **7 failed, 11 passed**. Restored → **18 passed**.
+2. **Web-charge gate revert** — `unit_amount: buyerSubtotal.buyerSubtotalCents` → `unit_amount: totalCents` at `index.ts:1096`:
+   `orch-1147-web-charge-allin` gate **EXIT=1** ("web Checkout Session bills `unit_amount: totalCents` — it MUST bill `buyerSubtotal.buyerSubtotalCents`"). Restored → **EXIT=0**.
+3. **Trip stub pass-through revert** — deleted `priceAllInGbp: tier.priceAllInGbp ?? null` from `tierToTicketStub`:
+   `✕ T-7a source: tierToTicketStub passes priceAllInGbp through` → **1 failed**. Restored → **18 passed**.
+
+The implementor's happy-path test and the amendment's source assertions exercise the actual fix lines. Confirmed independently.
+
+---
+
+## 5. Adversarial test added (tester-owned, DIFFERENT angle)
+
+- **Path:** `mingla-business/src/components/checkout/__tests__/orch_1147_cart_charge_parity.tester-adversarial.test.ts`
+- **Commit:** `57056d238` (on branch, in `git diff origin/main...HEAD --name-only`).
+- **Angle (distinct from the implementor's display-math / source-mapping tests):** the **economic display==charge invariant** — imports the REAL server money engine (`supabase/functions/_shared/allInPricingEngine.ts`, pure TS) and asserts the cart's quoted Total (`useCartTotals.allInTotal`) equals the web-charge basis (`computeBuyerSubtotal.buyerSubtotalCents`) to the cent. Plus a fee-rounding boundary base (5037c), a quantity>1 per-unit-grossing case (333c × 7, where qty×round(perUnit) is the contract), an absorb→pass toggle flip (the toggle is the sole driver of the delta), and a pre-tax-basis guard (`pass_tax` must NOT change `buyerSubtotal` → no double-tax).
+- **Result:** 5 passed. **fails-on-revert verified at `57056d238`** — deleting the cart all-in accumulation fails 4/5 (the engine-only double-tax guard D survives, correctly).
+- **In closing diff:** both the implementor `orch_1147_cart_allin_total.test.ts` AND this tester file appear in `git diff origin/main...HEAD --name-only`. Append-only (no existing test file modified).
+
+---
+
+## 6. Gates + jest (committed state)
+
+```
+ORCH-1147 cart-total-is-allin gate passed.        EXIT=0   (self-test EXIT=0)
+ORCH-1147 web-charge-allin gate passed.           EXIT=0   (self-test EXIT=0)
+ORCH-1147 allin-single-owner gate passed.         EXIT=0   (self-test EXIT=0)   (SC-11)
+ORCH-1130 no-buyer-tax-form gate passed.          EXIT=0                        (SC-8)
+
+jest src/components/checkout:  55 passed (incl. implementor 18 + tester adversarial 5).
+  2 "failed suites" = pre-existing Playwright specs (throwIfRunningInsideJest) — present on origin/main, unrelated.
+
+tsc --noEmit: ZERO new type errors in the 8 touched product files (pre-existing buyer.tsx TS7006 untouched).
+deno check ticket-checkout-create: PASS (per impl report; web-charge line is a 1-line in-scope swap).
+```
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Note |
+|---------|---------|------|
+| Consumer iOS / Android | N/A | not in scope (app-mobile untouched; already correct) |
+| **Buyer / anon Web** (event/trip/exp display) | **SUSPECTED** (BLOCKED render) | source + live-RPC + engine-math proven. Local buyer-web dev server (`expo start --web`) crashes on a **pre-existing unrelated** motion-token error: `Cannot read properties of undefined (reading 'duration')` at `LinearTransition.duration(durations.entry)` originating in `BusinessNotificationsScreen.tsx` (NOT an ORCH-1147 file; no motion/duration file touched). Route never renders the payment Total in dev. Real web ships via Vercel prod build, not this dev server. |
+| **Buyer / anon Web** (CHARGE, SC-6) | **PASS (source) / NOT LIVE** | deployed `ticket-checkout-create` v206 still bills `totalCents`; fix inert until deploy-from-merged-main at CLOSE |
+| **Business iOS** (native display) | **SUSPECTED** | iPhone 17 Pro sim booted but the native business checkout needs a logged-in business account + multi-step nav not reachable autonomously; hook+display source proven |
+| **Business Android** | **SUSPECTED** | Samsung device attached; shared RN code (auto-parity); not driven |
+| Admin Web / Business Web preview | N/A | non-buyer surfaces |
+
+**Live deploy state (read-only):** `ticket-checkout-create` v206, `verify_jwt: true`, ACTIVE. The merged-main deploy at CLOSE preserves `verify_jwt`. **Physical iPhone HITL:** not requested this pass; the buyer-web blocker is environmental (dev-bundle), and the charge fix needs deploy first — driving a stale bundle would prove nothing. If Seth wants a pixel-render confirmation, the cleanest path is post-OTA on the dev channel + a 1-brand pass-fee toggle (instructions in §B handoff).
+
+---
+
+## 8. Pass-fee fixture used + cleanup confirmation
+
+- **Toggled (temporary):** `default_pass_mingla_fee=true, default_pass_service_fee=true` on brands `22a18413` (Leggo This / event), `becddd00` (Travel Brand / trip), `53aaea42` (Lantern & Vine / experience). Original state for all three: false/false (recorded before mutation).
+- **Exercised:** RPC gross-up proven per type — event 5000→5225 (fees 225), trip 50000→52250 (fees 2250), experience 7000→7315 (fees 315), all 4.5% (150bps take + 300bps service). NGN brand (already pass-fee) 500000→522500.
+- **Cleanup:** all 3 brands RESTORED to false/false; RPC re-verified all_in==base for all three. **No prod brand left mutated.** (Web dev server killed; port 8097 free.)
+
+---
+
+## 9. Stripe charge-amount evidence (web)
+
+- Source: web Checkout Session line item `unit_amount: buyerSubtotal.buyerSubtotalCents` (`ticket-checkout-create/index.ts:1096`), with `automatic_tax: { enabled: true }` (`:1115`). `buyerSubtotalCents = base + (pass_mingla? round(base*take/10000):0) + (pass_service? round(base*svc/10000):0)` (`_shared/allInPricingEngine.ts:182-189`) — fee-grossed PRE-TAX. Billing `buyer_total_cents` instead would double-tax (it already includes tax) — correctly avoided. `application_fee_amount = buyerSubtotal.miglaFeeCents` unchanged.
+- **For the live fixture (event 5000, pass both):** the web line item would bill **5225** (= the cart's quoted Total to the cent), Stripe adds tax on top. This equals the native fee gross-up. My adversarial test A pins `quotedChargeCents === billedChargeCents === 5225`.
+- **NOT YET LIVE:** deployed v206 still bills `totalCents` (5000) — operator must deploy from merged main at CLOSE for the charge fix to take effect.
+
+---
+
+## 10. NGN / Paystack parity (D-4 / SC-7)
+
+- **Display:** shared `CartContext` → NGN cart reads `priceAllInGbp` (RPC, fee-grossed) like every other arm. RPC for the NGN fixture: 500000 → 522500 (fees 22500). Display shows the fee-grossed floor.
+- **Charge:** `computeConfigVat(psSubtotal.buyerSubtotalCents, …)` → `psBuyerTotalCents` is the Paystack `amount` (`ticket-checkout-create.ts:~686/755`). DO-NOT-TOUCH, unchanged by ORCH-1147 — already bills base+fees+VAT. No under-bill of the fee gross-up.
+- **Caveat (P2-1):** NG is exclusive-tax, so the display floor (fee-only) is below the charge (fee+VAT) by the VAT. This is the OQ-2 residual, non-zero on the NG arm. Named, parked.
+
+---
+
+## 11. Constitution 14-rule matrix (vs the diff)
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | N/A | no new interactive control (display + 1 line) |
+| 2 | One owner per truth | **PASS** | single `pg_public_event_tier_allin` caller = `fetchTierAllInCents`; SC-11 gate |
+| 3 | No silent failures | **PASS** | RPC miss → empty map → base fallback (never blank/throw); experience guards kept on the 3 Supabase reads |
+| 4 | One query key per entity | N/A | no new query key |
+| 5 | Server state server-side | **PASS** | all-in is server-computed (RPC); cart only sums/subtracts |
+| 6 | Logout clears everything | N/A | no auth/persistence change |
+| 7 | `[TRANSITIONAL]` labeled | **PASS** | none introduced |
+| 8 | Subtract before adding | **PASS** | reused existing `computeBuyerSubtotal`/RPC; no parallel money path added |
+| 9 | No fabricated data | **PASS** | null/free all-in → base fallback (`?? priceGbp ?? 0`), never an invented markup |
+| 10 | Currency-aware | **PASS** | all-in seed carries the same `currency` as base; no new `?? "GBP"` (ORCH-1034 boundary respected) |
+| 11 | One auth instance | N/A | none |
+| 12 | Validate at the right time | N/A | no datetime logic |
+| 13 | Exclusion consistency | N/A | none |
+| 14 | Persisted-state startup | N/A | no hydration change |
+
+No violations.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **SC-6-Web not live:** deployed `ticket-checkout-create` is **v206** still billing `totalCents`. The web under-bill persists in prod until the CLOSE deploy-from-merged-main. (Expected, but it means the D-1 economic fix is inert until then — call it out in the close banner.)
+2. **OQ-2 scope must name NG:** the exclusive-tax display residual is non-zero on the NGN/Paystack arm (the NG test brand passes tax). The parked OQ-2 decision names only "US pass_tax=true" — extend it to NG, or the follow-on ORCH will miss the Paystack arm.
+3. **Pre-existing buyer-web dev crash:** `expo start --web` crashes on `durations.duration` (`LinearTransition` / `BusinessNotificationsScreen.tsx`) before any checkout route renders — blocks autonomous buyer-web live-fire. Unrelated to ORCH-1147 (no motion file touched). Latent dev-tooling gap; flag if the team relies on local web checkout testing.
+4. **jest.config.cjs jsx flip (`react-native`→`react-jsx`)** is a test-infra deviation (not on the explicit allowlist) — minimal and Metro-build-irrelevant. Already flagged by the implementor; noting for the close reconciliation.
+
+---
+
+## 13. Accepted conditions (CONDITIONAL PASS)
+
+This verdict is CONDITIONAL on two **operator-owned CLOSE actions** (not code rework):
+
+- **C1:** deploy `ticket-checkout-create` from **merged main** at CLOSE (the only way SC-6-Web becomes live; preserves `verify_jwt: true`).
+- **C2:** OTA the business app (runtime 1.0.0, pure RN/JS) at CLOSE so the display fix reaches devices; a post-OTA pixel-render spot-check (1 pass-fee brand toggled briefly) would upgrade the SUSPECTED display cells to runtime-PASS.
+
+Both are the standard CLOSE deploy/OTA per `feedback_edge_deploy_and_migration_apply_hazards` + `reference_eas_cli_ota_publish_gotchas`. No P1 requires implementor rework. If Seth wants display cells at runtime-PASS before CLOSE, route a short post-OTA device spot-check back to tester.
+
+---
+
+## 14. Downstream routing
+
+- **No REWORK needed** (zero P0/P1). → orchestrator CLOSE with conditions C1/C2.
+- At CLOSE: flip `I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN` + `I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL` ACTIVE; commit the tester adversarial test (already on branch `57056d238`); deploy `ticket-checkout-create` from merged main; OTA business app; extend OQ-2 scope to NG; reconcile COMMS-0013/0014/0016.
+- **Working tree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]/` on branch `ORCH-1147-cart-true-price`.

--- a/Mingla_Artifacts/specs/SPEC_AMENDMENT_ORCH-1147_TRIP_EXPERIENCE_ALLIN_SOURCE.md
+++ b/Mingla_Artifacts/specs/SPEC_AMENDMENT_ORCH-1147_TRIP_EXPERIENCE_ALLIN_SOURCE.md
@@ -1,0 +1,226 @@
+# SPEC AMENDMENT — ORCH-1147 [cart does not reflect the TRUE price] · TRIP + EXPERIENCE all-in SOURCE plumbing
+
+**Phase:** SPEC AMENDMENT (binding contract extension — no product code in this turn).
+**Amends:** `Mingla_Artifacts/specs/SPEC_ORCH-1147_CART_TRUE_PRICE.md` (§4.3 stop-and-amend trigger; OQ-3).
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]` on branch `ORCH-1147-cart-true-price` (rebased on origin/main, 0 behind at write time).
+**Skill:** mingla-forensics (SPEC mode).
+**Trigger:** the implementor's `IMPLEMENTATION_ORCH-1147_CART_TRUE_PRICE.md` §11 STOP-AND-AMEND (OQ-3). Event is end-to-end live; trip + experience CART Total fall back to BASE because the per-tier server all-in (`priceAllInGbp`) is never attached to their two SOURCE services, which lie outside the original spec allowlist. The implementor correctly stopped rather than widening scope. This amendment authorizes and specifies the exact ~30-line plumbing.
+**Comms:** COMMS_LEDGER read on entry — **no OPEN entries** addressed to forensics / ORCH-1147 / ALL. Nothing to ack.
+
+---
+
+## A. Why this amendment exists (verified, not assumed)
+
+The core ORCH-1147 implementation (`a622e9494`, now on this branch) made the cart's headline **Total** read a server-computed per-tier all-in (`priceAllInGbp` → `CartLine.unitPriceAllIn` → `useCartTotals.allInTotal`). The **consumer side** of that chain is already wired for ALL THREE offering types:
+
+- `TicketStub.priceAllInGbp?` field exists (`mingla-business/src/store/draftEventStore.ts:94`).
+- Trip seed reads `sole.priceAllInGbp` (`checkout-trip/[tripEventId]/index.tsx:250`, multi-tier `:458`).
+- Experience seed reads `stub.priceAllInGbp` (`checkout-experience/[experienceEventId]/index.tsx:281`).
+
+The gap — verified by reading the source — is purely in the two SOURCE services that produce the trip tiers / experience ticket the stubs are mapped from:
+
+| Verified fact | File:line (this branch) |
+|---|---|
+| `TripPricingTier` interface has NO `priceAllInGbp` field | `mingla-business/src/services/tripsService.ts:73-98` |
+| Trip tier producer `getPublicTripById.pricingTiers.map` never sets an all-in | `mingla-business/src/services/publicEventsService.ts:1402-1426` |
+| `tierToTicketStub` does NOT pass `priceAllInGbp` to the stub | `checkout-trip/[tripEventId]/index.tsx:66-78` |
+| `PublicExperienceTicket` interface has NO `priceAllInGbp` field | `mingla-business/src/services/publicExperienceService.ts:40-51` |
+| Experience ticket producer `mapExperience` never sets an all-in | `mingla-business/src/services/publicExperienceService.ts:193-208` |
+| `ticketToStub` does NOT pass `priceAllInGbp` to the stub | `checkout-experience/[experienceEventId]/index.tsx:51-...` |
+| The all-in fetch helper EXISTS but is module-private (not exported) | `publicEventsService.ts:840 const fetchTierAllInCents` |
+| Helper returns `Map<ticket_types.id, all_in_cents>` from `pg_public_event_tier_allin` | `publicEventsService.ts:840-857` |
+
+Because `tier.priceAllInGbp` / `ticket.priceAllInGbp` are `undefined`, `sole.priceAllInGbp ?? sole.priceGbp` resolves to the BASE price → trip/experience Total = base (no fee gross-up). Event works because it routes through `publicEventsService.fetchTickets` (`:879-895`), which already attaches `priceAllInGbp` via `fetchTierAllInCents`.
+
+**The fix is to feed the existing consumer wiring the real number** — one owner of the all-in fetch (`fetchTierAllInCents`), no duplicated RPC math, no new SQL.
+
+---
+
+## B. Authorization — expanded file allowlist (additions ONLY)
+
+These files are ADDED to the SPEC's "Scoped allowlist (implementor MAY change)". Everything in the original SPEC's allowlist and DO-NOT-TOUCH list stands unchanged.
+
+| # | File | Authorized change | New? |
+|---|------|-------------------|------|
+| A1 | `mingla-business/src/services/publicEventsService.ts` | **Export** the existing `fetchTierAllInCents` helper (`:840`) so the experience service can reuse it. ALSO populate `TripPricingTier.priceAllInGbp` inside `getPublicTripById` (`:1402-1426`). (This file was already conditionally on the allowlist for exactly this helper — now confirmed required.) | no |
+| A2 | `mingla-business/src/services/tripsService.ts` | Add `priceAllInGbp?: number \| null` to `interface TripPricingTier` (`:73-98`). TYPE-only change. | no |
+| A3 | `mingla-business/src/services/publicExperienceService.ts` | Add `priceAllInGbp?: number \| null` to `interface PublicExperienceTicket` (`:40-51`); import + call `fetchTierAllInCents`; thread the all-in cents through `loadExperienceSidecars` → `MapInput` → `mapExperience` onto the ticket. | no |
+| A4 | `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | In `tierToTicketStub` (`:66`) add `priceAllInGbp: tier.priceAllInGbp ?? null` to the returned `TicketStub`. (Already allowlisted; the seed already reads `stub.priceAllInGbp` — this is the missing pass-through.) | no |
+| A5 | `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | In `ticketToStub` (`:51`) add `priceAllInGbp: ticket.priceAllInGbp ?? null` to the returned `TicketStub`. (Already allowlisted; seed already reads `stub.priceAllInGbp`.) | no |
+
+**Single owner of the all-in fetch:** `fetchTierAllInCents(eventId)` in `publicEventsService.ts` is the ONE place that calls `pg_public_event_tier_allin`. The experience service IMPORTS and CALLS it; the trip producer (already living in `publicEventsService.ts`) calls it inline. **DO NOT** copy the RPC call, re-derive fees, or add a second helper. If the implementor finds themselves writing `supabase.rpc("pg_public_event_tier_allin", …)` anywhere other than the body of `fetchTierAllInCents`, STOP — that is a scope violation.
+
+**DO-NOT-TOUCH carried forward unchanged** (from the original SPEC §"DO-NOT-TOUCH"): `compute_all_in_cents` / `pg_public_event_tier_allin` SQL (no migration; OQ-2 PARKED — do NOT make the RPC tax-aware); native PI amount + preview return; Paystack/NGN charge path; any `app-mobile/` consumer file; ORCH-1034 GBP fallbacks; any buyer billing-address / tax form (keep `orch-1130-no-buyer-tax-form.mjs` GREEN); `useCartTotals.total`/`.subtotal` MEANING. **No new files** are created by this amendment.
+
+---
+
+## C. Exact per-file specification
+
+### C1. `publicEventsService.ts` — export the helper + populate trip tiers
+
+**C1a — export the single-owner fetch helper.**
+At `:840` change the declaration from module-private to exported:
+```ts
+export const fetchTierAllInCents = async (
+```
+No body change. (Its contract is unchanged: returns `Map<string /*ticket_types.id*/, number /*all_in_cents*/>`; RPC failure → empty map → base fallback downstream. Never throws.)
+
+**C1b — populate `TripPricingTier.priceAllInGbp` in `getPublicTripById`.**
+`getPublicTripById` already awaits `fetchTicketTypesRemaining(tripEventId)` at `:1326`. Add a parallel all-in fetch keyed identically by `ticket_types.id` (the trip tier producer keys `t.ticket_type_id`, which IS `ticket_types.id` — same key space as the helper's map, VERIFIED). Recommended: fold both fetches into the existing pattern, e.g.:
+```ts
+// ORCH-1147 — per-tier server all-in (same single owner as the event path).
+const [remainingById, allInById] = await Promise.all([
+  fetchTicketTypesRemaining(tripEventId),
+  fetchTierAllInCents(tripEventId),
+]);
+```
+Then in the `pricingTiers.map` (`:1413-1425`) add, on each returned `TripPricingTier`:
+```ts
+priceAllInGbp: (() => {
+  const cents = allInById.get(t.ticket_type_id);
+  return typeof cents === "number" ? cents / 100 : null;
+})(),
+```
+Mirror the EXACT fallback semantics `fetchTickets` uses (`:885-889`): free tier → `null`; numeric all-in → `cents/100`; otherwise `null` (NOT a fabricated base). The trip seed's `?? sole.priceGbp` provides the base fallback — do NOT also fall back to base here (keep `null` so the seed owns the single base-fallback decision, exactly as the event path does where the stub maps `priceAllInGbp` and the seed reads it). The all-in is in MAJOR units (`/100`) to match `TicketStub.priceAllInGbp` (major-unit, same as `priceGbp`).
+
+### C2. `tripsService.ts` — interface field (TYPE-only)
+
+In `interface TripPricingTier` (`:73-98`), add after `currency` (alongside the other optional metadata fields), preserving the file's doc-comment convention:
+```ts
+/**
+ * ORCH-1147 — server fee-grossed per-tier all-in in MAJOR units
+ * (`pg_public_event_tier_allin` → /100). Null = free tier or RPC miss;
+ * the cart seed falls back to `priceCents`/base. NEVER recompute fees in TS.
+ */
+priceAllInGbp?: number | null;
+```
+No other change in this file. (`mapTripPricingTier` and admin draft loads MAY leave it unset → `undefined` → base fallback; that is correct, those paths are not buyer-checkout.)
+
+### C3. `publicExperienceService.ts` — interface field + call the helper + thread it through
+
+**C3a — interface field.** In `interface PublicExperienceTicket` (`:40-51`) add:
+```ts
+/**
+ * ORCH-1147 — server fee-grossed all-in in MAJOR units
+ * (`pg_public_event_tier_allin` → /100). Null = free / RPC miss; cart seed
+ * falls back to `priceCents`/base. NEVER recompute fees in TS.
+ */
+priceAllInGbp?: number | null;
+```
+
+**C3b — import + call the single-owner helper.** Add the import (experience service currently imports only `./supabase`, `../store/draftEventStore`):
+```ts
+import { fetchTierAllInCents } from "./publicEventsService";
+```
+In `loadExperienceSidecars` (`:254-290`) add `fetchTierAllInCents(eventId)` to the existing `Promise.all` and return its map, e.g.:
+```ts
+const [stopsResp, ticketsResp, datesResp, allInById] = await Promise.all([
+  /* …existing three… */,
+  fetchTierAllInCents(eventId),
+]);
+/* …existing error guards… */
+return { stops: …, tickets: …, dates: …, allInById };
+```
+(`fetchTierAllInCents` never throws → no new error guard needed; keep the existing throw-on-RLS guards for the three Supabase responses.)
+
+**C3c — thread through `MapInput` → `mapExperience`.** Add to `interface MapInput` (`:134-146`):
+```ts
+/** ORCH-1147 — ticket_types.id → server all-in cents (single-owner fetch). */
+allInById?: Map<string, number>;
+```
+Both call sites already spread sidecars into `mapExperience({ event, brand, ...sidecars, bookable })` (`:338`, `:380`) — so once `loadExperienceSidecars` returns `allInById`, it flows in automatically; no call-site edit needed beyond C3b.
+
+In `mapExperience` (`:193-208`) set `priceAllInGbp` on the constructed ticket using the SAME free/miss semantics as the event path:
+```ts
+const allInCents = tt !== undefined ? input.allInById?.get(tt.id) : undefined;
+// …inside the ticket object:
+priceAllInGbp:
+  (tt.is_free === true || (tt.price_cents ?? 0) === 0)
+    ? null
+    : typeof allInCents === "number" ? allInCents / 100 : null,
+```
+The experience ticket is keyed by `tt.id` (= `ticket_types.id`, `:197`), which matches the helper's map key — VERIFIED. MAJOR units (`/100`).
+
+### C4 / C5. The two stub mappers — pass `priceAllInGbp` through
+
+These mappers live in the ALREADY-allowlisted `index.tsx` files but were not touched by the core impl, so the stub never carries the all-in even after C1-C3. Add the pass-through.
+
+**C4 — trip `tierToTicketStub` (`checkout-trip/[tripEventId]/index.tsx:66-78`):** add to the returned `TicketStub`:
+```ts
+priceAllInGbp: tier.priceAllInGbp ?? null,
+```
+(The multi-tier seed at `:455-458` reads `ticket.priceAllInGbp` off the stub mapped here; the sole-tier seed at `:250` reads `sole.priceAllInGbp` off the same stub. Both are fed once `tierToTicketStub` passes it.)
+
+**C5 — experience `ticketToStub` (`checkout-experience/[experienceEventId]/index.tsx:51-...`):** add to the returned `TicketStub`:
+```ts
+priceAllInGbp: ticket.priceAllInGbp ?? null,
+```
+
+After C1-C5, for BOTH trip and experience: `pg_public_event_tier_allin` → `fetchTierAllInCents` → `TripPricingTier.priceAllInGbp` / `PublicExperienceTicket.priceAllInGbp` → stub `priceAllInGbp` → seed `unitPriceAllIn` → `useCartTotals.allInTotal` → headline Total + "Fees & tax" line. This is byte-for-byte the same display path the event already uses — the trip/experience CART Total then reads the all-in IDENTICALLY to the event path.
+
+---
+
+## D. Success-criteria amendment (the original SC-4 / SC-5 now have a SOURCE contract)
+
+The original SPEC §5 SC-4 (trip) / SC-5 (experience) demanded each offering independently satisfy SC-1/SC-2. They were `◑` (display-wired, source-pending) in the implementation report. This amendment makes them fully testable:
+
+- **SC-4 (trip) — UPGRADED.** On a **pass-fee** trip (brand passes Mingla and/or service fee), the trip checkout/payment **Total** EQUALS the server fee-grossed all-in (`Σ priceAllInGbp × qty`), NOT the base subtotal, AND the combined "Fees & tax" line renders = (Total − base). Source: `TripPricingTier.priceAllInGbp` populated via `fetchTierAllInCents` in `getPublicTripById`.
+- **SC-5 (experience) — UPGRADED.** Same on a **pass-fee** experience. Source: `PublicExperienceTicket.priceAllInGbp` populated via `fetchTierAllInCents` threaded through `loadExperienceSidecars` → `mapExperience`.
+- **SC-4b / SC-5b (no-regression).** On an absorb-all brand (current prod: all 8 charges-enabled), trip + experience `feesTaxCents=0`, no "Fees & tax" line, Total == base exactly as before. On a free tier, `priceAllInGbp=null` → seed falls back to 0/base.
+- **SC-11 (single-owner gate, NEW).** `pg_public_event_tier_allin` is called from exactly ONE place: the body of `fetchTierAllInCents` in `publicEventsService.ts`. No second RPC call, no duplicated fee math anywhere in `tripsService.ts` / `publicExperienceService.ts`.
+
+---
+
+## E. Test-contract EXTENSION (Step-0.5 + tester per-type verification)
+
+### E1. Implementor happy-path test — EXTEND, do not replace
+
+The original Step-0.5 test `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts` asserts `useCartTotals.allInTotal` + the EVENT headline binds to the all-in. **Extend that same file** (it is already on the allowlist) so the happy-path also asserts the TRIP and EXPERIENCE cart Total equals the server all-in — not only event:
+
+1. **T-7a (trip source → cart Total).** Given a `TripPricingTier` with `priceAllInGbp` > `priceGbp`, assert that after `tierToTicketStub` + the seed mapping (`unitPriceAllIn: stub.priceAllInGbp ?? stub.priceGbp`), `useCartTotals.allInTotal` reflects the trip all-in and `feesTaxCents > 0` (Total > base). Unit-test the pure mapping (`tierToTicketStub` → stub → seed-shape → `useCartTotals`), no network.
+2. **T-7b (experience source → cart Total).** Same for a `PublicExperienceTicket` with `priceAllInGbp` > base via `ticketToStub`: `useCartTotals.allInTotal` reflects the experience all-in, `feesTaxCents > 0`.
+3. **T-7c (fallback, both types).** With `priceAllInGbp` absent/null on the source, the stub carries `null`, the seed falls back to base, `feesTaxCents == 0` (no regression / no fabrication) — for BOTH trip and experience.
+
+**Fails-on-revert requirement (carry the original contract):** T-7a/T-7b MUST FAIL if any of these are reverted — the `TripPricingTier.priceAllInGbp` field removed, the `getPublicTripById` populate deleted, `tierToTicketStub` stops passing `priceAllInGbp`, or the experience equivalents. They MUST PASS when restored. The implementor proves the fail-on-revert by true line deletion (not comment-out), mirroring the original report §6.
+
+**Single-owner structural gate (SC-11).** Either extend the existing `orch-1147-cart-total-is-allin.mjs` strict-grep OR add an assertion that `pg_public_event_tier_allin` appears in `publicEventsService.ts` ONLY (and that `tripsService.ts` / `publicExperienceService.ts` contain NO `supabase.rpc("pg_public_event_tier_allin"` string). This catches a future duplicate-RPC regression. (Implementor's choice of extend-vs-new, but the assertion is mandatory.)
+
+### E2. Tester per-type verification — MANDATORY, all three types separately
+
+The tester MUST device-verify the cart Total == server all-in on a **pass-fee fixture** for **all three offering types separately** (event already passing; trip + experience are the new surfaces):
+
+1. Stand up / temporarily toggle a charges-enabled, **pass-fee** brand (D-3 from the original SPEC — a green run on absorb-only prod data proves NOTHING; 0/8 brands pass a fee today).
+2. **EVENT** — confirm Total > base by the fee gross-up + "Fees & tax" line (regression check; already live).
+3. **TRIP** — open the trip checkout for the pass-fee brand; confirm the cart/payment Total EQUALS `Σ priceAllInGbp × qty` (NOT base) and the "Fees & tax" line renders; confirm `getPublicTripById` returns tiers with `priceAllInGbp` populated (network/log evidence).
+4. **EXPERIENCE** — same for the experience checkout; confirm `PublicExperienceTicket.priceAllInGbp` is populated and the cart Total reflects it.
+5. **Per-platform:** business iOS + business Android + buyer-web for each of the three types (display-only RN change inherits parity via shared `CartContext`; web display branch verified explicitly).
+6. **No-regression:** on an absorb brand, all three show Total == base, no fees line (SC-4b/SC-5b/SC-9).
+
+A verdict that verifies only the event type, or only one platform, is INCOMPLETE and must be rejected. Three types × (display Total + "Fees & tax" line) is the gate.
+
+---
+
+## F. Implementation order (append to original SPEC §8 as steps 7-9)
+
+7. **`publicEventsService.ts`** — export `fetchTierAllInCents` (C1a); populate `TripPricingTier.priceAllInGbp` in `getPublicTripById` (C1b).
+8. **Trip type + stub** — `tripsService.ts` interface field (C2); `checkout-trip/.../index.tsx` `tierToTicketStub` pass-through (C4).
+9. **Experience** — `publicExperienceService.ts` interface field + import + `loadExperienceSidecars` fetch + `MapInput` + `mapExperience` (C3); `checkout-experience/.../index.tsx` `ticketToStub` pass-through (C5).
+10. **Tests/gate** — extend the Step-0.5 jest with T-7a/T-7b/T-7c (E1); add/extend the single-owner SC-11 gate; prove fails-on-revert; run the business jest suite + `orch-1147-*` + `orch-1130-no-buyer-tax-form.mjs` green; `npx tsc --noEmit` on the 5 touched files clean.
+
+Estimated net: ~30 lines of product code across the 5 files + test/gate additions.
+
+---
+
+## G. Open questions
+
+- **OQ-2 (exclusive-tax residual) — STILL PARKED by Seth.** `priceAllInGbp` folds FEES, excludes TAX, so in exclusive-tax regions (US `pass_tax=true`) the trip/experience floor — like the event floor — understates by tax. Blast radius ZERO today (all charges-enabled brands inclusive GB/EU/CH). This amendment does NOT change that and does NOT make the RPC tax-aware. The OQ-2 comment the core impl placed at each `displayAllIn` site already covers trip + experience payment screens — no new caveat site needed.
+- No new open questions. The two source files + the helper export discharge OQ-3 in full.
+
+---
+
+## H. Downstream routing
+
+- **Next = mingla-implementor.** Build §F (steps 7-10) in the worktree `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]/` on branch `ORCH-1147-cart-true-price`. Touch ONLY the 5 files in §B (plus the existing test/gate files). Reuse `fetchTierAllInCents` — do NOT duplicate the RPC. Extend the Step-0.5 test with trip + experience assertions. Append to the implementation report (do not overwrite). Prove fails-on-revert.
+- **Then = mingla-tester.** Per-type pass-fee verification (§E2) — event + trip + experience, all on business iOS + Android + web; SC-4/SC-5/SC-4b/SC-5b/SC-11; the original SC-6/SC-7/SC-8 still hold. Reject any single-type or single-platform pass.
+- **Then = mingla-orchestrator CLOSE.** Flip `I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN` + `I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL` ACTIVE (now satisfied for all three types); commit the tester adversarial test before merge; OTA the business app (runtime 1.0.0; pure RN/JS) on close.
+- **Working tree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]/` on branch `ORCH-1147-cart-true-price`.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1147_CART_TRUE_PRICE.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1147_CART_TRUE_PRICE.md
@@ -1,0 +1,306 @@
+# SPEC — ORCH-1147 [cart does not reflect the TRUE price of a trip/event/experience]
+
+**Phase:** SPEC ONLY (binding build contract — no product code in this turn).
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]` on branch `ORCH-1147-cart-true-price` (rebased on origin/main @ `61156a6e5`, 0 behind).
+**Project ref:** `gqnoajqerqhnvulmnyvv`.
+**Skill:** mingla-forensics (SPEC mode).
+**Inputs ingested:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1147_CART_TRUE_PRICE_FEE_TAX_OMISSION.md` (root cause, six-field evidence, per-surface matrix); `COMMS_LEDGER.md` (COMMS-0013 / 0014 / 0016 factored — see §1).
+**Comms ack:** COMMS-0013 (WARN, OPEN — web-vs-native tax basis divergence, ORCH-1006) + COMMS-0014 + COMMS-0016 (WARN — experience checkout MUST stay on `ticket-checkout-create`) read + factored into §2/§4/§6. This SPEC is the partial discharge of COMMS-0013's planned "follow-up web-checkout sub-ORCH" for the fee-gross-up leg (the web CHARGE under-bill), and explicitly leaves the residual exclusive-tax web/native divergence as a NAMED, scoped caveat (§4.3, OQ-2) rather than silently shipping it.
+
+---
+
+## 1. Executive summary
+
+The buyer-facing **cart / checkout "Total"** on the business app and on buyer-web shows the **bare ticket subtotal** (base price × qty) with **no Mingla fee, no service fee, and no tax folded in** — while the server actually charges the full all-in (base + passed Mingla fee + passed service fee + tax). Display and charge therefore diverge: a buyer can be **charged more than the quoted Total** (business iOS/Android + buyer-web), violating Mingla's all-in / WYSIWYP promise (ORCH-1025/1130, `feedback_cart_combined_fees_tax_line`).
+
+Three distinct defects, one promise:
+- **F-1/F-2 (display):** the business cart total (`useCartTotals.total`) is the base subtotal; the payment-screen `displayAllIn` only shows the server all-in via a fragile, native-only, buyer-details-gated async preview, and falls back to the base subtotal on web (always) and on any native preview miss.
+- **D-1 / F-4 (web CHARGE under-bill):** the buyer-web hosted Stripe Checkout line item is `unit_amount: totalCents` (BASE only) — the passed Mingla/service-fee gross-up is **dropped from the charge itself**, so web buyers UNDER-pay vs native for the same passed-fee offering. This is an economic/revenue bug, not just display.
+- **D-2 / F-6 (tax term):** the per-tier all-in RPC (`compute_all_in_cents` → `pg_public_event_tier_allin`) folds FEES but **excludes TAX**, so a fee-grossed display still understates by the tax amount in **exclusive-tax regions** (US sales tax, `pass_tax=true`).
+
+This SPEC makes the displayed cart/checkout **Total equal the server all-in** across **event / trip / experience** on business iOS, business Android, and buyer-web; renders the single combined **"Fees & tax"** line; and fixes the web CHARGE to bill the fee-grossed subtotal. The structural fix is **one owner of the money**: the per-tier server all-in (`priceAllInGbp`, fee-grossed) becomes the cart's display basis (synchronous, no buyer form, web + native parity), and the server engine remains the charge authority — the client stops re-deriving the total from the bare base subtotal.
+
+**Currently masked:** 0 of 8 charges-enabled brands pass any fee/tax toggle today (all are inclusive-tax GB/EU/CH), so no live checkout shows the divergence — it is a launch-time landmine the instant any charges-enabled brand flips a toggle. Tester MUST stand up a synthetic pass-fee fixture (§D-3 / §7).
+
+---
+
+## 2. Scope & non-goals
+
+### In scope
+- Make the **business cart/payment displayed Total** equal the server fee-grossed all-in (`priceAllInGbp`), across event / trip / experience, on business iOS + business Android + buyer-web — synchronously, with no buyer-detail precondition and no buyer tax form.
+- Add the single combined **"Fees & tax"** line (all-in − base) to the business cart/payment order summary, per `feedback_cart_combined_fees_tax_line` (one line, NOT split service-fee + VAT).
+- Fix the **buyer-web CHARGE** (`ticket-checkout-create` web/mobile-web Checkout Session) so the line item bills the **fee-grossed pre-tax subtotal** (`buyerSubtotal.buyerSubtotalCents`), letting Stripe `automatic_tax` add tax on top — so the web charge equals the native charge for the fee gross-up (closes D-1/F-4).
+- Establish the per-tier server all-in as the SINGLE display authority the cart reads; remove the client's independent re-derivation of the headline Total from the bare base subtotal.
+- Pre-stage DRAFT invariants + the strict-grep/test enforcement family (§6).
+- Per-offering-type coverage proven separately (trip / event / experience use different checkout routes; §3, §5).
+
+### Non-goals (explicitly OUT — with reason)
+- **Making the SQL all-in RPC tax-aware for exclusive-tax regions.** `compute_all_in_cents` is a pure IMMUTABLE fee-only SQL function with no region/venue/registration input; faithfully replicating Stripe Tax's jurisdiction calculation in SQL is impossible (Stripe Tax is the authority, venue+registration dependent). The residual exclusive-tax (US `pass_tax=true`) display understatement is left as a **named, scoped caveat** (§4.3, OQ-2), NOT fixed here — fixing it requires routing display off the server preview's tax-inclusive `buyer_total_cents`, which gates on buyer details and is a larger redesign. **Today's blast radius is ZERO** (all charges-enabled brands are inclusive-tax GB/EU/CH where tax is inside the base and `all_in_cents == buyer_total_cents`).
+- **ORCH-1034 GBP currency-fallback work** (`?? "GBP"`, `priceGbp` field naming, `normalizeCurrency→GBP`). The cart still seeds `currency: ticket.currency ?? event.currency ?? "GBP"` and field names carry `Gbp` — this is the separate, not-yet-started ORCH-1034 and is NOT the fee/tax-omission root cause. Display reads `totals.currency` already; do not touch the GBP fallbacks. (Interaction noted: the all-in seed must carry the SAME `currency` as the base seed; no new currency fallback introduced.)
+- **Paystack/NGN charge-path rewrite.** The NGN arm shares the business cart DISPLAY bug (fixed here via the shared cart) but charges via `computeConfigVat` (`ticket-checkout-create.ts:686`), not the Stripe engine. This SPEC requires **parity confirmation** only (§D-4 / §5 SC-7) — no NGN charge-path change.
+- **Buyer tax form / billing-address re-introduction** — barred by I-PROPOSED-1130-NO-BUYER-TAX-FORM (§6). The fix consumes server-computed numbers; it adds NO form.
+- **Consumer app (app-mobile) display change.** Consumer already shows a fee-grossed all-in correctly (F-5, the reference pattern). The consumer tax-gap (F-6) is the SAME exclusive-tax caveat as OQ-2 and is OUT for the same reason. No consumer file is touched.
+- **Checkout redesign / new screens / new payment methods.** Total-display + charge-correctness only.
+
+### Assumptions
+- `pg_public_event_tier_allin` / `priceAllInGbp` is already fetched on every business checkout ticket record (`publicEventsService.fetchTickets:879-895`) for event; the trip and experience checkout index screens must source the same per-tier all-in (verify each path in §4 — trip/experience seed from their own stubs and may need the all-in plumbed through).
+- The server `mode:"preview"` round-trip stays as the native upfront tax-inclusive confirmation (it gates on buyer name/email/phone — lines 257/261/264 — so it CANNOT be the cart-screen source; it remains the late, native-only tax-inclusive refinement). The cart-screen display basis is the synchronous per-tier `priceAllInGbp`.
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY per-surface table)
+
+| # | Surface | Covered | User-visible behavior demanded | Files touched here | Parity |
+|---|---------|---------|--------------------------------|--------------------|--------|
+| 1 | **Consumer iOS** (`app-mobile/` iOS) | NO | Already correct (fee-grossed all-in, F-5). Tax-gap = OQ-2 caveat, OUT. | none | — |
+| 2 | **Consumer Android** (`app-mobile/` Android) | NO | Same as #1. | none | — |
+| 3 | **Buyer / anon Web** (`mingla-business` `/checkout/{eventId}`, `/checkout-trip/...`, `/checkout-experience/...`) | YES | Displayed Total = fee-grossed all-in (NOT base); combined "Fees & tax" line shown; **the CHARGE bills the fee-grossed subtotal** (D-1 fixed) + Stripe adds tax. | `CartContext.tsx`, 3× `index.tsx`, 3× `payment.tsx`, `ticket-checkout-create/index.ts:1086` | Manual (web display branch + web charge branch are distinct from native) |
+| 4 | **Business iOS** | YES | Displayed Total = fee-grossed all-in synchronously (no buyer-detail gate); combined "Fees & tax" line; native preview still refines to tax-inclusive when buyer details present. | `CartContext.tsx`, 3× `index.tsx`, 3× `payment.tsx` | Auto across the 3 offerings via shared `CartContext`; manual vs web |
+| 5 | **Business Android** | YES | Same as #4. | same as #4 | Auto (shared RN code) |
+| 6 | **Admin Web** (`mingla-admin/`, adjacent) | NO | No buyer checkout surface. | none | — |
+| 7 | **Business Web preview** (adjacent) | NO | Non-buyer surface. | none | — |
+
+**Hard gate note:** surfaces 3/4/5 are the ONLY covered surfaces. Web (3) is the only surface with a CHARGE change (D-1); native (4/5) is display-only (the native charge already bills `buyer_total_cents` — F-3 — correctly).
+
+---
+
+## 4. Layered specification
+
+### 4.1 Data flow (the structural fix — read this first)
+
+**Before (broken):**
+```
+ticket record .priceGbp ──seed──▶ CartLine.unitPrice ──Σ×qty──▶ useCartTotals.total (BASE) ──▶ "Total" display
+                                                                                            (re-derived, no fee/tax)
+server engine buyer_total_cents ──────────────────────────────────────────────────────────▶ CHARGE (native)
+server Checkout line unit_amount: totalCents (BASE) ───────────────────────────────────────▶ CHARGE (web)  ← under-bills
+```
+
+**After (one owner):**
+```
+ticket record .priceAllInGbp (server fee-grossed, pg_public_event_tier_allin)
+        │
+        ├─seed──▶ CartLine.unitPrice (BASE, unchanged — for the per-line "Tickets" subtotal)
+        └─seed──▶ CartLine.unitPriceAllIn (NEW — server fee-grossed all-in)
+                          │
+                          ▼
+            useCartTotals → { subtotal (base), allInTotal (Σ allIn×qty), feesTaxCents = allInTotal − subtotal }
+                          │
+                          ▼
+       payment.tsx: "Total" = allInTotal; "Fees & tax" line = feesTaxCents; Pay button = allInTotal
+                     (native: optional tax-inclusive refinement from preview when buyer details present)
+
+server CHARGE (web): unit_amount: buyerSubtotal.buyerSubtotalCents (fee-grossed pre-tax) + automatic_tax → equals native fee gross-up
+server CHARGE (native): amount: buyer_total_cents  (UNCHANGED — already correct)
+```
+
+The display now reads a **server-computed** per-tier all-in (`priceAllInGbp`) instead of re-deriving from base. The client performs ZERO fee/tax math beyond `Σ(serverAllIn × qty)` and `allIn − base` (the same two ops the consumer reference pattern uses — `TicketCartSheet.tsx:305-328`).
+
+### 4.2 Client layer — business cart (`CartContext.tsx`)
+
+**File:** `mingla-business/src/components/checkout/CartContext.tsx`
+
+1. **`CartLine` (interface, ~L34-46):** add an OPTIONAL field
+   `unitPriceAllIn?: number;` — major units in `currency`, the server fee-grossed all-in per unit (from `priceAllInGbp`). Optional so a missing all-in (free tier, or a path that hasn't plumbed it) falls back to `unitPrice` (base) and contributes 0 to fees/tax — never undefined, never NaN.
+2. **`SET_LINE_QUANTITY` action + reducer (~L144-238) + `setLineQuantity` signature (~L270-318):** thread `unitPriceAllIn?: number` through the action, the reducer line-write (both the new-line and existing-line branches must persist it), and the public setter params. When absent, store `unitPriceAllIn: unitPriceAllIn ?? unitPrice`.
+3. **`CartTotals` (interface, ~L389-400):** add
+   `allInTotal: number;` (Σ `unitPriceAllIn × qty`, fee-grossed),
+   `feesTaxCents: number;` (in MINOR units = `round((allInTotal − subtotal) × 100)`, GREATEST(0, …)),
+   `hasFeesTaxDelta: boolean;`.
+   Keep `subtotal` / `total` as the BASE subtotal for the per-line "Tickets" recap (do NOT repurpose `total`; downstream legacy reads of `total` as base must not silently change meaning — the headline Total is sourced from `allInTotal`).
+4. **`useCartTotals` (~L402-426):** in the reduce loop also accumulate `allInTotal += (line.unitPriceAllIn ?? line.unitPrice) × line.quantity`; compute `feesTaxCents` + `hasFeesTaxDelta`; return them. All math in major units then convert the delta to cents once (mirror `TicketCartSheet.tsx:323`). No currency mixing change (existing guard stays).
+
+**Error/empty states:** empty cart → `allInTotal=0, feesTaxCents=0, hasFeesTaxDelta=false`. Free cart (`subtotal===0`) → `allInTotal=0` (free tiers carry `priceAllInGbp=null` → seed falls back to `unitPrice=0`).
+
+### 4.3 Client layer — the three checkout INDEX (cart-seed) screens
+
+Each seeds `CartLine`. Each must additionally pass `unitPriceAllIn` sourced from the SAME ticket record's server all-in.
+
+| Offering | File | Current seed line | Change |
+|----------|------|-------------------|--------|
+| **Event** | `mingla-business/app/checkout/[eventId]/index.tsx` | `:271-274` `unitPrice: ticket.priceGbp ?? 0` | add `unitPriceAllIn: ticket.priceAllInGbp ?? ticket.priceGbp ?? 0` (record already carries `priceAllInGbp` — `PublicTicketTypeRecord`). |
+| **Trip** | `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | `:246` (`sole`) + `:450` (multi) `unitPrice: …priceGbp ?? 0` | add `unitPriceAllIn` from the stub's server all-in. **VERIFY the trip stub carries the per-tier all-in** (`:69` maps `priceGbp` from `priceCents`; confirm `priceAllInGbp`/`allInCents` is fetched on the trip checkout query — if NOT, plumb `pg_public_event_tier_allin` / the same `fetchTierAllInCents` into the trip ticket fetch first, mirroring `publicEventsService.fetchTickets:879-895`). |
+| **Experience** | `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | `:277` `unitPrice: stub.priceGbp ?? 0` | add `unitPriceAllIn` from the stub's server all-in. **VERIFY the experience stub carries the per-tier all-in** (`:54` maps `priceGbp`; confirm `priceAllInGbp` present — plumb if missing, same as trip). |
+
+> **Stop-and-amend trigger:** if either trip or experience checkout does NOT already fetch the per-tier all-in and plumbing it requires touching a service/hook outside the allowlist (§ Allowlist), the implementor requests a SPEC amendment naming the exact service/query before widening. The expected source is the same `pg_public_event_tier_allin` RPC the event path uses — confirm whether trip/experience route through `publicEventsService.fetchTickets` (which already adds `priceAllInGbp`) or a separate fetch.
+
+### 4.4 Client layer — the three PAYMENT screens (display)
+
+| Offering | File | displayAllIn block |
+|----------|------|--------------------|
+| **Event** | `mingla-business/app/checkout/[eventId]/payment.tsx` | `:558-561` |
+| **Trip** | `mingla-business/app/checkout-trip/[tripEventId]/payment.tsx` | `:573-576` |
+| **Experience** | `mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx` | `:476-480` |
+
+For EACH (identical change, three sites):
+
+1. **Headline Total source.** Replace the bare-subtotal fallback. New rule:
+   ```ts
+   // base for the "Tickets" line; allInTotal (server fee-grossed) is the headline floor
+   const baseTotalCents = Math.round(totals.subtotal * 100);
+   const allInFloorCents = Math.round(totals.allInTotal * 100);   // fee-grossed, sync, web+native
+   // native refinement: when the preview resolved, it is tax-INCLUSIVE (≥ floor) → prefer it
+   const headlineCents = (Platform.OS !== "web" && allInPreviewCents !== null && allInPreviewCents >= allInFloorCents)
+     ? allInPreviewCents
+     : allInFloorCents;
+   const displayAllIn = formatCurrency(headlineCents, totals.currency, /*isMinor*/ true);
+   ```
+   - **Web** now shows `allInFloorCents` (fee-grossed all-in) instead of the base subtotal — the web display bug is fixed by data, no `Platform.OS` branch hiding the all-in.
+   - **Native** still upgrades to the tax-inclusive `allInPreviewCents` when the non-blocking preview resolves; otherwise the fee-grossed floor (never the bare base).
+   - The `>= allInFloorCents` guard prevents a stale/lower preview from regressing the headline.
+2. **Add the combined "Fees & tax" line** to the ORDER SUMMARY GlassCard (event `:602-630`; trip/experience analogous), rendered ONLY when `totals.hasFeesTaxDelta` (mirror consumer `TicketCartSheet`):
+   ```
+   Tickets        {formatCurrency(baseTotalCents, currency, minor)}     ← per-line Σ stays as-is
+   Fees & tax     {formatCurrency(feesTaxLineCents, currency, minor)}   ← NEW, single combined line
+   ─────────
+   Total          {displayAllIn}
+   ```
+   where `feesTaxLineCents = headlineCents − baseTotalCents` (so on native with a tax-inclusive preview the line correctly includes tax; on web/floor it is the fee delta). NEVER split into separate service-fee + VAT lines (`feedback_cart_combined_fees_tax_line`).
+3. **Bottom-bar Total (event `:672-677`) + Pay button (event `:678-689`)** already read `displayAllIn` — they inherit the fix automatically. Confirm the same for trip/experience bottom bars.
+4. **Copy:** Total label unchanged ("Total"); new line label exactly `Fees & tax`. The `accessibilityLabel` on Pay already interpolates `displayAllIn` — inherits the all-in.
+
+**States (all three screens):** loading/seed-incomplete → existing empty-shell guard unchanged. Preview-miss (native) → fee-grossed floor (NOT base). Web → fee-grossed floor always. Free cart → existing free-path guard (no all-in row).
+
+**Exclusive-tax caveat (OQ-2, documented, NOT fixed):** on web AND on the native floor, the headline omits tax in **exclusive-tax regions** (US `pass_tax=true`) because `priceAllInGbp` excludes tax (F-6). For all current charges-enabled brands (GB/EU/CH inclusive) the floor EQUALS the charge. A code comment at each `displayAllIn` site MUST name this caveat + OQ-2 so it is not mistaken for a complete tax fix.
+
+### 4.5 Edge layer — buyer-web CHARGE fix (D-1 / F-4)
+
+**File:** `supabase/functions/ticket-checkout-create/index.ts`
+**Site:** web/mobile-web Checkout Session, `:1082-1090`, specifically `:1086 unit_amount: totalCents`.
+
+Change `unit_amount` from `totalCents` (BASE) to **`buyerSubtotal.buyerSubtotalCents`** — the fee-grossed PRE-TAX subtotal computed at `:919` (`computeBuyerSubtotal`), which is in scope at the web branch (web branch `:971` is after `:919`).
+
+**Why `buyerSubtotalCents`, NOT `buyer_total_cents`:** the web Checkout Session has `automatic_tax: { enabled: true }` (`:1105`) — Stripe ADDS tax on top of the line item. If the line item were `buyer_total_cents` (which already includes tax), Stripe would **double-tax**. The correct web line item is the fee-grossed PRE-TAX subtotal; `automatic_tax` then adds the jurisdiction tax → the web buyer pays base + passed fees + tax, matching the native `buyer_total_cents` for the fee gross-up. (This corrects the dispatch's shorthand "bill `buyer_total_cents`" for the web path specifically — see OQ-1.)
+
+`application_fee_amount` (`:1073-1076 = buyerSubtotal.miglaFeeCents`) is UNCHANGED — it is Mingla's platform skim out of the merchant cut, independent of the buyer gross-up.
+
+**No other edge change.** The native PI amount (`:1559 buyer_total_cents`) and preview return (`:1519 buyer_total_cents`) are already correct (F-3). The `verify_jwt`, auth, validation, and error shapes are untouched.
+
+**Web-vs-native tax basis residual (COMMS-0013):** the web branch uses Stripe `automatic_tax` (buyer-billing-address basis) while native uses venue-sourced `tax.calculations.create`. This SPEC fixes the FEE divergence (the under-bill) but does NOT unify the tax BASIS — that residual stays exactly as COMMS-0013 registered it (operator-accepted at launch; ≈0 live pass-tax brands). Named, not silently shipped.
+
+### 4.6 DB layer
+
+**No migration.** `compute_all_in_cents` / `pg_public_event_tier_allin` are NOT changed (non-goal §2: SQL cannot faithfully compute exclusive-region tax). The display reads the existing fee-grossed RPC output already exposed via `priceAllInGbp`.
+
+### 4.7 Service / Hook layer
+
+- `publicEventsService.fetchTickets` already attaches `priceAllInGbp` (event path) — no change unless §4.3 verification finds trip/experience do NOT route through it, in which case the SAME `fetchTierAllInCents(eventId)` helper (`:840-857`) is added to that path (stop-and-amend if it touches a non-allowlisted file).
+- No new hook, no new query key, no React Query change.
+
+---
+
+## 5. Success criteria (per-surface where parity is manual)
+
+- **SC-1-iOS / SC-1-Android / SC-1-Web** — On a **pass-fee** event (a brand passing Mingla and/or service fee), the cart/payment **"Total"** displayed EQUALS the server fee-grossed all-in (`Σ priceAllInGbp × qty`), NOT the bare base subtotal. (Web shows it synchronously; native shows it synchronously, refined to tax-inclusive when the preview resolves.)
+- **SC-2-iOS / SC-2-Android / SC-2-Web** — The order summary renders a single combined **"Fees & tax"** line = (headline Total − base "Tickets" subtotal), rendered iff `hasFeesTaxDelta`; never split into separate service-fee + VAT lines.
+- **SC-3 (event) / SC-4 (trip) / SC-5 (experience)** — Each offering type independently satisfies SC-1/SC-2 (different checkout routes; verified separately).
+- **SC-6-Web (D-1)** — The buyer-web hosted Stripe Checkout Session line item bills `buyerSubtotal.buyerSubtotalCents` (fee-grossed pre-tax), so the web charge total (line item + Stripe `automatic_tax`) equals the native charge's fee gross-up. A pass-fee web checkout no longer under-bills the passed fee.
+- **SC-7 (D-4 parity)** — On the Paystack/NGN arm, the business cart DISPLAY shows the same fee-grossed all-in (shared `CartContext`), and the NGN CHARGE (`computeConfigVat` path) is confirmed to already bill the all-in (no regression; parity documented, no NGN charge change).
+- **SC-8 (invariant preserved)** — No buyer-facing billing-address form or "Calculate tax" control is introduced; `orch-1130-no-buyer-tax-form.mjs` still passes.
+- **SC-9 (no-regression on absorb brands)** — On an absorb-all brand (current prod: all 8 charges-enabled), `feesTaxCents=0`, no "Fees & tax" line renders, and the displayed Total equals the base subtotal exactly as before (zero visible change).
+- **SC-10 (free)** — Free tiers: Total = "Free"/0, no fees/tax line, unchanged.
+
+Each SC is observable in the running app (display) or via the edge function request body (SC-6) or DB/Paystack config read (SC-7).
+
+---
+
+## 6. Invariants
+
+### Preserved
+- **I-PROPOSED-1130-NO-BUYER-TAX-FORM (DRAFT, ACTIVE-enforced via gate):** preserved. The fix consumes server-computed numbers and adds NO buyer form. Verified by the existing `orch-1130-no-buyer-tax-form.mjs` strict-grep gate (must still pass — SC-8).
+- **WYSIWYP / all-in single "Fees & tax" line** (`feedback_cart_combined_fees_tax_line`, ORCH-1025/1006/1130): this SPEC brings business + web display into compliance; the combined-line contract is honored (single line, SC-2).
+- **ORCH-1034 de-GBP boundary:** untouched. The all-in seed carries the SAME `currency` as the base seed; no new `?? "GBP"` introduced.
+
+### NEW — proposed DRAFT (orchestrator flips ACTIVE on CLOSE)
+- **I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).** The business cart/payment headline "Total" and Pay-button amount MUST be sourced from the server fee-grossed all-in (`priceAllInGbp` → `CartLine.unitPriceAllIn` → `useCartTotals.allInTotal`), never from the bare base subtotal (`totals.subtotal`/`totals.total`) as the headline. **Enforcement family:** strict-grep + jest. Strict-grep `orch-1147-cart-total-is-allin.mjs`: assert the three `payment.tsx` headline `displayAllIn`/Pay sites do NOT bind the headline directly to `totals.total`/`totals.subtotal` without the `allInTotal`/`allInPreviewCents` path; jest on `useCartTotals` proving `allInTotal ≠ subtotal` when `unitPriceAllIn > unitPrice`.
+- **I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL (DRAFT).** The buyer-web Checkout Session line item MUST bill `buyerSubtotal.buyerSubtotalCents` (fee-grossed pre-tax), NOT the bare `totalCents`, so the web charge equals the native fee gross-up (with `automatic_tax` adding tax). **Enforcement family:** strict-grep `orch-1147-web-charge-allin.mjs` asserting the web `line_items[].price_data.unit_amount` is `buyerSubtotal.buyerSubtotalCents` (and fails if it reverts to `unit_amount: totalCents`). Comment-anchored fails-on-revert.
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-1 (happy, implementor) | `useCartTotals` with a pass-fee line | line `{ unitPrice: 50, unitPriceAllIn: 52.25, qty: 1, currency: "GBP" }` | `subtotal=50`, `allInTotal=52.25`, `feesTaxCents=225`, `hasFeesTaxDelta=true` | hook (jest) |
+| T-2 (happy) | event payment headline source | preview unresolved, `allInTotal=52.25` | `displayAllIn` formats `5225` cents (all-in floor), NOT `5000` | component |
+| T-3 (error/edge) | preview resolves LOWER than floor (stale) | `allInPreviewCents=5000`, floor `5225` | headline stays `5225` (`>= floor` guard) | component |
+| T-4 (edge) | absorb-all brand (SC-9) | `unitPriceAllIn === unitPrice` | `feesTaxCents=0`, no "Fees & tax" line, Total == base | hook + component |
+| T-5 (edge) | free tier (SC-10) | `unitPrice=0, unitPriceAllIn` null→0 | Total "Free"/0, no fees line | hook + component |
+| T-6 (web charge, **adversarial — tester**) | web Checkout Session body on a pass-fee event | edge `surface:"web"`, brand passes Mingla fee | `line_items[0].price_data.unit_amount === buyerSubtotal.buyerSubtotalCents` (fee-grossed), NOT `totalCents`; `automatic_tax.enabled===true` | edge |
+| T-7 (offering parity) | trip + experience payment screens | pass-fee trip + pass-fee experience | each shows fee-grossed Total + "Fees & tax" line (SC-4/SC-5) | component ×2 |
+| T-8 (invariant) | gate run | repo | `orch-1130-no-buyer-tax-form.mjs` PASS; `orch-1147-*` gates PASS | CI |
+| T-9 (NGN parity, SC-7) | NGN cart display + charge config | NGN pass-fee brand | display shows all-in; `computeConfigVat` charge confirmed all-in (no under-bill) | component + edge read |
+
+### Step 0.5 regression-test contract (mandatory)
+- **Implementor happy-path test (fails-on-revert):** `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts` — asserts T-1 + T-2: `useCartTotals.allInTotal` reflects `unitPriceAllIn` and the event payment headline binds to the all-in, not the base. MUST FAIL if `useCartTotals` is reverted to `total: subtotal`-only / the headline rebinds to `totals.total`. Committed BEFORE merge (per `feedback_close_gate_verify_against_merged_main_not_stale_anchor`).
+- **Tester adversarial test (DIFFERENT angle):** a pass-fee fixture where the OLD code under-quotes — drive BOTH (a) the **web CHARGE** (T-6: assert the Checkout Session line item bills the fee-grossed subtotal, not the bare base — this catches D-1 directly and fails on revert of `:1086`), AND (b) a business payment render where the displayed Total exceeds the bare base by exactly the fee gross-up. The tester's angle is the CHARGE-side under-bill + a synthetic pass-fee brand, distinct from the implementor's display-math unit test.
+
+### Tester-enablement requirement (D-3 — MANDATORY in the test plan)
+No charges-enabled brand passes any fee/tax toggle today (0/8; the lone pass-fee brand is NGN/Paystack, charges-disabled), so **a green test against current prod data proves NOTHING** — every brand absorbs, so `feesTaxCents=0` everywhere. Downstream TEST MUST:
+1. Stand up (or temporarily toggle) a **charges-enabled, pass-fee** brand + offering — either a synthetic fixture in the jest tests (preferred; deterministic) OR, for live-fire, temporarily flip `default_pass_mingla_fee=true` on a sandbox charges-enabled brand and revert after.
+2. Exercise the discrepancy: confirm display Total > base by the fee gross-up, and confirm the web Checkout Session bills the grossed-up subtotal.
+3. Confirm the **Paystack/NGN arm** (D-4/SC-7) shows the all-in in the cart and its `computeConfigVat` charge bills the all-in (no regression).
+A test run on absorb-only data is INSUFFICIENT and must be rejected as non-probative.
+
+---
+
+## 8. Implementation order
+
+1. **`CartContext.tsx`** — add `unitPriceAllIn` to `CartLine` + action + reducer + setter; add `allInTotal`/`feesTaxCents`/`hasFeesTaxDelta` to `CartTotals` + `useCartTotals`. (§4.2)
+2. **Event checkout** — `checkout/[eventId]/index.tsx` seed `unitPriceAllIn`; `checkout/[eventId]/payment.tsx` headline + "Fees & tax" line. (§4.3/§4.4)
+3. **Trip checkout** — verify/plumb per-tier all-in into the trip ticket fetch; `checkout-trip/.../index.tsx` seed; `checkout-trip/.../payment.tsx` display. (§4.3/§4.4)
+4. **Experience checkout** — verify/plumb per-tier all-in; `checkout-experience/.../index.tsx` seed; `checkout-experience/.../payment.tsx` display. (§4.3/§4.4)
+5. **Web CHARGE** — `ticket-checkout-create/index.ts:1086` `unit_amount: totalCents` → `buyerSubtotal.buyerSubtotalCents`. (§4.5)
+6. **Gates + tests** — add `orch-1147-cart-total-is-allin.mjs` + `orch-1147-web-charge-allin.mjs` strict-greps; the Step-0.5 implementor jest. (§6/§7)
+
+---
+
+## 9. Regression prevention (fails-on-revert)
+
+- **Structural safeguard:** the cart consumes a server-computed all-in (`priceAllInGbp`) as its display basis — the client no longer owns the fee/tax math (it only sums and subtracts). The server engine remains the single charge authority. One owner per truth.
+- **Display regression test:** `orch_1147_cart_allin_total.test.ts` (T-1/T-2) — FAILS when `useCartTotals` reverts to `total: subtotal`-only or the payment headline rebinds to `totals.total`; PASSES when the all-in path is restored.
+- **Charge regression test/gate:** `orch-1147-web-charge-allin.mjs` (+ tester T-6) — FAILS when `ticket-checkout-create:1086` reverts to `unit_amount: totalCents`; PASSES when it bills `buyerSubtotal.buyerSubtotalCents`.
+- **Protective comments:** at each `displayAllIn` site and at `:1086`, a comment naming ORCH-1147 + the invariant + the OQ-2 exclusive-tax caveat, so a future editor knows the headline/line-item must stay server-all-in-sourced and why the web uses pre-tax-subtotal (not `buyer_total_cents`).
+
+---
+
+## 10. Open questions
+
+- **OQ-1 (RESOLVED in-spec, flagged for orchestrator awareness):** the dispatch said "bill `buyer_total_cents`" for the web charge. For the WEB hosted-Checkout path specifically, billing `buyer_total_cents` would **double-tax** (the Session has `automatic_tax: enabled`). The SPEC bills `buyerSubtotal.buyerSubtotalCents` (fee-grossed pre-tax) instead — this is the correct discharge of D-1 and matches the native fee gross-up. Confirm the orchestrator accepts this refinement.
+- **OQ-2 (exclusive-tax residual — operator decision deferred, NOT blocking):** the fee-grossed display floor (`priceAllInGbp`) excludes tax, so on **exclusive-tax regions** (US `pass_tax=true`) the displayed floor understates the charge by the tax. Today's blast radius is ZERO (all charges-enabled brands are inclusive GB/EU/CH). Closing this requires routing the display off the server preview's tax-inclusive `buyer_total_cents` (which gates on buyer name/email/phone and cannot run on the cart screen) — a larger follow-on. Ship the fee fix now; track exclusive-tax display as a future ORCH. Operator to confirm acceptance at launch (mirrors COMMS-0013's operator-accepted residual).
+- **OQ-3 (trip/experience all-in source):** the implementor must verify whether trip + experience checkout already carry the per-tier `priceAllInGbp` (vs only the event path via `publicEventsService.fetchTickets`). If a separate fetch needs the `fetchTierAllInCents` helper added, that is in scope but must be done via the existing RPC (stop-and-amend if it touches a non-allowlisted service).
+
+---
+
+## 11. Downstream routing
+
+- **Next = mingla-implementor.** Build §8 in order in the worktree; add the gates + the Step-0.5 implementor test; run the business jest suite + the two new strict-greps + `orch-1130-no-buyer-tax-form.mjs`; prove the implementor test fails-on-revert; write the implementation report.
+- **Then = mingla-tester.** Stand up the synthetic/charges-enabled pass-fee fixture (D-3 — a green run on absorb-only data is rejected); write the DIFFERENT-angle adversarial test (web CHARGE under-bill T-6 + display-exceeds-base); confirm NGN parity (SC-7); device-verify on business iOS + Android + web buyer route across event/trip/experience.
+- **Then = mingla-orchestrator CLOSE.** Flip I-PROPOSED-1147-* ACTIVE; sync World Map / invariant registry / decision log; commit the tester test before merge; reconcile against COMMS-0013/0014/0016.
+- **Working tree:** `~/Desktop/mingla-orchs/ORCH-1147-[cart-true-price]/` on branch `ORCH-1147-cart-true-price`.
+
+---
+
+## Scoped allowlist (implementor MAY change)
+
+- `mingla-business/src/components/checkout/CartContext.tsx`
+- `mingla-business/app/checkout/[eventId]/index.tsx`
+- `mingla-business/app/checkout/[eventId]/payment.tsx`
+- `mingla-business/app/checkout-trip/[tripEventId]/index.tsx`
+- `mingla-business/app/checkout-trip/[tripEventId]/payment.tsx`
+- `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx`
+- `mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx`
+- `supabase/functions/ticket-checkout-create/index.ts` (ONLY `:1086 unit_amount`)
+- `mingla-business/src/services/publicEventsService.ts` (ONLY IF §4.3 verification proves trip/experience need `fetchTierAllInCents` plumbed — stop-and-amend first)
+- NEW: `.github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs`, `.github/scripts/strict-grep/orch-1147-web-charge-allin.mjs`
+- NEW: `mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts`
+
+## DO-NOT-TOUCH (stop-and-amend before any change)
+
+- `compute_all_in_cents` / `pg_public_event_tier_allin` (no migration; non-goal §2).
+- The native PI amount (`ticket-checkout-create:1559`) and preview return (`:1519`) — already correct.
+- The Paystack/NGN charge path (`:686 computeConfigVat`) — parity confirm only, no edit.
+- Any `app-mobile/` consumer file (consumer display already correct).
+- ORCH-1034 GBP fallbacks (`?? "GBP"`, `priceGbp` field renames, `normalizeCurrency`).
+- Any buyer billing-address / tax form (I-1130).
+- `useCartTotals.total` / `.subtotal` MEANING (keep = base; the headline is a NEW `allInTotal`, do not repurpose `total`).

--- a/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
+++ b/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
@@ -275,6 +275,10 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
               ticketTypeId: stub.id,
               ticketName: stub.name,
               unitPrice: stub.priceGbp ?? 0,
+              // ORCH-1147 — server fee-grossed all-in (priceAllInGbp) as the
+              // headline-Total basis; falls back to base until the experience
+              // source plumbs the per-tier all-in (never fabricate).
+              unitPriceAllIn: stub.priceAllInGbp ?? stub.priceGbp ?? 0,
               currency: stub.currency ?? experience.ticket?.currency ?? "USD",
               isFree: stub.isFree,
               quantity: next,

--- a/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
+++ b/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
@@ -52,6 +52,9 @@ const ticketToStub = (ticket: PublicExperienceTicket): TicketStub => ({
   id: ticket.ticketTypeId,
   name: ticket.name,
   priceGbp: ticket.priceCents > 0 ? ticket.priceCents / 100 : null,
+  // ORCH-1147 — pass the server fee-grossed all-in through to the cart seed
+  // (which reads stub.priceAllInGbp). Null → seed falls back to priceGbp/base.
+  priceAllInGbp: ticket.priceAllInGbp ?? null,
   currency: ticket.currency,
   capacity: ticket.ticketsRemaining ?? ticket.quantityTotal,
   isFree: ticket.priceCents === 0 || ticket.isFree,

--- a/mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx
+++ b/mingla-business/app/checkout-experience/[experienceEventId]/payment.tsx
@@ -471,13 +471,28 @@ function CheckoutExperiencePaymentScreenContent({
     router,
   ]);
 
-  // ORCH-1130 Fix #2 — display the server-computed all-in (incl. tax) when the
-  // silent no-address preview has resolved (native); otherwise the base Total.
-  const displayTotalCents = totals.total;
-  const displayAllIn =
-    Platform.OS !== "web" && allInPreviewCents !== null
-      ? formatCurrency(allInPreviewCents, totals.currency, true)
-      : formatCurrency(displayTotalCents, totals.currency);
+  // ORCH-1147 — the headline Total is the server fee-grossed all-in
+  // (totals.allInTotal, from priceAllInGbp/pg_public_event_tier_allin), NOT the
+  // bare base subtotal. Web shows it synchronously; native upgrades to the
+  // tax-inclusive preview once it resolves (>= floor guard). The client owns
+  // ZERO fee/tax math. I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).
+  //
+  // OQ-2 exclusive-tax CAVEAT (documented, NOT fixed): priceAllInGbp folds FEES
+  // but EXCLUDES tax — in exclusive-tax regions (US pass_tax=true) the floor
+  // understates by tax. Today's blast radius is ZERO (all charges-enabled brands
+  // are inclusive-tax GB/EU/CH). Larger follow-on (ORCH-1147 OQ-2).
+  const baseTotalCents = Math.round(totals.subtotal * 100);
+  const allInFloorCents = Math.round(totals.allInTotal * 100);
+  const headlineCents =
+    Platform.OS !== "web" &&
+    allInPreviewCents !== null &&
+    allInPreviewCents >= allInFloorCents
+      ? allInPreviewCents
+      : allInFloorCents;
+  // ORCH-1147 — single combined "Fees & tax" line (never split service-fee + VAT).
+  const feesTaxLineCents = Math.max(0, headlineCents - baseTotalCents);
+  const showFeesTaxLine = feesTaxLineCents > 0;
+  const displayAllIn = formatCurrency(headlineCents, totals.currency, true);
 
   // Defensive shell while guards redirect.
   if (
@@ -540,6 +555,16 @@ function CheckoutExperiencePaymentScreenContent({
             </View>
           ))}
           <View style={styles.summaryDivider} />
+          {/* ORCH-1147 — single combined "Fees & tax" line (all-in − base);
+              rendered only on a real delta (absorb-all brands show nothing). */}
+          {showFeesTaxLine ? (
+            <View style={styles.summaryFeesTaxRow}>
+              <Text style={styles.summaryFeesTaxLabel}>Fees &amp; tax</Text>
+              <Text style={styles.summaryFeesTaxValue}>
+                {formatCurrency(feesTaxLineCents, totals.currency, true)}
+              </Text>
+            </View>
+          ) : null}
           <View style={styles.summaryTotalRow}>
             <Text style={styles.summaryTotalLabel}>Total</Text>
             <Text style={styles.summaryTotalValue}>
@@ -653,6 +678,23 @@ const styles = StyleSheet.create({
     marginVertical: spacing.sm,
     height: StyleSheet.hairlineWidth,
     backgroundColor: "rgba(255, 255, 255, 0.08)",
+  },
+  // ORCH-1147 — combined "Fees & tax" line.
+  summaryFeesTaxRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  summaryFeesTaxLabel: {
+    fontSize: 13,
+    color: textTokens.tertiary,
+    fontWeight: "500",
+  },
+  summaryFeesTaxValue: {
+    fontSize: 14,
+    color: textTokens.secondary,
+    fontWeight: "600",
   },
   summaryTotalRow: {
     flexDirection: "row",

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -67,6 +67,9 @@ const tierToTicketStub = (tier: TripPricingTier): TicketStub => ({
   id: tier.ticketTypeId,
   name: tier.tierName,
   priceGbp: tier.priceCents > 0 ? tier.priceCents / 100 : null,
+  // ORCH-1147 — pass the server fee-grossed all-in through to the cart seed
+  // (which reads stub.priceAllInGbp). Null → seed falls back to priceGbp/base.
+  priceAllInGbp: tier.priceAllInGbp ?? null,
   currency: tier.currency,
   // ORCH-0946 — buyer-checkout sold-out gate + QuantityRow "+" cap need
   // remaining bookable seats, not total tier capacity. `quantityTotal`

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -244,6 +244,10 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
         ticketTypeId: sole.id,
         ticketName: sole.name,
         unitPrice: sole.priceGbp ?? 0,
+        // ORCH-1147 — seed the server fee-grossed all-in (priceAllInGbp) as the
+        // headline-Total basis; falls back to base until the trip source plumbs
+        // the per-tier all-in (never fabricate).
+        unitPriceAllIn: sole.priceAllInGbp ?? sole.priceGbp ?? 0,
         currency: sole.currency ?? trip.pricingTiers[0]?.currency ?? "USD",
         isFree: sole.isFree,
         quantity: 1,
@@ -448,6 +452,10 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
                     ticketTypeId: ticket.id,
                     ticketName: ticket.name,
                     unitPrice: ticket.priceGbp ?? 0,
+                    // ORCH-1147 — server fee-grossed all-in (priceAllInGbp) as
+                    // the headline-Total basis; base fallback (never fabricate).
+                    unitPriceAllIn:
+                      ticket.priceAllInGbp ?? ticket.priceGbp ?? 0,
                     currency:
                       ticket.currency ??
                       trip.pricingTiers[0]?.currency ??

--- a/mingla-business/app/checkout-trip/[tripEventId]/payment.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/payment.tsx
@@ -566,14 +566,28 @@ function CheckoutTripPaymentScreenContent({
     router,
   ]);
 
-  // ORCH-1130 Fix #2 — display the server-computed all-in (incl. tax) when the
-  // silent no-address preview has resolved (native); otherwise the base Total.
-  // Web shows the all-in on Stripe's hosted page. The all-in is shown in MINOR
-  // units (cents) when sourced from the preview, MAJOR units from totals.total.
-  const displayTotalCents = totals.total;
-  const displayAllIn = Platform.OS !== "web" && allInPreviewCents !== null
-    ? formatCurrency(allInPreviewCents, totals.currency, true)
-    : formatCurrency(displayTotalCents, totals.currency);
+  // ORCH-1147 — the headline Total is the server fee-grossed all-in
+  // (totals.allInTotal, from priceAllInGbp/pg_public_event_tier_allin), NOT the
+  // bare base subtotal. Web shows it synchronously; native upgrades to the
+  // tax-inclusive preview once it resolves (>= floor guard). The client owns
+  // ZERO fee/tax math. I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).
+  //
+  // OQ-2 exclusive-tax CAVEAT (documented, NOT fixed): priceAllInGbp folds FEES
+  // but EXCLUDES tax — in exclusive-tax regions (US pass_tax=true) the floor
+  // understates by tax. Today's blast radius is ZERO (all charges-enabled brands
+  // are inclusive-tax GB/EU/CH). Larger follow-on (ORCH-1147 OQ-2).
+  const baseTotalCents = Math.round(totals.subtotal * 100);
+  const allInFloorCents = Math.round(totals.allInTotal * 100);
+  const headlineCents =
+    Platform.OS !== "web" &&
+    allInPreviewCents !== null &&
+    allInPreviewCents >= allInFloorCents
+      ? allInPreviewCents
+      : allInFloorCents;
+  // ORCH-1147 — single combined "Fees & tax" line (never split service-fee + VAT).
+  const feesTaxLineCents = Math.max(0, headlineCents - baseTotalCents);
+  const showFeesTaxLine = feesTaxLineCents > 0;
+  const displayAllIn = formatCurrency(headlineCents, totals.currency, true);
 
   // Defensive shell while guards redirect.
   if (
@@ -694,6 +708,16 @@ function CheckoutTripPaymentScreenContent({
             </View>
           ))}
           <View style={styles.summaryDivider} />
+          {/* ORCH-1147 — single combined "Fees & tax" line (all-in − base);
+              rendered only on a real delta (absorb-all brands show nothing). */}
+          {showFeesTaxLine ? (
+            <View style={styles.summaryFeesTaxRow}>
+              <Text style={styles.summaryFeesTaxLabel}>Fees &amp; tax</Text>
+              <Text style={styles.summaryFeesTaxValue}>
+                {formatCurrency(feesTaxLineCents, totals.currency, true)}
+              </Text>
+            </View>
+          ) : null}
           <View style={styles.summaryTotalRow}>
             <Text style={styles.summaryTotalLabel}>Total</Text>
             <Text style={styles.summaryTotalValue}>
@@ -946,6 +970,23 @@ const styles = StyleSheet.create({
     marginVertical: spacing.sm,
     height: StyleSheet.hairlineWidth,
     backgroundColor: "rgba(255, 255, 255, 0.08)",
+  },
+  // ORCH-1147 — combined "Fees & tax" line.
+  summaryFeesTaxRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  summaryFeesTaxLabel: {
+    fontSize: 13,
+    color: textTokens.tertiary,
+    fontWeight: "500",
+  },
+  summaryFeesTaxValue: {
+    fontSize: 14,
+    color: textTokens.secondary,
+    fontWeight: "600",
   },
   summaryTotalRow: {
     flexDirection: "row",

--- a/mingla-business/app/checkout/[eventId]/index.tsx
+++ b/mingla-business/app/checkout/[eventId]/index.tsx
@@ -272,6 +272,12 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
                   ticketTypeId: ticket.id,
                   ticketName: ticket.name,
                   unitPrice: ticket.priceGbp ?? 0,
+                  // ORCH-1147 — seed the server fee-grossed all-in
+                  // (priceAllInGbp, from pg_public_event_tier_allin) as the
+                  // headline-Total basis; fall back to base when the tier has
+                  // no all-in (free / RPC miss — never fabricate).
+                  unitPriceAllIn:
+                    ticket.priceAllInGbp ?? ticket.priceGbp ?? 0,
                   currency: ticket.currency ?? event.currency ?? "GBP",
                   isFree: ticket.isFree,
                   quantity: next,

--- a/mingla-business/app/checkout/[eventId]/payment.tsx
+++ b/mingla-business/app/checkout/[eventId]/payment.tsx
@@ -551,14 +551,35 @@ function CheckoutPaymentScreenContent({
     router,
   ]);
 
-  // ORCH-1130 Fix #2 — display the server-computed all-in (incl. tax) when the
-  // silent no-address preview has resolved (native); otherwise the base Total.
-  // Web shows the all-in on Stripe's hosted page. The all-in is in MINOR units
-  // (cents) when sourced from the preview, MAJOR units from totals.total.
-  const displayTotalCents = totals.total;
-  const displayAllIn = Platform.OS !== "web" && allInPreviewCents !== null
-    ? formatCurrency(allInPreviewCents, totals.currency, true)
-    : formatCurrency(displayTotalCents, totals.currency);
+  // ORCH-1147 — the headline Total is sourced from the server fee-grossed
+  // all-in (totals.allInTotal, from priceAllInGbp/pg_public_event_tier_allin),
+  // NOT the bare base subtotal. Web shows it synchronously; native shows it
+  // synchronously and UPGRADES to the tax-inclusive preview once the silent
+  // no-address preview resolves (>= floor guard prevents a stale/lower preview
+  // from regressing the headline). The client owns ZERO fee/tax math — it sums
+  // the server per-tier all-in and subtracts the base.
+  // I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).
+  //
+  // OQ-2 exclusive-tax CAVEAT (documented, NOT fixed here): priceAllInGbp folds
+  // FEES but EXCLUDES tax, so in exclusive-tax regions (US pass_tax=true) the
+  // web/native floor understates by the tax. Today's blast radius is ZERO (all
+  // charges-enabled brands are inclusive-tax GB/EU/CH where all_in == buyer_total).
+  // Closing it requires routing display off the buyer-detail-gated preview — a
+  // larger follow-on (ORCH-1147 OQ-2).
+  const baseTotalCents = Math.round(totals.subtotal * 100);
+  const allInFloorCents = Math.round(totals.allInTotal * 100);
+  const headlineCents =
+    Platform.OS !== "web" &&
+    allInPreviewCents !== null &&
+    allInPreviewCents >= allInFloorCents
+      ? allInPreviewCents
+      : allInFloorCents;
+  // ORCH-1147 — single combined "Fees & tax" line (NEVER split service-fee +
+  // VAT, per feedback_cart_combined_fees_tax_line). On native with a tax-
+  // inclusive preview this correctly folds tax; on web/floor it is the fee delta.
+  const feesTaxLineCents = Math.max(0, headlineCents - baseTotalCents);
+  const showFeesTaxLine = feesTaxLineCents > 0;
+  const displayAllIn = formatCurrency(headlineCents, totals.currency, true);
 
   // Render an empty shell while defensive guards redirect.
   if (
@@ -621,6 +642,17 @@ function CheckoutPaymentScreenContent({
             </View>
           ))}
           <View style={styles.summaryDivider} />
+          {/* ORCH-1147 — single combined "Fees & tax" line (all-in − base);
+              rendered only when there's a real delta (absorb-all brands show
+              nothing, unchanged). NEVER split service-fee + VAT. */}
+          {showFeesTaxLine ? (
+            <View style={styles.summaryFeesTaxRow}>
+              <Text style={styles.summaryFeesTaxLabel}>Fees &amp; tax</Text>
+              <Text style={styles.summaryFeesTaxValue}>
+                {formatCurrency(feesTaxLineCents, totals.currency, true)}
+              </Text>
+            </View>
+          ) : null}
           <View style={styles.summaryTotalRow}>
             <Text style={styles.summaryTotalLabel}>Total</Text>
             <Text style={styles.summaryTotalValue}>
@@ -762,6 +794,23 @@ const styles = StyleSheet.create({
     marginVertical: spacing.sm,
     height: StyleSheet.hairlineWidth,
     backgroundColor: "rgba(255, 255, 255, 0.08)",
+  },
+  // ORCH-1147 — combined "Fees & tax" line in the order summary.
+  summaryFeesTaxRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  summaryFeesTaxLabel: {
+    fontSize: 13,
+    color: textTokens.tertiary,
+    fontWeight: "500",
+  },
+  summaryFeesTaxValue: {
+    fontSize: 14,
+    color: textTokens.secondary,
+    fontWeight: "600",
   },
   summaryTotalRow: {
     flexDirection: "row",

--- a/mingla-business/jest.config.cjs
+++ b/mingla-business/jest.config.cjs
@@ -21,7 +21,15 @@ module.exports = {
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   transform: {
-    "^.+\\.(ts|tsx)$": ["ts-jest", { tsconfig: { jsx: "react-native" } }],
+    // ORCH-1147 — `jsx: "react-jsx"` (was "react-native", which PRESERVES JSX
+    // and makes node/ts-jest choke on any runtime import of a JSX-bearing .tsx —
+    // e.g. importing `useCartTotals` from CartContext.tsx). The automatic JSX
+    // runtime transpiles `<X/>` to `_jsx(...)` so node-env unit tests can import
+    // hook logic from a .tsx module. Jest-only; the app build is Metro/babel and
+    // is unaffected. The existing carousel .tsx tests read source as TEXT
+    // (readFileSync), so they are unaffected; the RTL render tests run under
+    // their own dedicated configs (ignored here).
+    "^.+\\.(ts|tsx)$": ["ts-jest", { tsconfig: { jsx: "react-jsx" } }],
     // ORCH-1137 (rework) — the biz-web lucide shim deep-requires per-icon ESM
     // modules from `lucide-react/dist/esm/icons/<kebab>.js` (the tree-shakeable
     // import form that keeps the eager web `__common` chunk under the ORCH-1083

--- a/mingla-business/src/components/checkout/CartContext.tsx
+++ b/mingla-business/src/components/checkout/CartContext.tsx
@@ -40,6 +40,18 @@ export interface CartLine {
   unitPrice: number;
   /** Legacy compatibility only. New code writes `unitPrice`. */
   unitPriceGbp?: number;
+  /**
+   * ORCH-1147 — server fee-grossed ALL-IN per unit (major units in `currency`),
+   * seeded from the tier's server-computed `priceAllInGbp`
+   * (`pg_public_event_tier_allin`). This is the SINGLE display authority for the
+   * headline Total — the client performs ZERO fee/tax math beyond Σ(allIn×qty).
+   * Optional: a free tier, or a checkout path that has not plumbed the all-in
+   * yet, falls back to `unitPrice` (base) and contributes 0 to fees/tax — never
+   * undefined, never NaN. NEVER fabricate (Constitution #9): when the server has
+   * no all-in for a tier the seed uses the base, it does not invent a markup.
+   * I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).
+   */
+  unitPriceAllIn?: number;
   /** ISO 4217 event currency. */
   currency: string;
   isFree: boolean;
@@ -148,6 +160,8 @@ type CartAction =
     ticketName: string;
     unitPrice: number;
     unitPriceGbp?: number;
+    // ORCH-1147 — server fee-grossed all-in per unit (see CartLine.unitPriceAllIn).
+    unitPriceAllIn?: number;
     currency: string;
     isFree: boolean;
     quantity: number;
@@ -190,6 +204,7 @@ const reducer = (state: CartState, action: CartAction): CartState => {
         ticketName,
         unitPrice,
         unitPriceGbp,
+        unitPriceAllIn,
         currency,
         isFree,
         quantity,
@@ -223,16 +238,29 @@ const reducer = (state: CartState, action: CartAction): CartState => {
               quantity,
               unitPrice,
               unitPriceGbp: unitPriceGbp ?? unitPrice,
+              // ORCH-1147 — store the server fee-grossed all-in; fall back to the
+              // base when the path has not plumbed it (never undefined/NaN, never
+              // fabricated — see CartLine.unitPriceAllIn).
+              unitPriceAllIn: unitPriceAllIn ?? unitPrice,
               currency: normalizedCurrency,
               isFree,
             },
           ],
         };
       }
+      // ORCH-1147 — on a quantity update, re-write unitPriceAllIn too so a
+      // re-seed carrying a freshly-resolved all-in is not stranded on the
+      // existing line (the seed always passes the latest server figure).
       return {
         ...state,
         lines: state.lines.map((l) =>
-          l.ticketTypeId === ticketTypeId ? { ...l, quantity } : l
+          l.ticketTypeId === ticketTypeId
+            ? {
+              ...l,
+              quantity,
+              unitPriceAllIn: unitPriceAllIn ?? l.unitPriceAllIn ?? l.unitPrice,
+            }
+            : l
         ),
       };
     }
@@ -272,6 +300,8 @@ export interface CartContextValue extends CartState {
     ticketName: string;
     unitPrice: number;
     unitPriceGbp?: number;
+    // ORCH-1147 — server fee-grossed all-in per unit (see CartLine.unitPriceAllIn).
+    unitPriceAllIn?: number;
     currency: string;
     isFree: boolean;
     quantity: number;
@@ -310,6 +340,8 @@ export const CartProvider: React.FC<CartProviderProps> = ({ children }) => {
       ticketName: string;
       unitPrice: number;
       unitPriceGbp?: number;
+      // ORCH-1147 — server fee-grossed all-in per unit (see CartLine.unitPriceAllIn).
+      unitPriceAllIn?: number;
       currency: string;
       isFree: boolean;
       quantity: number;
@@ -391,8 +423,28 @@ export interface CartTotals {
   subtotalGbp: number;
   /** Legacy compatibility only. Same value as total. */
   totalGbp: number;
+  /**
+   * BASE ticket subtotal (Σ unitPrice×qty), major units. UNCHANGED MEANING
+   * (ORCH-1147 DO-NOT-REPURPOSE): `subtotal`/`total` remain the per-line
+   * "Tickets" recap basis; the headline Total is sourced from `allInTotal`.
+   */
   subtotal: number;
   total: number;
+  /**
+   * ORCH-1147 — server fee-grossed ALL-IN (Σ unitPriceAllIn×qty), major units.
+   * This is the headline Total floor (synchronous, web + native). The client
+   * never re-derives it — it sums the server per-tier all-in.
+   * I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).
+   */
+  allInTotal: number;
+  /**
+   * ORCH-1147 — the combined fees+tax delta (allInTotal − subtotal) in MINOR
+   * units, GREATEST(0,…). Rendered as the SINGLE combined "Fees & tax" line
+   * (feedback_cart_combined_fees_tax_line — never split service-fee + VAT).
+   */
+  feesTaxCents: number;
+  /** ORCH-1147 — true iff feesTaxCents > 0 (gates the "Fees & tax" line). */
+  hasFeesTaxDelta: boolean;
   currency: string;
   totalQuantity: number;
   isFree: boolean;
@@ -403,20 +455,31 @@ export const useCartTotals = (): CartTotals => {
   const { lines } = useCart();
   return useMemo<CartTotals>((): CartTotals => {
     let subtotal = 0;
+    // ORCH-1147 — accumulate the server fee-grossed all-in alongside the base.
+    // Each line falls back to its base when no all-in was plumbed (never NaN,
+    // never fabricated). All math in major units; convert the delta to cents
+    // once at the end (mirrors the consumer reference TicketCartSheet.tsx).
+    let allInTotal = 0;
     let totalQuantity = 0;
     let currency = "";
     for (const line of lines) {
       subtotal += line.unitPrice * line.quantity;
+      allInTotal += (line.unitPriceAllIn ?? line.unitPrice) * line.quantity;
       totalQuantity += line.quantity;
       currency = line.currency;
     }
     const isEmpty = totalQuantity === 0;
     const isFree = !isEmpty && subtotal === 0;
+    // ORCH-1147 — combined fees+tax delta in MINOR units, GREATEST(0,…).
+    const feesTaxCents = Math.max(0, Math.round((allInTotal - subtotal) * 100));
     return {
       subtotalGbp: subtotal,
       totalGbp: subtotal,
       subtotal,
       total: subtotal,
+      allInTotal,
+      feesTaxCents,
+      hasFeesTaxDelta: feesTaxCents > 0,
       currency,
       totalQuantity,
       isFree,

--- a/mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts
+++ b/mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts
@@ -169,3 +169,160 @@ describe("ORCH-1147 — payment headline source (T-2 / T-3)", () => {
     expect(headlineCents).toBe(5225); // >= floor guard holds
   });
 });
+
+// --- T-7a/b/c: TRIP + EXPERIENCE source → stub → seed → cart Total ---------
+// (SPEC AMENDMENT E1.) The cart Total must read the server fee-grossed all-in
+// for TRIP and EXPERIENCE exactly as it does for EVENT. Two parts per type:
+//
+//   (1) MAPPING MATH — replicate the real mappers' pure pass-through:
+//         source.priceAllInGbp -> stub.priceAllInGbp -> seed.unitPriceAllIn
+//       then feed useCartTotals and assert allInTotal == Σ all-in × qty and
+//       feesTaxCents > 0 (Total > base).
+//   (2) SOURCE-TEXT FAILS-ON-REVERT — read the ACTUAL source files and assert
+//       the six fix lines exist (the field on each interface, the populate in
+//       getPublicTripById / mapExperience, the pass-through in each stub mapper).
+//       True line-deletion of ANY of them flips the relevant T-7 assertion RED.
+//
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..", "..", "..");
+const read = (rel: string): string =>
+  readFileSync(join(repoRoot, rel), "utf8");
+
+// The real mappers' pass-through is `priceAllInGbp: source.priceAllInGbp ?? null`,
+// and the seeds read `(stub.priceAllInGbp ?? stub.priceGbp ?? 0)` as
+// unitPriceAllIn. Replicate that EXACT shape (no network, no RN render).
+const stubFrom = (src: {
+  priceGbp: number | null;
+  priceAllInGbp?: number | null;
+}): { priceGbp: number | null; priceAllInGbp: number | null } => ({
+  priceGbp: src.priceGbp,
+  priceAllInGbp: src.priceAllInGbp ?? null,
+});
+const seedUnitAllIn = (stub: {
+  priceGbp: number | null;
+  priceAllInGbp: number | null;
+}): number => stub.priceAllInGbp ?? stub.priceGbp ?? 0;
+
+describe("ORCH-1147 AMENDMENT — TRIP source → cart Total (T-7a)", () => {
+  const tripService = read("mingla-business/src/services/tripsService.ts");
+  const publicEvents = read(
+    "mingla-business/src/services/publicEventsService.ts",
+  );
+  const tripStubMapper = read(
+    "mingla-business/app/checkout-trip/[tripEventId]/index.tsx",
+  );
+
+  test("T-7a: a pass-fee trip tier grosses the cart all-in (Total > base)", () => {
+    // TripPricingTier all-in £52.25 > base £50, qty 2.
+    const stub = stubFrom({ priceGbp: 50, priceAllInGbp: 52.25 });
+    const totals = totalsFor([
+      line({
+        unitPrice: stub.priceGbp ?? 0,
+        unitPriceAllIn: seedUnitAllIn(stub),
+        quantity: 2,
+        currency: "GBP",
+      }),
+    ]);
+    expect(totals.subtotal).toBe(100); // base
+    expect(totals.allInTotal).toBeCloseTo(104.5, 5); // fee-grossed all-in
+    expect(totals.feesTaxCents).toBe(450);
+    expect(totals.hasFeesTaxDelta).toBe(true);
+    expect(totals.allInTotal).not.toBe(totals.subtotal);
+  });
+
+  // FAILS-ON-REVERT: each of these is a real fix line. Deleting it → RED.
+  test("T-7a source: TripPricingTier carries priceAllInGbp (field exists)", () => {
+    expect(tripService).toMatch(/priceAllInGbp\?:\s*number\s*\|\s*null/);
+  });
+  test("T-7a source: getPublicTripById populates priceAllInGbp from the single owner", () => {
+    expect(publicEvents).toMatch(/export const fetchTierAllInCents\b/);
+    expect(publicEvents).toMatch(/fetchTierAllInCents\(tripEventId\)/);
+    expect(publicEvents).toMatch(
+      /priceAllInGbp:\s*\(\(\)\s*=>\s*\{[\s\S]*?allInById\.get\(t\.ticket_type_id\)/,
+    );
+  });
+  test("T-7a source: tierToTicketStub passes priceAllInGbp through", () => {
+    expect(tripStubMapper).toMatch(
+      /priceAllInGbp:\s*tier\.priceAllInGbp\s*\?\?\s*null/,
+    );
+  });
+});
+
+describe("ORCH-1147 AMENDMENT — EXPERIENCE source → cart Total (T-7b)", () => {
+  const expService = read(
+    "mingla-business/src/services/publicExperienceService.ts",
+  );
+  const expStubMapper = read(
+    "mingla-business/app/checkout-experience/[experienceEventId]/index.tsx",
+  );
+
+  test("T-7b: a pass-fee experience ticket grosses the cart all-in (Total > base)", () => {
+    // PublicExperienceTicket all-in £33 > base £30, qty 1.
+    const stub = stubFrom({ priceGbp: 30, priceAllInGbp: 33 });
+    const totals = totalsFor([
+      line({
+        unitPrice: stub.priceGbp ?? 0,
+        unitPriceAllIn: seedUnitAllIn(stub),
+        quantity: 1,
+        currency: "GBP",
+      }),
+    ]);
+    expect(totals.subtotal).toBe(30);
+    expect(totals.allInTotal).toBeCloseTo(33, 5);
+    expect(totals.feesTaxCents).toBe(300);
+    expect(totals.hasFeesTaxDelta).toBe(true);
+    expect(totals.allInTotal).not.toBe(totals.subtotal);
+  });
+
+  // FAILS-ON-REVERT (experience side).
+  test("T-7b source: PublicExperienceTicket carries priceAllInGbp + reuses the single owner", () => {
+    expect(expService).toMatch(/priceAllInGbp\?:\s*number\s*\|\s*null/);
+    expect(expService).toMatch(
+      /import\s*\{\s*fetchTierAllInCents\s*\}\s*from\s*"\.\/publicEventsService"/,
+    );
+    expect(expService).toMatch(/fetchTierAllInCents\(eventId\)/);
+    // mapExperience sets priceAllInGbp from the threaded all-in map.
+    expect(expService).toMatch(/priceAllInGbp:[\s\S]*?allInCents\s*\/\s*100/);
+  });
+  test("T-7b source: ticketToStub passes priceAllInGbp through", () => {
+    expect(expStubMapper).toMatch(
+      /priceAllInGbp:\s*ticket\.priceAllInGbp\s*\?\?\s*null/,
+    );
+  });
+});
+
+describe("ORCH-1147 AMENDMENT — fallback, both types (T-7c)", () => {
+  test("T-7c: absent/null source all-in → seed falls back to base, zero delta (no fabrication)", () => {
+    // Trip-shaped source with NO all-in.
+    const tripStub = stubFrom({ priceGbp: 50, priceAllInGbp: undefined });
+    expect(tripStub.priceAllInGbp).toBeNull();
+    const tripTotals = totalsFor([
+      line({
+        unitPrice: tripStub.priceGbp ?? 0,
+        unitPriceAllIn: seedUnitAllIn(tripStub),
+        quantity: 1,
+        currency: "GBP",
+      }),
+    ]);
+    expect(tripTotals.allInTotal).toBe(50);
+    expect(tripTotals.feesTaxCents).toBe(0);
+    expect(tripTotals.hasFeesTaxDelta).toBe(false);
+
+    // Experience-shaped source with explicit null all-in (free / RPC miss).
+    const expStub = stubFrom({ priceGbp: 30, priceAllInGbp: null });
+    expect(expStub.priceAllInGbp).toBeNull();
+    const expTotals = totalsFor([
+      line({
+        unitPrice: expStub.priceGbp ?? 0,
+        unitPriceAllIn: seedUnitAllIn(expStub),
+        quantity: 1,
+        currency: "GBP",
+      }),
+    ]);
+    expect(expTotals.allInTotal).toBe(30);
+    expect(expTotals.feesTaxCents).toBe(0);
+    expect(expTotals.hasFeesTaxDelta).toBe(false);
+  });
+});

--- a/mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts
+++ b/mingla-business/src/components/checkout/__tests__/orch_1147_cart_allin_total.test.ts
@@ -1,0 +1,171 @@
+// ORCH-1147 [cart does not reflect the TRUE price of a trip/event/experience]
+// — implementor happy-path regression test (Step 0.5).
+//
+// Covers SPEC §7 T-1 (useCartTotals all-in math) + T-2 (the event payment
+// headline binds to the server fee-grossed all-in, NOT the bare base subtotal),
+// plus T-4 (absorb-all → no fees/tax delta) and T-5 (free tier).
+//
+// Runs under the default node/ts-jest config (no RTL). `useCartTotals` is a thin
+// `useMemo` over `useContext(CartCtx)`; we make React's `useMemo` eager and feed
+// `useContext` a stub cart, so the hook's PURE reduce math is exercised
+// deterministically without a device or a React renderer.
+//
+// FAILS-ON-REVERT (proven by line-deletion, not comment-out): if `useCartTotals`
+// reverts to a base-only total (drops `allInTotal`/`feesTaxCents`), T-1/T-4
+// fail; if the payment headline rebinds to the base subtotal, T-2 fails.
+// I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN (DRAFT).
+
+import { describe, expect, jest, test } from "@jest/globals";
+
+import type { CartLine } from "../CartContext";
+
+// --- Make React hooks eager + inject a stub cart -------------------------
+// `useMemo(factory)` -> factory(); `useContext(ctx)` -> the injected cart value.
+let stubLines: CartLine[] = [];
+jest.mock("react", () => {
+  const actual = jest.requireActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown): unknown => factory(),
+    useContext: (): unknown => ({ lines: stubLines }),
+  };
+});
+
+// Imported AFTER the mock so the hook picks up the eager React shims.
+// eslint-disable-next-line import/first
+import { useCartTotals } from "../CartContext";
+
+const line = (over: Partial<CartLine>): CartLine => ({
+  ticketTypeId: over.ticketTypeId ?? "tt_1",
+  ticketName: over.ticketName ?? "General",
+  quantity: over.quantity ?? 1,
+  unitPrice: over.unitPrice ?? 0,
+  unitPriceGbp: over.unitPriceGbp,
+  unitPriceAllIn: over.unitPriceAllIn,
+  currency: over.currency ?? "GBP",
+  isFree: over.isFree ?? false,
+});
+
+const totalsFor = (lines: CartLine[]): ReturnType<typeof useCartTotals> => {
+  stubLines = lines;
+  return useCartTotals();
+};
+
+describe("ORCH-1147 — useCartTotals reflects the server fee-grossed all-in", () => {
+  test("T-1: a pass-fee line yields allInTotal ≠ subtotal + a fees/tax delta", () => {
+    // base £50, server all-in £52.25 (Mingla + service fee passed), qty 1.
+    const totals = totalsFor([
+      line({ unitPrice: 50, unitPriceAllIn: 52.25, quantity: 1, currency: "GBP" }),
+    ]);
+    // Base subtotal is UNCHANGED (do-not-repurpose contract).
+    expect(totals.subtotal).toBe(50);
+    expect(totals.total).toBe(50);
+    // The headline floor is the server all-in.
+    expect(totals.allInTotal).toBeCloseTo(52.25, 5);
+    // Combined "Fees & tax" delta in MINOR units.
+    expect(totals.feesTaxCents).toBe(225);
+    expect(totals.hasFeesTaxDelta).toBe(true);
+    // The all-in must NOT equal the base when a fee is passed — the exact
+    // divergence ORCH-1147 fixes. Fails if allInTotal reverts to subtotal.
+    expect(totals.allInTotal).not.toBe(totals.subtotal);
+  });
+
+  test("T-1b: multi-qty grosses the all-in per unit", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 20, unitPriceAllIn: 21.5, quantity: 3, currency: "GBP" }),
+    ]);
+    expect(totals.subtotal).toBe(60);
+    expect(totals.allInTotal).toBeCloseTo(64.5, 5);
+    expect(totals.feesTaxCents).toBe(450);
+    expect(totals.hasFeesTaxDelta).toBe(true);
+  });
+
+  test("T-4: absorb-all brand (allIn === base) shows zero delta, no line", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 40, unitPriceAllIn: 40, quantity: 2, currency: "GBP" }),
+    ]);
+    expect(totals.subtotal).toBe(80);
+    expect(totals.allInTotal).toBe(80);
+    expect(totals.feesTaxCents).toBe(0);
+    expect(totals.hasFeesTaxDelta).toBe(false);
+  });
+
+  test("missing all-in falls back to base (never NaN, never fabricated)", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 30, unitPriceAllIn: undefined, quantity: 1, currency: "GBP" }),
+    ]);
+    expect(totals.allInTotal).toBe(30);
+    expect(totals.feesTaxCents).toBe(0);
+    expect(Number.isNaN(totals.allInTotal)).toBe(false);
+  });
+
+  test("T-5: free tier → empty/zero totals, no fees line", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 0, unitPriceAllIn: 0, quantity: 1, isFree: true, currency: "GBP" }),
+    ]);
+    expect(totals.subtotal).toBe(0);
+    expect(totals.allInTotal).toBe(0);
+    expect(totals.feesTaxCents).toBe(0);
+    expect(totals.hasFeesTaxDelta).toBe(false);
+    expect(totals.isFree).toBe(true);
+  });
+
+  test("empty cart → all zero", () => {
+    const totals = totalsFor([]);
+    expect(totals.subtotal).toBe(0);
+    expect(totals.allInTotal).toBe(0);
+    expect(totals.feesTaxCents).toBe(0);
+    expect(totals.isEmpty).toBe(true);
+  });
+});
+
+// --- T-2: the payment headline binds to the all-in, not the base ----------
+// The payment screens compute the headline as:
+//   floor = round(totals.allInTotal * 100); base = round(totals.subtotal * 100);
+//   headline (web / no preview) = floor;
+//   headline (native, preview >= floor) = preview;
+//   feesTaxLine = max(0, headline - base).
+// This replicates that EXACT rule so a regression that rebinds the headline to
+// the base subtotal (`totals.total`) is caught here.
+describe("ORCH-1147 — payment headline source (T-2 / T-3)", () => {
+  const headline = (
+    subtotal: number,
+    allInTotal: number,
+    previewCents: number | null,
+    isWeb: boolean,
+  ): { headlineCents: number; feesTaxLineCents: number } => {
+    const baseTotalCents = Math.round(subtotal * 100);
+    const allInFloorCents = Math.round(allInTotal * 100);
+    const headlineCents =
+      !isWeb && previewCents !== null && previewCents >= allInFloorCents
+        ? previewCents
+        : allInFloorCents;
+    return {
+      headlineCents,
+      feesTaxLineCents: Math.max(0, headlineCents - baseTotalCents),
+    };
+  };
+
+  test("T-2: web shows the fee-grossed all-in floor (5225), NOT the base (5000)", () => {
+    const { headlineCents, feesTaxLineCents } = headline(50, 52.25, null, true);
+    expect(headlineCents).toBe(5225);
+    expect(feesTaxLineCents).toBe(225);
+  });
+
+  test("T-2: native with no preview shows the floor, never the bare base", () => {
+    const { headlineCents } = headline(50, 52.25, null, false);
+    expect(headlineCents).toBe(5225);
+    expect(headlineCents).not.toBe(5000);
+  });
+
+  test("native upgrades to the tax-inclusive preview when it exceeds the floor", () => {
+    const { headlineCents, feesTaxLineCents } = headline(50, 52.25, 5500, false);
+    expect(headlineCents).toBe(5500); // base 50 + fees + tax
+    expect(feesTaxLineCents).toBe(500);
+  });
+
+  test("T-3: a stale/lower preview NEVER regresses the headline below the floor", () => {
+    const { headlineCents } = headline(50, 52.25, 5000, false);
+    expect(headlineCents).toBe(5225); // >= floor guard holds
+  });
+});

--- a/mingla-business/src/components/checkout/__tests__/orch_1147_cart_charge_parity.tester-adversarial.test.ts
+++ b/mingla-business/src/components/checkout/__tests__/orch_1147_cart_charge_parity.tester-adversarial.test.ts
@@ -1,0 +1,219 @@
+// ORCH-1147 [cart does not reflect the TRUE price] — TESTER adversarial test.
+//
+// DIFFERENT ANGLE than the implementor's happy-path (orch_1147_cart_allin_total
+// .test.ts), which unit-tests the DISPLAY math + the source-stub mapping. This
+// test attacks the ECONOMIC under-bill (D-1 / SC-6-Web) and the rounding floor:
+// it proves the CART display all-in (what the buyer is QUOTED, via useCartTotals)
+// EQUALS the WEB CHARGE basis (what Stripe actually bills, via the REAL shared
+// engine `computeBuyerSubtotal.buyerSubtotalCents`) for the SAME pass-fee inputs.
+// If display and charge ever diverge — the exact bug ORCH-1147 fixes — this fails.
+//
+// It imports the genuine server money engine (supabase/functions/_shared/
+// allInPricingEngine.ts — pure TS, no Deno deps) so the quoted Total is checked
+// against the SAME fee formula `pg_public_event_tier_allin` →
+// `compute_all_in_cents` use server-side (base + round(base*take/10000) +
+// round(base*service/10000)). No mock of the fee math.
+//
+// Angles (none overlap the implementor's tests):
+//   A. display == web-charge basis (pass-fee), incl. a ROUNDING boundary base
+//      where per-unit fee rounding matters (5037c base, 150bps take, 300bps svc).
+//   B. quantity>1: the cart grosses PER UNIT then sums — proving it does NOT
+//      compute base*qty then gross once (a classic rounding off-by-cents bug).
+//   C. absorb -> pass FLIP: same line, the toggle is the ONLY driver of the delta
+//      (absorb => feesTax 0; pass => feesTax == engine fee gross-up).
+//   D. web charge must be the PRE-TAX subtotal, NOT the tax-inclusive total
+//      (billing buyer_total_cents would double-tax under automatic_tax).
+//
+// FAILS-ON-REVERT: if useCartTotals reverts to a base-only total, A/B/C fail
+// (allInTotal collapses to subtotal while the engine still grosses up).
+// I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN / I-PROPOSED-1147-WEB-CHARGE-BILLS-
+// FEE-GROSSED-SUBTOTAL (DRAFT).
+
+import { describe, expect, jest, test } from "@jest/globals";
+
+import type { CartLine } from "../CartContext";
+
+// The REAL server money engine (pure TS). buyerSubtotalCents = the exact basis
+// the web Checkout Session line item bills at ticket-checkout-create:1096.
+import {
+  computeBuyerSubtotal,
+  feeFromBps,
+  MINGLA_SERVICE_FEE_BPS,
+} from "../../../../../supabase/functions/_shared/allInPricingEngine";
+
+// --- Same eager-hook harness as the implementor test (independent copy) ----
+let stubLines: CartLine[] = [];
+jest.mock("react", () => {
+  const actual = jest.requireActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown): unknown => factory(),
+    useContext: (): unknown => ({ lines: stubLines }),
+  };
+});
+// eslint-disable-next-line import/first
+import { useCartTotals } from "../CartContext";
+
+const line = (over: Partial<CartLine>): CartLine => ({
+  ticketTypeId: over.ticketTypeId ?? "tt_1",
+  ticketName: over.ticketName ?? "General",
+  quantity: over.quantity ?? 1,
+  unitPrice: over.unitPrice ?? 0,
+  unitPriceGbp: over.unitPriceGbp,
+  unitPriceAllIn: over.unitPriceAllIn,
+  currency: over.currency ?? "USD",
+  isFree: over.isFree ?? false,
+});
+const totalsFor = (lines: CartLine[]): ReturnType<typeof useCartTotals> => {
+  stubLines = lines;
+  return useCartTotals();
+};
+
+// The SAME fee formula pg_public_event_tier_allin / compute_all_in_cents apply
+// server-side: base + (pass_mingla? round(base*take/10000):0)
+//                   + (pass_service? round(base*svc/10000):0). MAJOR units /100.
+const serverAllInMajor = (
+  baseCents: number,
+  takeBps: number,
+  passMingla: boolean,
+  passService: boolean,
+): number => {
+  const { buyerSubtotalCents } = computeBuyerSubtotal({
+    baseCents,
+    switches: { pass_tax: false, pass_mingla_fee: passMingla, pass_service_fee: passService },
+    region: "US",
+    currency: "USD",
+    effectiveTakeRateBps: takeBps,
+    takeRateSource: "platform_default",
+  });
+  return buyerSubtotalCents / 100;
+};
+
+describe("ORCH-1147 ADVERSARIAL — cart Total quoted == web charge billed", () => {
+  // A. The exact divergence ORCH-1147 fixes: the buyer is quoted what Stripe
+  //    bills. Uses the live prod fixture numbers (event $50, take 150, svc 300).
+  test("A: pass-fee event — display all-in == web-charge buyerSubtotal (no under-bill)", () => {
+    const baseCents = 5000; // $50.00 — the live "The party block" tier.
+    const takeBps = 150; // brand effective take-rate.
+    const allInMajor = serverAllInMajor(baseCents, takeBps, true, true); // 52.25
+    const totals = totalsFor([
+      line({ unitPrice: baseCents / 100, unitPriceAllIn: allInMajor, quantity: 1 }),
+    ]);
+
+    // The quoted Total (cart) and the charge basis (engine) agree to the cent.
+    const quotedChargeCents = Math.round(totals.allInTotal * 100);
+    const billedChargeCents = computeBuyerSubtotal({
+      baseCents,
+      switches: { pass_tax: false, pass_mingla_fee: true, pass_service_fee: true },
+      region: "US",
+      currency: "USD",
+      effectiveTakeRateBps: takeBps,
+      takeRateSource: "platform_default",
+    }).buyerSubtotalCents;
+
+    expect(quotedChargeCents).toBe(5225); // 5000 + 75 + 150 (matches live RPC)
+    expect(quotedChargeCents).toBe(billedChargeCents); // display == charge
+    expect(totals.feesTaxCents).toBe(225);
+    // And it is STRICTLY above the bare base — the under-quote bug is gone.
+    expect(quotedChargeCents).toBeGreaterThan(baseCents);
+  });
+
+  // A-rounding. A base where the per-unit fee rounds (5037 * 150 / 10000 = 75.555
+  // -> 76; * 300 / 10000 = 151.11 -> 151). The cart must match the engine's
+  // round()-per-component, not a truncation or a recompute on the major total.
+  test("A-rounding: a fee-rounding base still has display == charge to the cent", () => {
+    const baseCents = 5037;
+    const takeBps = 150;
+    const expectMingla = feeFromBps(baseCents, takeBps); // round(75.555)=76
+    const expectService = feeFromBps(baseCents, MINGLA_SERVICE_FEE_BPS); // round(151.11)=151
+    const expectAllInCents = baseCents + expectMingla + expectService; // 5264
+    const allInMajor = serverAllInMajor(baseCents, takeBps, true, true);
+
+    const totals = totalsFor([
+      line({ unitPrice: baseCents / 100, unitPriceAllIn: allInMajor, quantity: 1 }),
+    ]);
+    expect(Math.round(totals.allInTotal * 100)).toBe(expectAllInCents);
+    expect(totals.feesTaxCents).toBe(expectMingla + expectService);
+    expect(expectAllInCents).toBe(5264); // pins the arithmetic
+  });
+
+  // B. quantity>1: gross PER UNIT then sum. With a per-unit fee that rounds,
+  //    qty*round(perUnit) can differ from gross(base*qty). The cart MUST do the
+  //    former (per-line unit all-in * qty), matching how the buyer is charged
+  //    one line item per seat at the per-unit grossed price.
+  test("B: qty>1 grosses per-unit then sums (not base*qty grossed once)", () => {
+    const baseCents = 333; // $3.33 — per-unit fee rounds.
+    const takeBps = 150;
+    const perUnitAllIn = baseCents + feeFromBps(baseCents, takeBps) + feeFromBps(baseCents, MINGLA_SERVICE_FEE_BPS);
+    // round(333*150/10000)=round(4.995)=5 ; round(333*300/10000)=round(9.99)=10 -> 348
+    expect(perUnitAllIn).toBe(348);
+    const qty = 7;
+    const totals = totalsFor([
+      line({ unitPrice: baseCents / 100, unitPriceAllIn: perUnitAllIn / 100, quantity: qty }),
+    ]);
+    // Per-unit grossed * qty (what the cart does) = 348 * 7 = 2436.
+    expect(Math.round(totals.allInTotal * 100)).toBe(perUnitAllIn * qty);
+    expect(Math.round(totals.allInTotal * 100)).toBe(2436);
+    // Base subtotal stays the bare base * qty (do-not-repurpose).
+    expect(Math.round(totals.subtotal * 100)).toBe(baseCents * qty);
+    expect(totals.feesTaxCents).toBe(2436 - baseCents * qty);
+  });
+
+  // C. absorb -> pass FLIP: the toggle is the ONLY driver. Same base line; under
+  //    absorb the cart Total == base (no fees line); flip to pass and the Total
+  //    rises by EXACTLY the engine fee gross-up. Proves no fabrication on absorb.
+  test("C: absorb -> pass flip moves the delta by exactly the engine fee", () => {
+    const baseCents = 7000; // the live experience tier ($70 / £70).
+    const takeBps = 150;
+
+    // Absorb arm: seed all-in == base (RPC returns all_in == base on absorb).
+    const absorb = totalsFor([
+      line({ unitPrice: baseCents / 100, unitPriceAllIn: baseCents / 100, quantity: 1 }),
+    ]);
+    expect(absorb.feesTaxCents).toBe(0);
+    expect(absorb.hasFeesTaxDelta).toBe(false);
+    expect(Math.round(absorb.allInTotal * 100)).toBe(baseCents); // Total == base
+
+    // Pass arm: seed all-in == engine gross-up.
+    const passAllIn = serverAllInMajor(baseCents, takeBps, true, true);
+    const pass = totalsFor([
+      line({ unitPrice: baseCents / 100, unitPriceAllIn: passAllIn, quantity: 1 }),
+    ]);
+    const engineFee = feeFromBps(baseCents, takeBps) + feeFromBps(baseCents, MINGLA_SERVICE_FEE_BPS); // 105+210=315
+    expect(pass.feesTaxCents).toBe(engineFee);
+    expect(pass.feesTaxCents).toBe(315);
+    expect(pass.hasFeesTaxDelta).toBe(true);
+    // The flip moved the headline by exactly the fee, nothing else.
+    expect(Math.round(pass.allInTotal * 100) - Math.round(absorb.allInTotal * 100)).toBe(engineFee);
+  });
+
+  // D. The web charge basis is the PRE-TAX subtotal (buyerSubtotalCents), which
+  //    must be < the tax-inclusive total would be. Guards against a future edit
+  //    re-pointing the web line item at buyer_total_cents (double-tax under
+  //    automatic_tax). buyerSubtotalCents NEVER contains tax — assert it equals
+  //    base+fees only, independent of any pass_tax switch.
+  test("D: web charge basis is pre-tax (pass_tax does not change buyerSubtotal)", () => {
+    const baseCents = 5000;
+    const takeBps = 150;
+    const taxOff = computeBuyerSubtotal({
+      baseCents,
+      switches: { pass_tax: false, pass_mingla_fee: true, pass_service_fee: true },
+      region: "US",
+      currency: "USD",
+      effectiveTakeRateBps: takeBps,
+      takeRateSource: "platform_default",
+    }).buyerSubtotalCents;
+    const taxOn = computeBuyerSubtotal({
+      baseCents,
+      switches: { pass_tax: true, pass_mingla_fee: true, pass_service_fee: true },
+      region: "US",
+      currency: "USD",
+      effectiveTakeRateBps: takeBps,
+      takeRateSource: "platform_default",
+    }).buyerSubtotalCents;
+    // The web line item bills this number; it is fee-only, tax-excluded — Stripe
+    // automatic_tax adds tax on top, so it must be invariant to pass_tax.
+    expect(taxOff).toBe(taxOn);
+    expect(taxOff).toBe(5225); // base + fees, no tax folded in
+  });
+});

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -837,7 +837,9 @@ const fetchTicketTypesRemaining = async (
 // compute_all_in_cents the cart + view use (pg_public_event_tier_allin RPC),
 // ZERO fee math in TS. RPC failure is non-fatal → every tier falls back to its
 // base price (never blank). Mirrors app-mobile's publicEventTicketsService.
-const fetchTierAllInCents = async (
+// ORCH-1147 — EXPORTED so the experience service reuses the SAME single owner
+// of pg_public_event_tier_allin (no duplicated RPC / fee math anywhere else).
+export const fetchTierAllInCents = async (
   eventId: string,
 ): Promise<Map<string, number>> => {
   const map = new Map<string, number>();
@@ -1323,7 +1325,12 @@ export const getPublicTripById = async (
   const tickets = (ticketsResp.data ?? []) as any[];
 
   // ORCH-0946 — remaining-capacity per ticket_type for the sold-out gate.
-  const remainingById = await fetchTicketTypesRemaining(tripEventId);
+  // ORCH-1147 — per-tier server all-in (the SAME single owner as the event
+  // path); RPC failure → empty map → base fallback downstream (never blank).
+  const [remainingById, allInById] = await Promise.all([
+    fetchTicketTypesRemaining(tripEventId),
+    fetchTierAllInCents(tripEventId),
+  ]);
 
   const ticketsById = new Map(tickets.map((tt) => [tt.id, tt]));
   const bt =
@@ -1422,6 +1429,13 @@ export const getPublicTripById = async (
         ticketsRemaining,
         isUnlimited,
         installmentSchedule,
+        // ORCH-1147 — server fee-grossed per-tier all-in (MAJOR units). Free
+        // tier / RPC miss → null; the cart seed owns the single base fallback
+        // (mirrors the event path). NEVER recompute fees in TS.
+        priceAllInGbp: (() => {
+          const cents = allInById.get(t.ticket_type_id);
+          return typeof cents === "number" ? cents / 100 : null;
+        })(),
       };
     }),
     inclusions: inclusions.map(

--- a/mingla-business/src/services/publicExperienceService.ts
+++ b/mingla-business/src/services/publicExperienceService.ts
@@ -25,6 +25,9 @@
 
 import { supabase } from "./supabase";
 import type { RecurrenceRule } from "../store/draftEventStore";
+// ORCH-1147 — reuse the SINGLE owner of pg_public_event_tier_allin (no
+// duplicated RPC / fee math here). The trip + event paths use the same helper.
+import { fetchTierAllInCents } from "./publicEventsService";
 
 export type PublicExperienceWhenMode = "single" | "recurring" | "multi_date";
 
@@ -48,6 +51,12 @@ export interface PublicExperienceTicket {
   isFree: boolean;
   /** Remaining bookable seats (null = unlimited / unknown). */
   ticketsRemaining: number | null;
+  /**
+   * ORCH-1147 — server fee-grossed all-in in MAJOR units
+   * (`pg_public_event_tier_allin` → /100). Null = free / RPC miss; cart seed
+   * falls back to `priceCents`/base. NEVER recompute fees in TS.
+   */
+  priceAllInGbp?: number | null;
 }
 
 export interface PublicExperienceDate {
@@ -143,6 +152,8 @@ interface MapInput {
   dates: any[];
   /** ORCH-1076 — resolved buyer-readiness; defaults to true (back-compat). */
   bookable?: boolean;
+  /** ORCH-1147 — ticket_types.id → server all-in cents (single-owner fetch). */
+  allInById?: Map<string, number>;
 }
 
 /**
@@ -191,6 +202,9 @@ function mapExperience(input: MapInput): PublicExperience {
       : (stops[0]?.address ?? null);
 
   const tt = tickets[0];
+  // ORCH-1147 — server fee-grossed all-in (MAJOR units) from the single-owner
+  // fetch; free tier / RPC miss → null; the cart seed owns the base fallback.
+  const allInCents = tt !== undefined ? input.allInById?.get(tt.id) : undefined;
   const ticket: PublicExperienceTicket | null =
     tt !== undefined
       ? {
@@ -204,6 +218,12 @@ function mapExperience(input: MapInput): PublicExperience {
           // Sub-C preview does not gate sold-out per-occurrence; the checkout
           // chain (usePublicExperienceById) computes remaining. Set null here.
           ticketsRemaining: null,
+          priceAllInGbp:
+            tt.is_free === true || (tt.price_cents ?? 0) === 0
+              ? null
+              : typeof allInCents === "number"
+                ? allInCents / 100
+                : null,
         }
       : null;
 
@@ -258,8 +278,13 @@ async function loadExperienceSidecars(eventId: string): Promise<{
   tickets: any[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dates: any[];
+  /** ORCH-1147 — ticket_types.id → server all-in cents (single-owner fetch). */
+  allInById: Map<string, number>;
 }> {
-  const [stopsResp, ticketsResp, datesResp] = await Promise.all([
+  // ORCH-1147 — fold the per-tier all-in fetch into the existing parallel load.
+  // fetchTierAllInCents never throws (RPC failure → empty map → base fallback
+  // downstream); keep the throw-on-RLS guards on the three Supabase reads.
+  const [stopsResp, ticketsResp, datesResp, allInById] = await Promise.all([
     supabase
       .from("experience_stops")
       .select("id, stop_order, place_name, address, image_urls, start_time")
@@ -278,6 +303,7 @@ async function loadExperienceSidecars(eventId: string): Promise<{
       .select("id, start_at, end_at, timezone, is_master")
       .eq("event_id", eventId)
       .order("start_at", { ascending: true }),
+    fetchTierAllInCents(eventId),
   ]);
   if (stopsResp.error) throw stopsResp.error;
   if (ticketsResp.error) throw ticketsResp.error;
@@ -286,6 +312,7 @@ async function loadExperienceSidecars(eventId: string): Promise<{
     stops: stopsResp.data ?? [],
     tickets: ticketsResp.data ?? [],
     dates: datesResp.data ?? [],
+    allInById,
   };
 }
 

--- a/mingla-business/src/services/tripsService.ts
+++ b/mingla-business/src/services/tripsService.ts
@@ -95,6 +95,14 @@ export interface TripPricingTier {
    * plan configured.
    */
   installmentSchedule: TripInstallmentScheduleData | null;
+  /**
+   * ORCH-1147 — server fee-grossed per-tier all-in in MAJOR units
+   * (`pg_public_event_tier_allin` → /100). Null = free tier or RPC miss;
+   * the cart seed falls back to `priceCents`/base. NEVER recompute fees in TS.
+   * Only the public buyer-read path (`getPublicTripById`) populates it; admin
+   * draft loads (`mapTripPricingTier`) leave it unset → base fallback.
+   */
+  priceAllInGbp?: number | null;
 }
 
 /**

--- a/supabase/functions/ticket-checkout-create/index.ts
+++ b/supabase/functions/ticket-checkout-create/index.ts
@@ -1083,7 +1083,17 @@ serve(wrapEdgeHandler("ticket-checkout-create", async (req) => {
             {
               price_data: {
                 currency,
-                unit_amount: totalCents,
+                // ORCH-1147 (D-1 / I-PROPOSED-1147-WEB-CHARGE-BILLS-FEE-GROSSED-SUBTOTAL,
+                // DRAFT) — bill the fee-grossed PRE-TAX subtotal
+                // (buyerSubtotal.buyerSubtotalCents = base + passed Mingla fee +
+                // passed service fee), NOT the bare base `totalCents`, so the web
+                // charge matches the native fee gross-up. The hosted Checkout
+                // Session has automatic_tax.enabled below — Stripe ADDS tax on
+                // top of this line item; billing the tax-inclusive
+                // buyer_total_cents here would DOUBLE-tax. Pre-tax subtotal is
+                // the correct basis. (OQ-1: corrects the dispatch's shorthand
+                // "bill buyer_total_cents" for the WEB hosted-Checkout path.)
+                unit_amount: buyerSubtotal.buyerSubtotalCents,
                 product_data: { name: `Tickets — ${eventName}` },
               },
               quantity: 1,


### PR DESCRIPTION
## ORCH-1147 — cart does not reflect the TRUE price of a trip/event/experience

**Seth-reported + screenshot-confirmed:** the public page quoted the all-in price ($67.93) but the cart fell back to the bare base ($65.00), dropping the passed Mingla + service fees (+4.5%). The buyer was quoted less than what the server charges — a WYSIWYP/checkout-surprise breach.

### Root cause
The business-app cart + buyer-web checkout DISPLAYED the bare ticket subtotal as "Total", re-deriving it independently from base price, while the server charges the full fee-grossed all-in. Classic display↔charge divergence, same across all three offering types (shared checkout path).

### Fix
- Cart "Total" now reads the server fee-grossed all-in (`priceAllInGbp` via the single shared owner `fetchTierAllInCents` → `pg_public_event_tier_allin`) instead of re-deriving from base — event, trip, AND experience, on business iOS/Android + buyer-web. Single combined "Fees & tax" line.
- **Web charge fix:** `ticket-checkout-create` line item now bills the fee-grossed PRE-TAX subtotal (`buyerSubtotal.buyerSubtotalCents`), not the bare base (web buyers were under-paying) and not the tax-inclusive number (Stripe `automatic_tax` adds tax on top — would double-tax).
- Server all-in is the single source BOTH display and charge consume; client no longer re-derives.

### Out of scope (parked, Seth-confirmed)
OQ-2: exclusive-tax regions (US **and Nigeria/Paystack** pass-tax) still understate by the tax line — zero live-brand blast radius today (all 8 sellable brands inclusive-tax GB/EU/CH, all absorb fees). No buyer tax form reintroduced. ORCH-1034 GBP fallbacks untouched. Consumer app already correct for fees (ORCH-1025) — no change.

### Evidence
- Money math proven against the live `pg_public_event_tier_allin` for all 3 types on a synthetic pass-fee fixture (event $50→$52.25, trip €500→€522.50, experience $70→$73.15), fixtures fully restored.
- Implementor test `orch_1147_cart_allin_total.test.ts` (18/18, T-7a/b/c trip+experience) fails-on-revert @ `e968e00b3`; tester adversarial `orch_1147_cart_charge_parity.tester-adversarial.test.ts` @ `57056d238` (display==charge / rounding / qty>1 / absorb→pass flip / pre-tax basis) — different angle, fails-on-revert.
- 4 strict-grep gates green: `orch-1147-allin-single-owner` (new), `orch-1147-cart-total-is-allin`, `orch-1147-web-charge-allin`, `orch-1130-no-buyer-tax-form`.
- No migration, no schema change.

### TEST verdict: CONDITIONAL PASS (P0:0 P1:0 P2:1 P4:2)
Conditions are CLOSE/deploy steps: (C1) deploy `ticket-checkout-create` from merged main (preserve `verify_jwt: true`); (C2) per-platform business OTA (rt 1.0.0) for the display fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)