### PR TITLE
ORCH-1147R2: cart SELECTION screen leads with the all-in price (event/trip/experience) [deploy]

### DIFF
--- a/.github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs
+++ b/.github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1147R2 — the business checkout SELECTION step leads with the server
+ * fee-grossed all-in, NOT the bare base subtotal.
+ *
+ * Invariant I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN (DRAFT): the three
+ * mingla-business checkout SELECTION index screens (event / trip / experience)
+ * MUST bind the displayed full-total headline value + the Continue button's
+ * accessibility label to the server all-in (`totals.allInTotal`), NOT the bare
+ * base (`totals.total` / `totals.subtotal`); AND the business `QuantityRow.tsx`
+ * wrapper MUST forward `priceAllInGbp` into the shared row so each per-tier row
+ * leads with the all-in. The trip installments deposit branch (`dueTodayCents`)
+ * is explicitly EXEMPT — it legitimately renders the deposit, not the base.
+ *
+ * R1 fixed the payment step; R2 extends the all-in to the selection step.
+ *
+ * The gate fails if any of:
+ *   (a) any of the 3 SELECTION index.tsx files does NOT reference
+ *       `totals.allInTotal` (the server all-in basis); OR
+ *   (b) any binds the full-total headline value or Continue a11y directly to
+ *       the bare base — i.e. `formatCurrency(totals.total ...)` or any
+ *       `totals.subtotal` reference still exists (the deposit branch uses
+ *       `dueTodayCents`, never the base, so a healthy fix leaves NO
+ *       `formatCurrency(totals.total ...)` and NO `totals.subtotal`); OR
+ *   (c) `mingla-business/src/components/checkout/QuantityRow.tsx` does NOT
+ *       forward `priceAllInGbp` into `ticketForPackage`.
+ *
+ * Comments are stripped so the explanatory ORCH-1147R2 notes never trip the
+ * gate. Mirrors the modular gate pattern (sibling: orch-1147-cart-total-is-allin.mjs).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+const failures = [];
+
+const selectionScreens = [
+  "mingla-business/app/checkout/[eventId]/index.tsx",
+  "mingla-business/app/checkout-trip/[tripEventId]/index.tsx",
+  "mingla-business/app/checkout-experience/[experienceEventId]/index.tsx",
+];
+
+const wrapperFile = "mingla-business/src/components/checkout/QuantityRow.tsx";
+
+// Strip line + block comments so prose like "// ...totals.total..." never trips.
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+// --- per-selection-screen evaluation --------------------------------------
+const evaluateScreen = (rel, rawCode) => {
+  const code = stripComments(rawCode);
+  const fileFailures = [];
+
+  // (a) the all-in basis must be referenced.
+  if (!/\btotals\.allInTotal\b/.test(code)) {
+    fileFailures.push(
+      `${rel}: selection bottom bar must read the server fee-grossed all-in (totals.allInTotal). The bare base subtotal omits the passed Mingla/service fee. I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.`,
+    );
+  }
+
+  // (b) the full-total headline / a11y must NOT bind to the bare base.
+  // A healthy fix leaves NO `formatCurrency(totals.total ...)` (the deposit
+  // branch uses dueTodayCents) and NO `totals.subtotal` reference.
+  if (/formatCurrency\(\s*totals\.total\b/.test(code)) {
+    fileFailures.push(
+      `${rel}: the full-total headline/a11y binds to the bare base (formatCurrency(totals.total, …)). Bind it to the all-in (headlineAllIn / totals.allInTotal) instead. I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.`,
+    );
+  }
+  if (/\btotals\.subtotal\b/.test(code)) {
+    fileFailures.push(
+      `${rel}: the selection screen must not bind the headline to totals.subtotal (bare base). Use the server all-in. I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.`,
+    );
+  }
+
+  return fileFailures;
+};
+
+// (c) the wrapper must forward priceAllInGbp into the adapter object.
+const evaluateWrapper = (rel, rawCode) => {
+  const code = stripComments(rawCode);
+  if (!/priceAllInGbp:\s*ticket\.priceAllInGbp/.test(code)) {
+    return [
+      `${rel}: ticketForPackage must forward priceAllInGbp (priceAllInGbp: ticket.priceAllInGbp ?? null) so the shared row renders the per-tier all-in. I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.`,
+    ];
+  }
+  return [];
+};
+
+// --- self-test fixtures (run with --self-test) ----------------------------
+const SELF_TEST = process.argv.includes("--self-test");
+
+if (SELF_TEST) {
+  const GOOD_SCREEN = `
+    const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+    const showFeesTaxLine = !totals.isEmpty && !totals.isFree && totals.hasFeesTaxDelta;
+    <Text>{dueTodayCents !== null ? formatCurrency(dueTodayCents, totals.currency, true) : headlineAllIn}</Text>
+  `;
+  const BAD_NO_ALLIN = `
+    <Text>{formatCurrency(totals.total, totals.currency)}</Text>
+  `;
+  const BAD_BASE_INLINE = `
+    const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+    <Text>{formatCurrency(totals.total, totals.currency)}</Text>
+  `;
+  const BAD_SUBTOTAL = `
+    const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+    <Text>{formatCurrency(totals.subtotal, totals.currency)}</Text>
+  `;
+  const GOOD_WRAPPER = `
+    () => ({ id: ticket.id, priceGbp: ticket.priceGbp, priceAllInGbp: ticket.priceAllInGbp ?? null })
+  `;
+  const BAD_WRAPPER = `
+    () => ({ id: ticket.id, priceGbp: ticket.priceGbp })
+  `;
+
+  const goodScreen = evaluateScreen("good.tsx", GOOD_SCREEN);
+  const badNoAllin = evaluateScreen("bad-no-allin.tsx", BAD_NO_ALLIN);
+  const badBaseInline = evaluateScreen("bad-base.tsx", BAD_BASE_INLINE);
+  const badSubtotal = evaluateScreen("bad-subtotal.tsx", BAD_SUBTOTAL);
+  const goodWrapper = evaluateWrapper("good-wrapper.tsx", GOOD_WRAPPER);
+  const badWrapper = evaluateWrapper("bad-wrapper.tsx", BAD_WRAPPER);
+
+  const ok =
+    goodScreen.length === 0 &&
+    badNoAllin.length >= 1 &&
+    badBaseInline.length >= 1 &&
+    badSubtotal.length >= 1 &&
+    goodWrapper.length === 0 &&
+    badWrapper.length >= 1;
+
+  if (!ok) {
+    console.error("ORCH-1147R2 selection-shows-allin SELF-TEST failed:", {
+      goodScreen,
+      badNoAllin,
+      badBaseInline,
+      badSubtotal,
+      goodWrapper,
+      badWrapper,
+    });
+    process.exit(1);
+  }
+  console.log("ORCH-1147R2 selection-shows-allin gate self-test passed.");
+  process.exit(0);
+}
+
+for (const rel of selectionScreens) {
+  const abs = join(root, rel);
+  if (!existsSync(abs)) {
+    failures.push(`${rel}: expected checkout selection screen not found.`);
+    continue;
+  }
+  failures.push(...evaluateScreen(relative(root, abs), readFileSync(abs, "utf8")));
+}
+
+const wrapperAbs = join(root, wrapperFile);
+if (!existsSync(wrapperAbs)) {
+  failures.push(`${wrapperFile}: expected business QuantityRow wrapper not found.`);
+} else {
+  failures.push(
+    ...evaluateWrapper(relative(root, wrapperAbs), readFileSync(wrapperAbs, "utf8")),
+  );
+}
+
+if (failures.length > 0) {
+  console.error("ORCH-1147R2 selection-shows-allin gate failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log("ORCH-1147R2 selection-shows-allin gate passed.");

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2359,6 +2359,19 @@ jobs:
       - name: Run ORCH-1147 allin-single-owner gate
         run: node .github/scripts/strict-grep/orch-1147-allin-single-owner.mjs
 
+  orch-1147r2-selection-shows-allin:
+    name: "ORCH-1147R2: checkout SELECTION step leads with the server all-in (I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test the gate (all-in vs base-bound fixtures)
+        run: node .github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs --self-test
+      - name: Run ORCH-1147R2 selection-shows-allin gate
+        run: node .github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs
+
   orch-1138-trip-reserve-straight-to-cart:
     name: "ORCH-1138: trip Reserve opens the cart directly, never EBES (I-PROPOSED-1138-TRIP-RESERVE-STRAIGHT-TO-CART)"
     runs-on: ubuntu-latest

--- a/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md
+++ b/Mingla_Artifacts/reports/IMPLEMENTATION_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md
@@ -1,0 +1,163 @@
+# IMPLEMENTATION — ORCH-1147R2 [cart SELECTION screen must show the all-in price, not the bare base]
+
+**Status:** implemented and verified (source + gate + jest; runtime device proof deferred to tester on a synthetic pass-fee fixture per SPEC §11).
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1147R2-[cart-selection-screen-allin]/` on branch `ORCH-1147R2-cart-selection-screen-allin` (rebased on origin/main `676369448`, 0 behind).
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md` (followed exactly; touched ONLY the §"Scoped allowlist").
+**Implementation commit:** `f03cd66c3`.
+**Comms ledger:** read on entry. No `BLOCK`+`OPEN` row targets mingla-implementor / ORCH-1147R2 / ALL. The OPEN `ALL` rows (COMMS-0002/0003/0004/0011/0012/0013/0015/0016/0018/0019/0021/0024/0025/0027/0028/0032/0035) are WARN/FYI — `biz_update_live_trip` migration coordination, HEIC/expo-image-manipulator native drift, OTA cache hygiene — none touch checkout-display code. Read, no action this turn. No new COMMS discovered.
+
+---
+
+## 1. Summary
+
+The business-app ticket-SELECTION step ("Get tickets · Select your tickets · 1 OF 3") now leads with the TRUE all-in price (e.g. `$67.93`) — the same number the public page shows — instead of the bare base (`$65`), for event / trip / experience. R1 already computed and seeded the all-in (`allInTotal`, `feesTaxCents`, per-tier `priceAllInGbp`) and bound it on the payment step; R2 is a pure DISPLAY bind of that existing data onto the selection screen's two surfaces:
+
+- **Per-tier QuantityRow** — the business wrapper now forwards `priceAllInGbp` into the adapter object, so the shared row renders the per-tier all-in + the quiet "incl. VAT & fees" caption (falls back to base + no caption when null/free — no fabrication).
+- **Sticky bottom bar** — the headline relabels "Subtotal" → "Total" bound to `totals.allInTotal`, with a single combined "Fees & tax" line gated on `feesTaxCents > 0` (never split service-fee + VAT); the Continue accessibility label uses the all-in. The trip installments "Due today" deposit branch is untouched, and the Fees & tax line is suppressed on the installments path.
+
+No math/engine/RPC/migration/edge change. `payment.tsx` ×3 and `CartContext.tsx` are byte-unchanged (`total`/`subtotal` stay base).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Commit |
+|----|-----------|--------|--------|
+| SC-1 (event) | Selection headline == `allInTotal` (not base); label "Total" | ✓ verified (jest T-1 + source-text + gate) | `f03cd66c3` |
+| SC-1-iOS / -Android / -Web | identical (shared RN files) | ✓ auto (one codebase) | `f03cd66c3` |
+| SC-2 (trip) | Full-total branch all-in; installments "Due today" deposit UNCHANGED, no Fees & tax line | ✓ verified (jest T-2/T-3 + source-text) | `f03cd66c3` |
+| SC-3 (experience) | Same as SC-1 for experience selection | ✓ verified (jest T-4 + source-text + gate) | `f03cd66c3` |
+| SC-4 (per-tier, all 3) | QuantityRow price == tier all-in + caption; base + no caption when null/free | ✓ verified (wrapper forward + gate + jest source-text) | `f03cd66c3` |
+| SC-5 (combined Fees & tax) | Exactly ONE "Fees & tax" line when `feesTaxCents > 0`; none + Total==base when 0 | ✓ verified (jest T-1/T-5/T-6/T-7) | `f03cd66c3` |
+| SC-6 (Continue a11y) | a11y label uses the all-in (full-total branch); free/empty/deposit unchanged | ✓ verified (source-text + gate) | `f03cd66c3` |
+| SC-7 (no payment regression) | `payment.tsx` ×3 byte-unchanged | ✓ verified (not in commit; R1 gate green) | n/a |
+| SC-8 (no buyer tax form) | `orch-1130-no-buyer-tax-form.mjs` GREEN | ✓ verified (ran: passed) | n/a |
+| SC-9 (base not repurposed) | `useCartTotals.total`/`.subtotal` still base; CartContext untouched | ✓ verified (CartContext not in commit; R1 test 18/18) | n/a |
+
+---
+
+## 3. Files changed (commit `f03cd66c3`)
+
+| File | Type | Δ |
+|------|------|---|
+| `mingla-business/src/components/checkout/QuantityRow.tsx` | source | +6 (1 field + comment) |
+| `mingla-business/app/checkout/[eventId]/index.tsx` | source | +~35 (derived vars, fees line, relabel, a11y, 3 styles) |
+| `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | source | +~35 |
+| `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | source | +~40 (installments-aware) |
+| `mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.test.ts` | NEW test | +~250 |
+| `.github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs` | NEW gate | +~210 |
+| `.github/workflows/strict-grep-mingla-business.yml` | gate registration | +12 |
+
+Only these 7 files staged/committed. The spec (`Mingla_Artifacts/specs/SPEC_ORCH-1147R2_...md`) and this report are orchestrator-owned and left untracked in the worktree.
+
+---
+
+## 4. Data-model changes applied
+
+None. No tables / columns / constraints / indexes / RLS touched. R2 is component-layer-only.
+
+---
+
+## 5. Edge functions touched
+
+None. No edge functions, RPCs, or `_shared/` touched. Nothing to deploy.
+
+---
+
+## 6. Regression tests added
+
+- **Path:** `mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.test.ts` (NEW, append-only).
+- **Count:** 17 tests, all green. Two layers: (1) pure cart-math against the real `useCartTotals` reduce (T-1..T-7 — headline reads `allInTotal`, fees line gated on `hasFeesTaxDelta`, RPC-miss/absorb/free fall to base, no fabrication, trip deposit suppresses the line); (2) source-text fails-on-revert across all four changed files.
+- **Strict-grep gate:** `.github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs` (NEW, `--self-test` supported, comment-stripping). Registered as job `orch-1147r2-selection-shows-allin` in `strict-grep-mingla-business.yml`.
+
+### Fails-on-revert — PROVEN by TRUE LINE DELETION at commit `f03cd66c3`
+
+**Axis 1 — per-tier forward (QuantityRow.tsx):** deleted the line `priceAllInGbp: ticket.priceAllInGbp ?? null,` from `ticketForPackage` (grep confirmed 0 occurrences post-delete).
+- Gate output: `ORCH-1147R2 selection-shows-allin gate failed: - …/QuantityRow.tsx: ticketForPackage must forward priceAllInGbp …` → **exit 1**.
+- Jest: `✕ the business wrapper forwards priceAllInGbp into ticketForPackage` → **1 failed, 16 passed**.
+- Restored via `git checkout -- …/QuantityRow.tsx` → grep 1, gate + test green again.
+
+**Axis 2 — bottom-bar all-in bind (event index.tsx):** rebound the full-total value branch from `: headlineAllIn}` to `: formatCurrency(totals.total, totals.currency)}` (true edit deleting the all-in bind; grep confirmed base bind present).
+- Gate output: `…/checkout/[eventId]/index.tsx: the full-total headline/a11y binds to the bare base (formatCurrency(totals.total, …)). …` → **exit 1**.
+- Jest: `✕ the full-total headline + a11y no longer bind to the bare base` → **1 failed, 16 passed**.
+- Restored via `git checkout -- '…/checkout/[eventId]/index.tsx'` → gate **exit 0**, jest **17 passed**.
+
+`fails-on-revert verified at f03cd66c3` on both axes (per-tier forward AND bottom-bar all-in bind). Working tree clean after restore (only the untracked orchestrator-owned spec remains).
+
+---
+
+## 7. Old → New receipts
+
+### mingla-business/src/components/checkout/QuantityRow.tsx
+**Before:** the `ticketForPackage` memo built the shared-row adapter with `priceGbp` but OMITTED `priceAllInGbp` entirely → the shared row fell to its base branch → per-tier base shown, no "incl. VAT & fees" caption.
+**Now:** forwards `priceAllInGbp: ticket.priceAllInGbp ?? null` (the `TicketStub` already carries it; populated by all three index seeds) → the shared row renders the per-tier all-in + caption, exact parity with the public page.
+**Why:** F-2 root cause (the single dropper). SC-4.
+**Lines:** +6 (1 field + 4-line scoped comment).
+
+### mingla-business/app/checkout/[eventId]/index.tsx
+**Before:** bottom-bar headline labeled "Subtotal" bound to `formatCurrency(totals.total, …)` (base); Continue a11y `…total ${formatCurrency(totals.total, …)}`.
+**Now:** derives `headlineAllIn = formatCurrency(totals.allInTotal, …)` and `showFeesTaxLine = !isEmpty && !isFree && hasFeesTaxDelta`; renders a gated "Fees & tax" line (`formatCurrency(totals.feesTaxCents, currency, true)`) above a "Total" row bound to `headlineAllIn`; a11y `…total ${headlineAllIn}`. Empty (`"—"`) / free (`"Free"`) branches unchanged.
+**Why:** F-1 root cause; SC-1/SC-5/SC-6.
+**Lines:** +~35.
+
+### mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
+**Before/Now:** identical to the event file (no installments branch).
+**Why:** SC-3.
+**Lines:** +~35.
+
+### mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+**Before:** non-deposit label "Subtotal", full-total value + a11y bound to `formatCurrency(totals.total, …)`; deposit branch rendered `dueTodayCents`.
+**Now:** the FULL-TOTAL (non-deposit) branch only — label "Total", value + a11y bound to `headlineAllIn`; `showFeesTaxLine` additionally gated on `dueTodayCents === null` so the Fees & tax line shows only on the full-total path. The installments "Due today" deposit branch (`formatCurrency(dueTodayCents, …, true)`) and its label are BYTE-UNCHANGED.
+**Why:** SC-2; the single manual-care parity point (deposit branch is a separate Seth-binding truth).
+**Lines:** +~40.
+
+---
+
+## 8. Cross-surface impact
+
+| # | Surface | Affected | Behavior | Parity |
+|---|---------|----------|----------|--------|
+| 1 | Consumer iOS (`app-mobile`) | NO | own `TicketCartSheet`, already all-in | — |
+| 2 | Consumer Android | NO | same | — |
+| 3 | Buyer / anon Web (`mingla-business` `/checkout/*`) | YES | selection bottom bar + per-tier row all-in; Fees & tax line on delta | Auto (shared RN), except trip deposit branch (manual — handled) |
+| 4 | Business iOS | YES | same | Auto via shared CartContext + wrapper |
+| 5 | Business Android | YES | same | Auto (shared RN) |
+| 6 | Admin Web | NO | no buyer checkout surface | — |
+| 7 | Business Web preview | NO | non-buyer surface | — |
+
+Manual-parity point: the trip bottom bar's two branches (full-total vs installments deposit) — only the full-total branch changed; deposit branch unchanged. Verified by jest T-2/T-3 + source-text assertions.
+
+---
+
+## 9. Smoke result
+
+- **Strict-grep gate** `orch-1147r2-selection-shows-allin.mjs`: `--self-test` PASS; live run PASS.
+- **R1 gate** `orch-1147-cart-total-is-allin.mjs`: PASS (no payment-step regression).
+- **orch-1130-no-buyer-tax-form.mjs**: PASS (SC-8).
+- **Jest** `orch_1147r2_selection_allin.test.ts`: 17/17 PASS. **R1 jest** `orch_1147_cart_allin_total.test.ts`: 18/18 PASS (no regression).
+- **tsc** (`mingla-business`): 325 pre-existing errors (project-wide baseline), ZERO in any of the 4 touched source files — the errors are all in `buyer.tsx` / unrelated files. No new type error introduced.
+- **Runtime device proof:** NOT run this pass. Per SPEC §Repro-evidence + §11, runtime visual proof requires a SYNTHETIC pass-fee charges-enabled fixture (0/8 prod brands pass a fee → base==all-in on prod data, so a sim run on prod data renders `$65==$65` and proves nothing). Deferred to the tester (T-10).
+
+---
+
+## 10. Known issues / deferred
+
+- **OQ-R2-2 (PARKED):** US/NG exclusive-tax residual — `priceAllInGbp` folds fees but excludes exclusive tax. Zero blast today (all charges-enabled brands inclusive GB/EU/CH). Not fixed here, per dispatch.
+- No `[TRANSITIONAL]` code introduced.
+- `I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` enforcement is WIRED (gate references it by name; test + site comments cite it) but the registry ROW is orchestrator-owned (`INVARIANT_REGISTRY.md` is a global index, not in the implementor allowlist) and stays DRAFT — the orchestrator flips it ACTIVE at CLOSE.
+
+---
+
+## 11. Operator action required
+
+- **Migration `db push`:** NONE (no migration).
+- **Edge-fn deploy:** NONE.
+- **Next phase:** tester device-verify on a synthetic pass-fee charges-enabled fixture (SPEC §11 T-10) across event/trip/experience × business iOS + Android + buyer-web; a green run on prod data is non-probative.
+- **At CLOSE (orchestrator):** flip `I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` DRAFT→ACTIVE in `INVARIANT_REGISTRY.md`; OTA the business app (pure RN/JS, runtime 1.0.0); ensure both the implementor happy-path test and the tester adversarial test are in the closing PR diff.
+
+---
+
+## 12. Discoveries for orchestrator
+
+- **Tester masking gotcha (carry forward from R1):** a green visual test on prod data is non-probative — 0/8 prod brands pass a fee → base==all-in. The tester MUST use a synthetic pass-fee charges-enabled brand fixture so base ≠ all-in, otherwise the all-in bind is unproven at runtime.
+- No unrelated bugs found in the touched files. The 325 pre-existing `tsc` errors (implicit-`any` in `buyer.tsx` and others) are a project-wide baseline, untouched by R2 — flagged only as context, not introduced here.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md
@@ -1,0 +1,178 @@
+# TEST — ORCH-1147R2 [cart SELECTION screen must show the all-in price, not the bare base]
+
+**Verdict: PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 0 · P4: 2
+Render-level runtime proof delivered for the selection screen (the R1 blind spot is closed).
+Regression gate satisfied: implementor happy-path test + tester adversarial **render** test both on-branch, in closing diff, fails-on-revert proven.
+
+- Worktree: `~/Desktop/mingla-orchs/ORCH-1147R2-[cart-selection-screen-allin]/`
+- Branch: `ORCH-1147R2-cart-selection-screen-allin`
+- Impl commit under test: `f03cd66c3`
+- Tester adversarial test commit: `eed4448b2`
+- Branch is current with origin/main (0 behind).
+
+---
+
+## 1. What the change does (verified against the actual diff)
+
+Pure DISPLAY bind of R1-computed data. Three checkout SELECTION screens
+(`checkout/[eventId]`, `checkout-trip/[tripEventId]`, `checkout-experience/[experienceEventId]`)
++ the shared per-tier `QuantityRow` wrapper:
+
+- **Per-tier row** — `QuantityRow.tsx` wrapper forwards `priceAllInGbp: ticket.priceAllInGbp ?? null`
+  into the shared `@mingla/event-rendering` row, which already (ORCH-1006) renders the all-in +
+  a quiet "incl. VAT & fees" caption when `priceAllInGbp > priceGbp`. Null → falls back to base, no caption.
+- **Bottom bar** — `headlineAllIn = formatCurrency(totals.allInTotal, totals.currency)`; label
+  relabeled `Subtotal → Total`; a single combined `Fees & tax` line gated on
+  `!isEmpty && !isFree && hasFeesTaxDelta` (`+ dueTodayCents === null` on trip); Continue a11y uses the all-in.
+- **Trip deposit branch** — `dueTodayCents !== null` still renders `Due today` + the deposit; the
+  Fees & tax line is suppressed on the installments path.
+
+---
+
+## 2. SC-by-SC matrix (render/runtime evidence per row)
+
+| SC | Criterion | Surface | Verdict | Evidence |
+|----|-----------|---------|---------|----------|
+| SC-1 | Event selection bottom bar leads with the all-in | event | **PASS (render)** | RTL mount: bar-label="Total", bar-value="£67.93", fees-tax contains "£2.93"; "Subtotal" absent |
+| SC-2 | Trip full-total binds all-in; deposit branch untouched | trip | **PASS (render)** | full-total: Total/£67.93/£2.93; installments (dueTodayCents=2000): label="Due today", value="£20.00", NO fees line |
+| SC-3 | Experience selection bottom bar leads with the all-in | experience | **PASS (render)** | RTL mount: Total/£67.93/£2.93; "Subtotal" absent |
+| SC-4 | Per-tier QuantityRow shows the all-in + caption | event/trip/experience | **PASS (render)** | REAL <QuantityRow> wrapper mount renders "£67.93" + "incl. VAT & fees"; "£65.00" NOT rendered |
+| SC-5 | Single combined "Fees & tax" line, never split | all | **PASS (render)** | exactly one fees-tax node rendering the combined delta; no separate service-fee/VAT node |
+| SC-6 | Continue a11y uses the all-in | all | **PASS (source+impl-test)** | a11yLabel binds headlineAllIn; implementor test asserts it; gate enforces it |
+| SC-7 (T-5) | Absorb: Total==base, no fees line, no caption | event | **PASS (render)** | base==all-in (65/65): "Total £65.00", NO fees-tax, NO caption |
+| SC-8 (T-6) | Free: "Free", no fees line, no caption | all | **PASS (render)** | free tier: "Free", NO fees-tax, NO caption |
+| SC-9 (T-7) | RPC miss: falls to base, no fabrication | all | **PASS (render)** | priceAllInGbp=null: renders "£65.00", NO caption, "£67.93" NOT rendered |
+| SC-10 (T-9) | Strict-grep gate fails on revert | CI | **PASS** | gate exit 1 on bare-base revert; exit 0 restored |
+| SC-11 (T-10) | Pass-fee real-data case renders all-in | prod data | **PASS (DB-anchored)** | prod event 09b4ece6… tier "The paid": base 6500 → all-in 6793 → delta 293 (USD) — exactly the synthetic fixture |
+
+All 12 render assertions green under `jest.orch1147r2.render.cjs`
+(RN preset + react-test-renderer 19.1.0 + @testing-library/react-native 13.3.3, react pinned to the business 19.1.0 install).
+
+---
+
+## 3. Findings
+
+**P4-1 (NOTE — praise).** The R2 change reuses the shared row's existing ORCH-1006 all-in/caption path
+rather than reimplementing it, and the trip deposit gate (dueTodayCents === null) is exactly right — the
+installments "Due today" deposit is a partial figure and must not carry a "Fees & tax" delta line. No
+fabrication on the RPC-miss path (Constitution rule 9 honoured).
+
+**P4-2 (NOTE — discovery, not a finding against R2).** The dispatch's masking-gotcha "0/8 live
+charges-enabled brands pass any fee" is now **stale**: prod has 8 charges-enabled brands and **1 passes
+a fee** (event 09b4ece6-eabc-4734-8ce3-3a25d90417e4 "Vibes and Stuff", USD, pass_mingla_fee=pass_service_fee=true,
+tier base $65.00 → all-in $67.93). A prod render of THAT brand's selection screen is now probative.
+
+No P0/P1/P2/P3.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Re-ran the implementor's `orch_1147r2_selection_allin.test.ts` (committed at `f03cd66c3`) against a TRUE
+line-deletion revert (not a comment-out):
+
+- **Restored (HEAD):** `Tests: 17 passed, 17 total`.
+- **Revert** (deleted the priceAllInGbp wrapper forward + rebound the event bottom bar to
+  formatCurrency(totals.total, …)): `Tests: 2 failed, 15 passed` — RED assertions:
+  `the business wrapper forwards priceAllInGbp into ticketForPackage` and
+  `the full-total headline + a11y no longer bind to the bare base`.
+
+Implementor fails-on-revert independently **confirmed** at restored commit `f03cd66c3`.
+
+---
+
+## 5. Adversarial test added (tester-owned, DIFFERENT ANGLE)
+
+- **Path:** `mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.render.test.tsx`
+- **Commit:** `eed4448b2`
+- **Angle:** the implementor's test is **math-replication + source-text grep** (never mounts a React
+  tree — the exact R1 blind spot). This test is a **true component RENDER proof**: it MOUNTS the REAL
+  mingla-business <QuantityRow> wrapper (→ shared @mingla/event-rendering row) and the bottom-bar
+  derivation driven by the REAL useCartTotals over a REAL CartProvider, then asserts the ACTUAL RENDERED
+  TEXT (getByText("£67.93"), getByText(/incl. VAT & fees/), testID bar-value/fees-tax).
+- **Config / infra (worktree-local, in closing diff):** `jest.orch1147r2.render.cjs` +
+  `jest.orch1147r2.blur-stub.cjs` + `jest.orch1147r2.haptics-stub.cjs`; registered in `jest.config.cjs`
+  testPathIgnorePatterns so the default node/ts-jest run skips it (requires RN preset + RTL — same
+  pattern as ORCH-1118/1122/1143). RTL deps live in gitignored node_modules
+  (provision: `cd .orch1118-testdeps && npm i react-test-renderer@19.1.0 @testing-library/react-native@^13 --legacy-peer-deps`).
+- **fails-on-revert verified at `eed4448b2`:** with both binds line-deleted, the render test goes
+  `Tests: 3 failed, 9 passed` — three RED cells are the event/trip/experience per-tier rows, each failing
+  at `expect(screen.getByText("£67.93")).toBeTruthy()`. Restored → `12 passed, 12 total`.
+- **Both tests appear in `git diff origin/main...HEAD --name-only`:** confirmed.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | N/A | display-only; no new tap |
+| 2 | One owner per truth | PASS | all-in single-owned by R1 useCartTotals.allInTotal; R2 only reads it |
+| 3 | No silent failures | PASS | null all-in falls back to base visibly; no swallowed error |
+| 4 | One query key per entity | N/A | no query change |
+| 5 | Server state server-side | PASS | no Zustand; cart provider-local; all-in server-sourced |
+| 6 | Logout clears everything | N/A | no auth/persistence touch |
+| 7 | Label [TRANSITIONAL] | N/A | none introduced |
+| 8 | Subtract before adding | PASS | reused shared row + R1 totals; net additive display only |
+| 9 | No fabricated data | **PASS** | RPC-miss render test proves base shown, NO grossed-up number invented |
+| 10 | Currency-aware | PASS | formatCurrency(value, totals.currency); GBP test, USD prod both correct |
+| 11 | One auth instance | N/A | buyer/selection screen anon-tolerant; untouched |
+| 12 | Validate at right time | N/A | no validation change |
+| 13 | Exclusion consistency | N/A | none |
+| 14 | Persisted-state startup | N/A | cart not persisted (CartContext doc: no AsyncStorage) |
+
+No violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Evidence |
+|---------|---------|----------|
+| Business iOS (selection screen) | **PASS (component-render)** | RTL haste.defaultPlatform="ios"; real <QuantityRow> + bottom-bar rendered, all-in text asserted (event/trip/experience) |
+| Business Android | **PASS (parity, render)** | same shared row + same useCartTotals derivation; render proof platform-agnostic (RN preset). No Android-specific branch in the changed lines |
+| Buyer/anonymous Web (/checkout/{eventId}) | **BLOCKED (bonus, deferred)** | no expo-web dev server (localhost:19006=000; metro 8081=200). Synthetic pass-fee web fixture + seeded brand + buyer-web build out of reach this run, as the dispatch anticipated. MANDATORY component-render proof stands in its place; shared row + derivation render identically on web (same RN codebase). Real prod brand 09b4ece6… exists for a future web spot-check. |
+| Consumer iOS/Android | N/A | change is business-app checkout only |
+| Admin Web | N/A | not a checkout surface |
+| Physical iPhone (HITL) | NOT REQUESTED | render-level proof + DB anchor sufficient for this display bind; no hardware-keyboard/gesture path |
+
+Byte-unchanged guard (DO-NOT-TOUCH): `payment.tsx ×3`, `CartContext.tsx`, and the shared
+`packages/event-rendering/QuantityRow.tsx` are **byte-identical to origin/main** (confirmed via
+git diff + a direct diff of payment.tsx against origin/main). No money-engine / payment regression possible.
+
+---
+
+## 8. Gate + jest results
+
+- **Strict-grep orch-1147r2-selection-shows-allin.mjs** — exit 0 (restored); exit 1 on bare-base revert. Fails-on-revert proven.
+- **Strict-grep orch-1130-no-buyer-tax-form.mjs** (required) — **exit 0 (green).**
+- **R1 gates** orch-1147-allin-single-owner / orch-1147-cart-total-is-allin / orch-1147-web-charge-allin — all exit 0.
+- **Tester render test** (jest.orch1147r2.render.cjs) — 12/12 PASS.
+- **Implementor test** (orch_1147r2_selection_allin.test.ts) — 17/17 PASS.
+- **R1 cart-allin test** (orch_1147_cart_allin_total.test.ts) — PASS.
+- **Default jest no longer matches the render test** — `No tests found` (correctly ignored); the committed render test does not break the default CI jest run.
+
+### Pre-existing suite noise (NOT R2 — Discovery for Orchestrator)
+
+The full mingla-business default jest run shows **~85 failed suites / 388 passed** — PRE-EXISTING, outside R2's blast radius:
+- meta_orch_0952_carousel_browser.test.ts is a **Playwright** test mis-run under Jest ("Playwright Test needs to be invoked via npx playwright test") — config issue, unrelated to R2.
+- The orch_0911 / orch_0915 source-text tests (readFileSync the byte-unchanged payment.tsx) fail with empty Received:"" under heavy parallel contention, yet **PASS in isolation** (orch_0915_pay_in_full_choice_adversarial → RC 0, 7.85 s). Failures hit many unrelated domains (keyboard, brands, cover media, social preview, trip visual parity).
+- Every R2-relevant suite passes in isolation and runInBand. No failing suite reads a file R2 changed except the R1/R2 cart tests, which pass.
+
+---
+
+## 9. Discoveries for Orchestrator
+
+1. **Stale masking-gotcha** — prod now has 1/8 charges-enabled brands passing a fee (event
+   09b4ece6-eabc-4734-8ce3-3a25d90417e4, tier base $65.00 → all-in $67.93). Update the "0/8 → green run
+   non-probative" framing; a real probative web/device spot-check is now possible.
+2. **mingla-business jest health** — ~85 suites fail under the full parallel run (Playwright-under-jest
+   misconfig + source-read flakiness under contention). Pre-dates R2; worth a dedicated cleanup ORCH.
+   Related to the stale-node_modules / COMMS-0035 class of environment drift.
+
+---
+
+## Routing
+
+PASS → CLOSE (orchestrator). Tester adversarial render test committed at `eed4448b2`; both regression
+tests in the closing diff; all required gates green; byte-unchanged guard confirmed.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1147R2_CART_SELECTION_SCREEN_ALLIN.md
@@ -1,0 +1,285 @@
+# SPEC — ORCH-1147R2 [cart SELECTION screen still shows the bare base price, not the all-in]
+
+**Phase:** INVESTIGATE-THEN-SPEC (forensics). **Skill:** mingla-forensics.
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1147R2-[cart-selection-screen-allin]/` on branch `ORCH-1147R2-cart-selection-screen-allin` (rebased on origin/main @ `676369448`, 0 behind).
+**Predecessor:** ORCH-1147 R1 (CLOSE `676369448`) — fixed the payment.tsx headline Total + combined "Fees & tax" line + seeded `unitPriceAllIn`/`allInTotal`/`feesTaxCents` into CartContext; did NOT touch the ticket-SELECTION step.
+**Comms:** `COMMS_LEDGER.md` read on entry. No OPEN BLOCK row targets mingla-forensics / ORCH-1147R2 / ALL. The matching `ALL`-targeted rows (COMMS-0027/0028/0029/0031/0032/0033/0035) concern `biz_update_live_trip` migration coordination, HEIC/expo-image-manipulator native drift, and OTA cache hygiene — none touch checkout-display code; read, no action this turn.
+
+---
+
+## PART I — INVESTIGATION CONFIRMATION
+
+The R1 dispatch's root cause is **CONFIRMED by code on merged-main `676369448`**. This is a display gap on the selection step, not OTA lag and not a data gap — the all-in data is present at every relevant render boundary and is simply not bound to the UI.
+
+### Investigation manifest (files read, in trace order)
+
+| # | File | Why |
+|---|------|-----|
+| 1 | `mingla-business/src/components/checkout/CartContext.tsx` | confirm the all-in fields exist (R1) and base stays base |
+| 2 | `mingla-business/src/components/checkout/QuantityRow.tsx` | the business-app per-tier wrapper — does it pass the all-in? |
+| 3 | `packages/event-rendering/QuantityRow.tsx` | the SHARED row the public page uses — does it already render all-in? |
+| 4 | `mingla-business/src/components/event/PublicEventPage.tsx` | parity reference — how the public page feeds the all-in to the shared row |
+| 5 | `mingla-business/src/store/draftEventStore.ts` (`TicketStub`) | does the stub the wrapper receives carry `priceAllInGbp`? |
+| 6 | `mingla-business/app/checkout/[eventId]/index.tsx` | event selection bottom bar + QuantityRow stub seed |
+| 7 | `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` | trip selection bottom bar (+ `dueTodayCents` installments branch) + stub |
+| 8 | `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` | experience selection bottom bar + stub |
+| 9 | `mingla-business/app/checkout/[eventId]/payment.tsx` | R1 reference — exact all-in + "Fees & tax" presentation to match |
+| 10 | `mingla-business/src/utils/currency.ts` | `formatCurrency(value, currency, minor=false)` signature |
+| 11 | `.github/scripts/strict-grep/orch-1147-cart-total-is-allin.mjs` | gate pattern to model the R2 gate on |
+
+### Q-scorecard
+
+**Q1 — Does the selection-step bottom bar render base or all-in?**
+**Verdict: BASE — CONFIRMED (`proven`, source on merged main).** All three index.tsx bottom bars bind the displayed value AND the Continue accessibility label to `formatCurrency(totals.total, totals.currency)`. `totals.total === subtotal === Σ(unitPrice×qty)` = BASE (CartContext.tsx:478-479, `DO-NOT-REPURPOSE`).
+- Event `checkout/[eventId]/index.tsx:305` (value) + `:320` (a11y label).
+- Trip `checkout-trip/[tripEventId]/index.tsx:496` (value, the non-deposit branch) + `:513` (a11y label).
+- Experience `checkout-experience/[experienceEventId]/index.tsx:306` (value) + `:321` (a11y label).
+
+**Q2 — Does the per-tier QuantityRow render base or all-in?**
+**Verdict: BASE — CONFIRMED (`proven`).** The mingla-business wrapper `QuantityRow.tsx` builds `ticketForPackage` (`:86-104`) with `priceGbp: ticket.priceGbp` and **omits `priceAllInGbp` entirely**. The shared `PackageQuantityRow` therefore receives no all-in and falls to its base branch (`effectivePrice = ticket.priceAllInGbp ?? ticket.priceGbp ?? 0`, `packages/event-rendering/QuantityRow.tsx:245`). The wrapper is the single dropper.
+
+**Q3 — Is the all-in data already present at both render boundaries (i.e. is this purely a display bind, not a data gap)?**
+**Verdict: YES — CONFIRMED (`proven`).** Two independent proofs:
+- **Bottom bar:** `useCartTotals()` already returns `allInTotal` (Σ `unitPriceAllIn×qty`), `feesTaxCents` (= `max(0, round((allInTotal−subtotal)×100))`), and `hasFeesTaxDelta` (CartContext.tsx:439-447, 467-482). All three index files already SEED `unitPriceAllIn` into the cart on every quantity change (event `:279-280`, trip `:253` + `:460-461`, experience `:284`). The headline all-in is one field read away.
+- **Per-tier:** `TicketStub` carries `priceAllInGbp?: number | null` (draftEventStore.ts:94). The stubs the wrapper receives already populate it: event passes the live `ticket` (which has it), trip `tierToTicketStub` sets `priceAllInGbp: tier.priceAllInGbp ?? null` (index.tsx:72), experience `ticketToStub` sets `priceAllInGbp: ticket.priceAllInGbp ?? null` (index.tsx:57). The wrapper just doesn't forward it into `ticketForPackage`.
+
+**Q4 — Does the PUBLIC page (the reference) prove the desired presentation is already a solved pattern?**
+**Verdict: YES — CONFIRMED (`proven`).** The public page's `mapTicket` threads `priceAllInGbp: t.priceAllInGbp ?? null` into the SAME shared `PackageQuantityRow` (PublicEventPage.tsx:84-87). That row then renders the all-in number + a quiet "incl. VAT & fees" caption when `priceAllInGbp > priceGbp` (`packages/event-rendering/QuantityRow.tsx:245-255, 399-401`). The selection screen shows base ONLY because the business wrapper drops the field the public path forwards.
+
+**Q5 — Did R1 already make the payment step correct (so R2 must not double-change it)?**
+**Verdict: YES — CONFIRMED (`proven`).** `payment.tsx` (all three) source the headline from `totals.allInTotal` → `allInFloorCents` → `displayAllIn`, render the combined "Fees & tax" line off `feesTaxLineCents`, and bind Pay + a11y to `displayAllIn` (event payment.tsx:569-582, 645-720). R2 does NOT touch any payment.tsx.
+
+### Findings (six-field)
+
+**F-1 — Selection bottom bar binds the headline number + Continue a11y to the bare base. CONFIRMED ROOT CAUSE.**
+1. **Symptom:** "Get tickets · Select your tickets · 1 OF 3" shows `$65` while the public page shows `$67.93`; Seth screenshotted twice.
+2. **Layer:** code (RN component).
+3. **Probe:** `grep -n "totals\.total\|formatCurrency\|Subtotal" app/checkout/[eventId]/index.tsx` (+ trip + experience).
+4. **Evidence:** event `index.tsx:299` `<Text>Subtotal</Text>` / `:305` `formatCurrency(totals.total, totals.currency)` / `:320` `…total ${formatCurrency(totals.total, …)}`. Trip `:484-496` (label "Subtotal" / value `totals.total` in the non-deposit branch) / `:513` a11y. Experience `:300/:306/:321`. CartContext.tsx:478-479 `subtotal/total = Σ(unitPrice×qty)` (base).
+5. **Mechanism:** the bottom bar reads `totals.total` (deliberately base) instead of `totals.allInTotal` (the R1 all-in) → the buyer sees base on the lead screen, contradicting the public page's all-in.
+6. **Severity:** `CONFIRMED ROOT CAUSE`.
+
+**F-2 — The business-app QuantityRow wrapper drops `priceAllInGbp`. CONFIRMED ROOT CAUSE (per-tier).**
+1. **Symptom:** per-tier row shows `$65` not `$67.93`; no "incl. VAT & fees" caption (the public row has both).
+2. **Layer:** code.
+3. **Probe:** read `mingla-business/src/components/checkout/QuantityRow.tsx:86-104`; compare to `PublicEventPage.tsx:80-88`.
+4. **Evidence:** wrapper `ticketForPackage` memo sets `priceGbp: ticket.priceGbp` and has NO `priceAllInGbp` key (`:90`). The shared row supports it (`packages/event-rendering/QuantityRow.tsx:66, 245, 251-255, 399-401`). The stub already carries it (`TicketStub.priceAllInGbp`, draftEventStore.ts:94; populated by all three index seeds).
+5. **Mechanism:** the wrapper omits one field on the adapter object → shared row falls to its base branch → per-tier base shown.
+6. **Severity:** `CONFIRMED ROOT CAUSE`.
+
+**F-3 — R1 fields exist and are correctly base/all-in separated. RULED OUT as a defect (this is the enabler).**
+1. **Symptom:** none (positive finding).
+2. **Layer:** code.
+3. **Probe:** read CartContext.tsx:421-489.
+4. **Evidence:** `allInTotal`, `feesTaxCents`, `hasFeesTaxDelta` exist; `subtotal/total` keep base meaning with a `DO-NOT-REPURPOSE` comment (`:426-431`).
+5. **Mechanism:** R2 reads these existing fields; no engine/math change.
+6. **Severity:** `RULED OUT` (no defect — the data is present, only the bind is missing).
+
+### Five-truth-layer reconciliation
+
+| Layer | Reads as | Contradiction? |
+|-------|----------|----------------|
+| Docs | `feedback_cart_combined_fees_tax_line` (ONE combined line); R1 IMPLEMENTATION report says payment step done, selection NOT in scope | none — confirms R2 is the open follow-on |
+| Schema | `pg_public_event_tier_allin` is the per-tier all-in authority; unchanged | none — R2 touches no SQL |
+| Code | selection binds `totals.total` (base); wrapper drops `priceAllInGbp` | **THIS IS THE BUG (F-1/F-2)** vs payment.tsx already binding `allInTotal` |
+| Runtime | not live-fired this pass (see below) | n/a |
+| Data | `allInTotal`/`unitPriceAllIn`/`priceAllInGbp` all populated on pass-fee tiers; 0/8 prod brands pass a fee today | masking gotcha for the tester (synthetic fixture required) |
+
+### Repro evidence
+
+**Not live-fired this pass (source-confirmed only).** Rationale exemption: the defect is a static display bind proven by reading merged-main source at exact lines, and a runtime repro requires a SYNTHETIC pass-fee charges-enabled brand fixture (0/8 prod brands pass a fee → base==all-in on all prod data, so a sim run on prod data would render `$65 == $65` and prove nothing — the same masking gotcha R1's tester flagged). Confidence is `proven` for the source bind (the lines are unambiguous and match the screenshot symptom exactly) and the runtime visual proof is the downstream tester's job on the synthetic fixture. No fix proposed in this section.
+
+### Blast radius / cross-surface map
+
+- **In scope (selection step display only):** business iOS, business Android, buyer/anon Web — all three offering types (event/trip/experience), via the 3 `index.tsx` bottom bars + the one shared business `QuantityRow.tsx` wrapper. Web and native share these RN files, so parity is automatic except where the trip deposit branch differs (manual care, see SPEC §4).
+- **Out of scope:** consumer app-mobile (its own `TicketCartSheet`, already all-in — F-5 in R1); admin web + business-web preview (non-buyer); the payment step (R1, correct — must not be re-touched); the money engine / RPCs / edge functions (unchanged).
+
+### Invariant impact
+
+- Preserves `I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN` (DRAFT) — extends its reach from payment to selection.
+- Preserves `orch-1130-no-buyer-tax-form` (no buyer tax form added).
+- Establishes new DRAFT `I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` (see SPEC §6).
+
+### Discoveries for orchestrator
+
+- **OQ-2 (US/NG exclusive-tax) stays PARKED** — `priceAllInGbp` folds fees but excludes tax in exclusive-tax regions; identical residual to R1, zero blast today (all charges-enabled brands inclusive GB/EU/CH). Do not fix here.
+- **Tester masking gotcha (mandatory):** a green visual test on prod data is non-probative — needs a synthetic pass-fee charges-enabled fixture so base ≠ all-in. Carry forward from R1.
+
+### Confidence
+
+`proven` (source) for F-1/F-2/F-3 on merged-main `676369448`; runtime visual proof deferred to the tester on a synthetic pass-fee fixture. Recommended next phase: **IMPLEMENT** the SPEC below (display-only, ~scoped files), then **TEST** on the synthetic fixture across all three types × 3 surfaces.
+
+---
+
+## PART II — BUILD SPEC (11 sections)
+
+### 1. Executive summary
+
+The business-app ticket-SELECTION step ("Get tickets · Select your tickets · 1 OF 3") must lead with the TRUE all-in price — the same `$67.93` the public page shows — instead of the bare base `$65`. R1 already computed and stored the all-in (`allInTotal`, `feesTaxCents`, per-tier `priceAllInGbp`) and uses it on the payment step; R2 simply BINDS the existing all-in data to the selection screen's two display surfaces (the sticky bottom bar and the per-tier QuantityRow), with the single combined "Fees & tax" line gated on a real delta. No new math, no engine change, no payment-step change.
+
+### 2. Scope & non-goals
+
+**In scope:**
+- The selection bottom bar (the headline number + the Continue button's accessibility label) → all-in.
+- An optional small "Fees & tax" breakdown line in the bottom bar, gated on `feesTaxCents > 0`.
+- The per-tier QuantityRow price → all-in per unit, via threading `priceAllInGbp` through the business wrapper.
+- All three offering types: event / trip / experience selection index screens + the one shared business `QuantityRow.tsx` wrapper.
+
+**Non-goals (explicit):**
+- The payment step (`payment.tsx` ×3) — correct from R1, MUST NOT be touched.
+- The money engine, `pg_public_event_tier_allin`, `compute_all_in_cents`, any RPC/edge function/migration — unchanged.
+- `useCartTotals.total`/`.subtotal` semantics — STAY base (`DO-NOT-REPURPOSE`). R2 READS `allInTotal`/`priceAllInGbp`; it never repurposes base.
+- The trip **installments "Due today" deposit branch** — that is a separate Seth-binding truth (`dueTodayCents`); R2 swaps ONLY the non-deposit "full total" branch to all-in and leaves the deposit branch exactly as-is.
+- OQ-2 (US/NG exclusive-tax residual) — PARKED.
+- The shared `packages/event-rendering/QuantityRow.tsx` — already correct (renders all-in when fed `priceAllInGbp`); NOT touched.
+
+**Assumptions:** the all-in fields populated by R1 are present at runtime for all three types (proven by source); free / RPC-miss tiers carry `priceAllInGbp == null` → fall back to base with `feesTaxCents == 0` (no fabrication).
+
+### 3. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behavior demanded | Files touched there | Parity |
+|---|---------|---------|--------------------------------|---------------------|--------|
+| 1 | Consumer iOS (`app-mobile`) | NO | already all-in (own `TicketCartSheet`) | none | — |
+| 2 | Consumer Android (`app-mobile`) | NO | same | none | — |
+| 3 | Buyer / anon Web (`mingla-business` `/checkout/*`) | YES | selection bottom bar + per-tier row show all-in; "Fees & tax" line when delta>0 | the 3 `index.tsx` + `QuantityRow.tsx` wrapper | Auto (shared RN), except the trip deposit branch (manual, §4) |
+| 4 | Business iOS | YES | same | same | Auto via shared CartContext + wrapper |
+| 5 | Business Android | YES | same | same | Auto (shared RN) |
+| 6 | Admin Web | NO | no buyer checkout surface | none | — |
+| 7 | Business Web preview | NO | non-buyer surface | none | — |
+
+Manual-parity note: the trip selection bottom bar has TWO branches (full-total vs installments deposit). R2 changes ONLY the full-total branch to all-in; the deposit branch is unchanged. This is the single manual-care point.
+
+### 4. Layered specification
+
+Only the **Component** layer is touched. No DB / edge / service / hook / realtime changes.
+
+#### 4.1 Component — business `QuantityRow.tsx` wrapper (per-tier all-in)
+
+**File:** `mingla-business/src/components/checkout/QuantityRow.tsx`
+**Change:** in the `ticketForPackage` memo (`:86-104`), add the all-in field so the shared row receives it:
+```ts
+priceAllInGbp: ticket.priceAllInGbp ?? null,
+```
+inserted alongside `priceGbp: ticket.priceGbp` (the shared `QuantityRowTicket` already declares `priceAllInGbp?: number | null` at `packages/event-rendering/QuantityRow.tsx:66`). Add `ticket.priceAllInGbp` to the memo dependency note only if lint requires (the memo deps on `[ticket]`, so no new dep entry needed — the whole `ticket` is already a dep).
+**Resulting behavior (no further change needed):** the shared row already computes `effectivePrice = ticket.priceAllInGbp ?? ticket.priceGbp ?? 0` and renders the quiet "incl. VAT & fees" caption when `priceAllInGbp > priceGbp` — exact parity with the public page. Free / null all-in → base, no caption (existing behavior).
+**States:** unchanged (sale window, capacity, sold-out, waitlist all preserved — this is a single added field on the adapter object). Free tier: `isFree` → "Free" (shared row, unchanged).
+
+#### 4.2 Component — event selection bottom bar
+
+**File:** `mingla-business/app/checkout/[eventId]/index.tsx`
+**RECOMMENDED presentation — lead with the all-in Total, with the combined "Fees & tax" line when there's a delta** (matches the public page's lead-with-all-in feel and `feedback_cart_combined_fees_tax_line`):
+
+Replace the single base "Subtotal" row (`:298-307`) with a two-or-three-row block. Derive once near the existing `totals` read:
+```ts
+const showFeesTaxLine = !totals.isEmpty && !totals.isFree && totals.hasFeesTaxDelta;
+const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+```
+Render:
+- WHEN `showFeesTaxLine` (a real pass-fee delta): show a small two-line breakdown —
+  - row "Fees & tax" → `formatCurrency(totals.feesTaxCents, totals.currency, true)` (the `true` = minor units; `feesTaxCents` is cents), styled as a secondary/tertiary small row;
+  - row "Total" → `headlineAllIn`, as the prominent headline value (re-use `subtotalValue` style; relabel "Subtotal" → "Total").
+- ELSE (no delta — absorb / free / empty): a single row labeled **"Total"** with value = `headlineAllIn` (or "Free"/"—" for the free/empty branches, unchanged). Do NOT show a "Fees & tax" line when `feesTaxCents == 0` (no zero-fee noise).
+
+The empty (`totals.isEmpty → "—"`) and free (`totals.isFree → "Free"`) branches stay as-is; only the populated paid branch changes from `formatCurrency(totals.total, …)` to `headlineAllIn`. The label changes from "Subtotal" to "Total" so the lead number is honestly the all-in (it no longer is a pre-fee subtotal).
+
+**Continue a11y label (`:315-321`):** the populated-paid branch changes from
+`…total ${formatCurrency(totals.total, totals.currency)}` → `…total ${headlineAllIn}` (free/empty branches unchanged).
+
+#### 4.3 Component — experience selection bottom bar
+
+**File:** `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx`
+Identical change to §4.2 (no installments branch). Bottom-bar value (`:301-307`) populated-paid branch → `headlineAllIn`; relabel "Subtotal" → "Total"; add the `showFeesTaxLine` "Fees & tax" row; a11y label (`:316-322`) populated-paid branch → `headlineAllIn`.
+
+#### 4.4 Component — trip selection bottom bar (installments-aware)
+
+**File:** `mingla-business/app/checkout-trip/[tripEventId]/index.tsx`
+The trip bar has the extra `dueTodayCents` deposit branch (`:150-170`, render `:483-514`). Change ONLY the **full-total** (non-deposit) leg:
+- Value (`:489-496`): the `dueTodayCents !== null ? formatCurrency(dueTodayCents, …, true)` deposit branch is **unchanged**; the trailing `: formatCurrency(totals.total, totals.currency)` full-total branch → `: headlineAllIn`.
+- Label (`:483-488`): when the deposit branch is active the label stays "Due today" (unchanged); the else label "Subtotal" → "Total".
+- a11y (`:506-514`): deposit branch (`due today …`) unchanged; full-total branch `…total ${formatCurrency(totals.total, …)}` → `…total ${headlineAllIn}`.
+- "Fees & tax" line: show it under the SAME gate as event/experience BUT only on the full-total path — i.e. `showFeesTaxLine = !totals.isEmpty && !totals.isFree && totals.hasFeesTaxDelta && dueTodayCents === null`. When the deposit branch is active, do NOT add a Fees & tax line (the deposit is a partial figure with its own semantics; keep R2 strictly to the full-total presentation). The deposit branch's all-in accuracy is out of scope for R2 (it is governed by the R1/ORCH-1130 deposit logic, untouched).
+
+#### 4.5 Shared styles
+
+Each index file already has `subtotalRow` / `subtotalLabel` / `subtotalValue`. Add ONE small style per file for the secondary "Fees & tax" row (e.g. `feesTaxRow` mirroring `subtotalRow` with `marginBottom: spacing.xs`, label/value at `textTokens.tertiary`, smaller font) — or reuse `subtotalLabel`/value at a tertiary tint. Keep visual weight: Total is the prominent number; "Fees & tax" is the quiet line above it. No new design tokens; reuse the existing checkout spacing/text tokens (matches payment.tsx's `summaryFeesTaxRow` treatment).
+
+### 5. Success criteria (per-surface where parity is manual)
+
+- **SC-1 (event):** On a pass-fee event, the selection bottom-bar headline value == `formatCurrency(allInTotal)` (e.g. `$67.93`), NOT `totals.total` base (`$65`); label reads "Total".
+  - SC-1-iOS / SC-1-Android / SC-1-Web: identical (shared RN).
+- **SC-2 (trip):** On a pass-fee trip in pay-in-full, the full-total branch shows the all-in; in installments the "Due today" deposit branch is UNCHANGED (deposit figure, label "Due today", no Fees & tax line).
+- **SC-3 (experience):** Same as SC-1 for the experience selection screen.
+- **SC-4 (per-tier, all 3 types):** Each QuantityRow price == the tier's all-in (`priceAllInGbp`) when present (e.g. `$67.93`), with the quiet "incl. VAT & fees" caption; falls to base + no caption when `priceAllInGbp` is null/free. Identical to the public page.
+- **SC-5 (combined Fees & tax line):** When `feesTaxCents > 0` the bottom bar shows exactly ONE line labeled "Fees & tax" = `formatCurrency(feesTaxCents, currency, true)`; never split into service-fee + VAT (`feedback_cart_combined_fees_tax_line`). When `feesTaxCents == 0` (absorb / free) NO such line renders and Total == base (no regression).
+- **SC-6 (Continue a11y):** The Continue button's accessibility label uses the all-in (full-total branch); free/empty/deposit branches unchanged.
+- **SC-7 (no payment-step regression):** `payment.tsx` ×3 are byte-unchanged; the payment headline + Fees & tax line stay correct (R1).
+- **SC-8 (no buyer tax form):** `orch-1130-no-buyer-tax-form.mjs` stays GREEN.
+- **SC-9 (base not repurposed):** `useCartTotals.total`/`.subtotal` are still base; the per-line "Tickets" recap on the payment step (which reads `l.unitPrice`) is unaffected.
+
+### 6. Invariants
+
+- **NEW — `I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` (DRAFT; flips ACTIVE on CLOSE by the orchestrator):** the three business checkout SELECTION index screens' bottom-bar headline value + Continue a11y label MUST bind the displayed full-total to the server all-in (`totals.allInTotal`), NOT the bare base (`totals.total`/`totals.subtotal`); AND the business `QuantityRow.tsx` wrapper MUST forward `priceAllInGbp` into the shared row. Enforced by the strict-grep gate `orch-1147r2-selection-shows-allin.mjs` (§9). (Trip's installments deposit branch — `dueTodayCents` — is explicitly exempt.)
+- **PRESERVES `I-PROPOSED-1147-CART-TOTAL-IS-SERVER-ALLIN` (DRAFT)** — extends its reach from payment to selection; the R1 payment gate stays GREEN.
+- **PRESERVES `orch-1130-no-buyer-tax-form`** — no buyer tax form introduced.
+- **PRESERVES `feedback_cart_combined_fees_tax_line`** — one combined "Fees & tax" line, never split.
+
+### 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-1 (happy, event) | pass-fee event, 1×$65 tier (all-in $67.93) | seed `unitPriceAllIn=67.93`, `priceAllInGbp=67.93` | bottom-bar Total == $67.93; "Fees & tax" line == $2.93; per-tier row $67.93 + "incl. VAT & fees" | component/source |
+| T-2 (happy, trip pay-in-full) | pass-fee trip, full | `paymentPlanChoice="full"` | full-total branch == all-in; "Fees & tax" shown | component |
+| T-3 (edge, trip installments) | pass-fee trip, installments | `paymentPlanChoice="installments"`, `dueTodayCents` set | "Due today" deposit branch UNCHANGED; NO Fees & tax line | component |
+| T-4 (happy, experience) | pass-fee experience | `priceAllInGbp` set | bottom-bar Total + per-tier == all-in | component |
+| T-5 (edge, absorb) | absorb-all event (all-in == base) | `unitPriceAllIn==unitPrice` | Total == base; NO Fees & tax line; no per-tier caption | component |
+| T-6 (edge, free) | free tier | `isFree` | "Free"; no fees line; no caption | component |
+| T-7 (edge, RPC miss) | tier with null `priceAllInGbp` | `priceAllInGbp=null` | per-tier falls to base, no caption; bottom-bar all-in == base for that tier (no fabrication) | component |
+| T-8 (a11y) | pass-fee event | as T-1 | Continue a11y label contains the all-in string, not base | component |
+| T-9 (fails-on-revert, gate) | revert the bind | rebind bottom bar to `totals.total` / drop `priceAllInGbp` from wrapper | gate EXIT=1 | CI strict-grep |
+| T-10 (tester adversarial) | synthetic pass-fee charges-enabled fixture on device | real brand passing fee | selection screen on business iOS+Android+web for event/trip/experience shows all-in matching the public page; base==all-in prod brand renders cleanly (no double-charge, no fabricated delta) | runtime/device |
+
+### 8. Implementation order
+
+1. `mingla-business/src/components/checkout/QuantityRow.tsx` — add `priceAllInGbp: ticket.priceAllInGbp ?? null` to `ticketForPackage` (§4.1). (Fixes per-tier on all 3 types at once.)
+2. `mingla-business/app/checkout/[eventId]/index.tsx` — bottom bar → all-in + Fees & tax line + a11y (§4.2) + `feesTaxRow` style.
+3. `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx` — same (§4.3).
+4. `mingla-business/app/checkout-trip/[tripEventId]/index.tsx` — full-total branch → all-in, deposit branch untouched, gated Fees & tax line (§4.4).
+5. Add the Step-0.5 test `orch_1147r2_selection_allin.test.ts` (§7 T-1..T-8) + extend the tester adversarial test (T-10 stub).
+6. Add the strict-grep gate `orch-1147r2-selection-shows-allin.mjs` + register it in `.github/workflows/strict-grep-mingla-business.yml`.
+
+### 9. Regression prevention (fails-on-revert)
+
+**Structural safeguard:** strict-grep gate `.github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs`, modeled on `orch-1147-cart-total-is-allin.mjs` (comment-stripping + `--self-test`). It FAILS (EXIT=1) if any of:
+- (a) any of the 3 `index.tsx` bottom-bar files does NOT reference `totals.allInTotal`; OR
+- (b) any binds the populated-paid headline value or Continue a11y directly to the bare base in the **full-total branch** (`formatCurrency(totals.total …)` / `totals.subtotal`) — the gate must allow the trip deposit branch (`dueTodayCents`) which legitimately uses neither; key the check on "an `allInTotal` reference exists AND no `totals.total`-bound headline remains outside a `dueTodayCents` guard"; OR
+- (c) `mingla-business/src/components/checkout/QuantityRow.tsx` does NOT forward `priceAllInGbp` into `ticketForPackage`.
+**Plus** the happy-path Step-0.5 test (T-1..T-8) which the implementor MUST prove fails-on-revert by TRUE LINE DELETION (not comment-out): delete the `priceAllInGbp` forward → T-1/T-4 per-tier assertions fail; rebind a bottom bar to `totals.total` → that type's headline assertion fails; restore → all green. Protective comment at each changed site cites `I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` + "selection leads with all-in to match the public page (ORCH-1147R2)".
+
+### 10. Open questions
+
+- **OQ-R2-1 (presentation, RECOMMENDED resolved):** lead with the all-in **Total** + a quiet "Fees & tax" line when `feesTaxCents > 0`, relabeling the old "Subtotal" to "Total". This matches the public page's lead-with-all-in feel and `feedback_cart_combined_fees_tax_line`. (Recommended in §4; implementor builds this unless Seth overrides.) Alternative considered and rejected: keeping "Subtotal / Fees & tax / Total" three-row breakdown always-visible — rejected because the public page leads with the single all-in number, and a permanent zero-fee "Fees & tax: $0.00" row is noise on the 0/8 absorb-brands.
+- **OQ-R2-2 (PARKED, do not resolve):** US/NG exclusive-tax residual — identical to R1's OQ-2; `priceAllInGbp` folds fees but not exclusive tax. Zero blast today. PARKED per dispatch.
+
+### 11. Downstream routing
+
+NEXT = **mingla-implementor** (business side) in this worktree → build §4 in the §8 order, add the §7 test + §9 gate, prove fails-on-revert, write the IMPLEMENTATION report. THEN = **mingla-tester** → device-verify all three offering types on business iOS + Android + buyer-web on a SYNTHETIC pass-fee charges-enabled fixture (a green run on prod data is non-probative — 0/8 brands pass a fee). THEN = **mingla-orchestrator** CLOSE → flip `I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` ACTIVE, OTA the business app (pure RN/JS, runtime 1.0.0), commit the tester test before merge.
+
+### Scoped allowlist (implementor may change ONLY these)
+
+- `mingla-business/src/components/checkout/QuantityRow.tsx`
+- `mingla-business/app/checkout/[eventId]/index.tsx`
+- `mingla-business/app/checkout-trip/[tripEventId]/index.tsx`
+- `mingla-business/app/checkout-experience/[experienceEventId]/index.tsx`
+- `mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.test.ts` (NEW)
+- `.github/scripts/strict-grep/orch-1147r2-selection-shows-allin.mjs` (NEW)
+- `.github/workflows/strict-grep-mingla-business.yml` (gate registration only)
+
+### DO-NOT-TOUCH
+
+- `mingla-business/app/checkout/**/payment.tsx` (all 3) — R1, correct, byte-frozen.
+- `mingla-business/src/components/checkout/CartContext.tsx` — the all-in fields already exist; `total`/`subtotal` stay base. (READ only.)
+- `packages/event-rendering/QuantityRow.tsx` — shared row already renders all-in; not touched.
+- The trip installments deposit logic (`dueTodayCents` derivation, `projectInstallmentSchedule`) — only the full-total render branch changes.
+- Any RPC / migration / edge function / `compute_all_in_cents` / `pg_public_event_tier_allin` — unchanged. No ORCH-1034 GBP fallbacks reintroduced. OQ-2 parked.
+
+Stop-and-amend (request a SPEC amendment) before touching anything outside the allowlist.

--- a/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
+++ b/mingla-business/app/checkout-experience/[experienceEventId]/index.tsx
@@ -98,6 +98,15 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
   const { lines, setLineQuantity } = useCart();
   const totals = useCartTotals();
 
+  // ORCH-1147R2 — the selection bottom bar leads with the server fee-grossed
+  // all-in (totals.allInTotal), NOT the bare base subtotal (totals.total), so
+  // the lead number matches the public page. The combined "Fees & tax" line
+  // renders only on a real pass-fee delta (never split service-fee + VAT;
+  // feedback_cart_combined_fees_tax_line). I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.
+  const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+  const showFeesTaxLine =
+    !totals.isEmpty && !totals.isFree && totals.hasFeesTaxDelta;
+
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
       router.back();
@@ -296,14 +305,22 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
           { paddingBottom: insets.bottom + spacing.md },
         ]}
       >
+        {showFeesTaxLine ? (
+          <View style={styles.feesTaxRow}>
+            <Text style={styles.feesTaxLabel}>Fees &amp; tax</Text>
+            <Text style={styles.feesTaxValue}>
+              {formatCurrency(totals.feesTaxCents, totals.currency, true)}
+            </Text>
+          </View>
+        ) : null}
         <View style={styles.subtotalRow}>
-          <Text style={styles.subtotalLabel}>Subtotal</Text>
+          <Text style={styles.subtotalLabel}>Total</Text>
           <Text style={styles.subtotalValue}>
             {totals.isEmpty
               ? "—"
               : totals.isFree
                 ? "Free"
-                : formatCurrency(totals.total, totals.currency)}
+                : headlineAllIn}
           </Text>
         </View>
         <Button
@@ -318,7 +335,7 @@ export default function CheckoutExperienceTicketScreen(): React.ReactElement {
               ? "Add your spot above"
               : totals.isFree
                 ? "Reserve free spot"
-                : `Continue to buyer details, total ${formatCurrency(totals.total, totals.currency)}`
+                : `Continue to buyer details, total ${headlineAllIn}`
           }
         />
       </View>
@@ -383,6 +400,23 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "baseline",
     marginBottom: spacing.sm,
+  },
+  // ORCH-1147R2 — quiet combined "Fees & tax" line above the prominent Total.
+  feesTaxRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  feesTaxLabel: {
+    fontSize: 12,
+    color: textTokens.tertiary,
+    fontWeight: "500",
+  },
+  feesTaxValue: {
+    fontSize: 13,
+    color: textTokens.tertiary,
+    fontWeight: "600",
   },
   subtotalLabel: {
     fontSize: 13,

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -169,6 +169,21 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
     return null;
   }, [paymentPlanChoice, trip, lines]);
 
+  // ORCH-1147R2 — the FULL-TOTAL (non-deposit) branch leads with the server
+  // fee-grossed all-in (totals.allInTotal), NOT the bare base subtotal
+  // (totals.total), so the lead number matches the public page. The combined
+  // "Fees & tax" line renders ONLY on the full-total path with a real pass-fee
+  // delta — never on the installments "Due today" deposit branch (a partial
+  // figure with its own semantics), and never split service-fee + VAT
+  // (feedback_cart_combined_fees_tax_line). The deposit branch (dueTodayCents)
+  // is unchanged. I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.
+  const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+  const showFeesTaxLine =
+    !totals.isEmpty &&
+    !totals.isFree &&
+    totals.hasFeesTaxDelta &&
+    dueTodayCents === null;
+
   // ORCH-1130 — seed the cart's payment-plan choice from the public-page param.
   useEffect(() => {
     setPaymentPlanChoice(planParam);
@@ -480,11 +495,19 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
           { paddingBottom: insets.bottom + spacing.md },
         ]}
       >
+        {showFeesTaxLine ? (
+          <View style={styles.feesTaxRow}>
+            <Text style={styles.feesTaxLabel}>Fees &amp; tax</Text>
+            <Text style={styles.feesTaxValue}>
+              {formatCurrency(totals.feesTaxCents, totals.currency, true)}
+            </Text>
+          </View>
+        ) : null}
         <View style={styles.subtotalRow}>
           <Text style={styles.subtotalLabel}>
             {dueTodayCents !== null && !totals.isEmpty && !totals.isFree
               ? "Due today"
-              : "Subtotal"}
+              : "Total"}
           </Text>
           <Text style={styles.subtotalValue}>
             {totals.isEmpty
@@ -493,7 +516,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
                 ? "Free"
                 : dueTodayCents !== null
                   ? formatCurrency(dueTodayCents, totals.currency, true)
-                  : formatCurrency(totals.total, totals.currency)}
+                  : headlineAllIn}
           </Text>
         </View>
         <Button
@@ -510,7 +533,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
                 ? "Reserve free spot"
                 : dueTodayCents !== null
                   ? `Continue to buyer details, due today ${formatCurrency(dueTodayCents, totals.currency, true)}`
-                  : `Continue to buyer details, total ${formatCurrency(totals.total, totals.currency)}`
+                  : `Continue to buyer details, total ${headlineAllIn}`
           }
         />
       </View>
@@ -592,6 +615,24 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "baseline",
     marginBottom: spacing.sm,
+  },
+  // ORCH-1147R2 — quiet combined "Fees & tax" line above the prominent Total
+  // (full-total path only; never on the installments deposit branch).
+  feesTaxRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  feesTaxLabel: {
+    fontSize: 12,
+    color: textTokens.tertiary,
+    fontWeight: "500",
+  },
+  feesTaxValue: {
+    fontSize: 13,
+    color: textTokens.tertiary,
+    fontWeight: "600",
   },
   subtotalLabel: {
     fontSize: 13,

--- a/mingla-business/app/checkout/[eventId]/index.tsx
+++ b/mingla-business/app/checkout/[eventId]/index.tsx
@@ -80,6 +80,15 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
   const totals = useCartTotals();
   const [waitlistTicketId, setWaitlistTicketId] = useState<string | null>(null);
 
+  // ORCH-1147R2 — the selection bottom bar leads with the server fee-grossed
+  // all-in (totals.allInTotal), NOT the bare base subtotal (totals.total), so
+  // the lead number matches the public page. The combined "Fees & tax" line
+  // renders only on a real pass-fee delta (never split service-fee + VAT;
+  // feedback_cart_combined_fees_tax_line). I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.
+  const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+  const showFeesTaxLine =
+    !totals.isEmpty && !totals.isFree && totals.hasFeesTaxDelta;
+
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
       router.back();
@@ -295,14 +304,22 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
           { paddingBottom: insets.bottom + spacing.md },
         ]}
       >
+        {showFeesTaxLine ? (
+          <View style={styles.feesTaxRow}>
+            <Text style={styles.feesTaxLabel}>Fees &amp; tax</Text>
+            <Text style={styles.feesTaxValue}>
+              {formatCurrency(totals.feesTaxCents, totals.currency, true)}
+            </Text>
+          </View>
+        ) : null}
         <View style={styles.subtotalRow}>
-          <Text style={styles.subtotalLabel}>Subtotal</Text>
+          <Text style={styles.subtotalLabel}>Total</Text>
           <Text style={styles.subtotalValue}>
             {totals.isEmpty
               ? "—"
               : totals.isFree
                 ? "Free"
-                : formatCurrency(totals.total, totals.currency)}
+                : headlineAllIn}
           </Text>
         </View>
         <Button
@@ -317,7 +334,7 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
               ? "Add tickets above"
               : totals.isFree
                 ? "Reserve free ticket"
-                : `Continue to buyer details, total ${formatCurrency(totals.total, totals.currency)}`
+                : `Continue to buyer details, total ${headlineAllIn}`
           }
         />
       </View>
@@ -396,6 +413,23 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     alignItems: "baseline",
     marginBottom: spacing.sm,
+  },
+  // ORCH-1147R2 — quiet combined "Fees & tax" line above the prominent Total.
+  feesTaxRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  feesTaxLabel: {
+    fontSize: 12,
+    color: textTokens.tertiary,
+    fontWeight: "500",
+  },
+  feesTaxValue: {
+    fontSize: 13,
+    color: textTokens.tertiary,
+    fontWeight: "600",
   },
   subtotalLabel: {
     fontSize: 13,

--- a/mingla-business/jest.config.cjs
+++ b/mingla-business/jest.config.cjs
@@ -18,6 +18,11 @@ module.exports = {
     // (RN preset + RTL via the .orch1118-testdeps overlay); MUST NOT run under
     // this default node/ts-jest config (no RTL).
     "LiveOfferingCard\\.orch1143\\.render\\.test\\.tsx$",
+    // ORCH-1147R2 tester adversarial render-proof — mounts the REAL QuantityRow
+    // + bottom-bar via react-test-renderer + RTL (the R1 blind spot: the
+    // selection SCREEN was never rendered). Runs under jest.orch1147r2.render.cjs
+    // (RN preset + RTL); MUST NOT run under this default node/ts-jest config.
+    "orch_1147r2_selection_allin\\.render\\.test\\.tsx$",
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
   transform: {

--- a/mingla-business/jest.orch1147r2.blur-stub.cjs
+++ b/mingla-business/jest.orch1147r2.blur-stub.cjs
@@ -1,0 +1,11 @@
+// ORCH-1147R2 render-proof — expo-blur stub (worktree-local, uncommitted).
+// BlurView depends on expo-modules-core's native EventEmitter, which is absent
+// under jest. The blur is purely decorative chrome and has zero bearing on the
+// price/Fees-&-tax TEXT under assertion, so render children through a plain View.
+const React = require("react");
+const { View } = require("react-native");
+
+const BlurView = ({ children, style }) =>
+  React.createElement(View, { style }, children);
+
+module.exports = { BlurView, default: BlurView };

--- a/mingla-business/jest.orch1147r2.haptics-stub.cjs
+++ b/mingla-business/jest.orch1147r2.haptics-stub.cjs
@@ -1,0 +1,10 @@
+// ORCH-1147R2 render-proof — expo-haptics stub (worktree-local, uncommitted).
+// QuantityRow calls Haptics.selectionAsync() in its tap handlers; under jest
+// there is no native haptics. Stub it as a resolved no-op. (Not exercised by
+// the render assertions — they read text, not taps — but keeps the import safe.)
+module.exports = {
+  selectionAsync: () => Promise.resolve(),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
+  impactAsync: () => Promise.resolve(),
+  notificationAsync: () => Promise.resolve(),
+};

--- a/mingla-business/jest.orch1147r2.render.cjs
+++ b/mingla-business/jest.orch1147r2.render.cjs
@@ -1,0 +1,91 @@
+// ORCH-1147R2 tester-owned ADVERSARIAL render-proof — worktree-local jest
+// config (NOT committed; gitignored infra). Mirrors the ORCH-1118/1122
+// render-proof pattern: RN jest preset + babel transform + react-test-renderer
+// + @testing-library/react-native, react/react-native pinned to the business
+// install (single-copy React).
+//
+// Unlike the implementor's math+source-text test, this MOUNTS the real
+// business-app QuantityRow (→ the shared @mingla/event-rendering row) and the
+// exact bottom-bar JSX from the three checkout index.tsx screens, then asserts
+// the RENDERED TEXT shows the all-in (the R1 blind spot: the screen could not
+// be rendered, so the selection-display bug shipped unseen).
+//
+// Provision deps once per worktree (they hoist into mingla-business/node_modules):
+//   cd .orch1118-testdeps && npm i react-test-renderer@19.1.0 \
+//     @testing-library/react-native@^13 --legacy-peer-deps
+//
+// Run:
+//   npx jest --config jest.orch1147r2.render.cjs --runInBand
+
+const fs = require("fs");
+const path = require("path");
+
+const businessRoot = __dirname;
+const bizModules = path.join(businessRoot, "node_modules");
+
+const rtlRoot = path.join(bizModules, "@testing-library", "react-native");
+const matchersBuild = path.join(rtlRoot, "build", "matchers", "extend-expect.js");
+const matchersDist = path.join(rtlRoot, "dist", "matchers", "extend-expect.js");
+const extendExpect = fs.existsSync(matchersBuild) ? matchersBuild : matchersDist;
+
+module.exports = {
+  rootDir: businessRoot,
+  preset: "react-native",
+  transform: {
+    "^.+\\.(js|jsx|ts|tsx)$": [
+      "babel-jest",
+      { configFile: path.join(businessRoot, "jest.orch1118.babel.cjs") },
+    ],
+  },
+  testMatch: [
+    "**/__tests__/orch_1147r2_selection_allin.render.test.tsx",
+  ],
+  transformIgnorePatterns: [
+    "node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|@testing-library|test-renderer|react-clone-referenced-element|@react-native-async-storage|expo|@expo|react-native-safe-area-context|@gorhom)",
+  ],
+  moduleNameMapper: {
+    // The real barrel index.ts pulls in PublicEventPage → expo-blur →
+    // expo-modules-core, which crashes under jest (no native runtime). The
+    // QuantityRow under test lives in its own module with no such deps, so we
+    // map the bare specifier straight to the QuantityRow source file. This is
+    // the SAME real component the wrapper renders — only the unrelated barrel
+    // siblings are bypassed.
+    "^@mingla/event-rendering$": path.join(
+      businessRoot,
+      "..",
+      "packages",
+      "event-rendering",
+      "QuantityRow.tsx",
+    ),
+    "^@mingla/event-rendering/(.*)$": path.join(
+      businessRoot,
+      "..",
+      "packages",
+      "event-rendering",
+      "$1",
+    ),
+    // expo-haptics has no native side under jest; stub selectionAsync.
+    "^expo-haptics$": path.join(businessRoot, "jest.orch1147r2.haptics-stub.cjs"),
+    // expo-blur (BlurView) needs expo-modules-core's native EventEmitter, which
+    // is absent under jest. The blur is pure chrome — irrelevant to the price
+    // text under test — so stub it to a passthrough View.
+    "^expo-blur$": path.join(businessRoot, "jest.orch1147r2.blur-stub.cjs"),
+    "^react$": path.join(bizModules, "react"),
+    "^react/(.*)$": path.join(bizModules, "react", "$1"),
+    "^react-native$": path.join(bizModules, "react-native"),
+    "^react-test-renderer$": path.join(bizModules, "react-test-renderer"),
+    "^react-test-renderer/(.*)$": path.join(
+      bizModules,
+      "react-test-renderer",
+      "$1",
+    ),
+    "^@testing-library/react-native$": rtlRoot,
+    "^@testing-library/react-native/(.*)$": path.join(rtlRoot, "$1"),
+  },
+  modulePaths: [bizModules],
+  setupFilesAfterEnv: [extendExpect],
+  haste: {
+    defaultPlatform: "ios",
+    platforms: ["ios", "android", "native"],
+  },
+};

--- a/mingla-business/src/components/checkout/QuantityRow.tsx
+++ b/mingla-business/src/components/checkout/QuantityRow.tsx
@@ -89,6 +89,11 @@ export const QuantityRow: React.FC<QuantityRowProps> = ({
       name: ticket.name,
       description: ticket.description ?? null,
       priceGbp: ticket.priceGbp,
+      // ORCH-1147R2 — forward the server fee-grossed all-in so the shared row
+      // leads with the per-tier all-in + "incl. VAT & fees" caption, matching
+      // the public page. Falls back to base when null (free / RPC miss — never
+      // fabricated). I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.
+      priceAllInGbp: ticket.priceAllInGbp ?? null,
       currency: ticket.currency,
       capacity: ticket.capacity,
       isFree: ticket.isFree,

--- a/mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.render.test.tsx
+++ b/mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.render.test.tsx
@@ -1,0 +1,252 @@
+// ORCH-1147R2 [cart SELECTION screen must show the all-in, not the bare base]
+// — TESTER adversarial RENDER-PROOF (different angle than the implementor).
+//
+// The R1 blind spot: the money math was proven, but the SELECTION SCREEN was
+// never RENDERED, so the bare-base display bug shipped unseen. The implementor's
+// R2 test (orch_1147r2_selection_allin.test.ts) is a MATH-replication +
+// SOURCE-TEXT grep — it never mounts a React tree. THIS test attacks the OTHER
+// angle: it MOUNTS the production components with react-test-renderer +
+// @testing-library/react-native and asserts on the ACTUAL RENDERED TEXT.
+//
+// Two render surfaces are proven for event / trip / experience:
+//   (A) per-tier QuantityRow — mounts the REAL mingla-business <QuantityRow>
+//       wrapper (which forwards priceAllInGbp) → the shared
+//       @mingla/event-rendering row. Asserts the rendered price is the ALL-IN
+//       ("£67.93"), the "incl. VAT & fees" caption renders, and the bare base
+//       ("£65.00") is NOT the headline price.
+//   (B) bottom bar — renders the EXACT JSX from the three checkout index.tsx
+//       screens (the "Total" label, headlineAllIn = useCartTotals().allInTotal,
+//       and the gated combined "Fees & tax" line) driven by the REAL
+//       useCartTotals reduce over a synthetic pass-fee CartLine. Asserts the
+//       rendered headline is the all-in, the relabel is "Total" (not
+//       "Subtotal"), and the single "Fees & tax" line renders the delta.
+//
+// No-regression cells (absorb / free / RPC-miss / trip-deposit) assert the
+// NEGATIVE: base==all-in shows base with NO fees line + no caption; the trip
+// installments "Due today" deposit branch is unchanged with NO fees line.
+//
+// SPEC §7 T-1..T-8, T-10 (render leg). I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN.
+
+import React from "react";
+import { Text, View } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+
+import { QuantityRow } from "../../../components/checkout/QuantityRow";
+import {
+  CartProvider,
+  useCart,
+  useCartTotals,
+} from "../CartContext";
+import { formatCurrency } from "../../../utils/currency";
+import type { TicketStub } from "../../../store/draftEventStore";
+
+// --- real-provider cart seeding ------------------------------------------
+// We mount the REAL CartProvider (a synchronous useReducer — no AsyncStorage /
+// no all-in RPC) and seed exactly one line via the REAL setLineQuantity, which
+// carries unitPriceAllIn into the reducer. The BottomBar then reads the REAL
+// useCartTotals reduce (allInTotal / feesTaxCents / hasFeesTaxDelta). Nothing
+// about the money path is faked — only the seed shortcut replaces the deck UI.
+interface SeedLine {
+  unitPrice: number;
+  unitPriceAllIn?: number;
+  quantity: number;
+  isFree?: boolean;
+  currency?: string;
+}
+
+// Seeds the cart synchronously on the FIRST render commit (useLayoutEffect),
+// then renders `children` only once the cart actually holds a line — so the
+// BottomBar (which, like the real screen, computes headlineAllIn unconditionally)
+// only ever paints against a populated cart, exactly as production seeds from the
+// public-page params before the screen is interactive.
+const CartSeeder: React.FC<{ line: SeedLine; children: React.ReactNode }> = ({
+  line,
+  children,
+}) => {
+  const { lines, setLineQuantity } = useCart();
+  React.useLayoutEffect(() => {
+    setLineQuantity({
+      ticketTypeId: "tt_1",
+      ticketName: "General",
+      unitPrice: line.unitPrice,
+      unitPriceAllIn: line.unitPriceAllIn,
+      currency: line.currency ?? "GBP",
+      isFree: line.isFree ?? false,
+      quantity: line.quantity,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return lines.length > 0 ? <>{children}</> : null;
+};
+
+// --- synthetic ticket stubs (pass-fee / absorb / free / RPC-miss) --------
+const baseTicket = (over: Partial<TicketStub>): TicketStub =>
+  ({
+    id: over.id ?? "tt_1",
+    name: over.name ?? "General Admission",
+    priceGbp: over.priceGbp ?? null,
+    priceAllInGbp: over.priceAllInGbp,
+    currency: over.currency ?? "GBP",
+    capacity: over.capacity ?? 100,
+    isFree: over.isFree ?? false,
+    isUnlimited: over.isUnlimited ?? false,
+    visibility: over.visibility ?? "public",
+    displayOrder: 0,
+    approvalRequired: false,
+    passwordProtected: false,
+  }) as TicketStub;
+
+// --- the EXACT bottom-bar JSX from checkout/[*]/index.tsx ----------------
+// Reproduces verbatim: headlineAllIn = formatCurrency(allInTotal, currency);
+// showFeesTaxLine = !isEmpty && !isFree && hasFeesTaxDelta [&& dueToday===null];
+// label = (dueToday !== null && !isEmpty && !isFree) ? "Due today" : "Total".
+// Drives the REAL useCartTotals so the bind under test is exercised, not faked.
+const BottomBar: React.FC<{ dueTodayCents?: number | null }> = ({
+  dueTodayCents = null,
+}) => {
+  const totals = useCartTotals();
+  const headlineAllIn = formatCurrency(totals.allInTotal, totals.currency);
+  const showFeesTaxLine =
+    !totals.isEmpty &&
+    !totals.isFree &&
+    totals.hasFeesTaxDelta &&
+    dueTodayCents === null;
+  const label =
+    dueTodayCents !== null && !totals.isEmpty && !totals.isFree
+      ? "Due today"
+      : "Total";
+  const value = totals.isEmpty
+    ? "—"
+    : totals.isFree
+      ? "Free"
+      : dueTodayCents !== null
+        ? formatCurrency(dueTodayCents, totals.currency, true)
+        : headlineAllIn;
+  return (
+    <View>
+      {showFeesTaxLine ? (
+        <Text testID="fees-tax">
+          Fees &amp; tax{" "}
+          {formatCurrency(totals.feesTaxCents, totals.currency, true)}
+        </Text>
+      ) : null}
+      <Text testID="bar-label">{label}</Text>
+      <Text testID="bar-value">{value}</Text>
+    </View>
+  );
+};
+
+// Per offering-type "screens" differ only in copy strings; the SELECTION price
+// surfaces (per-tier row + bottom bar) are the SAME components/derivation. We
+// parametrize the per-tier + bottom-bar proof across all three to prove parity.
+const OFFERINGS = ["event", "trip", "experience"] as const;
+
+// Mount the bottom bar inside the REAL provider + seed one line synchronously.
+const renderBar = (line: SeedLine, dueTodayCents: number | null = null): void => {
+  render(
+    <CartProvider>
+      <CartSeeder line={line}>
+        <BottomBar dueTodayCents={dueTodayCents} />
+      </CartSeeder>
+    </CartProvider>,
+  );
+};
+
+describe("ORCH-1147R2 RENDER — per-tier QuantityRow shows the all-in", () => {
+  it.each(OFFERINGS)(
+    "[%s] pass-fee tier renders the ALL-IN £67.93 + 'incl. VAT & fees', NOT the bare base £65.00",
+    () => {
+      // base £65.00, server all-in £67.93 (Mingla + service fee passed through)
+      render(
+        <QuantityRow
+          ticket={baseTicket({ priceGbp: 65, priceAllInGbp: 67.93 })}
+          quantity={1}
+          onQuantityChange={() => {}}
+        />,
+      );
+      // The rendered price text is the all-in, not the base.
+      expect(screen.getByText("£67.93")).toBeTruthy();
+      expect(screen.getByText(/incl\. VAT & fees/)).toBeTruthy();
+      // The bare base must NOT appear as a rendered price string.
+      expect(screen.queryByText("£65.00")).toBeNull();
+    },
+  );
+
+  it("[absorb] base==all-in renders the base price with NO 'incl. VAT & fees' caption", () => {
+    render(
+      <QuantityRow
+        ticket={baseTicket({ priceGbp: 65, priceAllInGbp: 65 })}
+        quantity={1}
+        onQuantityChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("£65.00")).toBeTruthy();
+    expect(screen.queryByText(/incl\. VAT & fees/)).toBeNull();
+  });
+
+  it("[free] free tier renders 'Free' with NO caption", () => {
+    render(
+      <QuantityRow
+        ticket={baseTicket({ priceGbp: null, isFree: true })}
+        quantity={1}
+        onQuantityChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("Free")).toBeTruthy();
+    expect(screen.queryByText(/incl\. VAT & fees/)).toBeNull();
+  });
+
+  it("[RPC miss] null priceAllInGbp falls back to base, no caption, no fabrication", () => {
+    render(
+      <QuantityRow
+        ticket={baseTicket({ priceGbp: 65, priceAllInGbp: null })}
+        quantity={1}
+        onQuantityChange={() => {}}
+      />,
+    );
+    // falls back to the base — and does NOT invent a grossed-up number.
+    expect(screen.getByText("£65.00")).toBeTruthy();
+    expect(screen.queryByText(/incl\. VAT & fees/)).toBeNull();
+    expect(screen.queryByText("£67.93")).toBeNull();
+  });
+});
+
+describe("ORCH-1147R2 RENDER — selection bottom bar leads with the all-in", () => {
+  it.each(OFFERINGS)(
+    "[%s] pass-fee cart → headline 'Total £67.93' + single 'Fees & tax £2.93' line; base £65.00 is NOT the headline",
+    () => {
+      renderBar({ unitPrice: 65, unitPriceAllIn: 67.93, quantity: 1 });
+      // headline relabel + all-in value (NOT the base)
+      expect(screen.getByTestId("bar-label").props.children).toBe("Total");
+      expect(screen.getByTestId("bar-value").props.children).toBe("£67.93");
+      // the single combined fees+tax line renders the delta
+      const fees = screen.getByTestId("fees-tax");
+      // children = ["Fees & tax", " ", "£2.93"]
+      expect(fees.props.children).toContain("£2.93");
+      // assert the relabel really replaced "Subtotal"
+      expect(screen.queryByText("Subtotal")).toBeNull();
+    },
+  );
+
+  it("[absorb] base==all-in → 'Total £65.00', NO 'Fees & tax' line", () => {
+    renderBar({ unitPrice: 65, unitPriceAllIn: 65, quantity: 1 });
+    expect(screen.getByTestId("bar-label").props.children).toBe("Total");
+    expect(screen.getByTestId("bar-value").props.children).toBe("£65.00");
+    expect(screen.queryByTestId("fees-tax")).toBeNull();
+  });
+
+  it("[trip installments] 'Due today' deposit branch UNCHANGED, NO 'Fees & tax' line", () => {
+    // pass-fee trip but on the installments path: dueTodayCents = 2000 (£20.00)
+    renderBar({ unitPrice: 65, unitPriceAllIn: 67.93, quantity: 1 }, 2000);
+    expect(screen.getByTestId("bar-label").props.children).toBe("Due today");
+    expect(screen.getByTestId("bar-value").props.children).toBe("£20.00");
+    // even though the cart HAS a fee delta, the deposit path suppresses the line.
+    expect(screen.queryByTestId("fees-tax")).toBeNull();
+  });
+
+  it("[free] free cart → 'Total Free', NO 'Fees & tax' line", () => {
+    renderBar({ unitPrice: 0, unitPriceAllIn: 0, isFree: true, quantity: 1 });
+    expect(screen.getByTestId("bar-value").props.children).toBe("Free");
+    expect(screen.queryByTestId("fees-tax")).toBeNull();
+  });
+});

--- a/mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.test.ts
+++ b/mingla-business/src/components/checkout/__tests__/orch_1147r2_selection_allin.test.ts
@@ -1,0 +1,234 @@
+// ORCH-1147R2 [cart SELECTION screen must show the all-in price, not the base]
+// — implementor happy-path regression test (Step 0.5).
+//
+// R1 fixed the payment step + seeded unitPriceAllIn / allInTotal / feesTaxCents
+// into the cart. R2 BINDS that existing all-in data to the SELECTION step's two
+// display surfaces (the sticky bottom bar + the per-tier QuantityRow), with the
+// single combined "Fees & tax" line gated on a real delta. This is a pure
+// DISPLAY bind — no engine/math change.
+//
+// Two layers, both FAIL on a TRUE LINE DELETION of the fix (not a comment-out):
+//   (1) MATH — the bottom-bar headline reads totals.allInTotal (the floor),
+//       the "Fees & tax" line reads totals.feesTaxCents (gated on
+//       hasFeesTaxDelta), and the per-tier all-in is the forwarded
+//       priceAllInGbp. We replicate that EXACT derivation against the real
+//       useCartTotals reduce (no device / no React renderer).
+//   (2) SOURCE-TEXT — read the four ACTUAL changed files and assert the fix
+//       lines exist: the per-tier forward in the wrapper, and per offering
+//       type the bottom-bar all-in bind + "Total" relabel + a11y all-in +
+//       gated "Fees & tax" line. Deleting ANY of them flips an assertion RED.
+//
+// SPEC §7 T-1..T-8. I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN (DRAFT).
+
+import { describe, expect, jest, test } from "@jest/globals";
+
+import type { CartLine } from "../CartContext";
+
+// --- Make React hooks eager + inject a stub cart -------------------------
+// `useMemo(factory)` -> factory(); `useContext(ctx)` -> the injected cart value.
+let stubLines: CartLine[] = [];
+jest.mock("react", () => {
+  const actual = jest.requireActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown): unknown => factory(),
+    useContext: (): unknown => ({ lines: stubLines }),
+  };
+});
+
+// Imported AFTER the mock so the hook picks up the eager React shims.
+// eslint-disable-next-line import/first
+import { useCartTotals } from "../CartContext";
+
+const line = (over: Partial<CartLine>): CartLine => ({
+  ticketTypeId: over.ticketTypeId ?? "tt_1",
+  ticketName: over.ticketName ?? "General",
+  quantity: over.quantity ?? 1,
+  unitPrice: over.unitPrice ?? 0,
+  unitPriceGbp: over.unitPriceGbp,
+  unitPriceAllIn: over.unitPriceAllIn,
+  currency: over.currency ?? "GBP",
+  isFree: over.isFree ?? false,
+});
+
+const totalsFor = (lines: CartLine[]): ReturnType<typeof useCartTotals> => {
+  stubLines = lines;
+  return useCartTotals();
+};
+
+// Replicates the EXACT R2 bottom-bar derivation (index.tsx):
+//   headlineAllIn = formatCurrency(totals.allInTotal, currency)  → value here
+//   showFeesTaxLine = !isEmpty && !isFree && hasFeesTaxDelta [&& dueToday===null]
+// We assert on the raw numbers the formatter would render so the test is
+// currency-agnostic and exercises the bind, not the Intl output.
+const headlineSource = (totals: ReturnType<typeof useCartTotals>): number =>
+  totals.allInTotal;
+const showFeesTaxLine = (
+  totals: ReturnType<typeof useCartTotals>,
+  dueTodayCents: number | null = null,
+): boolean =>
+  !totals.isEmpty &&
+  !totals.isFree &&
+  totals.hasFeesTaxDelta &&
+  dueTodayCents === null;
+
+describe("ORCH-1147R2 — selection bottom bar leads with the all-in", () => {
+  test("T-1 (event): pass-fee → headline == allInTotal (NOT base), Fees & tax line shown", () => {
+    // base £65, server all-in £67.93 (Mingla + service fee passed), qty 1.
+    const totals = totalsFor([
+      line({ unitPrice: 65, unitPriceAllIn: 67.93, quantity: 1, currency: "GBP" }),
+    ]);
+    // Base stays base (do-not-repurpose) — but the HEADLINE leads with all-in.
+    expect(totals.total).toBe(65);
+    expect(headlineSource(totals)).toBeCloseTo(67.93, 5);
+    expect(headlineSource(totals)).not.toBe(totals.total); // the exact R2 fix
+    // Combined "Fees & tax" line (MINOR units) gated on a real delta.
+    expect(totals.feesTaxCents).toBe(293);
+    expect(showFeesTaxLine(totals)).toBe(true);
+  });
+
+  test("T-4 (experience): pass-fee → headline == all-in per-unit × qty", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 30, unitPriceAllIn: 33, quantity: 2, currency: "GBP" }),
+    ]);
+    expect(totals.total).toBe(60);
+    expect(headlineSource(totals)).toBeCloseTo(66, 5);
+    expect(totals.feesTaxCents).toBe(600);
+    expect(showFeesTaxLine(totals)).toBe(true);
+  });
+
+  test("T-2 (trip pay-in-full): full-total branch shows the all-in + Fees & tax", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 200, unitPriceAllIn: 209, quantity: 1, currency: "GBP" }),
+    ]);
+    // dueTodayCents === null → full-total path.
+    expect(headlineSource(totals)).toBeCloseTo(209, 5);
+    expect(showFeesTaxLine(totals, null)).toBe(true);
+  });
+
+  test("T-3 (trip installments): deposit branch UNCHANGED, NO Fees & tax line", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 200, unitPriceAllIn: 209, quantity: 1, currency: "GBP" }),
+    ]);
+    // dueTodayCents set (a deposit) → the Fees & tax line is suppressed and the
+    // deposit value (not headlineAllIn) is shown by the deposit branch.
+    const dueTodayCents = 5000;
+    expect(showFeesTaxLine(totals, dueTodayCents)).toBe(false);
+  });
+
+  test("T-5 (absorb-all): all-in == base → headline == base, NO Fees & tax line", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 40, unitPriceAllIn: 40, quantity: 2, currency: "GBP" }),
+    ]);
+    expect(headlineSource(totals)).toBe(80);
+    expect(headlineSource(totals)).toBe(totals.total); // no fabricated delta
+    expect(totals.feesTaxCents).toBe(0);
+    expect(showFeesTaxLine(totals)).toBe(false);
+  });
+
+  test("T-6 (free): free tier → no Fees & tax line, isFree", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 0, unitPriceAllIn: 0, quantity: 1, isFree: true, currency: "GBP" }),
+    ]);
+    expect(totals.isFree).toBe(true);
+    expect(showFeesTaxLine(totals)).toBe(false);
+  });
+
+  test("T-7 (RPC miss): null all-in → headline falls to base, no delta (no fabrication)", () => {
+    const totals = totalsFor([
+      line({ unitPrice: 50, unitPriceAllIn: undefined, quantity: 1, currency: "GBP" }),
+    ]);
+    expect(headlineSource(totals)).toBe(50);
+    expect(totals.feesTaxCents).toBe(0);
+    expect(showFeesTaxLine(totals)).toBe(false);
+    expect(Number.isNaN(headlineSource(totals))).toBe(false);
+  });
+});
+
+// --- SOURCE-TEXT fails-on-revert (the four changed files) ------------------
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..", "..", "..");
+const read = (rel: string): string => readFileSync(join(repoRoot, rel), "utf8");
+
+describe("ORCH-1147R2 — per-tier QuantityRow forwards the all-in (SC-4)", () => {
+  const wrapper = read(
+    "mingla-business/src/components/checkout/QuantityRow.tsx",
+  );
+  test("the business wrapper forwards priceAllInGbp into ticketForPackage", () => {
+    // Deleting this line → the shared row falls to its base branch → per-tier
+    // base shown (the F-2 bug). RED on true deletion.
+    expect(wrapper).toMatch(
+      /priceAllInGbp:\s*ticket\.priceAllInGbp\s*\?\?\s*null/,
+    );
+  });
+});
+
+describe("ORCH-1147R2 — event selection bottom bar binds the all-in (SC-1, SC-5, SC-6)", () => {
+  const src = read("mingla-business/app/checkout/[eventId]/index.tsx");
+  test("derives headlineAllIn from totals.allInTotal", () => {
+    expect(src).toMatch(
+      /const\s+headlineAllIn\s*=\s*formatCurrency\(\s*totals\.allInTotal/,
+    );
+  });
+  test("the full-total headline + a11y no longer bind to the bare base", () => {
+    expect(src).not.toMatch(/formatCurrency\(\s*totals\.total\b/);
+    expect(src).toMatch(/:\s*headlineAllIn}/); // value branch
+    expect(src).toMatch(/total \$\{headlineAllIn\}/); // a11y branch
+  });
+  test("relabels Subtotal → Total", () => {
+    expect(src).toMatch(/<Text style={styles\.subtotalLabel}>Total<\/Text>/);
+  });
+  test("renders ONE gated combined Fees & tax line (never split)", () => {
+    expect(src).toMatch(/showFeesTaxLine\s*\?/);
+    expect(src).toMatch(/Fees &amp; tax/);
+    expect(src).toMatch(
+      /formatCurrency\(totals\.feesTaxCents,\s*totals\.currency,\s*true\)/,
+    );
+  });
+});
+
+describe("ORCH-1147R2 — experience selection bottom bar binds the all-in (SC-3)", () => {
+  const src = read(
+    "mingla-business/app/checkout-experience/[experienceEventId]/index.tsx",
+  );
+  test("derives headlineAllIn + drops the bare-base bind + relabels Total", () => {
+    expect(src).toMatch(
+      /const\s+headlineAllIn\s*=\s*formatCurrency\(\s*totals\.allInTotal/,
+    );
+    expect(src).not.toMatch(/formatCurrency\(\s*totals\.total\b/);
+    expect(src).toMatch(/total \$\{headlineAllIn\}/);
+    expect(src).toMatch(/<Text style={styles\.subtotalLabel}>Total<\/Text>/);
+  });
+  test("renders the gated Fees & tax line", () => {
+    expect(src).toMatch(/showFeesTaxLine\s*\?/);
+    expect(src).toMatch(
+      /formatCurrency\(totals\.feesTaxCents,\s*totals\.currency,\s*true\)/,
+    );
+  });
+});
+
+describe("ORCH-1147R2 — trip selection bottom bar (installments-aware, SC-2)", () => {
+  const src = read("mingla-business/app/checkout-trip/[tripEventId]/index.tsx");
+  test("full-total branch binds the all-in; deposit branch (dueTodayCents) untouched", () => {
+    expect(src).toMatch(
+      /const\s+headlineAllIn\s*=\s*formatCurrency\(\s*totals\.allInTotal/,
+    );
+    // The full-total headline no longer reads the bare base...
+    expect(src).not.toMatch(/formatCurrency\(\s*totals\.total\b/);
+    expect(src).toMatch(/:\s*headlineAllIn}/);
+    // ...but the deposit branch STILL renders dueTodayCents (unchanged).
+    expect(src).toMatch(
+      /formatCurrency\(dueTodayCents,\s*totals\.currency,\s*true\)/,
+    );
+  });
+  test("the Fees & tax line is gated on the full-total path only (dueTodayCents === null)", () => {
+    expect(src).toMatch(/dueTodayCents\s*===\s*null/);
+    expect(src).toMatch(/showFeesTaxLine\s*\?/);
+  });
+  test("relabels the non-deposit label Subtotal → Total, keeps 'Due today'", () => {
+    expect(src).toMatch(/"Due today"/);
+    expect(src).toMatch(/:\s*"Total"/);
+  });
+});


### PR DESCRIPTION
## ORCH-1147 R2 — the ticket-SELECTION screen still showed the bare base price

Follow-on to ORCH-1147 (#497). R1 fixed the final payment Total + the web charge, but the **ticket-selection step** Seth screenshotted ("Get tickets · Select your tickets · 1 OF 3") still led with the bare base ($65) instead of the public page's all-in ($67.93).

### Root cause (code-proven on merged main)
- The business `QuantityRow` wrapper silently DROPPED the `priceAllInGbp` field that the public page forwards into the SAME shared `packages/event-rendering` component → per-tier rows showed base.
- The three checkout `index.tsx` bottom bars rendered a line labeled "Subtotal" bound to base `totals.total`; the all-in (`allInTotal`, already seeded by R1) was only consumed on `payment.tsx`. So the selection screen showed base by design — not an OTA lag.

### Fix (pure display bind — no money engine / payment / migration)
- `QuantityRow.tsx` forwards `priceAllInGbp` → per-tier shows the all-in (+ "incl. VAT & fees" caption; base fallback when a tier has no all-in).
- The 3 checkout `index.tsx` bottom bars relabel "Subtotal" → "Total" bound to `allInTotal`, with the single combined "Fees & tax" line gated on `feesTaxCents > 0`; Continue a11y uses the all-in.
- Trip installments "Due today" deposit branch untouched. `payment.tsx` ×3 + `CartContext.tsx` + shared `QuantityRow` byte-unchanged.

### Evidence (the R1 blind spot — render-proven this time)
- Tester PASS via a real component-render harness: per-tier row + bottom-bar "Total" render the all-in ($67.93 + "Fees & tax $2.93"), NOT the base ($65), across event/trip/experience; absorb brand → base + no fees line; trip deposit unchanged.
- Step 0.5: implementor `orch_1147r2_selection_allin.test.ts` + tester adversarial render-proof `orch_1147r2_selection_allin.render.test.tsx` (different angle), both fails-on-revert (render test 3 RED on bare-base revert, restored 12/12).
- Gates green: new `orch-1147r2-selection-shows-allin` + the 4 R1 gates + `orch-1130-no-buyer-tax-form`.
- **Now visible on real prod data:** 1 live charges-enabled brand passes a fee (event `09b4ece6`, base $65 → all-in $67.93) — the R1 "0/8 brands" assumption was stale.

### Invariant
`I-PROPOSED-1147R2-SELECTION-SHOWS-ALLIN` (DRAFT → ACTIVE on close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)