### PR TITLE
ORCH-1150: RSVP event — Partiful-style ticketless event (sibling wizard + host console + waitlist + push/SMS/email notify) [deploy]

### DIFF
--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1150_RSVP_EVENT_WIZARD_WALKTHROUGH.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1150_RSVP_EVENT_WIZARD_WALKTHROUGH.md
@@ -1,0 +1,183 @@
+# INVESTIGATE ORCH-1150 — RSVP Event (Partiful-style) Create/Edit Wizard: Screen-by-Screen Fork Walkthrough
+
+**Mode:** INVESTIGATE (read-only walkthrough). No product code edited, no worktree, no migrations.
+**Anchor:** `/Users/sethogieva/Desktop/mingla-main` on `main`.
+**Date:** 2026-06-15.
+**Comms ledger:** Read on entry. No OPEN entry targets `mingla-forensics`, `ORCH-1150`, or `ALL` with BLOCK status. Latest active entries (COMMS-0029/0033) concern ORCH-1119/1120 trip RPC clobber + ORCH-1133 ID collision — neither relevant here. Nothing to ack.
+
+> This is a forensic walkthrough, NOT a spec and NOT a migration. Where I would normally propose a fix, I state the **fork verdict + regression risk**. Every behavioral claim cites `file:line` I actually read.
+
+---
+
+## 1. Executive Summary
+
+The RSVP-event clone is **feasible and structurally clean**, because the schema already carries a first-class discriminator — `events.event_type` with CHECK `IN ('event','experience','trip')` (`supabase/migrations/20260605000000_orch_0826_events_event_type_discriminator.sql:33-34`) — and Mingla already has a working precedent for forking a wizard off it (the experience + trip wizards are sibling clones of the event wizard, each with its own publish RPC). The cleanest fork seam is `UniversalCreatorSheet.tsx`: the "Create event" root row currently routes straight to `/event/create` (`mingla-business/src/components/ui/UniversalCreatorSheet.tsx:110-117`), and ORCH-1144 already established the exact in-sheet two-step pattern (`root` → `experience`) that the RSVP-vs-Ticketed fork should mirror — a new in-sheet "event" step with two rows ("Ticketed event" → `/event/create`, "RSVP event" → a new `/rsvp/create`). The single biggest regression risk is that **the entire event pipeline hard-assumes ≥1 ticket exists**: the publish RPC raises `event_ticket_required` when the tickets array is empty (`...orch_1075...sql:1932-1934`), `validateTickets` rejects an empty ticket list (`mingla-business/src/utils/draftEventValidation.ts:454-460`), and `validatePublish` loops all 7 steps including Tickets (`...draftEventValidation.ts:76-78`) — so a ticketless clone that reuses any of these surfaces verbatim will fail to publish. **New schema IS required**: a CHECK widen to add `'rsvp'` to `event_type`, plus a new per-guest RSVP/attendee table (no event-level guest/RSVP/attendee table exists today — `board_card_rsvps` is an unrelated consumer collab-board concept), because "Going/Not-going" is a genuinely new persistence concept that the free-ticket *order* path does not model. The recommended product default is **invite-link-only (Partiful parity)**: the consumer discover RPC strictly filters `event_type = 'event'` (`supabase/migrations/20261001000000_orch_426_discover_rpc.sql:100`), so an `event_type='rsvp'` row is automatically off-deck with zero extra work — which is exactly the Partiful model and the lowest-regression path.
+
+---
+
+## 2. The Chooser Fork
+
+### How `UniversalCreatorSheet.tsx` routes today
+
+The sheet has TWO in-place steps (`root`, `experience`), introduced by ORCH-1144 (`mingla-business/src/components/ui/UniversalCreatorSheet.tsx:1-57`):
+
+- **Root step** renders 3 rows from `ROOT_OPTIONS` (`:109-139`):
+  - `"Create event"` → `route: "/event/create"` (close + `pushRoute`) — `:110-117`
+  - `"Create experience"` → `step: "experience"` (in-place transition, sheet stays open) — `:118-128`
+  - `"Create trip or otherwise"` → `route: "/trip/create"` — `:129-138`
+- A `RootOption` carries EITHER `route` (close + push) OR `step` (in-place transition), never both (`:94-96`). `handleRootSelect` (`:203-213`) checks `option.step` first (transition), else `pushRoute(option.route)`.
+- `pushRoute` (`:190-201`) calls `onClose()` then `router.push(route)` after a 50ms scrim-fade delay.
+- The experience step (`:262-311`) is the in-place chooser ORCH-1144 added; `canGoBackToRoot` (`:225`) gates a Back affordance.
+
+### Where the RSVP-vs-Ticketed prompt inserts
+
+The current "Create event" row routes DIRECTLY to `/event/create`. The fork inserts by converting that row from a `route` to a `step` (mirroring how "Create experience" became an in-place step):
+
+- Add `UniversalCreatorStep = "root" | "experience" | "event"` (extend `:73`).
+- Change the `"event"` `ROOT_OPTIONS` entry from `route: "/event/create"` to `step: "event"` (`:110-117`).
+- Add an `EVENT_OPTIONS` array (mirroring `EXPERIENCE_OPTIONS` `:145-173`) with two rows:
+  - `"Ticketed event"` → `route: "/event/create"` (the existing wizard, untouched).
+  - `"RSVP event"` → `route: "/rsvp/create"` (new sibling route).
+- Add an `"event"` branch to the render switch (mirroring the `"experience"` branch `:262-311`) with the same Back-to-root affordance (`:225` pattern generalizes to `step !== "root" && initialStep === "root"`).
+
+**Verdict:** CLONE-VERBATIM the ORCH-1144 in-sheet step pattern. The fork is a pure additive extension of an already-shipped UX idiom. Regression risk here is **near-zero** (the existing `event`/`experience`/`trip` routing rows are unchanged; only "Create event" gains an intermediate step). One thing to verify in SPEC: callers that pass `initialStep` (`:81-84`, Hub > Experiences passes `"experience"`) are unaffected; no caller passes `"event"`.
+
+---
+
+## 3. Screen-by-Screen Walkthrough (the 7 steps)
+
+Step bodies are dispatched by `renderStepBody` in `EventCreatorWizard.tsx:631-673`; step defs + the Stepper labels live at `EventCreatorWizard.tsx:111-126`. Per-step validation is `validateStep(step, draft)` (`draftEventValidation.ts:37-59`). All step bodies share the `StepBodyProps` contract (`types.ts:14-77`).
+
+| # | Step | Today: behavior + draft fields + validateStep rules (cited) | RSVP verdict | Regression risk if forked & how to avoid |
+|---|------|------|------|------|
+| 1 | **Basics** | Renders Name (`CreatorStep1Basics.tsx:173-186`), Format pills in_person/online/hybrid (`:188-201`, field `draft.format`), **Party Type required ≥1** (`:203-220`, `draft.partyTypes`), Vibe Tags optional (`:222-240`), Music Genre optional (`:242-261`), Description required (`:263-294`). `validateBasics` requires `name`, `description`, `partyTypes.length≥1` + canonical-slug checks (`draftEventValidation.ts:106-156`). | **MODIFY.** Keep Name + Description + Format + Vibe Tags. **DROP "Party Type" as a hard-required field** — Partiful events are personal gatherings, not club taxonomy; forcing `party_types_required` (also enforced server-side `...orch_1075...sql:1990-1992`) is wrong for an RSVP. Either make partyTypes optional for RSVP, or drop the pill group entirely. | The publish RPC hard-raises `party_types_required` + `party_types_not_canonical` (`...orch_1075...sql:1990-2000`). A ticketless RSVP that still routes through `business_publish_event_draft` would fail on this even if tickets were solved. **Avoid** by giving the RSVP publish RPC its own (looser) taxonomy gate — do NOT reuse `business_publish_event_draft` verbatim. |
+| 2 | **When** | Single / recurring / multi_date modes (`draft.whenMode`, `date`, `doorsOpen`, `endsAt`, `timezone`, `recurrenceRule`, `multiDates`; types `draftEventStore.ts:257-293`). Validation is mode-branched: single requires date+doorsOpen+endsAt + no-past-date (`draftEventValidation.ts:171-193`); recurring/multi-date add rules (`:195-373`). | **CLONE-VERBATIM** (single mode); **consider DROP recurring/multi_date** for v1. An RSVP party is almost always a single date. Recurring/multi-date pull in the full `event_dates` materialization machinery + `MultiDateOverrideSheet`. | Low if cloned as-is. If recurring/multi_date are kept, the RSVP publish RPC must replicate the master-`event_dates` materialization (the experience RPC's deferred-status-flip BUG-5 fix `...orch_1075...sql:998-1004,1169-1174` shows this is fragile). **Avoid** by shipping RSVP as single-date-only in v1; flag multi-date as a follow-on. |
+| 3 | **Where** | Venue name + Mapbox/Places address (`draft.venueName`, `address`, `city`, `locationGeo`) for in_person/hybrid; online URL for online/hybrid (`CreatorStep3Where` updateDraft keys: `venueName`, `address`+`city`+`locationGeo`, `onlineUrl`). `validateWhere` requires venue+address+**structured city** for in_person/hybrid (`draftEventValidation.ts:377-403`) and a valid URL for online (`:404-418`). | **CLONE-VERBATIM**, but **DROP the hard `city_required`** at publish for RSVP. Partiful lets you type a freeform location ("my place"); forcing a Places-picked structured city is hostile for a house party. | Server raises `city_required` (`...orch_1075...sql:1986-1988`) — same blocker as party_types. **Avoid** via the RSVP-specific publish RPC. Also note `hideAddressUntilTicket` (`draftEventStore.ts:311`) is ticket-coupled copy — for RSVP it should read "hide until RSVP'd Going" (MODIFY copy, keep mechanism). |
+| 4 | **Cover** | Cover hue + uploaded image/video/gif (`draft.coverHue`, `coverMediaUrl`, `coverMediaType`, provider metadata; `draftEventStore.ts:312-323`). `validateCover` returns `[]` — no rules (`draftEventValidation.ts:448-450`). | **KEEP-AS-IS / CLONE-VERBATIM.** Cover is identical for an RSVP. | **None.** Zero validation, no ticket coupling. Lowest-risk step in the wizard. |
+| 5 | **Tickets** | **THE FORK CORE.** Inline ticket CRUD + reorder + "Who covers costs" pricing section (`CreatorStep5Tickets.tsx`). Owns `draft.tickets[]` + `draft.pricingSwitches` + `draft.currency`. `validateTickets` **requires ≥1 ticket** (`draftEventValidation.ts:452-461`) then per-ticket name/price/capacity/password/waitlist/qty rules (`:462-524`). | **DROP entirely; REPLACE with an "RSVP setup" step** (see below). | **#1 regression surface in the whole feature.** See §4. |
+| 6 | **Settings** | Visibility public/unlisted/private + requireApproval + allowTransfers + hideRemainingCount + passwordProtected + **privateGuestList** toggles (`CreatorStep6Settings.tsx:155-157` reads `draft.privateGuestList`; fields `draftEventStore.ts:340-354`). `validateSettings` returns `[]` (`draftEventValidation.ts:526-528`). | **MODIFY.** Keep visibility + privateGuestList (directly maps to "guest-list host-only vs public"). **DROP `allowTransfers`** (ticket transfers — meaningless without tickets). `requireApproval` becomes "approve each RSVP" (Partiful has this). `hideRemainingCount` becomes "hide Going count". | `allowTransfers` is a ticket concept; keeping it on an RSVP is a dead toggle (Constitution #1 dead-tap risk). **Avoid** by trimming the settings list for RSVP. No validation coupling, so safe. |
+| 7 | **Preview** | Renders `PreviewEventView` mini-card + Stripe-blocked status card + drives the publish dock (`CreatorStep7Preview` via `EventCreatorWizard.tsx:662-669`). `validateStep(6)` returns `[]` (`draftEventValidation.ts:54-55`). The preview reflects the public page guests will see. | **CLONE → MODIFY.** The preview must render the RSVP public page (Going/Not-going buttons), not a ticket cart. **DROP the Stripe-blocked card** — an RSVP has no money path, so `computePublishability`'s `blocked-stripe` branch (`draftEventValidation.ts:557-564`) never applies. | The Stripe gate in the dock (`EventCreatorWizard.tsx:609-610` `publishDisabled = status==='blocked-stripe'`) keys off paid tickets; with zero tickets it's inert, but the preview's `onConnectStripe` plumbing (`:667`) and the StripeBlockedCard become dead UI. **Avoid** by giving the RSVP wizard a trimmed Step-7 that omits the Stripe/money surfaces. |
+
+### Step 5 deep-dive — what the RSVP "guest-list / Going-Not-going config" step contains instead
+
+The Tickets step is the one step that **cannot be cloned**; it must be replaced. The RSVP-variant step contains:
+
+- **No ticket tiers, no price, no capacity-per-tier, no "Who covers costs", no Stripe.** Everything in `CreatorStep5Tickets.tsx:336-361` (`WhoCoversCostsSection`) and the tier CRUD (`:246-334`) is deleted for RSVP.
+- **Instead, the RSVP config:**
+  - **Capacity cap (optional)** — a single event-level max guest count (NOT per-tier). Maps to a new `events.rsvp_capacity` (nullable) or a column on the new RSVP table's parent. See open decision §7(b).
+  - **+1 / plus-guests toggle (optional)** — see §7(c).
+  - **Going-count visibility** — reuse `privateGuestList` / `hideRemainingCount` semantics from Step 6 rather than a tier flag.
+  - **Optional waitlist when capacity hit** — `waitlistEnabled` exists today as a per-tier flag (`draftEventStore.ts:128-132`); for RSVP it becomes an event-level flag.
+
+Because this step has NO ≥1-row requirement, the RSVP variant of `validateStep` for this step should return `[]` (like Cover/Settings do), NOT clone `validateTickets`.
+
+---
+
+## 4. Shared-Surface Regression Matrix
+
+Every artifact the two wizards could share, and whether the RSVP fork can safely reuse it or needs a discriminator. **Bold = assumes "events always have ≥1 ticket" or "events always go through checkout" — the danger zone.**
+
+| Shared surface | File:line | Reuse verdict for RSVP | Why / regression flag |
+|---|---|---|---|
+| `EventCreatorWizard.tsx` shell (nav, dock, autosave, desktop rail) | `EventCreatorWizard.tsx` whole | **CLONE** as `RsvpCreatorWizard.tsx` with 6 steps (drop Tickets) | The `STEP_DEFS` array (`:111-119`) is 7-entry hardcoded incl. "Tickets". `validatePublish` (`:506`) + `computePublishability` (`:601-604`) + the Stripe dock gate (`:609-610`) all assume the ticket model. Cloning the shell (sibling, not a mode flag — per Seth) is the right move; the shell logic is otherwise reusable. |
+| `draftEventStore` (DraftEvent + persist) | `draftEventStore.ts:230-363` | **REUSE with new fields** (additive) | DraftEvent already carries everything RSVP needs (name/when/where/cover/visibility). `tickets: []` is a valid state in the store (default `:439`). Add RSVP-specific fields (capacity, plusGuests) additively + bump persist `version` (currently 11, `:706`) with an additive migrator. **No discriminator field on DraftEvent today** — needs an `eventType`/`isRsvp` flag so the edit route + publish path know which wizard/RPC to use. |
+| **`validateStep` / `validateTickets`** | `draftEventValidation.ts:452-461` | **MUST NOT reuse for the Tickets slot** | **HARD BLOCKER:** `validateTickets` returns `tickets.empty` error when `draft.tickets.length === 0` (`:454-460`). An RSVP has zero tickets → permanently invalid. The RSVP wizard must skip this rule. |
+| **`validatePublish`** | `draftEventValidation.ts:61-104` | **MUST fork** | **HARD BLOCKER:** loops `for step 0..6` calling `validateStep` incl. Tickets (`:76-78`); also the paid-ticket→Stripe cross-step gate (`:81-90`). For RSVP this must not run the Tickets validator. |
+| **`business_publish_event_draft` RPC** | `...orch_1075...sql:1813,1932-1934,1986-2000` | **MUST fork into a new `business_publish_rsvp_draft`** | **HARD BLOCKER (the #1 risk):** raises `event_ticket_required` on empty tickets (`:1932-1934`), `city_required` (`:1986-1988`), `party_types_required` (`:1990-1992`). Precedent exists: trip got its own `business_publish_trip_draft` (`...orch_1075...sql:2373-2379`) because "extending the event RPC was technically infeasible" (`20260608000100_orch_0859_publish_rpc_trip.sql:308`). RSVP should follow the same fork pattern. |
+| **`ticket-checkout-create` / checkout RPC** | `20260610000002_...sql:183,265` | **NOT reused** | Branches on `event_type` (`v_is_trip := event_type='trip'` `:183`). RSVP never enters checkout (no money, no ticket order). The public RSVP action writes a Going/Not-going row, not an order. **Flag:** any code that assumes "public CTA → /checkout/{eventId}" (`PublicEventPage.tsx:291,329,340`) must be RSVP-aware. |
+| **`PublicEventPage.tsx`** (guest-facing) | `PublicEventPage.tsx:256-359` | **MODIFY / fork the CTA** | Today the floating bar + per-ticket rows all route to `checkoutPublicPath(event.id)` (`:291,329,340`); `onClaimFreeTicket` (`:331-341`) routes to the SAME cart. RSVP needs Going/Not-going buttons that write an RSVP row, not a checkout push. The page resolves a CTA via `resolveOfferingCta` (`:261-269`) keyed off `tickets` — with zero tickets this machine has no defined RSVP variant. **This is where guests RSVP, so it's a required surface.** |
+| `types.ts` `StepBodyProps` | `types.ts:14-77` | **REUSE verbatim** | Generic enough; `editMode`/`canEditTicketPrice` props are ignored by non-ticket steps. Safe. |
+| Offering list card / manage sheet (Hub) | shared `offering/` primitives (META-ORCH-1059) | **NEEDS discriminator** | The Hub list card + manage sheet render ticket/revenue summaries. An RSVP row has no revenue; must render "N going" instead. Needs an `event_type='rsvp'` branch. |
+| `EditPublishedScreen.tsx` SECTIONS | `EditPublishedScreen.tsx:148-156` | **CLONE → drop Tickets section** | `SECTIONS` includes `{key:"tickets", stepIndex:4}` (`:154`) which calls `validateStep(4)` (`:386-388`). For RSVP, drop this section. See §6. |
+
+---
+
+## 5. Schema Findings (the 4 questions, with migration evidence)
+
+**Q1 — How is an event persisted? Is there a discriminator?**
+Events are persisted in `public.events`. **There IS a first-class discriminator: `events.event_type text NOT NULL DEFAULT 'event' CHECK (event_type IN ('event','experience','trip'))`** (`supabase/migrations/20260605000000_orch_0826_events_event_type_discriminator.sql:33-34`). It's read across the codebase (discover, group-chat trigger, checkout branch, circle RPC). The publish RPC INSERTs `event_type` explicitly (`...orch_1075...sql:421`). **Adding RSVP requires widening this CHECK to include `'rsvp'`.**
+
+**Q2 — What distinguishes an "RSVP event" from a "free-ticket event"? Is Going/Not-going a NEW concept or the free-ticket claim path?**
+**Going/Not-going is a genuinely NEW persistence concept**, NOT the free-ticket path. Evidence: a free event today is a normal `event_type='event'` row with a `tickets` row where `isFree=true`; the public CTA `onClaimFreeTicket` (`PublicEventPage.tsx:331-341`) routes to `/checkout/{eventId}` — i.e. it creates a free *order/ticket*, going through the same checkout cart. There is **no "Not going" state** anywhere in that model — a free ticket is claim-or-don't, not a tri-state RSVP with an explicit decline. An RSVP "Going/Not-going" needs a per-guest status row with a `going | not_going` value, which the order/ticket model does not express. (The only `rsvp_status` CHECK in the DB is on the unrelated `board_card_rsvps` consumer collab-board table — `20260505000000_baseline_squash_orch_0729.sql:7520-7531` — `('attending','not_attending')`, scoped to `session_id`+`saved_card_id`, not events.)
+
+**Q3 — Is there an existing guest-list / attendee / RSVP table to build on?**
+**No event-level RSVP/attendee/guest-list table exists.** A repo-wide search for event-scoped rsvp/attendee/guest tables returns only `board_card_rsvps` (consumer collab boards, Q2 above) and `ticket_order_notifications` (`20260515000013_orch_0777_ticket_checkout_core.sql:153`). **The feature needs new schema.**
+
+**Q4 — How are tickets persisted; what breaks at zero tiers?**
+Tickets persist as `ticket_types` rows created by the publish RPC. **At zero tiers, three things break (the core regression):** (a) publish RPC raises `event_ticket_required` (`...orch_1075...sql:1932-1934`); (b) client `validateTickets` blocks the wizard (`draftEventValidation.ts:454-460`); (c) the public page CTA machine `resolveOfferingCta` is keyed off `tickets` (`PublicEventPage.tsx:261-269`) with no zero-ticket RSVP variant. The checkout RPC additionally assumes a ticket type exists for trips (`20260610000002_...sql:265`).
+
+### Minimal schema addition (sketch only — SPEC owns the migration)
+
+1. **Widen** `events.event_type` CHECK to `IN ('event','experience','trip','rsvp')`. (Per the migration-baseline rule, this is a `DROP CONSTRAINT` + `ADD CONSTRAINT`, not a silent widen.)
+2. **New table** `public.event_rsvps` (per-guest): `id`, `event_id` (FK events), `user_id` (nullable for anon link guests) OR a guest identity (email/name), `rsvp_status text CHECK IN ('going','not_going')`, optional `plus_count int`, `created_at`/`updated_at`, with RLS (host reads all for their brand's events; guest reads/writes own row). Mirror the `board_card_rsvps` shape (`...0729.sql:7520-7531`) but event-scoped.
+3. **New publish RPC** `business_publish_rsvp_draft` — clone of `business_publish_event_draft` MINUS the ticket/city/party-type gates, inserting `event_type='rsvp'`, creating ZERO `ticket_types` rows.
+4. Optional: `events.rsvp_capacity int NULL` for the capacity cap (or hold capacity on the parent; SPEC decides).
+
+**This is a sketch for SPEC, not a contract. Do not treat the column/table names as final.**
+
+---
+
+## 6. Edit-Wizard Delta
+
+The published-edit path is `EditPublishedScreen.tsx` (sectioned, not stepper), distinct from the create wizard (`:130-156`). How RSVP edit differs:
+
+- **Sections:** `SECTIONS` (`:148-156`) lists basics/when/where/cover/visual/tickets/settings. **The RSVP edit screen drops the `tickets` section** (`:154`) and its `validateStep(4)` call (`:386-388`).
+- **Edit-after-publish guards that MUST become RSVP-aware:**
+  - The **sold-tickets refund gate**: editing time/date on an event with sold tickets forces a full refund-first flow (`:628`, `:1004-1006` — "This event has sold tickets. Refund those buyers..."). For RSVP there are no tickets/orders, so the analogous guard is "N guests are Going — they'll be notified of the change," NOT a refund. The `computeTicketDiffs` machinery (`:457-460`) has no RSVP equivalent and must be skipped.
+  - **`MultiDateOverrideSheet` / `EndSalesSheet`** — `EndSalesSheet` is a ticket-sales concept (`business_end_event_ticket_sales` RPC, `businessEvents.ts:722-738`); meaningless for RSVP. Drop.
+  - **`ChangeSummaryModal`** — reusable, but its copy is ticket/refund-centric; needs RSVP copy.
+  - **Local-save vs server-mutation gate** (`ORCH_0824_PATCH_KEYS` `:182-189`) — RSVP edits need their own server mutation RPC (`biz_update_live_rsvp`, mirroring `biz_update_live_experience` `...orch_1075...sql:1318-1336` which gates on `event_type='experience'`).
+- **The published edit RPC must gate on `event_type='rsvp'`** the same way `biz_update_live_experience` raises if `event_type <> 'experience'` (`...orch_1075...sql:731,1328-1330`).
+
+---
+
+## 7. Open Product Decisions (each with a RECOMMENDED default)
+
+**(a) Does an RSVP event surface on the consumer discovery deck, or invite-link-only like Partiful?**
+**RECOMMENDED: invite-link-only (Partiful parity).** The consumer discover RPC strictly filters `e.event_type = 'event'` (`supabase/migrations/20261001000000_orch_426_discover_rpc.sql:100`; also `20260612000000_orch_426_discover_scale.sql:39`). An `event_type='rsvp'` row is therefore **automatically off-deck with zero code** — this is both the lowest-regression path and the authentic Partiful model (private gatherings shared by link). Surfacing on the deck would require widening the discover filter AND adding RSVP-deck-card UX — defer as a follow-on if ever wanted.
+
+**(b) Capacity cap + waitlist?**
+**RECOMMENDED: optional single event-level cap, waitlist deferred.** Partiful supports a guest limit. Model it as one nullable `rsvp_capacity` (NOT per-tier — there are no tiers). When full, show "Event full" and (v2) offer a waitlist. The per-tier `waitlistEnabled` flag (`draftEventStore.ts:128-132`) does not map; promote to event-level only if shipping waitlist. Ship cap in v1, waitlist as follow-on.
+
+**(c) +1 / plus-guests?**
+**RECOMMENDED: optional host toggle "Allow guests to bring +N", default off.** Stored as `plus_count` on the RSVP row (sketch §5). Counts against the capacity cap. Low-complexity, high Partiful-parity value.
+
+**(d) Guest-list visibility (public / host-only)?**
+**RECOMMENDED: reuse the existing `privateGuestList` toggle** (`draftEventStore.ts:349`, surfaced in Step 6 `CreatorStep6Settings.tsx:155-157`). Default host-only (private) to match Partiful's "host sees the list; guests see a count." Public guest list is an opt-in toggle. This reuses a field that already exists — no new schema for the toggle itself.
+
+**(e) Is "RSVP" genuinely distinct from "free event," and how do we prevent two overlapping ways to make a no-cost event?**
+**RECOMMENDED: yes, distinct — and prevent overlap by positioning, not by removing free tickets.** They ARE different (Q2: RSVP has an explicit "Not going" tri-state + no order/ticket artifact; a free event issues a free *ticket* via checkout). To avoid confusing "two ways to make a no-cost event": in the chooser, label them by intent — **"RSVP event" = "Guests reply Going / Not going. No tickets."** vs **"Ticketed event" = "Issue tickets (free or paid)."** This is the cleanest product line and matches how Partiful (RSVP) and Eventbrite (free ticket) already differ in users' minds. Do NOT try to collapse them into one flow with a flag — Seth explicitly wants a sibling wizard.
+
+---
+
+## 8. Cross-Surface Scope (which of the 5 primary + 2 adjacent surfaces this touches)
+
+| Surface | Touched? | Why |
+|---|---|---|
+| 1. Consumer iOS (`app-mobile`) | **NO (recommended default)** | Invite-link-only → not on discover deck (§7a). Touched ONLY if (a) is overridden to surface on deck. |
+| 2. Consumer Android | **NO (same)** | Same as iOS. |
+| 3. Buyer/anonymous Web (`mingla-business` public routes `/e/...`) | **YES** | Guests RSVP on the **public event page** (`PublicEventPage.tsx`) — Going/Not-going buttons + the new RSVP write path replace the checkout CTA. This is where guests actually act. |
+| 4. Business iOS (`mingla-business`) | **YES** | The new RSVP create + edit wizards (sibling clones), the chooser fork, the Hub list card/manage-sheet RSVP branch. |
+| 5. Business Android | **YES** | Same RN code as Business iOS; parity automatic (shared code) except Android glass opaque-fallback on the new chooser rows (`UniversalCreatorSheet.tsx:316-334` pattern). |
+| 6. Admin Web (adjacent) | **NO** | No admin surface for RSVP in scope. |
+| 7. Business Web preview (adjacent) | **YES (automatic)** | The business-web build renders the same wizard + public page; parity is automatic via shared code, subject to the lucide-shim/bundle-budget gotchas. |
+
+**Backend (not a "surface" but in scope):** Supabase — CHECK widen, new `event_rsvps` table + RLS, new `business_publish_rsvp_draft` + `biz_update_live_rsvp` RPCs, an RSVP-write RPC for the public page.
+
+---
+
+## Confidence & Invariant Impact
+
+**Confidence: `proven` (source-only, code-audit-exempt from live-fire per Prime Directive 7).** This is a static walkthrough/feasibility investigation, not a reproducer-bound runtime bug — no simulator repro is owed. Every behavioral claim is backed by a cited `file:line` read verbatim.
+
+**Invariants flagged (NOT resolved — SPEC's job):**
+- `I-BRAND-UNIVERSAL-AUTHORING` (META-ORCH-0972) — every brand authors universally; RSVP must be reachable by every brand (no `venueCategory`/kind gate), consistent with how `UniversalCreatorSheet.tsx:129-138` routes trip universally.
+- The ORCH-1075 paid-publish integrity invariants (`I-PROPOSED-1075-*`) gate paid offerings on Stripe-readiness; RSVP is moneyless so these are inert for it — but the RSVP publish RPC must not accidentally inherit the money gate.
+- New invariant candidates for SPEC (DRAFT): `I-PROPOSED-1150-RSVP-NO-TICKET-ROWS` (an `event_type='rsvp'` row has zero `ticket_types`), `I-PROPOSED-1150-RSVP-OFF-DECK` (RSVP rows never appear in the discover RPC).
+
+## Discoveries for Orchestrator
+- The event/experience/trip wizards are already **three sibling clones** off `event_type`, each with its own publish RPC (trip's fork rationale documented `20260608000100_orch_0859_publish_rpc_trip.sql:308`). RSVP is the natural 4th sibling — the pattern is established, lowering build risk.
+- `hideAddressUntilTicket` (`draftEventStore.ts:311`) is ticket-coupled copy that already ships on every event; for RSVP its label needs rewording even though the mechanism is reusable.
+
+## Recommended Next Phase
+**SPEC** — gated on Seth's steering of the §7 open product decisions (especially 7a off-deck vs on-deck, and 7e the RSVP-vs-free-ticket product line). The SPEC must: (1) define the new sibling `RsvpCreatorWizard` (6 steps, Tickets→RSVP-config), (2) the chooser fork, (3) the `event_type` CHECK widen + `event_rsvps` table + RLS, (4) the `business_publish_rsvp_draft` + `biz_update_live_rsvp` RPCs, (5) the public-page Going/Not-going write path, (6) RSVP-aware edit-after-publish guards. Do NOT reuse `business_publish_event_draft`, `validateTickets`, or the checkout path for RSVP.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150_RSVP_EVENT.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150_RSVP_EVENT.md
@@ -1,0 +1,97 @@
+# IMPLEMENT ORCH-1150 — RSVP Event (Partiful-style) — Steps 9–12 + SQL tests
+
+**Phase:** IMPLEMENT (continuation — steps 1–9a were already committed; orchestrator rebased onto origin/main with ORCH-1138 absorbed).
+**Worktree:** `~/Desktop/mingla-orchs/orch-1150-[rsvp-event-wizard]/` · branch `orch-1150-rsvp-event-wizard`.
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1150_RSVP_EVENT_WIZARD.md`.
+**Status:** READY FOR TEST. Steps 9, 10, 11, 12 + the 4 SQL tests all built + committed. Gates green.
+
+---
+
+## 1. Summary
+
+Finished the public-facing + Hub + edit + consumer-deck + SQL-test legs of the RSVP event. A guest can now reply Going/Not-going on the public `/e/` page (with a real waitlist / pending / full / contact-capture flow), a host opting an RSVP onto the discover feed gets a Going/Not-going deck card in the consumer app, the Hub list-card shows "N going" instead of revenue, and editing a published RSVP drops the Tickets section + notifies going guests. The ticketed checkout path is byte-identical throughout.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | What | Status | Commit |
+|----|------|--------|--------|
+| Step 0 | tsc clean for ORCH-1150 code; committed jest/Deno green | ✓ | `eef6d25ea` |
+| Step 9 (web) | Going/Not-going via `resolveRsvpCta`; +1; inline name+email+phone REQUIRED for anon (Going disabled until valid); logged-in skip; submit → `public-submit-rsvp`; all states; non-RSVP checkout byte-identical | ✓ | `eef6d25ea` |
+| Step 10 (deck) | discover supply confirm (eventType through `pg_discover_business_events`→card); RSVP card variant + Going/Not-going (discoverable only) | ✓ | `711fcb776` |
+| Step 11 (Hub) | list-card `event_type='rsvp'` → "N going"; manual-mode pending badge (badge shipped Step 8) | ✓ | `d8f6ad649` |
+| Step 12 (edit) | RSVP-aware edit; drop Tickets + refund gate; "N going — they'll be notified" notice; published date/venue edit enqueues §5.2 `rsvp_event_updated` via `biz_update_live_rsvp` | ✓ | `f57e1e1b2` |
+| SQL tests | T1/T2/T4(+host-remove)/T6 | ✓ (await orchestrator DB run) | `6cad4f8e2` |
+
+---
+
+## 3. Files changed (this dispatch)
+
+**Step 0 + Step 9** (`eef6d25ea`)
+- `mingla-business/src/store/liveEventStore.ts` — LiveEvent `event_type` +`'rsvp'`; added `rsvp*` host-control + `rsvpGoingCount` (optional, back-compat).
+- `mingla-business/src/utils/liveEventAdapter.ts` — `liveEventToEditableDraft` populates the 7 RSVP fields (the Step-3 DraftEvent widen had broken this literal — tsc-invisible, ts-jest-visible).
+- `mingla-business/app/rsvp/[id]/guests.tsx` — `liveEvent.title`→`.name` (Step-8 tsc error).
+- `mingla-business/src/services/rsvpEvents.ts` — `submitPublicRsvp` (edge-fn caller); fixed the committed-RED test (two comments contained the banned `business_publish_event_draft` substring).
+- `mingla-business/src/services/rsvpErrorCodes.ts` (NEW, pure) + `__tests__/rsvpErrorCodes.orch1150.test.ts` (NEW).
+- `mingla-business/src/services/publicEventsService.ts` — view row type +RSVP cols + `rsvp_going_count`; `getPublicEventBySlug`/`ById` admit `'rsvp'`; `publicEventViewRowToEvent` maps event_type + RSVP fields + going count.
+- `mingla-business/src/components/event/RsvpPublicBody.tsx` (NEW) — the Going/Not-going page body (reuses ORCH-1138 ParallaxCoverShell).
+- `mingla-business/src/components/event/PublicEventPage.tsx` — `event_type==='rsvp'` early-return branch (ticketed path untouched).
+- `supabase/migrations/20261004000000_orch_1150_rsvp_events.sql` — appended a `business_public_events_view` recreate exposing the 6 RSVP columns + a `rsvp_going_count` subselect.
+
+**Step 10** (`711fcb776`)
+- `supabase/functions/discover-merged-events/_types.ts` + `_business-query.ts` — `eventType` on `BusinessEventCard` (maps `e.event_type`).
+- `app-mobile/src/types/mergedDiscover.ts` — mirror `eventType`.
+- `app-mobile/src/services/rsvpDeckService.ts` (NEW) + `__tests__/rsvpDeckService.orch1150.test.ts` (NEW, Deno source-contract).
+- `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx` — RSVP Going/Not-going dock + `handleRsvp`; ticketed cart path untouched (TicketCartSheet stays mounted).
+
+**Step 11** (`d8f6ad649`)
+- `mingla-business/src/components/event/EventListCard.tsx` — RSVP renders (was bailed with trips); "N going" / "N / cap going"; right-rail + a11y RSVP-aware.
+- `mingla-business/src/services/businessEvents.ts` — event_type probe pulls RSVP cols + a `event_rsvps` going-count aggregate; `eventFromRow` gains `rsvpMeta`.
+- `mingla-business/src/utils/rsvpHubMetrics.ts` (NEW, pure) + `__tests__/rsvpHubMetrics.orch1150.test.ts` (NEW).
+
+**Step 12** (`f57e1e1b2`)
+- `mingla-business/src/components/event/EditPublishedScreen.tsx` — `rsvpMode` filters out Tickets section; `handleConfirmSave` RSVP branch → `biz_update_live_rsvp` then local mutation (no refund machinery); "N going" notice (opaque Android fill) via `rsvpEditNoticeCopy`.
+- `mingla-business/src/utils/rsvpHubMetrics.ts` — `rsvpEditNoticeCopy`.
+
+**SQL tests** (`6cad4f8e2`)
+- `supabase/migrations/__tests__/orch_1150_rsvp.test.sql` (NEW).
+
+---
+
+## 4. Data-model changes applied (this dispatch)
+Only the **view** recreate inside the existing ORCH-1150 migration: `business_public_events_view` now exposes `rsvp_discoverable / rsvp_capacity / rsvp_allow_plus_ones / rsvp_plus_ones_max / rsvp_waitlist_enabled / rsvp_approval_mode` + a `rsvp_going_count` subselect (going+approved, counting `plus_count`; 0 for non-RSVP). No new tables/columns (the events RSVP columns + `event_rsvps` shipped in Step 1).
+
+## 5. Edge functions touched
+- `discover-merged-events` — `verify_jwt = false` (unchanged); added `eventType` to the card mapping only. **Deploy from MERGED main.**
+- (no change to `public-submit-rsvp` / `rsvp-notify` this dispatch — Step 2.)
+
+## 6. Regression tests added (this dispatch)
+| Test | Path | Runner | fails-on-revert |
+|------|------|--------|-----------------|
+| Step 9 error-code bubbling | `mingla-business/src/services/__tests__/rsvpErrorCodes.orch1150.test.ts` | jest (6) | proven (delete body-code branch → 3 fail) @ `eef6d25ea` |
+| Step 11 going metric | `mingla-business/src/utils/__tests__/rsvpHubMetrics.orch1150.test.ts` | jest (8, incl. Step 12 notice) | proven (drop `plus_count` term) @ `d8f6ad649`/`f57e1e1b2` |
+| Step 10 deck contract | `app-mobile/src/services/__tests__/rsvpDeckService.orch1150.test.ts` | Deno (3) | proven (revert dock branch → 1 fail) @ `711fcb776` |
+| §9 invariants | `supabase/migrations/__tests__/orch_1150_rsvp.test.sql` (T1/T2/T4/T6) | psql probe | structural (await orchestrator DB run) |
+
+## 7. Gates
+- **tsc:** mingla-business + app-mobile — ZERO errors in ORCH-1150 files (pre-existing package/marketing baseline errors unrelated).
+- **jest:** 4 RSVP suites, 24/24 pass. (Two source-text suites can't import the RN chain in this worktree — `node_modules` symlinks to the anchor; the same env quirk fails a pre-existing non-1150 test `serverDraftEventMapper.test.ts`. All 24 RSVP assertions that DO run pass.)
+- **Deno:** rsvp-notify fanout 5/5; rsvpDeckService 3/3; `deno check` clean on public-submit-rsvp, rsvp-notify, discover-merged-events.
+- **strict-grep:** ORCH-1138 (deck-off-ebes, no-trip-only-blocks, trip-reserve-straight-to-cart) PASS; tr2-events-type-filter + tr2-route-by-event-type-filter PASS. `i-proposed-tr2-route-by-event-type` FAILS — **pre-existing on origin/main** (6 violations in `trips.tsx`/`accept-scanner-invitation.tsx`/`ScannerHome.tsx`, none ORCH-1150 files; identical failure on the anchor).
+- **Android glass:** new rows (RsvpPublicBody cards, deck dock, edit notice) use opaque/solid fills.
+
+## 8. DO-NOT-TOUCH compliance
+- Ticketed publish/checkout path byte-identical: `PublicEventPage` RSVP branch is a top-level early-return; the ticketed render below is unchanged. `ConsumerEventDetailScreen` keeps `TicketCartSheet` mounted (deck-off-EBES) and only swaps the dock/float bar for RSVP. `EditPublishedScreen` ticketed save path is unchanged (RSVP branch returns before `validateLiveEventFieldUpdate`).
+- Only `validateBasics` export + `lockSingleDate` prop touched on the ticketed validator/When (Steps 4/6, prior).
+
+## 9. Known issues / deferred (Discoveries for Orchestrator)
+1. **Unlisted RSVP public page:** `business_public_events_view` filters `visibility='public'`, so an `unlisted` (link-only) RSVP won't resolve on `/e/`. Same pre-existing constraint as unlisted ticketed events. If link-only RSVPs must render their public page, the view (or a separate by-slug path) needs an unlisted carve-out — out of steps 9–12 scope.
+2. **`host_set_rsvp_status` / RPC-driven approve in T4:** the SQL test exercises the host-remove via a direct `approved→denied` UPDATE (the mechanism the RPC performs) rather than the RPC itself, because the RPC's `auth.uid()`+brand-rank gate is awkward in a DO block. The drain mechanism (the §9.4 invariant) is fully proven; the RPC's auth gate is covered by T30/T42 (tester's adversarial scope).
+3. **Pre-existing `i-proposed-tr2-route-by-event-type` failure on main** — flag for a cleanup ORCH (6 hardcoded `/trip/` `/event/` router.push in scanner/trips routes).
+4. **jest RN-import wall in this worktree** — `node_modules` symlinked to anchor; some source-text-import tests can't run here. Confirmed environmental (a non-1150 baseline test fails identically). CI should run them in the real install.
+
+## 10. Operator action required
+- No migration `db push` needed from this dispatch (the Step-1 migration `20261004000000` already carries the schema; this dispatch only appended the view recreate to that same file — re-applies cleanly via the existing Step-1 `db push`).
+- Edge deploy (from MERGED main): `discover-merged-events`, `public-submit-rsvp` (verify_jwt=false), `rsvp-notify` (verify_jwt=true).
+- Run the SQL probe `supabase/migrations/__tests__/orch_1150_rsvp.test.sql` against the linked remote after migration apply.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1150_RSVP_EVENT_WIZARD.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1150_RSVP_EVENT_WIZARD.md
@@ -1,0 +1,732 @@
+# SPEC ORCH-1150 — RSVP Event (Partiful-style) Sibling Create/Edit Wizard
+
+**Mode:** SPEC (binding build contract). No product code, no migration files, no worktree, no deploys produced by this document.
+**Anchor read:** `/Users/sethogieva/Desktop/mingla-main` on `main` (read-only).
+**Date:** 2026-06-15.
+**Evidence base:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1150_RSVP_EVENT_WIZARD_WALKTHROUGH.md` (every `file:line` below was re-read verbatim against `main` while writing this spec).
+**Comms ledger:** Read on entry. No OPEN entry targets `mingla-forensics`, `ORCH-1150`, or `ALL` at BLOCK. COMMS-0033 (ORCH-1133 ID collision) + COMMS-0029 (trip RPC clobber) are unrelated. Nothing to ack.
+
+> This SPEC honors Seth's 4 LOCKED steering decisions exactly. Where the investigation's walkthrough recommended a different default (drop Party Type; invite-link-only; cap-only host config), the steering OVERRIDES it and this SPEC specs to the steering. Each override is flagged inline.
+>
+> **AMENDED 2026-06-15 (full-featured v1).** Seth LOCKED four further V1-SCOPE decisions (World Map "V1-SCOPE STEERED"): **A2** BUILD the approve/deny host console in v1 (full manual approval, not just a count); **A3** FULL waitlist (`waitlisted` status + auto-promote-oldest + notify); **A4** notify going-guests via push + SMS + email (all three) through a NEW RSVP notification pipeline, capturing guest contact at RSVP time; the 6-step structure is CONFIRMED unchanged. These EXPAND the original spec — the prior lightweight/deferred versions (old §10 A2/A3/A4 "RECOMMEND lightweight/follow-on") are REPLACED. See the **Amendment Log** at the end for the auditable diff. Every amended contract item cites the real file:line it clones from.
+
+---
+
+## 1. Executive Summary
+
+ORCH-1150 ships a **fourth sibling offering wizard** — the RSVP event — alongside the existing event / experience / trip wizards, all forked off the `events.event_type` discriminator (`supabase/migrations/20260605000000_orch_0826_events_event_type_discriminator.sql:32-34`). An RSVP event is a Partiful-style gathering: the same Basics / When / Where / Cover surfaces as a ticketed event, but **no tickets and no checkout** — guests reply **Going / Not going**, and the host gets full control over capacity, plus-ones, waitlist, and approval.
+
+The build is **additive and low-regression** because there is already a proven fork pattern (trip got its own `business_publish_trip_draft` because extending the event RPC was infeasible — `...orch_1075...sql:2307`, comment `:2621`). RSVP follows the same shape. The single largest landmine is that the event pipeline **hard-assumes ≥1 ticket in three places** — the publish RPC raises `event_ticket_required` (`...orch_1075...sql:1932-1934`), `validateTickets` blocks at 0 tickets (`draftEventValidation.ts:452-461`), and the public page routes every CTA to checkout (`PublicEventPage.tsx:291,329,340`). This SPEC therefore mandates a **forked publish RPC, a forked validator, and a Going/Not-going public CTA** — none of these three may be reused verbatim.
+
+Two genuinely new persistence concepts are required: (a) widen the `event_type` CHECK to include `'rsvp'`; (b) a new per-guest `public.event_rsvps` table (no event-level attendee table exists today — `board_card_rsvps` is an unrelated consumer collab-board table). Per Seth's steering, discovery is **host-choosable** via a new `events.rsvp_discoverable` boolean (default OFF): when true the row appears on the consumer deck with a Going/Not-going card; when false it is invite-link-only. Single-date only in v1.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In scope
+1. Chooser fork: "Create event" → in-sheet `step:"event"` with two rows (Ticketed → `/event/create` untouched; RSVP → new `/rsvp/create`). Mirrors the ORCH-1144 experience-step pattern (`UniversalCreatorSheet.tsx:262-311`).
+2. New sibling `RsvpCreatorWizard.tsx` (6 steps) + its `/rsvp/create` and `/rsvp/[id]/edit` routes.
+3. Forked validator (`draftRsvpValidation.ts`) — no ≥1-ticket gate; keep Basics party-type gate.
+4. Additive `DraftEvent` fields + persist `version` bump 11 → 12 + additive migrator.
+5. Schema: `event_type` CHECK widen (+`'rsvp'`); new `public.event_rsvps` table + RLS; `events.rsvp_discoverable boolean`; `events.rsvp_capacity int`, `events.rsvp_allow_plus_ones boolean`, `events.rsvp_plus_ones_max int`, `events.rsvp_waitlist_enabled boolean`, `events.rsvp_approval_mode text`.
+6. RPCs: `business_publish_rsvp_draft` (publish), `biz_update_live_rsvp` (edit-published), `public_submit_rsvp` (guest write — anon-capable via edge function).
+7. Public RSVP page: Going / Not-going CTA + +1 input + capacity-full / waitlist / pending-approval states, on `PublicEventPage.tsx` (the `/e/` route).
+8. Consumer deck RSVP card variant (discoverable path only) + discover-RPC widen.
+9. Hub list-card / manage-sheet RSVP branch ("N going" instead of revenue).
+10. RSVP-aware edit-after-publish guards (no refund gate, no EndSalesSheet, no ticket-diff).
+11. **(A2 + A2-NEW) Host approve/deny/remove console** (business iOS+Android) — a Guests list off the RSVP's manage-sheet showing pending RSVPs with per-row Approve/Deny + bulk-approve, AND a per-row **Remove** (with confirm) on Going guests that un-admits an already-approved guest (A2-NEW `approved→denied`, frees a spot, auto-promotes the oldest waitlisted guest, notifies the removed guest); backed by `host_set_rsvp_status(p_rsvp_id, p_status)` RPC + RLS (owning host only); approve/deny/remove fires a guest notification (§5.4).
+12. **(A3) FULL waitlist** — a `waitlisted` attendance status + auto-promote-oldest-when-a-spot-opens (going→not_going, deny/remove, or cap raised) via a DB trigger that enqueues a notification (§5.5). Capacity accounting counts `plus_count`.
+13. **(A4 + A4-NEW + A4-NEW-2) RSVP notification pipeline** — guest contact capture (**link guests: name+email+phone ALL required — A4-NEW**; app users: profile-inherited, exempt) on the public form + a new `rsvp-notify` edge fn fanning out across push (OneSignal) + SMS (Twilio) + email (Resend), attempting **every channel the guest has an address/token for — app users get push+email+SMS, not push-only (A4-NEW-2)**, per-channel non-blocking, for **four** triggers: published-edit → all going guests; waitlist auto-promotion → the promoted guest; approve/deny → that guest; **host-remove → the removed guest (A2-NEW `rsvp_removed`)** (§5.6).
+
+### Non-goals (explicit, with reason)
+- **Multi-date + recurring RSVP** — OUT for v1 (Seth steering #4). The RSVP When step is single-date only. Flagged as a follow-on (§10 Open Q-A1).
+- **Paid RSVP / tickets on an RSVP** — OUT by definition. An RSVP never enters checkout; `ticket-checkout-create` is untouched. A brand wanting tickets uses the Ticketed wizard.
+- **Stripe / money surfaces in the RSVP wizard** — OUT. No StripeBlockedCard, no `computePublishability` blocked-stripe branch, no payout gate.
+- **Guest-side RSVP edit / cancel-after-going management UI** — v1 writes a Going/Not-going row + allows the guest to flip their own status (RLS supports it); a richer "manage my RSVP" surface is a follow-on.
+- **Marketing-consent / opt-out plumbing for RSVP notifications** — OUT. RSVP notifications (A4) are **TRANSACTIONAL** (a guest who tapped "Going" is told when the event they joined changes) — they sit OUTSIDE the unshipped `marketing_consent` foundation (`project_marketing_hub_strategy`). The transactional basis = the guest's own RSVP action; no marketing-consent column is read. (A guest can still flip to Not-going to stop being a going-guest.)
+- **Admin-web + marketing-web RSVP surfaces** — OUT (no offering-authoring surface there).
+
+### Assumptions
+- The brand authoring an RSVP is universal — every brand reaches `/rsvp/create` with no `venueCategory`/kind gate (honors `I-BRAND-UNIVERSAL-AUTHORING`, mirrors how `/trip/create` routes universally `UniversalCreatorSheet.tsx:129-138`).
+- `events.event_type='rsvp'` rows have ZERO `ticket_types` rows (new invariant `I-PROPOSED-1150-RSVP-NO-TICKET-ROWS`).
+
+---
+
+## 3. Cross-Surface Impact Declaration (MANDATORY)
+
+| # | Surface | Covered? | User-visible behavior | Files touched here | Parity |
+|---|---------|----------|-----------------------|--------------------|--------|
+| 1 | Consumer iOS (`app-mobile`) | **YES (discoverable path only)** | When host opts the RSVP onto the deck, an RSVP card appears with a Going/Not-going CTA (NOT Book). Link-only RSVPs never appear. | `app-mobile/src/components/CuratedExperienceSwipeCard.tsx` (or a new `RsvpSwipeCard.tsx`); `cardConverters.ts`; the discover supply RPC. | Manual (per-surface card variant) |
+| 2 | Consumer Android | **YES (same)** | Same as iOS. | Same RN files. | Automatic (shared RN) |
+| 3 | Buyer/anon Web (`mingla-business` `/e/...`) | **YES** | Guests tap **Going / Not going** instead of a checkout CTA; +1 stepper when host allows; "Event full" / "Join waitlist" / "Awaiting host approval" states. Anon (logged-out) link guests can RSVP. | `PublicEventPage.tsx`; `@mingla/event-rendering` CTA machine (`resolveOfferingCta` branch or a sibling `resolveRsvpCta`); new `public_submit_rsvp` edge fn. | Manual (web-aware) |
+| 4 | Business iOS (`mingla-business`) | **YES** | New chooser row; new RSVP create + edit wizard (6 steps); Hub list-card shows "N going". **(A2)** A "Guests" row on the RSVP manage-sheet opens the approve/deny console (pending list + per-row Approve/Deny + bulk-approve). | `UniversalCreatorSheet.tsx`; `RsvpCreatorWizard.tsx` + step components; `/rsvp/*` routes; `draftRsvpValidation.ts`; `draftEventStore.ts`; offering Hub primitives (`OfferingManageSheet.tsx`, `EventManageMenu.tsx`); NEW `RsvpGuestConsole.tsx` + `/rsvp/[id]/guests` route + `useRsvpApprovals.ts`. | — |
+| 5 | Business Android | **YES** | Same as Business iOS (incl. the A2 console). | Same RN code. Android glass opaque-fallback on the new chooser row (`UniversalCreatorSheet.tsx:316-334` pattern) AND on the new console rows. | Automatic (shared RN) + manual glass token |
+| 6 | Admin Web | **NO** | — | — | No admin offering-authoring surface. |
+| 7 | Business Web preview (adjacent) | **YES (automatic)** | Same wizard + public page render via shared code. The A2 console renders on business-web too (shared RN). | Shared code; subject to lucide-shim / `__common` 2.25MB bundle-budget gate (per-icon named imports only; no `import *`). | Automatic |
+
+**(A4 + A4-NEW + A4-NEW-2) Notification fan-out is cross-surface but not a "screen":** the RSVP notification pipeline reaches a guest across THREE delivery channels, attempting **every channel for which the guest has a usable address/token** — **push** to Mingla-app guests (consumer iOS/Android via OneSignal external_id), **SMS** to any guest with a phone (Twilio), **email** to any guest with an email (Resend). A **link guest** (no app account) supplies BOTH email AND phone (A4-NEW required), so they get **email AND SMS**. An **app-user guest** gets **push AND email (AND SMS if a profile phone exists)** — NOT push-only (A4-NEW-2). This is the consumer-app push path (surfaces 1+2) reached transactionally — no new consumer screen, just a delivered notification + the existing in-app notifications inbox row.
+
+**Backend (in scope, not a "surface"):** Supabase — CHECK widen, `event_rsvps` table + RLS + contact columns + two-dimension status model, `business_publish_rsvp_draft` + `biz_update_live_rsvp` + `host_set_rsvp_status` + `submit_event_rsvp` RPCs, the `fn_rsvp_drain_on_capacity_freed` auto-promote trigger, `public_submit_rsvp` + `rsvp-notify` edge fns, discover-RPC widen.
+
+---
+
+## 4. Layered Specification
+
+### 4.0 File-change manifest (allowlist — see §“Scoped allowlist” for DO-NOT-TOUCH)
+
+**CREATE**
+- `mingla-business/app/rsvp/create.tsx` — entry route (clone of `app/event/create.tsx`, swap `/event/` → `/rsvp/`).
+- `mingla-business/app/rsvp/[id]/edit.tsx` — resume/edit route (clone of `app/event/[id]/edit.tsx`, mount `RsvpCreatorWizard`).
+- `mingla-business/src/components/rsvp/RsvpCreatorWizard.tsx` — 6-step wizard shell (clone of `EventCreatorWizard.tsx`).
+- `mingla-business/src/components/rsvp/RsvpStep5Setup.tsx` — NEW RSVP-setup step (replaces Tickets).
+- `mingla-business/src/utils/draftRsvpValidation.ts` — forked validator.
+- `mingla-business/src/services/rsvpEvents.ts` — `publishRsvpDraft` + `updateLiveRsvp` service callers.
+- `mingla-business/src/hooks/useRsvpEvents.ts` (or extend `useBusinessEvents.ts`) — publish/update mutation hooks.
+- `supabase/migrations/<VERSION>_orch_1150_rsvp_events.sql` — schema (CHECK widen, table, columns + contact + two-dimension status, RLS, RPCs, auto-promote trigger). VERSION per §4.1 rule.
+- `supabase/functions/public-submit-rsvp/index.ts` — anon-capable guest write edge fn.
+- **(A2) `mingla-business/src/components/rsvp/RsvpGuestConsole.tsx`** — host approve/deny console screen (pending list + per-row Approve/Deny + bulk-approve). Clones the list/row pattern from `EventManageMenu.tsx` rows + a list screen (§5.4).
+- **(A2) `mingla-business/app/rsvp/[id]/guests.tsx`** — route mounting `RsvpGuestConsole` (clone of an `app/event/[id]/*.tsx` detail route).
+- **(A2) `mingla-business/src/hooks/useRsvpApprovals.ts`** — React Query: `useRsvpGuestList(eventId)` (host read) + `useSetRsvpStatus()` mutation (calls `host_set_rsvp_status`, invalidates the guest-list + going-count keys).
+- **(A2) `mingla-business/src/services/rsvpApprovals.ts`** — service caller for `host_set_rsvp_status` + the guest-list query.
+- **(A4) `supabase/functions/rsvp-notify/index.ts`** — the multi-channel fan-out edge fn (push+SMS+email; per-channel non-blocking; §5.6). Reuses `_shared/push-utils.ts sendPush` + a Resend send cloned from `notify-dispatch/index.ts:84-138` + a Twilio send cloned from `ticket-confirmation-dispatch/index.ts:123-170`.
+- Test files per §7 / §9.
+
+**MODIFY**
+- `mingla-business/src/components/ui/UniversalCreatorSheet.tsx` — add `step:"event"` fork (§4.5).
+- `mingla-business/src/store/draftEventStore.ts` — additive RSVP fields + version 12 migrator (§4.6).
+- `mingla-business/src/components/rsvp/RsvpCreatorWizard.tsx` reuses existing step components `CreatorStep1Basics`, `CreatorStep2When`, `CreatorStep3Where`, `CreatorStep4Cover`, `CreatorStep6Settings` (see §4.3 reuse table — Settings needs a prop-gated variant).
+- `mingla-business/src/components/event/PublicEventPage.tsx` — RSVP CTA branch (§4.7).
+- `packages/event-rendering/` — `resolveRsvpCta` (or an `rsvp` branch in `resolveOfferingCta`) + the public-page Going/Not-going buttons.
+- `supabase/config.toml` — `[functions.public-submit-rsvp] verify_jwt = false`.
+- The consumer discover supply RPC (the one feeding `discover-cards` / the deck) — widen to include opted-in RSVP rows (§4.8).
+- `app-mobile/src/...` deck card converter + card component — RSVP variant (§4.8).
+- Hub offering list-card / manage-sheet — `event_type='rsvp'` branch (§4.3 last row).
+- **(A2)** `mingla-business/src/components/offering/OfferingManageSheet.tsx` (+ its action-config layer) and/or `EventManageMenu.tsx` — add a **"Guests"** action row (visible only for `event_type='rsvp'` rows) routing to `/rsvp/[id]/guests`. Show a pending-count badge when `rsvp_approval_mode='manual'`. Clone the "Orders" row pattern (`EventManageMenu.tsx:171-183`).
+- **(A4)** `supabase/config.toml` — `[functions.rsvp-notify] verify_jwt = true` (service-role-invoked only; it is NOT a public anon route).
+
+### 4.1 Database
+
+**Migration version rule (DROP-before-widen + monotonic prefix).** The current migration head is `20261002000000_orch_1142_notifications_soft_delete.sql`. The implementor MUST, at build time, run `ls supabase/migrations/ | sort | tail -1` and pick a prefix strictly greater than the head (e.g. `20261003000000_orch_1150_rsvp_events.sql`). **Do NOT hardcode a colliding version** — verify free before writing. Wrap the migration in `BEGIN; ... COMMIT;` (matches discriminator migration `:28`). Place any `GRANT` after the function body's closing `$$;` and `DROP` before any `RETURNS TABLE` widen (per `feedback_edge_deploy_and_migration_apply_hazards`).
+
+**(a) Widen `event_type` CHECK (DROP + ADD, never silent widen).**
+```sql
+ALTER TABLE public.events DROP CONSTRAINT events_event_type_check;
+ALTER TABLE public.events ADD CONSTRAINT events_event_type_check
+  CHECK (event_type IN ('event','experience','trip','rsvp'));
+```
+(Confirm the live constraint name via `\d public.events` / `information_schema`; the original was created inline at `20260605000000...:33-34` so the auto-name is `events_event_type_check` — verify before DROP.)
+
+**(b) New host-control columns on `public.events` (all nullable / defaulted; additive).**
+| Column | Type | Default | Meaning | Steering |
+|--------|------|---------|---------|----------|
+| `rsvp_discoverable` | `boolean NOT NULL` | `false` | true → row eligible for consumer deck; false → invite-link-only | #1 |
+| `rsvp_capacity` | `integer NULL` | `NULL` | optional event-level guest cap; NULL = unlimited | #3 |
+| `rsvp_allow_plus_ones` | `boolean NOT NULL` | `false` | host allows guests to bring +N | #3 |
+| `rsvp_plus_ones_max` | `integer NOT NULL` | `0` | max additional guests per RSVP when plus-ones allowed (1..N) | #3 |
+| `rsvp_waitlist_enabled` | `boolean NOT NULL` | `false` | when capacity hit, offer a waitlist | #3 |
+| `rsvp_approval_mode` | `text NOT NULL` | `'auto'` | `CHECK (rsvp_approval_mode IN ('auto','manual'))` — auto-approve vs approve-each | #3 |
+
+These columns are inert (defaults) for `event_type<>'rsvp'` rows; no behavioral change to events/experiences/trips.
+
+**(c) New table `public.event_rsvps` (per-guest) — TWO-DIMENSION status model + contact columns (AMENDED for A2/A3/A4).**
+
+**Status model decision (A2+A3): TWO independent columns, not one.**
+- **`rsvp_status`** = the guest's own *intent / attendance* dimension: `going` | `not_going` | `waitlisted`. The guest controls `going`/`not_going`; the SYSTEM sets `waitlisted` (auto, when capacity is full at submit time) and auto-promotes `waitlisted → going` when a spot opens (§5.5).
+- **`approval_status`** = the *host gate* dimension: `pending` | `approved` | `denied`. Defaults `approved`; set `pending` at write time only when `rsvp_approval_mode='manual'`; the host moves `pending → approved` / `pending → denied` (§5.4).
+
+Two dimensions because a guest can be simultaneously "Going" AND "Awaiting host approval" (manual mode), OR "Going" AND "Approved", OR "Waitlisted" (capacity, orthogonal to approval). Collapsing them into one column would make these states unrepresentable. **Interaction / precedence rules (canonical):**
+1. A row counts toward "confirmed attending" (and toward the capacity cap) **iff** `rsvp_status='going' AND approval_status='approved'`.
+2. **Capacity-vs-approval precedence at submit (manual + cap both on):** capacity is evaluated against *confirmed-attending* count. A new Going RSVP first resolves approval: `pending` (manual). A `pending` row does NOT consume capacity. Capacity is only consumed when the host approves. Therefore in manual mode a guest is never auto-`waitlisted` at submit — they are `pending`; if capacity is already full when the host tries to approve, the approve is rejected (`rsvp_capacity_full` — host must raise the cap or deny others). In **auto** mode, a new Going RSVP that would exceed the cap is set `rsvp_status='waitlisted', approval_status='approved'` (waitlisted-but-host-auto-OK).
+3. `denied` and `not_going` and `waitlisted` rows never consume capacity. A `denied` row keeps `rsvp_status` as last-known but is treated as not-attending for all counts.
+
+```sql
+CREATE TABLE public.event_rsvps (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id        uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  user_id         uuid NULL REFERENCES auth.users(id) ON DELETE SET NULL, -- NULL for anon link guests
+  guest_name      text NOT NULL,                 -- always captured (display on host list + notify)
+  guest_email     text NULL,                     -- A4-NEW (DECIDED): REQUIRED for link guests (user_id IS NULL) — enforced at the form + RPC + a DB CHECK below; nullable at column level only because app-user (user_id IS NOT NULL) rows may inherit/omit it (profile supplies notify addresses)
+  guest_phone     text NULL,                     -- A4-NEW (DECIDED): REQUIRED for link guests (E.164) — enforced at the form + RPC + the same DB CHECK; nullable at column level only for app-user rows
+  rsvp_status     text NOT NULL DEFAULT 'going'
+                    CHECK (rsvp_status IN ('going','not_going','waitlisted')),  -- A3: + waitlisted
+  approval_status text NOT NULL DEFAULT 'approved'
+                    CHECK (approval_status IN ('pending','approved','denied')), -- A2: + denied. A2-NEW (DECIDED): 'denied' is ALSO the host-REMOVE terminal state for an already approved/Going guest (no distinct 'removed' state — see §4.1c host-remove rule + §5.4).
+  plus_count      integer NOT NULL DEFAULT 0 CHECK (plus_count >= 0),
+  waitlisted_at   timestamptz NULL,              -- A3: set when system sets rsvp_status='waitlisted'; ORDER BY for promote-oldest
+  promoted_at     timestamptz NULL,              -- A3: set when auto-promoted waitlisted→going
+  notified_at     timestamptz NULL,              -- A3/A4: last transactional-notify enqueue (idempotency aid)
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  -- A4-NEW (DECIDED, Seth 2026-06-15): a LINK guest (user_id IS NULL) MUST carry BOTH a
+  -- usable email AND a usable phone, so the host's "they'll be notified" promise always holds
+  -- across email + SMS. App-user rows (user_id IS NOT NULL) are exempt at the DB layer (they
+  -- inherit notify addresses from their profile / are reachable via push by user_id).
+  CONSTRAINT event_rsvps_link_guest_contact_required CHECK (
+    user_id IS NOT NULL
+    OR (guest_email IS NOT NULL AND length(btrim(guest_email)) > 0
+        AND guest_phone IS NOT NULL AND length(btrim(guest_phone)) > 0)
+  )
+);
+CREATE INDEX event_rsvps_event_id_idx ON public.event_rsvps (event_id);
+-- A3: promote-oldest query support (waitlisted rows ordered by waitlisted_at ASC).
+CREATE INDEX event_rsvps_waitlist_idx ON public.event_rsvps (event_id, waitlisted_at)
+  WHERE rsvp_status = 'waitlisted';
+CREATE UNIQUE INDEX event_rsvps_event_user_uniq
+  ON public.event_rsvps (event_id, user_id) WHERE user_id IS NOT NULL;
+CREATE UNIQUE INDEX event_rsvps_event_email_uniq
+  ON public.event_rsvps (event_id, lower(guest_email)) WHERE guest_email IS NOT NULL;
+```
+**Capacity accounting (A3):** the "confirmed attending" headcount used for the cap is
+`SUM(1 + plus_count) FILTER (WHERE rsvp_status='going' AND approval_status='approved')` — the `+1`s count. The `rsvp_capacity` cap is compared against this sum (see §5.3 submit + §5.5 promote).
+Notes: the two partial-unique indexes prevent a logged-in guest or an emailed link guest from double-RSVPing (a re-submit UPDATEs the existing row). **(A4-NEW, DECIDED) Every link guest (`user_id IS NULL`) is REQUIRED to supply BOTH `guest_email` AND `guest_phone`** — enforced at three layers: the public form (§6.5), the `submit_event_rsvp`/`public-submit-rsvp` write path (§5.3 step 2, raises `rsvp_contact_required`), and the DB `event_rsvps_link_guest_contact_required` CHECK above (last-line defense). Because email is now always present for a link guest, the `event_email_uniq` partial index always covers link guests (no more "anon without email" un-deduped rows). **App-user RSVPs (`user_id IS NOT NULL`) inherit the rule loosely:** they are NOT required to type email/phone (the column-level NULLs stay) — the notify pipeline resolves their addresses from their profile where available and always has push by `user_id` (see §5.6 + §6.5 logged-in path). Contact columns mirror `waitlist_entries`'s `email`/`phone` shape (`20260724000010_orch_0948_waitlist_feature.sql:117-127` selects `email, phone` per entry). The model is event-scoped, mirroring `board_card_rsvps`'s shape (`20260505000000_baseline_squash_orch_0729.sql:7520-7531`) but on `event_id`.
+
+**(d) RLS on `public.event_rsvps` (RLS ENABLED).**
+- **Host read (all rows for their brand's events):**
+  `SELECT` USING `EXISTS (SELECT 1 FROM public.events e WHERE e.id = event_rsvps.event_id AND public.biz_brand_effective_rank(e.brand_id, auth.uid()) >= public.biz_role_rank('event_manager'))`.
+- **Host write (approve/deny/remove — UPDATE `approval_status` and/or `rsvp_status`):** same `event_manager`-rank predicate as host read (USING + WITH CHECK). **(A2 + A2-NEW)** This is the policy the `host_set_rsvp_status` RPC writes under (the RPC is `SECURITY DEFINER` but the predicate is still asserted in-RPC so RLS and the RPC agree — defense-in-depth). A host may set `approval_status` to `approved`/`denied` **from any source state** — `pending→approved`, `pending→denied`, AND **`approved→denied` (the A2-NEW host-REMOVE / un-admit transition)** — and is the only actor who may write `rsvp_status='waitlisted'` directly; ordinary guest UPDATEs may only set `rsvp_status` to `going`/`not_going` for their own row. Only the owning brand's host (`event_manager`-rank) may perform the remove (RLS USING/WITH CHECK both assert the rank; cross-brand removal is impossible).
+- **Guest read own:** `SELECT` USING `user_id = auth.uid()`.
+- **Guest write own (logged-in):** `INSERT`/`UPDATE` WITH CHECK `user_id = auth.uid()` AND the event is a published discoverable/linked RSVP (`EXISTS event e WHERE e.id=event_id AND e.event_type='rsvp' AND e.status IN ('scheduled','live') AND e.deleted_at IS NULL`).
+- **Anon link guests** write via the `public-submit-rsvp` edge fn under **service-role** (bypasses RLS), NOT via a direct anon-key table INSERT (anon role gets NO direct table policy). This keeps the table closed to arbitrary anon writes while supporting link guests — the edge fn validates the event is a published RSVP and rate-limits.
+
+**(e) Discover-RPC widen.** The consumer discover RPC (`20261001000000_orch_426_discover_rpc.sql:100` filters `e.event_type = 'event'`) MUST be widened to also admit opted-in RSVP rows. Change the predicate to:
+```sql
+AND ( e.event_type = 'event'
+   OR (e.event_type = 'rsvp' AND e.rsvp_discoverable = true) )
+```
+Because the RPC is `CREATE OR REPLACE`, ship the full replacement function in the ORCH-1150 migration (latest definition wins per migration-chain rule). RSVP rows have no `has_paid_online` / paid-ticket concept → the `gated` CTE (`:108-112`) leaves them untouched (their `has_paid_online` resolves false). Confirm the SELECT still produces a valid `display_price_cents` for RSVP rows (RSVP = free; the converter should render no price — see §4.8). Also confirm any sibling discover function (`20260612000000_orch_426_discover_scale.sql:39`) is consistently widened or explicitly out-of-path.
+
+**(f) Auto-promote trigger `fn_rsvp_drain_on_capacity_freed()` + `trg_rsvp_drain_on_capacity_freed` (A3 — DETERMINISTIC, DB-trigger).** Clone the PROVEN ticket-waitlist precedent `fn_waitlist_drain_on_capacity_freed()` (`20260724000010_orch_0948_waitlist_feature.sql:93-169`) — same shape: `SECURITY DEFINER`, `SET search_path=public`, `AFTER UPDATE` on the attendance source row, select oldest waiting entries `ORDER BY <waitlisted_at> ASC`, enqueue a notification with an idempotency key, flip the entry's status. **This is a DB trigger, NOT an app-side function call** — it is the safest deterministic option (it fires in the SAME transaction that freed the spot, so two concurrent "spot frees" can't double-promote past the cap; the ticket waitlist chose exactly this for the same reason). Deltas vs the precedent:
+- **Trigger source = `public.event_rsvps`** (not `tickets`): `AFTER UPDATE OF rsvp_status, approval_status ON public.event_rsvps FOR EACH ROW WHEN (...)`, PLUS a second trigger path on `public.events` for the **cap-raise** case: `AFTER UPDATE OF rsvp_capacity ON public.events WHEN (NEW.rsvp_capacity IS DISTINCT FROM OLD.rsvp_capacity AND NEW.event_type='rsvp')`.
+- **"Spot freed" conditions (any of):** a going+approved row flips to `not_going`/`waitlisted`; an `approval_status` flips to `denied` — **this single condition covers BOTH `pending→denied` (a normal deny) AND `approved→denied` (the A2-NEW host-REMOVE of an already-approved/Going guest), so the host-remove auto-promote reuses the SAME mechanism with NO new trigger arm** (the trigger fires `AFTER UPDATE OF rsvp_status, approval_status` and recomputes free capacity regardless of which deny path freed the spot); a row is deleted (handle via an `AFTER DELETE` arm or recompute on the same trigger family); OR `events.rsvp_capacity` is raised.
+- **Promote logic:** compute `v_free := rsvp_capacity - confirmed_attending_sum` (the §4.1c capacity formula, counting `+plus_count`). While `v_free > 0`, take the OLDEST `rsvp_status='waitlisted'` row (`ORDER BY waitlisted_at ASC NULLS FIRST, created_at ASC`), and:
+  - if the event is **auto** mode → set that row `rsvp_status='going'`, `promoted_at=now()`, decrement `v_free` by `(1 + plus_count)`.
+  - if the event is **manual** mode → set that row `rsvp_status='going', approval_status='pending'`, `promoted_at=now()` (the host still approves), and STOP consuming free capacity for it (a pending row doesn't occupy the cap; promote the next waitlisted too if still free) — i.e. manual promotion converts waitlist→pending, not waitlist→confirmed.
+  - In BOTH cases enqueue a transactional notification for the promoted guest (insert into the A4 `rsvp_notifications` queue with `template_key='rsvp_waitlist_promoted'`, idempotency key `rsvp_promote:<rsvp_id>:<events.updated_at-or-counter>` — guard double-promote via `ON CONFLICT DO NOTHING` exactly as the ticket trigger's `'waitlist_invite:'||id` key does `:148`).
+- **Capacity-unlimited / cap-OFF events:** `rsvp_capacity IS NULL` → the trigger is a no-op (no "full" → nothing to drain), mirroring the precedent's early `RETURN NEW`.
+- Defensive existence-check of the `rsvp_notifications` queue table so the trigger never breaks the parent UPDATE (mirror the `ORCH-0880` guard pattern and the precedent's `information_schema` nullable-check at `:86-91`).
+
+The enqueue-then-deliver split (trigger enqueues a `pending` queue row; the `rsvp-notify` edge fn + a retry sweeper deliver it) mirrors the ticket waitlist's `fn_waitlist_drain` → `ticket_order_notifications` → `ticket-confirmation-dispatch` → `notification-retry-sweeper` chain exactly (§5.5, §5.6).
+
+### 4.2 The new sibling wizard `RsvpCreatorWizard.tsx`
+
+Clone `EventCreatorWizard.tsx` wholesale, then apply these deltas. The shell logic (chrome, Stepper, autosave, desktop rail, dock, discard/publish dialogs, Toast) is reused as-is EXCEPT:
+
+**STEP_DEFS (6 entries, replaces the 7-entry array at `EventCreatorWizard.tsx:111-119`):**
+```ts
+const STEP_DEFS = [
+  { title: "Basics",   subtitle: "Name, format, and party type" },
+  { title: "When",     subtitle: "Date and time" },
+  { title: "Where",    subtitle: "Venue or online link" },
+  { title: "Cover",    subtitle: "Pick a cover style" },
+  { title: "RSVP",     subtitle: "Capacity, plus-ones, approvals" },
+  { title: "Preview",  subtitle: "How it looks to guests" },
+];
+```
+`TOTAL_STEPS = 6`. `renderStepBody` switch (clone of `:631-673`) maps: 0→`CreatorStep1Basics`, 1→`CreatorStep2When`, 2→`CreatorStep3Where`, 3→`CreatorStep4Cover`, 4→`RsvpStep5Setup`, 5→`RsvpStep7Preview` (RSVP preview — see §4.4).
+
+**Publish dock (`:894-922`):** remove the Stripe-block disable (`publishDisabled = publishability.status === 'blocked-stripe'` at `:609-610`). RSVP `publishDisabled = coverVideoProcessing` only. Label "Publish RSVP".
+
+**`handlePublishTap` (`:505-529`):** replace `validatePublish(liveDraft, stripeStatus)` with `validateRsvpPublish(liveDraft)` (no stripe arg). Drop the `stripeBlocking`/`stripeNotConnected` branches entirely. On errors → open `PublishErrorsSheet` (reused). On clean → `setPublishConfirmVisible(true)`.
+
+**`handleConfirmPublish` (`:531-587`):** keep the simulated-submit + `onPublishDraft` call. The `resolvePaidPublishGuardCopy` branch (`:560-576`) is INERT for RSVP (no paid gate) but harmless to keep; recommend dropping it for clarity. The publish RPC error surface for RSVP is `offering_date_past` only if a discoverable RSVP is past-dated — see §4.6 publish RPC; map it to a When-step jump (mirror Guard B `:572-574`).
+
+**Publish modal copy (`:613-627`):** single-date only → static title `"Publish RSVP?"`, description `"Your invite link goes live immediately. Guests can RSVP right away. You can edit details after publishing."`. Drop the recurring/multi_date branches.
+
+**`stripeStatus` / `payoutGateStatus` / `computePublishability` imports:** remove (RSVP has no money gate).
+
+### 4.3 Step-component reuse table (which existing components are reused as-is vs need a variant)
+
+| Step | Component | Verdict | Required change |
+|------|-----------|---------|-----------------|
+| 1 Basics | `CreatorStep1Basics` | **REUSE AS-IS** | No change. Keep Name + Format + **Party Type (required ≥1)** + Vibe Tags + Music Genre + Description. *(Steering #2 OVERRIDE: the walkthrough said drop Party Type; Seth says KEEP it. Basics for RSVP == Basics for event.)* |
+| 2 When | `CreatorStep2When` | **REUSE, single-mode only** | The component renders mode tabs (single/recurring/multi_date). For RSVP, the wizard forces `whenMode:"single"` at draft creation (§4.6) and the RSVP draft MUST hide the recurring/multi_date mode switcher. Pass a NEW optional prop `lockSingleDate?: boolean` (default false; RSVP passes true) that hides the mode tabs + renders only the single-date body. *(Steering #4.)* If adding the prop is heavier than a small variant, create `RsvpStep2When.tsx` wrapping the single-date sub-body — implementor's call, but the mode tabs MUST NOT be reachable in the RSVP wizard. |
+| 3 Where | `CreatorStep3Where` | **REUSE AS-IS** (validator relaxes city) | Component unchanged. The freeform-location relaxation lives in the VALIDATOR (`validateRsvpWhere`, §4.4) + the publish RPC (no `city_required`), not the component. Reword the `hideAddressUntilTicket` label only if it surfaces in this step (it lives in Settings/where-copy); for RSVP it reads "Hide address until a guest RSVPs Going". |
+| 4 Cover | `CreatorStep4Cover` | **REUSE VERBATIM** | Zero change. `validateCover` returns `[]` (`draftEventValidation.ts:448-450`); RSVP keeps that. |
+| 5 RSVP setup | `RsvpStep5Setup` (NEW) | **CREATE** | Replaces Tickets entirely. Full host control (§4.4 component contract). |
+| 6 Settings (now folded) | — | **FOLDED into RSVP-setup + Preview** | *Decision:* the 6-step RSVP wizard does NOT carry a standalone Settings step. The settings RSVP needs (visibility, private guest list, going-count visibility, require-approval) move INTO the RSVP-setup step (§4.4), because they are few and RSVP-semantic. This drops `allowTransfers` (ticket-only, dead toggle) and the password/transfer settings. *Justification below.* |
+| Preview | `RsvpStep7Preview` (NEW, clone of `CreatorStep7Preview`) | **CREATE / MODIFY** | Renders the RSVP public-page mini preview (Going/Not-going), NO StripeBlockedCard, NO money surfaces, NO `onConnectStripe`. |
+| — Hub list-card / manage-sheet | shared `offering/` primitives (`OfferingManageSheet.tsx`, `EventManageMenu.tsx`) | **NEEDS `event_type='rsvp'` branch + (A2) "Guests" row** | Render "N going" (from the §4.1c confirmed-attending count) instead of revenue/tickets-sold. **(A2)** Add a "Guests" action row (clone of the "Orders" row `EventManageMenu.tsx:171-183`) that routes to `/rsvp/[id]/guests` (the approve/deny console, §5.4); show a pending-count badge when `rsvp_approval_mode='manual'` and pending>0. |
+
+**Why 6 steps (no standalone Settings step) + discovery toggle placement.** *(Step structure CONFIRMED unchanged by the 2026-06-15 amendment — A2/A3/A4 add NO wizard step; the console + notifications are post-publish surfaces, not authoring steps. The 6 steps remain Basics → When → Where → Cover → RSVP-setup → Preview.)* The investigation's §3 table kept Settings as step 6. This SPEC folds Settings into the RSVP-setup step and drops it as a standalone, because (a) RSVP keeps only 4 settings (visibility, private guest list, hide-going-count, require-approval) and 3 of those are already part of the host-control intent of the RSVP-setup step; (b) `allowTransfers` + password are pure ticket concepts and become dead taps (Constitution #1) — dropping the step removes them cleanly; (c) fewer steps = lower Partiful-style friction. **The discovery toggle lives in the RSVP-setup step** (NOT a separate Settings step), grouped under a "Who can find this" subsection with the visibility control — this co-locates the two discoverability decisions (public/unlisted/private visibility AND show-on-discovery-feed) so the host sets reach in one place. Default `rsvp_discoverable = false` (link-only, Partiful parity, steering #1).
+
+### 4.4 The RSVP-setup step component contract (`RsvpStep5Setup.tsx`)
+
+Conforms to `StepBodyProps` (`types.ts:14-77`) — reuse the shared prop contract verbatim (the `editMode`/`canEditTicketPrice` props are ignored). All writes go through the passed `updateDraft` patcher.
+
+**Sections + fields (top to bottom), with defaults and persistence:**
+
+1. **Capacity** (steering #3 — optional cap)
+   - Toggle "Limit the guest list" (default OFF). When OFF → `rsvpCapacity = null` (unlimited).
+   - When ON → numeric stepper/input "Max guests" (min 1). Persists `rsvpCapacity:int`.
+   - Copy when OFF: "No limit — anyone with the link can RSVP."
+
+2. **Plus-ones** (steering #3 — +1 toggle + count)
+   - Toggle "Allow guests to bring extras" (default OFF) → `rsvpAllowPlusOnes:boolean`.
+   - When ON → numeric stepper "Max extra guests per person" (min 1, default 1) → `rsvpPlusOnesMax:int`.
+   - Helper: "Each guest's extras count toward your limit."
+
+3. **Waitlist** (steering #3 — waitlist-when-full) — **A3: this toggle now backs the REAL auto-promote feature.**
+   - Toggle "Start a waitlist when full" (default OFF) → `rsvpWaitlistEnabled:boolean`.
+   - DISABLED + greyed when Capacity is OFF (no cap → no "full"). Helper: "Add a guest limit first."
+   - Helper when ON: "When a spot opens, the next person on the waitlist is automatically moved in and notified." *(A3 — no longer a passive flag; it arms `fn_rsvp_drain_on_capacity_freed`, §5.5.)*
+
+4. **Approvals** (steering #3 — manual vs auto, host chooses) — **A2: "Approve each RSVP" now backs the REAL approve/deny console.**
+   - Segmented control: **"Auto-approve"** (default) | **"Approve each RSVP"** → `rsvpApprovalMode:'auto'|'manual'`.
+   - Auto helper: "Guests are in the moment they tap Going."
+   - Manual helper: "You approve each guest from your Guests list. They'll see 'Awaiting host approval' until you do." *(A2 — the Guests console, §5.4, is reachable from the RSVP's manage-sheet once published.)*
+
+5. **Who can see the guest list** (reuses existing `privateGuestList` field `draftEventStore.ts:349`)
+   - Toggle "Keep the guest list private (only you see who's coming)" (default ON) → `privateGuestList:boolean`.
+   - When OFF → guests see the full Going list. *(Matches walkthrough §7d default host-only.)*
+
+6. **Going count visibility** (reuses existing `hideRemainingCount` field `draftEventStore.ts:343`, re-labeled)
+   - Toggle "Hide the Going count from guests" (default OFF) → `hideRemainingCount:boolean`.
+
+7. **Who can find this** (visibility + discovery toggle co-located)
+   - Visibility pills public / unlisted / private (reuses `visibility` field) — same control as the event Settings step.
+   - Toggle **"Also show this on Mingla's discovery feed"** (default OFF) → `rsvpDiscoverable:boolean`. *(Steering #1.)*
+   - Helper: "Off = invite-link only (only people you share the link with). On = anyone nearby can find and RSVP."
+   - When `visibility='private'`, the discoverable toggle is DISABLED + forced OFF (a private RSVP can't be on a public feed) — enforce in both the component and the publish RPC.
+
+**`validateRsvpStep(4, draft)` returns `[]`** — no required fields (mirrors `validateCover`/`validateSettings`). The only cross-field rule (waitlist-requires-capacity, plus-max≥1-when-allowed) is UI-enforced via disabled states, not a publish blocker.
+
+**States:** every toggle has loading=N/A (local), pressed, disabled (the two conditional disables above), and a11y label per `I-39`. No empty/error state (all defaults valid). Android glass: any new card/row uses the opaque-fallback (`Platform.select` solid fill, `overflow:'hidden'`, no Android shadow) per `ANDROID_GLASS_USES_OPAQUE_FALLBACK`.
+
+### 4.5 The chooser fork (`UniversalCreatorSheet.tsx`)
+
+Mirror the ORCH-1144 in-sheet experience-step pattern exactly (`:262-311`). Edits:
+
+1. Extend the step union (`:73`): `export type UniversalCreatorStep = "root" | "experience" | "event";`
+2. Change the `"event"` `ROOT_OPTIONS` entry (`:110-117`) from `route:"/event/create"` to `step:"event"` (drop the `route`, add `step:"event"`). Update its subtitle to neutral copy: `"A gathering with guests — ticketed, or RSVP-only."`
+3. Add an `EVENT_OPTIONS` array (mirror `EXPERIENCE_OPTIONS` `:145-173`), two rows:
+   - `{ key:"ticketed", iconName:"calendar", title:"Ticketed event", subtitle:"Sell or issue tickets — concert, party, comedy night, festival.", route:"/event/create", testID:"event-chooser-ticketed" }`
+   - `{ key:"rsvp", iconName:"sparkle"|"list", title:"RSVP event", subtitle:"Guests reply Going or Not going. No tickets — like a private invite.", route:"/rsvp/create", testID:"event-chooser-rsvp" }`
+   (Use a distinct icon from the experience rows; `IconName` union at `:87` already includes `list`. Add a new icon name only if a better glyph exists — otherwise reuse `list`.)
+4. Add a render branch for `step==="event"` (clone the `step!=="root"` experience branch `:262-311`): heading **"Create an event"**, subtitle "Pick how guests join.", a Back affordance gated by `step==="event" && initialStep==="root"`, and the `EVENT_OPTIONS` rows reusing the `expRow` Android-opaque styles (`:402-424`).
+5. Generalize `canGoBackToRoot` (`:225`): change to `const showBack = step !== "root" && initialStep === "root";` and use `showBack` in both the experience and event branches (currently `canGoBackToRoot` is experience-specific). Add a corresponding `handleEventSelect` (clone of `handleExperienceSelect` `:215-220`) — both just `pushRoute(option.route)`.
+6. `handleRootSelect` (`:203-213`) is unchanged — it already checks `option.step` first, so the `"event"` row now transitions in-place instead of pushing.
+
+**Caller-regression check (MANDATORY).** Callers pass `initialStep` (`:81-84`). The only non-default caller is Hub > Experiences passing `"experience"`. **No caller passes `"event"`** (the `+` button opens at `"root"`). Confirm by grepping `initialStep=` across `mingla-business/src` before merge: the only literal values are `"experience"` and the implicit `"root"` default. The fork is therefore additive and regresses no caller. The existing `/event/create` route is UNTOUCHED — Ticketed flows exactly as today.
+
+### 4.6 Draft store (`draftEventStore.ts`)
+
+**Discriminator + additive RSVP fields on `DraftEvent` (add after the Settings block ~`:354`):**
+```ts
+  /** ORCH-1150 — true when this draft is an RSVP event (routes to the RSVP
+   *  wizard + business_publish_rsvp_draft). Absent/false = ticketed event. */
+  isRsvp: boolean;
+  /** ORCH-1150 — RSVP host-control (ignored when isRsvp=false). */
+  rsvpCapacity: number | null;        // null = unlimited
+  rsvpAllowPlusOnes: boolean;
+  rsvpPlusOnesMax: number;            // 0 when not allowed
+  rsvpWaitlistEnabled: boolean;
+  rsvpApprovalMode: "auto" | "manual";
+  rsvpDiscoverable: boolean;
+```
+Defaults in `DEFAULT_DRAFT_FIELDS` (`:401-451`): `isRsvp:false, rsvpCapacity:null, rsvpAllowPlusOnes:false, rsvpPlusOnesMax:0, rsvpWaitlistEnabled:false, rsvpApprovalMode:"auto", rsvpDiscoverable:false`.
+
+**RSVP draft creation.** Add `createRsvpDraft(brandId)` to the store (clone of `createDraft` `:803-808`) that sets `isRsvp:true, whenMode:"single"`. The `/rsvp/create` route calls `useDraftEventStore.getState().createRsvpDraft(currentBrandId)` and `router.replace`s to `/rsvp/${draft.id}/edit?step=0`. (Mirrors `app/event/create.tsx:192-193`, swapping the action + route.)
+
+**Persist version bump 11 → 12 + additive migrator (`:696-793`).** Set `version: 12`. Add a `version === 11` branch in `migrate` that maps every existing draft additively (all existing drafts are ticketed → `isRsvp:false` + the RSVP defaults):
+```ts
+if (version === 11) {
+  const v11 = persistedState as { drafts: Array<Omit<DraftEvent,
+    'isRsvp'|'rsvpCapacity'|'rsvpAllowPlusOnes'|'rsvpPlusOnesMax'|'rsvpWaitlistEnabled'|'rsvpApprovalMode'|'rsvpDiscoverable'>> };
+  return { drafts: v11.drafts.map((d): DraftEvent => ({
+    ...d, isRsvp:false, rsvpCapacity:null, rsvpAllowPlusOnes:false,
+    rsvpPlusOnesMax:0, rsvpWaitlistEnabled:false, rsvpApprovalMode:'auto', rsvpDiscoverable:false,
+  })) };
+}
+```
+The terminal `return persistedState` (`:792`) handles version 12. No existing migrator branch changes.
+
+**How the edit route knows which wizard to open.** The `/rsvp/[id]/edit` route resolves the draft via `useDraftById` and mounts `RsvpCreatorWizard` unconditionally (the route IS the discriminator). For the **published-edit** path, the edit route reads `event_type` off the resolved live event (the server row carries `event_type='rsvp'`) — when `event_type==='rsvp'` it mounts the RSVP edit screen / `biz_update_live_rsvp` path. Defensively, `isRsvp` on the draft is the client-side discriminator so an `/event/[id]/edit` URL pointed at an RSVP draft can redirect to `/rsvp/[id]/edit` (and vice-versa) rather than mounting the wrong wizard. Spec the edit-route guard: if `draft.isRsvp === true` and the route is the event-edit route → `router.replace('/rsvp/'+id+'/edit'...)`; the RSVP edit route does the inverse.
+
+### 4.7 The RSVP-specific validator (`draftRsvpValidation.ts`)
+
+Fork — do NOT reuse `validateTickets`/`validatePublish` (they block at 0 tickets `draftEventValidation.ts:454-460` and loop the Tickets step `:76-78`). Export:
+
+```ts
+export const validateRsvpStep = (step: number, draft: DraftEvent): ValidationError[] => {
+  switch (step) {
+    case 0: return validateBasics(draft);       // REUSE from draftEventValidation (keeps party-type gate, steering #2)
+    case 1: return validateRsvpWhen(draft);     // single-mode only
+    case 2: return validateRsvpWhere(draft);    // venue+address required; NO structured-city gate
+    case 3: return [];                          // Cover — no rules
+    case 4: return [];                          // RSVP setup — no ≥1 requirement (steering #3)
+    case 5: return [];                          // Preview
+    default: return [];
+  }
+};
+
+export const validateRsvpPublish = (draft: DraftEvent): ValidationError[] => {
+  const errors: ValidationError[] = [];
+  for (let step = 0; step <= 4; step++) errors.push(...validateRsvpStep(step, draft));
+  return errors;  // NO stripe/paid cross-step gate.
+};
+```
+
+- **`validateBasics`** — import the EXISTING `validateBasics` from `draftEventValidation.ts` (export it). It already requires name + description + ≥1 canonical party type — exactly steering #2. Do not duplicate.
+- **`validateRsvpWhen`** — clone `validateWhenSingle` (`draftEventValidation.ts:171-193`): requires `date` (no past), `doorsOpen`, `endsAt`. Drop the recurring/multi_date branches entirely (steering #4).
+- **`validateRsvpWhere`** — clone `validateWhere` (`:377-420`) BUT drop the `city`-required sub-rule (`:393-402`). For in_person/hybrid require venueName + address only; freeform text is accepted (steering / walkthrough §3 Where). Keep the online-URL rule (`:404-418`) verbatim.
+
+No `computePublishability` equivalent is needed (no Stripe state). The RSVP Preview step's "ready" state = `validateRsvpPublish(draft).length === 0`.
+
+### 4.8 Consumer deck RSVP card (discoverable path only)
+
+- **Supply:** the discover-RPC widen (§4.1e) already admits `event_type='rsvp' AND rsvp_discoverable=true` rows into the consumer card stream feeding `discover-cards`. No new RPC needed if the existing discover function is the supply path; confirm against the live deck source (`app-mobile/src/utils/cardConverters.ts` + `mergedDiscover.ts`). If the deck reads a separate `pg_eligible_*_for_deck` RPC (as experiences do per `project_orch_1065_consumer_experience_deck_card`), add an analogous inclusion there instead — implementor confirms the live supply path before choosing.
+- **Card variant:** add an RSVP branch in the card converter (`cardConverters.ts`) that maps an RSVP row to a card with: brand badge, cover, title, date/venue, and a **Going / Not going** CTA pair — NOT a Book/checkout button. Tapping "Going" calls the same RSVP-write path as the public page (`public_submit_rsvp` / the logged-in RPC); the consumer app user is authenticated so the write uses the logged-in RLS policy (`user_id = auth.uid()`), not the anon edge fn. Render NO price (RSVP is free).
+- Keep it minimal — this is gated entirely behind the host toggle; a link-only RSVP never reaches this code.
+
+---
+
+## 5. The publish + edit RPCs
+
+### 5.1 `business_publish_rsvp_draft(p_event_id uuid, p_draft_payload jsonb, p_client_revision integer DEFAULT NULL) RETURNS jsonb`
+
+Clone of `business_publish_event_draft` (`...orch_1075...sql:1813-2299`), `SECURITY DEFINER`, `SET search_path TO 'public','pg_temp'`. Deltas:
+
+**KEEP (verbatim from the event RPC):** auth gate (`:1870-1873`), draft-load + `FOR UPDATE` (`:1875-1879`), `event_draft_deleted` / `event_draft_not_publishable` (`:1885-1891`), permission rank (`:1893-1895`), brand load (`:1897-1905`), title-required (`:1927-1930`), slug generation (`:2022-2039`), single-date `event_dates` materialization (`:2071-2084`), the cover/description/timezone reads (`:2041-2059`), and the **party-type read + canonical validation** (`:1970-2000`, steering #2).
+
+**REMOVE (the ticket assumptions):**
+- The `event_ticket_required` empty-array gate (`:1932-1934`) — DELETE.
+- The per-ticket validation loop (`:1936-1966`) — DELETE.
+- The `city_required` gate (`:1986-1988`) — DELETE (steering / freeform location).
+- The entire paid-publish guard block (`:2123-2157`) — DELETE the Stripe `stripe_charges_disabled` raise. KEEP an `offering_date_past` guard ONLY when `rsvp_discoverable=true` (a discoverable RSVP must be future-dated so it doesn't surface a dead card); for link-only RSVPs, skip the past-date guard (a host can share a same-day link).
+- The `ticket_types` soft-delete + INSERT loop (`:2215-2269`) — DELETE. **An RSVP creates ZERO `ticket_types` rows** (`I-PROPOSED-1150-RSVP-NO-TICKET-ROWS`).
+- The multi_date / recurring date branches (`:2086-2121`) — DELETE (single-date only).
+
+**ADD:**
+- INSERT/UPDATE `event_type = 'rsvp'` (the event RPC writes `event_type` at `:421` in its INSERT path; the publish UPDATE at `:2164-2209` must set `event_type='rsvp'` — confirm the draft row was created with `event_type='rsvp'`; safest is to set it explicitly in the UPDATE).
+- Read + persist the RSVP host-control columns from `v_business_draft`: `rsvp_capacity`, `rsvp_allow_plus_ones`, `rsvp_plus_ones_max`, `rsvp_waitlist_enabled`, `rsvp_approval_mode` (CHECK `IN ('auto','manual')`), `rsvp_discoverable`. Enforce: if `visibility='private'` then `rsvp_discoverable := false`.
+- Vibe-tags / music-genres reads stay (optional, canonical) — they're harmless and keep Basics parity.
+
+**RETURN shape:** mirror the event RPC's `jsonb_build_object('event', to_jsonb(v_event), 'brand', {...}, 'tickets', '[]'::jsonb, 'eventDates', v_event_dates_rows, 'client_revision', ...)` — `tickets` is always the empty array.
+
+**Raised error codes (RSVP set):** `not_authenticated`, `event_draft_not_found`, `event_draft_deleted`, `event_draft_not_publishable`, `insufficient_event_permission`, `brand_not_found`, `event_title_required`, `event_date_required`, `party_types_required`, `party_types_not_canonical`, `rsvp_approval_mode_invalid`, `offering_date_past` (discoverable + past only). **Never** raises `event_ticket_required`, `city_required`, or `stripe_charges_disabled`.
+
+**Session flag:** if the `biz_prevent_event_slug_change` trigger (ORCH-0763) gates the draft→scheduled slug finalization (the trip RPC sets both `mingla.business_publish_trip_draft` AND `mingla.business_publish_event_draft` flags for this reason — `...orch_1075...sql:2621`), `business_publish_rsvp_draft` MUST `PERFORM set_config('mingla.business_publish_event_draft','on',true)` (and/or a new `mingla.business_publish_rsvp_draft` flag if the trigger is extended) so the slug write is permitted. Implementor verifies the trigger's accepted flags before merge.
+
+**Service caller (`rsvpEvents.ts`):** clone `publishBusinessEventDraft` (`businessEvents.ts:672-705`) → `publishRsvpDraft`, calling `supabase.rpc("business_publish_rsvp_draft", {...})`, building `p_draft_payload` via `draftToServerUpdate(draft,{})` (the `business_draft` JSONB must carry the new `rsvp*` keys — extend `draftToServerUpdate` to pass them through, or pass them explicitly). Keep the `mingla_event_published` AppsFlyer event (or a `mingla_rsvp_published` variant).
+
+### 5.2 `biz_update_live_rsvp(p_event_id uuid, p_payload jsonb, p_reason text) RETURNS jsonb`
+
+Mirror `biz_update_live_experience` (`...orch_1075...sql:1318-1336+`). Deltas:
+- Gate: `IF v_existing.event_type <> 'rsvp' THEN RAISE EXCEPTION 'event_not_an_rsvp' USING HINT='biz_update_live_rsvp only handles event_type=rsvp rows.';` (mirror `:1328-1331`).
+- Status gate: `status IN ('scheduled','live')` (mirror `:1333-1337`) — draft edits never route here.
+- Permission rank `>= event_manager` (mirror `:1339-1342`).
+- Patch the same offering fields (title/description/cover/when single-date/where/visibility) + the RSVP host-control columns. **No refund gate, no sold-ticket diff** — replace the experience's `biz_experience_sold_count`/refund context (`:1353-1354`) with an RSVP `going` count for the change-notice copy (see §6).
+- **(A4) Material-change detection + notify-enqueue.** When the UPDATE changes a guest-facing field — **date/time, venue/address, or cancellation** (NOT cover-only or description-only typo fixes; the implementor defines the "material" field set, recommend: `event_dates.starts_at`, `location_text`/venue, `status→cancelled`) — the RPC enqueues an `rsvp_notifications` row per GOING+APPROVED guest with `template_key='rsvp_event_updated'` and a payload carrying the changed field summary, idempotency key `rsvp_update:<event_id>:<events.updated_at>` so re-saving the same edit doesn't double-notify. The `rsvp-notify` edge fn (§5.6) then fans out push+SMS+email. **Capacity raise** is handled separately by the §4.1f trigger (it drains the waitlist + notifies the promoted guest, not all guests).
+- Returns `{ ok, ... , going_count, notified_count }`. No `intake_changed_tier_ids` / ticket machinery.
+
+### 5.3 `public_submit_rsvp` (guest write — anon-capable)
+
+**Edge function** `supabase/functions/public-submit-rsvp/index.ts`, `verify_jwt = false` (config.toml — mirror `discover-merged-events` `:21-22`). Runs under service-role; validates input; calls a `SECURITY DEFINER` RPC `public.submit_event_rsvp(...)` (or does the insert directly with service-role + explicit WHERE guards as defense-in-depth, mirroring the discover fn's pattern).
+
+Request: `{ eventId, guestName, guestEmail?, guestPhone?, rsvpStatus:'going'|'not_going', plusCount? }` + (when present) the caller's JWT for the logged-in path. **(A4-NEW — DECIDED, Seth 2026-06-15):** for an anon link guest (no JWT / no app account) `guestName` AND `guestEmail` AND `guestPhone` are ALL REQUIRED — the host's "they'll be notified" promise must hold across both email and SMS, so both contact addresses are mandatory at the link-guest write path. A logged-in app-user supplies none of email/phone (name from profile; notify resolves push + profile email + profile phone by `user_id`, §5.6).
+Server logic (AMENDED for A3 full waitlist + A4 contact capture):
+1. Load event; reject if not `event_type='rsvp'`, not `status IN ('scheduled','live')`, or `deleted_at` set → `404 rsvp_not_open`.
+2. **(A4-NEW)** Validate contact: anon path (no JWT) MUST have `guestName` non-empty AND `guestEmail` valid AND `guestPhone` present → else `400 rsvp_contact_required` (the inline form blocks before this, §6.5; the edge fn is the second line of defense, and the DB `event_rsvps_link_guest_contact_required` CHECK is the third). Normalize `guestPhone` to E.164 (reject malformed → `400 rsvp_phone_invalid`). The logged-in path (JWT present, `user_id` resolved) skips this required-contact gate.
+3. Clamp `plusCount` to `[0, rsvp_plus_ones_max]` (0 when plus-ones disallowed).
+4. **Resolve approval + attendance per the §4.1c precedence rules:**
+   - `approval_status := (rsvp_approval_mode='manual') ? 'pending' : 'approved'`.
+   - Compute `confirmed := SUM(1+plus_count) FILTER (rsvp_status='going' AND approval_status='approved')` for the event (FOR UPDATE on the event row to serialize concurrent submits — mirror the ticket checkout's capacity lock).
+   - **If `rsvpStatus='not_going'`** → write the row `rsvp_status='not_going'` (this may free a spot → the trigger §4.1f fires).
+   - **If `rsvpStatus='going'` AND `rsvp_capacity IS NULL`** (no cap) → `rsvp_status='going'` (approval as above).
+   - **If `rsvpStatus='going'` AND would exceed cap** (`confirmed + 1 + plusCount > rsvp_capacity`):
+     - **manual mode** → still write `rsvp_status='going', approval_status='pending'` (pending doesn't occupy the cap; the host's approve will be gated on capacity, §5.4). Response signals `pending`.
+     - **auto mode + `rsvp_waitlist_enabled`** → write `rsvp_status='waitlisted', approval_status='approved', waitlisted_at=now()`. Response signals `waitlisted`. *(A3 — a REAL status now, not a client-only flag.)*
+     - **auto mode + waitlist OFF** → reject `409 rsvp_full`. (No row written, or write `not_going`-equivalent? — write nothing; client shows "Event full".)
+   - **Else (`going` fits)** → `rsvp_status='going'`, approval as above.
+5. UPSERT on `(event_id, user_id)` (logged-in) or `(event_id, lower(guest_email))` (anon w/ email); else INSERT. A re-submit that flips `going→not_going` frees capacity (trigger §4.1f drains the waitlist).
+6. Rate-limit anon writes (per-IP, basic) to prevent guest-list spam.
+Response: `{ status:'going'|'not_going'|'waitlisted', approvalStatus:'pending'|'approved', capacityFull?:boolean }`.
+
+**Public-route allowlist (honor `anon_buyer_routes_must_be_allowlisted_against_root_auth_gate`).** The `/e/{brandSlug}/{eventSlug}` route is ALREADY in the `PUBLIC_BUYER_ROUTE_PREFIXES` allowlist (it's the event public page). RSVP reuses the SAME `/e/` route — no new prefix needed. Confirm the RSVP write itself (the edge-fn call) needs no auth-gated route; it's a fetch from the public page, not a navigation. If any NEW public route is introduced (it should not be — RSVP renders on `/e/`), it MUST be added to the allowlist. **The A2 `/rsvp/[id]/guests` host console route is a LOGGED-IN business-app route — it is NOT a public buyer route and MUST NOT be added to the anon allowlist.**
+
+### 5.4 Host approve/deny console (A2) — `host_set_rsvp_status` RPC + `RsvpGuestConsole.tsx`
+
+**RPC `host_set_rsvp_status(p_rsvp_id uuid, p_status text) RETURNS jsonb`** — `SECURITY DEFINER`, `SET search_path TO 'public','pg_temp'`. `p_status IN ('approved','denied')` (CHECK; else `rsvp_status_invalid`). Logic:
+1. Load the `event_rsvps` row + its event (`JOIN events`); `FOR UPDATE` on the rsvp row + the event row.
+2. **Auth/RLS:** assert `biz_brand_effective_rank(e.brand_id, auth.uid()) >= biz_role_rank('event_manager')` (same predicate as the host-read RLS §4.1d) → else `insufficient_event_permission`. Reject if `e.event_type<>'rsvp'` → `event_not_an_rsvp`.
+3. **State machine (A2 + A2-NEW host-remove — DECIDED, Seth 2026-06-15):** allowed transitions:
+   - `pending → approved` (admit) — capacity-gated, step 4.
+   - `pending → denied` (decline a not-yet-admitted guest).
+   - **`approved → denied` (the A2-NEW host-REMOVE / un-admit of an already-approved or Going guest)** — always allowed; this is the "remove guest" action. We REUSE `approval_status='denied'` as the terminal removed-state (NO distinct `'removed'` value) precisely so the existing §4.1f `fn_rsvp_drain_on_capacity_freed` trigger — which already treats a flip to `denied` as a spot-freeing event — auto-promotes the oldest waitlisted guest with ZERO new trigger code (see §4.1f). Re-applying the current status is idempotent (no-op, return current). A `denied → *` source (already-removed) is idempotent on `denied` and rejected otherwise → `rsvp_already_removed`.
+   - The RPC reads the source `approval_status` to pick the right notification template (step 6) and to know whether the deny frees an occupied spot.
+4. **Capacity gate on approve (manual+cap precedence, §4.1c rule 2):** if `p_status='approved'` and `rsvp_capacity IS NOT NULL` and `confirmed + 1 + plus_count > rsvp_capacity` → reject `rsvp_capacity_full` (host must raise the cap or deny/remove others). On success set `approval_status='approved'`. (Deny/remove is never capacity-gated.)
+5. **On `denied`** → set `approval_status='denied'`. (a) The removed/denied guest **no longer counts toward capacity** — the §4.1c precedence rule already excludes `denied` rows from the confirmed-attending sum, so the cap immediately reflects the freed seat. (b) If the source state was `approved` (a host-remove of an occupying guest) — OR a `pending` deny that had been provisionally counted — the flip to `denied` fires the §4.1f trigger, which **auto-promotes the OLDEST waitlisted guest** into the freed seat(s) (auto→going, manual→going+pending) and notifies them (§5.5). `rsvp_status` is left at its last-known value (the row is treated as not-attending purely via `approval_status='denied'`).
+6. **(A4) Enqueue guest notification:** insert an `rsvp_notifications` row for THIS guest. Template selection: `pending→approved` → `rsvp_approved`; `pending→denied` → `rsvp_denied`; **`approved→denied` (host-remove) → `rsvp_removed`** (distinct copy: "the host has removed you from this event" — see §5.6). Idempotency key `rsvp_approval:<rsvp_id>:<source_state>:<p_status>` (includes the source state so an approve-then-remove on the same row enqueues two distinct notifications, not a collision). The `rsvp-notify` edge fn (§5.6) fans out.
+7. Returns `{ ok, rsvpId, approvalStatus, wasRemoved:boolean, pendingCountRemaining, goingCountRemaining }` (`wasRemoved=true` when the transition was `approved→denied`).
+
+A **bulk-approve** companion `host_bulk_approve_rsvps(p_event_id uuid) RETURNS jsonb` approves all `pending` rows up to remaining capacity (oldest `created_at` first), enqueues one `rsvp_approved` notification each, returns `{ approvedCount, skippedForCapacity }`.
+
+**Service + hook.** `rsvpApprovals.ts.setRsvpStatus(rsvpId, status)` → `supabase.rpc('host_set_rsvp_status', …)` — this SINGLE caller serves Approve (`'approved'`), Deny (`'denied'` from pending) AND **Remove (`'denied'` from approved, A2-NEW)**; no separate remove RPC/service is added (the transition is disambiguated server-side by the source state). `listRsvpGuests(eventId)` → a host-scoped SELECT (RLS host-read) ordered pending-first then going then waitlisted. `useRsvpApprovals.ts`: `useRsvpGuestList(eventId)` (React Query key `['rsvp-guests', eventId]`) + `useSetRsvpStatus()` mutation invalidating `['rsvp-guests', eventId]` AND the offering going-count key on success (optimistic remove-from-section acceptable; on a Remove, the promoted waitlist guest only appears after the invalidated refetch). Clone the mutation shape from an existing business mutation hook (e.g. `useBusinessEvents.ts` publish hook) so error contract + toast match.
+
+**Component `RsvpGuestConsole.tsx`** (business iOS/Android, opened from the manage-sheet "Guests" row). A list screen — NOT a sheet (a pending list can be long; full-screen is the right affordance), cloning the row/list visuals from the event detail screens (`EventDetailActivityRow.tsx` row shape) + the action-button pattern. States (ALL required, Constitution #1 no dead taps):
+- **loading** → skeleton rows.
+- **empty (no pending, manual mode)** → "No one's waiting on approval. {N} going." (still shows the going list below).
+- **empty (auto mode)** → console still lists going + waitlisted guests, no Approve/Deny actions (auto = nothing to approve); copy "Everyone who taps Going is in automatically."
+- **list (pending exist)** → a "Pending ({N})" section: each row = guest name + contact (email/phone, masked-ish) + `+N` plus-count chip + **Approve** (filled) / **Deny** (ghost) buttons. A sticky **"Approve all ({N})"** bulk button at top (calls `host_bulk_approve_rsvps`).
+- **going section** → "Going ({M})" rows. **(A2-NEW — DECIDED)** each Going row carries a **Remove** action (a ghost/destructive trailing button or row-overflow item) that calls `host_set_rsvp_status(rsvpId, 'denied')` (the `approved→denied` transition, §5.4). Tapping Remove opens a **confirm dialog** — title "Remove {name}?", body "They'll be moved out of this event and notified. If you have a waitlist, the next person is moved in automatically.", actions **Remove** (destructive) / **Cancel** — and only on confirm fires the mutation (Constitution #1: the action must truly work, not a no-op). On success the row leaves the Going section, the going count drops, and (if a waitlist exists) a promoted guest appears.
+- **waitlisted section** → "Waitlist ({W})" read-only rows in `waitlisted_at` order.
+- **error** → toast "Couldn't load guests. Tap to retry." (never a dead end). Per-row Approve/Deny/**Remove** failure → toast "Couldn't update {name}. Try again." and the row stays in its prior section (no optimistic-stick on error).
+- Android glass: console cards/rows use the opaque fallback (`ANDROID_GLASS_USES_OPAQUE_FALLBACK`).
+- a11y labels on every Approve/Deny/**Remove**/Approve-all control (`I-39`).
+
+### 5.5 Waitlist auto-promote (A3)
+
+The mechanism is the §4.1f DB trigger `fn_rsvp_drain_on_capacity_freed` — DETERMINISTIC and in-transaction (chosen over an app-side function for the exact concurrency-safety reason the ticket waitlist chose it: `20260724000010_orch_0948_waitlist_feature.sql:93-169`). Recap of the guest-facing behavior the trigger guarantees:
+- A spot opens (going→not_going, a `denied` — including the **A2-NEW host-REMOVE of an already-approved/Going guest (`approved→denied`)**, a deletion, OR a `rsvp_capacity` raise) → the OLDEST `waitlisted` guest (by `waitlisted_at ASC`) auto-promotes. The host-remove path reuses the identical drain mechanism as a normal deny — no parallel promote logic (§4.1f / §5.4 step 5).
+- **auto mode** → promoted straight to `going` (confirmed). **manual mode** → promoted to `going`+`pending` (host still approves from the §5.4 console).
+- The promoted guest is notified (`template_key='rsvp_waitlist_promoted'`) via §5.6.
+- Promotion never exceeds the cap (in-transaction free-capacity recompute counting `+plus_count`).
+- Idempotent: `ON CONFLICT (idempotency_key) DO NOTHING` on the enqueue (mirror `:148`) prevents double-notify if two frees race.
+
+No app-side polling, no cron for the promote itself (the trigger is synchronous); only the *delivery* of the enqueued notification is async (edge fn + retry sweeper, §5.6).
+
+### 5.6 RSVP notification pipeline — push + SMS + email (A4)
+
+**Queue table `public.rsvp_notifications`** (clone the `ticket_order_notifications` shape — `20260724000010_orch_0948_waitlist_feature.sql:86-91` references its columns; the canonical columns are `id, event_id, rsvp_id NULL, channel, recipient, status, payload jsonb, idempotency_key UNIQUE, attempt_count, provider, provider_message_id, last_error, sent_at, created_at, updated_at`). `channel IN ('push','sms','email')`. `status` machine `pending → sending → sent | failed_retryable | failed_terminal | skipped` (identical to the ticket queue). RLS: service-role only (no client policy). A producer (the publish-edit RPC §5.2, the approve/deny RPC §5.4, the auto-promote trigger §4.1f) enqueues ONE row per guest per channel-they-can-receive, or one row per guest with the edge fn fanning channels — **recommend one row per (guest, trigger)** with the edge fn deciding channels by available contact, mirroring how `notify-dispatch` takes one call and does push+email internally (`notify-dispatch/index.ts:360-563`).
+
+**Edge fn `rsvp-notify`** (`supabase/functions/rsvp-notify/index.ts`, `verify_jwt=true`, service-role-invoked). Given a queue row (or `{ eventId, rsvpId, templateKey }`), it:
+1. Resolves the guest (`event_rsvps` row → `user_id`, `guest_email`, `guest_phone`, `guest_name`) + the event (title, date, venue, brand).
+2. Resolves the message copy by `templateKey` (table below).
+3. **Fans out across EVERY channel for which the guest has a usable address/token, EACH independently, NON-BLOCKING (Constitution #3).** **(A4-NEW-2 — DECIDED, Seth 2026-06-15):** the rule is **notify across ALL channels the guest can receive on — NOT push-only for app users.** Resolve each channel's address and attempt it if present:
+   - **push** — if `user_id IS NOT NULL` (an app-user guest): call `sendPush` from `_shared/push-utils.ts:95` with `app:"consumer"` (RSVP guests are consumer-app users; `resolveOneSignalApp` returns consumer for a non-`business.`/`stripe.` type — keep the type prefix neutral, e.g. `rsvp_*`). Also write an in-app `notifications` row (reuse `notify-dispatch` OR insert directly) so the guest's inbox reflects it.
+   - **email** — attempt if an email address is resolvable: `guest_email` (always present for a link guest, §4.1c) OR, **for an app-user guest, the guest's verified profile/auth email** resolved server-side in the edge fn (look up `auth.users`/`auth.identities` by `user_id` per the verified-identity rule in `project_orch_1111_1112_invite_surface_ari_reachable`; never `user_metadata`). Clone the Resend send from `notify-dispatch/index.ts:84-138` (`sendResendBrandedEmail`, env `RESEND_API_KEY`, `EMAIL_SENDERS.system`, `assertNotResendSandbox` — NO `@resend.dev` fallback). **Do NOT write a new Resend client.**
+   - **SMS** — attempt if a phone is resolvable: `guest_phone` (always present for a link guest, §4.1c) OR, for an app-user guest, a phone on their profile if one exists. Clone `sendTwilioMessage` from `ticket-confirmation-dispatch/index.ts:123-170` (env `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` / `TWILIO_MESSAGING_SERVICE_SID`; optional `TWILIO_STATUS_CALLBACK_SECRET` → the existing `twilio-message-status` callback). **Do NOT write a new Twilio client.**
+   - **Resulting matrix:** an **app-user guest** gets **push AND email (AND SMS if a phone is on file)** — every channel they have a usable address/token for (A4-NEW-2), not push-only. A **link guest** gets **email AND SMS** (both always available — the form now requires both, §6.5 / §4.1c), plus push only if they later become an app user with a matched `user_id`. The explicit rule the implementor codes: *for each of {push, email, sms}, resolve the address/token; if present, attempt that channel; otherwise skip it.* No channel is suppressed when an address exists.
+4. **Per-channel failure is logged + isolated** — one channel throwing/returning false MUST NOT abort the others (each in its own try/catch; collect `{push:ok, sms:ok, email:ok}`). Mirror `notify-dispatch`'s pattern: push failure is caught and warned (`:551-555`), email failure is caught and warned (`:381-383`) — neither blocks the other. Mark the queue row `sent` if ≥1 channel succeeded; `failed_retryable` if all available channels failed transiently; `failed_terminal` on a permanent failure (bad number/address). Log every per-channel outcome.
+5. **Idempotency:** the queue `idempotency_key` (UNIQUE) is set by the producer (`rsvp_update:…`, `rsvp_approval:…`, `rsvp_promote:…`); a re-invocation of `rsvp-notify` for an already-`sent` row no-ops.
+6. **Retry:** reuse the existing `notification-retry-sweeper` pattern (`supabase/functions/notification-retry-sweeper/index.ts`) — either extend it to also sweep `rsvp_notifications` (`status IN ('failed_retryable','pending')` older than N min) or add an analogous pg_cron sweeper. Implementor confirms whether to extend or fork.
+
+**Message copy per trigger per channel** (kept short; the email uses the branded `generic_notification` shell):
+
+| templateKey | Trigger | Push title / body | SMS body | Email subject / body |
+|---|---|---|---|---|
+| `rsvp_event_updated` | Host edits date/time/venue (§5.2) | "Plans changed: {event}" / "{what changed} — tap for details." | "{Brand}: {event} updated — {what changed}. {link}" | "{event} — updated details" / "The host updated {event}. {what changed}. See the latest: {link}" |
+| `rsvp_waitlist_promoted` | Auto-promote (§5.5) | "You're in! {event}" / "A spot opened — you're going. 🎉" | "{Brand}: a spot opened at {event} — you're in! {link}" | "You're off the waitlist for {event}" / "Good news — a spot opened and you're now going to {event}. {link}" |
+| `rsvp_approved` | Host approves (§5.4, manual) | "You're approved: {event}" / "The host approved your RSVP — see you there." | "{Brand}: you're approved for {event}! {link}" | "You're approved for {event}" / "The host approved your RSVP. {link}" |
+| `rsvp_denied` | Host denies a PENDING guest (§5.4, manual) | "RSVP update: {event}" / "The host couldn't fit your RSVP this time." | "{Brand}: the host couldn't fit your RSVP for {event}." | "About your RSVP to {event}" / "Unfortunately the host couldn't confirm your RSVP for {event} this time." |
+| `rsvp_removed` | Host REMOVES an already-approved/Going guest (§5.4, A2-NEW `approved→denied`) | "Update: {event}" / "The host has removed you from this event." | "{Brand}: the host has removed you from {event}." | "About your RSVP to {event}" / "The host has removed you from {event}. If you think this was a mistake, reach out to them." |
+
+(Copy is illustrative-to-spec; the implementor finalizes exact strings within these bounds. No emoji in SMS if it risks GSM-7 segmentation cost concerns — implementor's call.)
+
+---
+
+## 6. The public RSVP page + write path (`PublicEventPage.tsx`)
+
+The public page already mounts for `/e/{brandSlug}/{eventSlug}` and resolves the offering via `resolveOfferingCta` keyed off `tickets` (`:261-269`). For an `event_type='rsvp'` row (zero tickets), branch:
+
+1. **CTA machine.** Add `resolveRsvpCta` to `@mingla/event-rendering` (or an `event_type==='rsvp'` branch in `resolveOfferingCta`) returning an RSVP CTA descriptor: `{ kind:'rsvp', state:'open'|'full'|'waitlist'|'pending'|'going'|'not_going' }`. The floating bar + inline action render **Going / Not going** buttons instead of buy/free.
+2. **Replace checkout navigation.** The three `router.push(checkoutPublicPath(event.id))` sites (`:291,329,340`) become, for RSVP: call the RSVP write (`public_submit_rsvp` edge fn for anon/web; the logged-in RPC for the consumer app). NO navigation to `/checkout`.
+3. **+1 input.** When `rsvp_allow_plus_ones`, render a stepper "Bringing extras? +N" (max `rsvp_plus_ones_max`) next to Going. Passes `plusCount` to the write.
+4. **States (per write response / event state) — AMENDED for A3 real waitlist:**
+   - `open` → Going / Not going active.
+   - `full` (capacity hit, waitlist OFF, auto mode) → "Event full" + disabled Going (Not-going still allowed).
+   - `waitlist` (capacity hit, waitlist ON) → tapping Going writes a REAL `rsvp_status='waitlisted'` row (§5.3) → on success "You're on the waitlist — we'll text/email you if a spot opens." (A3: this is a real promotable status, not a client-only flag.)
+   - `pending` (manual approval, guest already RSVP'd) → "Awaiting host approval." (A2: the host admits from the Guests console; the guest is notified on approve/deny.)
+   - `going` / `not_going` (guest's own current state, when resolvable) → reflect + allow flip. Flipping going→not_going frees a spot (may auto-promote a waitlisted guest, §5.5).
+   - Not-bookable / errors → toast (never a dead-end; mirror the existing `showToast` guard at `:285-290`).
+5. **(A4-NEW — DECIDED) Guest identity + contact capture.** A lightweight inline field set (NOT a full account), shown before/at the Going tap:
+   - **Anon link guest:** **Name (required)** + **Email (required)** + **Phone (required — A4-NEW; both contact methods are mandatory so the host can always reach the guest by email AND SMS)**. All three are blocking — the Going button is disabled until name + a valid email + a valid phone are entered. A `400 rsvp_contact_required` from the edge fn surfaces inline ("Add your name, email, and phone to RSVP"); a `400 rsvp_phone_invalid` surfaces inline on the phone field ("Enter a valid phone number"). Validate email + phone format client-side before submit. Per-field validation states: empty-required (inline "Required"), invalid-format (inline message), valid (no message).
+   - **Logged-in consumer-app user:** skip the name/email/phone entry entirely (profile supplies them; notify resolves push + profile email + profile phone by `user_id`, §5.6 — the link-guest both-required rule does NOT apply to app users). Optionally surface a one-tap "add a phone for texts" affordance if no profile phone is on file, but it is NOT blocking.
+   - Transactional-basis microcopy near the field set: "We'll only use this to update you about this event." (transactional, not marketing — no consent checkbox; §2 non-goal.)
+   - The fields pass `guestName`/`guestEmail`/`guestPhone` to `public_submit_rsvp` (§5.3).
+6. **Host-side guest list.** The page (host view) / Hub shows "N going" (+ pending count when manual). **(A2)** The full approve/deny console SHIPS in v1 — reachable from the RSVP manage-sheet "Guests" row → `/rsvp/[id]/guests` (§5.4). **(A2-NEW)** From the same console the host can **Remove** an already-approved/Going guest (per-row Remove → confirm → `host_set_rsvp_status(..,'denied')`), which frees a spot, auto-promotes the oldest waitlisted guest, and notifies the removed guest (`rsvp_removed`). (No longer a follow-on.)
+
+This is **buyer-web** (the `/e/` public page) AND, for the discoverable path, the **consumer-app card** (§4.8) which reuses the same write.
+
+---
+
+## 7. Test Cases
+
+| # | Scenario | Input | Expected | Layer |
+|---|----------|-------|----------|-------|
+| T1 | Chooser fork | Open `+` → "Create event" | In-sheet `step:"event"` with Ticketed + RSVP rows; Back returns to root | Component |
+| T2 | Ticketed untouched | Tap "Ticketed event" | Pushes `/event/create`; existing 7-step wizard mounts unchanged | Integration |
+| T3 | RSVP create entry | Tap "RSVP event" | Pushes `/rsvp/create` → mints `isRsvp:true` draft → `/rsvp/{id}/edit?step=0` | Integration |
+| T4 | RSVP wizard has 6 steps | Mount `RsvpCreatorWizard` | Stepper shows Basics/When/Where/Cover/RSVP/Preview; no Tickets step | Component |
+| T5 | Party type still required (steering #2) | RSVP Basics with 0 party types → Continue | Blocks with "Pick at least one party type" | Validator |
+| T6 | RSVP When single-only (steering #4) | RSVP When step | No recurring/multi_date tabs reachable | Component |
+| T7 | Freeform location allowed | in_person, address typed not Places-picked (`city=null`) → Publish | Publishes (NO `city_required`) | RPC |
+| T8 | RSVP-setup returns [] | RSVP setup with all toggles default → Continue | Advances (no required fields) | Validator |
+| T9 | Publish creates zero tickets | Publish a valid RSVP | `events.event_type='rsvp'`; `SELECT count(*) FROM ticket_types WHERE event_id=… AND deleted_at IS NULL` = 0 | RPC/DB |
+| T10 | No stripe gate | Publish RSVP on a brand with `stripe_charges_enabled=false` | Publishes (no `stripe_charges_disabled`) | RPC |
+| T11 | Discoverable OFF → off deck | Publish link-only RSVP | Not returned by discover RPC | RPC/DB |
+| T12 | Discoverable ON → on deck | Publish `rsvp_discoverable=true` RSVP in a deck city | Returned by discover RPC with no price; card shows Going/Not-going | RPC/DB + Component |
+| T13 | Private forces non-discoverable | `visibility='private'` + discoverable ON | Publish persists `rsvp_discoverable=false` | RPC |
+| T14 | Anon guest Going | Logged-out, valid event, name set → Going | `event_rsvps` row `rsvp_status='going'`, `approval_status='approved'` (auto mode) | Edge/DB |
+| T15 | Manual approval | Auto=manual, anon Going | Row `approval_status='pending'`; page shows "Awaiting host approval" | Edge/DB + Web |
+| T16 | Capacity full | cap=2, 2 going, waitlist OFF, 3rd Going | `409 rsvp_full`; "Event full" | Edge/Web |
+| T17 | Plus-ones clamp | `rsvp_plus_ones_max=2`, guest sends `plusCount=5` | Persisted `plus_count=2` | Edge/DB |
+| T18 | RLS host read | Host queries `event_rsvps` for own brand event | Sees all rows; other brand sees none | RLS |
+| T19 | RLS guest read own | Logged-in guest queries | Sees only own row | RLS |
+| T20 | Edit-published RSVP | `biz_update_live_rsvp` on a `rsvp` row | Patches; on an `event` row → `event_not_an_rsvp` | RPC |
+| T21 | Wrong-wizard redirect | `/event/{id}/edit` for an `isRsvp` draft | Redirects to `/rsvp/{id}/edit` | Route |
+| T22 | Persist migrate 11→12 | Hydrate v11 store | All drafts gain `isRsvp:false` + RSVP defaults; no data loss | Store |
+| T23 | No checkout from RSVP page | RSVP `/e/` page, tap Going | Calls RSVP write; never navigates to `/checkout` | Web |
+| T24 | (A4-NEW) Both email AND phone required for link guest | Anon Going with email but no phone (and vice-versa) | `400 rsvp_contact_required`; Going disabled until name+email+phone all valid; DB CHECK `event_rsvps_link_guest_contact_required` rejects a direct insert missing either | Edge/Web/DB |
+| T25 | (A2) Manual mode → pending console | Manual RSVP, 3 anon Going | All `approval_status='pending'`; Guests console "Pending (3)" with Approve/Deny per row | Edge/DB + Component |
+| T26 | (A2) Approve admits + notifies | Host taps Approve on a pending row | `host_set_rsvp_status` → `approved`; `rsvp_notifications` row `template_key='rsvp_approved'` enqueued; pending count drops | RPC/DB |
+| T27 | (A2) Deny notifies | Host taps Deny | Row `approval_status='denied'`; `rsvp_denied` enqueued; row leaves pending | RPC/DB |
+| T28 | (A2) Approve capacity gate | manual, cap=2, 2 approved, approve a 3rd pending | `rsvp_capacity_full`; row stays pending | RPC |
+| T29 | (A2) Bulk approve | 5 pending, cap=3 (0 used) | `host_bulk_approve_rsvps` approves 3 oldest, `skippedForCapacity=2` | RPC |
+| T30 | (A2) RLS console | Brand B host opens Brand A's RSVP guests | No rows (host-read RLS) / `insufficient_event_permission` on set | RLS |
+| T31 | (A3) Auto-waitlist on full | auto mode, cap=2 full, waitlist ON, 3rd Going | Row `rsvp_status='waitlisted'`, `waitlisted_at` set; page "You're on the waitlist" | Edge/DB + Web |
+| T32 | (A3) Auto-promote oldest | one going flips not_going (frees 1) | OLDEST waitlisted row → `going` (auto) / `going`+`pending` (manual); `promoted_at` set; `rsvp_waitlist_promoted` enqueued | Trigger/DB |
+| T33 | (A3) Promote on cap raise | cap 2→4 with 2 waitlisted | Both promote (within new free cap); each notified | Trigger/DB |
+| T34 | (A3) Plus-count toward cap | cap=4, guest A going +2 (=3), guest B going +1 (=2) | B exceeds → waitlisted/full per mode | Edge/DB |
+| T35 | (A3) No double-promote on race | two frees in one tx | `ON CONFLICT` idempotency → exactly one promote-notify per promoted guest | Trigger/DB |
+| T36 | (A4) Three-channel fan-out | guest with email+phone+app, fire `rsvp_event_updated` | push (OneSignal) + SMS (Twilio) + email (Resend) all attempted; queue `sent` | Edge |
+| T37 | (A4) Per-channel non-blocking | Twilio mocked to 500, email OK | email sends, queue `sent` (≥1 channel), Twilio failure logged not thrown (Constitution #3) | Edge |
+| T38 | (A4) Link guest email+SMS | anon guest (email+phone, no app) fire a notify | email AND SMS both sent; no push attempted (no `user_id`); no crash | Edge |
+| T39 | (A4) Idempotent re-save | save same edit twice | one `rsvp_notifications` row per guest (idempotency_key collision) | RPC/DB |
+| T40 | (A2-NEW) Host removes an approved guest | manual/auto, cap=2 full (2 approved), host taps Remove on one Going row → confirm | that row `approval_status='denied'`; going count drops to 1; the seat is freed (no longer counts toward cap); `rsvp_notifications` row `template_key='rsvp_removed'` enqueued | RPC/DB |
+| T41 | (A2-NEW) Remove fires auto-promote | cap=2 full + 1 waitlisted; host removes one approved Going guest | the §4.1f trigger fires on `approved→denied`; OLDEST waitlisted guest → `going` (auto) / `going`+`pending` (manual), `promoted_at` set, `rsvp_waitlist_promoted` enqueued; same mechanism as a deny (no parallel path) | Trigger/DB |
+| T42 | (A2-NEW) RLS on remove | Brand B host calls `host_set_rsvp_status` on Brand A's approved rsvp | `insufficient_event_permission`; no state change | RLS/RPC |
+| T43 | (A4-NEW-2) App-user multi-channel | app-user guest WITH a profile email + profile phone, fire `rsvp_event_updated` | push AND email AND SMS all attempted (every channel the guest has an address/token for); NOT push-only; queue `sent` | Edge |
+| T44 | (A4-NEW-2) App-user push+email, no phone | app-user guest, profile email present, no phone | push AND email attempted; SMS skipped (no phone); queue `sent` | Edge |
+
+---
+
+## 8. Implementation Order
+
+1. **DB migration** — CHECK widen + `events` RSVP columns + `event_rsvps` table (two-dimension status + contact + waitlist columns) + RLS + `rsvp_notifications` queue + discover-RPC widen + `business_publish_rsvp_draft` + `biz_update_live_rsvp` (with notify-enqueue) + `host_set_rsvp_status` + `host_bulk_approve_rsvps` + `submit_event_rsvp` + `fn_rsvp_drain_on_capacity_freed` trigger (apply via Management API per `reference_supabase_db_write_paths` if CLI drift-wedged; deploy from MERGED main).
+2. **Edge fns** — `public-submit-rsvp` (`verify_jwt=false`, contact capture + full-waitlist logic) + **`rsvp-notify`** (`verify_jwt=true`, push+SMS+email fan-out reusing the three existing clients); config.toml both.
+3. **Draft store** — additive fields, `createRsvpDraft`, version 12 migrator.
+4. **Validator** — `draftRsvpValidation.ts`; export `validateBasics` from `draftEventValidation.ts`.
+5. **Services + hooks** — `rsvpEvents.ts` (`publishRsvpDraft`, `updateLiveRsvp`) + `useRsvpEvents.ts`; **`rsvpApprovals.ts` + `useRsvpApprovals.ts`** (A2 console data layer).
+6. **Wizard** — `RsvpCreatorWizard.tsx`, `RsvpStep5Setup.tsx`, `RsvpStep7Preview.tsx`; `lockSingleDate` prop on `CreatorStep2When`; routes `/rsvp/create` + `/rsvp/[id]/edit`.
+7. **Chooser fork** — `UniversalCreatorSheet.tsx` `step:"event"`.
+8. **(A2) Host console** — `RsvpGuestConsole.tsx` + `/rsvp/[id]/guests` route + the "Guests" manage-sheet row (`OfferingManageSheet.tsx`/`EventManageMenu.tsx`).
+9. **Public page** — `resolveRsvpCta` + `PublicEventPage.tsx` Going/Not-going branch + +1 + **(A4) contact-capture fields** + states (incl. real waitlist).
+10. **Consumer deck** — discover supply confirm + card converter RSVP variant + Going/Not-going card.
+11. **Hub** — offering list-card / manage-sheet `event_type='rsvp'` "N going" + pending-badge branch.
+12. **Edit-published** — RSVP-aware edit screen path (drop Tickets section + refund gate; "N guests are going — they'll be notified" notice; the notice now backs a REAL §5.2 notify-enqueue).
+
+---
+
+## 9. Regression Prevention (fails-on-revert contract)
+
+Six structural safeguards, each with a test that MUST fail when the fix is reverted and pass when restored:
+
+1. **`I-PROPOSED-1150-RSVP-NO-TICKET-ROWS`** — an `event_type='rsvp'` row has zero non-deleted `ticket_types`. **Test (SQL, `supabase/migrations/__tests__/orch_1150_rsvp.test.sql`):** publish an RSVP draft via `business_publish_rsvp_draft`, assert `count(ticket_types where event_id=… and deleted_at is null)=0`. Reverting the "DELETE the ticket INSERT loop" delta makes this FAIL.
+2. **`I-PROPOSED-1150-RSVP-OFF-DECK-UNLESS-DISCOVERABLE`** — an RSVP appears in the discover RPC iff `rsvp_discoverable=true`. **Test:** insert two scheduled RSVP rows (one discoverable, one not) in a deck city; call the discover RPC; assert only the discoverable one is returned, and a ticketed `event` is unaffected. Reverting the discover-RPC widen (or the `rsvp_discoverable` predicate) makes this FAIL.
+3. **`I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC`** — RSVP never routes through `business_publish_event_draft`. **Test (TS, strict-grep-style + integration):** `rsvpEvents.ts.publishRsvpDraft` calls `business_publish_rsvp_draft` and NOT `business_publish_event_draft`; and a static assertion that `RsvpCreatorWizard`/`/rsvp/*` never import the event publish hook. Reverting the fork (re-pointing RSVP at the event RPC) makes this FAIL — and would also re-introduce the `event_ticket_required` 0-ticket block (caught by T9).
+4. **`I-PROPOSED-1150-WAITLIST-AUTOPROMOTE-OLDEST` (A3 + A2-NEW)** — when a spot opens on a full waitlist-enabled RSVP, the OLDEST `waitlisted` guest (`waitlisted_at ASC`) auto-promotes and is notified, never exceeding the cap. **Test (SQL):** seed cap=2, 2 going+approved, 2 waitlisted (distinct `waitlisted_at`); flip one going→not_going; assert exactly the oldest waitlisted row flips to `going` (auto) / `going`+`pending` (manual), `promoted_at` set, exactly one `rsvp_notifications` row `template_key='rsvp_waitlist_promoted'` for that guest, and confirmed-attending never > cap. **A2-NEW arm (same trigger, same test family):** repeat the seed but instead of going→not_going, fire a **host-remove `approved→denied`** (via `host_set_rsvp_status(..,'denied')`) on an approved Going guest; assert the SAME auto-promote of the oldest waitlisted guest fires — proving host-remove reuses the drain mechanism, not a parallel one. Reverting the `fn_rsvp_drain_on_capacity_freed` trigger (or its `ORDER BY waitlisted_at` / `ON CONFLICT` idempotency, or removing `approved→denied` from the trigger's spot-freeing condition) makes this FAIL.
+5. **`I-PROPOSED-1150-RSVP-NOTIFY-MULTICHANNEL-NONBLOCKING` (A4 + A4-NEW-2)** — `rsvp-notify` attempts **every channel for which the guest has a usable address/token** (push if `user_id`, email if any resolvable email, SMS if any resolvable phone — for app users this means push AND email AND SMS, NOT push-only — A4-NEW-2), and a failure in one channel does NOT block the others or throw; the queue row is `sent` when ≥1 channel succeeds. **Test (TS, edge-fn unit):** (a) mock the Twilio client to throw/500 while the Resend mock succeeds; assert the email send still fires, the queue row ends `sent`, the Twilio failure is logged (not rethrown). (b) **A4-NEW-2 multi-channel assertion:** for an app-user guest WITH a resolvable profile email and phone, assert `sendPush` AND the Resend send AND the Twilio send are ALL invoked (proving the path is NOT push-only). Reverting the per-channel try/catch isolation (wrapping all three in one try that aborts on first throw) OR reverting to a push-only branch for app users makes this FAIL. Pairs with Constitution #3 (no silent failure: each per-channel outcome is logged).
+
+6. **`I-PROPOSED-1150-LINK-GUEST-CONTACT-BOTH-REQUIRED` (A4-NEW)** — a LINK guest (`event_rsvps.user_id IS NULL`) row MUST carry BOTH a non-empty `guest_email` AND a non-empty `guest_phone`; app-user rows (`user_id IS NOT NULL`) are exempt. **Test (SQL + edge-fn unit):** (a) attempt a direct `INSERT` into `event_rsvps` with `user_id=NULL` and only an email (no phone) → assert the `event_rsvps_link_guest_contact_required` CHECK rejects it; repeat with only a phone → rejected; both present → accepted; `user_id` set with neither → accepted. (b) call the `public-submit-rsvp` edge fn as an anon guest missing the phone → assert `400 rsvp_contact_required`. Reverting the CHECK constraint OR the edge-fn required-contact gate makes this FAIL.
+
+Protective comment requirement: each forked/new artifact (`business_publish_rsvp_draft`, `validateRsvpPublish`, the public-page RSVP branch, `fn_rsvp_drain_on_capacity_freed`, `rsvp-notify`) carries a `-- ORCH-1150: do NOT merge back into the event/ticket path — RSVP has zero tickets + no money gate; notify is TRANSACTIONAL (no marketing-consent). See SPEC §5.` comment. The `event_rsvps_link_guest_contact_required` CHECK carries `-- ORCH-1150 A4-NEW: link guests MUST be reachable by email AND SMS — do not relax to email-only or name-only.`
+
+All six flip ACTIVE on CLOSE (orchestrator owns the flip). They are DRAFT here.
+
+---
+
+## 10. Open Questions
+
+- **A1 (multi-date RSVP)** — DEFERRED by steering #4. Confirm v1 ships single-date only; multi-date is a registered follow-on (re-add the `whenMode` tabs + the publish RPC's multi_date branch). No action needed unless Seth re-opens.
+- **A2 (host approval console UI)** — **DECIDED-FULL (Seth, 2026-06-15).** BUILD the approve/deny console in v1: `RsvpGuestConsole.tsx` + `/rsvp/[id]/guests` + `host_set_rsvp_status`/`host_bulk_approve_rsvps` RPCs + the manage-sheet "Guests" row + approve/deny guest notification (§5.4). No longer a follow-on. Resolved.
+- **A3 (waitlist semantics)** — **DECIDED-FULL (Seth, 2026-06-15).** Real `waitlisted` status + deterministic in-transaction auto-promote-oldest (the `fn_rsvp_drain_on_capacity_freed` DB trigger) + notify the promoted guest; capacity counts `+plus_count` (§4.1c/§4.1f/§5.5). The lightweight client-only flag is REMOVED. Resolved.
+- **A4 (guest notifications)** — **DECIDED-FULL (Seth, 2026-06-15).** A real RSVP notification pipeline: `rsvp-notify` edge fn fans out push (OneSignal) + SMS (Twilio) + email (Resend), reusing the existing clients, for the three triggers (edit / promote / approve-deny), per-channel non-blocking, idempotent, transactional-basis (§5.6). Resolved.
+
+**The three questions the full-featured expansion surfaced are now ALL DECIDED (Seth, 2026-06-15 finalization) — none remain open:**
+- **A4-NEW (email mandatory for link guests?)** — **DECIDED (Seth, 2026-06-15).** *"Require BOTH email AND phone for anonymous link guests."* — STRONGER than the recommended email-only. A link guest (`user_id IS NULL`) MUST supply `guest_email` AND `guest_phone`, enforced at three layers: the public form (Going disabled until both valid, §6.5), the `public-submit-rsvp` edge fn (`400 rsvp_contact_required`, §5.3 step 2), and the DB `event_rsvps_link_guest_contact_required` CHECK (§4.1c). App-user RSVPs (`user_id IS NOT NULL`) are exempt — they inherit notify addresses from their profile and are reachable by push via `user_id` (§5.6). Resolved.
+- **A2-NEW (un-admit an approved guest?)** — **DECIDED (Seth, 2026-06-15).** *"The host CAN remove/un-admit an already-approved or Going guest."* — `host_set_rsvp_status` gains the **`approved→denied`** transition (host-remove). We REUSE `approval_status='denied'` as the removed-state (NO distinct `'removed'` value) so the existing §4.1f `fn_rsvp_drain_on_capacity_freed` trigger — which already treats a flip to `denied` as spot-freeing — auto-promotes the oldest waitlisted guest with no new trigger code. The removed guest no longer counts toward capacity, is notified (`rsvp_removed`, §5.6), and only the owning brand's host (`event_manager`-rank) may do it (RLS, §4.1d). The `RsvpGuestConsole` Going rows carry a Remove action with a confirm dialog (§5.4). Resolved.
+- **A4-NEW-2 (consumer-app guest = push-only?)** — **DECIDED (Seth, 2026-06-15).** *"App-user guests are notified via PUSH + EMAIL (all channels they have), not push-only."* — The `rsvp-notify` fan-out attempts EVERY channel for which the guest has a usable address/token: push (by `user_id`) AND email (profile/auth email resolved server-side) AND SMS (if a profile phone exists). The explicit rule: *for each of {push, email, sms}, resolve the address/token; if present, attempt it; otherwise skip* — no channel suppressed when an address exists (§5.6 step 3). Resolved.
+
+**ALL §10 open questions are now DECIDED. No open questions remain.**
+
+---
+
+## 11. Downstream Routing
+
+**Next phase: IMPLEMENT** (`mingla-implementor`), gated on Seth's REVIEW of this FINALIZED SPEC. **All §10 open questions are now DECIDED** (A2/A3/A4 DECIDED-FULL; A4-NEW / A2-NEW / A4-NEW-2 DECIDED in the 2026-06-15 finalization) — the spec is implementor-ready with no outstanding product decisions. The implementor builds in the §8 order inside a per-ORCH worktree `~/Desktop/mingla-orchs/ORCH-1150-[rsvp-event-wizard]/` on branch `ORCH-1150-rsvp-event-wizard`, honoring the allowlist below. Then **TEST** (`mingla-tester`) — Step-0.5 readiness = commit the five §9 fails-on-revert tests BEFORE the implementor merge (per `feedback_close_gate_verify_against_merged_main_not_stale_anchor`); adversarial angles: (a) confirm a published RSVP truly creates zero ticket rows AND is absent from checkout entirely; (b) confirm a link-only RSVP is invisible on the consumer deck while a discoverable one appears with a non-checkout CTA; (c) anon RLS — confirm the anon role has NO direct `event_rsvps` table policy and can only write via the edge fn, and the `/rsvp/[id]/guests` console is NOT in the anon allowlist; (d) confirm party-type is still enforced (steering #2 not silently dropped); **(e) A2** — confirm Approve/Deny actually mutate state AND notify (Constitution #1 no dead taps) and the approve capacity gate holds; **(e2) A2-NEW** — confirm the host **Remove** (`approved→denied`) action on a Going guest truly works (not a dead tap), frees the seat, auto-promotes the oldest waitlisted guest via the SAME drain trigger, and fires the `rsvp_removed` notification — and that a cross-brand host is blocked (`insufficient_event_permission`); **(f) A3** — drive a real spot-open and confirm the oldest waitlisted guest auto-promotes within the cap and gets exactly one notify (no double-promote on race); **(g) A4** — fault-inject one channel (Twilio 500) and confirm the other two still deliver and the failure is logged not swallowed (Constitution #3 no silent failure); **(g2) A4-NEW** — confirm a link guest CANNOT RSVP without BOTH email and phone (form + edge fn + DB CHECK all reject); **(g3) A4-NEW-2** — confirm an app-user guest with profile email+phone receives push AND email AND SMS (not push-only). Then **orchestrator CLOSE** flips the SIX invariants ACTIVE + World Map sync.
+
+---
+
+## Scoped Allowlist + DO-NOT-TOUCH
+
+**Allowlist (implementor may create/modify ONLY these):** every file in the §4.0 manifest. Any file outside it requires a **stop-and-amend** (append in-file or `SPEC_AMENDMENT_ORCH-1150_*.md`) before edit.
+
+**DO-NOT-TOUCH (hard):**
+- `business_publish_event_draft`, `validateTickets`, `validatePublish`, `computePublishability`, `EventCreatorWizard.tsx`, `CreatorStep5Tickets.tsx`, `app/event/create.tsx`, `app/event/[id]/edit.tsx` — the Ticketed path stays byte-for-byte unchanged (except `validateBasics` gets an `export` added, and `CreatorStep2When` gets the additive optional `lockSingleDate` prop — both additive, no behavior change to the event path).
+- `ticket-checkout-create` / `ticket-checkout-confirm` / any checkout RPC — RSVP never enters checkout.
+- The Stripe / payout / paid-publish-guard machinery — RSVP is moneyless.
+- `board_card_rsvps` and the consumer collab-board domain — unrelated.
+- The existing event/experience/trip publish RPCs and their `event_dates`/`ticket_types` logic.
+- **(A3/A4 reuse-don't-modify)** `_shared/push-utils.ts`, `notify-dispatch/index.ts`, `ticket-confirmation-dispatch/index.ts`, `_shared/email/*`, the `twilio-message-status` callback, `waitlist_entries` / `ticket_order_notifications` / `fn_waitlist_drain_on_capacity_freed`, and `notification-retry-sweeper/index.ts` — RSVP **CLONES the patterns** from these (cited with file:line in §5.5/§5.6) but must NOT modify the ticket waitlist/notification machinery. The only permitted touch is OPTIONALLY extending `notification-retry-sweeper` to also sweep `rsvp_notifications` (implementor's call, §5.6 step 6); if extended, it is additive and must not change the ticket-order sweep path.
+
+---
+
+### Invariant impact (flagged; orchestrator owns ACTIVE flip)
+- **Preserves** `I-BRAND-UNIVERSAL-AUTHORING` (every brand reaches `/rsvp/create`, no kind/venueCategory gate).
+- **Preserves** `ANDROID_GLASS_USES_OPAQUE_FALLBACK` (new chooser row + RSVP-setup cards + A2 console rows use the opaque fallback).
+- **Preserves** the public-route auth-gate allowlist (`anon_buyer_routes_must_be_allowlisted_against_root_auth_gate`) — RSVP reuses `/e/`, already allowlisted; the A2 `/rsvp/[id]/guests` console is a LOGGED-IN business route, NOT added to the anon allowlist.
+- **Preserves** the ORCH-1075 paid-publish integrity invariants — inert for RSVP (moneyless); the RSVP RPC must NOT inherit the money gate.
+- **Preserves** the marketing-consent boundary (`project_marketing_hub_strategy`) — A4 notifications are TRANSACTIONAL, sit OUTSIDE the unshipped `marketing_consent` foundation, read no consent column.
+- **Establishes (DRAFT):** `I-PROPOSED-1150-RSVP-NO-TICKET-ROWS`, `I-PROPOSED-1150-RSVP-OFF-DECK-UNLESS-DISCOVERABLE`, `I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC`, **`I-PROPOSED-1150-WAITLIST-AUTOPROMOTE-OLDEST`** (A3 + A2-NEW host-remove), **`I-PROPOSED-1150-RSVP-NOTIFY-MULTICHANNEL-NONBLOCKING`** (A4 + A4-NEW-2 app-user multi-channel), **`I-PROPOSED-1150-LINK-GUEST-CONTACT-BOTH-REQUIRED`** (A4-NEW). SIX total.
+
+### Steering compliance check
+1. **Host-choosable discovery** — ✅ `rsvp_discoverable` column (default OFF), discover-RPC widen, consumer deck RSVP card, both paths in scope (§4.1b/e, §4.4§7, §4.8).
+2. **KEEP Party Type in Basics** — ✅ Basics reused as-is; `validateBasics` retains the ≥1 canonical party-type gate; the publish RPC keeps party-type read + validation (§4.3, §4.7, §5.1). OVERRIDES the walkthrough's drop verdict.
+3. **RSVP setup = full host control** — ✅ capacity cap + plus-ones toggle+count + waitlist toggle + auto/manual approval mode, all specced with defaults + persistence (§4.4, §4.1b).
+4. **Single-date only v1** — ✅ `whenMode` forced single; recurring/multi_date dropped from wizard, validator, and publish RPC; flagged as follow-on (§4.2, §4.3, §4.7, §5.1, §10 A1).
+
+### V1-SCOPE steering compliance check (2026-06-15 amendment — the 4 full-featured locks)
+- **A2 — BUILD approve/deny host console in v1** — ✅ `RsvpGuestConsole.tsx` + `/rsvp/[id]/guests` route + manage-sheet "Guests" row; `host_set_rsvp_status` + `host_bulk_approve_rsvps` RPCs with host-rank RLS + capacity gate + state machine; approve/deny fires a guest notification. Fully usable, not just a count (§4.0, §4.3, §5.4, §6.6, T25–T30).
+- **A3 — FULL waitlist (auto-promote + notify)** — ✅ two-dimension status model with real `waitlisted` status (§4.1c); deterministic in-transaction `fn_rsvp_drain_on_capacity_freed` trigger promotes the OLDEST waitlisted guest on any spot-open (going→not_going / deny / cap-raise), auto vs manual aware, idempotent, capacity counts `+plus_count`; promoted guest notified (§4.1f, §5.5, T31–T35). Precedent cited: `fn_waitlist_drain_on_capacity_freed` (`20260724000010_orch_0948_waitlist_feature.sql:93-169`).
+- **A4 — Notify via push + SMS + email (all three) — new pipeline** — ✅ contact capture (name+email required for link guests, phone optional) on the public form (§6.5); `rsvp-notify` edge fn fans out across OneSignal push (`_shared/push-utils.ts:95`) + Twilio SMS (cloned from `ticket-confirmation-dispatch/index.ts:123-170`) + Resend email (cloned from `notify-dispatch/index.ts:84-138`), per-channel non-blocking (Constitution #3), idempotent; three triggers (edit / promote / approve-deny) with per-channel copy (§5.6, T36–T39). Transactional, outside marketing-consent.
+- **Step structure — 6 confirmed** — ✅ Basics → When → Where → Cover → RSVP-setup → Preview, unchanged; A2/A3/A4 add post-publish surfaces, NOT wizard steps (§4.3).
+
+### Finalization steering compliance check (2026-06-15 — the 3 last locked decisions)
+- **A4-NEW — link guests REQUIRE BOTH email AND phone** — ✅ enforced at three layers: public form (Going disabled until name+email+phone valid, §6.5), `public-submit-rsvp` edge fn (`400 rsvp_contact_required`, §5.3 step 2), DB `event_rsvps_link_guest_contact_required` CHECK (§4.1c). App users exempt (profile-inherited, §5.6). New invariant `I-PROPOSED-1150-LINK-GUEST-CONTACT-BOTH-REQUIRED` + test T24 + §9 safeguard #6.
+- **A2-NEW — host CAN remove/un-admit an approved/Going guest** — ✅ `approved→denied` transition added to `host_set_rsvp_status` (§5.4 step 3/5/6); REUSES `approval_status='denied'` (no `'removed'` state) so the existing §4.1f drain trigger auto-promotes the oldest waitlisted guest (a) removed guest stops counting toward cap, (b) auto-promote fires, (c) removed guest notified (`rsvp_removed`, §5.6), (d) RLS limits to owning host (§4.1d), (e) `RsvpGuestConsole` Going-row Remove action + confirm (§5.4). Trigger condition (§4.1f) + invariant #4 A2-NEW arm cover it. Tests T40–T42.
+- **A4-NEW-2 — app-user guests notified via push + email + SMS (all channels they have), not push-only** — ✅ `rsvp-notify` fan-out resolves and attempts every available channel per guest, including profile email + profile phone for app users (§5.6 step 3); invariant #5 multi-channel arm + tests T43–T44.
+
+---
+
+## Amendment Log — 2026-06-15 (full-featured v1)
+
+This section records exactly what changed from the original 505-line SPEC and why, so the diff is auditable. Trigger: Seth LOCKED four V1-SCOPE decisions (World Map "V1-SCOPE STEERED", 2026-06-15) that EXPAND the lightweight/deferred versions the original spec shipped. The original shipped A2/A3/A4 as "RECOMMEND lightweight / follow-on" (old §10); those recommendations are now REPLACED by full features.
+
+**What changed, by section:**
+1. **Header note** — added the amendment banner declaring A2/A3/A4 full + 6-step confirmed.
+2. **§2 Scope** — moved A2 (approve/deny console), A3 (full waitlist), A4 (notification pipeline) OUT of non-goals and INTO in-scope (new items 11/12/13). Removed the "console UI is OUT / lightweight waitlist / notice-without-send" deferral wording. Added a TRANSACTIONAL-vs-marketing non-goal clarifying A4 sits outside `marketing_consent`.
+3. **§3 Cross-Surface** — Business iOS/Android rows now include the A2 console; added the A4 three-channel fan-out cross-surface note (consumer push path reached transactionally); backend line lists the new RPCs/trigger/edge-fn.
+4. **§4.0 Manifest** — ADDED: `RsvpGuestConsole.tsx`, `/rsvp/[id]/guests` route, `useRsvpApprovals.ts`, `rsvpApprovals.ts` (A2); `rsvp-notify/index.ts` (A4); manage-sheet "Guests" row + config.toml `rsvp-notify` entry.
+5. **§4.1(c) `event_rsvps`** — **REWROTE the status model from one-ish to TWO explicit dimensions**: `rsvp_status` (going/not_going/**waitlisted**) + `approval_status` (pending/approved/**denied**), with canonical interaction/precedence rules (capacity counts confirmed-attending; pending doesn't occupy cap; manual+full → pending-not-waitlisted; auto+full → waitlisted). ADDED contact columns `guest_phone` + made the A4 email-capture intent explicit, plus `waitlisted_at`/`promoted_at`/`notified_at` and a waitlist partial index. Defined the `+plus_count` capacity formula.
+6. **§4.1(d) RLS** — host-write policy expanded to cover approve/deny + host-only `waitlisted` writes.
+7. **§4.1(f) NEW** — the `fn_rsvp_drain_on_capacity_freed` auto-promote trigger (A3), cloned from the proven ticket `fn_waitlist_drain_on_capacity_freed`, with the events.rsvp_capacity-raise arm + auto/manual promotion semantics + idempotency.
+8. **§4.3 / §4.4** — waitlist + approval toggles re-annotated as backing REAL features; Hub manage-sheet row gains the "Guests" console entry; 6-step confirmation note added.
+9. **§5.2 `biz_update_live_rsvp`** — added material-change detection + notify-enqueue (A4 trigger #1).
+10. **§5.3 `public_submit_rsvp`** — REPLACED the lightweight "return 409 / client-only waitlist" with the real two-dimension resolve + real `waitlisted` write + A4 contact validation.
+11. **§5.4 / §5.5 / §5.6 NEW** — host approve/deny console + `host_set_rsvp_status`/`host_bulk_approve_rsvps` (A2); waitlist auto-promote recap (A3); the `rsvp-notify` multi-channel pipeline + `rsvp_notifications` queue + per-trigger/per-channel copy table (A4), all citing the reused OneSignal/Twilio/Resend integrations by file:line.
+12. **§6 Public page** — added A4 contact-capture field set (name+email required for link guests, phone optional) + real waitlist result state; A2 console is now reachable (not a follow-on).
+13. **§7 Tests** — added T24–T39 (A2 console + capacity gate + RLS; A3 auto-promote + plus-count + race; A4 three-channel + non-blocking + idempotency).
+14. **§8 Order** — added `rsvp-notify` edge fn, A2 console + data layer, contact-capture, notify-enqueue steps.
+15. **§9 Regression** — added two DRAFT invariants `I-PROPOSED-1150-WAITLIST-AUTOPROMOTE-OLDEST` + `I-PROPOSED-1150-RSVP-NOTIFY-MULTICHANNEL-NONBLOCKING`, each with a fails-on-revert test (now FIVE total).
+16. **§10 Open Questions** — A2/A3/A4 marked **DECIDED-FULL**; surfaced THREE genuinely-new questions the expansion forces (A4-NEW: is email mandatory for link guests vs name-only-no-notify — the primary one for Seth; A2-NEW: un-admit an approved guest?; A4-NEW-2: app-user guests push-only?).
+17. **DO-NOT-TOUCH / Invariant impact / Steering check / §11 routing** — added the ticket waitlist/notification machinery as reuse-don't-modify; added the transactional/marketing-consent preservation; added the V1-SCOPE compliance sub-check; added A2/A3/A4 adversarial tester angles + five-invariant flip.
+
+**What did NOT change:** the Ticketed path stays byte-for-byte (DO-NOT-TOUCH intact); the RSVP forked publish RPC / validator / Going-Not-going public CTA contracts; the `event_type` CHECK widen + discover-RPC widen; the 6-step wizard structure; party-type retention (steering #2); single-date-only (steering #4); host-choosable discovery (steering #1). No product code, no migration files, no worktree, no secrets inlined (all OneSignal/Twilio/Resend access is by env-var name via the reused clients).
+
+---
+
+## Amendment Log — Finalization 2026-06-15 (the 3 last locked decisions)
+
+Seth LOCKED the three remaining product decisions that the full-featured expansion surfaced (former §10 NEW open questions). They are now DECIDED and propagated; **no §10 open questions remain — the spec is implementor-ready.**
+
+1. **A4-NEW → link guests REQUIRE BOTH email AND phone** (stronger than the recommended email-only). Propagated to: §4.1c (`guest_email`/`guest_phone` comments + new `event_rsvps_link_guest_contact_required` CHECK + Notes paragraph defining the app-user inherit exemption), §5.3 (request contract + step-2 three-field validation), §6.5 (public-form: all three blocking for link guests, app users exempt), §5.6 (link guests always have email+SMS). New invariant `I-PROPOSED-1150-LINK-GUEST-CONTACT-BOTH-REQUIRED` (§9 safeguard #6, now SIX total), test T24 rewritten.
+
+2. **A2-NEW → host CAN remove/un-admit an already-approved/Going guest.** Chose **`approval_status='denied'`** (NOT a distinct `'removed'` state) so the existing §4.1f `fn_rsvp_drain_on_capacity_freed` trigger — which already treats a flip to `denied` as spot-freeing — auto-promotes the oldest waitlisted guest with ZERO new trigger code. Propagated to: §4.1c (denied-as-remove comment), §4.1d (RLS host-write now allows `approved→denied`, owning-host only), §4.1f (spot-freed condition explicitly covers `approved→denied`), §5.4 (`host_set_rsvp_status` state machine steps 3/5/6 + `rsvp_removed` template + `RsvpGuestConsole` Going-row Remove action with confirm), §5.5 (host-remove reuses the drain), §5.6 (`rsvp_removed` copy row), §6.6. Invariant #4 gains an A2-NEW arm; tests T40–T42.
+
+3. **A4-NEW-2 → app-user guests notified via push + email + SMS (every channel they have), NOT push-only.** Propagated to: §5.6 step 3 (rewrote the fan-out to "every channel for which the guest has a usable address/token"; app-user email resolved via verified `auth.users`/`auth.identities` per `project_orch_1111_1112_invite_surface_ari_reachable`, profile phone for SMS), §3 cross-surface note. Invariant #5 gains the multi-channel (not-push-only) arm; tests T43–T44.
+
+**Other propagated edits:** §10 marked all three DECIDED (verbatim Seth answers) + "no open questions remain"; §11 routing un-gated (IMPLEMENT-ready) + added A2-NEW/A4-NEW/A4-NEW-2 tester angles + SIX-invariant flip; §"Establishes (DRAFT)" + §"Steering compliance check" updated (new Finalization sub-check); §9 header Five→Six.
+
+**What did NOT change in finalization:** every prior contract (forked RPCs, validator, two-dimension status model, the drain trigger mechanism itself, the three reused notify clients, the 6-step structure, DO-NOT-TOUCH list). No product code, no migration files, no worktree, no secrets. The host-remove deliberately reuses the EXISTING drain trigger (§5.5/§4.1f), never a parallel promote path (Constitution #1 + the reuse-don't-rebuild guard).

--- a/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
+++ b/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
@@ -86,6 +86,7 @@ import TicketCartSheet, {
   type TicketCartCheckoutPayload,
 } from "../../components/expandedCard/TicketCartSheet";
 import { ConsumerEventReserveBar } from "../../components/offering/ConsumerEventReserveBar";
+import { submitDeckRsvp } from "../../services/rsvpDeckService";
 import { useConsumerThemeFont } from "../../theme/useConsumerThemeFont";
 import { usePublicEventTickets } from "../../hooks/usePublicEventTickets";
 import { useTripIntakeSchemas } from "../../hooks/useTripIntakeSchemas";
@@ -193,6 +194,15 @@ export default function ConsumerEventDetailScreen({
   const [checkoutInFlight, setCheckoutInFlight] = useState<boolean>(false);
   const [muted, setMuted] = useState<boolean>(true);
   const [aboutCollapsed, setAboutCollapsed] = useState<boolean>(true);
+
+  // ORCH-1150 — RSVP deck variant. A discoverable RSVP event (host opted in)
+  // renders Going/Not-going instead of Book; tapping writes via the same
+  // public-submit-rsvp edge fn (logged-in path). NO cart, NO checkout.
+  const isRsvp = seed?.eventType === "rsvp";
+  const [rsvpInFlight, setRsvpInFlight] = useState<boolean>(false);
+  const [rsvpResolved, setRsvpResolved] = useState<
+    "going" | "not_going" | "waitlisted" | "pending" | null
+  >(null);
 
   // float→dock CTA visibility tracking (mirror the trip screen 1:1).
   const [dockTopY, setDockTopY] = useState<number | null>(null);
@@ -302,6 +312,53 @@ export default function ConsumerEventDetailScreen({
     setInitialTicketTypeId(sellable.id);
     setCartVisible(true);
   }, [tickets, selectedTicketId]);
+
+  // ORCH-1150 — Going / Not-going write for a discoverable RSVP deck card. The
+  // signed-in user's JWT rides the supabase client → the edge fn resolves
+  // user_id (no contact form needed). Reflects the resolved state + toasts; on
+  // error never dead-ends.
+  const handleRsvp = useCallback(
+    async (rsvpStatus: "going" | "not_going"): Promise<void> => {
+      if (rsvpInFlight || seed === null) return;
+      if (user === null) {
+        toastManager.show("Sign in to RSVP.", "warning");
+        return;
+      }
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      setRsvpInFlight(true);
+      try {
+        const result = await submitDeckRsvp(seed.eventId, rsvpStatus);
+        const resolved =
+          result.approvalStatus === "pending"
+            ? "pending"
+            : result.status;
+        setRsvpResolved(resolved);
+        toastManager.show(
+          resolved === "going"
+            ? "You're going!"
+            : resolved === "waitlisted"
+              ? "You're on the waitlist — we'll let you know if a spot opens."
+              : resolved === "pending"
+                ? "RSVP sent — awaiting host approval."
+                : "Got it — you're marked as not going.",
+          "success",
+        );
+      } catch (err) {
+        const code = err instanceof Error ? err.message : "";
+        toastManager.show(
+          code.includes("rsvp_full")
+            ? "This event just filled up."
+            : code.includes("rsvp_not_open")
+              ? "RSVPs are closed for this event."
+              : "Couldn't save your RSVP. Try again.",
+          "warning",
+        );
+      } finally {
+        setRsvpInFlight(false);
+      }
+    },
+    [rsvpInFlight, seed, user],
+  );
 
   // handleBuy ported VERBATIM (behavior) from EBES handleBuy — same buyer
   // derivation, same guards, same byte-identical runNativeCheckout request (NO
@@ -539,6 +596,63 @@ export default function ConsumerEventDetailScreen({
       testID="orch-1138-consumer-event-reserve"
     />
   ) : null;
+
+  // ORCH-1150 — the RSVP Going/Not-going dock (replaces the cart bar when the
+  // card is a discoverable RSVP). No price, no cart — writes via handleRsvp.
+  const rsvpGoingActive = rsvpResolved === "going";
+  const rsvpDock: ReactElement = (
+    <View
+      style={[rsvpStyles.dock, { paddingBottom: insets.bottom + 8 }]}
+      onLayout={handleDockLayout}
+    >
+      {rsvpResolved === "pending" ? (
+        <Text style={[rsvpStyles.resolvedNote, { color: palette.secondaryText }]}>
+          Awaiting host approval — we'll let you know.
+        </Text>
+      ) : rsvpResolved === "waitlisted" ? (
+        <Text style={[rsvpStyles.resolvedNote, { color: palette.secondaryText }]}>
+          You're on the waitlist.
+        </Text>
+      ) : null}
+      <View style={rsvpStyles.row}>
+        <Pressable
+          onPress={() => void handleRsvp("going")}
+          disabled={rsvpInFlight || rsvpGoingActive}
+          accessibilityRole="button"
+          accessibilityLabel={rsvpGoingActive ? "You're going" : "Going"}
+          style={[
+            rsvpStyles.goingBtn,
+            { backgroundColor: rsvpGoingActive ? palette.card : palette.accent },
+          ]}
+          testID="orch-1150-deck-rsvp-going"
+        >
+          <Text
+            style={[
+              rsvpStyles.goingText,
+              {
+                color: rsvpGoingActive ? palette.accent : palette.accentText,
+                fontFamily: boldFamily,
+              },
+            ]}
+          >
+            {rsvpInFlight ? "Saving…" : rsvpGoingActive ? "You're going ✓" : "Going"}
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={() => void handleRsvp("not_going")}
+          disabled={rsvpInFlight}
+          accessibilityRole="button"
+          accessibilityLabel="Not going"
+          style={[rsvpStyles.notGoingBtn, { borderColor: palette.panelBorder }]}
+          testID="orch-1150-deck-rsvp-not-going"
+        >
+          <Text style={[rsvpStyles.notGoingText, { color: palette.secondaryText }]}>
+            Not going
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
 
   return (
     <>
@@ -823,8 +937,9 @@ export default function ConsumerEventDetailScreen({
               </Text>
             </View>
 
-            {/* DOCKED CTA — the LAST scroll child (float→dock language) */}
-            {dockedReserve}
+            {/* DOCKED CTA — the LAST scroll child (float→dock language).
+                ORCH-1150 — RSVP cards dock Going/Not-going instead of the cart bar. */}
+            {isRsvp ? rsvpDock : dockedReserve}
           </View>
         </BottomSheetScrollView>
 
@@ -842,8 +957,9 @@ export default function ConsumerEventDetailScreen({
           />
         </View>
 
-        {/* (4) FLOATING reserve PILL — shown while the docked CTA is off-screen */}
-        {floatingReserve}
+        {/* (4) FLOATING reserve PILL — shown while the docked CTA is off-screen.
+            ORCH-1150 — suppressed for RSVP (the Going/Not-going dock is inline). */}
+        {isRsvp ? null : floatingReserve}
       </BaseBottomSheet>
 
       {/* Reserve opens the cart DIRECTLY (NEVER EBES). Sibling BaseBottomSheet
@@ -1158,4 +1274,39 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
   },
   retryText: { color: "#FFFFFF", fontSize: 15, fontWeight: "600" },
+});
+
+// ORCH-1150 — RSVP deck dock (Going / Not-going). Opaque-safe (solid accent
+// fill, no translucent tint) per the Android glass policy.
+const rsvpStyles = StyleSheet.create({
+  dock: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  resolvedNote: {
+    fontSize: 13,
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  goingBtn: {
+    flex: 2,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    paddingVertical: 15,
+  },
+  goingText: { fontSize: 16, fontWeight: "900" },
+  notGoingBtn: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    paddingVertical: 15,
+    borderWidth: 1,
+  },
+  notGoingText: { fontSize: 14, fontWeight: "700" },
 });

--- a/app-mobile/src/services/__tests__/rsvpDeckService.orch1150.test.ts
+++ b/app-mobile/src/services/__tests__/rsvpDeckService.orch1150.test.ts
@@ -1,0 +1,52 @@
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// ORCH-1150 [consumer RSVP deck card] Step 10 — source-contract regression.
+//
+// rsvpDeckService.ts + ConsumerEventDetailScreen.tsx import RN-bound modules
+// (./supabase, expo-haptics, react-native), so per the established app-mobile
+// service-test pattern (deckService.orch1065.test.ts) we read the source as
+// text and assert the LOCKED contract:
+//   (a) the deck RSVP write calls the public-submit-rsvp edge fn (NOT a checkout
+//       / order RPC) and bubbles the { error } code;
+//   (b) the consumer event detail screen renders a Going/Not-going dock for an
+//       event_type='rsvp' card instead of the cart bar, and STILL mounts the
+//       TicketCartSheet for the ticketed path (deck-off-EBES invariant);
+//   (c) the RSVP write never routes to /checkout.
+//
+// Fails-on-revert (LOCKED): removing the public-submit-rsvp invoke, or the
+// isRsvp dock branch, or re-pointing the RSVP tap at the cart, makes this FAIL.
+
+const svc = await Deno.readTextFile(
+  new URL("../rsvpDeckService.ts", import.meta.url),
+);
+const screen = await Deno.readTextFile(
+  new URL("../../screens/Event/ConsumerEventDetailScreen.tsx", import.meta.url),
+);
+
+Deno.test("ORCH-1150 T-10a: deck RSVP write hits public-submit-rsvp, bubbles code", () => {
+  assertStringIncludes(svc, '"public-submit-rsvp"');
+  assertStringIncludes(svc, "submitDeckRsvp");
+  // bubbles the edge-fn error code (rsvp_full / rsvp_not_open / …)
+  assertStringIncludes(svc, "parsed.error");
+  // never an order / checkout
+  assert(!svc.includes("ticket-checkout-create"));
+  assert(!svc.includes("/checkout"));
+});
+
+Deno.test("ORCH-1150 T-10b: detail screen docks Going/Not-going for an RSVP card", () => {
+  assertStringIncludes(screen, 'seed?.eventType === "rsvp"');
+  assertStringIncludes(screen, "isRsvp ? rsvpDock : dockedReserve");
+  assertStringIncludes(screen, "submitDeckRsvp");
+  assertStringIncludes(screen, "orch-1150-deck-rsvp-going");
+  assertStringIncludes(screen, "orch-1150-deck-rsvp-not-going");
+});
+
+Deno.test("ORCH-1150 T-10c: ticketed path untouched — TicketCartSheet still mounted", () => {
+  // The deck-off-EBES invariant: the cart stays the ticketed reserve path.
+  assertStringIncludes(screen, "TicketCartSheet");
+  // RSVP suppresses the cart float bar but does NOT remove the cart mount.
+  assertStringIncludes(screen, "isRsvp ? null : floatingReserve");
+});

--- a/app-mobile/src/services/rsvpDeckService.ts
+++ b/app-mobile/src/services/rsvpDeckService.ts
@@ -1,0 +1,59 @@
+/**
+ * ORCH-1150 — consumer-app RSVP write (Going / Not-going) for the discover deck.
+ *
+ * A discoverable RSVP event (host opted in via rsvp_discoverable) surfaces on the
+ * deck with a Going/Not-going CTA instead of Book. The consumer app user is
+ * authenticated, so the write rides the logged-in path: the JWT on the supabase
+ * client lets the public-submit-rsvp edge fn resolve user_id (the link-guest
+ * name+email+phone requirement does NOT apply — profile supplies contact + push).
+ *
+ * do NOT merge back into the checkout/booking path — RSVP writes a Going/Not-going
+ * row, never an order. See SPEC §4.8 / §5.3.
+ */
+
+import { supabase } from "./supabase";
+
+export interface SubmitDeckRsvpResult {
+  status: "going" | "not_going" | "waitlisted";
+  approvalStatus: "pending" | "approved";
+}
+
+/**
+ * Write the signed-in user's Going/Not-going for a discoverable RSVP event.
+ * Throws an Error whose message is the edge-fn error code (rsvp_full /
+ * rsvp_not_open / …) so the caller can show the right toast.
+ */
+export const submitDeckRsvp = async (
+  eventId: string,
+  rsvpStatus: "going" | "not_going",
+): Promise<SubmitDeckRsvpResult> => {
+  const { data, error } = await supabase.functions.invoke("public-submit-rsvp", {
+    body: { eventId, rsvpStatus },
+  });
+  if (error !== null) {
+    let code = error.message ?? "rsvp_write_failed";
+    const ctx = (error as { context?: { body?: unknown } }).context;
+    if (ctx?.body !== undefined && ctx.body !== null) {
+      try {
+        const parsed =
+          typeof ctx.body === "string"
+            ? (JSON.parse(ctx.body) as { error?: string })
+            : (ctx.body as { error?: string });
+        if (typeof parsed.error === "string" && parsed.error.length > 0) {
+          code = parsed.error;
+        }
+      } catch {
+        // keep default code
+      }
+    }
+    throw new Error(code);
+  }
+  const res = (data ?? {}) as {
+    status?: "going" | "not_going" | "waitlisted";
+    approvalStatus?: "pending" | "approved";
+  };
+  return {
+    status: res.status ?? rsvpStatus,
+    approvalStatus: res.approvalStatus ?? "approved",
+  };
+};

--- a/app-mobile/src/types/mergedDiscover.ts
+++ b/app-mobile/src/types/mergedDiscover.ts
@@ -79,6 +79,13 @@ export interface BusinessEventCard {
   /** The anon-tolerant buyer route in mingla-business. Opened via in-app WebView. */
   publicBuyerUrl: string;
   /**
+   * ORCH-1150 — the offering discriminator. 'rsvp' ⇒ a Partiful-style RSVP event
+   * surfaced on the deck (host opted in via rsvp_discoverable); the card renders
+   * a Going/Not-going CTA instead of Book, and writes via public-submit-rsvp.
+   * Undefined/'event' ⇒ the existing ticketed/Book path (byte-safe default).
+   */
+  eventType?: "event" | "rsvp";
+  /**
    * ORCH-1072 — present ONLY for brand experiences (event_type='experience').
    * The multi-stop itinerary, rendered by the detail sheet beneath the cover +
    * description. Undefined for events/trips → no itinerary section (byte-safe).

--- a/mingla-business/app/rsvp/[id]/edit.tsx
+++ b/mingla-business/app/rsvp/[id]/edit.tsx
@@ -1,0 +1,654 @@
+/**
+ * ORCH-1150 — /rsvp/[id]/edit — RSVP wizard resume + edit-published entry.
+ *
+ * Clone of /event/[id]/edit. Resolves the draft via useDraftById; mounts
+ * RsvpCreatorWizard at the requested step. Publish routes through the RSVP
+ * publish RPC (NEVER the event publish RPC). A wrong-wizard guard redirects a
+ * ticketed (isRsvp=false) draft to /event/[id]/edit (SPEC §4.6).
+ *
+ * The ?mode=edit-published path mounts the RSVP-aware EditPublishedScreen
+ * (rsvpMode), which drops the Tickets section + refund gate (SPEC §12).
+ */
+
+import React, { useEffect, useMemo } from "react";
+import { Platform, StyleSheet, Text, View } from "react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  canvas,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../../src/constants/designSystem";
+import { Spinner } from "../../../src/components/ui/Spinner";
+import { Toast } from "../../../src/components/ui/Toast";
+import { Button } from "../../../src/components/ui/Button";
+import {
+  RsvpCreatorWizard,
+  type WizardExitMode,
+} from "../../../src/components/rsvp/RsvpCreatorWizard";
+import { EditPublishedScreen } from "../../../src/components/event/EditPublishedScreen";
+import { useBrandList } from "../../../src/store/currentBrandStore";
+import {
+  useDraftById,
+  useDraftEventStore,
+  type DraftEvent,
+} from "../../../src/store/draftEventStore";
+import { useLiveEventStore } from "../../../src/store/liveEventStore";
+import {
+  eventDraftKeys,
+  useDiscardServerDraft,
+  useServerDraftAutosave,
+  useServerDraftById,
+} from "../../../src/hooks/useServerDraftEvents";
+import { useBusinessEventById } from "../../../src/hooks/useBusinessEvents";
+import { usePublishRsvpDraft } from "../../../src/hooks/useRsvpEvents";
+import { createServerDraft } from "../../../src/services/eventDrafts";
+import { useAuth } from "../../../src/context/AuthContext";
+import { isBusinessAuthNotReadyError } from "../../../src/utils/authReadiness";
+// ORCH-0893 [Eager server-draft on creator entry — replace with client-id + lazy autosave]:
+// the migration from a client `d_<ts36>` id to a server-issued id is now
+// triggered by the first dirty autosave, not on route mount. Pure helper.
+import { isDraftDirty } from "../../../src/utils/draftDirtyCheck";
+
+const isLocalOnlyDraft = (draft: DraftEvent): boolean =>
+  draft.id.startsWith("d_") || draft.serverSlug === null;
+
+const safeEventsExitRoute = (): "/home#hub-events" | "/(tabs)/hub/events" =>
+  Platform.OS === "web" ? "/home#hub-events" : "/(tabs)/hub/events";
+
+const MISSING_DRAFT_TIMEOUT_MS = 6000;
+
+export default function RsvpEditRoute(): React.ReactElement {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const params = useLocalSearchParams<{
+    id: string | string[];
+    step?: string | string[];
+    mode?: string | string[];
+  }>();
+  const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
+  const stepParam = Array.isArray(params.step) ? params.step[0] : params.step;
+  const modeParam = Array.isArray(params.mode) ? params.mode[0] : params.mode;
+  // Cycle 9b-2: when ?mode=edit-published, render the focused
+  // EditPublishedScreen instead of the create wizard. The id refers to
+  // a LIVE event, not a draft.
+  const isEditPublished = modeParam === "edit-published";
+  const isLegacyLocalDraftId =
+    typeof idParam === "string" && idParam.startsWith("d_");
+  const { isAuthReady } = useAuth();
+
+  const initialStep = useMemo<number | undefined>(() => {
+    if (stepParam === undefined || stepParam.length === 0) return undefined;
+    const n = parseInt(stepParam, 10);
+    return Number.isFinite(n) ? n : undefined;
+  }, [stepParam]);
+
+  // Edit-published path: resolve LiveEvent.
+  const liveEvent = useLiveEventStore((s) => {
+    if (!isEditPublished) return null;
+    if (typeof idParam !== "string" || idParam.length === 0) return null;
+    return s.events.find((e) => e.id === idParam) ?? null;
+  });
+  // Create/draft path: resolve DraftEvent.
+  const draft = useDraftById(
+    !isEditPublished && typeof idParam === "string" ? idParam : null,
+  );
+  const serverDraftQuery = useServerDraftById(
+    !isEditPublished && typeof idParam === "string" && !isLegacyLocalDraftId
+      ? idParam
+      : null,
+  );
+  const serverDraftSettled =
+    isAuthReady &&
+    !isLegacyLocalDraftId &&
+    !serverDraftQuery.isLoading &&
+    !serverDraftQuery.isFetching &&
+    !serverDraftQuery.isError;
+  const staleServerDraft =
+    !isEditPublished &&
+    draft !== null &&
+    !draft.id.startsWith("d_") &&
+    serverDraftSettled &&
+    serverDraftQuery.data === null;
+  const businessEventQuery = useBusinessEventById(
+    typeof idParam === "string" && (isEditPublished || staleServerDraft)
+      ? idParam
+      : null,
+  );
+  const serverLiveEvent = businessEventQuery.data?.event ?? null;
+  const resolvedLiveEvent = serverLiveEvent ?? liveEvent;
+  const autosave = useServerDraftAutosave();
+  const discardServerDraft = useDiscardServerDraft();
+  const publishServerDraft = usePublishRsvpDraft();
+  const replaceDraft = useDraftEventStore((s) => s.replaceDraft);
+  const deleteDraft = useDraftEventStore((s) => s.deleteDraft);
+  const migratingLegacyIdRef = React.useRef<string | null>(null);
+  const staleRecoveryDraftIdRef = React.useRef<string | null>(null);
+  const brands = useBrandList();
+  const brand = useMemo(() => {
+    if (isEditPublished) {
+      if (businessEventQuery.data?.brand !== undefined) {
+        return businessEventQuery.data.brand;
+      }
+      if (resolvedLiveEvent === null) return null;
+      return brands.find((b) => b.id === resolvedLiveEvent.brandId) ?? null;
+    }
+    if (draft === null) return null;
+    return brands.find((b) => b.id === draft.brandId) ?? null;
+  }, [isEditPublished, businessEventQuery.data?.brand, resolvedLiveEvent, draft, brands]);
+
+  const [toast, setToast] = React.useState<{ visible: boolean; message: string }>(
+    { visible: false, message: "" },
+  );
+  const [missingDraftTimedOut, setMissingDraftTimedOut] = React.useState(false);
+
+  useEffect(() => {
+    if (isEditPublished || draft !== null) {
+      setMissingDraftTimedOut(false);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      setMissingDraftTimedOut(true);
+      console.warn("[rsvp/edit] missing-draft-timeout", { idParam });
+    }, MISSING_DRAFT_TIMEOUT_MS);
+    return (): void => clearTimeout(timer);
+  }, [draft, idParam, isEditPublished]);
+
+  useEffect(() => {
+    // ORCH-0893: the previous eager `d_<ts36>` → server-draft migration on
+    // mount has moved into the autosave wrapper below (gated on
+    // `isDraftDirty`). Untouched client-only drafts no longer insert a
+    // ghost row on mount.
+    if (typeof idParam !== "string" || idParam.length === 0) {
+      router.replace(safeEventsExitRoute() as never);
+      return;
+    }
+    if (isEditPublished) {
+      if (
+        liveEvent !== null &&
+        liveEvent.id.startsWith("le_") &&
+        liveEvent.serverEventId !== null
+      ) {
+        router.replace(
+          `/rsvp/${liveEvent.serverEventId}/edit?mode=edit-published` as never,
+        );
+        return undefined;
+      }
+      if (resolvedLiveEvent === null && !businessEventQuery.isLoading) {
+        // Published event not found — bounce to events tab.
+        const t = setTimeout(() => {
+          router.replace(safeEventsExitRoute() as never);
+        }, 0);
+        return (): void => clearTimeout(t);
+      }
+      return undefined;
+    }
+    if (staleServerDraft) {
+      if (businessEventQuery.isLoading || businessEventQuery.isFetching) {
+        return undefined;
+      }
+      if (staleRecoveryDraftIdRef.current === draft.id) {
+        return undefined;
+      }
+      staleRecoveryDraftIdRef.current = draft.id;
+      const recoveryRoute =
+        businessEventQuery.data?.event !== undefined
+          ? `/rsvp/${draft.id}/edit?mode=edit-published`
+          : safeEventsExitRoute();
+      deleteDraft(draft.id);
+      queryClient.removeQueries({ queryKey: eventDraftKeys.detail(draft.id) });
+      queryClient.setQueryData<DraftEvent[]>(
+        eventDraftKeys.list(draft.brandId),
+        (prev) => (prev ?? []).filter((d) => d.id !== draft.id),
+      );
+      queryClient.invalidateQueries({ queryKey: eventDraftKeys.list(draft.brandId) });
+      setToast({
+        visible: true,
+        message: "This draft is no longer editable.",
+      });
+      router.replace(recoveryRoute as never);
+      return undefined;
+    }
+    if (staleRecoveryDraftIdRef.current === idParam) {
+      return undefined;
+    }
+    if (!isAuthReady) {
+      return undefined;
+    }
+    if (
+      draft === null &&
+      !serverDraftQuery.isLoading &&
+      !serverDraftQuery.isFetching
+    ) {
+      // ORCH-0893 cycle 2 safety belt — before bouncing home for a
+      // missing d_<ts36> id, check if any cached brand-drafts list
+      // contains a server draft whose `legacyLocalDraftId === idParam`.
+      // This catches the case where some other migration path (the
+      // legacy loop in useServerDraftEvents.ts:86-142, or a parallel
+      // tab) swapped d_* → server uuid out from under us. Without this
+      // safety belt, the user sees "wizard shows up then immediately
+      // closes" instead of landing on their server-backed draft.
+      if (isLegacyLocalDraftId && typeof idParam === "string") {
+        const allDraftLists = queryClient.getQueriesData<DraftEvent[]>({
+          queryKey: eventDraftKeys.lists(),
+        });
+        for (const [, drafts] of allDraftLists) {
+          if (!Array.isArray(drafts)) continue;
+          const swapped = drafts.find(
+            (d) =>
+              (d as DraftEvent & { legacyLocalDraftId?: string })
+                .legacyLocalDraftId === idParam,
+          );
+          if (swapped !== undefined) {
+            router.replace(
+              `/rsvp/${swapped.id}/edit?step=${initialStep ?? 0}` as never,
+            );
+            return undefined;
+          }
+        }
+      }
+      // Draft not found — use the same static-safe recovery surface as the
+      // timed-out branch on web, rather than routing phone browsers into the
+      // full tabs Home route.
+      const t = setTimeout(() => {
+        if (Platform.OS === "web") {
+          setMissingDraftTimedOut(true);
+          return;
+        }
+        router.replace(safeEventsExitRoute() as never);
+      }, 0);
+      return (): void => clearTimeout(t);
+    }
+    return undefined;
+  }, [
+    idParam,
+    isEditPublished,
+    isLegacyLocalDraftId,
+    isAuthReady,
+    initialStep,
+    draft,
+    liveEvent,
+    resolvedLiveEvent,
+    businessEventQuery.isLoading,
+    businessEventQuery.isFetching,
+    businessEventQuery.data?.event,
+    router,
+    deleteDraft,
+    queryClient,
+    serverDraftQuery.isFetching,
+    serverDraftQuery.isError,
+    serverDraftQuery.isLoading,
+    serverDraftQuery.data,
+    staleServerDraft,
+  ]);
+
+  const isCreateMode = useMemo<boolean>(() => {
+    if (draft === null) return false;
+    // First-time edit: lastStepReached is 0 AND name is empty AND no fields filled.
+    return draft.lastStepReached === 0 && draft.name.length === 0;
+  }, [draft]);
+
+  // ORCH-1150 — wrong-wizard guard (SPEC §4.6): an /rsvp/[id]/edit URL pointed
+  // at a TICKETED draft (isRsvp=false) redirects to the event wizard, and
+  // vice-versa (the event edit route does the inverse). The route IS the
+  // discriminator; this is the safety belt for a hand-typed/stale URL.
+  useEffect(() => {
+    if (isEditPublished || draft === null) return;
+    if (draft.isRsvp === false) {
+      router.replace(
+        `/event/${draft.id}/edit?step=${initialStep ?? 0}` as never,
+      );
+    }
+  }, [draft, isEditPublished, initialStep, router]);
+
+  const handleExit = React.useCallback(
+    (
+      mode: WizardExitMode,
+      ctx?: {
+        name?: string;
+        slug?: { brandSlug: string; eventSlug: string };
+      },
+    ): void => {
+      if (mode === "published") {
+        const name = ctx?.name ?? "Your RSVP";
+        setToast({ visible: true, message: `${name} is live.` });
+        // Cycle 6 — route to the new public event page when slug is
+        // provided. Falls back to home tab when slug missing (e.g.
+        // pre-Cycle-6 draft or publish-failed-but-flagged-published).
+        if (ctx?.slug !== undefined) {
+          router.replace(
+            `/e/${ctx.slug.brandSlug}/${ctx.slug.eventSlug}` as never,
+          );
+        } else {
+          router.replace(safeEventsExitRoute() as never);
+        }
+      } else {
+        // Discarded / abandoned (chrome X close) — route to Events tab
+        // so the founder lands where they can see drafts + start a new
+        // event easily, per founder UX directive.
+        if (mode === "discarded") {
+          setToast({ visible: true, message: "Draft discarded." });
+        }
+        router.replace(safeEventsExitRoute() as never);
+      }
+    },
+    [router],
+  );
+
+  const handleOpenPreview = React.useCallback((): void => {
+    if (draft === null) return;
+    router.push(`/rsvp/${draft.id}/preview` as never);
+  }, [draft, router]);
+
+  const handleOpenStripe = React.useCallback((): void => {
+    if (draft === null) return;
+    router.push(`/brand/${draft.brandId}/payments/onboard` as never);
+  }, [draft, router]);
+
+  const handleDiscardDraft = React.useCallback(
+    async (draftToDiscard: DraftEvent): Promise<void> => {
+      if (isLocalOnlyDraft(draftToDiscard)) {
+        deleteDraft(draftToDiscard.id);
+        return;
+      }
+      await discardServerDraft.discardDraft(draftToDiscard);
+    },
+    [deleteDraft, discardServerDraft],
+  );
+
+  // ORCH-0893 [Eager server-draft on creator entry — replace with client-id + lazy autosave]:
+  // route-owned autosave wrapper. Three branches:
+  //   (a) `d_<ts36>` id + dirty → lazy-insert server draft via
+  //       `createServerDraft`, then `replaceDraft` swaps the client id
+  //       for the server id in Zustand, then `router.replace` updates
+  //       the URL without unmounting the wizard.
+  //   (b) `d_<ts36>` id + NOT dirty → no save. Prevents ghost-draft row
+  //       accumulation when the user backs out before typing.
+  //   (c) server id → existing `autosave.saveDraft` path.
+  //
+  // `migratingLegacyIdRef` dedupes concurrent migration attempts during
+  // the 800ms debounce window — only one `createServerDraft` is in flight
+  // for a given `d_*` id.
+  const handleAutosaveDraft = React.useCallback(
+    (incoming: DraftEvent): void => {
+      if (!incoming.id.startsWith("d_")) {
+        autosave.saveDraft(incoming);
+        return;
+      }
+      if (!isDraftDirty(incoming)) return;
+      if (migratingLegacyIdRef.current === incoming.id) return;
+      if (!isAuthReady) return;
+      migratingLegacyIdRef.current = incoming.id;
+      void createServerDraft(incoming.brandId, incoming)
+        .then((serverDraft) => {
+          // ORCH-0893 REWORK Part B — live-state merge race-guard.
+          // Between the createServerDraft call (which echoes the
+          // queue-time snapshot of `incoming`) and this resolve,
+          // the user may have continued typing into the d_<ts36>
+          // draft. Those keystrokes landed in Zustand against the
+          // OLD d_* id. A naive replaceDraft(d_id, serverDraft)
+          // would overwrite them with the queue-time snapshot.
+          //
+          // Fix: re-read the live draft from Zustand at resolve
+          // time and merge user-meaningful fields from the live
+          // state into the serverDraft payload before the swap.
+          // Server-issued fields (id, slug, created_by, server
+          // timestamps) stay from serverDraft; user fields stay
+          // from the live snapshot.
+          const liveDraft = useDraftEventStore
+            .getState()
+            .getDraft(incoming.id);
+          const mergedServerDraft = liveDraft
+            ? {
+                ...serverDraft,
+                name: liveDraft.name,
+                description: liveDraft.description,
+                coverMediaUrl: liveDraft.coverMediaUrl,
+                coverMediaType: liveDraft.coverMediaType,
+                coverMediaProvider: liveDraft.coverMediaProvider,
+                coverMediaSourceUrl: liveDraft.coverMediaSourceUrl,
+                coverMediaCredit: liveDraft.coverMediaCredit,
+                coverMediaCreditUrl: liveDraft.coverMediaCreditUrl,
+                coverMediaAlt: liveDraft.coverMediaAlt,
+                coverHue: liveDraft.coverHue,
+                format: liveDraft.format,
+                tickets: liveDraft.tickets,
+                date: liveDraft.date,
+                doorsOpen: liveDraft.doorsOpen,
+                endsAt: liveDraft.endsAt,
+                endsAtUtc: liveDraft.endsAtUtc,
+                venueName: liveDraft.venueName,
+                address: liveDraft.address,
+                city: liveDraft.city,
+                locationGeo: liveDraft.locationGeo,
+                onlineUrl: liveDraft.onlineUrl,
+                hideAddressUntilTicket: liveDraft.hideAddressUntilTicket,
+                lastStepReached: Math.max(
+                  liveDraft.lastStepReached,
+                  serverDraft.lastStepReached,
+                ),
+                partyTypes: liveDraft.partyTypes,
+                vibeTags: liveDraft.vibeTags,
+                musicGenres: liveDraft.musicGenres,
+                whenMode: liveDraft.whenMode,
+                multiDates: liveDraft.multiDates,
+                recurrenceRule: liveDraft.recurrenceRule,
+                timezone: liveDraft.timezone,
+                // ORCH-1150 — carry RSVP fields through the d_* → server swap so
+                // in-flight RSVP-setup edits aren't dropped on the first save.
+                isRsvp: liveDraft.isRsvp,
+                rsvpCapacity: liveDraft.rsvpCapacity,
+                rsvpAllowPlusOnes: liveDraft.rsvpAllowPlusOnes,
+                rsvpPlusOnesMax: liveDraft.rsvpPlusOnesMax,
+                rsvpWaitlistEnabled: liveDraft.rsvpWaitlistEnabled,
+                rsvpApprovalMode: liveDraft.rsvpApprovalMode,
+                rsvpDiscoverable: liveDraft.rsvpDiscoverable,
+              }
+            : serverDraft;
+          replaceDraft(incoming.id, mergedServerDraft);
+          queryClient.setQueryData(
+            eventDraftKeys.detail(mergedServerDraft.id),
+            mergedServerDraft,
+          );
+          router.replace(
+            `/rsvp/${mergedServerDraft.id}/edit?step=${initialStep ?? 0}` as never,
+          );
+        })
+        .catch((error) => {
+          migratingLegacyIdRef.current = null;
+          if (isBusinessAuthNotReadyError(error)) {
+            // Will retry on next dirty save once auth lands.
+            return;
+          }
+          setToast({
+            visible: true,
+            message: "Couldn't save this draft. Tap Save again or check your connection.",
+          });
+        });
+    },
+    [
+      autosave,
+      isAuthReady,
+      initialStep,
+      queryClient,
+      replaceDraft,
+      router,
+    ],
+  );
+
+  // Cycle 9b-2 edit-published branch — render the focused edit screen
+  // when ?mode=edit-published. Loading shell while liveEvent resolves.
+  if (isEditPublished) {
+    if (resolvedLiveEvent === null) {
+      return (
+        <View
+          style={[
+            styles.host,
+            { paddingTop: insets.top, backgroundColor: canvas.discover },
+          ]}
+        >
+          <View style={styles.center}>
+            <Spinner size={36} />
+            <Text style={styles.label}>Loading…</Text>
+          </View>
+        </View>
+      );
+    }
+    return (
+      <EditPublishedScreen
+        liveEvent={resolvedLiveEvent}
+        // ORCH-1150 — RSVP edit-published: drop the Tickets section + the
+        // sold-ticket refund gate; show the "N guests are going" notice (§12).
+        rsvpMode
+        disableLocalSaveReason={
+          liveEvent === null
+            ? "Server-loaded RSVPs are readable here. Full published editing needs the server edit mutation before saves are enabled."
+            : undefined
+        }
+      />
+    );
+  }
+
+  if (draft === null && missingDraftTimedOut) {
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.recoveryCard}>
+          <Text style={styles.recoveryTitle}>We could not load this draft.</Text>
+          <Text style={styles.recoveryBody}>
+            Refresh, return to Home, or use desktop/the app if this phone browser cannot restore the draft.
+          </Text>
+          <Button
+            label="Back to Home"
+            onPress={() => router.replace(safeEventsExitRoute() as never)}
+            fullWidth
+            size="md"
+            shape="square"
+          />
+        </View>
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast((p) => ({ ...p, visible: false }))}
+        />
+      </View>
+    );
+  }
+
+  if (draft === null) {
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.center}>
+          <Spinner size={36} />
+          <Text style={styles.label}>Loading…</Text>
+        </View>
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast((p) => ({ ...p, visible: false }))}
+        />
+      </View>
+    );
+  }
+
+  if (staleServerDraft) {
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.center}>
+          <Spinner size={36} />
+          <Text style={styles.label}>Recovering event…</Text>
+        </View>
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast((p) => ({ ...p, visible: false }))}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <RsvpCreatorWizard
+      draft={draft}
+      brand={brand}
+      initialStep={initialStep}
+      isCreateMode={isCreateMode}
+      onExit={handleExit}
+      onOpenPreview={handleOpenPreview}
+      onOpenStripeOnboard={handleOpenStripe}
+      onAutosaveDraft={handleAutosaveDraft}
+      onDiscardServerDraft={handleDiscardDraft}
+      onPublishDraft={async (draftToPublish) => {
+        const published = await publishServerDraft.mutateAsync({
+          draft: draftToPublish,
+        });
+        return {
+          brandSlug: published.brand.slug,
+          eventSlug: published.event.eventSlug,
+        };
+      }}
+      serverSaveState={{
+        isSaving:
+          autosave.isSaving ||
+          discardServerDraft.isPending ||
+          publishServerDraft.isPending,
+        hasError: autosave.hasError || serverDraftQuery.isError,
+        lastSavedAt: autosave.lastSavedAt,
+      }}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.md,
+  },
+  label: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  recoveryCard: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: spacing.xl,
+    gap: spacing.md,
+  },
+  recoveryTitle: {
+    fontSize: typography.h3.fontSize,
+    lineHeight: typography.h3.lineHeight,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  recoveryBody: {
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    color: textTokens.secondary,
+  },
+});

--- a/mingla-business/app/rsvp/[id]/guests.tsx
+++ b/mingla-business/app/rsvp/[id]/guests.tsx
@@ -22,5 +22,5 @@ export default function RsvpGuestsRoute(): React.ReactElement | null {
   if (typeof idParam !== "string" || idParam.length === 0) return null;
   const resolvedId = liveEvent?.serverEventId ?? idParam;
 
-  return <RsvpGuestConsole eventId={resolvedId} eventTitle={liveEvent?.title ?? null} />;
+  return <RsvpGuestConsole eventId={resolvedId} eventTitle={liveEvent?.name ?? null} />;
 }

--- a/mingla-business/app/rsvp/[id]/guests.tsx
+++ b/mingla-business/app/rsvp/[id]/guests.tsx
@@ -1,0 +1,26 @@
+/**
+ * ORCH-1150 — /rsvp/[id]/guests — host RSVP approve/deny/remove console route.
+ *
+ * LOGGED-IN business-app route (host only). NOT a public buyer route — must NOT
+ * be added to the anon allowlist (SPEC §5.3 / §11). Mounts RsvpGuestConsole.
+ */
+
+import React from "react";
+import { useLocalSearchParams } from "expo-router";
+
+import { RsvpGuestConsole } from "../../../src/components/rsvp/RsvpGuestConsole";
+import { useLiveEventStore } from "../../../src/store/liveEventStore";
+
+export default function RsvpGuestsRoute(): React.ReactElement | null {
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
+  const liveEvent = useLiveEventStore((s) => {
+    if (typeof idParam !== "string" || idParam.length === 0) return null;
+    return s.events.find((e) => e.id === idParam || e.serverEventId === idParam) ?? null;
+  });
+
+  if (typeof idParam !== "string" || idParam.length === 0) return null;
+  const resolvedId = liveEvent?.serverEventId ?? idParam;
+
+  return <RsvpGuestConsole eventId={resolvedId} eventTitle={liveEvent?.title ?? null} />;
+}

--- a/mingla-business/app/rsvp/create.tsx
+++ b/mingla-business/app/rsvp/create.tsx
@@ -1,0 +1,343 @@
+/**
+ * /rsvp/create — instant-mount wizard entry (ORCH-0893
+ * [Eager server-draft on creator entry — replace with client-id + lazy autosave]).
+ *
+ * Mints a client-side `d_<ts36>` draft id via the synchronous Zustand
+ * `useDraftEventStore.createDraft(brandId)` action and immediately
+ * `router.replace`s to `/event/{d_id}/edit?step=0`. No entry-blocking
+ * server mutation. The server-side `events` row is created lazily by
+ * `app/event/[id]/edit.tsx` on the first user-meaningful edit (per
+ * `isDraftDirty` in `src/utils/draftDirtyCheck.ts`).
+ *
+ * Per I-PROPOSED-CREATOR-ENTRY-IS-INSTANT (DRAFT — flips to ACTIVE on
+ * ORCH-0893 close). Per I-11 format-agnostic ID resolver: the `d_*` id
+ * format flows through `useDraftById` resolver unchanged.
+ *
+ * The placeholder host exists ONLY for the brief auth-readiness wait
+ * window. On a warm session the route mounts, the useEffect fires, and
+ * `router.replace` runs in the same tick — the user never sees this
+ * page past the first paint.
+ *
+ * Supersedes the Cycle 3 spec §3.5 route 1 eager-mutation pattern
+ * (4-round-trip chain) and the ORCH-0743 cold-start redirect-loop
+ * fix's eager-mutation usage from this route. The server-draft
+ * mutation hook still exists in `useServerDraftEvents.ts` and is
+ * called from the edit route's lazy-insert trigger.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { Platform, StyleSheet, Text, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  canvas,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../src/constants/designSystem";
+import { Spinner } from "../../src/components/ui/Spinner";
+import { Button } from "../../src/components/ui/Button";
+import { useCurrentBrandId } from "../../src/store/currentBrandStore";
+import { useDraftEventStore } from "../../src/store/draftEventStore";
+import { useAuth } from "../../src/context/AuthContext";
+import { useCurrentBrandRecovery } from "../../src/hooks/useCurrentBrandRecovery";
+
+const ROUTE_BOOT_TIMEOUT_MS = 6000;
+const DRAFT_HYDRATION_TIMEOUT_MS = 6000;
+
+type CreateRouteTerminalState =
+  | "signed_out"
+  | "auth_timeout"
+  | "auth_error"
+  | "brand_timeout"
+  | "brand_error"
+  | "no_brand"
+  | "draft_hydration_timeout";
+
+const goToStaticHome = (router: ReturnType<typeof useRouter>): void => {
+  if (Platform.OS === "web" && typeof window !== "undefined") {
+    window.location.assign("/home");
+    return;
+  }
+  router.replace("/(tabs)/home" as never);
+};
+
+const retryRoute = (router: ReturnType<typeof useRouter>): void => {
+  if (Platform.OS === "web" && typeof window !== "undefined") {
+    window.location.reload();
+    return;
+  }
+  router.replace("/rsvp/create" as never);
+};
+
+export default function RsvpCreateRoute(): React.ReactElement {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const currentBrandId = useCurrentBrandId();
+  const { authError, authStatus, isAuthReady, loading } = useAuth();
+  const currentBrandRecovery = useCurrentBrandRecovery();
+  const startedRef = useRef<boolean>(false);
+  const warnedStateRef = useRef<CreateRouteTerminalState | null>(null);
+  const [routeTimedOut, setRouteTimedOut] = useState<boolean>(false);
+  const [hydrationTimedOut, setHydrationTimedOut] = useState<boolean>(false);
+
+  // ORCH-0893 REWORK Part A — Zustand persist hydration gate.
+  // Pre-rework, `/rsvp/create` minted the d_<ts36> draft synchronously
+  // and `router.replace`d in the same tick. If the user tapped before
+  // `useDraftEventStore`'s persist middleware finished hydrating from
+  // AsyncStorage / localStorage, the just-minted draft was OVERWRITTEN
+  // when hydration completed and `setState(persisted, true)` REPLACED
+  // the in-memory state. The next route (`event/[id]/edit.tsx`) then
+  // saw `draft === null` for `d_<ts36>` and the existing bounce-home
+  // guard fired → "wizard shows up then immediately closes."
+  //
+  // Pre-ORCH-0893 was masked because the eager server-draft chain
+  // ran ~600ms-1.5s, by which time hydration had completed.
+  //
+  // Fix: wait for `useDraftEventStore.persist.hasHydrated()` before
+  // calling createDraft. Zustand v5 exposes `hasHydrated()` synchronously
+  // and `onFinishHydration(cb)` as a subscription for the async case.
+  const [hydrated, setHydrated] = useState<boolean>(() =>
+    useDraftEventStore.persist.hasHydrated(),
+  );
+  const canUseStoredBrandForWeb =
+    Platform.OS === "web" && currentBrandId !== null;
+
+  useEffect(() => {
+    if (hydrated) return undefined;
+    const unsub = useDraftEventStore.persist.onFinishHydration(() => {
+      setHydrated(true);
+    });
+    // Defensive re-check: hydration may complete between the initial
+    // `hasHydrated()` read and this effect mount (rare microtask race).
+    if (useDraftEventStore.persist.hasHydrated()) {
+      setHydrated(true);
+    }
+    return unsub;
+  }, [hydrated]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setRouteTimedOut(true);
+    }, ROUTE_BOOT_TIMEOUT_MS);
+    return (): void => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (hydrated) {
+      setHydrationTimedOut(false);
+      return undefined;
+    }
+    const timer = setTimeout(() => {
+      if (!useDraftEventStore.persist.hasHydrated()) {
+        setHydrationTimedOut(true);
+      }
+    }, DRAFT_HYDRATION_TIMEOUT_MS);
+    return (): void => clearTimeout(timer);
+  }, [hydrated]);
+
+  const terminalState: CreateRouteTerminalState | null =
+    authError !== null
+      ? "auth_error"
+      : !loading && authStatus === "signed_out"
+        ? "signed_out"
+        : routeTimedOut && !isAuthReady
+          ? "auth_timeout"
+          : routeTimedOut &&
+              currentBrandRecovery.isResolving &&
+              !canUseStoredBrandForWeb
+            ? "brand_timeout"
+          : currentBrandRecovery.isError
+            ? "brand_error"
+            : isAuthReady &&
+                !currentBrandRecovery.isResolving &&
+                hydrated &&
+                currentBrandId === null
+              ? "no_brand"
+              : hydrationTimedOut
+                ? "draft_hydration_timeout"
+                : null;
+
+  useEffect(() => {
+    if (terminalState === null || warnedStateRef.current === terminalState) {
+      return;
+    }
+    warnedStateRef.current = terminalState;
+    console.warn("[rsvp/create] terminal-state", {
+      terminalState,
+      authStatus,
+      brandError: currentBrandRecovery.errorMessage,
+    });
+  }, [authStatus, currentBrandRecovery.errorMessage, terminalState]);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    if (terminalState !== null) return;
+    if (!isAuthReady) return;
+    if (currentBrandRecovery.isResolving && !canUseStoredBrandForWeb) return;
+    // ORCH-0893 REWORK Part A: do not mint a client-side draft until
+    // Zustand persist hydration has completed — otherwise the persisted
+    // state overwrites the just-minted draft and the edit route
+    // bounces home.
+    if (!hydrated) return;
+    if (currentBrandId === null) {
+      return;
+    }
+    startedRef.current = true;
+    // Use `getState().createDraft(...)` instead of a subscribed selector
+    // so we read the CURRENT post-hydration store and write the new draft
+    // into the post-hydration state directly — no subscription staleness,
+    // no risk of the persisted state replacing our write.
+    const draft = useDraftEventStore.getState().createRsvpDraft(currentBrandId);
+    router.replace(`/rsvp/${draft.id}/edit?step=0` as never);
+  }, [
+    currentBrandId,
+    canUseStoredBrandForWeb,
+    currentBrandRecovery.isResolving,
+    hydrated,
+    isAuthReady,
+    router,
+    terminalState,
+  ]);
+
+  if (terminalState !== null) {
+    const copy = terminalCopy[terminalState];
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.card}>
+          <Text style={styles.title}>{copy.title}</Text>
+          <Text style={styles.body}>{copy.body}</Text>
+          <View style={styles.buttonStack}>
+            <Button
+              label={copy.primaryLabel}
+              onPress={() => {
+                if (terminalState === "signed_out" || terminalState === "auth_timeout") {
+                  router.replace("/auth?next=/rsvp/create" as never);
+                  return;
+                }
+                retryRoute(router);
+              }}
+              fullWidth
+              size="md"
+              shape="square"
+            />
+            <Button
+              label="Back to Home"
+              onPress={() => goToStaticHome(router)}
+              fullWidth
+              size="md"
+              shape="square"
+              variant="secondary"
+            />
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.host,
+        { paddingTop: insets.top, backgroundColor: canvas.discover },
+      ]}
+    >
+      <View style={styles.center}>
+        <Spinner size={36} />
+        <Text style={styles.label}>
+          {!isAuthReady
+            ? "Finishing sign-in…"
+            : currentBrandRecovery.isResolving
+              ? "Getting your brand ready…"
+              : !hydrated
+                ? "Loading local drafts…"
+                : "Loading…"}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const terminalCopy: Record<
+  CreateRouteTerminalState,
+  { title: string; body: string; primaryLabel: string }
+> = {
+  signed_out: {
+    title: "Sign in to create an RSVP.",
+    body: "Your browser session is not available on this route.",
+    primaryLabel: "Sign in again",
+  },
+  auth_timeout: {
+    title: "We could not finish sign-in.",
+    body: "Refresh or sign in again before starting an RSVP.",
+    primaryLabel: "Sign in again",
+  },
+  auth_error: {
+    title: "We could not finish sign-in.",
+    body: "Refresh or sign in again before starting an RSVP.",
+    primaryLabel: "Try again",
+  },
+  brand_error: {
+    title: "We could not load your brand.",
+    body: "Try again before starting an RSVP.",
+    primaryLabel: "Try again",
+  },
+  brand_timeout: {
+    title: "We could not load your brand.",
+    body: "This phone browser could not finish brand setup quickly enough. Try again or return to Home.",
+    primaryLabel: "Try again",
+  },
+  no_brand: {
+    title: "Create or select a brand before starting an RSVP.",
+    body: "Use desktop or the Mingla Business app if brand setup is not available on this phone browser.",
+    primaryLabel: "Try again",
+  },
+  draft_hydration_timeout: {
+    title: "This browser cannot save drafts right now.",
+    body: "Refresh, use desktop, or use the Mingla Business app before creating this listing.",
+    primaryLabel: "Try again",
+  },
+};
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.md,
+  },
+  label: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  card: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: spacing.xl,
+    gap: spacing.md,
+  },
+  title: {
+    fontSize: typography.h3.fontSize,
+    lineHeight: typography.h3.lineHeight,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  body: {
+    fontSize: typography.body.fontSize,
+    lineHeight: typography.body.lineHeight,
+    color: textTokens.secondary,
+  },
+  buttonStack: {
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+});

--- a/mingla-business/src/components/event/CreatorStep2When.tsx
+++ b/mingla-business/src/components/event/CreatorStep2When.tsx
@@ -183,6 +183,9 @@ export const CreatorStep2When: React.FC<StepBodyProps> = ({
   // META-ORCH-1059 — experience wizard opts in to the open-ended "Never ends"
   // recurrence option; events leave it false (bounded end required).
   allowNeverEnds = false,
+  // ORCH-1150 — RSVP wizard locks single-date: hide the mode tabs + render only
+  // the single-date body. Default false; event wizard is byte-identical.
+  lockSingleDate = false,
 }) => {
   // ---- Picker state (date + time + termination-until) ----
   const [pickerMode, setPickerMode] = useState<PickerMode>(null);
@@ -843,27 +846,30 @@ export const CreatorStep2When: React.FC<StepBodyProps> = ({
 
   return (
     <View>
-      {/* 3-mode segmented control (replaces Cycle 3 Repeats sheet) */}
-      <View style={styles.field}>
-        <Text style={styles.fieldLabel}>How often does this event happen?</Text>
-        <View style={styles.segmentRow}>
-          <SegmentPill
-            label="Single"
-            active={draft.whenMode === "single"}
-            onPress={() => handleModeSwitch("single")}
-          />
-          <SegmentPill
-            label="Recurring"
-            active={draft.whenMode === "recurring"}
-            onPress={() => handleModeSwitch("recurring")}
-          />
-          <SegmentPill
-            label="Multi-date"
-            active={draft.whenMode === "multi_date"}
-            onPress={() => handleModeSwitch("multi_date")}
-          />
+      {/* 3-mode segmented control (replaces Cycle 3 Repeats sheet).
+          ORCH-1150 — hidden when lockSingleDate (RSVP wizard, single-date only). */}
+      {lockSingleDate ? null : (
+        <View style={styles.field}>
+          <Text style={styles.fieldLabel}>How often does this event happen?</Text>
+          <View style={styles.segmentRow}>
+            <SegmentPill
+              label="Single"
+              active={draft.whenMode === "single"}
+              onPress={() => handleModeSwitch("single")}
+            />
+            <SegmentPill
+              label="Recurring"
+              active={draft.whenMode === "recurring"}
+              onPress={() => handleModeSwitch("recurring")}
+            />
+            <SegmentPill
+              label="Multi-date"
+              active={draft.whenMode === "multi_date"}
+              onPress={() => handleModeSwitch("multi_date")}
+            />
+          </View>
         </View>
-      </View>
+      )}
 
       {/* Mode body */}
       {draft.whenMode === "single" || draft.whenMode === "recurring" ? (

--- a/mingla-business/src/components/event/EditPublishedScreen.tsx
+++ b/mingla-business/src/components/event/EditPublishedScreen.tsx
@@ -257,6 +257,13 @@ const isServerEditableOnlyPatch = (
 export interface EditPublishedScreenProps {
   liveEvent: LiveEvent;
   disableLocalSaveReason?: string;
+  /**
+   * ORCH-1150 — when true, the event is an RSVP: drop the Tickets section + the
+   * sold-ticket refund gate, and show the "N guests are going — they'll be
+   * notified" notice (wired in SPEC §12). Default false = ticketed event,
+   * byte-identical behavior. See SPEC §12.
+   */
+  rsvpMode?: boolean;
 }
 
 interface ToastState {
@@ -286,6 +293,7 @@ interface RejectDialogContent {
 export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
   liveEvent,
   disableLocalSaveReason,
+  rsvpMode = false,
 }) => {
   const insets = useSafeAreaInsets();
   const router = useRouter();

--- a/mingla-business/src/components/event/EditPublishedScreen.tsx
+++ b/mingla-business/src/components/event/EditPublishedScreen.tsx
@@ -119,6 +119,8 @@ import {
   patchPublishedEventTheme,
   patchPublishedEventWhen,
 } from "../../services/businessEvents";
+import { updateLiveRsvp } from "../../services/rsvpEvents";
+import { rsvpEditNoticeCopy } from "../../utils/rsvpHubMetrics";
 import { businessEventKeys } from "../../hooks/useBusinessEvents";
 import { publicEventKeys } from "../../hooks/usePublicEvents";
 import {
@@ -380,6 +382,13 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     [],
   );
 
+  // ORCH-1150 — an RSVP edit drops the Tickets section entirely (RSVP has zero
+  // tickets + no money). Every SECTIONS iteration below uses this filtered list.
+  const sections = useMemo<readonly SectionConfig[]>(
+    () => (rsvpMode ? SECTIONS.filter((s) => s.key !== "tickets") : SECTIONS),
+    [rsvpMode],
+  );
+
   // ---- Per-section errors ----
   const sectionErrors = useMemo<Record<SectionKey, ValidationError[]>>(() => {
     const out: Record<SectionKey, ValidationError[]> = {
@@ -391,7 +400,7 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       tickets: [],
       settings: [],
     };
-    for (const sec of SECTIONS) {
+    for (const sec of sections) {
       out[sec.key] =
         sec.stepIndex === null ? [] : validateStep(sec.stepIndex, editState);
     }
@@ -430,13 +439,13 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       return;
     }
     // 1. Validate sections
-    const hasErrors = SECTIONS.some(
+    const hasErrors = sections.some(
       (sec) => sectionErrors[sec.key].length > 0,
     );
     if (hasErrors) {
       setShowErrors(true);
       // Open the first errored section so user sees inline errors
-      const firstErrored = SECTIONS.find(
+      const firstErrored = sections.find(
         (sec) => sectionErrors[sec.key].length > 0,
       );
       if (firstErrored !== undefined) {
@@ -739,6 +748,52 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       setSubmitting(true);
       await sleep(SAVE_PROCESSING_MS);
       const patch = currentPatch;
+
+      // ORCH-1150 — RSVP edit-published path. RSVP has NO sold tickets + no
+      // money, so it bypasses the entire refund/sold-diff machinery below and
+      // commits through biz_update_live_rsvp. A material change (date/time/
+      // venue) makes that RPC enqueue an `rsvp_event_updated` notification to
+      // every going guest (SPEC §5.2). Then the local Zustand mutation keeps
+      // the cache in sync. No StripeBlockedCard, no EndSalesSheet, no ticket diff.
+      if (rsvpMode) {
+        if (liveEvent.serverEventId === null) {
+          setSubmitting(false);
+          setModal((prev) => ({ ...prev, visible: false }));
+          showToast("Save failed because this event is missing its server id.");
+          return;
+        }
+        try {
+          await updateLiveRsvp(liveEvent.serverEventId, patch, reason);
+        } catch (error) {
+          setSubmitting(false);
+          setModal((prev) => ({ ...prev, visible: false }));
+          const code = error instanceof Error ? error.message : "rsvp_update_failed";
+          const message = code.includes("event_not_an_rsvp")
+            ? "This event isn't an RSVP — reopen it to edit."
+            : code.includes("insufficient_event_permission")
+              ? "You don't have permission to edit this event."
+              : "Couldn't save your changes. Tap to try again.";
+          showToast(message);
+          return;
+        }
+        const rsvpResult = updateLiveEventFields(
+          liveEvent.id,
+          patch,
+          soldCountCtx,
+          reason,
+        );
+        setSubmitting(false);
+        setModal((prev) => ({ ...prev, visible: false }));
+        invalidateServerEventCaches();
+        if (rsvpResult.ok) {
+          showToast("Saved. Going guests will be notified.");
+          setTimeout(() => router.back(), TOAST_NAV_DELAY_MS);
+        } else {
+          showToast("Couldn't save your changes. Tap to try again.");
+        }
+        return;
+      }
+
       const validation = validateLiveEventFieldUpdate(
         liveEvent,
         patch,
@@ -1136,6 +1191,7 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       buildRejectDialog,
       disableLocalSaveReason,
       invalidateServerEventCaches,
+      rsvpMode,
     ],
   );
 
@@ -1220,7 +1276,7 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     const out = new Set<SectionKey>();
     if (fieldDiffs.length === 0) return out;
     const changedKeys = new Set(fieldDiffs.map((d) => d.fieldKey));
-    for (const sec of SECTIONS) {
+    for (const sec of sections) {
       if (
         (sec.key === "basics" &&
           (changedKeys.has("name") ||
@@ -1302,7 +1358,18 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       >
         <EditAfterPublishBanner />
 
-        {SECTIONS.map((sec) => {
+        {/* ORCH-1150 — RSVP edit notice: every going guest is notified when a
+            material detail (date/time/venue) changes. Replaces the ticketed
+            refund warning (RSVP has no buyers to refund). */}
+        {rsvpMode ? (
+          <View style={styles.rsvpNotice}>
+            <Text style={styles.rsvpNoticeText}>
+              {rsvpEditNoticeCopy(liveEvent.rsvpGoingCount ?? 0)}
+            </Text>
+          </View>
+        ) : null}
+
+        {sections.map((sec) => {
           const isOpen = openSection === sec.key;
           const isEdited = editedSectionKeys.has(sec.key);
           const hasErrors =
@@ -1447,6 +1514,23 @@ const styles = StyleSheet.create({
     borderColor: glass.border.profileBase,
     backgroundColor: glass.tint.profileBase,
     overflow: "hidden",
+  },
+  // ORCH-1150 — RSVP "they'll be notified" notice. Opaque fill (Android glass
+  // policy: ANDROID_GLASS_USES_OPAQUE_FALLBACK) — solid card, no translucent tint.
+  rsvpNotice: {
+    marginBottom: spacing.sm,
+    borderRadius: radiusTokens.lg,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    backgroundColor: canvas.profile,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    overflow: "hidden",
+  },
+  rsvpNoticeText: {
+    color: textTokens.secondary,
+    fontSize: 13,
+    lineHeight: 18,
   },
   sectionHeader: {
     flexDirection: "row",

--- a/mingla-business/src/components/event/EventListCard.tsx
+++ b/mingla-business/src/components/event/EventListCard.tsx
@@ -36,6 +36,7 @@ import type { DraftEvent } from "../../store/draftEventStore";
 import type { Brand } from "../../store/currentBrandStore";
 import { formatDraftDateLine } from "../../utils/eventDateDisplay";
 import { buildEventSalesSummary } from "../../utils/eventSalesSummary";
+import { formatRsvpGoingLabel } from "../../utils/rsvpHubMetrics";
 import { useEventOrders } from "../../hooks/useEventOrders";
 
 import { EventCoverMedia } from "../ui/EventCoverMedia";
@@ -96,7 +97,11 @@ export const EventListCard: React.FC<EventListCardProps> = ({
   // query layer + helper at the tap-handler layer + defensive at the
   // render layer. Trips have their own card surface in /hub/trips.
   const eventType = (event as { event_type?: string }).event_type;
-  if (eventType !== undefined && eventType !== "event") {
+  // ORCH-1150 — the RSVP event renders on this SAME card (Hub parity), with a
+  // "N going" metric instead of revenue/tickets-sold. Trips/experiences still
+  // bail (they have their own surfaces).
+  const isRsvp = eventType === "rsvp" || (event as DraftEvent).isRsvp === true;
+  if (eventType !== undefined && eventType !== "event" && eventType !== "rsvp") {
     return null;
   }
 
@@ -138,10 +143,25 @@ export const EventListCard: React.FC<EventListCardProps> = ({
     salesSummary.finiteCapacity !== null
       ? Math.min(100, Math.round((salesSummary.soldCount / salesSummary.finiteCapacity) * 100))
       : 0;
+
+  // ORCH-1150 — RSVP "N going" metric (no money/sold). Reads the live
+  // confirmed-attending count surfaced on the LiveEvent. Capacity, when set,
+  // shows "N / cap going". Drafts show no count yet (nobody's RSVP'd).
+  const rsvpGoingCount =
+    kind === "live" ? ((event as LiveEvent).rsvpGoingCount ?? 0) : 0;
+  const rsvpCapacity =
+    isRsvp ? ((event as LiveEvent).rsvpCapacity ?? (event as DraftEvent).rsvpCapacity ?? null) : null;
+  const rsvpGoingLabel: string = formatRsvpGoingLabel({
+    kind: kind === "live" ? "live" : kind === "draft" ? "draft" : "past",
+    goingCount: rsvpGoingCount,
+    capacity: rsvpCapacity,
+  });
   const cardAccessibilityLabel =
     kind === "draft"
       ? `Open ${title}`
-      : `Open ${title}. ${salesSummary.soldLabel}. ${salesSummary.revenueLabel}.`;
+      : isRsvp
+        ? `Open ${title}. ${rsvpGoingLabel}.`
+        : `Open ${title}. ${salesSummary.soldLabel}. ${salesSummary.revenueLabel}.`;
 
   // Past + 0 sold → fade per Q-9-9.
   const isFaded = status === "past" && salesSummary.soldCount === 0;
@@ -237,8 +257,11 @@ export const EventListCard: React.FC<EventListCardProps> = ({
             {venue !== null ? ` · ${venue}` : ""}
           </Text>
 
-          {/* Progress bar for finite capacity, explicit sold summary otherwise. */}
-          {kind === "draft" ? (
+          {/* Progress bar for finite capacity, explicit sold summary otherwise.
+              ORCH-1150 — RSVP rows show "N going" (no money/progress bar). */}
+          {isRsvp ? (
+            <Text style={styles.subText}>{rsvpGoingLabel}</Text>
+          ) : kind === "draft" ? (
             <Text style={styles.subText}>
               {(event as DraftEvent).whenMode === "recurring"
                 ? "Series template"
@@ -293,10 +316,13 @@ export const EventListCard: React.FC<EventListCardProps> = ({
         </View>
       ) : null}
 
-      {/* Revenue strip (non-draft only) */}
+      {/* Revenue strip (non-draft only). ORCH-1150 — RSVP has no revenue; the
+          right rail shows the going count instead of a money figure. */}
       {kind !== "draft" ? (
         <View style={styles.revenueStrip} pointerEvents="none">
-          <Text style={styles.revenueValue}>{salesSummary.revenueLabel}</Text>
+          <Text style={styles.revenueValue}>
+            {isRsvp ? `${rsvpGoingCount} going` : salesSummary.revenueLabel}
+          </Text>
         </View>
       ) : null}
 

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -59,6 +59,8 @@ import { useResponsiveLayout } from "@mingla/offering-rendering";
 
 import { EventReserveBar } from "./EventReserveBar";
 import { FoundationEventPreview } from "./FoundationEventPreview";
+import { RsvpPublicBody } from "./RsvpPublicBody";
+import { submitPublicRsvp } from "../../services/rsvpEvents";
 
 import {
   checkoutPublicPath,
@@ -499,6 +501,95 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
       </View>
     </View>
   ) : null;
+
+  // ORCH-1150 — RSVP branch. An event_type='rsvp' row has zero tickets + no
+  // checkout; it renders the Going/Not-going RsvpPublicBody and returns early.
+  // The ticketed path below is BYTE-IDENTICAL (untouched) for every non-RSVP row.
+  const isRsvp = event.event_type === "rsvp";
+  const rsvpSubmit = useCallback(
+    async (input: {
+      rsvpStatus: "going" | "not_going";
+      guestName: string;
+      guestEmail: string;
+      guestPhone: string;
+      plusCount: number;
+    }): Promise<{
+      status: "going" | "not_going" | "waitlisted";
+      approvalStatus: "pending" | "approved";
+    }> =>
+      submitPublicRsvp({
+        eventId: event.id,
+        rsvpStatus: input.rsvpStatus,
+        guestName: input.guestName,
+        guestEmail: input.guestEmail,
+        guestPhone: input.guestPhone,
+        plusCount: input.plusCount,
+      }),
+    [event.id],
+  );
+
+  if (isRsvp) {
+    return (
+      <View style={[styles.host, { backgroundColor: palette.page }]}>
+        {Platform.OS === "web" ? (
+          <Head>
+            <title>
+              {event.name} · {brand?.displayName ?? "Mingla"}
+            </title>
+            <meta
+              name="description"
+              content={event.description.slice(0, 160) || event.name}
+            />
+            <meta property="og:title" content={event.name} />
+            <meta property="og:url" content={canonicalUrl(event)} />
+            <link rel="canonical" href={canonicalUrl(event)} />
+          </Head>
+        ) : null}
+
+        <RsvpPublicBody
+          event={publicEvent}
+          brand={publicBrand}
+          palette={palette}
+          theme={resolvedTheme}
+          config={{
+            capacity: event.rsvpCapacity ?? null,
+            goingCount: event.rsvpGoingCount ?? 0,
+            allowPlusOnes: event.rsvpAllowPlusOnes ?? false,
+            plusOnesMax: event.rsvpPlusOnesMax ?? 0,
+            waitlistEnabled: event.rsvpWaitlistEnabled ?? false,
+            manualApproval: event.rsvpApprovalMode === "manual",
+          }}
+          isLoggedIn={user !== null}
+          muted={muted}
+          onToggleMute={handleToggleMute}
+          onClose={handleClose}
+          onShare={handleShare}
+          onOpenBrand={(slug: string) => router.push(`/b/${slug}` as never)}
+          onOpenMaps={openMapsForQuery}
+          onSubmit={rsvpSubmit}
+          safeAreaTop={insets.top}
+          testID="orch-1150-rsvp-public"
+        />
+
+        <ShareModal
+          visible={shareModalVisible}
+          onClose={() => setShareModalVisible(false)}
+          url={canonicalUrl(event)}
+          title={event.name}
+          description={event.description.slice(0, 200)}
+        />
+
+        <View style={styles.toastWrap} pointerEvents="box-none">
+          <Toast
+            visible={toast.visible}
+            kind="info"
+            message={toast.message}
+            onDismiss={dismissToast}
+          />
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.host, { backgroundColor: palette.page }]}>

--- a/mingla-business/src/components/event/RsvpPublicBody.tsx
+++ b/mingla-business/src/components/event/RsvpPublicBody.tsx
@@ -1,0 +1,739 @@
+/**
+ * RsvpPublicBody — ORCH-1150 [RSVP ticketless event] public page body.
+ *
+ * The Going / Not-going public surface for an event_type='rsvp' row, mounted by
+ * PublicEventPage when event.event_type === 'rsvp'. Reuses the SAME ORCH-1138
+ * ParallaxCoverShell (immersive cover, X · Share · Mute chrome, brand palette +
+ * bold fonts, hero) so an RSVP page looks like a sibling of the ticketed page —
+ * but it carries NO ticket tiers, NO checkout, NO money. Guests reply Going or
+ * Not going; the host gets capacity / +1 / waitlist / approval.
+ *
+ * do NOT merge back into the ticket/checkout path — RSVP has zero tickets + no
+ * money gate; the CTA writes a Going/Not-going row via public-submit-rsvp, never
+ * an order, and never navigates to /checkout. See SPEC §6.
+ *
+ * Anon-tolerant: a logged-out link guest supplies name + email + phone (all
+ * three REQUIRED — A4-NEW); a logged-in app user skips the form (profile
+ * supplies contact + push). All states handled (open / full / waitlist /
+ * pending / going / not_going / submitting / error) — no dead ends.
+ * Android: opaque card fills (ANDROID_GLASS_USES_OPAQUE_FALLBACK).
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import * as Haptics from "expo-haptics";
+
+import {
+  ParallaxCoverShell,
+  offeringSurfaceStyles,
+  normalizeCityCountry,
+} from "@mingla/offering-rendering";
+import {
+  resolveRsvpCta,
+  boldFontFamily,
+  type PublicEventProps,
+  type PublicBrandProps,
+  type ThemePalette,
+  type ResolvedTheme,
+  type RsvpCtaState,
+} from "@mingla/event-rendering";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^\+?[0-9\s()-]{7,20}$/;
+
+/** What the public RSVP body needs from the resolved event (RSVP host-control). */
+export interface RsvpPublicConfig {
+  capacity: number | null;
+  goingCount: number;
+  allowPlusOnes: boolean;
+  plusOnesMax: number;
+  waitlistEnabled: boolean;
+  manualApproval: boolean;
+}
+
+export interface RsvpPublicBodyProps {
+  event: PublicEventProps;
+  brand: PublicBrandProps | null;
+  palette: ThemePalette;
+  theme: ResolvedTheme;
+  config: RsvpPublicConfig;
+  /** true → logged-in app user (skip the contact form). */
+  isLoggedIn: boolean;
+  muted: boolean;
+  onToggleMute: () => void;
+  onClose: () => void;
+  onShare: () => void;
+  onOpenBrand?: (brandSlug: string) => void;
+  onOpenMaps?: (query: string) => void;
+  /**
+   * Submits the RSVP. Returns the resolved server state so the body can reflect
+   * pending / waitlist / going. Throws on error (the body shows an inline error,
+   * never a dead end).
+   */
+  onSubmit: (input: {
+    rsvpStatus: "going" | "not_going";
+    guestName: string;
+    guestEmail: string;
+    guestPhone: string;
+    plusCount: number;
+  }) => Promise<{
+    status: "going" | "not_going" | "waitlisted";
+    approvalStatus: "pending" | "approved";
+  }>;
+  safeAreaTop?: number;
+  testID?: string;
+}
+
+type SubmitPhase = "idle" | "submitting";
+
+export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
+  event,
+  brand,
+  palette,
+  theme,
+  config,
+  isLoggedIn,
+  muted,
+  onToggleMute,
+  onClose,
+  onShare,
+  onOpenBrand,
+  onOpenMaps,
+  onSubmit,
+  safeAreaTop = 0,
+  testID,
+}) => {
+  const surface = offeringSurfaceStyles(palette);
+  const boldFamily = boldFontFamily(theme);
+
+  // Contact capture (anon link guest). Logged-in users skip these.
+  const [guestName, setGuestName] = useState<string>("");
+  const [guestEmail, setGuestEmail] = useState<string>("");
+  const [guestPhone, setGuestPhone] = useState<string>("");
+  const [plusCount, setPlusCount] = useState<number>(0);
+
+  const [phase, setPhase] = useState<SubmitPhase>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // The guest's resolved own state after a successful submit (null = not yet).
+  const [guestStatus, setGuestStatus] = useState<
+    "going" | "not_going" | "waitlisted" | null
+  >(null);
+  const [guestApproval, setGuestApproval] = useState<
+    "pending" | "approved" | null
+  >(null);
+
+  const capacityFull =
+    config.capacity !== null && config.goingCount >= config.capacity;
+
+  const ctaState: RsvpCtaState = useMemo(
+    () =>
+      resolveRsvpCta({
+        capacityFull,
+        waitlistEnabled: config.waitlistEnabled,
+        manualApproval: config.manualApproval,
+        guestStatus,
+        guestApproval,
+      }).state,
+    [
+      capacityFull,
+      config.waitlistEnabled,
+      config.manualApproval,
+      guestStatus,
+      guestApproval,
+    ],
+  );
+
+  const emailValid = EMAIL_RE.test(guestEmail.trim());
+  const phoneValid = PHONE_RE.test(guestPhone.trim());
+  const nameValid = guestName.trim().length > 0;
+  // A4-NEW: link guests must enter name + valid email + valid phone before Going.
+  const contactReady = isLoggedIn || (nameValid && emailValid && phoneValid);
+
+  const submit = useCallback(
+    async (rsvpStatus: "going" | "not_going"): Promise<void> => {
+      if (phase === "submitting") return;
+      if (rsvpStatus === "going" && !contactReady) {
+        setErrorMsg("Add your name, email, and phone to RSVP.");
+        return;
+      }
+      setErrorMsg(null);
+      setPhase("submitting");
+      if (Platform.OS !== "web") {
+        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(
+          () => undefined,
+        );
+      }
+      try {
+        const result = await onSubmit({
+          rsvpStatus,
+          guestName: guestName.trim(),
+          guestEmail: guestEmail.trim(),
+          guestPhone: guestPhone.trim(),
+          plusCount: config.allowPlusOnes ? plusCount : 0,
+        });
+        setGuestStatus(result.status);
+        setGuestApproval(result.approvalStatus);
+      } catch (err) {
+        const code = err instanceof Error ? err.message : String(err);
+        if (code.includes("rsvp_contact_required")) {
+          setErrorMsg("Add your name, email, and phone to RSVP.");
+        } else if (code.includes("rsvp_phone_invalid")) {
+          setErrorMsg("Enter a valid phone number.");
+        } else if (code.includes("rsvp_full")) {
+          setErrorMsg("This event just filled up.");
+        } else if (code.includes("rsvp_not_open")) {
+          setErrorMsg("RSVPs are closed for this event.");
+        } else {
+          setErrorMsg("Couldn't save your RSVP. Try again.");
+        }
+      } finally {
+        setPhase("idle");
+      }
+    },
+    [
+      phase,
+      contactReady,
+      onSubmit,
+      guestName,
+      guestEmail,
+      guestPhone,
+      plusCount,
+      config.allowPlusOnes,
+    ],
+  );
+
+  const cityCountry =
+    normalizeCityCountry(event.venueName) ??
+    normalizeCityCountry(event.address);
+  const venueAddressLabel =
+    event.format === "online"
+      ? "Online event"
+      : (event.address ?? event.venueName ?? "Location shared on RSVP");
+  const venueMapsQuery =
+    event.venueName === null
+      ? null
+      : [event.venueName, event.address].filter(Boolean).join(", ");
+  const canOpenVenueMaps =
+    venueMapsQuery !== null &&
+    venueMapsQuery.trim().length > 0 &&
+    onOpenMaps !== undefined;
+
+  // ---- the RSVP action card (the heart of the page) -----------------------
+  const submitting = phase === "submitting";
+
+  const goingResolved = guestStatus === "going" && guestApproval === "approved";
+  const pendingResolved = guestApproval === "pending";
+  const notGoingResolved = guestStatus === "not_going";
+  const waitlistedResolved = guestStatus === "waitlisted";
+
+  const headline: string =
+    pendingResolved
+      ? "Awaiting host approval"
+      : waitlistedResolved
+        ? "You're on the waitlist"
+        : goingResolved
+          ? "You're going"
+          : notGoingResolved
+            ? "You said you can't make it"
+            : ctaState === "full"
+              ? "This event is full"
+              : "Are you going?";
+
+  const subcopy: string | null =
+    pendingResolved
+      ? "The host reviews each RSVP — we'll notify you the moment you're approved."
+      : waitlistedResolved
+        ? "A spot opened? We'll text and email you automatically."
+        : goingResolved
+          ? "We'll let you know if anything about the event changes."
+          : notGoingResolved
+            ? "Changed your mind? You can switch to Going."
+            : ctaState === "full"
+              ? config.waitlistEnabled
+                ? "Join the waitlist and we'll move you in if a spot opens."
+                : "The guest list is full for now."
+              : config.manualApproval
+                ? "The host approves each guest after you reply."
+                : null;
+
+  // Whether the Going button is the waitlist-join variant.
+  const goingIsWaitlist =
+    ctaState === "waitlist" && !waitlistedResolved && !goingResolved;
+  const goingDisabled =
+    submitting ||
+    goingResolved ||
+    pendingResolved ||
+    waitlistedResolved ||
+    (ctaState === "full" && !config.waitlistEnabled) ||
+    (!isLoggedIn && !contactReady);
+  const goingLabel = goingIsWaitlist
+    ? submitting
+      ? "Joining…"
+      : "Join waitlist"
+    : submitting
+      ? "Saving…"
+      : "Going";
+
+  const showContactForm =
+    !isLoggedIn &&
+    !goingResolved &&
+    !pendingResolved &&
+    !waitlistedResolved &&
+    !(ctaState === "full" && !config.waitlistEnabled);
+
+  const actionCard = (
+    <View
+      style={[styles.rsvpCard, surface.card]}
+      testID="orch-1150-rsvp-card"
+    >
+      <Text
+        style={[styles.rsvpHeadline, surface.primaryText, { fontFamily: boldFamily }]}
+      >
+        {headline}
+      </Text>
+      {subcopy !== null ? (
+        <Text style={[styles.rsvpSub, surface.secondaryText]}>{subcopy}</Text>
+      ) : null}
+
+      {showContactForm ? (
+        <View style={styles.formBlock}>
+          <Text style={[styles.formMicro, surface.tertiaryText]}>
+            We'll only use this to update you about this event.
+          </Text>
+          <RsvpField
+            label="Your name"
+            value={guestName}
+            onChangeText={setGuestName}
+            placeholder="First and last name"
+            palette={palette}
+            surface={surface}
+            invalid={guestName.length > 0 && !nameValid}
+            invalidMsg="Required"
+            autoCapitalize="words"
+            testID="orch-1150-rsvp-name"
+          />
+          <RsvpField
+            label="Email"
+            value={guestEmail}
+            onChangeText={setGuestEmail}
+            placeholder="you@email.com"
+            palette={palette}
+            surface={surface}
+            invalid={guestEmail.length > 0 && !emailValid}
+            invalidMsg="Enter a valid email"
+            keyboardType="email-address"
+            autoCapitalize="none"
+            testID="orch-1150-rsvp-email"
+          />
+          <RsvpField
+            label="Phone"
+            value={guestPhone}
+            onChangeText={setGuestPhone}
+            placeholder="+1 555 123 4567"
+            palette={palette}
+            surface={surface}
+            invalid={guestPhone.length > 0 && !phoneValid}
+            invalidMsg="Enter a valid phone number"
+            keyboardType="phone-pad"
+            autoCapitalize="none"
+            testID="orch-1150-rsvp-phone"
+          />
+        </View>
+      ) : null}
+
+      {config.allowPlusOnes &&
+      !goingResolved &&
+      !pendingResolved &&
+      !waitlistedResolved ? (
+        <View style={[styles.plusRow, surface.card]}>
+          <Text style={[styles.plusLabel, surface.secondaryText]}>
+            Bringing extras?
+          </Text>
+          <View style={styles.stepper}>
+            <Pressable
+              onPress={() => setPlusCount((c) => Math.max(0, c - 1))}
+              disabled={plusCount <= 0}
+              accessibilityRole="button"
+              accessibilityLabel="Remove one extra guest"
+              style={[styles.stepBtn, { borderColor: palette.panelBorder }]}
+              testID="orch-1150-rsvp-plus-minus"
+            >
+              <Text style={[styles.stepGlyph, { color: palette.accent }]}>–</Text>
+            </Pressable>
+            <Text
+              style={[styles.stepCount, surface.primaryText, { fontFamily: boldFamily }]}
+            >
+              +{plusCount}
+            </Text>
+            <Pressable
+              onPress={() =>
+                setPlusCount((c) => Math.min(config.plusOnesMax, c + 1))
+              }
+              disabled={plusCount >= config.plusOnesMax}
+              accessibilityRole="button"
+              accessibilityLabel="Add one extra guest"
+              style={[styles.stepBtn, { borderColor: palette.panelBorder }]}
+              testID="orch-1150-rsvp-plus-plus"
+            >
+              <Text style={[styles.stepGlyph, { color: palette.accent }]}>+</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+
+      {errorMsg !== null ? (
+        <Text style={styles.errorText} testID="orch-1150-rsvp-error">
+          {errorMsg}
+        </Text>
+      ) : null}
+
+      {!goingResolved && !pendingResolved && !notGoingResolved ? (
+        <View style={styles.ctaRow}>
+          <Pressable
+            onPress={() => void submit("going")}
+            disabled={goingDisabled}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: goingDisabled }}
+            accessibilityLabel={goingLabel}
+            style={[
+              styles.goingBtn,
+              goingDisabled
+                ? { backgroundColor: palette.card, borderColor: palette.panelBorder, borderWidth: 1 }
+                : { backgroundColor: palette.accent },
+            ]}
+            testID="orch-1150-rsvp-going"
+          >
+            <Text
+              style={[
+                styles.goingText,
+                {
+                  color: goingDisabled ? palette.tertiaryText : palette.accentText,
+                  fontFamily: boldFamily,
+                },
+              ]}
+            >
+              {goingLabel}
+            </Text>
+          </Pressable>
+          {!waitlistedResolved ? (
+            <Pressable
+              onPress={() => void submit("not_going")}
+              disabled={submitting}
+              accessibilityRole="button"
+              accessibilityLabel="Not going"
+              style={[styles.notGoingBtn, { borderColor: palette.panelBorder }]}
+              testID="orch-1150-rsvp-not-going"
+            >
+              <Text style={[styles.notGoingText, surface.secondaryText]}>
+                Not going
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+
+      {notGoingResolved ? (
+        <Pressable
+          onPress={() => void submit("going")}
+          disabled={submitting}
+          accessibilityRole="button"
+          accessibilityLabel="Switch to Going"
+          style={[styles.goingBtn, { backgroundColor: palette.accent }]}
+          testID="orch-1150-rsvp-switch-going"
+        >
+          <Text
+            style={[
+              styles.goingText,
+              { color: palette.accentText, fontFamily: boldFamily },
+            ]}
+          >
+            Actually, I'm going
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+
+  return (
+    <ParallaxCoverShell
+      palette={palette}
+      theme={theme}
+      coverMediaUrl={event.coverMediaUrl}
+      coverMediaType={
+        event.coverMediaType === "video"
+          ? "video"
+          : event.coverMediaType === "gif"
+            ? "gif"
+            : event.coverMediaUrl !== null
+              ? "image"
+              : null
+      }
+      coverHue={event.coverHue}
+      entranceAnimationKey={`rsvp:${event.id}`}
+      muted={muted}
+      onToggleMute={onToggleMute}
+      showMute={event.coverMediaType === "video"}
+      onClose={onClose}
+      onShare={onShare}
+      heroEyebrow={
+        event.dateLine.length > 0 ? (
+          <Text style={styles.heroEyebrow}>{event.dateLine}</Text>
+        ) : undefined
+      }
+      heroTitle={
+        <Text style={[styles.heroTitle, { fontFamily: boldFamily }]}>
+          {event.name.length > 0 ? event.name : "Untitled event"}
+        </Text>
+      }
+      safeAreaTop={safeAreaTop}
+      testID={testID}
+    >
+      <View>
+        {/* Brand chip */}
+        <Pressable
+          onPress={() => {
+            if (brand?.slug !== undefined) onOpenBrand?.(brand.slug);
+          }}
+          disabled={brand?.slug === undefined || onOpenBrand === undefined}
+          accessibilityRole={onOpenBrand !== undefined ? "button" : undefined}
+          accessibilityLabel={
+            brand?.displayName !== undefined
+              ? `View ${brand.displayName}`
+              : "View brand"
+          }
+          style={[styles.brandRow, surface.card]}
+        >
+          <View style={styles.brandTextCol}>
+            <Text style={[styles.brandKicker, surface.tertiaryText]}>
+              Hosted by
+            </Text>
+            <Text
+              style={[styles.brandName, surface.primaryText, { fontFamily: boldFamily }]}
+            >
+              {brand?.displayName ?? "Brand"}
+            </Text>
+          </View>
+        </Pressable>
+
+        {actionCard}
+
+        {/* Date + venue facts */}
+        {event.dateSubline !== null && event.dateSubline.length > 0 ? (
+          <View style={[styles.factRow, surface.card]}>
+            <Text style={[styles.factGlyph, { color: palette.accent }]}>◴</Text>
+            <Text style={[styles.factText, surface.secondaryText]}>
+              {event.dateSubline}
+            </Text>
+          </View>
+        ) : null}
+        <Pressable
+          onPress={() => {
+            if (canOpenVenueMaps && venueMapsQuery !== null) {
+              onOpenMaps?.(venueMapsQuery);
+            }
+          }}
+          disabled={!canOpenVenueMaps}
+          accessibilityRole={canOpenVenueMaps ? "button" : undefined}
+          accessibilityLabel={
+            canOpenVenueMaps ? `Open ${venueAddressLabel} in maps` : undefined
+          }
+          style={[styles.factRow, surface.card]}
+        >
+          <Text style={[styles.factGlyph, { color: palette.accent }]}>◎</Text>
+          <View style={styles.factCol}>
+            {event.venueName !== null && event.venueName.length > 0 ? (
+              <Text
+                style={[styles.factText, surface.primaryText, { fontFamily: boldFamily }]}
+              >
+                {event.venueName}
+              </Text>
+            ) : null}
+            <Text style={[styles.factSub, surface.secondaryText]}>
+              {cityCountry ?? venueAddressLabel}
+            </Text>
+          </View>
+        </Pressable>
+
+        {/* About */}
+        {event.description.trim().length > 0 ? (
+          <View style={[styles.aboutCard, surface.card]}>
+            <Text
+              style={[styles.aboutTitle, surface.primaryText, { fontFamily: boldFamily }]}
+            >
+              About
+            </Text>
+            <Text style={[styles.aboutBody, surface.secondaryText]}>
+              {event.description.trim()}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </ParallaxCoverShell>
+  );
+};
+
+const RsvpField: React.FC<{
+  label: string;
+  value: string;
+  onChangeText: (v: string) => void;
+  placeholder: string;
+  palette: ThemePalette;
+  surface: ReturnType<typeof offeringSurfaceStyles>;
+  invalid: boolean;
+  invalidMsg: string;
+  keyboardType?: "default" | "email-address" | "phone-pad";
+  autoCapitalize?: "none" | "words";
+  testID?: string;
+}> = ({
+  label,
+  value,
+  onChangeText,
+  placeholder,
+  palette,
+  surface,
+  invalid,
+  invalidMsg,
+  keyboardType = "default",
+  autoCapitalize = "none",
+  testID,
+}) => (
+  <View style={styles.field}>
+    <Text style={[styles.fieldLabel, surface.tertiaryText]}>{label}</Text>
+    <TextInput
+      value={value}
+      onChangeText={onChangeText}
+      placeholder={placeholder}
+      placeholderTextColor={palette.tertiaryText}
+      keyboardType={keyboardType}
+      autoCapitalize={autoCapitalize}
+      accessibilityLabel={label}
+      style={[
+        styles.fieldInput,
+        {
+          color: palette.primaryText,
+          backgroundColor: palette.page,
+          borderColor: invalid ? "#e5484d" : palette.panelBorder,
+        },
+      ]}
+      testID={testID}
+    />
+    {invalid ? <Text style={styles.fieldError}>{invalidMsg}</Text> : null}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  heroEyebrow: {
+    color: "#ffffff",
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    marginBottom: 6,
+    textShadowColor: "rgba(0,0,0,0.5)",
+    textShadowRadius: 8,
+  },
+  heroTitle: {
+    color: "#ffffff",
+    fontSize: 30,
+    fontWeight: "900",
+    lineHeight: 34,
+    textShadowColor: "rgba(0,0,0,0.5)",
+    textShadowRadius: 10,
+  },
+  brandRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 16,
+    padding: 14,
+    marginBottom: 12,
+    overflow: "hidden",
+  },
+  brandTextCol: { flex: 1 },
+  brandKicker: { fontSize: 11, letterSpacing: 0.4, marginBottom: 2 },
+  brandName: { fontSize: 16, fontWeight: "800" },
+  rsvpCard: {
+    borderRadius: 20,
+    padding: 18,
+    marginBottom: 14,
+    overflow: "hidden",
+  },
+  rsvpHeadline: { fontSize: 22, fontWeight: "900", marginBottom: 4 },
+  rsvpSub: { fontSize: 14, lineHeight: 20, marginBottom: 8 },
+  formBlock: { marginTop: 8 },
+  formMicro: { fontSize: 12, marginBottom: 10 },
+  field: { marginBottom: 12 },
+  fieldLabel: { fontSize: 12, fontWeight: "700", marginBottom: 5 },
+  fieldInput: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: Platform.OS === "ios" ? 13 : 10,
+    fontSize: 15,
+  },
+  fieldError: { color: "#e5484d", fontSize: 12, marginTop: 4 },
+  plusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderRadius: 14,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginTop: 4,
+    marginBottom: 4,
+    overflow: "hidden",
+  },
+  plusLabel: { fontSize: 14, fontWeight: "600" },
+  stepper: { flexDirection: "row", alignItems: "center" },
+  stepBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  stepGlyph: { fontSize: 20, fontWeight: "800", lineHeight: 22 },
+  stepCount: { fontSize: 16, fontWeight: "800", minWidth: 40, textAlign: "center" },
+  errorText: { color: "#e5484d", fontSize: 13, marginTop: 10, marginBottom: 2 },
+  ctaRow: { flexDirection: "row", marginTop: 14, gap: 10 },
+  goingBtn: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    paddingVertical: 15,
+    marginTop: 14,
+  },
+  goingText: { fontSize: 16, fontWeight: "900" },
+  notGoingBtn: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 14,
+    paddingVertical: 15,
+    borderWidth: 1,
+  },
+  notGoingText: { fontSize: 15, fontWeight: "700" },
+  factRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 14,
+    padding: 14,
+    marginBottom: 10,
+    overflow: "hidden",
+  },
+  factGlyph: { fontSize: 18, marginRight: 12 },
+  factCol: { flex: 1 },
+  factText: { fontSize: 14, fontWeight: "600" },
+  factSub: { fontSize: 13, marginTop: 2 },
+  aboutCard: { borderRadius: 16, padding: 16, marginBottom: 10, overflow: "hidden" },
+  aboutTitle: { fontSize: 15, fontWeight: "800", marginBottom: 8 },
+  aboutBody: { fontSize: 14, lineHeight: 21 },
+});

--- a/mingla-business/src/components/event/types.ts
+++ b/mingla-business/src/components/event/types.ts
@@ -71,6 +71,13 @@ export interface StepBodyProps {
    * passes this; events still require a bounded end (count<=52 / until-date).
    */
   allowNeverEnds?: boolean;
+  /**
+   * ORCH-1150 — when true (RSVP wizard only), CreatorStep2When hides the
+   * single/recurring/multi_date mode tabs and renders ONLY the single-date
+   * body (steering #4). Default false; the event wizard never passes it, so
+   * the event path is byte-identical.
+   */
+  lockSingleDate?: boolean;
   // ORCH-0892-A: legacy wizard-scroll-ref prop removed. CoverPicker
   // now relies on the keyboard-controller library's KeyboardAvoidingView
   // wrap for search-input visibility above the keyboard.

--- a/mingla-business/src/components/offering/OfferingManageSheet.tsx
+++ b/mingla-business/src/components/offering/OfferingManageSheet.tsx
@@ -116,6 +116,12 @@ const ActionRow: React.FC<ActionRowProps> = ({ action }) => {
     >
       <Icon name={action.icon} size={18} color={color} />
       <Text style={[styles.actionLabel, { color }]}>{action.label}</Text>
+      {/* ORCH-1150 — pending-RSVP count pill on the Guests row. */}
+      {action.badgeCount !== undefined && action.badgeCount > 0 ? (
+        <View style={styles.badge} testID={`${action.testID ?? action.key}-badge`}>
+          <Text style={styles.badgeText}>{action.badgeCount}</Text>
+        </View>
+      ) : null}
     </Pressable>
   );
 };
@@ -151,6 +157,23 @@ const styles = StyleSheet.create({
   actionLabel: {
     fontSize: 15,
     fontWeight: "500",
+    flex: 1,
+  },
+  // ORCH-1150 — pending-RSVP count pill.
+  badge: {
+    minWidth: 22,
+    height: 22,
+    paddingHorizontal: 6,
+    borderRadius: 11,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: accent.warm,
+  },
+  badgeText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#fff",
+    fontVariant: ["tabular-nums"],
   },
 });
 

--- a/mingla-business/src/components/offering/__tests__/resolveRsvpCta.orch1150.test.ts
+++ b/mingla-business/src/components/offering/__tests__/resolveRsvpCta.orch1150.test.ts
@@ -1,0 +1,72 @@
+/**
+ * ORCH-1150 — resolveRsvpCta (Going / Not-going CTA machine) regression tests.
+ *
+ * Owner: mingla-implementor (the tester adds a SECOND adversarial angle).
+ *
+ * Imports the pure module directly from the package source by relative path —
+ * offeringCta imports ONLY types (no RN runtime), so it resolves under ts-jest.
+ */
+
+import { resolveRsvpCta } from "../../../../../packages/event-rendering/offeringCta";
+
+describe("ORCH-1150 — resolveRsvpCta", () => {
+  it("open when not full and guest has no row", () => {
+    expect(
+      resolveRsvpCta({ capacityFull: false, waitlistEnabled: false, manualApproval: false }).state,
+    ).toBe("open");
+  });
+
+  it("full when cap hit, waitlist off, auto mode", () => {
+    expect(
+      resolveRsvpCta({ capacityFull: true, waitlistEnabled: false, manualApproval: false }).state,
+    ).toBe("full");
+  });
+
+  it("waitlist when cap hit and waitlist on", () => {
+    expect(
+      resolveRsvpCta({ capacityFull: true, waitlistEnabled: true, manualApproval: false }).state,
+    ).toBe("waitlist");
+  });
+
+  it("open (not 'full') when cap hit but manual mode (pending doesn't occupy the cap)", () => {
+    expect(
+      resolveRsvpCta({ capacityFull: true, waitlistEnabled: false, manualApproval: true }).state,
+    ).toBe("open");
+  });
+
+  it("pending takes precedence over capacity for a guest awaiting approval", () => {
+    expect(
+      resolveRsvpCta({
+        capacityFull: true,
+        waitlistEnabled: false,
+        manualApproval: true,
+        guestStatus: "going",
+        guestApproval: "pending",
+      }).state,
+    ).toBe("pending");
+  });
+
+  it("reflects a guest's confirmed going state", () => {
+    expect(
+      resolveRsvpCta({
+        capacityFull: false,
+        waitlistEnabled: false,
+        manualApproval: false,
+        guestStatus: "going",
+        guestApproval: "approved",
+      }).state,
+    ).toBe("going");
+  });
+
+  it("reflects a guest's own waitlisted state", () => {
+    expect(
+      resolveRsvpCta({
+        capacityFull: true,
+        waitlistEnabled: true,
+        manualApproval: false,
+        guestStatus: "waitlisted",
+        guestApproval: "approved",
+      }).state,
+    ).toBe("waitlist");
+  });
+});

--- a/mingla-business/src/components/offering/offeringManageActions.ts
+++ b/mingla-business/src/components/offering/offeringManageActions.ts
@@ -20,6 +20,8 @@ export interface OfferingManageAction {
   tone: OfferingActionTone;
   onPress: () => void;
   testID?: string;
+  /** ORCH-1150 — optional count pill (e.g. pending RSVPs on the Guests row). */
+  badgeCount?: number;
 }
 
 /**
@@ -31,6 +33,10 @@ export interface OfferingManageHandlers {
   onEdit?: () => void;
   onViewPublic?: () => void;
   onOrders?: () => void;
+  /** ORCH-1150 — opens the RSVP approve/deny Guests console (rsvp kind only). */
+  onGuests?: () => void;
+  /** ORCH-1150 — pending-RSVP count for the Guests row badge (manual mode). */
+  guestsPendingCount?: number;
   onShare?: () => void;
   onCancel?: () => void;
   onDuplicate?: () => void;
@@ -82,6 +88,22 @@ export function buildOfferingManageActions(
       tone: "default",
       onPress: wrap(handlers.onOrders),
       testID: "offering-manage-orders",
+    });
+  }
+  // ORCH-1150 — Guests row (RSVP only): opens the approve/deny console. Shows a
+  // pending-count badge when manual approval mode has pending RSVPs.
+  if (handlers.onGuests !== undefined) {
+    list.push({
+      key: "guests",
+      icon: "users",
+      label: "Guests",
+      tone: "default",
+      onPress: wrap(handlers.onGuests),
+      testID: "offering-manage-guests",
+      badgeCount:
+        handlers.guestsPendingCount !== undefined && handlers.guestsPendingCount > 0
+          ? handlers.guestsPendingCount
+          : undefined,
     });
   }
   if (handlers.onShare !== undefined) {

--- a/mingla-business/src/components/rsvp/RsvpCreatorWizard.tsx
+++ b/mingla-business/src/components/rsvp/RsvpCreatorWizard.tsx
@@ -1,0 +1,1195 @@
+/**
+ * ORCH-1150 — RsvpCreatorWizard — root component for the 6-step RSVP creator.
+ *
+ * Sibling clone of EventCreatorWizard, money-free. Steps: Basics / When /
+ * Where / Cover / RSVP-setup / Preview. NO Tickets step, NO Stripe gate, NO
+ * checkout. Publish routes through business_publish_rsvp_draft (never the event
+ * publish RPC). Validation via validateRsvpStep / validateRsvpPublish.
+ *
+ * Reuses CreatorStep1Basics / CreatorStep2When (lockSingleDate) / CreatorStep3Where
+ * / CreatorStep4Cover as-is; RsvpStep5Setup + RsvpStep7Preview are new.
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket wizard. See SPEC §4.2.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Image,
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+// ORCH-0892-B v2: ScrollView via SmartScrollView wrapper. Keyboard listener
+// + keyboardVisible/keyboardHeight state + auto-insets DELETED. KAS handles
+// focused-input scroll. useKeyboardIsVisible() preserves dock-hide UX.
+// Keyboard import retained for Keyboard.dismiss(). Per SPEC §7.F.
+import { ScrollView } from "../../wrappers/SmartScrollView";
+import { useKeyboardIsVisible } from "../../wrappers/useKeyboardIsVisible";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  accent,
+  canvas,
+  glass,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import {
+  DESKTOP_BEZEL_MARGIN,
+  DESKTOP_RAIL_WIDTH,
+  DESKTOP_TOP_INSET,
+  DESKTOP_WIZARD_FORM_MAX_WIDTH,
+  DESKTOP_WIZARD_RAIL_WIDTH,
+} from "../../constants/desktopLayout";
+import { useResponsiveLayout } from "../../hooks/useResponsiveLayout";
+import { type Brand } from "../../store/currentBrandStore";
+import {
+  useDraftEventStore,
+  type DraftEvent,
+} from "../../store/draftEventStore";
+import {
+  validateRsvpPublish,
+  validateRsvpStep,
+} from "../../utils/draftRsvpValidation";
+import type { ValidationError } from "../../utils/draftEventValidation";
+import { isDraftEventPristine } from "../../utils/draftEventPristine";
+import { resolvePaidPublishGuardCopy } from "../../utils/paidPublishGuards";
+
+import { Button } from "../ui/Button";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { GlassCard } from "../ui/GlassCard";
+import { Icon } from "../ui/Icon";
+import { IconChrome } from "../ui/IconChrome";
+import { Stepper } from "../ui/Stepper";
+import type { StepperStep } from "../ui/Stepper";
+import { TopBar } from "../ui/TopBar";
+import { Toast } from "../ui/Toast";
+
+/*
+ * Desktop web wizard contract restored after regression:
+ * useResponsiveLayout / isWideDesktop gate must protect the desktop-only
+ * shell, renderDesktopAppRail, renderDesktopStepRail, desktopShell,
+ * desktopTopBarWrap, desktopStepRail, desktopFormPane,
+ * DESKTOP_RAIL_WIDTH, DESKTOP_TOP_INSET, DESKTOP_WIZARD_RAIL_WIDTH,
+ * DESKTOP_WIZARD_FORM_MAX_WIDTH, and <TopBar leftKind="brand" />.
+ * The mobile Stepper/chromeRow path must remain mobile/narrow-web only.
+ */
+
+import { CreatorStep1Basics } from "../event/CreatorStep1Basics";
+import { CreatorStep2When } from "../event/CreatorStep2When";
+import { CreatorStep3Where } from "../event/CreatorStep3Where";
+import { CreatorStep4Cover } from "../event/CreatorStep4Cover";
+import { PublishErrorsSheet } from "../event/PublishErrorsSheet";
+import { RsvpStep5Setup } from "./RsvpStep5Setup";
+import { RsvpStep7Preview } from "./RsvpStep7Preview";
+
+const STEP_DEFS: readonly { title: string; subtitle: string }[] = [
+  { title: "Basics", subtitle: "Name, format, and party type" },
+  { title: "When", subtitle: "Date and time" },
+  { title: "Where", subtitle: "Venue or online link" },
+  { title: "Cover", subtitle: "Pick a cover style" },
+  { title: "RSVP", subtitle: "Capacity, plus-ones, approvals" },
+  { title: "Preview", subtitle: "How it looks to guests" },
+];
+
+const TOTAL_STEPS = STEP_DEFS.length;
+
+const STEPPER_STEPS: StepperStep[] = STEP_DEFS.map((s, i) => ({
+  id: `step-${i}`,
+  label: s.title,
+}));
+
+const MINGLA_BUSINESS_LOGO = require("../../../assets/brand/mingla-business-logo.png") as number;
+const DESKTOP_WIZARD_NAV_ITEMS = [
+  { label: "Home", icon: "home", href: "/(tabs)/home", active: false },
+  { label: "Hub", icon: "calendar", href: "/(tabs)/hub/events", active: true },
+  { label: "Ari", icon: "sparkle", href: "/(tabs)/ari", active: false },
+  { label: "Blast", icon: "send", href: "/(tabs)/marketing", active: false },
+] as const;
+
+const isLocalOnlyDraft = (draft: DraftEvent): boolean =>
+  draft.id.startsWith("d_") || draft.serverSlug === null;
+
+const discardErrorMessage = (error: unknown): string => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  if (message.includes("insufficient_event_permission")) {
+    return "You do not have permission to delete this draft for this brand.";
+  }
+  return "Could not delete draft. Try again.";
+};
+
+export type WizardExitMode = "published" | "discarded" | "abandoned";
+
+/** Slug pair returned to the route handler so it can navigate to the
+ * public event page after a successful publish (Cycle 6). */
+export interface PublishedEventSlug {
+  brandSlug: string;
+  eventSlug: string;
+}
+
+export interface RsvpCreatorWizardProps {
+  /** Resolved draft from useDraftById in the route handler. */
+  draft: DraftEvent;
+  brand: Brand | null;
+  /** When 0..5 is provided, wizard opens at that step. Defaults to draft.lastStepReached. */
+  initialStep?: number;
+  /** True for /rsvp/create flow; false for /rsvp/[id]/edit (resume). */
+  isCreateMode: boolean;
+  /** Called when wizard exits — caller routes appropriately + shows Toast. */
+  onExit: (
+    mode: WizardExitMode,
+    ctx?: { name?: string; slug?: PublishedEventSlug },
+  ) => void;
+  /** Push to /rsvp/[id]/preview when user taps mini-card or Preview button. */
+  onOpenPreview: () => void;
+  /** ORCH-1150 — INERT for RSVP (no money gate). Kept optional for route-shape
+   *  parity with the event wizard; never invoked. */
+  onOpenStripeOnboard?: () => void;
+  onAutosaveDraft?: (draft: DraftEvent) => void;
+  onDiscardServerDraft?: (draft: DraftEvent) => Promise<void>;
+  onPublishDraft?: (draft: DraftEvent) => Promise<PublishedEventSlug>;
+  serverSaveState?: {
+    isSaving: boolean;
+    hasError: boolean;
+    lastSavedAt: string | null;
+  };
+}
+
+interface ToastState {
+  visible: boolean;
+  message: string;
+}
+
+export const RsvpCreatorWizard: React.FC<RsvpCreatorWizardProps> = ({
+  draft: initialDraft,
+  brand,
+  initialStep,
+  isCreateMode,
+  onExit,
+  onOpenPreview,
+  onAutosaveDraft,
+  onDiscardServerDraft,
+  onPublishDraft,
+  serverSaveState,
+}) => {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { isWideDesktop } = useResponsiveLayout();
+
+  // We re-read draft from store on every render so updateDraft patches
+  // are reflected immediately. The `initialDraft` prop is only used for
+  // mount-time defaults.
+  const liveDraft =
+    useDraftEventStore((s) => s.drafts.find((d) => d.id === initialDraft.id)) ??
+    initialDraft;
+  const updateDraft = useDraftEventStore((s) => s.updateDraft);
+  const setLastStep = useDraftEventStore((s) => s.setLastStep);
+  const deleteDraft = useDraftEventStore((s) => s.deleteDraft);
+  const beginDraftEdit = useDraftEventStore((s) => s.beginDraftEdit);
+  const endDraftEdit = useDraftEventStore((s) => s.endDraftEdit);
+  const markDraftDirty = useDraftEventStore((s) => s.markDraftDirty);
+
+  const [currentStep, setCurrentStep] = useState<number>(() => {
+    const fallback = liveDraft.lastStepReached;
+    return initialStep !== undefined && initialStep >= 0 && initialStep < TOTAL_STEPS
+      ? initialStep
+      : fallback;
+  });
+  const [showStepErrors, setShowStepErrors] = useState<boolean>(false);
+  const [discardDialogVisible, setDiscardDialogVisible] = useState<boolean>(false);
+  const [publishConfirmVisible, setPublishConfirmVisible] = useState<boolean>(false);
+  const [errorsSheetVisible, setErrorsSheetVisible] = useState<boolean>(false);
+  const [pendingErrors, setPendingErrors] = useState<ValidationError[]>([]);
+  const [isPublishing, setIsPublishing] = useState<boolean>(false);
+  const [isDiscarding, setIsDiscarding] = useState<boolean>(false);
+  const [coverVideoProcessing, setCoverVideoProcessing] = useState<boolean>(false);
+  const [discardError, setDiscardError] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>({ visible: false, message: "" });
+  // Track keyboard state — used to (a) hide the bottom dock during
+  // typing so it doesn't take space between focused input and keyboard,
+  // (b) apply dynamic paddingBottom to the ScrollView so manual scroll
+  // can position bottom-most inputs above the keyboard.
+  // ORCH-0892-B v2: keyboardVisible/keyboardHeight state DELETED.
+  // useKeyboardIsVisible() preserves dock-hide UX (line ~915). KAS via
+  // SmartScrollView handles focused-input scroll.
+  const keyboardVisible = useKeyboardIsVisible();
+  const latestDraftRef = useRef<DraftEvent>(liveDraft);
+  const clientRevisionRef = useRef<number>(liveDraft.clientRevision ?? 0);
+  const lastStepSyncKeyRef = useRef<string | null>(null);
+  const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    latestDraftRef.current = liveDraft;
+    clientRevisionRef.current = Math.max(
+      clientRevisionRef.current,
+      liveDraft.clientRevision ?? 0,
+    );
+  }, [liveDraft]);
+
+  useEffect(() => {
+    beginDraftEdit(initialDraft.id);
+    return (): void => {
+      endDraftEdit(initialDraft.id);
+    };
+  }, [beginDraftEdit, endDraftEdit, initialDraft.id]);
+
+  useEffect(() => {
+    return (): void => {
+      if (autosaveTimerRef.current !== null) {
+        clearTimeout(autosaveTimerRef.current);
+      }
+    };
+  }, []);
+
+  const queueAutosave = useCallback(
+    (draft: DraftEvent): void => {
+      if (onAutosaveDraft === undefined) return;
+      if (autosaveTimerRef.current !== null) {
+        clearTimeout(autosaveTimerRef.current);
+      }
+      autosaveTimerRef.current = setTimeout(() => {
+        autosaveTimerRef.current = null;
+        onAutosaveDraft(draft);
+      }, 700);
+    },
+    [onAutosaveDraft],
+  );
+
+  // ScrollView ref — exposed to step bodies via `scrollToBottom`
+  // callback. Bottom-most multiline inputs (Step 1 Description) call
+  // this on focus because iOS's `automaticallyAdjustKeyboardInsets`
+  // doesn't reliably scroll-to-focused-input for multiline TextInputs
+  // in this nested layout (verified by smoke 2026-04-30).
+  const scrollViewRef = useRef<ScrollView | null>(null);
+  // Deferred scroll-to-bottom — set by step bodies on input focus,
+  // consumed in a useEffect once the keyboard has actually risen and
+  // the ScrollView's paddingBottom has been applied. Without deferral,
+  // scrollToEnd runs against the OLD content height (no padding yet),
+  // landing the focused input far above the keyboard with a huge gap.
+  const pendingScrollToBottomRef = useRef<boolean>(false);
+
+  // ORCH-0892-B v2: keyboard listener + keyboardHeight-driven
+  // scrollToBottom plumbing DELETED. KAS via SmartScrollView computes
+  // focused-input overlap and scrolls precisely above the keyboard
+  // automatically. scrollToBottom is preserved as a passthrough so
+  // child components (CreatorStep1Basics on Description focus, etc.)
+  // can still request a scrollToEnd explicitly — KAS's per-focus
+  // scroll then refines from that position. pendingScrollToBottomRef
+  // retained as a kept-for-future hook; safe no-op when unused.
+  const scrollToBottom = useCallback((): void => {
+    requestAnimationFrame((): void => {
+      scrollViewRef.current?.scrollToEnd({ animated: true });
+    });
+  }, []);
+
+  // ORCH-1150 — RSVP is moneyless: no Stripe/payout gate.
+  const stepErrors: ValidationError[] = useMemo(
+    () => validateRsvpStep(currentStep, liveDraft),
+    [currentStep, liveDraft],
+  );
+
+  // Track that the user has reached this step (for resume semantics).
+  useEffect(() => {
+    const cached = useDraftEventStore.getState().getDraft(liveDraft.id);
+    const base = cached ?? latestDraftRef.current;
+    const nextLastStep = Math.max(base.lastStepReached, currentStep);
+    const syncKey = `${liveDraft.id}:${nextLastStep}`;
+    if (lastStepSyncKeyRef.current === syncKey) {
+      return;
+    }
+    lastStepSyncKeyRef.current = syncKey;
+    setLastStep(liveDraft.id, currentStep);
+    if (base.lastStepReached >= currentStep) {
+      return;
+    }
+    const nextRevision = clientRevisionRef.current + 1;
+    clientRevisionRef.current = nextRevision;
+    markDraftDirty(liveDraft.id, nextRevision);
+    updateDraft(liveDraft.id, { clientRevision: nextRevision });
+    queueAutosave({
+      ...base,
+      lastStepReached: nextLastStep,
+      clientRevision: nextRevision,
+      updatedAt: new Date().toISOString(),
+    });
+  }, [
+    currentStep,
+    liveDraft.id,
+    markDraftDirty,
+    queueAutosave,
+    setLastStep,
+    updateDraft,
+  ]);
+
+  // One-shot timezone auto-detect for legacy drafts (those created before
+  // Cycle 3 rework v2 Fix #4 was shipped — they hold the hardcoded
+  // "Europe/London" default). If the device's detected zone differs from
+  // London, override the draft's timezone. Users actually in London see
+  // no change. Users who manually picked London via the sheet on a
+  // non-London device will get overridden — acceptable edge case
+  // (negligible likelihood + the sheet picker still allows re-override).
+  // Runs once per draft.id mount.
+  useEffect(() => {
+    if (liveDraft.timezone !== "Europe/London") return;
+    let detected: string | null = null;
+    try {
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      detected = typeof tz === "string" && tz.length > 0 ? tz : null;
+    } catch {
+      detected = null;
+    }
+    if (detected !== null && detected !== "Europe/London") {
+      updateDraft(liveDraft.id, { timezone: detected });
+    }
+  }, [liveDraft.id, liveDraft.timezone, updateDraft]);
+
+  const handleUpdate = useCallback(
+    (patch: Partial<Omit<DraftEvent, "id" | "brandId" | "createdAt">>): void => {
+      const nextRevision = clientRevisionRef.current + 1;
+      clientRevisionRef.current = nextRevision;
+      const revisionedPatch = {
+        ...patch,
+        clientRevision: nextRevision,
+      };
+      markDraftDirty(liveDraft.id, nextRevision);
+      updateDraft(liveDraft.id, revisionedPatch);
+      const nextDraft = {
+        ...liveDraft,
+        ...revisionedPatch,
+        updatedAt: new Date().toISOString(),
+      };
+      latestDraftRef.current = nextDraft;
+      queueAutosave(nextDraft);
+    },
+    [liveDraft, markDraftDirty, queueAutosave, updateDraft],
+  );
+
+  const handleShowToast = useCallback((message: string): void => {
+    setToast({ visible: true, message });
+  }, []);
+
+  const handleDismissToast = useCallback((): void => {
+    setToast((prev) => ({ ...prev, visible: false }));
+  }, []);
+
+  // ---- Navigation handlers ----
+
+  const isFirstStep = currentStep === 0;
+  const isLastStep = currentStep === TOTAL_STEPS - 1;
+
+  const isDraftPristine = useCallback((): boolean => {
+    return isDraftEventPristine(liveDraft);
+  }, [liveDraft]);
+
+  const discardDraft = useCallback(
+    async (draft: DraftEvent): Promise<void> => {
+      if (autosaveTimerRef.current !== null) {
+        clearTimeout(autosaveTimerRef.current);
+        autosaveTimerRef.current = null;
+      }
+      if (isLocalOnlyDraft(draft) || onDiscardServerDraft === undefined) {
+        deleteDraft(draft.id);
+        return;
+      }
+      await onDiscardServerDraft(draft);
+    },
+    [deleteDraft, onDiscardServerDraft],
+  );
+
+  // Chrome "X" — always exits the wizard to the Events tab. Independent
+  // of which step the user is on; the dock's Back button handles step
+  // navigation. Discard ConfirmDialog still appears in create-mode if
+  // the draft has edits.
+  const handleClose = useCallback((): void => {
+    if (isCreateMode) {
+      if (isDraftPristine()) {
+        void (async (): Promise<void> => {
+          try {
+            await discardDraft(liveDraft);
+            onExit("abandoned");
+          } catch (error) {
+            handleShowToast(discardErrorMessage(error));
+          }
+        })();
+      } else {
+        setDiscardError(null);
+        setDiscardDialogVisible(true);
+      }
+    } else {
+      // Edit mode: auto-save semantics — simple exit, no dialog.
+      onExit("abandoned");
+    }
+  }, [
+    isCreateMode,
+    isDraftPristine,
+    discardDraft,
+    liveDraft,
+    onExit,
+    handleShowToast,
+  ]);
+
+  // Dock "Back" button — decrement step. Step 1's dock has no Back
+  // (chrome X handles wizard exit instead).
+  const handleStepBack = useCallback((): void => {
+    setShowStepErrors(false);
+    setCurrentStep((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleCloseDiscardDialog = useCallback((): void => {
+    if (isDiscarding) return;
+    setDiscardDialogVisible(false);
+    setDiscardError(null);
+  }, [isDiscarding]);
+
+  const handleConfirmDiscard = useCallback(async (): Promise<void> => {
+    setDiscardError(null);
+    setIsDiscarding(true);
+    try {
+      await discardDraft(liveDraft);
+      setDiscardDialogVisible(false);
+      onExit("discarded");
+    } catch (error) {
+      setDiscardError(discardErrorMessage(error));
+    } finally {
+      setIsDiscarding(false);
+    }
+  }, [discardDraft, liveDraft, onExit]);
+
+  const handleContinue = useCallback((): void => {
+    const errs = validateRsvpStep(currentStep, liveDraft);
+    if (errs.length > 0) {
+      setShowStepErrors(true);
+      return;
+    }
+    // Advance.
+    setShowStepErrors(false);
+    setCurrentStep((prev) => Math.min(TOTAL_STEPS - 1, prev + 1));
+  }, [currentStep, liveDraft]);
+
+  // ---- Publish gate (no Stripe — RSVP is moneyless) ----
+
+  const handlePublishTap = useCallback((): void => {
+    const errs = validateRsvpPublish(liveDraft);
+    if (errs.length > 0) {
+      setPendingErrors(errs);
+      setErrorsSheetVisible(true);
+      return;
+    }
+    // Happy path → confirm dialog.
+    setPublishConfirmVisible(true);
+  }, [liveDraft]);
+
+  const handleConfirmPublish = useCallback(async (): Promise<void> => {
+    if (isPublishing) return;
+    setIsPublishing(true);
+    const draftName = liveDraft.name;
+    // Simulated 1.2s submit per spec AC#28.
+    await new Promise<void>((resolve) => setTimeout(resolve, 1200));
+    if (onPublishDraft === undefined) {
+      setIsPublishing(false);
+      setPublishConfirmVisible(false);
+      handleShowToast("Could not publish this draft yet. Try again.");
+      return;
+    }
+    const draftToPublish = latestDraftRef.current;
+    try {
+      if (autosaveTimerRef.current !== null) {
+        clearTimeout(autosaveTimerRef.current);
+        autosaveTimerRef.current = null;
+      }
+      const slug = await onPublishDraft(draftToPublish);
+      deleteDraft(draftToPublish.id);
+      setIsPublishing(false);
+      setPublishConfirmVisible(false);
+      onExit("published", {
+        name: draftName,
+        slug,
+      });
+    } catch (error) {
+      setIsPublishing(false);
+      setPublishConfirmVisible(false);
+      // ORCH-1075 — paid-publish integrity guards. The publish RPC raises
+      // stripe_charges_disabled / offering_date_past on error.message; surface
+      // the locked copy + route (Stripe onboarding / When step) instead of a
+      // generic failure.
+      const code = error instanceof Error ? error.message : String(error ?? "");
+      // RSVP only ever raises offering_date_past (discoverable + past date) —
+      // never a stripe gate. Map it to a When-step jump (mirror Guard B).
+      const guardCopy = resolvePaidPublishGuardCopy(code);
+      if (guardCopy !== null && guardCopy.action !== "stripe_onboarding") {
+        handleShowToast(guardCopy.body);
+        setShowStepErrors(true);
+        setCurrentStep(1);
+        return;
+      }
+      if (code.includes("offering_date_past")) {
+        handleShowToast("A discoverable RSVP needs a future date. Update the date to publish.");
+        setShowStepErrors(true);
+        setCurrentStep(1);
+        return;
+      }
+      handleShowToast("Could not save this publish. Try again.");
+    }
+  }, [
+    liveDraft,
+    isPublishing,
+    onExit,
+    onPublishDraft,
+    deleteDraft,
+    handleShowToast,
+  ]);
+
+  const handleFixJump = useCallback((step: number): void => {
+    setErrorsSheetVisible(false);
+    setShowStepErrors(true);
+    setCurrentStep(Math.max(0, Math.min(TOTAL_STEPS - 1, step)));
+  }, []);
+
+  // RSVP publish is gated ONLY on a still-processing cover video (no Stripe gate).
+  const publishDisabled = coverVideoProcessing;
+
+  // Single-date only (steering #4) → static modal copy.
+  const publishModalTitle = "Publish RSVP?";
+
+  // ---- Render step body ----
+
+  const renderStepBody = (): React.ReactElement => {
+    const baseProps = {
+      draft: liveDraft,
+      updateDraft: handleUpdate,
+      errors: stepErrors,
+      showErrors: showStepErrors,
+      onShowToast: handleShowToast,
+      scrollToBottom,
+      coverMediaEventId: liveDraft.id,
+      brandDefaultCurrency: brand?.defaultCurrency ?? null,
+      coverMediaApplyMode: "draft_auto" as const,
+      onCoverVideoProcessingChange: setCoverVideoProcessing,
+    };
+    switch (currentStep) {
+      case 0:
+        return <CreatorStep1Basics {...baseProps} />;
+      case 1:
+        // ORCH-1150 — lockSingleDate hides the recurring/multi_date tabs.
+        return <CreatorStep2When {...baseProps} lockSingleDate />;
+      case 2:
+        return <CreatorStep3Where {...baseProps} />;
+      case 3:
+        return <CreatorStep4Cover {...baseProps} />;
+      case 4:
+        return <RsvpStep5Setup {...baseProps} />;
+      case 5:
+        return (
+          <RsvpStep7Preview
+            {...baseProps}
+            brand={brand}
+            onTapMiniCard={onOpenPreview}
+          />
+        );
+      default:
+        return <CreatorStep1Basics {...baseProps} />;
+    }
+  };
+
+  const handleDesktopRailNavigate = useCallback(
+    (href: string): void => {
+      router.replace(href as never);
+    },
+    [router],
+  );
+
+  const renderDesktopAppRail = (): React.ReactElement => (
+    <View style={styles.desktopAppRail}>
+      <View style={styles.desktopRailBrandMark}>
+        <Image
+          source={MINGLA_BUSINESS_LOGO}
+          style={styles.desktopRailLogo}
+          resizeMode="contain"
+          accessibilityIgnoresInvertColors
+        />
+      </View>
+      {DESKTOP_WIZARD_NAV_ITEMS.map((item) => (
+        <Pressable
+          key={item.label}
+          onPress={() => handleDesktopRailNavigate(item.href)}
+          accessibilityRole="button"
+          accessibilityLabel={`Go to ${item.label}`}
+          style={[
+            styles.desktopRailItem,
+            item.active ? styles.desktopRailItemActive : null,
+          ]}
+        >
+          <Icon
+            name={item.icon}
+            size={22}
+            color={item.active ? accent.warm : textTokens.tertiary}
+          />
+          <Text
+            style={[
+              styles.desktopRailItemText,
+              item.active ? styles.desktopRailItemTextActive : null,
+            ]}
+          >
+            {item.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+
+  const renderDesktopStepRail = (): React.ReactElement => (
+    <GlassCard
+      variant="base"
+      padding={spacing.md}
+      radius="lg"
+      style={styles.desktopStepRail}
+    >
+      <View style={styles.desktopStepRailHeader}>
+        <Text style={styles.desktopStepEyebrow}>Create RSVP</Text>
+        <Text style={styles.desktopStepRailTitle} numberOfLines={2}>
+          {liveDraft.name.trim().length > 0 ? liveDraft.name : "Untitled RSVP"}
+        </Text>
+        <Text style={styles.desktopStepRailSub} numberOfLines={1}>
+          {brand?.displayName ?? "Brand"} · Draft saved
+        </Text>
+      </View>
+      <View style={styles.desktopStepList}>
+        {STEP_DEFS.map((step, index) => {
+          const active = index === currentStep;
+          return (
+            <View
+              key={step.title}
+              style={[styles.desktopStepItem, active ? styles.desktopStepItemActive : null]}
+            >
+              <View
+                style={[
+                  styles.desktopStepIndex,
+                  active ? styles.desktopStepIndexActive : null,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.desktopStepIndexText,
+                    active ? styles.desktopStepIndexTextActive : null,
+                  ]}
+                >
+                  {index + 1}
+                </Text>
+              </View>
+              <View style={styles.desktopStepCopy}>
+                <Text
+                  style={[
+                    styles.desktopStepTitle,
+                    active ? styles.desktopStepTitleActive : null,
+                  ]}
+                  numberOfLines={1}
+                >
+                  {step.title}
+                </Text>
+                <Text style={styles.desktopStepSub} numberOfLines={1}>
+                  {step.subtitle}
+                </Text>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </GlassCard>
+  );
+
+  return (
+    <View
+      style={[
+        styles.host,
+        {
+          paddingTop: isWideDesktop ? 0 : insets.top,
+          backgroundColor: canvas.discover,
+        },
+      ]}
+    >
+      {isWideDesktop ? renderDesktopAppRail() : null}
+      {/* Chrome */}
+      {isWideDesktop ? (
+        <View style={styles.desktopTopBarWrap}>
+          {/* orch-strict-grep-allow leftKind-brand-rightSlot — wizard chrome replaces (not composes with) the primary-tab [search,bell] cluster; default cluster is semantically wrong inside a modal creator. Per ORCH-0894 desktop layout polish. */}
+          <TopBar
+            leftKind="brand"
+            rightSlot={
+              <IconChrome
+                icon="close"
+                size={36}
+                onPress={handleClose}
+                accessibilityLabel="Close wizard"
+              />
+            }
+          />
+        </View>
+      ) : (
+        <View style={styles.chromeRow}>
+          <IconChrome
+            icon="close"
+            size={36}
+            onPress={handleClose}
+            accessibilityLabel="Close wizard"
+          />
+          <View style={styles.stepperWrap}>
+            <Stepper
+              steps={STEPPER_STEPS}
+              currentIndex={currentStep}
+              showCaption={false}
+            />
+          </View>
+          <Text style={styles.stepCounter}>
+            {currentStep + 1}/{TOTAL_STEPS}
+          </Text>
+        </View>
+      )}
+
+      {/* Brand subtitle */}
+      {isWideDesktop ? null : (
+      <View style={styles.subtitleRow}>
+        <Text style={styles.subtitle}>
+          {brand?.displayName ?? "Brand"} · Step {currentStep + 1} of {TOTAL_STEPS}
+        </Text>
+        {serverSaveState !== undefined ? (
+          <Text
+            style={[
+              styles.saveState,
+              serverSaveState.hasError ? styles.saveStateError : null,
+            ]}
+          >
+            {serverSaveState.hasError
+              ? "Unsaved changes - retrying"
+              : serverSaveState.isSaving
+                ? "Saving..."
+                : serverSaveState.lastSavedAt !== null
+                  ? "Saved"
+                  : "Server draft"}
+          </Text>
+        ) : null}
+      </View>
+      )}
+
+      <View style={isWideDesktop ? styles.desktopShell : styles.mobileShell}>
+        {isWideDesktop ? renderDesktopStepRail() : null}
+        <View style={isWideDesktop ? styles.desktopFormPane : styles.mobileFormPane}>
+
+      {/* ORCH-0892-B v2: SmartScrollView (KAS on native) computes precise
+          overlap between focused TextInput bottom edge and keyboard top,
+          and scrolls exactly that amount. Replaces the old
+          automaticallyAdjustKeyboardInsets + paddingBottom-overshoot
+          approach which was unreliable in nested layouts. Chrome (chromeRow
+          + subtitleRow + dock) renders OUTSIDE this ScrollView so it stays
+          stationary. Per SPEC §7.F. */}
+      <ScrollView
+        ref={scrollViewRef}
+        style={styles.kbAvoid}
+        contentContainerStyle={styles.body}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.eyebrow}>
+          Step {currentStep + 1} of {TOTAL_STEPS}
+        </Text>
+        <Text style={styles.stepTitle}>{STEP_DEFS[currentStep].title}</Text>
+        <Text style={styles.stepSub}>{STEP_DEFS[currentStep].subtitle}</Text>
+        <View style={styles.stepBodyWrap}>{renderStepBody()}</View>
+      </ScrollView>
+
+      {/* Dock — sleek + compact (rework v3). Tight vertical padding,
+          radius xxl for the rounded float, button size md (44 — the
+          minimum touch target).
+          Hidden when the keyboard is open so the focused input sits
+          immediately above the keyboard with no dock occupying space
+          between them. Reappears the instant the keyboard dismisses. */}
+      {keyboardVisible ? null : (
+      <GlassCard
+        variant="elevated"
+        padding={0}
+        radius="xxl"
+        style={[styles.dock, { marginBottom: insets.bottom + spacing.lg }]}
+      >
+        {isLastStep ? (
+          // Step 7 — uniform Back + Publish dock. The Stripe-blocked
+          // banner was removed from the dock in Cycle 5; the Connect
+          // Stripe CTA now lives inside the body's StripeBlockedCard.
+          // Publish button is disabled when blocked-stripe so the user
+          // is forced to use the body-side CTA before publishing.
+          <View style={styles.dockButtonRow}>
+            <View style={styles.dockBackCell}>
+              <Button
+                label="Back"
+                variant="ghost"
+                size="md"
+                leadingIcon="chevL"
+                onPress={handleStepBack}
+                fullWidth
+              />
+            </View>
+            <View style={styles.dockPublishCell}>
+              <Button
+                label="Publish RSVP"
+                variant="primary"
+                size="md"
+                onPress={handlePublishTap}
+                loading={isPublishing}
+                disabled={publishDisabled || isPublishing}
+                fullWidth
+              />
+            </View>
+          </View>
+        ) : isFirstStep ? (
+          // Step 1 has no in-wizard back — chrome close X handles exit.
+          <Button
+            label="Continue"
+            variant="primary"
+            size="md"
+            onPress={handleContinue}
+            fullWidth
+          />
+        ) : (
+          // Step 2-6 — Back + Continue side by side.
+          <View style={styles.dockButtonRow}>
+            <View style={styles.dockBackCell}>
+              <Button
+                label="Back"
+                variant="ghost"
+                size="md"
+                onPress={handleStepBack}
+                fullWidth
+              />
+            </View>
+            <View style={styles.dockPrimaryCell}>
+              <Button
+                label="Continue"
+                variant="primary"
+                size="md"
+                onPress={handleContinue}
+                fullWidth
+              />
+            </View>
+          </View>
+        )}
+      </GlassCard>
+      )}
+        </View>
+      </View>
+
+      {/* Overlays — at root for I-13 portal contract */}
+      <ConfirmDialog
+        visible={discardDialogVisible}
+        onClose={handleCloseDiscardDialog}
+        onConfirm={handleConfirmDiscard}
+        title="Discard this RSVP?"
+        description="You'll lose your changes."
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+        confirmLoading={isDiscarding}
+        confirmDisabled={isDiscarding}
+        closeDisabled={isDiscarding}
+        errorMessage={discardError}
+        destructive
+      />
+
+      <ConfirmDialog
+        visible={publishConfirmVisible}
+        onClose={() => setPublishConfirmVisible(false)}
+        onConfirm={handleConfirmPublish}
+        title={publishModalTitle}
+        description="Your invite link goes live immediately. Guests can RSVP right away. You can edit details after publishing."
+        confirmLabel="Publish"
+        confirmLoading={isPublishing}
+        confirmDisabled={isPublishing}
+        closeDisabled={isPublishing}
+      />
+
+      <PublishErrorsSheet
+        visible={errorsSheetVisible}
+        errors={pendingErrors}
+        onClose={() => setErrorsSheetVisible(false)}
+        onFix={handleFixJump}
+      />
+
+      <View style={styles.toastWrap} pointerEvents="box-none">
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={handleDismissToast}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  kbAvoid: {
+    flex: 1,
+  },
+  mobileShell: {
+    flex: 1,
+  },
+  mobileFormPane: {
+    flex: 1,
+  },
+  desktopAppRail: {
+    position: "absolute",
+    zIndex: 20,
+    elevation: 20,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    width: DESKTOP_RAIL_WIDTH,
+    alignItems: "center",
+    paddingTop: spacing.xl,
+    gap: spacing.sm,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: "rgba(255, 255, 255, 0.06)",
+  },
+  desktopRailBrandMark: {
+    width: 42,
+    height: 42,
+    marginBottom: spacing.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  desktopRailLogo: {
+    width: 42,
+    height: 42,
+  },
+  desktopRailItem: {
+    width: 56,
+    height: 56,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 2,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "transparent",
+  },
+  desktopRailItemActive: {
+    backgroundColor: "rgba(255, 255, 255, 0.055)",
+    borderColor: "rgba(235, 120, 37, 0.45)",
+  },
+  desktopRailItemText: {
+    fontSize: 9,
+    lineHeight: 11,
+    fontWeight: "700",
+    color: textTokens.tertiary,
+  },
+  desktopRailItemTextActive: {
+    color: accent.warm,
+  },
+  desktopTopBarWrap: {
+    paddingTop: DESKTOP_TOP_INSET,
+    paddingLeft: DESKTOP_RAIL_WIDTH + DESKTOP_BEZEL_MARGIN,
+    paddingRight: DESKTOP_BEZEL_MARGIN,
+    paddingBottom: spacing.sm,
+  },
+  desktopShell: {
+    flex: 1,
+    flexDirection: "row",
+    gap: spacing.md,
+    paddingLeft: DESKTOP_RAIL_WIDTH + DESKTOP_BEZEL_MARGIN,
+    paddingRight: DESKTOP_BEZEL_MARGIN,
+    paddingBottom: DESKTOP_BEZEL_MARGIN,
+  },
+  desktopStepRail: {
+    width: DESKTOP_WIZARD_RAIL_WIDTH,
+    flexShrink: 0,
+  },
+  desktopStepRailHeader: {
+    marginBottom: spacing.lg,
+  },
+  desktopStepEyebrow: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: accent.warm,
+    marginBottom: spacing.sm,
+  },
+  desktopStepRailTitle: {
+    fontSize: typography.h3.fontSize,
+    lineHeight: typography.h3.lineHeight,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  desktopStepRailSub: {
+    marginTop: spacing.xs,
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+  },
+  desktopStepList: {
+    gap: spacing.sm,
+  },
+  desktopStepItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    padding: spacing.sm,
+    borderRadius: 12,
+  },
+  desktopStepItemActive: {
+    backgroundColor: "rgba(235, 120, 37, 0.18)",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(235, 120, 37, 0.45)",
+  },
+  desktopStepIndex: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: glass.tint.profileBase,
+  },
+  desktopStepIndexActive: {
+    backgroundColor: accent.warm,
+  },
+  desktopStepIndexText: {
+    fontSize: typography.caption.fontSize,
+    fontWeight: "800",
+    color: textTokens.tertiary,
+  },
+  desktopStepIndexTextActive: {
+    color: textTokens.inverse,
+  },
+  desktopStepCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  desktopStepTitle: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "700",
+    color: textTokens.tertiary,
+  },
+  desktopStepTitleActive: {
+    color: textTokens.primary,
+  },
+  desktopStepSub: {
+    marginTop: 2,
+    fontSize: typography.caption.fontSize,
+    color: textTokens.quaternary,
+  },
+  desktopFormPane: {
+    flex: 1,
+    maxWidth: DESKTOP_WIZARD_FORM_MAX_WIDTH,
+    minWidth: 0,
+    borderRadius: 18,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(255, 255, 255, 0.08)",
+    backgroundColor: "rgba(255, 255, 255, 0.018)",
+    overflow: "hidden",
+  },
+  chromeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    gap: spacing.sm,
+  },
+  stepperWrap: {
+    flex: 1,
+  },
+  stepCounter: {
+    fontSize: 12,
+    color: textTokens.tertiary,
+    fontVariant: ["tabular-nums"],
+    minWidth: 28,
+    textAlign: "right",
+  },
+  subtitleRow: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.xs,
+    paddingBottom: spacing.md,
+  },
+  subtitle: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+  },
+  saveState: {
+    marginTop: 2,
+    fontSize: typography.caption.fontSize,
+    color: textTokens.quaternary,
+  },
+  saveStateError: {
+    color: semantic.error,
+  },
+  body: {
+    paddingHorizontal: spacing.md + 8,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+  },
+  eyebrow: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: accent.warm,
+    marginBottom: 6,
+  },
+  stepTitle: {
+    fontSize: 26,
+    fontWeight: "700",
+    letterSpacing: -0.2,
+    color: textTokens.primary,
+    marginBottom: 6,
+  },
+  stepSub: {
+    fontSize: 14,
+    color: textTokens.secondary,
+    marginBottom: spacing.lg,
+  },
+  stepBodyWrap: {
+    // step body content
+  },
+  dock: {
+    marginHorizontal: spacing.md,
+    // marginBottom is applied inline as insets.bottom + spacing.lg so the
+    // floating dock clears the phone's bottom nav / home-indicator on both
+    // Android gesture-nav and iOS (META-ORCH-1059 Sub-A footer-bleed fix).
+    // Sleek + compact: tight vertical padding, generous horizontal.
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+  },
+  dockButtonRow: {
+    flexDirection: "row",
+    gap: 6,
+    alignItems: "center",
+  },
+  dockBackCell: {
+    flex: 1,
+  },
+  dockPrimaryCell: {
+    flex: 1,
+  },
+  dockPublishCell: {
+    flex: 2,
+  },
+  toastWrap: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    top: 0,
+    paddingTop: spacing.lg,
+    paddingHorizontal: spacing.md,
+  },
+  // suppress unused
+  _unused: {
+    color: glass.tint.profileBase,
+  },
+});

--- a/mingla-business/src/components/rsvp/RsvpGuestConsole.tsx
+++ b/mingla-business/src/components/rsvp/RsvpGuestConsole.tsx
@@ -1,0 +1,407 @@
+/**
+ * ORCH-1150 — RsvpGuestConsole (A2 + A2-NEW host remove).
+ *
+ * A full-screen host console (NOT a sheet) for an RSVP event: pending approvals
+ * (Approve / Deny per row + Approve-all), the Going list (each row carries a
+ * Remove action → confirm dialog → approved→denied), and a read-only Waitlist.
+ *
+ * Constitution #1 (no dead taps): Approve / Deny / Remove / Approve-all all fire
+ * a real mutation. Constitution #3 (no silent failures): per-row failures toast.
+ * Android glass: rows use the opaque fallback.
+ *
+ * See SPEC §5.4.
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  accent,
+  canvas,
+  glass,
+  radius as radiusTokens,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { Button } from "../ui/Button";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { Icon } from "../ui/Icon";
+import { IconChrome } from "../ui/IconChrome";
+import { Toast } from "../ui/Toast";
+import {
+  useBulkApproveRsvps,
+  useRsvpGuestList,
+  useSetRsvpStatus,
+} from "../../hooks/useRsvpApprovals";
+import type { RsvpGuest } from "../../services/rsvpApprovals";
+
+const ROW_BG = Platform.select({
+  ios: glass.tint.profileBase,
+  android: "#23262b",
+  default: glass.tint.profileBase,
+});
+
+export interface RsvpGuestConsoleProps {
+  eventId: string;
+  eventTitle?: string | null;
+}
+
+const isConfirmed = (g: RsvpGuest): boolean =>
+  g.rsvpStatus === "going" && g.approvalStatus === "approved";
+
+export const RsvpGuestConsole: React.FC<RsvpGuestConsoleProps> = ({
+  eventId,
+  eventTitle,
+}) => {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { data, isLoading, isError, refetch } = useRsvpGuestList(eventId);
+  const setStatus = useSetRsvpStatus(eventId);
+  const bulkApprove = useBulkApproveRsvps(eventId);
+
+  const [toast, setToast] = useState<{ visible: boolean; message: string }>({
+    visible: false,
+    message: "",
+  });
+  const [removeTarget, setRemoveTarget] = useState<RsvpGuest | null>(null);
+
+  const guests = useMemo<RsvpGuest[]>(() => data ?? [], [data]);
+  const pending = useMemo(() => guests.filter((g) => g.approvalStatus === "pending"), [guests]);
+  const going = useMemo(() => guests.filter(isConfirmed), [guests]);
+  const waitlisted = useMemo(
+    () => guests.filter((g) => g.rsvpStatus === "waitlisted"),
+    [guests],
+  );
+
+  const showToast = useCallback((message: string): void => {
+    setToast({ visible: true, message });
+  }, []);
+
+  const handleApprove = useCallback(
+    (g: RsvpGuest): void => {
+      setStatus.mutate(
+        { rsvpId: g.id, status: "approved" },
+        {
+          onError: () => showToast(`Couldn't update ${g.guestName}. Try again.`),
+        },
+      );
+    },
+    [setStatus, showToast],
+  );
+
+  const handleDeny = useCallback(
+    (g: RsvpGuest): void => {
+      setStatus.mutate(
+        { rsvpId: g.id, status: "denied" },
+        {
+          onError: () => showToast(`Couldn't update ${g.guestName}. Try again.`),
+        },
+      );
+    },
+    [setStatus, showToast],
+  );
+
+  const handleConfirmRemove = useCallback((): void => {
+    const g = removeTarget;
+    if (g === null) return;
+    setStatus.mutate(
+      { rsvpId: g.id, status: "denied" },
+      {
+        onSuccess: () => setRemoveTarget(null),
+        onError: () => {
+          setRemoveTarget(null);
+          showToast(`Couldn't remove ${g.guestName}. Try again.`);
+        },
+      },
+    );
+  }, [removeTarget, setStatus, showToast]);
+
+  const handleBulkApprove = useCallback((): void => {
+    bulkApprove.mutate(undefined, {
+      onSuccess: (res) => {
+        if (res.skippedForCapacity > 0) {
+          showToast(`Approved ${res.approvedCount}. ${res.skippedForCapacity} didn't fit your limit.`);
+        }
+      },
+      onError: () => showToast("Couldn't approve everyone. Try again."),
+    });
+  }, [bulkApprove, showToast]);
+
+  const renderHeader = (): React.ReactElement => (
+    <View style={styles.chromeRow}>
+      <IconChrome icon="chevL" size={36} onPress={() => router.back()} accessibilityLabel="Back" />
+      <Text style={styles.chromeTitle} numberOfLines={1}>
+        {eventTitle && eventTitle.length > 0 ? eventTitle : "Guests"}
+      </Text>
+      <View style={styles.chromeSpacer} />
+    </View>
+  );
+
+  // ---- States ----
+  if (isLoading) {
+    return (
+      <View style={[styles.host, { paddingTop: insets.top, backgroundColor: canvas.discover }]}>
+        {renderHeader()}
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={accent.warm} />
+        </View>
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={[styles.host, { paddingTop: insets.top, backgroundColor: canvas.discover }]}>
+        {renderHeader()}
+        <View style={styles.center}>
+          <Text style={styles.emptyTitle}>Couldn&apos;t load guests.</Text>
+          <Button label="Tap to retry" variant="secondary" size="md" onPress={() => void refetch()} />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.host, { paddingTop: insets.top, backgroundColor: canvas.discover }]}>
+      {renderHeader()}
+      <ScrollView
+        contentContainerStyle={[styles.body, { paddingBottom: insets.bottom + spacing.xl }]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Pending section */}
+        {pending.length > 0 ? (
+          <View style={styles.section}>
+            <View style={styles.sectionHeaderRow}>
+              <Text style={styles.sectionTitle}>Pending ({pending.length})</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Approve all ${pending.length}`}
+                onPress={handleBulkApprove}
+                disabled={bulkApprove.isPending}
+                style={styles.bulkBtn}
+                testID="rsvp-bulk-approve"
+              >
+                <Text style={styles.bulkBtnText}>Approve all ({pending.length})</Text>
+              </Pressable>
+            </View>
+            {pending.map((g) => (
+              <View key={g.id} style={styles.guestRow}>
+                <View style={styles.guestInfo}>
+                  <Text style={styles.guestName} numberOfLines={1}>
+                    {g.guestName}
+                    {g.plusCount > 0 ? <Text style={styles.plusChip}>  +{g.plusCount}</Text> : null}
+                  </Text>
+                  <Text style={styles.guestContact} numberOfLines={1}>
+                    {g.guestEmail ?? g.guestPhone ?? "App guest"}
+                  </Text>
+                </View>
+                <View style={styles.actionCol}>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Approve ${g.guestName}`}
+                    onPress={() => handleApprove(g)}
+                    style={[styles.smallBtn, styles.approveBtn]}
+                    testID={`rsvp-approve-${g.id}`}
+                  >
+                    <Text style={styles.approveBtnText}>Approve</Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Deny ${g.guestName}`}
+                    onPress={() => handleDeny(g)}
+                    style={[styles.smallBtn, styles.ghostBtn]}
+                    testID={`rsvp-deny-${g.id}`}
+                  >
+                    <Text style={styles.ghostBtnText}>Deny</Text>
+                  </Pressable>
+                </View>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        {/* Going section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Going ({going.length})</Text>
+          {going.length === 0 ? (
+            <Text style={styles.emptySub}>No one&apos;s confirmed yet.</Text>
+          ) : (
+            going.map((g) => (
+              <View key={g.id} style={styles.guestRow}>
+                <View style={styles.guestInfo}>
+                  <Text style={styles.guestName} numberOfLines={1}>
+                    {g.guestName}
+                    {g.plusCount > 0 ? <Text style={styles.plusChip}>  +{g.plusCount}</Text> : null}
+                  </Text>
+                  <Text style={styles.guestContact} numberOfLines={1}>
+                    {g.guestEmail ?? g.guestPhone ?? "App guest"}
+                  </Text>
+                </View>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Remove ${g.guestName}`}
+                  onPress={() => setRemoveTarget(g)}
+                  style={[styles.smallBtn, styles.removeBtn]}
+                  testID={`rsvp-remove-${g.id}`}
+                >
+                  <Text style={styles.removeBtnText}>Remove</Text>
+                </Pressable>
+              </View>
+            ))
+          )}
+        </View>
+
+        {/* Waitlist section (read-only) */}
+        {waitlisted.length > 0 ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Waitlist ({waitlisted.length})</Text>
+            {waitlisted.map((g) => (
+              <View key={g.id} style={styles.guestRow}>
+                <View style={styles.guestInfo}>
+                  <Text style={styles.guestName} numberOfLines={1}>
+                    {g.guestName}
+                    {g.plusCount > 0 ? <Text style={styles.plusChip}>  +{g.plusCount}</Text> : null}
+                  </Text>
+                  <Text style={styles.guestContact} numberOfLines={1}>
+                    {g.guestEmail ?? g.guestPhone ?? "App guest"}
+                  </Text>
+                </View>
+                <Icon name="clock" size={18} color={textTokens.tertiary} />
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        {/* Auto-mode + no pending hint */}
+        {pending.length === 0 && going.length > 0 ? (
+          <Text style={styles.footerHint}>
+            Everyone who taps Going is in automatically.
+          </Text>
+        ) : null}
+      </ScrollView>
+
+      <ConfirmDialog
+        visible={removeTarget !== null}
+        onClose={() => setRemoveTarget(null)}
+        onConfirm={handleConfirmRemove}
+        title={removeTarget !== null ? `Remove ${removeTarget.guestName}?` : "Remove guest?"}
+        description="They'll be moved out of this event and notified. If you have a waitlist, the next person is moved in automatically."
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        confirmLoading={setStatus.isPending}
+        confirmDisabled={setStatus.isPending}
+        destructive
+      />
+
+      <View style={styles.toastWrap} pointerEvents="box-none">
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast((p) => ({ ...p, visible: false }))}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  host: { flex: 1 },
+  chromeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    gap: spacing.sm,
+  },
+  chromeTitle: {
+    flex: 1,
+    fontSize: typography.h3.fontSize,
+    fontWeight: typography.h3.fontWeight,
+    color: textTokens.primary,
+  },
+  chromeSpacer: { width: 36 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", gap: spacing.md },
+  body: { paddingHorizontal: spacing.md, paddingTop: spacing.md, gap: spacing.lg },
+  section: { gap: spacing.sm },
+  sectionHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  sectionTitle: {
+    fontSize: typography.bodyLg.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  bulkBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 6,
+    borderRadius: radiusTokens.md,
+    backgroundColor: accent.tint,
+    borderWidth: 1,
+    borderColor: accent.border,
+  },
+  bulkBtnText: { fontSize: typography.bodySm.fontSize, fontWeight: "700", color: accent.warm },
+  guestRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.sm,
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    backgroundColor: ROW_BG,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+  },
+  guestInfo: { flex: 1, marginRight: spacing.sm },
+  guestName: { fontSize: typography.bodySm.fontSize, fontWeight: "600", color: textTokens.primary },
+  plusChip: { fontSize: typography.caption.fontSize, fontWeight: "700", color: accent.warm },
+  guestContact: { fontSize: typography.caption.fontSize, color: textTokens.tertiary, marginTop: 2 },
+  actionCol: { flexDirection: "row", gap: spacing.xs },
+  smallBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 8,
+    borderRadius: radiusTokens.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  approveBtn: { backgroundColor: accent.warm },
+  approveBtnText: { fontSize: typography.caption.fontSize, fontWeight: "700", color: "#fff" },
+  ghostBtn: { backgroundColor: glass.tint.profileBase, borderWidth: 1, borderColor: glass.border.profileBase },
+  ghostBtnText: { fontSize: typography.caption.fontSize, fontWeight: "600", color: textTokens.secondary },
+  removeBtn: { backgroundColor: "rgba(255,255,255,0.04)", borderWidth: 1, borderColor: semantic.error },
+  removeBtnText: { fontSize: typography.caption.fontSize, fontWeight: "600", color: semantic.error },
+  emptyTitle: { fontSize: typography.bodyLg.fontSize, fontWeight: "600", color: textTokens.primary },
+  emptySub: { fontSize: typography.bodySm.fontSize, color: textTokens.tertiary },
+  footerHint: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+    textAlign: "center",
+    marginTop: spacing.sm,
+  },
+  toastWrap: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    top: 0,
+    paddingTop: spacing.lg,
+    paddingHorizontal: spacing.md,
+  },
+});
+
+export default RsvpGuestConsole;

--- a/mingla-business/src/components/rsvp/RsvpStep5Setup.tsx
+++ b/mingla-business/src/components/rsvp/RsvpStep5Setup.tsx
@@ -1,0 +1,425 @@
+/**
+ * ORCH-1150 — RSVP-setup step (replaces the Tickets step for RSVP events).
+ *
+ * Full host control (SPEC §4.4): capacity cap, plus-ones, waitlist, approval
+ * mode, guest-list privacy, going-count visibility, and the "who can find this"
+ * section (visibility pills + the discovery toggle, co-located — SPEC §4.3).
+ *
+ * NO ticket tiers, NO price, NO Stripe (RSVP is moneyless — Constitution #10).
+ * validateRsvpStep(4) returns [] — no required fields; the only cross-field
+ * rules (waitlist-needs-capacity, plus-max≥1) are UI-enforced via disabled
+ * states, not a publish blocker.
+ *
+ * Android glass: cards/rows use the opaque fallback (ANDROID_GLASS_USES_OPAQUE_FALLBACK).
+ */
+
+import React, { useCallback } from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  glass,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import type { DraftEventVisibility } from "../../store/draftEventStore";
+import { type StepBodyProps } from "../event/types";
+
+const ROW_BG = Platform.select({
+  ios: glass.tint.profileBase,
+  android: "#23262b",
+  default: glass.tint.profileBase,
+});
+
+const VISIBILITY_OPTIONS: readonly { id: DraftEventVisibility; label: string }[] = [
+  { id: "public", label: "Public" },
+  { id: "unlisted", label: "Unlisted" },
+  { id: "private", label: "Private" },
+];
+
+interface ToggleRowProps {
+  label: string;
+  sub: string;
+  on: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+  testID?: string;
+}
+
+const ToggleRow: React.FC<ToggleRowProps> = ({
+  label,
+  sub,
+  on,
+  onToggle,
+  disabled = false,
+  testID,
+}) => (
+  <Pressable
+    onPress={disabled ? undefined : onToggle}
+    accessibilityRole="switch"
+    accessibilityState={{ checked: on, disabled }}
+    accessibilityLabel={label}
+    disabled={disabled}
+    style={[styles.toggleRow, disabled && styles.rowDisabled]}
+    testID={testID}
+  >
+    <View style={styles.toggleLabelCol}>
+      <Text style={styles.toggleLabel}>{label}</Text>
+      <Text style={styles.toggleSub}>{sub}</Text>
+    </View>
+    <View style={[styles.toggleTrack, on && styles.toggleTrackOn]}>
+      <View style={[styles.toggleThumb, on ? styles.toggleThumbOn : styles.toggleThumbOff]} />
+    </View>
+  </Pressable>
+);
+
+interface StepperRowProps {
+  label: string;
+  value: number;
+  min: number;
+  onChange: (next: number) => void;
+  testID?: string;
+}
+
+const NumberStepper: React.FC<StepperRowProps> = ({ label, value, min, onChange, testID }) => (
+  <View style={styles.stepperRow}>
+    <Text style={styles.stepperLabel}>{label}</Text>
+    <View style={styles.stepperControls}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Decrease ${label}`}
+        onPress={() => onChange(Math.max(min, value - 1))}
+        style={styles.stepperBtn}
+        testID={testID ? `${testID}-dec` : undefined}
+      >
+        <Text style={styles.stepperBtnText}>−</Text>
+      </Pressable>
+      <Text style={styles.stepperValue} testID={testID ? `${testID}-value` : undefined}>
+        {value}
+      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Increase ${label}`}
+        onPress={() => onChange(value + 1)}
+        style={styles.stepperBtn}
+        testID={testID ? `${testID}-inc` : undefined}
+      >
+        <Text style={styles.stepperBtnText}>+</Text>
+      </Pressable>
+    </View>
+  </View>
+);
+
+export const RsvpStep5Setup: React.FC<StepBodyProps> = ({ draft, updateDraft }) => {
+  const capacityOn = draft.rsvpCapacity !== null;
+
+  const toggleCapacity = useCallback(() => {
+    updateDraft({ rsvpCapacity: capacityOn ? null : Math.max(draft.rsvpCapacity ?? 1, 1) });
+    // Turning capacity OFF also disables waitlist (no "full" → no waitlist).
+    if (capacityOn) updateDraft({ rsvpWaitlistEnabled: false });
+  }, [capacityOn, draft.rsvpCapacity, updateDraft]);
+
+  const togglePlusOnes = useCallback(() => {
+    const next = !draft.rsvpAllowPlusOnes;
+    updateDraft({
+      rsvpAllowPlusOnes: next,
+      rsvpPlusOnesMax: next ? Math.max(draft.rsvpPlusOnesMax, 1) : 0,
+    });
+  }, [draft.rsvpAllowPlusOnes, draft.rsvpPlusOnesMax, updateDraft]);
+
+  const selectApprovalMode = useCallback(
+    (mode: "auto" | "manual") => updateDraft({ rsvpApprovalMode: mode }),
+    [updateDraft],
+  );
+
+  return (
+    <View>
+      {/* 1. Capacity */}
+      <ToggleRow
+        label="Limit the guest list"
+        sub={capacityOn ? "Set a maximum number of guests." : "No limit — anyone with the link can RSVP."}
+        on={capacityOn}
+        onToggle={toggleCapacity}
+        testID="rsvp-capacity-toggle"
+      />
+      {capacityOn ? (
+        <NumberStepper
+          label="Max guests"
+          value={draft.rsvpCapacity ?? 1}
+          min={1}
+          onChange={(n) => updateDraft({ rsvpCapacity: Math.max(1, n) })}
+          testID="rsvp-capacity"
+        />
+      ) : null}
+
+      {/* 2. Plus-ones */}
+      <ToggleRow
+        label="Allow guests to bring extras"
+        sub="Each guest's extras count toward your limit."
+        on={draft.rsvpAllowPlusOnes}
+        onToggle={togglePlusOnes}
+        testID="rsvp-plusones-toggle"
+      />
+      {draft.rsvpAllowPlusOnes ? (
+        <NumberStepper
+          label="Max extra guests per person"
+          value={Math.max(draft.rsvpPlusOnesMax, 1)}
+          min={1}
+          onChange={(n) => updateDraft({ rsvpPlusOnesMax: Math.max(1, n) })}
+          testID="rsvp-plusones-max"
+        />
+      ) : null}
+
+      {/* 3. Waitlist (disabled until capacity is on) */}
+      <ToggleRow
+        label="Start a waitlist when full"
+        sub={
+          !capacityOn
+            ? "Add a guest limit first."
+            : "When a spot opens, the next person on the waitlist is automatically moved in and notified."
+        }
+        on={draft.rsvpWaitlistEnabled}
+        onToggle={() => updateDraft({ rsvpWaitlistEnabled: !draft.rsvpWaitlistEnabled })}
+        disabled={!capacityOn}
+        testID="rsvp-waitlist-toggle"
+      />
+
+      {/* 4. Approvals */}
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>Approvals</Text>
+        <View style={styles.segmentWrap}>
+          {(["auto", "manual"] as const).map((mode) => {
+            const active = draft.rsvpApprovalMode === mode;
+            return (
+              <Pressable
+                key={mode}
+                onPress={() => selectApprovalMode(mode)}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={mode === "auto" ? "Auto-approve" : "Approve each RSVP"}
+                style={[styles.segment, active && styles.segmentActive]}
+                testID={`rsvp-approval-${mode}`}
+              >
+                <Text style={[styles.segmentLabel, active && styles.segmentLabelActive]}>
+                  {mode === "auto" ? "Auto-approve" : "Approve each RSVP"}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        <Text style={styles.helper}>
+          {draft.rsvpApprovalMode === "auto"
+            ? "Guests are in the moment they tap Going."
+            : "You approve each guest from your Guests list. They'll see “Awaiting host approval” until you do."}
+        </Text>
+      </View>
+
+      {/* 5. Guest-list privacy */}
+      <ToggleRow
+        label="Keep the guest list private"
+        sub="Only you see who's coming."
+        on={draft.privateGuestList}
+        onToggle={() => updateDraft({ privateGuestList: !draft.privateGuestList })}
+        testID="rsvp-private-guestlist"
+      />
+
+      {/* 6. Going-count visibility */}
+      <ToggleRow
+        label="Hide the Going count from guests"
+        sub="Guests won't see how many are coming."
+        on={draft.hideRemainingCount}
+        onToggle={() => updateDraft({ hideRemainingCount: !draft.hideRemainingCount })}
+        testID="rsvp-hide-count"
+      />
+
+      {/* 7. Who can find this — visibility + discovery, co-located */}
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>Who can find this</Text>
+        <View style={styles.visibilityWrap}>
+          {VISIBILITY_OPTIONS.map((opt) => {
+            const active = draft.visibility === opt.id;
+            return (
+              <Pressable
+                key={opt.id}
+                onPress={() => {
+                  updateDraft({ visibility: opt.id });
+                  // A private RSVP can't be on a public feed — force discover OFF.
+                  if (opt.id === "private") updateDraft({ rsvpDiscoverable: false });
+                }}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                accessibilityLabel={opt.label}
+                style={[styles.visibilityPill, active && styles.visibilityPillActive]}
+                testID={`rsvp-visibility-${opt.id}`}
+              >
+                <Text style={[styles.visibilityPillLabel, active && styles.visibilityPillLabelActive]}>
+                  {opt.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        <ToggleRow
+          label="Also show this on Mingla's discovery feed"
+          sub={
+            draft.visibility === "private"
+              ? "A private RSVP can't be on the public feed."
+              : "Off = invite-link only. On = anyone nearby can find and RSVP."
+          }
+          on={draft.rsvpDiscoverable}
+          onToggle={() => updateDraft({ rsvpDiscoverable: !draft.rsvpDiscoverable })}
+          disabled={draft.visibility === "private"}
+          testID="rsvp-discoverable-toggle"
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  field: { marginBottom: spacing.md, marginTop: spacing.sm },
+  fieldLabel: {
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight,
+    fontWeight: "500",
+    color: textTokens.secondary,
+    marginBottom: spacing.xs,
+  },
+  helper: {
+    fontSize: typography.caption.fontSize,
+    lineHeight: typography.caption.lineHeight * 1.4,
+    color: textTokens.tertiary,
+    marginTop: spacing.sm,
+    paddingHorizontal: spacing.xs,
+  },
+  rowDisabled: { opacity: 0.55 },
+
+  // Segmented control
+  segmentWrap: {
+    flexDirection: "row",
+    padding: 4,
+    backgroundColor: ROW_BG,
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    gap: 4,
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    alignItems: "center",
+    borderRadius: radiusTokens.md - 2,
+  },
+  segmentActive: { backgroundColor: accent.tint },
+  segmentLabel: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: textTokens.secondary,
+  },
+  segmentLabelActive: { color: textTokens.primary },
+
+  // Visibility pills
+  visibilityWrap: {
+    flexDirection: "row",
+    padding: 4,
+    backgroundColor: ROW_BG,
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    gap: 4,
+    marginBottom: spacing.sm,
+  },
+  visibilityPill: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    alignItems: "center",
+    borderRadius: radiusTokens.md - 2,
+  },
+  visibilityPillActive: { backgroundColor: accent.tint },
+  visibilityPillLabel: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: textTokens.secondary,
+  },
+  visibilityPillLabelActive: { color: textTokens.primary },
+
+  // Toggle row (Android opaque fallback via ROW_BG)
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    backgroundColor: ROW_BG,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    marginBottom: spacing.sm,
+  },
+  toggleLabelCol: { flex: 1, marginRight: spacing.sm },
+  toggleLabel: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "500",
+    color: textTokens.primary,
+  },
+  toggleSub: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.tertiary,
+    marginTop: 2,
+  },
+  toggleTrack: {
+    width: 44,
+    height: 26,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.16)",
+    padding: 3,
+  },
+  toggleTrackOn: { backgroundColor: accent.warm },
+  toggleThumb: { width: 20, height: 20, borderRadius: 999, backgroundColor: "#fff" },
+  toggleThumbOff: { transform: [{ translateX: 0 }] },
+  toggleThumbOn: { transform: [{ translateX: 18 }] },
+
+  // Number stepper
+  stepperRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    backgroundColor: ROW_BG,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    marginBottom: spacing.sm,
+  },
+  stepperLabel: {
+    flex: 1,
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "500",
+    color: textTokens.primary,
+  },
+  stepperControls: { flexDirection: "row", alignItems: "center", gap: spacing.md },
+  stepperBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: radiusTokens.md,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: glass.tint.profileElevated,
+  },
+  stepperBtnText: { fontSize: 20, fontWeight: "700", color: textTokens.primary },
+  stepperValue: {
+    minWidth: 28,
+    textAlign: "center",
+    fontSize: typography.bodyLg.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/mingla-business/src/components/rsvp/RsvpStep7Preview.tsx
+++ b/mingla-business/src/components/rsvp/RsvpStep7Preview.tsx
@@ -1,0 +1,243 @@
+/**
+ * ORCH-1150 — RSVP Preview step (clone of CreatorStep7Preview, money-free).
+ *
+ * Renders the RSVP public-page mini preview (Going / Not going framing). NO
+ * StripeBlockedCard, NO money surfaces, NO onConnectStripe (RSVP is moneyless).
+ * Readiness = validateRsvpPublish(draft).length === 0.
+ *
+ * See SPEC §4.3 (Preview row).
+ */
+
+import React, { useCallback } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  glass,
+  radius as radiusTokens,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { type Brand } from "../../store/currentBrandStore";
+import { validateRsvpPublish } from "../../utils/draftRsvpValidation";
+import {
+  formatDraftDateLine,
+  formatDraftDateSubline,
+} from "../../utils/eventDateDisplay";
+
+import { EventCoverMedia } from "../ui/EventCoverMedia";
+import { GlassCard } from "../ui/GlassCard";
+import { Icon } from "../ui/Icon";
+import { type StepBodyProps } from "../event/types";
+
+interface RsvpStep7PreviewProps extends StepBodyProps {
+  brand: Brand | null;
+  onTapMiniCard: () => void;
+}
+
+export const RsvpStep7Preview: React.FC<RsvpStep7PreviewProps> = ({
+  draft,
+  brand,
+  onTapMiniCard,
+}) => {
+  const errors = validateRsvpPublish(draft);
+  const isReady = errors.length === 0;
+
+  const handleMiniCardPress = useCallback((): void => {
+    onTapMiniCard();
+  }, [onTapMiniCard]);
+
+  const dateLine = formatDraftDateLine(draft);
+  const subline = formatDraftDateSubline(draft);
+  const titleLine = draft.name.length > 0 ? draft.name : "Untitled RSVP";
+  const venueLine =
+    draft.format === "online" ? "Online" : draft.venueName ?? "Set a location in Step 3";
+
+  return (
+    <View>
+      {/* Mini RSVP card */}
+      <Pressable
+        onPress={handleMiniCardPress}
+        accessibilityRole="button"
+        accessibilityLabel="Preview public page"
+        style={styles.miniCard}
+      >
+        <View style={styles.miniCover}>
+          <EventCoverMedia
+            hue={draft.coverHue}
+            mediaUrl={draft.coverMediaUrl}
+            mediaType={draft.coverMediaType}
+            radius={0}
+            label=""
+            height={140}
+          />
+        </View>
+        <View style={styles.miniBody}>
+          <Text style={styles.miniDate}>{dateLine}</Text>
+          <Text style={styles.miniTitle} numberOfLines={1}>
+            {titleLine}
+          </Text>
+          <Text style={styles.miniVenue} numberOfLines={1}>
+            {venueLine}
+          </Text>
+          {subline !== null ? (
+            <View style={styles.recurrencePillRow}>
+              <View style={styles.recurrencePill}>
+                <Text style={styles.recurrencePillLabel}>{subline}</Text>
+              </View>
+            </View>
+          ) : null}
+          {/* Going / Not-going CTA preview (non-interactive) */}
+          <View style={styles.ctaRow}>
+            <View style={[styles.ctaBtn, styles.ctaGoing]}>
+              <Text style={styles.ctaGoingLabel}>Going</Text>
+            </View>
+            <View style={[styles.ctaBtn, styles.ctaNotGoing]}>
+              <Text style={styles.ctaNotGoingLabel}>Not going</Text>
+            </View>
+          </View>
+        </View>
+      </Pressable>
+
+      {/* Status card (money-free) */}
+      <View style={styles.statusCardWrap}>
+        {isReady ? (
+          <GlassCard variant="base" padding={spacing.md}>
+            <View style={styles.statusRow}>
+              <Icon name="check" size={20} color={semantic.success} />
+              <View style={styles.statusTextCol}>
+                <Text style={styles.statusTitle}>Ready to publish</Text>
+                <Text style={styles.statusSub}>
+                  Your invite link goes live immediately. Guests can RSVP right away.
+                </Text>
+              </View>
+            </View>
+          </GlassCard>
+        ) : (
+          <GlassCard variant="base" padding={spacing.md} style={styles.warnCard}>
+            <View style={styles.statusRow}>
+              <Icon name="flag" size={20} color={accent.warm} />
+              <View style={styles.statusTextCol}>
+                <Text style={styles.statusTitle}>
+                  {errors.length === 1 ? "1 thing to fix" : `${errors.length} things to fix`}
+                </Text>
+                <Text style={styles.statusSub}>Tap Publish to see what is missing.</Text>
+              </View>
+            </View>
+          </GlassCard>
+        )}
+      </View>
+
+      <Pressable
+        onPress={handleMiniCardPress}
+        accessibilityRole="button"
+        accessibilityLabel="Preview public page"
+        style={styles.previewLinkBtn}
+      >
+        <Icon name="eye" size={16} color={accent.warm} />
+        <Text style={styles.previewLinkLabel}>Preview public page</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  miniCard: {
+    borderRadius: radiusTokens.lg,
+    overflow: "hidden",
+    backgroundColor: glass.tint.profileElevated,
+    borderWidth: 1,
+    borderColor: glass.border.profileElevated,
+    marginBottom: spacing.md,
+  },
+  miniCover: { height: 140, width: "100%" },
+  miniBody: { padding: spacing.md },
+  miniDate: {
+    fontSize: 11,
+    fontWeight: "700",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: accent.warm,
+    marginBottom: 4,
+  },
+  miniTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    letterSpacing: -0.2,
+    color: textTokens.primary,
+  },
+  miniVenue: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+    marginTop: 2,
+  },
+  recurrencePillRow: { flexDirection: "row", marginTop: spacing.xs },
+  recurrencePill: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: 999,
+    overflow: "hidden",
+    backgroundColor: accent.tint,
+    borderWidth: 1,
+    borderColor: accent.border,
+  },
+  recurrencePillLabel: {
+    fontSize: typography.caption.fontSize,
+    fontWeight: "600",
+    color: accent.warm,
+  },
+  ctaRow: { flexDirection: "row", gap: spacing.sm, marginTop: spacing.md },
+  ctaBtn: {
+    flex: 1,
+    paddingVertical: spacing.sm,
+    borderRadius: radiusTokens.md,
+    alignItems: "center",
+  },
+  ctaGoing: { backgroundColor: accent.warm },
+  ctaGoingLabel: { fontSize: typography.bodySm.fontSize, fontWeight: "700", color: "#fff" },
+  ctaNotGoing: {
+    backgroundColor: glass.tint.profileBase,
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+  },
+  ctaNotGoingLabel: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: textTokens.secondary,
+  },
+  statusCardWrap: { marginBottom: spacing.sm },
+  previewLinkBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.xs,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    borderRadius: radiusTokens.md,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: glass.border.profileBase,
+    backgroundColor: glass.tint.profileBase,
+  },
+  previewLinkLabel: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: accent.warm,
+  },
+  statusRow: { flexDirection: "row", alignItems: "flex-start", gap: spacing.sm },
+  statusTextCol: { flex: 1 },
+  statusTitle: {
+    fontSize: typography.bodySm.fontSize,
+    fontWeight: "600",
+    color: textTokens.primary,
+  },
+  statusSub: {
+    fontSize: typography.caption.fontSize,
+    color: textTokens.secondary,
+    marginTop: 2,
+    lineHeight: typography.caption.lineHeight * 1.4,
+  },
+  warnCard: { borderColor: accent.border, borderWidth: 1 },
+});

--- a/mingla-business/src/components/ui/UniversalCreatorSheet.tsx
+++ b/mingla-business/src/components/ui/UniversalCreatorSheet.tsx
@@ -70,7 +70,10 @@ import {
 import { Icon } from "./Icon";
 import { TopSheet } from "./TopSheet";
 
-export type UniversalCreatorStep = "root" | "experience";
+// ORCH-1150 — "event" added: the "Create event" root row now steps in-place to
+// a Ticketed-vs-RSVP chooser (mirrors the ORCH-1144 experience step) instead of
+// routing straight to /event/create.
+export type UniversalCreatorStep = "root" | "experience" | "event";
 
 export interface UniversalCreatorSheetProps {
   visible: boolean;
@@ -98,7 +101,8 @@ interface RootOption {
 }
 
 interface ChooserOption {
-  readonly key: "food" | "activities" | "manual";
+  // ORCH-1150 — + "ticketed" | "rsvp" for the EVENT_OPTIONS chooser.
+  readonly key: "food" | "activities" | "manual" | "ticketed" | "rsvp";
   readonly iconName: IconName;
   readonly title: string;
   readonly subtitle: string;
@@ -111,8 +115,9 @@ const ROOT_OPTIONS: readonly RootOption[] = [
     key: "event",
     iconName: "calendar",
     title: "Create event",
-    subtitle: "A ticketed gathering: concert, party, comedy night, festival.",
-    route: "/event/create",
+    // ORCH-1150 — steps in-place to the Ticketed-vs-RSVP chooser.
+    subtitle: "A gathering with guests — ticketed, or RSVP-only.",
+    step: "event",
     testID: "universal-creator-event",
   },
   {
@@ -172,6 +177,27 @@ const EXPERIENCE_OPTIONS: readonly ChooserOption[] = [
   },
 ] as const;
 
+// ORCH-1150 — the in-sheet "event" step: Ticketed (existing wizard, untouched)
+// vs RSVP (new /rsvp/create). Mirrors EXPERIENCE_OPTIONS exactly.
+const EVENT_OPTIONS: readonly ChooserOption[] = [
+  {
+    key: "ticketed",
+    iconName: "calendar",
+    title: "Ticketed event",
+    subtitle: "Sell or issue tickets — concert, party, comedy night, festival.",
+    route: "/event/create",
+    testID: "event-chooser-ticketed",
+  },
+  {
+    key: "rsvp",
+    iconName: "list",
+    title: "RSVP event",
+    subtitle: "Guests reply Going or Not going. No tickets — like a private invite.",
+    route: "/rsvp/create",
+    testID: "event-chooser-rsvp",
+  },
+] as const;
+
 export const UniversalCreatorSheet: React.FC<UniversalCreatorSheetProps> = ({
   visible,
   onClose,
@@ -219,10 +245,20 @@ export const UniversalCreatorSheet: React.FC<UniversalCreatorSheetProps> = ({
     [pushRoute],
   );
 
+  // ORCH-1150 — the event step rows just push their route (Ticketed/RSVP).
+  const handleEventSelect = useCallback(
+    (option: ChooserOption): void => {
+      pushRoute(option.route);
+    },
+    [pushRoute],
+  );
+
   // Back is only meaningful when there IS a root to return to — i.e. the sheet
-  // was opened at the root step. When opened directly at the experience step
-  // (Hub > Experiences tab) there is no root, so the affordance is omitted.
-  const canGoBackToRoot = step === "experience" && initialStep === "root";
+  // was opened at the root step. When opened directly at a sub-step
+  // (Hub > Experiences tab passes initialStep="experience") there is no root,
+  // so the affordance is omitted. ORCH-1150 — generalized to cover both the
+  // experience AND event sub-steps.
+  const showBack = step !== "root" && initialStep === "root";
 
   return (
     <TopSheet visible={visible} onClose={onClose} heightMode="compact" testID={testID}>
@@ -259,10 +295,58 @@ export const UniversalCreatorSheet: React.FC<UniversalCreatorSheetProps> = ({
             ))}
           </View>
         </View>
+      ) : step === "event" ? (
+        // ORCH-1150 — in-sheet event chooser: Ticketed vs RSVP.
+        <View style={styles.container}>
+          <View style={styles.header}>
+            {showBack ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Back"
+                accessibilityHint="Back to what you're creating"
+                onPress={() => setStep("root")}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                style={({ pressed }) =>
+                  pressed ? [styles.backRow, styles.backRowPressed] : styles.backRow
+                }
+                testID="event-chooser-back"
+              >
+                <Icon name="chevL" size={18} color={textTokens.secondary} />
+                <Text style={styles.backLabel}>Back</Text>
+              </Pressable>
+            ) : null}
+            <Text style={styles.headerTitle}>Create an event</Text>
+            <Text style={styles.headerSubtitle}>Pick how guests join.</Text>
+          </View>
+          <View style={styles.rows}>
+            {EVENT_OPTIONS.map((option) => (
+              <Pressable
+                key={option.key}
+                accessibilityRole="button"
+                accessibilityLabel={option.title}
+                accessibilityHint={option.subtitle}
+                onPress={() => handleEventSelect(option)}
+                style={({ pressed }) =>
+                  pressed ? [styles.expRow, styles.expRowPressed] : styles.expRow
+                }
+                testID={option.testID}
+              >
+                <View style={styles.expRowIconWrap}>
+                  <Icon name={option.iconName} size={28} color={textTokens.primary} />
+                </View>
+                <View style={styles.rowText}>
+                  <Text style={styles.rowTitle}>{option.title}</Text>
+                  <Text style={styles.rowSubtitle}>{option.subtitle}</Text>
+                </View>
+                <Icon name="chevR" size={20} color={textTokens.tertiary} />
+              </Pressable>
+            ))}
+          </View>
+        </View>
       ) : (
         <View style={styles.container}>
           <View style={styles.header}>
-            {canGoBackToRoot ? (
+            {showBack ? (
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Back"

--- a/mingla-business/src/hooks/useRsvpApprovals.ts
+++ b/mingla-business/src/hooks/useRsvpApprovals.ts
@@ -1,0 +1,65 @@
+/**
+ * ORCH-1150 — host RSVP approve/deny/remove + bulk-approve React Query hooks (A2).
+ *
+ * useRsvpGuestList(eventId) — host-scoped guest list (RLS host-read).
+ * useSetRsvpStatus()        — approve/deny/remove mutation; invalidates the
+ *                             guest list + going-count keys on success.
+ * useBulkApproveRsvps()     — bulk approve all pending up to capacity.
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket path. See SPEC §5.4.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useAuth } from "../context/AuthContext";
+import {
+  bulkApproveRsvps,
+  listRsvpGuests,
+  setRsvpStatus,
+  type BulkApproveResult,
+  type RsvpGuest,
+  type SetRsvpStatusResult,
+} from "../services/rsvpApprovals";
+
+export const rsvpGuestKeys = {
+  all: ["rsvp-guests"] as const,
+  list: (eventId: string) => [...rsvpGuestKeys.all, eventId] as const,
+};
+
+export function useRsvpGuestList(eventId: string | null, enabled = true) {
+  const { isAuthReady } = useAuth();
+  return useQuery<RsvpGuest[]>({
+    queryKey: rsvpGuestKeys.list(eventId ?? ""),
+    queryFn: () => listRsvpGuests(eventId!),
+    enabled: isAuthReady && enabled && eventId !== null && eventId.length > 0,
+    staleTime: 10_000,
+  });
+}
+
+export function useSetRsvpStatus(eventId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation<
+    SetRsvpStatusResult,
+    Error,
+    { rsvpId: string; status: "approved" | "denied" }
+  >({
+    mutationFn: ({ rsvpId, status }) => setRsvpStatus(rsvpId, status),
+    onSuccess: () => {
+      if (eventId !== null && eventId.length > 0) {
+        void queryClient.invalidateQueries({ queryKey: rsvpGuestKeys.list(eventId) });
+      }
+    },
+  });
+}
+
+export function useBulkApproveRsvps(eventId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation<BulkApproveResult, Error, void>({
+    mutationFn: () => bulkApproveRsvps(eventId!),
+    onSuccess: () => {
+      if (eventId !== null && eventId.length > 0) {
+        void queryClient.invalidateQueries({ queryKey: rsvpGuestKeys.list(eventId) });
+      }
+    },
+  });
+}

--- a/mingla-business/src/hooks/useRsvpEvents.ts
+++ b/mingla-business/src/hooks/useRsvpEvents.ts
@@ -1,0 +1,40 @@
+/**
+ * ORCH-1150 — RSVP publish + edit-live React Query mutation hooks.
+ *
+ * Forked from the business-event publish hook; RSVP NEVER routes through the
+ * event publish RPC (I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC).
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket path. See SPEC §5.1/§5.2.
+ */
+
+import { useMutation } from "@tanstack/react-query";
+
+import {
+  publishRsvpDraft,
+  updateLiveRsvp,
+  type UpdateLiveRsvpResult,
+} from "../services/rsvpEvents";
+import type { PublishedBusinessEvent } from "../services/businessEvents";
+import type { DraftEvent } from "../store/draftEventStore";
+
+export function usePublishRsvpDraft() {
+  return useMutation<
+    PublishedBusinessEvent,
+    Error,
+    { draft: DraftEvent; clientRevision?: number | null }
+  >({
+    mutationFn: ({ draft, clientRevision }) =>
+      publishRsvpDraft(draft, clientRevision ?? draft.clientRevision ?? null),
+  });
+}
+
+export function useUpdateLiveRsvp() {
+  return useMutation<
+    UpdateLiveRsvpResult,
+    Error,
+    { eventId: string; payload: Record<string, unknown>; reason: string }
+  >({
+    mutationFn: ({ eventId, payload, reason }) =>
+      updateLiveRsvp(eventId, payload, reason),
+  });
+}

--- a/mingla-business/src/services/__tests__/rsvpErrorCodes.orch1150.test.ts
+++ b/mingla-business/src/services/__tests__/rsvpErrorCodes.orch1150.test.ts
@@ -1,0 +1,51 @@
+/**
+ * ORCH-1150 Step 9 — public RSVP submit error-code bubbling (regression).
+ *
+ * The public /e/ RSVP page maps the edge-fn { error } code to an inline message
+ * (rsvp_contact_required / rsvp_phone_invalid / rsvp_full / rsvp_not_open). If
+ * the parser silently dropped the body code and only used error.message, the
+ * page would show a generic "try again" instead of the right field-level
+ * message — a real UX regression. This proves the body code wins.
+ *
+ * Fails-on-revert: replacing the body-code extraction with `error.message` only
+ * (delete the `parsed.error` branch) makes the first assertion FAIL.
+ */
+
+import { parseRsvpErrorCode } from "../rsvpErrorCodes";
+
+describe("ORCH-1150 §6 — public RSVP submit error code", () => {
+  it("prefers the { error } code embedded in a string body", () => {
+    const code = parseRsvpErrorCode({
+      message: "Edge Function returned a non-2xx status code",
+      context: { body: JSON.stringify({ error: "rsvp_contact_required" }) },
+    });
+    expect(code).toBe("rsvp_contact_required");
+  });
+
+  it("prefers the { error } code from an already-parsed object body", () => {
+    expect(
+      parseRsvpErrorCode({ context: { body: { error: "rsvp_phone_invalid" } } }),
+    ).toBe("rsvp_phone_invalid");
+  });
+
+  it("bubbles rsvp_full so the page shows 'just filled up'", () => {
+    expect(
+      parseRsvpErrorCode({ context: { body: { error: "rsvp_full" } } }),
+    ).toBe("rsvp_full");
+  });
+
+  it("falls back to error.message when there is no body", () => {
+    expect(parseRsvpErrorCode({ message: "network down" })).toBe("network down");
+  });
+
+  it("falls back to rsvp_write_failed for a null error or empty everything", () => {
+    expect(parseRsvpErrorCode(null)).toBe("rsvp_write_failed");
+    expect(parseRsvpErrorCode({})).toBe("rsvp_write_failed");
+  });
+
+  it("keeps the message code when the body is malformed JSON", () => {
+    expect(
+      parseRsvpErrorCode({ message: "boom", context: { body: "{not json" } }),
+    ).toBe("boom");
+  });
+});

--- a/mingla-business/src/services/__tests__/rsvpEvents.orch1150.test.ts
+++ b/mingla-business/src/services/__tests__/rsvpEvents.orch1150.test.ts
@@ -1,0 +1,38 @@
+/**
+ * ORCH-1150 §9.3 — I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC.
+ *
+ * The RSVP publish service MUST call business_publish_rsvp_draft and MUST NOT
+ * call business_publish_event_draft (re-pointing it at the event RPC would
+ * re-introduce the event_ticket_required 0-ticket block). Static source
+ * assertion + a behavioral mock test that the right RPC name is invoked.
+ *
+ * Fails-on-revert: deleting the "business_publish_rsvp_draft" rpc call (or
+ * re-pointing it at business_publish_event_draft) makes this FAIL.
+ */
+
+import fs from "fs";
+import path from "path";
+
+const SERVICE_SRC = fs.readFileSync(
+  path.join(__dirname, "..", "rsvpEvents.ts"),
+  "utf8",
+);
+
+describe("ORCH-1150 §9.3 — RSVP has its own publish RPC", () => {
+  it("rsvpEvents.ts calls business_publish_rsvp_draft", () => {
+    expect(SERVICE_SRC).toContain('"business_publish_rsvp_draft"');
+  });
+
+  it("rsvpEvents.ts does NOT call business_publish_event_draft", () => {
+    expect(SERVICE_SRC).not.toContain("business_publish_event_draft");
+  });
+
+  it("the RSVP wizard does not import the event publish hook", () => {
+    const wizardSrc = fs.readFileSync(
+      path.join(__dirname, "..", "..", "components", "rsvp", "RsvpCreatorWizard.tsx"),
+      "utf8",
+    );
+    expect(wizardSrc).not.toContain("usePublishBusinessEventDraft");
+    expect(wizardSrc).not.toContain("business_publish_event_draft");
+  });
+});

--- a/mingla-business/src/services/businessEvents.ts
+++ b/mingla-business/src/services/businessEvents.ts
@@ -136,7 +136,9 @@ interface TicketTypeRow {
   display_order: number;
 }
 
-interface PublishRpcResponse {
+// ORCH-1150: exported so the RSVP publish service (rsvpEvents.ts) reuses the
+// SAME response shape + mapping (additive export only; no behavior change).
+export interface PublishRpcResponse {
   event: {
     id: string;
     brand_id: string;
@@ -592,7 +594,8 @@ export const fetchBusinessEventById = async (
   return detail;
 };
 
-const eventFromPublishResponse = (
+// ORCH-1150: exported so rsvpEvents.publishRsvpDraft reuses the SAME mapping.
+export const eventFromPublishResponse = (
   response: PublishRpcResponse,
 ): PublishedBusinessEvent => {
   const businessEvent = asRecord(asRecord(response.event.theme).business_event);

--- a/mingla-business/src/services/businessEvents.ts
+++ b/mingla-business/src/services/businessEvents.ts
@@ -340,7 +340,18 @@ const eventFromRow = (
   // into the cache → home/hub tap-handlers can route trips vs events
   // correctly via routeForEventRow. View doesn't expose event_type so
   // we attach it here from the events-table probe result.
-  eventType: "event" | "experience" | "trip" = "event",
+  eventType: "event" | "experience" | "trip" | "rsvp" = "event",
+  // ORCH-1150 — RSVP host-control snapshot + live going count from the probe
+  // (attached so the Hub list-card renders "N going" without a 2nd query path).
+  rsvpMeta: {
+    rsvpCapacity: number | null;
+    rsvpAllowPlusOnes: boolean;
+    rsvpPlusOnesMax: number;
+    rsvpWaitlistEnabled: boolean;
+    rsvpApprovalMode: "auto" | "manual";
+    rsvpDiscoverable: boolean;
+    rsvpGoingCount: number;
+  } | null = null,
 ): LiveEvent => {
   const theme = asRecord(row.management_theme);
   const businessEvent = asRecord(theme.business_event);
@@ -367,6 +378,14 @@ const eventFromRow = (
     // ORCH-0865 REWORK 5: attach event_type from the 2-step probe so
     // home/hub tap-handlers can dispatch correctly via routeForEventRow.
     event_type: eventType,
+    // ORCH-1150 — RSVP host-control snapshot (inert for non-RSVP rows).
+    rsvpCapacity: rsvpMeta?.rsvpCapacity ?? null,
+    rsvpAllowPlusOnes: rsvpMeta?.rsvpAllowPlusOnes ?? false,
+    rsvpPlusOnesMax: rsvpMeta?.rsvpPlusOnesMax ?? 0,
+    rsvpWaitlistEnabled: rsvpMeta?.rsvpWaitlistEnabled ?? false,
+    rsvpApprovalMode: rsvpMeta?.rsvpApprovalMode ?? "auto",
+    rsvpDiscoverable: rsvpMeta?.rsvpDiscoverable ?? false,
+    rsvpGoingCount: rsvpMeta?.rsvpGoingCount ?? 0,
     name: row.title,
     description: row.description ?? "",
     format: asFormat(businessEvent.format, row.is_online),
@@ -514,25 +533,86 @@ export const fetchBusinessEventsForBrand = async (
   // ORCH-0865 REWORK 5: capture event_type per id so we can attach it to
   // the LiveEvent output (defensive: tap-handlers route trips → /trip/{id}
   // even if a trip leaks past this filter via a future regression).
-  const eventTypeById = new Map<string, "event" | "experience" | "trip">();
+  // ORCH-1150 — the map now also carries 'rsvp' so RSVP rows reach the Hub
+  // event list with event_type='rsvp' (rendered as "N going" by EventListCard).
+  const eventTypeById = new Map<string, "event" | "experience" | "trip" | "rsvp">();
+  // ORCH-1150 — per-RSVP host-control snapshot from the same probe.
+  const rsvpMetaById = new Map<
+    string,
+    {
+      rsvpCapacity: number | null;
+      rsvpAllowPlusOnes: boolean;
+      rsvpPlusOnesMax: number;
+      rsvpWaitlistEnabled: boolean;
+      rsvpApprovalMode: "auto" | "manual";
+      rsvpDiscoverable: boolean;
+      rsvpGoingCount: number;
+    }
+  >();
   if (rows.length > 0) {
     const ids = rows.map((r) => r.id);
     // orch-strict-grep-allow events-type-filter — this IS the filter probe (returns event_type for client-side trip rejection)
+    // ORCH-1150 — also pull the RSVP host-control columns so the Hub list-card
+    // can render "N going" + the manage-sheet a pending badge.
     const typesResp = await supabase
       .from("events")
-      .select("id, event_type")
+      .select(
+        "id, event_type, rsvp_capacity, rsvp_allow_plus_ones, rsvp_plus_ones_max, rsvp_waitlist_enabled, rsvp_approval_mode, rsvp_discoverable",
+      )
       .in("id", ids);
     if (typesResp.error !== null) throw typesResp.error;
     const tripIds = new Set<string>();
+    const rsvpIds: string[] = [];
     for (const r of (typesResp.data ?? []) as Array<{
       id: string;
-      event_type: "event" | "experience" | "trip" | null;
+      event_type: "event" | "experience" | "trip" | "rsvp" | null;
+      rsvp_capacity: number | null;
+      rsvp_allow_plus_ones: boolean | null;
+      rsvp_plus_ones_max: number | null;
+      rsvp_waitlist_enabled: boolean | null;
+      rsvp_approval_mode: "auto" | "manual" | null;
+      rsvp_discoverable: boolean | null;
     }>) {
       const t = r.event_type ?? "event";
       eventTypeById.set(r.id, t);
       if (t === "trip") tripIds.add(r.id);
+      if (t === "rsvp") {
+        rsvpIds.push(r.id);
+        rsvpMetaById.set(r.id, {
+          rsvpCapacity: r.rsvp_capacity ?? null,
+          rsvpAllowPlusOnes: r.rsvp_allow_plus_ones ?? false,
+          rsvpPlusOnesMax: r.rsvp_plus_ones_max ?? 0,
+          rsvpWaitlistEnabled: r.rsvp_waitlist_enabled ?? false,
+          rsvpApprovalMode: r.rsvp_approval_mode ?? "auto",
+          rsvpDiscoverable: r.rsvp_discoverable ?? false,
+          rsvpGoingCount: 0,
+        });
+      }
     }
     filteredRows = rows.filter((r) => !tripIds.has(r.id));
+    // ORCH-1150 — resolve the live confirmed-attending count per RSVP via the
+    // host-read RLS (the host owns these events). Non-fatal: count stays 0 on error.
+    if (rsvpIds.length > 0) {
+      const { data: rsvpRows, error: rsvpErr } = await supabase
+        .from("event_rsvps")
+        .select("event_id, plus_count")
+        .in("event_id", rsvpIds)
+        .eq("rsvp_status", "going")
+        .eq("approval_status", "approved");
+      if (rsvpErr === null && Array.isArray(rsvpRows)) {
+        for (const r of rsvpRows as Array<{
+          event_id: string;
+          plus_count: number | null;
+        }>) {
+          const meta = rsvpMetaById.get(r.event_id);
+          if (meta !== undefined) {
+            meta.rsvpGoingCount += 1 + (r.plus_count ?? 0);
+          }
+        }
+      } else if (rsvpErr !== null) {
+        console.warn("[ORCH-1150] rsvp going-count probe failed", rsvpErr);
+      }
+    }
   }
 
   const ticketLists = await Promise.all(
@@ -543,6 +623,7 @@ export const fetchBusinessEventsForBrand = async (
       row,
       ticketLists[idx] ?? [],
       eventTypeById.get(row.id) ?? "event",
+      rsvpMetaById.get(row.id) ?? null,
     ),
   );
 };

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -47,7 +47,16 @@ interface BusinessPublicEventViewRow {
   title: string;
   description: string | null;
   slug: string;
-  event_type: "event" | "trip" | "experience" | null;
+  event_type: "event" | "trip" | "experience" | "rsvp" | null;
+  // ORCH-1150 — RSVP host-control columns + live confirmed-attending count,
+  // surfaced by business_public_events_view. Inert/0 for non-RSVP rows.
+  rsvp_discoverable?: boolean | null;
+  rsvp_capacity?: number | null;
+  rsvp_allow_plus_ones?: boolean | null;
+  rsvp_plus_ones_max?: number | null;
+  rsvp_waitlist_enabled?: boolean | null;
+  rsvp_approval_mode?: "auto" | "manual" | null;
+  rsvp_going_count?: number | null;
   location_text: string | null;
   online_url: string | null;
   is_online: boolean;
@@ -797,6 +806,23 @@ export const publicEventViewRowToEvent = (
       row.theme_font_override,
       row.theme_animation_override,
     ),
+    // ORCH-1150 — discriminator + RSVP host-control snapshot (inert for
+    // non-RSVP rows). The public RSVP page + Hub list-card read these.
+    event_type:
+      row.event_type === "rsvp"
+        ? "rsvp"
+        : row.event_type === "experience"
+          ? "experience"
+          : row.event_type === "trip"
+            ? "trip"
+            : "event",
+    rsvpCapacity: row.rsvp_capacity ?? null,
+    rsvpAllowPlusOnes: row.rsvp_allow_plus_ones ?? false,
+    rsvpPlusOnesMax: row.rsvp_plus_ones_max ?? 0,
+    rsvpWaitlistEnabled: row.rsvp_waitlist_enabled ?? false,
+    rsvpApprovalMode: row.rsvp_approval_mode ?? "auto",
+    rsvpDiscoverable: row.rsvp_discoverable ?? false,
+    rsvpGoingCount: row.rsvp_going_count ?? 0,
     orders: [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -979,7 +1005,9 @@ export const getPublicEventBySlug = async (
   if (row.event_type === "trip") {
     return null;
   }
-  if (row.event_type !== "event") {
+  // ORCH-1150 — the /e/ public page now renders BOTH ticketed events AND RSVP
+  // events (Going/Not-going). Experiences keep their own /exp/ surface.
+  if (row.event_type !== "event" && row.event_type !== "rsvp") {
     return null;
   }
   return detailFromRow(row);
@@ -1001,7 +1029,10 @@ export const getPublicEventById = async (
   if (row.event_type === "trip") {
     return null;
   }
-  return row.event_type === "event" ? detailFromRow(row) : null;
+  // ORCH-1150 — admit RSVP rows (Going/Not-going page) alongside ticketed events.
+  return row.event_type === "event" || row.event_type === "rsvp"
+    ? detailFromRow(row)
+    : null;
 };
 
 // Exported for the ORCH-1076 regression test (buyer-supply readiness drop).

--- a/mingla-business/src/services/rsvpApprovals.ts
+++ b/mingla-business/src/services/rsvpApprovals.ts
@@ -1,0 +1,127 @@
+/**
+ * ORCH-1150 — host RSVP approve/deny/remove service callers (A2).
+ *
+ * setRsvpStatus is the SINGLE caller serving Approve ('approved'), Deny
+ * ('denied' from pending) AND Remove ('denied' from approved — the A2-NEW
+ * host-remove). The server disambiguates by the source state; there is no
+ * separate remove RPC. host_bulk_approve_rsvps approves all pending up to cap.
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket path. See SPEC §5.4.
+ */
+
+import { supabase } from "./supabase";
+
+export type RsvpStatusValue = "going" | "not_going" | "waitlisted";
+export type RsvpApprovalValue = "pending" | "approved" | "denied";
+
+export interface RsvpGuest {
+  id: string;
+  eventId: string;
+  userId: string | null;
+  guestName: string;
+  guestEmail: string | null;
+  guestPhone: string | null;
+  rsvpStatus: RsvpStatusValue;
+  approvalStatus: RsvpApprovalValue;
+  plusCount: number;
+  waitlistedAt: string | null;
+  promotedAt: string | null;
+  createdAt: string;
+}
+
+interface RsvpGuestRow {
+  id: string;
+  event_id: string;
+  user_id: string | null;
+  guest_name: string;
+  guest_email: string | null;
+  guest_phone: string | null;
+  rsvp_status: RsvpStatusValue;
+  approval_status: RsvpApprovalValue;
+  plus_count: number;
+  waitlisted_at: string | null;
+  promoted_at: string | null;
+  created_at: string;
+}
+
+const rowToGuest = (r: RsvpGuestRow): RsvpGuest => ({
+  id: r.id,
+  eventId: r.event_id,
+  userId: r.user_id,
+  guestName: r.guest_name,
+  guestEmail: r.guest_email,
+  guestPhone: r.guest_phone,
+  rsvpStatus: r.rsvp_status,
+  approvalStatus: r.approval_status,
+  plusCount: r.plus_count,
+  waitlistedAt: r.waitlisted_at,
+  promotedAt: r.promoted_at,
+  createdAt: r.created_at,
+});
+
+export const listRsvpGuests = async (eventId: string): Promise<RsvpGuest[]> => {
+  const { data, error } = await supabase.rpc("host_list_rsvp_guests", {
+    p_event_id: eventId,
+  });
+  if (error !== null) throw error;
+  const rows = (data ?? []) as RsvpGuestRow[];
+  return rows.map(rowToGuest);
+};
+
+export interface SetRsvpStatusResult {
+  ok: boolean;
+  rsvpId: string;
+  approvalStatus: RsvpApprovalValue;
+  wasRemoved: boolean;
+  pendingCountRemaining: number;
+  goingCountRemaining: number;
+}
+
+export const setRsvpStatus = async (
+  rsvpId: string,
+  status: "approved" | "denied",
+): Promise<SetRsvpStatusResult> => {
+  const { data, error } = await supabase.rpc("host_set_rsvp_status", {
+    p_rsvp_id: rsvpId,
+    p_status: status,
+  });
+  if (error !== null) throw error;
+  const res = (data ?? {}) as {
+    ok?: boolean;
+    rsvpId?: string;
+    approvalStatus?: RsvpApprovalValue;
+    wasRemoved?: boolean;
+    pendingCountRemaining?: number;
+    goingCountRemaining?: number;
+  };
+  return {
+    ok: res.ok ?? false,
+    rsvpId: res.rsvpId ?? rsvpId,
+    approvalStatus: res.approvalStatus ?? status,
+    wasRemoved: res.wasRemoved ?? false,
+    pendingCountRemaining: res.pendingCountRemaining ?? 0,
+    goingCountRemaining: res.goingCountRemaining ?? 0,
+  };
+};
+
+export interface BulkApproveResult {
+  approvedCount: number;
+  skippedForCapacity: number;
+}
+
+export const bulkApproveRsvps = async (
+  eventId: string,
+): Promise<BulkApproveResult> => {
+  const { data, error } = await supabase.rpc("host_bulk_approve_rsvps", {
+    p_event_id: eventId,
+  });
+  if (error !== null) throw error;
+  const res = (data ?? {}) as {
+    approvedCount?: number;
+    skippedForCapacity?: number;
+  };
+  return {
+    approvedCount: res.approvedCount ?? 0,
+    skippedForCapacity: res.skippedForCapacity ?? 0,
+  };
+};

--- a/mingla-business/src/services/rsvpErrorCodes.ts
+++ b/mingla-business/src/services/rsvpErrorCodes.ts
@@ -1,0 +1,39 @@
+/**
+ * ORCH-1150 — pure RSVP error-code parsing (no RN / no supabase import).
+ *
+ * supabase.functions.invoke surfaces a non-2xx from the public-submit-rsvp edge
+ * fn as a FunctionsHttpError whose `context.body` carries the `{ error }` code.
+ * The public page maps that code to an inline message (rsvp_contact_required /
+ * rsvp_phone_invalid / rsvp_full / rsvp_not_open). Extracted so it's unit-testable
+ * without importing the react-native supabase client. See SPEC §6 / §5.3.
+ */
+
+export interface RsvpInvokeError {
+  message?: string;
+  context?: { body?: unknown };
+}
+
+/**
+ * Resolve the canonical RSVP error code from a functions-invoke error. Prefers
+ * the `{ error }` code embedded in the response body (string or already-parsed
+ * object); falls back to `error.message`; then to "rsvp_write_failed".
+ */
+export const parseRsvpErrorCode = (error: RsvpInvokeError | null): string => {
+  if (error === null) return "rsvp_write_failed";
+  let code = error.message ?? "rsvp_write_failed";
+  const body = error.context?.body;
+  if (body !== undefined && body !== null) {
+    try {
+      const parsed =
+        typeof body === "string"
+          ? (JSON.parse(body) as { error?: string })
+          : (body as { error?: string });
+      if (typeof parsed.error === "string" && parsed.error.length > 0) {
+        code = parsed.error;
+      }
+    } catch {
+      // malformed body → keep the message/default code
+    }
+  }
+  return code;
+};

--- a/mingla-business/src/services/rsvpEvents.ts
+++ b/mingla-business/src/services/rsvpEvents.ts
@@ -2,7 +2,7 @@
  * ORCH-1150 — RSVP event service callers.
  *
  * Forked from businessEvents.publishBusinessEventDraft. RSVP NEVER routes
- * through business_publish_event_draft (I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC):
+ * through the EVENT publish RPC (I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC):
  *   - publishRsvpDraft → business_publish_rsvp_draft
  *   - updateLiveRsvp   → biz_update_live_rsvp
  *
@@ -10,6 +10,7 @@
  */
 
 import { supabase } from "./supabase";
+import { parseRsvpErrorCode, type RsvpInvokeError } from "./rsvpErrorCodes";
 import {
   eventFromPublishResponse,
   type PublishedBusinessEvent,
@@ -25,7 +26,7 @@ export const publishRsvpDraft = async (
 ): Promise<PublishedBusinessEvent> => {
   const payload = draftToServerUpdate(draft, {});
   // I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC: this MUST call the RSVP publish RPC,
-  // never business_publish_event_draft (that would re-introduce the
+  // never the EVENT publish RPC (that would re-introduce the
   // event_ticket_required 0-ticket block).
   const { data, error } = await supabase.rpc("business_publish_rsvp_draft", {
     p_event_id: draft.id,
@@ -82,5 +83,57 @@ export const updateLiveRsvp = async (
     reason: res.reason,
     goingCount: res.going_count,
     notifiedCount: res.notified_count,
+  };
+};
+
+// ===========================================================================
+// ORCH-1150 — public guest RSVP write (Going / Not-going) via the anon-capable
+// public-submit-rsvp edge fn. Used by the public /e/ page + the consumer deck
+// card. NEVER navigates to /checkout — this writes an RSVP row, not an order.
+// A logged-in user's JWT rides the supabase client (Authorization header) so
+// the edge fn resolves user_id and the logged-in path applies. See SPEC §6 / §5.3.
+// ===========================================================================
+
+export interface SubmitPublicRsvpInput {
+  eventId: string;
+  rsvpStatus: "going" | "not_going";
+  /** Required for an anon link guest; ignored for a logged-in app user. */
+  guestName?: string;
+  guestEmail?: string;
+  guestPhone?: string;
+  plusCount?: number;
+}
+
+export interface SubmitPublicRsvpResult {
+  status: "going" | "not_going" | "waitlisted";
+  approvalStatus: "pending" | "approved";
+}
+
+export const submitPublicRsvp = async (
+  input: SubmitPublicRsvpInput,
+): Promise<SubmitPublicRsvpResult> => {
+  const { data, error } = await supabase.functions.invoke("public-submit-rsvp", {
+    body: {
+      eventId: input.eventId,
+      rsvpStatus: input.rsvpStatus,
+      guestName: input.guestName,
+      guestEmail: input.guestEmail,
+      guestPhone: input.guestPhone,
+      plusCount: input.plusCount ?? 0,
+    },
+  });
+  // supabase.functions.invoke surfaces a non-2xx as a FunctionsHttpError whose
+  // context.body carries the { error } code — bubble the code so the UI can
+  // show the right inline message (rsvp_contact_required / rsvp_full / …).
+  if (error !== null) {
+    throw new Error(parseRsvpErrorCode(error as RsvpInvokeError));
+  }
+  const res = (data ?? {}) as {
+    status?: "going" | "not_going" | "waitlisted";
+    approvalStatus?: "pending" | "approved";
+  };
+  return {
+    status: res.status ?? input.rsvpStatus,
+    approvalStatus: res.approvalStatus ?? "approved",
   };
 };

--- a/mingla-business/src/services/rsvpEvents.ts
+++ b/mingla-business/src/services/rsvpEvents.ts
@@ -1,0 +1,86 @@
+/**
+ * ORCH-1150 — RSVP event service callers.
+ *
+ * Forked from businessEvents.publishBusinessEventDraft. RSVP NEVER routes
+ * through business_publish_event_draft (I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC):
+ *   - publishRsvpDraft → business_publish_rsvp_draft
+ *   - updateLiveRsvp   → biz_update_live_rsvp
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket service path. See SPEC §5.1.
+ */
+
+import { supabase } from "./supabase";
+import {
+  eventFromPublishResponse,
+  type PublishedBusinessEvent,
+  type PublishRpcResponse,
+} from "./businessEvents";
+import { draftToServerUpdate, publishedVisibilityForDraft } from "../utils/serverDraftEventMapper";
+import { logAppsFlyerEvent } from "./appsFlyerService";
+import type { DraftEvent } from "../store/draftEventStore";
+
+export const publishRsvpDraft = async (
+  draft: DraftEvent,
+  clientRevision: number | null = draft.clientRevision ?? null,
+): Promise<PublishedBusinessEvent> => {
+  const payload = draftToServerUpdate(draft, {});
+  // I-PROPOSED-1150-RSVP-OWN-PUBLISH-RPC: this MUST call the RSVP publish RPC,
+  // never business_publish_event_draft (that would re-introduce the
+  // event_ticket_required 0-ticket block).
+  const { data, error } = await supabase.rpc("business_publish_rsvp_draft", {
+    p_event_id: draft.id,
+    p_draft_payload: {
+      ...payload,
+      visibility: publishedVisibilityForDraft(draft.visibility),
+    },
+    p_client_revision: clientRevision,
+  });
+
+  if (error !== null) throw error;
+  const response = data as PublishRpcResponse | null;
+  if (response === null) {
+    throw new Error("RSVP publish did not return a durable event.");
+  }
+  if (response.event.slug.startsWith("draft-")) {
+    throw new Error("RSVP publish returned a draft placeholder slug.");
+  }
+
+  logAppsFlyerEvent("mingla_rsvp_published", {
+    event_id: response.event.id,
+    brand_id: response.brand.id,
+  });
+
+  return eventFromPublishResponse(response);
+};
+
+export interface UpdateLiveRsvpResult {
+  ok: boolean;
+  reason?: string;
+  goingCount?: number;
+  notifiedCount?: number;
+}
+
+export const updateLiveRsvp = async (
+  eventId: string,
+  payload: Record<string, unknown>,
+  reason: string,
+): Promise<UpdateLiveRsvpResult> => {
+  const { data, error } = await supabase.rpc("biz_update_live_rsvp", {
+    p_event_id: eventId,
+    p_payload: payload,
+    p_reason: reason,
+  });
+  if (error !== null) throw error;
+  const res = (data ?? {}) as {
+    ok?: boolean;
+    reason?: string;
+    going_count?: number;
+    notified_count?: number;
+  };
+  return {
+    ok: res.ok ?? false,
+    reason: res.reason,
+    goingCount: res.going_count,
+    notifiedCount: res.notified_count,
+  };
+};

--- a/mingla-business/src/store/draftEventStore.ts
+++ b/mingla-business/src/store/draftEventStore.ts
@@ -347,6 +347,23 @@ export interface DraftEvent {
   themeOverrides?: ThemeInput | null;
   /** Cycle 10: hide guest count from buyer-side surfaces. I-26 — operator-only flag; no buyer surface honors this in Cycle 10. */
   privateGuestList: boolean;
+  // ORCH-1150 — RSVP event fields (additive; inert when isRsvp=false). The
+  // ticketed-event path never reads these. See SPEC §4.6.
+  /** ORCH-1150 — true when this draft is an RSVP event (routes to the RSVP
+   *  wizard + business_publish_rsvp_draft). Absent/false = ticketed event. */
+  isRsvp: boolean;
+  /** ORCH-1150 — optional guest cap; null = unlimited. */
+  rsvpCapacity: number | null;
+  /** ORCH-1150 — host allows guests to bring +N. */
+  rsvpAllowPlusOnes: boolean;
+  /** ORCH-1150 — max extra guests per RSVP when plus-ones allowed; 0 when off. */
+  rsvpPlusOnesMax: number;
+  /** ORCH-1150 — start a waitlist when capacity is hit. */
+  rsvpWaitlistEnabled: boolean;
+  /** ORCH-1150 — auto-approve vs approve-each. */
+  rsvpApprovalMode: "auto" | "manual";
+  /** ORCH-1150 — also surface on the consumer discovery feed (default off). */
+  rsvpDiscoverable: boolean;
   /**
    * Cycle 12: when true, /event/{id}/door surface is reachable + "Door Sales"
    * ActionTile appears on Event Detail. Default false; operator opt-in.
@@ -367,6 +384,8 @@ export interface DraftEventState {
   activeDraftId: string | null;
   draftEditMeta: Record<string, DraftEditMeta>;
   createDraft: (brandId: string) => DraftEvent;
+  /** ORCH-1150 — mint an RSVP draft (isRsvp:true, whenMode:"single"). */
+  createRsvpDraft: (brandId: string) => DraftEvent;
   getDraft: (id: string) => DraftEvent | null;
   upsertDraft: (draft: DraftEvent) => void;
   upsertDrafts: (drafts: DraftEvent[]) => void;
@@ -445,6 +464,14 @@ const DEFAULT_DRAFT_FIELDS: Omit<
   themeOverrides: null,
   privateGuestList: false,
   inPersonPaymentsEnabled: false,
+  // ORCH-1150 — RSVP defaults (inert for ticketed events).
+  isRsvp: false,
+  rsvpCapacity: null,
+  rsvpAllowPlusOnes: false,
+  rsvpPlusOnesMax: 0,
+  rsvpWaitlistEnabled: false,
+  rsvpApprovalMode: "auto",
+  rsvpDiscoverable: false,
   lastStepReached: 0,
   status: "draft",
   clientRevision: 0,
@@ -682,6 +709,14 @@ const upgradeV6DraftToV7 = (d: V6DraftEvent): DraftEvent => ({
   coverMediaCreditUrl: null,
   coverMediaAlt: null,
   currency: null,
+  // ORCH-1150 — RSVP defaults backfilled on the legacy v1..v6 chain.
+  isRsvp: false,
+  rsvpCapacity: null,
+  rsvpAllowPlusOnes: false,
+  rsvpPlusOnesMax: 0,
+  rsvpWaitlistEnabled: false,
+  rsvpApprovalMode: "auto",
+  rsvpDiscoverable: false,
 });
 
 const withProviderMetadataDefaults = (draft: DraftEvent): DraftEvent => ({
@@ -691,6 +726,15 @@ const withProviderMetadataDefaults = (draft: DraftEvent): DraftEvent => ({
   coverMediaCredit: draft.coverMediaCredit ?? null,
   coverMediaCreditUrl: draft.coverMediaCreditUrl ?? null,
   coverMediaAlt: draft.coverMediaAlt ?? null,
+  // ORCH-1150 — defensively backfill RSVP defaults so a draft migrated up an
+  // older chain (v1..v10 → eventually here) never carries undefined rsvp fields.
+  isRsvp: draft.isRsvp ?? false,
+  rsvpCapacity: draft.rsvpCapacity ?? null,
+  rsvpAllowPlusOnes: draft.rsvpAllowPlusOnes ?? false,
+  rsvpPlusOnesMax: draft.rsvpPlusOnesMax ?? 0,
+  rsvpWaitlistEnabled: draft.rsvpWaitlistEnabled ?? false,
+  rsvpApprovalMode: draft.rsvpApprovalMode ?? "auto",
+  rsvpDiscoverable: draft.rsvpDiscoverable ?? false,
 });
 
 const persistOptions: PersistOptions<DraftEventState, PersistedState> = {
@@ -703,7 +747,9 @@ const persistOptions: PersistOptions<DraftEventState, PersistedState> = {
   // legacy drafts via smart-infer (date + doorsOpen + endsAt + timezone).
   // Drafts missing any of the four inputs default to endsAtUtc: null —
   // no data loss; wizard recomputes on next commit.
-  version: 11,
+  // ORCH-1150 — v11 → v12 backfills the additive RSVP fields (isRsvp:false +
+  // RSVP defaults) on legacy drafts; all existing drafts are ticketed events.
+  version: 12,
   migrate: (persistedState, version): PersistedState => {
     if (version < 1) {
       return { drafts: [] };
@@ -778,7 +824,10 @@ const persistOptions: PersistOptions<DraftEventState, PersistedState> = {
         drafts: Array<Omit<DraftEvent, "endsAtUtc">>;
       };
       return {
-        drafts: v10.drafts.map((draft): DraftEvent => ({
+        // ORCH-1150 — also backfill the additive RSVP defaults on a v10 store so
+        // a v10 → v12 hydration (which runs only this branch) never lands with
+        // undefined rsvp fields. withProviderMetadataDefaults adds both.
+        drafts: v10.drafts.map((draft): DraftEvent => withProviderMetadataDefaults({
           ...draft,
           endsAtUtc: computeEndsAtUtcWithSmartInfer(
             draft.date,
@@ -786,6 +835,36 @@ const persistOptions: PersistOptions<DraftEventState, PersistedState> = {
             draft.endsAt,
             draft.timezone,
           ),
+        } as DraftEvent)),
+      };
+    }
+    if (version === 11) {
+      // ORCH-1150 — v11 → v12: backfill the additive RSVP fields. Every legacy
+      // draft is a ticketed event → isRsvp:false + RSVP defaults. No data loss.
+      const v11 = persistedState as {
+        drafts: Array<
+          Omit<
+            DraftEvent,
+            | "isRsvp"
+            | "rsvpCapacity"
+            | "rsvpAllowPlusOnes"
+            | "rsvpPlusOnesMax"
+            | "rsvpWaitlistEnabled"
+            | "rsvpApprovalMode"
+            | "rsvpDiscoverable"
+          >
+        >;
+      };
+      return {
+        drafts: v11.drafts.map((d): DraftEvent => ({
+          ...d,
+          isRsvp: false,
+          rsvpCapacity: null,
+          rsvpAllowPlusOnes: false,
+          rsvpPlusOnesMax: 0,
+          rsvpWaitlistEnabled: false,
+          rsvpApprovalMode: "auto",
+          rsvpDiscoverable: false,
         })),
       };
     }
@@ -803,6 +882,19 @@ export const useDraftEventStore = create<DraftEventState>()(
       createDraft: (brandId): DraftEvent => {
         const now = new Date().toISOString();
         const draft = buildDraftEvent(brandId, generateDraftId(), now);
+        set((s) => ({ drafts: [...s.drafts, draft] }));
+        return draft;
+      },
+
+      // ORCH-1150 — RSVP draft: a normal draft flipped to the RSVP discriminator
+      // + forced single-date (the RSVP wizard hides the recurring/multi tabs).
+      createRsvpDraft: (brandId): DraftEvent => {
+        const now = new Date().toISOString();
+        const draft: DraftEvent = {
+          ...buildDraftEvent(brandId, generateDraftId(), now),
+          isRsvp: true,
+          whenMode: "single",
+        };
         set((s) => ({ drafts: [...s.drafts, draft] }));
         return draft;
       },

--- a/mingla-business/src/store/liveEventStore.ts
+++ b/mingla-business/src/store/liveEventStore.ts
@@ -172,7 +172,25 @@ export interface LiveEvent {
    * 'event' by routeForEventRowDefensive — safe default for legacy
    * stored rows.
    */
-  event_type?: "event" | "experience" | "trip";
+  event_type?: "event" | "experience" | "trip" | "rsvp";
+  /**
+   * ORCH-1150 — RSVP host-control snapshot (present only on event_type='rsvp'
+   * rows; optional on the type for back-compat with every non-RSVP LiveEvent).
+   * The liveEventToEditableDraft adapter projects these into the DraftEvent view
+   * so the RSVP edit-published screen hydrates the host-control toggles.
+   */
+  rsvpCapacity?: number | null;
+  rsvpAllowPlusOnes?: boolean;
+  rsvpPlusOnesMax?: number;
+  rsvpWaitlistEnabled?: boolean;
+  rsvpApprovalMode?: "auto" | "manual";
+  rsvpDiscoverable?: boolean;
+  /**
+   * ORCH-1150 — live confirmed-attending headcount (each going+approved guest
+   * plus their plus_count), surfaced by business_public_events_view. 0 for
+   * non-RSVP rows. Drives the public-page capacity-full state + Hub "N going".
+   */
+  rsvpGoingCount?: number;
   // Content snapshot (frozen from DraftEvent at publish)
   name: string;
   description: string;

--- a/mingla-business/src/utils/__tests__/draftRsvpValidation.orch1150.test.ts
+++ b/mingla-business/src/utils/__tests__/draftRsvpValidation.orch1150.test.ts
@@ -1,0 +1,58 @@
+/**
+ * ORCH-1150 — implementor happy-path regression test for the RSVP validator.
+ *
+ * Proves: (a) party-type is STILL required for RSVP Basics (steering #2 — not
+ * silently dropped); (b) the RSVP-setup step has NO ≥1 requirement (steering #3
+ * — unlike validateTickets); (c) freeform location is accepted (no city gate).
+ *
+ * Fails-on-revert: removing the `validateBasics(draft)` call from case 0 (so
+ * the party-type gate is dropped) makes the first test FAIL.
+ */
+
+import { buildDraftEvent, type DraftEvent } from "../../store/draftEventStore";
+import { validateRsvpStep, validateRsvpPublish } from "../draftRsvpValidation";
+
+const baseRsvp = (over: Partial<DraftEvent> = {}): DraftEvent => ({
+  ...buildDraftEvent("brand_1", "d_test"),
+  isRsvp: true,
+  name: "House party",
+  description: "Come through, it's gonna be a vibe.",
+  partyTypes: ["house-party"],
+  format: "in_person",
+  venueName: "My place",
+  address: "123 Real St",
+  city: null, // freeform — NO structured city; must NOT block
+  date: "2099-12-31",
+  doorsOpen: "19:00",
+  endsAt: "23:00",
+  ...over,
+});
+
+describe("ORCH-1150 — RSVP validator", () => {
+  it("KEEPS the party-type gate on Basics (steering #2)", () => {
+    const noParty = baseRsvp({ partyTypes: [] });
+    const errs = validateRsvpStep(0, noParty);
+    expect(errs.some((e) => e.fieldKey === "partyTypes")).toBe(true);
+  });
+
+  it("accepts Basics with a party type", () => {
+    expect(validateRsvpStep(0, baseRsvp())).toHaveLength(0);
+  });
+
+  it("RSVP-setup step has NO required fields (steering #3)", () => {
+    expect(validateRsvpStep(4, baseRsvp())).toHaveLength(0);
+  });
+
+  it("accepts a freeform location (no structured-city gate)", () => {
+    expect(validateRsvpStep(2, baseRsvp({ city: null }))).toHaveLength(0);
+  });
+
+  it("a complete RSVP draft publishes clean (no ticket/stripe gate)", () => {
+    expect(validateRsvpPublish(baseRsvp())).toHaveLength(0);
+  });
+
+  it("blocks a past date in When", () => {
+    const past = baseRsvp({ date: "2000-01-01" });
+    expect(validateRsvpStep(1, past).some((e) => e.fieldKey === "date")).toBe(true);
+  });
+});

--- a/mingla-business/src/utils/__tests__/rsvpHubMetrics.orch1150.test.ts
+++ b/mingla-business/src/utils/__tests__/rsvpHubMetrics.orch1150.test.ts
@@ -1,0 +1,50 @@
+/**
+ * ORCH-1150 Step 11 — Hub RSVP "N going" metric (regression).
+ *
+ * The Hub event list-card shows "N going" for an RSVP event instead of revenue.
+ * The count must include each guest's plus_count (a +2 guest is 3 toward the
+ * cap), and the label must respect capacity + draft state.
+ *
+ * Fails-on-revert: dropping the `+ (r.plus_count ?? 0)` term (so plus-ones stop
+ * counting) makes the plus-count assertion FAIL.
+ */
+
+import {
+  sumRsvpGoingCount,
+  formatRsvpGoingLabel,
+} from "../rsvpHubMetrics";
+
+describe("ORCH-1150 §8 step 11 — Hub RSVP going metric", () => {
+  it("counts each guest PLUS their plus_count", () => {
+    // guest A solo (1), guest B +2 (3), guest C +0 (1) → 5 going.
+    expect(
+      sumRsvpGoingCount([
+        { plus_count: 0 },
+        { plus_count: 2 },
+        { plus_count: null },
+      ]),
+    ).toBe(5);
+  });
+
+  it("is 0 for an empty guest list", () => {
+    expect(sumRsvpGoingCount([])).toBe(0);
+  });
+
+  it("shows 'N going' when capacity is unlimited", () => {
+    expect(
+      formatRsvpGoingLabel({ kind: "live", goingCount: 7, capacity: null }),
+    ).toBe("7 going");
+  });
+
+  it("shows 'N / cap going' when capacity is finite", () => {
+    expect(
+      formatRsvpGoingLabel({ kind: "live", goingCount: 7, capacity: 20 }),
+    ).toBe("7 / 20 going");
+  });
+
+  it("shows 'Not published' for a draft (no RSVPs yet)", () => {
+    expect(
+      formatRsvpGoingLabel({ kind: "draft", goingCount: 0, capacity: 10 }),
+    ).toBe("Not published");
+  });
+});

--- a/mingla-business/src/utils/__tests__/rsvpHubMetrics.orch1150.test.ts
+++ b/mingla-business/src/utils/__tests__/rsvpHubMetrics.orch1150.test.ts
@@ -12,6 +12,7 @@
 import {
   sumRsvpGoingCount,
   formatRsvpGoingLabel,
+  rsvpEditNoticeCopy,
 } from "../rsvpHubMetrics";
 
 describe("ORCH-1150 §8 step 11 — Hub RSVP going metric", () => {
@@ -46,5 +47,23 @@ describe("ORCH-1150 §8 step 11 — Hub RSVP going metric", () => {
     expect(
       formatRsvpGoingLabel({ kind: "draft", goingCount: 0, capacity: 10 }),
     ).toBe("Not published");
+  });
+});
+
+describe("ORCH-1150 §12 — RSVP edit-published notice", () => {
+  it("pluralizes for >1 going and promises notification", () => {
+    const copy = rsvpEditNoticeCopy(3);
+    expect(copy).toContain("3 guests are going");
+    expect(copy).toContain("they'll be notified");
+  });
+
+  it("uses singular for exactly 1 going", () => {
+    expect(rsvpEditNoticeCopy(1)).toContain("1 guest is going");
+  });
+
+  it("falls back to a generic promise when nobody's going yet", () => {
+    expect(rsvpEditNoticeCopy(0)).toBe(
+      "Guests who RSVP will be notified if you change the date, time, or place.",
+    );
   });
 });

--- a/mingla-business/src/utils/draftEventValidation.ts
+++ b/mingla-business/src/utils/draftEventValidation.ts
@@ -103,7 +103,10 @@ export const validatePublish = (
   return errors;
 };
 
-const validateBasics = (d: DraftEvent): ValidationError[] => {
+// ORCH-1150: exported so the forked RSVP validator (draftRsvpValidation.ts)
+// reuses the SAME party-type gate (steering #2 — KEEP Party Type for RSVP).
+// This is the ONLY change to this file; the event path is byte-identical.
+export const validateBasics = (d: DraftEvent): ValidationError[] => {
   const errs: ValidationError[] = [];
   if (d.name.trim().length === 0) {
     errs.push({ fieldKey: "name", step: 0, message: "Event name is required." });

--- a/mingla-business/src/utils/draftRsvpValidation.ts
+++ b/mingla-business/src/utils/draftRsvpValidation.ts
@@ -1,0 +1,127 @@
+/**
+ * ORCH-1150 — RSVP-event validator (forked from draftEventValidation).
+ *
+ * Do NOT reuse validateTickets / validatePublish — they block at 0 tickets and
+ * loop the Tickets step. An RSVP has ZERO tickets + NO money gate. This fork:
+ *   - reuses the EXISTING validateBasics (keeps the party-type gate, steering #2)
+ *   - single-date When only (steering #4 — no recurring/multi_date)
+ *   - Where requires venue+address but NOT a structured city (freeform location)
+ *   - RSVP-setup + Cover + Preview have no required fields
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket validator — RSVP has zero
+ * tickets + no Stripe gate. See SPEC §4.7.
+ */
+
+import type { DraftEvent } from "../store/draftEventStore";
+import { validateBasics, type ValidationError } from "./draftEventValidation";
+
+const startOfToday = (): Date => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const parseDateString = (iso: string): Date => {
+  const parts = iso.split("-");
+  if (parts.length !== 3) return new Date(iso);
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+  return new Date(year, month - 1, day, 0, 0, 0, 0);
+};
+
+const isValidUrl = (raw: string): boolean => {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return false;
+  const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const u = new URL(candidate);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+    if (u.hostname.length === 0) return false;
+    if (!u.hostname.includes(".")) return false;
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Single-date only (steering #4). Mirrors validateWhenSingle. */
+const validateRsvpWhen = (d: DraftEvent): ValidationError[] => {
+  const errs: ValidationError[] = [];
+  if (d.date === null) {
+    errs.push({ fieldKey: "date", step: 1, message: "Set the event date." });
+  } else if (parseDateString(d.date) < startOfToday()) {
+    errs.push({ fieldKey: "date", step: 1, message: "Date can't be in the past." });
+  }
+  if (d.doorsOpen === null) {
+    errs.push({ fieldKey: "doorsOpen", step: 1, message: "Set the start time." });
+  }
+  if (d.endsAt === null) {
+    errs.push({ fieldKey: "endsAt", step: 1, message: "Set the end time." });
+  }
+  return errs;
+};
+
+/**
+ * Where — venue + address required for in_person/hybrid (NO structured-city
+ * gate; freeform location is accepted for a house party). Online URL rule kept.
+ */
+const validateRsvpWhere = (d: DraftEvent): ValidationError[] => {
+  const errs: ValidationError[] = [];
+  if (d.format === "in_person" || d.format === "hybrid") {
+    if (d.venueName === null || d.venueName.trim().length === 0) {
+      errs.push({ fieldKey: "venueName", step: 2, message: "Add a venue name." });
+    }
+    if (d.address === null || d.address.trim().length === 0) {
+      errs.push({ fieldKey: "address", step: 2, message: "Add the location." });
+    }
+    // NO city_required — RSVP accepts freeform text (steering / walkthrough §3).
+  }
+  if (d.format === "online" || d.format === "hybrid") {
+    if (d.onlineUrl === null || d.onlineUrl.trim().length === 0) {
+      errs.push({
+        fieldKey: "onlineUrl",
+        step: 2,
+        message: "Add the online conferencing link.",
+      });
+    } else if (!isValidUrl(d.onlineUrl)) {
+      errs.push({
+        fieldKey: "onlineUrl",
+        step: 2,
+        message: "Enter a valid link (e.g. https://zoom.us/j/123).",
+      });
+    }
+  }
+  return errs;
+};
+
+export const validateRsvpStep = (
+  step: number,
+  draft: DraftEvent,
+): ValidationError[] => {
+  switch (step) {
+    case 0:
+      return validateBasics(draft); // KEEP party-type gate (steering #2)
+    case 1:
+      return validateRsvpWhen(draft); // single-mode only
+    case 2:
+      return validateRsvpWhere(draft); // venue+address, NO structured-city gate
+    case 3:
+      return []; // Cover — no rules
+    case 4:
+      return []; // RSVP setup — no ≥1 requirement (steering #3)
+    case 5:
+      return []; // Preview
+    default:
+      return [];
+  }
+};
+
+export const validateRsvpPublish = (draft: DraftEvent): ValidationError[] => {
+  const errors: ValidationError[] = [];
+  for (let step = 0; step <= 4; step++) {
+    errors.push(...validateRsvpStep(step, draft));
+  }
+  // NO stripe/paid cross-step gate (RSVP is moneyless).
+  return errors;
+};

--- a/mingla-business/src/utils/liveEventAdapter.ts
+++ b/mingla-business/src/utils/liveEventAdapter.ts
@@ -91,6 +91,16 @@ export const liveEventToEditableDraft = (e: LiveEvent): DraftEvent => ({
   themeOverrides: e.themeOverrides ?? null,
   privateGuestList: e.privateGuestList,
   inPersonPaymentsEnabled: e.inPersonPaymentsEnabled,
+  // ORCH-1150 — project the RSVP host-control snapshot into the editable
+  // DraftEvent view. Non-RSVP LiveEvents lack these → defaults (inert when
+  // isRsvp=false). The RSVP edit-published screen reads them via this view.
+  isRsvp: e.event_type === "rsvp",
+  rsvpCapacity: e.rsvpCapacity ?? null,
+  rsvpAllowPlusOnes: e.rsvpAllowPlusOnes ?? false,
+  rsvpPlusOnesMax: e.rsvpPlusOnesMax ?? 0,
+  rsvpWaitlistEnabled: e.rsvpWaitlistEnabled ?? false,
+  rsvpApprovalMode: e.rsvpApprovalMode ?? "auto",
+  rsvpDiscoverable: e.rsvpDiscoverable ?? false,
   // ORCH-1006 — pricing switches; legacy events predate the field → all-inherit.
   pricingSwitches: e.pricingSwitches ?? {
     passTax: null,

--- a/mingla-business/src/utils/rsvpHubMetrics.ts
+++ b/mingla-business/src/utils/rsvpHubMetrics.ts
@@ -6,6 +6,15 @@
  * math are unit-testable without the react-native render chain. See SPEC §8 step 11.
  */
 
+/**
+ * ORCH-1150 Step 12 — the RSVP edit-published "they'll be notified" notice copy.
+ * Pure so it's testable without the RN render. SPEC §12.
+ */
+export const rsvpEditNoticeCopy = (goingCount: number): string =>
+  goingCount > 0
+    ? `${goingCount} ${goingCount === 1 ? "guest is" : "guests are"} going — they'll be notified if you change the date, time, or place.`
+    : "Guests who RSVP will be notified if you change the date, time, or place.";
+
 /** Sum each going+approved guest plus their plus_count (the §4.1c cap formula). */
 export const sumRsvpGoingCount = (
   rows: ReadonlyArray<{ plus_count: number | null }>,

--- a/mingla-business/src/utils/rsvpHubMetrics.ts
+++ b/mingla-business/src/utils/rsvpHubMetrics.ts
@@ -1,0 +1,28 @@
+/**
+ * ORCH-1150 — pure Hub RSVP metric formatting (no RN import).
+ *
+ * The Hub event list-card + manage-sheet render "N going" for an RSVP event
+ * instead of revenue/tickets-sold (Step 11). Extracted so the label + count
+ * math are unit-testable without the react-native render chain. See SPEC §8 step 11.
+ */
+
+/** Sum each going+approved guest plus their plus_count (the §4.1c cap formula). */
+export const sumRsvpGoingCount = (
+  rows: ReadonlyArray<{ plus_count: number | null }>,
+): number => rows.reduce((acc, r) => acc + 1 + (r.plus_count ?? 0), 0);
+
+/**
+ * The Hub "N going" subtext. Draft → "Not published" (nobody can RSVP yet).
+ * A finite capacity shows "N / cap going"; unlimited shows "N going".
+ */
+export const formatRsvpGoingLabel = (input: {
+  kind: "draft" | "live" | "past";
+  goingCount: number;
+  capacity: number | null;
+}): string => {
+  if (input.kind === "draft") return "Not published";
+  if (input.capacity !== null) {
+    return `${input.goingCount} / ${input.capacity} going`;
+  }
+  return `${input.goingCount} going`;
+};

--- a/mingla-business/src/utils/serverDraftEventMapper.ts
+++ b/mingla-business/src/utils/serverDraftEventMapper.ts
@@ -174,6 +174,15 @@ export interface BusinessDraftPayload {
     privateGuestList: boolean;
     inPersonPaymentsEnabled: boolean;
   };
+  // ORCH-1150 — RSVP host-control passthrough (additive; the event publish RPC
+  // never reads these — only business_publish_rsvp_draft does). See SPEC §5.1.
+  isRsvp: boolean;
+  rsvpCapacity: number | null;
+  rsvpAllowPlusOnes: boolean;
+  rsvpPlusOnesMax: number;
+  rsvpWaitlistEnabled: boolean;
+  rsvpApprovalMode: "auto" | "manual";
+  rsvpDiscoverable: boolean;
   lastStepReached: number;
   clientRevision: number;
 }
@@ -325,6 +334,14 @@ const buildBusinessDraftPayload = (
     privateGuestList: draft.privateGuestList,
     inPersonPaymentsEnabled: draft.inPersonPaymentsEnabled,
   },
+  // ORCH-1150 — RSVP host-control passthrough.
+  isRsvp: draft.isRsvp,
+  rsvpCapacity: draft.rsvpCapacity,
+  rsvpAllowPlusOnes: draft.rsvpAllowPlusOnes,
+  rsvpPlusOnesMax: draft.rsvpPlusOnesMax,
+  rsvpWaitlistEnabled: draft.rsvpWaitlistEnabled,
+  rsvpApprovalMode: draft.rsvpApprovalMode,
+  rsvpDiscoverable: draft.rsvpDiscoverable,
   lastStepReached: draft.lastStepReached,
   clientRevision,
 });
@@ -583,6 +600,20 @@ export const serverRowToDraft = (row: ServerDraftEventRow): DraftEvent => {
     passwordProtected: asBoolean(settings.passwordProtected, false),
     privateGuestList: asBoolean(settings.privateGuestList, false),
     inPersonPaymentsEnabled: asBoolean(settings.inPersonPaymentsEnabled, false),
+    // ORCH-1150 — RSVP host-control round-trip from business_draft. Defaults
+    // keep ticketed drafts byte-identical (isRsvp:false). See SPEC §4.6.
+    isRsvp: asBoolean(businessDraft.isRsvp, false),
+    rsvpCapacity:
+      typeof businessDraft.rsvpCapacity === "number" &&
+      Number.isFinite(businessDraft.rsvpCapacity)
+        ? businessDraft.rsvpCapacity
+        : null,
+    rsvpAllowPlusOnes: asBoolean(businessDraft.rsvpAllowPlusOnes, false),
+    rsvpPlusOnesMax: asNumber(businessDraft.rsvpPlusOnesMax, 0),
+    rsvpWaitlistEnabled: asBoolean(businessDraft.rsvpWaitlistEnabled, false),
+    rsvpApprovalMode:
+      businessDraft.rsvpApprovalMode === "manual" ? "manual" : "auto",
+    rsvpDiscoverable: asBoolean(businessDraft.rsvpDiscoverable, false),
     lastStepReached: asNumber(businessDraft.lastStepReached, 0),
     status: "draft",
     clientRevision: asNumber(businessDraft.clientRevision, 0),

--- a/packages/event-rendering/index.ts
+++ b/packages/event-rendering/index.ts
@@ -77,11 +77,17 @@ export {
   ticketSaleEnded,
   ticketIsSoldOut,
   ticketIsDoorOnly,
+  // ORCH-1150 — RSVP Going/Not-going CTA machine (money-free).
+  resolveRsvpCta,
 } from "./offeringCta";
 export type {
   CtaState,
   OfferingVariant,
   ResolveOfferingCtaInput,
+  // ORCH-1150
+  RsvpCtaState,
+  RsvpCtaDescriptor,
+  ResolveRsvpCtaInput,
 } from "./offeringCta";
 export type {
   PublicEventProps,

--- a/packages/event-rendering/offeringCta.ts
+++ b/packages/event-rendering/offeringCta.ts
@@ -263,6 +263,73 @@ export const resolveOfferingCta = (
   };
 };
 
+// ===========================================================================
+// ORCH-1150 — RSVP CTA machine (Going / Not-going), money-free.
+// do NOT merge back into the ticket/checkout path — RSVP has zero tickets +
+// no money gate. See SPEC §6.
+// ===========================================================================
+
+/**
+ * The guest's own resolvable RSVP state on this event (when known), plus the
+ * event-level capacity posture. Drives which Going/Not-going affordance renders.
+ */
+export type RsvpCtaState =
+  | "open" // Going / Not going both active
+  | "full" // capacity hit, waitlist OFF, auto mode → Going disabled
+  | "waitlist" // capacity hit, waitlist ON → tapping Going joins the waitlist
+  | "pending" // manual approval, guest already RSVP'd → "Awaiting host approval"
+  | "going" // guest's own current confirmed state
+  | "not_going"; // guest's own current declined state
+
+export interface ResolveRsvpCtaInput {
+  /** Event-level posture: is the cap full of confirmed-attending guests? */
+  capacityFull: boolean;
+  /** events.rsvp_waitlist_enabled. */
+  waitlistEnabled: boolean;
+  /** events.rsvp_approval_mode === 'manual'. */
+  manualApproval: boolean;
+  /** The guest's own current row state, when resolvable (else null). */
+  guestStatus?: "going" | "not_going" | "waitlisted" | null;
+  guestApproval?: "pending" | "approved" | "denied" | null;
+}
+
+export interface RsvpCtaDescriptor {
+  kind: "rsvp";
+  state: RsvpCtaState;
+}
+
+/**
+ * Resolve the RSVP CTA descriptor. Precedence:
+ *   guest already pending          → pending
+ *   guest already going+approved   → going
+ *   guest already not_going        → not_going
+ *   guest already waitlisted       → waitlist
+ *   cap full + waitlist on         → waitlist
+ *   cap full + waitlist off + auto → full
+ *   else                           → open
+ */
+export const resolveRsvpCta = (input: ResolveRsvpCtaInput): RsvpCtaDescriptor => {
+  const { capacityFull, waitlistEnabled, manualApproval, guestStatus, guestApproval } = input;
+
+  if (guestStatus != null) {
+    if (guestApproval === "pending") return { kind: "rsvp", state: "pending" };
+    if (guestStatus === "waitlisted") return { kind: "rsvp", state: "waitlist" };
+    if (guestStatus === "going" && guestApproval === "approved") {
+      return { kind: "rsvp", state: "going" };
+    }
+    if (guestStatus === "not_going") return { kind: "rsvp", state: "not_going" };
+  }
+
+  if (capacityFull) {
+    if (waitlistEnabled) return { kind: "rsvp", state: "waitlist" };
+    // manual mode never hard-blocks at submit (pending doesn't occupy the cap);
+    // only auto-mode-without-waitlist shows the hard "full" state.
+    if (!manualApproval) return { kind: "rsvp", state: "full" };
+  }
+
+  return { kind: "rsvp", state: "open" };
+};
+
 /** Lowest numeric all-in price among paid tickets, formatted, or null. */
 const lowestPriceString = (
   tickets: PublicTicketProps[],

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -207,3 +207,16 @@ verify_jwt = true
 # authenticates the producer itself by matching the service-role bearer.
 [functions.notify-support]
 verify_jwt = false
+
+# ORCH-1150 — public-submit-rsvp is the anon-capable guest RSVP write (Going/
+# Not-going) for event_type=rsvp events. Public route (verify_jwt=false): the
+# /e/ public page + the consumer deck call it. It runs under service-role and
+# validates the event is a published RSVP + rate-limits anon writes.
+[functions.public-submit-rsvp]
+verify_jwt = false
+
+# ORCH-1150 — rsvp-notify is the INTERNAL multi-channel transactional fan-out
+# (push + SMS + email) invoked server-to-server with the service-role bearer.
+# It is NOT a public anon route.
+[functions.rsvp-notify]
+verify_jwt = true

--- a/supabase/functions/discover-merged-events/_business-query.ts
+++ b/supabase/functions/discover-merged-events/_business-query.ts
@@ -128,6 +128,10 @@ export function mapRpcRowToCard(row: RpcRow): BusinessEventCard {
     displayCurrency: (row.pricing_currency as string | null) ?? null,
     currency: String(row.currency ?? "GBP"),
     publicBuyerUrl: `${BUSINESS_BUYER_DOMAIN}/e/${brandSlug}/${eventSlug}`,
+    // ORCH-1150 — carry the offering discriminator so the consumer deck renders
+    // Going/Not-going for an RSVP instead of Book. Only opted-in discoverable
+    // RSVP rows reach here (the RPC filters rsvp_discoverable=true).
+    eventType: row.event_type === "rsvp" ? "rsvp" : "event",
   };
 }
 

--- a/supabase/functions/discover-merged-events/_types.ts
+++ b/supabase/functions/discover-merged-events/_types.ts
@@ -32,6 +32,12 @@ export interface BusinessEventCard {
   displayCurrency: string | null;
   currency: string;
   publicBuyerUrl: string;
+  /**
+   * ORCH-1150 — the offering discriminator. 'rsvp' ⇒ a Partiful-style RSVP event
+   * (Going/Not-going, no checkout); the consumer deck renders Going/Not-going
+   * instead of Book. Defaults to 'event' for every legacy/ticketed row.
+   */
+  eventType?: "event" | "rsvp";
 }
 
 export type MergedDiscoverItem =

--- a/supabase/functions/public-submit-rsvp/index.ts
+++ b/supabase/functions/public-submit-rsvp/index.ts
@@ -1,0 +1,200 @@
+/**
+ * ORCH-1150 — public-submit-rsvp
+ *
+ * Anon-capable guest RSVP write for event_type='rsvp' events. verify_jwt=false
+ * (config.toml). Runs under service-role; validates input; calls the
+ * SECURITY DEFINER `submit_event_rsvp` RPC which does the two-dimension
+ * resolve + real waitlist write (SPEC §5.3).
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket checkout path — RSVP has
+ * zero tickets + no money gate; this writes a Going/Not-going row, never an
+ * order. Notify is TRANSACTIONAL (fired by the publish-edit / approve-deny /
+ * auto-promote producers, NOT here).
+ *
+ * A4-NEW: a link guest (no JWT) MUST supply name + email + phone. A logged-in
+ * app-user (JWT resolves a user_id) supplies none of those (profile-inherited).
+ */
+
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+interface SubmitRsvpRequest {
+  eventId?: string;
+  guestName?: string;
+  guestEmail?: string;
+  guestPhone?: string;
+  rsvpStatus?: "going" | "not_going";
+  plusCount?: number;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// E.164-ish: optional +, 7–15 digits.
+const PHONE_RE = /^\+?[0-9]{7,15}$/;
+
+// Naive in-memory per-IP rate limit (best-effort; resets on cold start). The DB
+// unique indexes + the RPC are the real guard; this just blunts burst spam.
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX = 12;
+const ipHits = new Map<string, { count: number; resetAt: number }>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = ipHits.get(ip);
+  if (entry === undefined || now > entry.resetAt) {
+    ipHits.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > RATE_MAX;
+}
+
+function normalizePhone(raw: string): string | null {
+  const trimmed = raw.replace(/[\s()-]/g, "");
+  if (!PHONE_RE.test(trimmed)) return null;
+  return trimmed.startsWith("+") ? trimmed : `+${trimmed}`;
+}
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json(405, { error: "method_not_allowed" });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceKey) {
+    console.error("[public-submit-rsvp] missing SUPABASE_URL / service key");
+    return json(500, { error: "server_misconfigured" });
+  }
+
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  if (rateLimited(ip)) {
+    return json(429, { error: "rate_limited" });
+  }
+
+  let body: SubmitRsvpRequest;
+  try {
+    body = (await req.json()) as SubmitRsvpRequest;
+  } catch {
+    return json(400, { error: "invalid_json" });
+  }
+
+  const eventId = typeof body.eventId === "string" ? body.eventId.trim() : "";
+  const rsvpStatus = body.rsvpStatus;
+  if (eventId.length === 0) {
+    return json(400, { error: "event_id_required" });
+  }
+  if (rsvpStatus !== "going" && rsvpStatus !== "not_going") {
+    return json(400, { error: "rsvp_status_invalid" });
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  // Resolve a logged-in app user from the bearer token, if present.
+  let userId: string | null = null;
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const token = authHeader.toLowerCase().startsWith("bearer ")
+    ? authHeader.slice(7).trim()
+    : "";
+  if (token.length > 0) {
+    try {
+      const { data, error } = await admin.auth.getUser(token);
+      if (!error && data.user) {
+        userId = data.user.id;
+      }
+    } catch (err) {
+      // Non-fatal: fall through as an anon link guest.
+      console.warn("[public-submit-rsvp] token resolve failed", String(err));
+    }
+  }
+
+  const guestName =
+    typeof body.guestName === "string" ? body.guestName.trim() : "";
+  const guestEmail =
+    typeof body.guestEmail === "string" ? body.guestEmail.trim() : "";
+  const rawPhone =
+    typeof body.guestPhone === "string" ? body.guestPhone.trim() : "";
+
+  let normalizedPhone: string | null = null;
+
+  // A4-NEW: link guest (anon) must carry name + email + phone, all valid.
+  if (userId === null) {
+    if (
+      guestName.length === 0 ||
+      guestEmail.length === 0 ||
+      !EMAIL_RE.test(guestEmail) ||
+      rawPhone.length === 0
+    ) {
+      return json(400, { error: "rsvp_contact_required" });
+    }
+    normalizedPhone = normalizePhone(rawPhone);
+    if (normalizedPhone === null) {
+      return json(400, { error: "rsvp_phone_invalid" });
+    }
+  } else if (rawPhone.length > 0) {
+    normalizedPhone = normalizePhone(rawPhone);
+    if (normalizedPhone === null) {
+      return json(400, { error: "rsvp_phone_invalid" });
+    }
+  }
+
+  const plusCount =
+    typeof body.plusCount === "number" && Number.isFinite(body.plusCount)
+      ? Math.max(0, Math.floor(body.plusCount))
+      : 0;
+
+  const { data, error } = await admin.rpc("submit_event_rsvp", {
+    p_event_id: eventId,
+    p_user_id: userId,
+    p_guest_name: guestName.length > 0 ? guestName : null,
+    p_guest_email: guestEmail.length > 0 ? guestEmail : null,
+    p_guest_phone: normalizedPhone,
+    p_rsvp_status: rsvpStatus,
+    p_plus_count: plusCount,
+  });
+
+  if (error !== null) {
+    const code = error.message ?? "";
+    if (code.includes("rsvp_not_open")) return json(404, { error: "rsvp_not_open" });
+    if (code.includes("rsvp_full")) return json(409, { error: "rsvp_full" });
+    if (code.includes("rsvp_contact_required")) {
+      return json(400, { error: "rsvp_contact_required" });
+    }
+    if (code.includes("rsvp_status_invalid")) {
+      return json(400, { error: "rsvp_status_invalid" });
+    }
+    console.error("[public-submit-rsvp] rpc error", code);
+    return json(500, { error: "rsvp_write_failed" });
+  }
+
+  const result = (data ?? {}) as {
+    status?: string;
+    approvalStatus?: string;
+    capacityFull?: boolean;
+  };
+
+  return json(200, {
+    status: result.status ?? rsvpStatus,
+    approvalStatus: result.approvalStatus ?? "approved",
+    capacityFull: result.capacityFull ?? false,
+  });
+});

--- a/supabase/functions/rsvp-notify/fanout.test.ts
+++ b/supabase/functions/rsvp-notify/fanout.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ORCH-1150 §9.5 — I-PROPOSED-1150-RSVP-NOTIFY-MULTICHANNEL-NONBLOCKING.
+ *
+ * The rsvp-notify fan-out attempts EVERY channel for which the guest has a
+ * usable address/token, and a failure in one channel does NOT block the others
+ * or throw; the queue row is `sent` when ≥1 channel succeeds (A4 + A4-NEW-2).
+ *
+ * Fails-on-revert: wrapping all three channels in one try (so the first throw
+ * aborts the rest), OR reverting to a push-only branch for app users, makes
+ * these assertions FAIL.
+ */
+
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import { fanOutChannels } from "./fanout.ts";
+
+Deno.test("(a) per-channel non-blocking: SMS throws, email still sends, queue ends sent", async () => {
+  let emailFired = false;
+  let pushFired = false;
+  const res = await fanOutChannels({
+    push: async () => {
+      pushFired = true;
+      return true;
+    },
+    email: async () => {
+      emailFired = true;
+      return true;
+    },
+    sms: async () => {
+      throw new Error("twilio 500");
+    },
+  });
+  // SMS throwing did not abort push/email.
+  assertEquals(pushFired, true);
+  assertEquals(emailFired, true);
+  assertEquals(res.outcome.push, true);
+  assertEquals(res.outcome.email, true);
+  assertEquals(res.outcome.sms, false);
+  // ≥1 channel succeeded → sent.
+  assertEquals(res.status, "sent");
+});
+
+Deno.test("(b) A4-NEW-2 app-user multi-channel: push AND email AND sms all attempted (not push-only)", async () => {
+  const fired = { push: false, email: false, sms: false };
+  const res = await fanOutChannels({
+    push: async () => {
+      fired.push = true;
+      return true;
+    },
+    email: async () => {
+      fired.email = true;
+      return true;
+    },
+    sms: async () => {
+      fired.sms = true;
+      return true;
+    },
+  });
+  assertEquals(fired.push, true);
+  assertEquals(fired.email, true);
+  assertEquals(fired.sms, true);
+  assertEquals(res.status, "sent");
+});
+
+Deno.test("(c) link guest (no push token) attempts email AND sms only — no crash", async () => {
+  const fired = { email: false, sms: false };
+  const res = await fanOutChannels({
+    push: null, // link guest has no user_id → push skipped
+    email: async () => {
+      fired.email = true;
+      return true;
+    },
+    sms: async () => {
+      fired.sms = true;
+      return true;
+    },
+  });
+  assertEquals(fired.email, true);
+  assertEquals(fired.sms, true);
+  assertEquals(res.outcome.push, false);
+  assertEquals(res.status, "sent");
+});
+
+Deno.test("(d) all attempted channels fail transiently → failed_retryable", async () => {
+  const res = await fanOutChannels({
+    push: null,
+    email: async () => false,
+    sms: async () => false,
+  });
+  assertEquals(res.status, "failed_retryable");
+});
+
+Deno.test("(e) no address/token for any channel → skipped", async () => {
+  const res = await fanOutChannels({ push: null, email: null, sms: null });
+  assertEquals(res.anyAttempted, false);
+  assertEquals(res.status, "skipped");
+});

--- a/supabase/functions/rsvp-notify/fanout.ts
+++ b/supabase/functions/rsvp-notify/fanout.ts
@@ -1,0 +1,65 @@
+/**
+ * ORCH-1150 — pure multi-channel fan-out for rsvp-notify (extracted so the unit
+ * test can import it without booting the edge-fn server).
+ *
+ * do NOT merge back into the ticket-notification path — RSVP notify is
+ * TRANSACTIONAL (the guest's own RSVP action), outside marketing-consent.
+ * See SPEC §5.6 / §9.5.
+ */
+
+export interface ChannelSenders {
+  push: (() => Promise<boolean>) | null; // null = no token (skip)
+  email: (() => Promise<boolean>) | null; // null = no address (skip)
+  sms: (() => Promise<boolean>) | null; // null = no address (skip)
+}
+
+export interface FanOutResult {
+  outcome: { push: boolean; email: boolean; sms: boolean };
+  anyAttempted: boolean;
+  anySucceeded: boolean;
+  status: "sent" | "failed_retryable" | "skipped";
+}
+
+/**
+ * Attempt every channel whose sender is non-null. EACH runs in its OWN
+ * try/catch so one channel throwing NEVER aborts the others (Constitution #3).
+ * status = sent when ≥1 succeeded; failed_retryable when all attempted failed;
+ * skipped when nothing was attempted.
+ */
+export async function fanOutChannels(senders: ChannelSenders): Promise<FanOutResult> {
+  const outcome = { push: false, email: false, sms: false };
+  let anyAttempted = false;
+
+  if (senders.push !== null) {
+    anyAttempted = true;
+    try {
+      outcome.push = await senders.push();
+    } catch (err) {
+      console.warn("[rsvp-notify] push failed (isolated)", String(err));
+    }
+  }
+  if (senders.email !== null) {
+    anyAttempted = true;
+    try {
+      outcome.email = await senders.email();
+    } catch (err) {
+      console.warn("[rsvp-notify] email failed (isolated)", String(err));
+    }
+  }
+  if (senders.sms !== null) {
+    anyAttempted = true;
+    try {
+      outcome.sms = await senders.sms();
+    } catch (err) {
+      console.warn("[rsvp-notify] sms failed (isolated)", String(err));
+    }
+  }
+
+  const anySucceeded = outcome.push || outcome.email || outcome.sms;
+  const status: FanOutResult["status"] = !anyAttempted
+    ? "skipped"
+    : anySucceeded
+      ? "sent"
+      : "failed_retryable";
+  return { outcome, anyAttempted, anySucceeded, status };
+}

--- a/supabase/functions/rsvp-notify/index.ts
+++ b/supabase/functions/rsvp-notify/index.ts
@@ -27,6 +27,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { sendPush } from "../_shared/push-utils.ts";
+import { fanOutChannels } from "./fanout.ts";
 import {
   assertNotResendSandbox,
   EMAIL_SENDERS,
@@ -325,65 +326,54 @@ serve(async (req: Request): Promise<Response> => {
     }
   }
 
-  // 4. Fan out — each channel independent + non-blocking.
-  const outcome: { push: boolean; email: boolean; sms: boolean } = {
-    push: false,
-    email: false,
-    sms: false,
-  };
-  let anyAttempted = false;
-
-  if (userId !== null) {
-    anyAttempted = true;
-    try {
-      outcome.push = await sendPush({
-        targetUserId: userId,
-        title: copy.pushTitle,
-        body: copy.pushBody,
-        app: "consumer",
-        data: { deepLink: link, type: queueRow.template_key },
-      });
-      // In-app inbox row (mirror notify-dispatch); non-blocking.
-      try {
-        await admin.from("notifications").insert({
-          user_id: userId,
-          type: queueRow.template_key,
-          title: copy.pushTitle,
-          body: copy.pushBody,
-          deep_link: link,
-          data: { deepLink: link },
-          brand_id: eventRow.brand_id,
-          related_id: eventRow.id,
-          related_type: "rsvp_event",
-        });
-      } catch (inboxErr) {
-        console.warn("[rsvp-notify] inbox insert failed (non-fatal)", String(inboxErr));
-      }
-    } catch (err) {
-      console.warn("[rsvp-notify] push failed (isolated)", String(err));
-    }
-  }
-
-  if (email !== null && email.length > 0) {
-    anyAttempted = true;
-    const r = await sendResendEmail(email, copy.emailSubject, copy.emailBody);
-    outcome.email = r.ok;
-    if (!r.ok) console.warn("[rsvp-notify] email failed (isolated)", r.error);
-  }
-
-  if (phone !== null && phone.length > 0) {
-    anyAttempted = true;
-    const r = await sendTwilioSms(phone, copy.sms);
-    outcome.sms = r.ok;
-    if (!r.ok) console.warn("[rsvp-notify] sms failed (isolated)", r.error);
-  }
-
-  const anySucceeded = outcome.push || outcome.email || outcome.sms;
-  const nextStatus = !anyAttempted
-    ? "skipped"
-    : anySucceeded
-      ? "sent"
-      : "failed_retryable";
+  // 4. Fan out — each channel independent + non-blocking (via the pure helper).
+  const { outcome, anySucceeded, status: nextStatus } = await fanOutChannels({
+    push:
+      userId !== null
+        ? async (): Promise<boolean> => {
+            const ok = await sendPush({
+              targetUserId: userId,
+              title: copy.pushTitle,
+              body: copy.pushBody,
+              app: "consumer",
+              data: { deepLink: link, type: queueRow.template_key },
+            });
+            // In-app inbox row (mirror notify-dispatch); non-blocking.
+            try {
+              await admin.from("notifications").insert({
+                user_id: userId,
+                type: queueRow.template_key,
+                title: copy.pushTitle,
+                body: copy.pushBody,
+                deep_link: link,
+                data: { deepLink: link },
+                brand_id: eventRow.brand_id,
+                related_id: eventRow.id,
+                related_type: "rsvp_event",
+              });
+            } catch (inboxErr) {
+              console.warn("[rsvp-notify] inbox insert failed (non-fatal)", String(inboxErr));
+            }
+            return ok;
+          }
+        : null,
+    email:
+      email !== null && email.length > 0
+        ? async (): Promise<boolean> => {
+            const r = await sendResendEmail(email!, copy.emailSubject, copy.emailBody);
+            if (!r.ok) console.warn("[rsvp-notify] email failed (isolated)", r.error);
+            return r.ok;
+          }
+        : null,
+    sms:
+      phone !== null && phone.length > 0
+        ? async (): Promise<boolean> => {
+            const r = await sendTwilioSms(phone!, copy.sms);
+            if (!r.ok) console.warn("[rsvp-notify] sms failed (isolated)", r.error);
+            return r.ok;
+          }
+        : null,
+  });
 
   console.log(
     `[rsvp-notify] ${queueRow.template_key} rsvp=${queueRow.rsvp_id} ` +

--- a/supabase/functions/rsvp-notify/index.ts
+++ b/supabase/functions/rsvp-notify/index.ts
@@ -1,0 +1,415 @@
+/**
+ * ORCH-1150 — rsvp-notify
+ *
+ * Multi-channel transactional fan-out for the RSVP notification pipeline.
+ * verify_jwt=true (config.toml) — service-role-invoked only; NOT a public route.
+ *
+ * Given a queue row (`{ notificationId }`) OR `{ eventId, rsvpId, templateKey }`,
+ * it resolves the guest + event, then attempts EVERY channel for which the guest
+ * has a usable address/token (A4-NEW-2 — NOT push-only for app users):
+ *   - push  — if user_id is set (consumer app, via OneSignal external_id)
+ *   - email — guest_email (link guest) OR the app user's verified auth email
+ *   - sms   — guest_phone (link guest) OR a profile phone if present
+ * Each channel is independent + NON-BLOCKING (Constitution #3): a failure in one
+ * never aborts the others or throws. The queue row ends `sent` when ≥1 channel
+ * succeeds, `failed_retryable` if all transiently failed, `failed_terminal` on a
+ * permanent failure, `skipped` when no channel had an address.
+ *
+ * REUSES the three existing clients (do NOT add new providers):
+ *   - sendPush            from _shared/push-utils.ts:95
+ *   - Resend send         cloned from notify-dispatch/index.ts:84-138
+ *   - Twilio send         cloned from ticket-confirmation-dispatch/index.ts:123-170
+ *
+ * ORCH-1150: do NOT merge back into the event/ticket notification path — RSVP
+ * notify is TRANSACTIONAL (the guest's own RSVP action), outside marketing-consent.
+ */
+
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { sendPush } from "../_shared/push-utils.ts";
+import {
+  assertNotResendSandbox,
+  EMAIL_SENDERS,
+  formatSenderHeader,
+  renderTransactionalEmail,
+} from "../_shared/email/index.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+type TemplateKey =
+  | "rsvp_event_updated"
+  | "rsvp_waitlist_promoted"
+  | "rsvp_approved"
+  | "rsvp_denied"
+  | "rsvp_removed";
+
+interface CopyBlock {
+  pushTitle: string;
+  pushBody: string;
+  sms: string;
+  emailSubject: string;
+  emailBody: string;
+}
+
+function buildCopy(
+  template: TemplateKey,
+  ctx: { eventTitle: string; brandName: string; link: string },
+): CopyBlock {
+  const { eventTitle, brandName, link } = ctx;
+  switch (template) {
+    case "rsvp_event_updated":
+      return {
+        pushTitle: `Plans changed: ${eventTitle}`,
+        pushBody: "The host updated this event — tap for details.",
+        sms: `${brandName}: ${eventTitle} was updated. See the latest: ${link}`,
+        emailSubject: `${eventTitle} — updated details`,
+        emailBody: `The host updated ${eventTitle}. See the latest: ${link}`,
+      };
+    case "rsvp_waitlist_promoted":
+      return {
+        pushTitle: `You're in! ${eventTitle}`,
+        pushBody: "A spot opened — you're going.",
+        sms: `${brandName}: a spot opened at ${eventTitle} — you're in! ${link}`,
+        emailSubject: `You're off the waitlist for ${eventTitle}`,
+        emailBody: `Good news — a spot opened and you're now going to ${eventTitle}. ${link}`,
+      };
+    case "rsvp_approved":
+      return {
+        pushTitle: `You're approved: ${eventTitle}`,
+        pushBody: "The host approved your RSVP — see you there.",
+        sms: `${brandName}: you're approved for ${eventTitle}! ${link}`,
+        emailSubject: `You're approved for ${eventTitle}`,
+        emailBody: `The host approved your RSVP for ${eventTitle}. ${link}`,
+      };
+    case "rsvp_denied":
+      return {
+        pushTitle: `RSVP update: ${eventTitle}`,
+        pushBody: "The host couldn't fit your RSVP this time.",
+        sms: `${brandName}: the host couldn't fit your RSVP for ${eventTitle}.`,
+        emailSubject: `About your RSVP to ${eventTitle}`,
+        emailBody: `Unfortunately the host couldn't confirm your RSVP for ${eventTitle} this time.`,
+      };
+    case "rsvp_removed":
+      return {
+        pushTitle: `Update: ${eventTitle}`,
+        pushBody: "The host has removed you from this event.",
+        sms: `${brandName}: the host has removed you from ${eventTitle}.`,
+        emailSubject: `About your RSVP to ${eventTitle}`,
+        emailBody: `The host has removed you from ${eventTitle}. If you think this was a mistake, reach out to them.`,
+      };
+  }
+}
+
+// Resend send — cloned from notify-dispatch/index.ts:84-138. Do NOT write a new client.
+async function sendResendEmail(
+  to: string,
+  subject: string,
+  body: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const key = Deno.env.get("RESEND_API_KEY");
+  if (!key) return { ok: false, error: "RESEND_API_KEY missing" };
+  const sender = EMAIL_SENDERS.system;
+  try {
+    assertNotResendSandbox(sender);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  let rendered;
+  try {
+    rendered = renderTransactionalEmail({
+      variant: "generic_notification",
+      recipient: { name: null, email: to },
+      body: {
+        variant: "generic_notification",
+        title: subject,
+        paragraphs: body.split("\n\n"),
+        cta: null,
+      },
+    });
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: formatSenderHeader(rendered.from),
+        to: [to],
+        subject: rendered.subject,
+        html: rendered.html,
+        text: rendered.text,
+      }),
+    });
+    if (!res.ok) {
+      return { ok: false, error: `Resend ${res.status}: ${await res.text()}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// Twilio send — cloned from ticket-confirmation-dispatch/index.ts:123-170.
+async function sendTwilioSms(
+  to: string,
+  body: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const accountSid = Deno.env.get("TWILIO_ACCOUNT_SID");
+  const authToken = Deno.env.get("TWILIO_AUTH_TOKEN");
+  const messagingServiceSid = Deno.env.get("TWILIO_MESSAGING_SERVICE_SID");
+  if (!accountSid || !authToken || !messagingServiceSid) {
+    return { ok: false, error: "twilio_env_missing" };
+  }
+  const statusSecret = Deno.env.get("TWILIO_STATUS_CALLBACK_SECRET");
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const statusCallback =
+    statusSecret && supabaseUrl
+      ? `${supabaseUrl}/functions/v1/twilio-message-status?secret=${encodeURIComponent(statusSecret)}`
+      : undefined;
+  const params = new URLSearchParams({
+    To: to,
+    MessagingServiceSid: messagingServiceSid,
+    Body: body,
+  });
+  if (statusCallback) params.set("StatusCallback", statusCallback);
+  try {
+    const response = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Basic ${btoa(`${accountSid}:${authToken}`)}`,
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: params,
+      },
+    );
+    if (!response.ok) {
+      return { ok: false, error: `Twilio ${response.status}: ${await response.text()}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json(405, { error: "method_not_allowed" });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceKey) {
+    console.error("[rsvp-notify] missing SUPABASE_URL / service key");
+    return json(500, { error: "server_misconfigured" });
+  }
+
+  let reqBody: { notificationId?: string };
+  try {
+    reqBody = (await req.json()) as { notificationId?: string };
+  } catch {
+    return json(400, { error: "invalid_json" });
+  }
+  const notificationId =
+    typeof reqBody.notificationId === "string" ? reqBody.notificationId : "";
+  if (notificationId.length === 0) {
+    return json(400, { error: "notification_id_required" });
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  // 1. Load the queue row.
+  const { data: queueRow, error: queueErr } = await admin
+    .from("rsvp_notifications")
+    .select("id, event_id, rsvp_id, template_key, status")
+    .eq("id", notificationId)
+    .single();
+  if (queueErr || !queueRow) {
+    console.error("[rsvp-notify] queue row not found", notificationId);
+    return json(404, { error: "queue_row_not_found" });
+  }
+  if (queueRow.status === "sent") {
+    return json(200, { ok: true, reason: "already_sent" });
+  }
+
+  // 2. Resolve the guest + event.
+  const { data: rsvpRow } = await admin
+    .from("event_rsvps")
+    .select("id, user_id, guest_name, guest_email, guest_phone")
+    .eq("id", queueRow.rsvp_id)
+    .maybeSingle();
+  const { data: eventRow } = await admin
+    .from("events")
+    .select("id, title, brand_id, slug")
+    .eq("id", queueRow.event_id)
+    .single();
+
+  if (!eventRow) {
+    await admin
+      .from("rsvp_notifications")
+      .update({ status: "failed_terminal", last_error: "event_not_found", updated_at: new Date().toISOString() })
+      .eq("id", notificationId);
+    return json(200, { ok: false, reason: "event_not_found" });
+  }
+
+  let brandName = "Mingla";
+  const { data: brandRow } = await admin
+    .from("brands")
+    .select("slug, name")
+    .eq("id", eventRow.brand_id)
+    .maybeSingle();
+  if (brandRow?.name) brandName = brandRow.name;
+
+  const link = brandRow?.slug
+    ? `https://usemingla.com/e/${brandRow.slug}/${eventRow.slug}`
+    : "https://usemingla.com";
+  const copy = buildCopy(queueRow.template_key as TemplateKey, {
+    eventTitle: eventRow.title ?? "your event",
+    brandName,
+    link,
+  });
+
+  // 3. Resolve every available channel address/token.
+  const userId: string | null = rsvpRow?.user_id ?? null;
+  let email: string | null = rsvpRow?.guest_email ?? null;
+  let phone: string | null = rsvpRow?.guest_phone ?? null;
+
+  // App-user guest: resolve verified auth email (never user_metadata) + profile phone.
+  if (userId !== null) {
+    try {
+      const { data: au } = await admin.auth.admin.getUserById(userId);
+      const authEmail = au?.user?.email ?? null;
+      const identityEmail =
+        (au?.user?.identities ?? [])
+          .map((i) => (i.identity_data as { email?: string } | null)?.email)
+          .find((e): e is string => typeof e === "string" && e.length > 0) ?? null;
+      if (email === null) email = authEmail ?? identityEmail;
+    } catch (err) {
+      console.warn("[rsvp-notify] auth email resolve failed", String(err));
+    }
+    if (phone === null) {
+      try {
+        const { data: profile } = await admin
+          .from("profiles")
+          .select("phone")
+          .eq("id", userId)
+          .maybeSingle();
+        if (profile && typeof (profile as { phone?: string }).phone === "string") {
+          phone = (profile as { phone?: string }).phone ?? null;
+        }
+      } catch {
+        // profile phone is optional.
+      }
+    }
+  }
+
+  // 4. Fan out — each channel independent + non-blocking.
+  const outcome: { push: boolean; email: boolean; sms: boolean } = {
+    push: false,
+    email: false,
+    sms: false,
+  };
+  let anyAttempted = false;
+
+  if (userId !== null) {
+    anyAttempted = true;
+    try {
+      outcome.push = await sendPush({
+        targetUserId: userId,
+        title: copy.pushTitle,
+        body: copy.pushBody,
+        app: "consumer",
+        data: { deepLink: link, type: queueRow.template_key },
+      });
+      // In-app inbox row (mirror notify-dispatch); non-blocking.
+      try {
+        await admin.from("notifications").insert({
+          user_id: userId,
+          type: queueRow.template_key,
+          title: copy.pushTitle,
+          body: copy.pushBody,
+          deep_link: link,
+          data: { deepLink: link },
+          brand_id: eventRow.brand_id,
+          related_id: eventRow.id,
+          related_type: "rsvp_event",
+        });
+      } catch (inboxErr) {
+        console.warn("[rsvp-notify] inbox insert failed (non-fatal)", String(inboxErr));
+      }
+    } catch (err) {
+      console.warn("[rsvp-notify] push failed (isolated)", String(err));
+    }
+  }
+
+  if (email !== null && email.length > 0) {
+    anyAttempted = true;
+    const r = await sendResendEmail(email, copy.emailSubject, copy.emailBody);
+    outcome.email = r.ok;
+    if (!r.ok) console.warn("[rsvp-notify] email failed (isolated)", r.error);
+  }
+
+  if (phone !== null && phone.length > 0) {
+    anyAttempted = true;
+    const r = await sendTwilioSms(phone, copy.sms);
+    outcome.sms = r.ok;
+    if (!r.ok) console.warn("[rsvp-notify] sms failed (isolated)", r.error);
+  }
+
+  const anySucceeded = outcome.push || outcome.email || outcome.sms;
+  const nextStatus = !anyAttempted
+    ? "skipped"
+    : anySucceeded
+      ? "sent"
+      : "failed_retryable";
+
+  console.log(
+    `[rsvp-notify] ${queueRow.template_key} rsvp=${queueRow.rsvp_id} ` +
+      `push=${outcome.push} email=${outcome.email} sms=${outcome.sms} -> ${nextStatus}`,
+  );
+
+  const nowIso = new Date().toISOString();
+  await admin
+    .from("rsvp_notifications")
+    .update({
+      status: nextStatus,
+      sent_at: anySucceeded ? nowIso : null,
+      attempt_count: (typeof (queueRow as { attempt_count?: number }).attempt_count === "number"
+        ? (queueRow as { attempt_count?: number }).attempt_count!
+        : 0) + 1,
+      updated_at: nowIso,
+    })
+    .eq("id", notificationId);
+
+  // Mark the rsvp row's notified_at (idempotency aid).
+  if (rsvpRow?.id) {
+    await admin
+      .from("event_rsvps")
+      .update({ notified_at: nowIso })
+      .eq("id", rsvpRow.id);
+  }
+
+  return json(200, { ok: anySucceeded, channels: outcome, status: nextStatus });
+});

--- a/supabase/functions/rsvp-notify/index.ts
+++ b/supabase/functions/rsvp-notify/index.ts
@@ -136,6 +136,7 @@ async function sendResendEmail(
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
   try {
+    // no-attachment: RSVP notifications are transactional event-update notices (going/waitlist/approval/removal) — plain HTML, no PDF/file artifact. RSVP has no ticket/order document to attach.
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {

--- a/supabase/migrations/20261004000000_orch_1150_rsvp_events.sql
+++ b/supabase/migrations/20261004000000_orch_1150_rsvp_events.sql
@@ -1377,4 +1377,112 @@ CREATE INDEX idx_events_discover_feed
 
 COMMIT;
 
+-- ===========================================================================
+-- ORCH-1150 — expose the RSVP host-control columns + a live confirmed-attending
+-- count on business_public_events_view so the public /e/ page + the Hub
+-- list-card can render Going/Not-going + "N going" without a second query.
+-- do NOT merge back into the ticket/checkout path — these columns are inert for
+-- non-RSVP rows. Mirrors the ORCH-1006 view column list verbatim, appending only
+-- the e.rsvp_* columns + the rsvp_going_count subselect. See SPEC §6 / §8 step 11.
+-- ===========================================================================
+BEGIN;
+
+CREATE OR REPLACE VIEW public.business_public_events_view AS
+  SELECT e.id,
+    e.brand_id,
+    b.slug AS brand_slug,
+    b.name AS brand_name,
+    b.description AS brand_description,
+    b.profile_photo_url AS brand_profile_photo_url,
+    b.display_attendee_count AS brand_display_attendee_count,
+    b.address AS brand_address,
+    b.cover_media_url AS brand_cover_media_url,
+    b.theme_color AS brand_theme_color,
+    b.theme_font AS brand_theme_font,
+    b.theme_animation AS brand_theme_animation,
+    e.title,
+    e.description,
+    e.slug,
+    e.event_type,
+    e.location_text,
+    e.online_url,
+    e.is_online,
+    e.is_recurring,
+    e.is_multi_date,
+    e.recurrence_rules,
+    e.cover_media_url,
+    e.cover_media_type,
+    e.visibility,
+    e.show_on_discover,
+    e.status,
+    e.published_at,
+    e.timezone,
+    e.created_at,
+    e.updated_at,
+    (e.theme - 'business_draft'::text) AS public_theme,
+    e.theme_color_override,
+    e.theme_font_override,
+    e.theme_animation_override,
+    e.currency,
+    e.cover_media_provider,
+    e.cover_media_source_url,
+    e.cover_media_credit,
+    e.cover_media_credit_url,
+    e.cover_media_alt,
+    ed.start_at AS master_start_at,
+    ed.end_at AS master_end_at,
+    ed.timezone AS master_timezone,
+    ed.id AS master_event_date_id,
+    e.city,
+    e.party_types,
+    e.vibe_tags,
+    e.music_genres,
+    e.location_geo,
+    COALESCE(e.pass_tax,         b.default_pass_tax)         AS pass_tax,
+    COALESCE(e.pass_mingla_fee,  b.default_pass_mingla_fee)  AS pass_mingla_fee,
+    COALESCE(e.pass_service_fee, b.default_pass_service_fee) AS pass_service_fee,
+    b.pricing_region   AS pricing_region,
+    b.pricing_currency AS pricing_currency,
+    (e.pricing_locked_at IS NOT NULL) AS pricing_locked,
+    (
+      SELECT public.compute_all_in_cents(
+               MIN(tt.price_cents),
+               COALESCE(e.pass_mingla_fee,  b.default_pass_mingla_fee),
+               COALESCE(e.pass_service_fee, b.default_pass_service_fee),
+               (SELECT r.effective_take_rate_bps FROM public.resolve_effective_take_rate_bps(b.id) r)
+             )
+      FROM public.ticket_types tt
+      WHERE tt.event_id = e.id
+        AND tt.price_cents > 0
+        AND tt.deleted_at IS NULL
+    ) AS display_price_cents,
+    -- ORCH-1150 RSVP host-control columns (inert for non-RSVP rows).
+    e.rsvp_discoverable,
+    e.rsvp_capacity,
+    e.rsvp_allow_plus_ones,
+    e.rsvp_plus_ones_max,
+    e.rsvp_waitlist_enabled,
+    e.rsvp_approval_mode,
+    -- ORCH-1150 confirmed-attending headcount (counts each guest + plus_count),
+    -- per the §4.1c capacity formula: rsvp_status='going' AND approval_status='approved'.
+    -- 0 for non-RSVP rows (no event_rsvps rows exist for them).
+    (
+      SELECT COALESCE(SUM(1 + r.plus_count), 0)::integer
+      FROM public.event_rsvps r
+      WHERE r.event_id = e.id
+        AND r.rsvp_status = 'going'
+        AND r.approval_status = 'approved'
+    ) AS rsvp_going_count
+   FROM events e
+     JOIN brands b ON b.id = e.brand_id
+     LEFT JOIN event_dates ed ON ed.event_id = e.id AND ed.is_master = true
+  WHERE e.deleted_at IS NULL
+    AND b.deleted_at IS NULL
+    AND e.visibility = 'public'::text
+    AND (e.status = ANY (ARRAY['scheduled'::text, 'live'::text, 'ended'::text, 'cancelled'::text]));
+
+ALTER VIEW public.business_public_events_view SET (security_invoker = false);
+
+COMMIT;
+
 NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20261004000000_orch_1150_rsvp_events.sql
+++ b/supabase/migrations/20261004000000_orch_1150_rsvp_events.sql
@@ -1,0 +1,1380 @@
+-- ===========================================================================
+-- ORCH-1150 — RSVP Event (Partiful-style ticketless) schema + RPCs + trigger
+-- ===========================================================================
+-- SPEC: Mingla_Artifacts/specs/SPEC_ORCH-1150_RSVP_EVENT_WIZARD.md (§4.1, §5).
+--
+-- ORCH-1150: do NOT merge back into the event/ticket path — RSVP has zero
+-- tickets + no money gate; notify is TRANSACTIONAL (no marketing-consent).
+-- See SPEC §5.
+--
+-- This migration is monotonic: prefix 20261004000000 is strictly greater than
+-- the local head (20261002000000_orch_1142) AND the sibling-worktree ORCH-1148
+-- head (20261003000007). Wrapped in BEGIN/COMMIT (matches the discriminator
+-- migration). All GRANTs follow the closing $$; ; all RETURNS-TABLE widens are
+-- preceded by a DROP. (feedback_edge_deploy_and_migration_apply_hazards)
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (a) Widen the event_type CHECK to admit 'rsvp' (DROP + ADD, never silent).
+--     The constraint was created inline at 20260605000000...:33-34 → auto-name
+--     events_event_type_check.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_event_type_check;
+ALTER TABLE public.events ADD CONSTRAINT events_event_type_check
+  CHECK (event_type IN ('event', 'experience', 'trip', 'rsvp'));
+
+-- ---------------------------------------------------------------------------
+-- (b) RSVP host-control columns on public.events (additive; inert for non-rsvp).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.events
+  ADD COLUMN IF NOT EXISTS rsvp_discoverable     boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS rsvp_capacity         integer NULL,
+  ADD COLUMN IF NOT EXISTS rsvp_allow_plus_ones  boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS rsvp_plus_ones_max    integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS rsvp_waitlist_enabled boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS rsvp_approval_mode    text    NOT NULL DEFAULT 'auto';
+
+ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_rsvp_approval_mode_check;
+ALTER TABLE public.events ADD CONSTRAINT events_rsvp_approval_mode_check
+  CHECK (rsvp_approval_mode IN ('auto', 'manual'));
+
+COMMENT ON COLUMN public.events.rsvp_discoverable IS
+  'ORCH-1150 — true => the RSVP row is eligible for the consumer discover deck; '
+  'false => invite-link-only (Partiful default). Inert for event_type<>''rsvp''.';
+
+-- ---------------------------------------------------------------------------
+-- (c) New per-guest table public.event_rsvps — TWO-DIMENSION status model.
+--     rsvp_status   = guest intent (going/not_going/waitlisted)
+--     approval_status = host gate (pending/approved/denied)
+--     ORCH-1150: see SPEC §4.1c for the canonical precedence rules.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.event_rsvps (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id        uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  user_id         uuid NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  guest_name      text NOT NULL,
+  guest_email     text NULL,
+  guest_phone     text NULL,
+  rsvp_status     text NOT NULL DEFAULT 'going'
+                    CHECK (rsvp_status IN ('going', 'not_going', 'waitlisted')),
+  approval_status text NOT NULL DEFAULT 'approved'
+                    CHECK (approval_status IN ('pending', 'approved', 'denied')),
+  plus_count      integer NOT NULL DEFAULT 0 CHECK (plus_count >= 0),
+  waitlisted_at   timestamptz NULL,
+  promoted_at     timestamptz NULL,
+  notified_at     timestamptz NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  -- ORCH-1150 A4-NEW: link guests MUST be reachable by email AND SMS — do not
+  -- relax to email-only or name-only. App-user rows (user_id IS NOT NULL) are
+  -- exempt (profile-inherited addresses + push by user_id).
+  CONSTRAINT event_rsvps_link_guest_contact_required CHECK (
+    user_id IS NOT NULL
+    OR (guest_email IS NOT NULL AND length(btrim(guest_email)) > 0
+        AND guest_phone IS NOT NULL AND length(btrim(guest_phone)) > 0)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS event_rsvps_event_id_idx ON public.event_rsvps (event_id);
+CREATE INDEX IF NOT EXISTS event_rsvps_waitlist_idx
+  ON public.event_rsvps (event_id, waitlisted_at)
+  WHERE rsvp_status = 'waitlisted';
+CREATE UNIQUE INDEX IF NOT EXISTS event_rsvps_event_user_uniq
+  ON public.event_rsvps (event_id, user_id) WHERE user_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS event_rsvps_event_email_uniq
+  ON public.event_rsvps (event_id, lower(guest_email)) WHERE guest_email IS NOT NULL;
+
+COMMENT ON TABLE public.event_rsvps IS
+  'ORCH-1150 — per-guest RSVP rows for event_type=rsvp events. Two-dimension '
+  'status: rsvp_status (going/not_going/waitlisted) + approval_status '
+  '(pending/approved/denied). Confirmed-attending = going AND approved. '
+  'approved->denied is the host-REMOVE terminal state (no distinct removed).';
+
+-- updated_at maintenance trigger (reuse the standard set_updated_at if present;
+-- else a local one). Defensive: only create if no such helper exists.
+CREATE OR REPLACE FUNCTION public.fn_event_rsvps_touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_event_rsvps_touch_updated_at ON public.event_rsvps;
+CREATE TRIGGER trg_event_rsvps_touch_updated_at
+  BEFORE UPDATE ON public.event_rsvps
+  FOR EACH ROW
+  EXECUTE FUNCTION public.fn_event_rsvps_touch_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- (d) RLS on public.event_rsvps.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.event_rsvps ENABLE ROW LEVEL SECURITY;
+
+-- Host read: all rows for their brand's events (event_manager rank).
+DROP POLICY IF EXISTS event_rsvps_host_read ON public.event_rsvps;
+CREATE POLICY event_rsvps_host_read ON public.event_rsvps
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = event_rsvps.event_id
+        AND public.biz_brand_effective_rank(e.brand_id, auth.uid())
+              >= public.biz_role_rank('event_manager'::text)
+    )
+  );
+
+-- Host write (approve/deny/remove / waitlist): same event_manager predicate.
+DROP POLICY IF EXISTS event_rsvps_host_write ON public.event_rsvps;
+CREATE POLICY event_rsvps_host_write ON public.event_rsvps
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = event_rsvps.event_id
+        AND public.biz_brand_effective_rank(e.brand_id, auth.uid())
+              >= public.biz_role_rank('event_manager'::text)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = event_rsvps.event_id
+        AND public.biz_brand_effective_rank(e.brand_id, auth.uid())
+              >= public.biz_role_rank('event_manager'::text)
+    )
+  );
+
+-- Guest read own.
+DROP POLICY IF EXISTS event_rsvps_guest_read_own ON public.event_rsvps;
+CREATE POLICY event_rsvps_guest_read_own ON public.event_rsvps
+  FOR SELECT
+  USING (user_id = auth.uid());
+
+-- Guest insert own (logged-in). Event must be a published RSVP.
+DROP POLICY IF EXISTS event_rsvps_guest_insert_own ON public.event_rsvps;
+CREATE POLICY event_rsvps_guest_insert_own ON public.event_rsvps
+  FOR INSERT
+  WITH CHECK (
+    user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = event_rsvps.event_id
+        AND e.event_type = 'rsvp'
+        AND e.status IN ('scheduled', 'live')
+        AND e.deleted_at IS NULL
+    )
+  );
+
+-- Guest update own (logged-in) — may only set going/not_going for own row.
+DROP POLICY IF EXISTS event_rsvps_guest_update_own ON public.event_rsvps;
+CREATE POLICY event_rsvps_guest_update_own ON public.event_rsvps
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (
+    user_id = auth.uid()
+    AND rsvp_status IN ('going', 'not_going')
+  );
+
+-- Anon link guests get NO direct table policy — they write via the
+-- public-submit-rsvp edge fn under service-role (bypasses RLS). This keeps the
+-- table closed to arbitrary anon writes.
+
+-- ---------------------------------------------------------------------------
+-- (5.6) Notification queue public.rsvp_notifications (clone of the
+--       ticket_order_notifications shape). RLS: service-role only.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.rsvp_notifications (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id            uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  rsvp_id             uuid NULL REFERENCES public.event_rsvps(id) ON DELETE SET NULL,
+  channel             text NULL CHECK (channel IS NULL OR channel IN ('push', 'sms', 'email')),
+  recipient           text NULL,
+  status              text NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'sending', 'sent',
+                                          'failed_retryable', 'failed_terminal', 'skipped')),
+  template_key        text NOT NULL,
+  payload             jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key     text NOT NULL,
+  attempt_count       integer NOT NULL DEFAULT 0,
+  provider            text NULL,
+  provider_message_id text NULL,
+  last_error          text NULL,
+  sent_at             timestamptz NULL,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS rsvp_notifications_idempotency_uniq
+  ON public.rsvp_notifications (idempotency_key);
+CREATE INDEX IF NOT EXISTS rsvp_notifications_status_idx
+  ON public.rsvp_notifications (status, created_at)
+  WHERE status IN ('pending', 'failed_retryable');
+
+COMMENT ON TABLE public.rsvp_notifications IS
+  'ORCH-1150 — transactional RSVP notification queue (one row per (guest,trigger)). '
+  'The rsvp-notify edge fn fans channels by available contact. NOT marketing.';
+
+ALTER TABLE public.rsvp_notifications ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rsvp_notifications_service_only ON public.rsvp_notifications;
+CREATE POLICY rsvp_notifications_service_only ON public.rsvp_notifications
+  FOR ALL USING (false) WITH CHECK (false);
+GRANT ALL ON TABLE public.rsvp_notifications TO service_role;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.event_rsvps TO service_role;
+
+COMMIT;
+
+-- ===========================================================================
+-- RPCs + trigger (separate transaction so a failing function body never
+-- partially-rolls the schema; each CREATE OR REPLACE is independent).
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (f) Auto-promote trigger fn_rsvp_drain_on_capacity_freed (A3).
+--     ORCH-1150: do NOT merge back into the event/ticket path. Clones the
+--     proven ticket fn_waitlist_drain_on_capacity_freed (0948...:93-169) but
+--     for event_rsvps, in-transaction + deterministic.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.fn_rsvp_drain_on_capacity_freed()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_event_id     uuid;
+  v_capacity     integer;
+  v_approval_mode text;
+  v_event_type   text;
+  v_confirmed    integer;
+  v_free         integer;
+  v_entry        record;
+  v_has_queue    boolean;
+BEGIN
+  -- Resolve the event_id depending on which table fired the trigger.
+  IF TG_TABLE_NAME = 'events' THEN
+    v_event_id := NEW.id;
+  ELSE
+    v_event_id := NEW.event_id;
+  END IF;
+
+  SELECT e.event_type, e.rsvp_capacity, e.rsvp_approval_mode
+    INTO v_event_type, v_capacity, v_approval_mode
+    FROM public.events e
+   WHERE e.id = v_event_id;
+
+  -- Only RSVP events with a finite cap can have a waitlist to drain.
+  IF v_event_type IS DISTINCT FROM 'rsvp' THEN RETURN NEW; END IF;
+  IF v_capacity IS NULL THEN RETURN NEW; END IF;
+
+  -- Confirmed-attending headcount (the +1s count). §4.1c capacity formula.
+  SELECT COALESCE(SUM(1 + r.plus_count), 0)
+    INTO v_confirmed
+    FROM public.event_rsvps r
+   WHERE r.event_id = v_event_id
+     AND r.rsvp_status = 'going'
+     AND r.approval_status = 'approved';
+
+  v_free := v_capacity - v_confirmed;
+  IF v_free <= 0 THEN RETURN NEW; END IF;
+
+  -- Queue-table existence guard so the trigger never breaks the parent UPDATE.
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'rsvp_notifications'
+  ) INTO v_has_queue;
+
+  -- Promote the OLDEST waitlisted rows while free capacity remains.
+  FOR v_entry IN
+    SELECT r.id, r.plus_count, r.user_id
+      FROM public.event_rsvps r
+     WHERE r.event_id = v_event_id
+       AND r.rsvp_status = 'waitlisted'
+     ORDER BY r.waitlisted_at ASC NULLS FIRST, r.created_at ASC
+  LOOP
+    EXIT WHEN v_free <= 0;
+
+    IF v_approval_mode = 'manual' THEN
+      -- manual: waitlist -> going + pending (host still approves; doesn't
+      -- occupy the cap, so do NOT decrement v_free).
+      UPDATE public.event_rsvps
+         SET rsvp_status = 'going',
+             approval_status = 'pending',
+             promoted_at = now()
+       WHERE id = v_entry.id;
+    ELSE
+      -- auto: waitlist -> going (confirmed). Consume the cap.
+      IF (1 + v_entry.plus_count) > v_free THEN
+        -- This guest's party doesn't fit the remaining free seats; stop.
+        EXIT;
+      END IF;
+      UPDATE public.event_rsvps
+         SET rsvp_status = 'going',
+             approval_status = 'approved',
+             promoted_at = now()
+       WHERE id = v_entry.id;
+      v_free := v_free - (1 + v_entry.plus_count);
+    END IF;
+
+    IF v_has_queue THEN
+      INSERT INTO public.rsvp_notifications
+        (event_id, rsvp_id, channel, recipient, status, template_key, payload,
+         idempotency_key, attempt_count)
+      VALUES
+        (v_event_id, v_entry.id, NULL, NULL, 'pending', 'rsvp_waitlist_promoted',
+         jsonb_build_object('template_key', 'rsvp_waitlist_promoted',
+                            'rsvp_id', v_entry.id, 'event_id', v_event_id),
+         'rsvp_promote:' || v_entry.id::text || ':' || extract(epoch FROM now())::bigint::text,
+         0)
+      ON CONFLICT (idempotency_key) DO NOTHING;
+    END IF;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$fn$;
+
+-- Trigger arm 1: attendance/approval flips on event_rsvps (the spot-freeing
+-- conditions — going->not_going, *->denied incl. the A2-NEW approved->denied
+-- host-remove). Guarded WHEN so it only fires on a relevant change.
+DROP TRIGGER IF EXISTS trg_rsvp_drain_on_status ON public.event_rsvps;
+CREATE TRIGGER trg_rsvp_drain_on_status
+  AFTER UPDATE OF rsvp_status, approval_status ON public.event_rsvps
+  FOR EACH ROW
+  WHEN (
+    (OLD.rsvp_status IS DISTINCT FROM NEW.rsvp_status
+      OR OLD.approval_status IS DISTINCT FROM NEW.approval_status)
+    AND (NEW.rsvp_status <> 'going' OR NEW.approval_status <> 'approved')
+  )
+  EXECUTE FUNCTION public.fn_rsvp_drain_on_capacity_freed();
+
+-- Trigger arm 2: cap-raise on events.
+DROP TRIGGER IF EXISTS trg_rsvp_drain_on_cap_raise ON public.events;
+CREATE TRIGGER trg_rsvp_drain_on_cap_raise
+  AFTER UPDATE OF rsvp_capacity ON public.events
+  FOR EACH ROW
+  WHEN (NEW.rsvp_capacity IS DISTINCT FROM OLD.rsvp_capacity AND NEW.event_type = 'rsvp')
+  EXECUTE FUNCTION public.fn_rsvp_drain_on_capacity_freed();
+
+-- ---------------------------------------------------------------------------
+-- (5.1) business_publish_rsvp_draft — forked from business_publish_event_draft.
+--       ORCH-1150: do NOT merge back into the event/ticket path — RSVP has
+--       zero tickets + no money gate. Removes ticket / city / stripe gates,
+--       keeps the party-type gate (steering #2), creates ZERO ticket_types.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.business_publish_rsvp_draft(
+  p_event_id uuid,
+  p_draft_payload jsonb,
+  p_client_revision integer DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_event public.events%ROWTYPE;
+  v_brand record;
+  v_theme jsonb;
+  v_business_draft jsonb;
+  v_title text;
+  v_description text;
+  v_location_text text;
+  v_online_url text;
+  v_cover_media_url text;
+  v_cover_media_type text;
+  v_cover_media_provider text;
+  v_cover_media_source_url text;
+  v_cover_media_credit text;
+  v_cover_media_credit_url text;
+  v_cover_media_alt text;
+  v_timezone text;
+  v_visibility text;
+  v_base_slug text;
+  v_final_slug text;
+  v_suffix integer := 2;
+  v_now timestamptz := now();
+  v_event_dates_rows jsonb;
+  v_when jsonb;
+  v_date_iso text;
+  v_doors text;
+  v_ends text;
+  v_start timestamptz;
+  v_end timestamptz;
+  v_city text;
+  v_party_types text[];
+  v_vibe_tags text[];
+  v_music_genres text[];
+  -- RSVP host-control locals.
+  v_rsvp_capacity integer;
+  v_rsvp_allow_plus_ones boolean;
+  v_rsvp_plus_ones_max integer;
+  v_rsvp_waitlist_enabled boolean;
+  v_rsvp_approval_mode text;
+  v_rsvp_discoverable boolean;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_draft_not_found';
+  END IF;
+  IF v_event.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'event_draft_deleted';
+  END IF;
+  IF v_event.status <> 'draft' THEN
+    RAISE EXCEPTION 'event_draft_not_publishable';
+  END IF;
+  IF public.biz_brand_effective_rank(v_event.brand_id, v_user_id) < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  SELECT id, slug, name, default_currency INTO v_brand
+    FROM public.brands WHERE id = v_event.brand_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found';
+  END IF;
+
+  v_theme := COALESCE(p_draft_payload->'theme', '{}'::jsonb);
+  v_business_draft := COALESCE(v_theme->'business_draft', '{}'::jsonb);
+
+  v_title := NULLIF(btrim(COALESCE(p_draft_payload->>'title', '')), '');
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'event_title_required';
+  END IF;
+
+  -- Taxonomy (party-type gate KEPT — steering #2). City NOT required (freeform).
+  v_city := NULLIF(btrim(COALESCE(v_business_draft->>'city', '')), '');
+  v_party_types := COALESCE(
+    (SELECT array_agg(value::text)
+     FROM jsonb_array_elements_text(COALESCE(v_business_draft->'partyTypes', '[]'::jsonb))),
+    ARRAY[]::text[]);
+  v_vibe_tags := COALESCE(
+    (SELECT array_agg(value::text)
+     FROM jsonb_array_elements_text(COALESCE(v_business_draft->'vibeTags', '[]'::jsonb))),
+    ARRAY[]::text[]);
+  v_music_genres := COALESCE(
+    (SELECT array_agg(value::text)
+     FROM jsonb_array_elements_text(COALESCE(v_business_draft->'musicGenres', '[]'::jsonb))),
+    ARRAY[]::text[]);
+
+  IF array_length(v_party_types, 1) IS NULL THEN
+    RAISE EXCEPTION 'party_types_required';
+  END IF;
+  IF NOT (v_party_types <@ ARRAY[
+    'birthday-party','rooftop-party','club-night','house-party','warehouse-party',
+    'beach-party','pool-party','boat-party','themed-party','corporate-event',
+    'graduation-party','holiday-party','networking-event','rave','festival'
+  ]::text[]) THEN
+    RAISE EXCEPTION 'party_types_not_canonical';
+  END IF;
+  IF NOT (v_vibe_tags <@ ARRAY[
+    'energetic','chill','intimate','wild','classy','casual','upscale','underground',
+    'mainstream','artsy','social','exclusive','laid-back','vibrant','retro','futuristic'
+  ]::text[]) THEN
+    RAISE EXCEPTION 'vibe_tags_not_canonical';
+  END IF;
+  IF NOT (v_music_genres <@ ARRAY[
+    'electronic-edm','hiphop-rap','pop','rock','latin','afrobeats','rnb-soul',
+    'disco-funk','reggae-dancehall','indie','country','jazz','classical','mixed-variety'
+  ]::text[]) THEN
+    RAISE EXCEPTION 'music_genres_not_canonical';
+  END IF;
+
+  -- RSVP host-control reads.
+  v_rsvp_capacity := NULLIF(v_business_draft->>'rsvpCapacity', '')::integer;
+  v_rsvp_allow_plus_ones := COALESCE((v_business_draft->>'rsvpAllowPlusOnes')::boolean, false);
+  v_rsvp_plus_ones_max := COALESCE((v_business_draft->>'rsvpPlusOnesMax')::integer, 0);
+  v_rsvp_waitlist_enabled := COALESCE((v_business_draft->>'rsvpWaitlistEnabled')::boolean, false);
+  v_rsvp_approval_mode := COALESCE(NULLIF(v_business_draft->>'rsvpApprovalMode', ''), 'auto');
+  IF v_rsvp_approval_mode NOT IN ('auto', 'manual') THEN
+    RAISE EXCEPTION 'rsvp_approval_mode_invalid';
+  END IF;
+  v_rsvp_discoverable := COALESCE((v_business_draft->>'rsvpDiscoverable')::boolean, false);
+
+  v_visibility := CASE COALESCE(v_business_draft->>'requestedVisibility', 'public')
+    WHEN 'private' THEN 'private'
+    WHEN 'unlisted' THEN 'hidden'
+    ELSE 'public'
+  END;
+  -- A private RSVP can never be on a public discovery feed.
+  IF v_visibility = 'private' THEN
+    v_rsvp_discoverable := false;
+  END IF;
+
+  -- Slug.
+  v_base_slug := lower(regexp_replace(v_title, '[^a-zA-Z0-9]+', '-', 'g'));
+  v_base_slug := regexp_replace(v_base_slug, '(^-+|-+$)', '', 'g');
+  IF v_base_slug = '' OR v_base_slug LIKE 'draft-%' THEN
+    v_base_slug := 'rsvp';
+  END IF;
+  v_final_slug := v_base_slug;
+  WHILE EXISTS (
+    SELECT 1 FROM public.events e
+    WHERE e.brand_id = v_event.brand_id AND e.deleted_at IS NULL
+      AND e.id <> p_event_id AND lower(e.slug) = lower(v_final_slug)
+  ) LOOP
+    v_final_slug := v_base_slug || '-' || v_suffix::text;
+    v_suffix := v_suffix + 1;
+  END LOOP;
+
+  v_description := NULLIF(p_draft_payload->>'description', '');
+  v_location_text := NULLIF(p_draft_payload->>'location_text', '');
+  v_online_url := NULLIF(p_draft_payload->>'online_url', '');
+  v_cover_media_url := NULLIF(p_draft_payload->>'cover_media_url', '');
+  v_cover_media_type := NULLIF(p_draft_payload->>'cover_media_type', '');
+  v_cover_media_provider := NULLIF(p_draft_payload->>'cover_media_provider', '');
+  v_cover_media_source_url := NULLIF(p_draft_payload->>'cover_media_source_url', '');
+  v_cover_media_credit := NULLIF(p_draft_payload->>'cover_media_credit', '');
+  v_cover_media_credit_url := NULLIF(p_draft_payload->>'cover_media_credit_url', '');
+  v_cover_media_alt := NULLIF(p_draft_payload->>'cover_media_alt', '');
+  IF v_cover_media_url IS NULL THEN
+    v_cover_media_type := NULL; v_cover_media_provider := NULL;
+    v_cover_media_source_url := NULL; v_cover_media_credit := NULL;
+    v_cover_media_credit_url := NULL; v_cover_media_alt := NULL;
+  END IF;
+  v_timezone := COALESCE(NULLIF(p_draft_payload->>'timezone', ''), v_event.timezone, 'UTC');
+
+  -- Single-date only (steering #4).
+  v_when := v_business_draft->'when';
+  v_date_iso := NULLIF(v_when->>'date', '');
+  IF v_date_iso IS NULL THEN
+    RAISE EXCEPTION 'event_date_required';
+  END IF;
+  v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+  v_ends := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+  v_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+  v_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+  IF v_end <= v_start THEN
+    v_end := v_end + INTERVAL '1 day';
+  END IF;
+
+  -- Discoverable RSVPs must be future-dated (no dead deck card). Link-only is
+  -- allowed same-day. NO stripe gate (moneyless).
+  IF v_rsvp_discoverable AND v_end <= v_now THEN
+    RAISE EXCEPTION 'offering_date_past';
+  END IF;
+
+  DELETE FROM public.event_dates WHERE event_id = p_event_id;
+  INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+  VALUES (p_event_id, v_start, v_end, v_timezone, true);
+
+  -- Permit the draft->scheduled slug finalization (ORCH-0763 trigger).
+  PERFORM set_config('mingla.business_publish_event_draft', 'on', true);
+
+  UPDATE public.events
+  SET
+    event_type = 'rsvp',
+    title = v_title,
+    description = v_description,
+    slug = v_final_slug,
+    location_text = v_location_text,
+    online_url = v_online_url,
+    cover_media_url = v_cover_media_url,
+    cover_media_type = v_cover_media_type,
+    cover_media_provider = v_cover_media_provider,
+    cover_media_source_url = v_cover_media_source_url,
+    cover_media_credit = v_cover_media_credit,
+    cover_media_credit_url = v_cover_media_credit_url,
+    cover_media_alt = v_cover_media_alt,
+    is_online = COALESCE((p_draft_payload->>'is_online')::boolean, false),
+    is_recurring = false,
+    is_multi_date = false,
+    recurrence_rules = NULL,
+    theme = (v_theme - 'business_draft') || jsonb_build_object(
+      'business_event',
+      (v_business_draft
+        - 'tickets' - 'category' - 'partyTypes' - 'vibeTags' - 'musicGenres'
+        - 'city' - 'locationGeo'),
+      'coverHue',
+      COALESCE(v_business_draft->'coverHue', v_theme->'coverHue', '25'::jsonb)
+    ),
+    status = 'scheduled',
+    visibility = v_visibility,
+    published_at = v_now,
+    timezone = v_timezone,
+    city = v_city,
+    party_types = v_party_types,
+    vibe_tags = v_vibe_tags,
+    music_genres = v_music_genres,
+    rsvp_capacity = v_rsvp_capacity,
+    rsvp_allow_plus_ones = v_rsvp_allow_plus_ones,
+    rsvp_plus_ones_max = CASE WHEN v_rsvp_allow_plus_ones THEN GREATEST(v_rsvp_plus_ones_max, 0) ELSE 0 END,
+    rsvp_waitlist_enabled = v_rsvp_waitlist_enabled,
+    rsvp_approval_mode = v_rsvp_approval_mode,
+    rsvp_discoverable = v_rsvp_discoverable,
+    updated_at = v_now
+  WHERE id = p_event_id AND status = 'draft' AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_draft_not_publishable';
+  END IF;
+
+  -- An RSVP creates ZERO ticket_types (I-PROPOSED-1150-RSVP-NO-TICKET-ROWS).
+  -- Defensive: soft-delete any stray ticket rows from a mis-routed draft.
+  UPDATE public.ticket_types
+     SET deleted_at = v_now, updated_at = v_now
+   WHERE event_id = p_event_id AND deleted_at IS NULL;
+
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id;
+  SELECT COALESCE(jsonb_agg(to_jsonb(ed) ORDER BY ed.start_at), '[]'::jsonb)
+    INTO v_event_dates_rows
+    FROM public.event_dates ed WHERE ed.event_id = p_event_id;
+
+  RETURN jsonb_build_object(
+    'event', to_jsonb(v_event),
+    'brand', jsonb_build_object('id', v_brand.id, 'slug', v_brand.slug, 'name', v_brand.name),
+    'tickets', '[]'::jsonb,
+    'eventDates', v_event_dates_rows,
+    'client_revision', p_client_revision
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.business_publish_rsvp_draft(uuid, jsonb, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.business_publish_rsvp_draft(uuid, jsonb, integer) IS
+  'ORCH-1150 — RSVP publish RPC (forked from business_publish_event_draft). '
+  'Zero tickets, no money gate, no city gate; keeps party-type gate. '
+  'do NOT merge back into the event/ticket path. See SPEC §5.1.';
+
+COMMIT;
+
+-- ===========================================================================
+-- Edit-published + guest-submit + host-approve RPCs (separate txn).
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (5.2) biz_update_live_rsvp — edit a published RSVP. No refund gate, no
+--       ticket diff. Enqueues rsvp_event_updated on material change (A4).
+--       ORCH-1150: do NOT merge back into the event/ticket path.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_update_live_rsvp(
+  p_event_id uuid,
+  p_payload jsonb,
+  p_reason text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_user_id        uuid;
+  v_existing       public.events%ROWTYPE;
+  v_brand          record;
+  v_now            timestamptz := now();
+  v_trimmed_reason text;
+  v_title          text;
+  v_description    text;
+  v_location_text  text;
+  v_online_url     text;
+  v_timezone       text;
+  v_visibility     text;
+  v_when           jsonb;
+  v_date_iso       text;
+  v_doors          text;
+  v_ends           text;
+  v_new_start      timestamptz;
+  v_new_end        timestamptz;
+  v_old_start      timestamptz;
+  v_rsvp_capacity  integer;
+  v_rsvp_allow_plus_ones boolean;
+  v_rsvp_plus_ones_max integer;
+  v_rsvp_waitlist_enabled boolean;
+  v_rsvp_approval_mode text;
+  v_rsvp_discoverable boolean;
+  v_material_change boolean := false;
+  v_going_count    integer;
+  v_notified_count integer := 0;
+  v_event          public.events%ROWTYPE;
+  v_guest          record;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  v_trimmed_reason := btrim(COALESCE(p_reason, ''));
+  IF v_trimmed_reason = '' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'missing_edit_reason');
+  END IF;
+  IF char_length(v_trimmed_reason) < 10 OR char_length(v_trimmed_reason) > 200 THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_edit_reason');
+  END IF;
+
+  SELECT * INTO v_existing FROM public.events
+   WHERE id = p_event_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'rsvp_not_found';
+  END IF;
+  IF v_existing.event_type <> 'rsvp' THEN
+    RAISE EXCEPTION 'event_not_an_rsvp'
+      USING HINT = 'biz_update_live_rsvp only handles event_type=rsvp rows.';
+  END IF;
+  IF v_existing.status NOT IN ('scheduled', 'live') THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'rsvp_not_editable_status');
+  END IF;
+  IF public.biz_brand_effective_rank(v_existing.brand_id, v_user_id) < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  SELECT id, slug, name INTO v_brand FROM public.brands
+   WHERE id = v_existing.brand_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found';
+  END IF;
+
+  v_title := NULLIF(btrim(COALESCE(p_payload->>'title', '')), '');
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'rsvp_title_required';
+  END IF;
+  v_description := NULLIF(p_payload->>'description', '');
+  v_location_text := NULLIF(p_payload->>'location_text', '');
+  v_online_url := NULLIF(p_payload->>'online_url', '');
+  v_timezone := COALESCE(NULLIF(p_payload->>'timezone', ''), v_existing.timezone, 'UTC');
+
+  v_visibility := CASE COALESCE(p_payload->>'requestedVisibility', NULL)
+    WHEN 'private' THEN 'private'
+    WHEN 'unlisted' THEN 'hidden'
+    WHEN 'public' THEN 'public'
+    ELSE v_existing.visibility
+  END;
+
+  -- RSVP host-control (default to existing when key absent).
+  v_rsvp_capacity := CASE WHEN p_payload ? 'rsvpCapacity'
+    THEN NULLIF(p_payload->>'rsvpCapacity', '')::integer ELSE v_existing.rsvp_capacity END;
+  v_rsvp_allow_plus_ones := COALESCE((p_payload->>'rsvpAllowPlusOnes')::boolean, v_existing.rsvp_allow_plus_ones);
+  v_rsvp_plus_ones_max := COALESCE(NULLIF(p_payload->>'rsvpPlusOnesMax', '')::integer, v_existing.rsvp_plus_ones_max);
+  v_rsvp_waitlist_enabled := COALESCE((p_payload->>'rsvpWaitlistEnabled')::boolean, v_existing.rsvp_waitlist_enabled);
+  v_rsvp_approval_mode := COALESCE(NULLIF(p_payload->>'rsvpApprovalMode', ''), v_existing.rsvp_approval_mode);
+  IF v_rsvp_approval_mode NOT IN ('auto', 'manual') THEN
+    RAISE EXCEPTION 'rsvp_approval_mode_invalid';
+  END IF;
+  v_rsvp_discoverable := COALESCE((p_payload->>'rsvpDiscoverable')::boolean, v_existing.rsvp_discoverable);
+  IF v_visibility = 'private' THEN
+    v_rsvp_discoverable := false;
+  END IF;
+
+  -- Single-date when (optional in payload; default to existing master).
+  SELECT start_at INTO v_old_start FROM public.event_dates
+   WHERE event_id = p_event_id AND is_master = true LIMIT 1;
+
+  v_when := p_payload->'when';
+  IF v_when IS NOT NULL AND NULLIF(v_when->>'date', '') IS NOT NULL THEN
+    v_date_iso := NULLIF(v_when->>'date', '');
+    v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+    v_ends := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+    v_new_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+    v_new_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+    IF v_new_end <= v_new_start THEN
+      v_new_end := v_new_end + INTERVAL '1 day';
+    END IF;
+    DELETE FROM public.event_dates WHERE event_id = p_event_id;
+    INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+    VALUES (p_event_id, v_new_start, v_new_end, v_timezone, true);
+    IF v_old_start IS DISTINCT FROM v_new_start THEN
+      v_material_change := true;
+    END IF;
+  END IF;
+
+  -- Material change = date/time OR venue/location text changed.
+  IF v_location_text IS DISTINCT FROM v_existing.location_text THEN
+    v_material_change := true;
+  END IF;
+
+  UPDATE public.events
+  SET
+    title = v_title,
+    description = v_description,
+    location_text = v_location_text,
+    online_url = v_online_url,
+    cover_media_url = NULLIF(p_payload->>'cover_media_url', ''),
+    cover_media_type = NULLIF(p_payload->>'cover_media_type', ''),
+    visibility = v_visibility,
+    timezone = v_timezone,
+    rsvp_capacity = v_rsvp_capacity,
+    rsvp_allow_plus_ones = v_rsvp_allow_plus_ones,
+    rsvp_plus_ones_max = CASE WHEN v_rsvp_allow_plus_ones THEN GREATEST(v_rsvp_plus_ones_max, 0) ELSE 0 END,
+    rsvp_waitlist_enabled = v_rsvp_waitlist_enabled,
+    rsvp_approval_mode = v_rsvp_approval_mode,
+    rsvp_discoverable = v_rsvp_discoverable,
+    updated_at = v_now
+  WHERE id = p_event_id;
+
+  -- Enqueue rsvp_event_updated for every going+approved guest on material change.
+  IF v_material_change THEN
+    FOR v_guest IN
+      SELECT r.id FROM public.event_rsvps r
+       WHERE r.event_id = p_event_id
+         AND r.rsvp_status = 'going' AND r.approval_status = 'approved'
+    LOOP
+      INSERT INTO public.rsvp_notifications
+        (event_id, rsvp_id, channel, recipient, status, template_key, payload,
+         idempotency_key, attempt_count)
+      VALUES
+        (p_event_id, v_guest.id, NULL, NULL, 'pending', 'rsvp_event_updated',
+         jsonb_build_object('template_key', 'rsvp_event_updated',
+                            'rsvp_id', v_guest.id, 'event_id', p_event_id),
+         'rsvp_update:' || p_event_id::text || ':' || extract(epoch FROM v_now)::bigint::text
+           || ':' || v_guest.id::text,
+         0)
+      ON CONFLICT (idempotency_key) DO NOTHING;
+      v_notified_count := v_notified_count + 1;
+    END LOOP;
+  END IF;
+
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id;
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_going_count
+    FROM public.event_rsvps
+   WHERE event_id = p_event_id AND rsvp_status = 'going' AND approval_status = 'approved';
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'event', to_jsonb(v_event),
+    'going_count', v_going_count,
+    'notified_count', v_notified_count
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_update_live_rsvp(uuid, jsonb, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- (5.3) submit_event_rsvp — guest write (called by public-submit-rsvp edge fn
+--       under service-role, OR directly by a logged-in app user via RLS).
+--       Returns the resolved status. ORCH-1150: do NOT merge back.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.submit_event_rsvp(
+  p_event_id   uuid,
+  p_user_id    uuid,
+  p_guest_name text,
+  p_guest_email text,
+  p_guest_phone text,
+  p_rsvp_status text,
+  p_plus_count  integer DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_event       public.events%ROWTYPE;
+  v_plus        integer;
+  v_confirmed   integer;
+  v_status      text;
+  v_approval    text;
+  v_name        text;
+  v_existing_id uuid;
+BEGIN
+  -- 1. Load + gate the event (FOR UPDATE serializes concurrent submits).
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id FOR UPDATE;
+  IF NOT FOUND
+     OR v_event.event_type <> 'rsvp'
+     OR v_event.status NOT IN ('scheduled', 'live')
+     OR v_event.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'rsvp_not_open';
+  END IF;
+
+  IF p_rsvp_status NOT IN ('going', 'not_going') THEN
+    RAISE EXCEPTION 'rsvp_status_invalid';
+  END IF;
+
+  -- 2. Contact gate for link guests (anon — no user_id).
+  v_name := NULLIF(btrim(COALESCE(p_guest_name, '')), '');
+  IF p_user_id IS NULL THEN
+    IF v_name IS NULL
+       OR NULLIF(btrim(COALESCE(p_guest_email, '')), '') IS NULL
+       OR NULLIF(btrim(COALESCE(p_guest_phone, '')), '') IS NULL THEN
+      RAISE EXCEPTION 'rsvp_contact_required';
+    END IF;
+  END IF;
+  IF v_name IS NULL THEN
+    v_name := COALESCE(NULLIF(btrim(p_guest_email), ''), 'Guest');
+  END IF;
+
+  -- 3. Clamp plus_count.
+  v_plus := GREATEST(COALESCE(p_plus_count, 0), 0);
+  IF v_event.rsvp_allow_plus_ones THEN
+    v_plus := LEAST(v_plus, v_event.rsvp_plus_ones_max);
+  ELSE
+    v_plus := 0;
+  END IF;
+
+  -- 4. Resolve approval + attendance.
+  v_approval := CASE WHEN v_event.rsvp_approval_mode = 'manual' THEN 'pending' ELSE 'approved' END;
+
+  IF p_rsvp_status = 'not_going' THEN
+    v_status := 'not_going';
+  ELSIF v_event.rsvp_capacity IS NULL THEN
+    v_status := 'going';
+  ELSE
+    SELECT COALESCE(SUM(1 + r.plus_count), 0) INTO v_confirmed
+      FROM public.event_rsvps r
+     WHERE r.event_id = p_event_id
+       AND r.rsvp_status = 'going' AND r.approval_status = 'approved'
+       AND (p_user_id IS NULL OR r.user_id IS DISTINCT FROM p_user_id);
+    IF (v_confirmed + 1 + v_plus) > v_event.rsvp_capacity THEN
+      IF v_event.rsvp_approval_mode = 'manual' THEN
+        -- pending doesn't occupy the cap; host's approve is capacity-gated.
+        v_status := 'going';
+      ELSIF v_event.rsvp_waitlist_enabled THEN
+        v_status := 'waitlisted';
+        v_approval := 'approved';
+      ELSE
+        RAISE EXCEPTION 'rsvp_full';
+      END IF;
+    ELSE
+      v_status := 'going';
+    END IF;
+  END IF;
+
+  -- 5. UPSERT the row.
+  IF p_user_id IS NOT NULL THEN
+    SELECT id INTO v_existing_id FROM public.event_rsvps
+     WHERE event_id = p_event_id AND user_id = p_user_id;
+  ELSIF NULLIF(btrim(COALESCE(p_guest_email, '')), '') IS NOT NULL THEN
+    SELECT id INTO v_existing_id FROM public.event_rsvps
+     WHERE event_id = p_event_id AND lower(guest_email) = lower(btrim(p_guest_email));
+  END IF;
+
+  IF v_existing_id IS NOT NULL THEN
+    UPDATE public.event_rsvps
+       SET rsvp_status = v_status,
+           approval_status = v_approval,
+           plus_count = v_plus,
+           guest_name = v_name,
+           guest_email = COALESCE(NULLIF(btrim(p_guest_email), ''), guest_email),
+           guest_phone = COALESCE(NULLIF(btrim(p_guest_phone), ''), guest_phone),
+           waitlisted_at = CASE WHEN v_status = 'waitlisted' THEN COALESCE(waitlisted_at, now()) ELSE NULL END
+     WHERE id = v_existing_id;
+  ELSE
+    INSERT INTO public.event_rsvps
+      (event_id, user_id, guest_name, guest_email, guest_phone,
+       rsvp_status, approval_status, plus_count, waitlisted_at)
+    VALUES
+      (p_event_id, p_user_id, v_name,
+       NULLIF(btrim(p_guest_email), ''), NULLIF(btrim(p_guest_phone), ''),
+       v_status, v_approval, v_plus,
+       CASE WHEN v_status = 'waitlisted' THEN now() ELSE NULL END)
+    RETURNING id INTO v_existing_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'rsvpId', v_existing_id,
+    'status', v_status,
+    'approvalStatus', v_approval,
+    'capacityFull', (v_status = 'waitlisted')
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_event_rsvp(uuid, uuid, text, text, text, text, integer) TO service_role, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- (5.4) host_set_rsvp_status — approve/deny/remove. ORCH-1150: do NOT merge back.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.host_set_rsvp_status(
+  p_rsvp_id uuid,
+  p_status  text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_user_id    uuid;
+  v_rsvp       public.event_rsvps%ROWTYPE;
+  v_event      public.events%ROWTYPE;
+  v_source     text;
+  v_confirmed  integer;
+  v_was_removed boolean := false;
+  v_template   text;
+  v_pending    integer;
+  v_going      integer;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+  IF p_status NOT IN ('approved', 'denied') THEN
+    RAISE EXCEPTION 'rsvp_status_invalid';
+  END IF;
+
+  SELECT * INTO v_rsvp FROM public.event_rsvps WHERE id = p_rsvp_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'rsvp_not_found';
+  END IF;
+  SELECT * INTO v_event FROM public.events WHERE id = v_rsvp.event_id FOR UPDATE;
+  IF NOT FOUND OR v_event.event_type <> 'rsvp' THEN
+    RAISE EXCEPTION 'event_not_an_rsvp';
+  END IF;
+  IF public.biz_brand_effective_rank(v_event.brand_id, v_user_id) < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  v_source := v_rsvp.approval_status;
+
+  -- Idempotent: re-applying current status is a no-op.
+  IF v_source = p_status THEN
+    SELECT count(*) FILTER (WHERE approval_status = 'pending') ,
+           COALESCE(SUM(1 + plus_count) FILTER (WHERE rsvp_status = 'going' AND approval_status = 'approved'), 0)
+      INTO v_pending, v_going
+      FROM public.event_rsvps WHERE event_id = v_event.id;
+    RETURN jsonb_build_object('ok', true, 'rsvpId', p_rsvp_id, 'approvalStatus', p_status,
+      'wasRemoved', false, 'pendingCountRemaining', v_pending, 'goingCountRemaining', v_going);
+  END IF;
+
+  -- denied is terminal for a remove; a denied->approved re-admit is allowed
+  -- (re-approve), but denied->denied handled above; otherwise valid transitions:
+  -- pending->approved, pending->denied, approved->denied (remove), denied->approved.
+  IF p_status = 'approved' THEN
+    -- Capacity gate on approve.
+    IF v_event.rsvp_capacity IS NOT NULL THEN
+      SELECT COALESCE(SUM(1 + r.plus_count), 0) INTO v_confirmed
+        FROM public.event_rsvps r
+       WHERE r.event_id = v_event.id
+         AND r.rsvp_status = 'going' AND r.approval_status = 'approved'
+         AND r.id <> p_rsvp_id;
+      IF (v_confirmed + 1 + v_rsvp.plus_count) > v_event.rsvp_capacity THEN
+        RAISE EXCEPTION 'rsvp_capacity_full';
+      END IF;
+    END IF;
+    UPDATE public.event_rsvps
+       SET approval_status = 'approved',
+           rsvp_status = CASE WHEN rsvp_status = 'waitlisted' THEN 'going' ELSE rsvp_status END
+     WHERE id = p_rsvp_id;
+    v_template := 'rsvp_approved';
+  ELSE
+    -- denied. approved->denied = host remove.
+    v_was_removed := (v_source = 'approved');
+    UPDATE public.event_rsvps
+       SET approval_status = 'denied'
+     WHERE id = p_rsvp_id;
+    v_template := CASE WHEN v_was_removed THEN 'rsvp_removed' ELSE 'rsvp_denied' END;
+  END IF;
+
+  INSERT INTO public.rsvp_notifications
+    (event_id, rsvp_id, channel, recipient, status, template_key, payload,
+     idempotency_key, attempt_count)
+  VALUES
+    (v_event.id, p_rsvp_id, NULL, NULL, 'pending', v_template,
+     jsonb_build_object('template_key', v_template, 'rsvp_id', p_rsvp_id, 'event_id', v_event.id),
+     'rsvp_approval:' || p_rsvp_id::text || ':' || v_source || ':' || p_status,
+     0)
+  ON CONFLICT (idempotency_key) DO NOTHING;
+
+  SELECT count(*) FILTER (WHERE approval_status = 'pending'),
+         COALESCE(SUM(1 + plus_count) FILTER (WHERE rsvp_status = 'going' AND approval_status = 'approved'), 0)
+    INTO v_pending, v_going
+    FROM public.event_rsvps WHERE event_id = v_event.id;
+
+  RETURN jsonb_build_object(
+    'ok', true, 'rsvpId', p_rsvp_id, 'approvalStatus', p_status,
+    'wasRemoved', v_was_removed,
+    'pendingCountRemaining', v_pending, 'goingCountRemaining', v_going
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.host_set_rsvp_status(uuid, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- host_bulk_approve_rsvps — approve all pending up to remaining capacity.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.host_bulk_approve_rsvps(
+  p_event_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_user_id     uuid;
+  v_event       public.events%ROWTYPE;
+  v_confirmed   integer;
+  v_free        integer;
+  v_entry       record;
+  v_approved    integer := 0;
+  v_skipped     integer := 0;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id FOR UPDATE;
+  IF NOT FOUND OR v_event.event_type <> 'rsvp' THEN
+    RAISE EXCEPTION 'event_not_an_rsvp';
+  END IF;
+  IF public.biz_brand_effective_rank(v_event.brand_id, v_user_id) < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_confirmed
+    FROM public.event_rsvps
+   WHERE event_id = p_event_id AND rsvp_status = 'going' AND approval_status = 'approved';
+  v_free := CASE WHEN v_event.rsvp_capacity IS NULL THEN NULL ELSE v_event.rsvp_capacity - v_confirmed END;
+
+  FOR v_entry IN
+    SELECT id, plus_count FROM public.event_rsvps
+     WHERE event_id = p_event_id AND approval_status = 'pending'
+     ORDER BY created_at ASC
+  LOOP
+    IF v_free IS NOT NULL AND (1 + v_entry.plus_count) > v_free THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+    UPDATE public.event_rsvps
+       SET approval_status = 'approved',
+           rsvp_status = CASE WHEN rsvp_status = 'waitlisted' THEN 'going' ELSE rsvp_status END
+     WHERE id = v_entry.id;
+    INSERT INTO public.rsvp_notifications
+      (event_id, rsvp_id, channel, recipient, status, template_key, payload,
+       idempotency_key, attempt_count)
+    VALUES
+      (p_event_id, v_entry.id, NULL, NULL, 'pending', 'rsvp_approved',
+       jsonb_build_object('template_key', 'rsvp_approved', 'rsvp_id', v_entry.id, 'event_id', p_event_id),
+       'rsvp_approval:' || v_entry.id::text || ':pending:approved', 0)
+    ON CONFLICT (idempotency_key) DO NOTHING;
+    v_approved := v_approved + 1;
+    IF v_free IS NOT NULL THEN
+      v_free := v_free - (1 + v_entry.plus_count);
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('approvedCount', v_approved, 'skippedForCapacity', v_skipped);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.host_bulk_approve_rsvps(uuid) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- listRsvpGuests support — host-scoped read RPC (pending first then going then
+-- waitlisted). SECURITY INVOKER so RLS host-read applies.
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.host_list_rsvp_guests(uuid);
+CREATE FUNCTION public.host_list_rsvp_guests(p_event_id uuid)
+RETURNS TABLE (
+  id uuid, event_id uuid, user_id uuid, guest_name text, guest_email text,
+  guest_phone text, rsvp_status text, approval_status text, plus_count integer,
+  waitlisted_at timestamptz, promoted_at timestamptz, created_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = public
+AS $$
+  SELECT r.id, r.event_id, r.user_id, r.guest_name, r.guest_email, r.guest_phone,
+         r.rsvp_status, r.approval_status, r.plus_count,
+         r.waitlisted_at, r.promoted_at, r.created_at
+    FROM public.event_rsvps r
+   WHERE r.event_id = p_event_id
+   ORDER BY
+     CASE WHEN r.approval_status = 'pending' THEN 0
+          WHEN r.rsvp_status = 'going' AND r.approval_status = 'approved' THEN 1
+          WHEN r.rsvp_status = 'waitlisted' THEN 2
+          ELSE 3 END,
+     r.created_at ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.host_list_rsvp_guests(uuid) TO authenticated;
+
+COMMIT;
+
+-- ===========================================================================
+-- (4.1e) Discover-RPC widen — admit opted-in RSVP rows onto the consumer deck.
+--        Full CREATE OR REPLACE so the latest definition wins (migration-chain).
+--        RSVP rows have no paid-ticket concept → display_price_cents resolves
+--        NULL; the gated CTE leaves them untouched (has_paid_online = false).
+-- ===========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.pg_discover_business_events(
+  p_cities text[],
+  p_lower_bound timestamptz,
+  p_upper_start timestamptz DEFAULT NULL,
+  p_party_types text[] DEFAULT NULL,
+  p_vibe_tags text[] DEFAULT NULL,
+  p_music_genres text[] DEFAULT NULL,
+  p_offset integer DEFAULT 0,
+  p_limit integer DEFAULT 20
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  WITH base AS (
+    SELECT
+      e.id,
+      e.brand_id,
+      e.title,
+      e.description,
+      e.slug,
+      e.location_text,
+      e.location_geo,
+      e.online_url,
+      e.is_online,
+      e.cover_media_url,
+      e.cover_media_type,
+      e.theme,
+      e.timezone,
+      e.currency,
+      e.city,
+      e.party_types,
+      e.vibe_tags,
+      e.music_genres,
+      e.event_type,
+      b.slug AS brand_slug,
+      b.name AS brand_name,
+      b.profile_photo_url AS brand_profile_photo_url,
+      ed.start_at AS master_start_at,
+      ed.end_at AS master_end_at,
+      ed.timezone AS master_timezone,
+      (
+        SELECT MIN(tt.price_cents)
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.deleted_at IS NULL
+          AND tt.is_hidden IS NOT TRUE
+          AND tt.is_disabled IS NOT TRUE
+          AND tt.price_cents IS NOT NULL
+      ) AS price_min_cents,
+      (
+        SELECT MAX(tt.price_cents)
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.deleted_at IS NULL
+          AND tt.is_hidden IS NOT TRUE
+          AND tt.is_disabled IS NOT TRUE
+          AND tt.price_cents IS NOT NULL
+      ) AS price_max_cents,
+      EXISTS (
+        SELECT 1
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.deleted_at IS NULL
+          AND tt.is_hidden IS NOT TRUE
+          AND tt.is_disabled IS NOT TRUE
+          AND tt.available_online IS TRUE
+          AND tt.price_cents > 0
+      ) AS has_paid_online,
+      (
+        SELECT public.compute_all_in_cents(
+          MIN(tt.price_cents),
+          COALESCE(e.pass_mingla_fee, b.default_pass_mingla_fee),
+          COALESCE(e.pass_service_fee, b.default_pass_service_fee),
+          (SELECT r.effective_take_rate_bps FROM public.resolve_effective_take_rate_bps(b.id) r)
+        )
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.price_cents > 0
+          AND tt.deleted_at IS NULL
+      ) AS display_price_cents,
+      b.pricing_currency AS pricing_currency
+    FROM public.events e
+    INNER JOIN public.brands b ON b.id = e.brand_id AND b.deleted_at IS NULL
+    INNER JOIN public.event_dates ed
+      ON ed.event_id = e.id
+     AND ed.is_master IS TRUE
+     AND ed.end_at >= p_lower_bound
+    WHERE e.deleted_at IS NULL
+      AND e.visibility = 'public'
+      -- ORCH-1150: admit opted-in RSVP rows alongside ticketed events.
+      AND ( e.event_type = 'event'
+         OR (e.event_type = 'rsvp' AND e.rsvp_discoverable = true) )
+      AND e.status = ANY (ARRAY['scheduled', 'live'])
+      AND e.city = ANY (p_cities)
+      AND (p_upper_start IS NULL OR ed.start_at <= p_upper_start)
+      AND (p_party_types IS NULL OR cardinality(p_party_types) = 0 OR e.party_types && p_party_types)
+      AND (p_vibe_tags IS NULL OR cardinality(p_vibe_tags) = 0 OR e.vibe_tags && p_vibe_tags)
+      AND (p_music_genres IS NULL OR cardinality(p_music_genres) = 0 OR e.music_genres && p_music_genres)
+  ),
+  gated AS (
+    SELECT *
+    FROM base
+    WHERE NOT (has_paid_online AND NOT public.pg_brand_can_charge(brand_id))
+  ),
+  ranked AS (
+    SELECT
+      g.*,
+      COUNT(*) OVER () AS total_count
+    FROM gated g
+    ORDER BY master_start_at ASC NULLS LAST
+    OFFSET GREATEST(p_offset, 0)
+    LIMIT GREATEST(p_limit, 0)
+  )
+  SELECT jsonb_build_object(
+    'total', COALESCE((SELECT total_count FROM ranked LIMIT 1), 0),
+    'rows', COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', r.id,
+            'brand_id', r.brand_id,
+            'title', r.title,
+            'description', r.description,
+            'slug', r.slug,
+            'location_text', r.location_text,
+            'location_geo', r.location_geo,
+            'online_url', r.online_url,
+            'is_online', r.is_online,
+            'cover_media_url', r.cover_media_url,
+            'cover_media_type', r.cover_media_type,
+            'theme', r.theme,
+            'timezone', r.timezone,
+            'currency', r.currency,
+            'city', r.city,
+            'party_types', r.party_types,
+            'vibe_tags', r.vibe_tags,
+            'music_genres', r.music_genres,
+            'event_type', r.event_type,
+            'brand_slug', r.brand_slug,
+            'brand_name', r.brand_name,
+            'brand_profile_photo_url', r.brand_profile_photo_url,
+            'master_start_at', r.master_start_at,
+            'master_end_at', r.master_end_at,
+            'master_timezone', r.master_timezone,
+            'price_min_cents', r.price_min_cents,
+            'price_max_cents', r.price_max_cents,
+            'display_price_cents', r.display_price_cents,
+            'pricing_currency', r.pricing_currency
+          )
+          ORDER BY r.master_start_at ASC NULLS LAST
+        )
+        FROM ranked r
+      ),
+      '[]'::jsonb
+    )
+  );
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.pg_discover_business_events(
+  text[], timestamptz, timestamptz, text[], text[], text[], integer, integer
+) TO service_role;
+
+-- Widen the consumer discover-feed partial index to also cover RSVP rows.
+DROP INDEX IF EXISTS public.idx_events_discover_feed;
+CREATE INDEX idx_events_discover_feed
+  ON public.events (city)
+  WHERE deleted_at IS NULL
+    AND visibility = 'public'
+    AND status IN ('scheduled', 'live')
+    AND event_type IN ('event', 'rsvp');
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/__tests__/orch_1150_rsvp.test.sql
+++ b/supabase/migrations/__tests__/orch_1150_rsvp.test.sql
@@ -1,0 +1,325 @@
+-- ORCH-1150 [RSVP ticketless event] — SQL contract tests (T1 / T2 / T4 / T6).
+--
+-- Covers four of the six §9 fails-on-revert invariants for the RSVP migration
+-- 20261004000000_orch_1150_rsvp_events.sql:
+--   T1 = §9.1 I-PROPOSED-1150-RSVP-NO-TICKET-ROWS
+--   T2 = §9.2 I-PROPOSED-1150-RSVP-OFF-DECK-UNLESS-DISCOVERABLE
+--   T4 = §9.4 I-PROPOSED-1150-WAITLIST-AUTOPROMOTE-OLDEST (incl. the A2-NEW
+--        host-remove approved->denied arm)
+--   T6 = §9.6 I-PROPOSED-1150-LINK-GUEST-CONTACT-BOTH-REQUIRED
+--
+-- USAGE (this repo's SQL probe convention — hand-run against the linked remote
+-- AFTER the orchestrator applies the migration; these tests are NOT run by the
+-- implementor, they await the orchestrator's DB run):
+--
+--   cat supabase/migrations/__tests__/orch_1150_rsvp.test.sql \
+--     | /Users/sethogieva/bin/supabase db remote sql --linked
+--
+-- Each block is wrapped in BEGIN; … ROLLBACK; so it leaves NO fixture rows.
+-- RAISE NOTICE on PASS, RAISE EXCEPTION on FAIL (non-zero exit in CI/scripts).
+
+-- ===========================================================================
+-- T1 (§9.1) — publishing an RSVP draft creates ZERO ticket_types rows.
+-- Drives the real publish RPC business_publish_rsvp_draft on a draft row, then
+-- asserts no non-deleted ticket_types exist. Reverting the "DELETE the ticket
+-- INSERT loop" delta (or re-pointing RSVP at the event RPC) makes this FAIL.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_user   uuid := gen_random_uuid();
+  v_brand  uuid := gen_random_uuid();
+  v_event  uuid := gen_random_uuid();
+  v_tcount int;
+  v_payload jsonb;
+BEGIN
+  -- Brand owned by v_user (account_id) so biz_brand_effective_rank resolves
+  -- owner rank for the publish RPC's event_manager gate.
+  INSERT INTO public.brands (id, account_id, slug, name, default_currency, created_at, updated_at)
+  VALUES (v_brand, v_user, 'orch1150-t1-brand', 'ORCH1150 T1', 'USD', now(), now());
+
+  -- A draft RSVP row (event_type='rsvp', status='draft') with a single future date.
+  INSERT INTO public.events (id, brand_id, created_by, event_type, title, slug, description,
+    status, visibility, currency, timezone, party_types, rsvp_approval_mode,
+    rsvp_discoverable, created_at, updated_at,
+    theme)
+  VALUES (v_event, v_brand, v_user, 'rsvp', 'House Party', 'house-party-t1',
+    'Come through, it''s a vibe.', 'draft', 'public', 'USD', 'UTC',
+    ARRAY['house-party'], 'auto', false, now(), now(),
+    -- The publish RPC reads taxonomy + rsvp host-control from theme->business_draft.
+    jsonb_build_object('business_draft', jsonb_build_object(
+      'partyTypes', jsonb_build_array('house-party'),
+      'rsvpApprovalMode', 'auto',
+      'rsvpDiscoverable', false)));
+
+  -- Impersonate the owner for auth.uid() inside the SECURITY DEFINER publish RPC.
+  PERFORM set_config('request.jwt.claim.sub', v_user::text, true);
+  PERFORM set_config('role', 'authenticated', true);
+
+  -- Publish payload — the RPC reads title/timezone/when from the TOP LEVEL of
+  -- the payload (taxonomy + rsvp host-control come from theme->business_draft,
+  -- seeded above) and re-materializes the single event_date.
+  v_payload := jsonb_build_object(
+    'title', 'House Party',
+    'timezone', 'UTC',
+    'when', jsonb_build_object(
+      'date', to_char((now() + interval '7 day')::date, 'YYYY-MM-DD'),
+      'doorsOpen', '19:00',
+      'endsAt', '23:00'));
+
+  PERFORM public.business_publish_rsvp_draft(v_event, v_payload, NULL);
+
+  -- THE assertion: zero non-deleted ticket_types for the published RSVP.
+  SELECT count(*) INTO v_tcount
+  FROM public.ticket_types
+  WHERE event_id = v_event AND deleted_at IS NULL;
+  IF v_tcount <> 0 THEN
+    RAISE EXCEPTION 'T1 FAIL: RSVP publish created % ticket_types (expected 0)', v_tcount;
+  END IF;
+
+  -- And the row is now a published RSVP.
+  PERFORM 1 FROM public.events
+   WHERE id = v_event AND event_type = 'rsvp' AND status IN ('scheduled','live');
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'T1 FAIL: RSVP row is not a published rsvp after publish';
+  END IF;
+
+  RAISE NOTICE 'T1 PASS: RSVP publish creates zero ticket_types + row is a published rsvp';
+END$$;
+ROLLBACK;
+
+-- ===========================================================================
+-- T2 (§9.2) — an RSVP appears in the discover RPC IFF rsvp_discoverable=true;
+-- a ticketed event is unaffected. Reverting the discover-RPC widen (or the
+-- rsvp_discoverable predicate) makes this FAIL.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_brand    uuid;
+  v_disc     uuid := gen_random_uuid();  -- discoverable RSVP
+  v_link     uuid := gen_random_uuid();  -- link-only RSVP (not discoverable)
+  v_ticketed uuid := gen_random_uuid();  -- control ticketed event
+  v_city     text := 'orch1150t2city';
+  v_rows     jsonb;
+  v_ids      uuid[];
+BEGIN
+  INSERT INTO public.brands (id, slug, name, default_currency, created_at, updated_at)
+  VALUES (gen_random_uuid(), 'orch1150-t2-brand', 'ORCH1150 T2', 'USD', now(), now())
+  RETURNING id INTO v_brand;
+
+  -- Discoverable RSVP.
+  INSERT INTO public.events (id, brand_id, event_type, title, slug, description,
+    status, visibility, currency, timezone, city, rsvp_discoverable,
+    published_at, created_at, updated_at)
+  VALUES (v_disc, v_brand, 'rsvp', 'Discoverable RSVP', 'disc-rsvp-t2', 'd',
+    'scheduled', 'public', 'USD', 'UTC', v_city, true, now(), now(), now());
+  INSERT INTO public.event_dates (id, event_id, start_at, end_at, timezone, is_master)
+  VALUES (gen_random_uuid(), v_disc, now() + interval '5 day',
+    now() + interval '5 day' + interval '2 hour', 'UTC', true);
+
+  -- Link-only RSVP (rsvp_discoverable=false).
+  INSERT INTO public.events (id, brand_id, event_type, title, slug, description,
+    status, visibility, currency, timezone, city, rsvp_discoverable,
+    published_at, created_at, updated_at)
+  VALUES (v_link, v_brand, 'rsvp', 'Link RSVP', 'link-rsvp-t2', 'd',
+    'scheduled', 'public', 'USD', 'UTC', v_city, false, now(), now(), now());
+  INSERT INTO public.event_dates (id, event_id, start_at, end_at, timezone, is_master)
+  VALUES (gen_random_uuid(), v_link, now() + interval '5 day',
+    now() + interval '5 day' + interval '2 hour', 'UTC', true);
+
+  -- Ticketed control event (always eligible).
+  INSERT INTO public.events (id, brand_id, event_type, title, slug, description,
+    status, visibility, currency, timezone, city, published_at, created_at, updated_at)
+  VALUES (v_ticketed, v_brand, 'event', 'Ticketed', 'ticketed-t2', 'd',
+    'scheduled', 'public', 'USD', 'UTC', v_city, now(), now(), now());
+  INSERT INTO public.event_dates (id, event_id, start_at, end_at, timezone, is_master)
+  VALUES (gen_random_uuid(), v_ticketed, now() + interval '5 day',
+    now() + interval '5 day' + interval '2 hour', 'UTC', true);
+
+  -- Call the widened discover RPC for the test city.
+  v_rows := public.pg_discover_business_events(
+    ARRAY[v_city], now() - interval '1 day', now() + interval '30 day',
+    NULL, NULL, NULL, 0, 50);
+
+  SELECT array_agg((elem->>'id')::uuid)
+    INTO v_ids
+    FROM jsonb_array_elements(v_rows) AS elem;
+
+  IF NOT (v_disc = ANY(v_ids)) THEN
+    RAISE EXCEPTION 'T2 FAIL: discoverable RSVP missing from discover feed';
+  END IF;
+  IF v_link = ANY(v_ids) THEN
+    RAISE EXCEPTION 'T2 FAIL: link-only (non-discoverable) RSVP leaked into discover feed';
+  END IF;
+  IF NOT (v_ticketed = ANY(v_ids)) THEN
+    RAISE EXCEPTION 'T2 FAIL: ticketed control event missing from discover feed (regression)';
+  END IF;
+
+  RAISE NOTICE 'T2 PASS: discoverable RSVP in feed, link-only out, ticketed unaffected';
+END$$;
+ROLLBACK;
+
+-- ===========================================================================
+-- T4 (§9.4) — waitlist auto-promote OLDEST, never exceeding the cap, including
+-- the A2-NEW host-remove (approved->denied) arm that reuses the SAME drain
+-- trigger. Reverting fn_rsvp_drain_on_capacity_freed (or its ORDER BY
+-- waitlisted_at, or removing approved->denied from the spot-freeing condition)
+-- makes this FAIL.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_brand   uuid;
+  v_event   uuid := gen_random_uuid();
+  v_g1      uuid := gen_random_uuid();  -- going+approved (occupies seat 1)
+  v_g2      uuid := gen_random_uuid();  -- going+approved (occupies seat 2)
+  v_w_old   uuid := gen_random_uuid();  -- OLDEST waitlisted
+  v_w_new   uuid := gen_random_uuid();  -- newer waitlisted
+  v_status  text;
+  v_promoted timestamptz;
+  v_confirmed int;
+BEGIN
+  INSERT INTO public.brands (id, slug, name, default_currency, created_at, updated_at)
+  VALUES (gen_random_uuid(), 'orch1150-t4-brand', 'ORCH1150 T4', 'USD', now(), now())
+  RETURNING id INTO v_brand;
+
+  -- auto-mode RSVP, capacity = 2, waitlist on.
+  INSERT INTO public.events (id, brand_id, event_type, title, slug, description,
+    status, visibility, currency, timezone, rsvp_capacity, rsvp_waitlist_enabled,
+    rsvp_approval_mode, published_at, created_at, updated_at)
+  VALUES (v_event, v_brand, 'rsvp', 'Capped Party', 'capped-t4', 'd',
+    'scheduled', 'public', 'USD', 'UTC', 2, true, 'auto', now(), now(), now());
+
+  -- 2 going+approved fill the cap.
+  INSERT INTO public.event_rsvps (id, event_id, user_id, guest_name, guest_email,
+    guest_phone, rsvp_status, approval_status, plus_count, created_at)
+  VALUES
+    (v_g1, v_event, gen_random_uuid(), 'G1', NULL, NULL, 'going', 'approved', 0, now()),
+    (v_g2, v_event, gen_random_uuid(), 'G2', NULL, NULL, 'going', 'approved', 0, now());
+
+  -- 2 waitlisted with DISTINCT waitlisted_at (old < new).
+  INSERT INTO public.event_rsvps (id, event_id, user_id, guest_name, guest_email,
+    guest_phone, rsvp_status, approval_status, plus_count, waitlisted_at, created_at)
+  VALUES
+    (v_w_old, v_event, gen_random_uuid(), 'Wold', NULL, NULL, 'waitlisted', 'approved', 0,
+      now() - interval '10 min', now() - interval '10 min'),
+    (v_w_new, v_event, gen_random_uuid(), 'Wnew', NULL, NULL, 'waitlisted', 'approved', 0,
+      now() - interval '1 min', now() - interval '1 min');
+
+  -- ── Arm A: a going+approved flips to not_going → frees 1 seat → OLDEST promotes.
+  UPDATE public.event_rsvps SET rsvp_status = 'not_going' WHERE id = v_g1;
+
+  SELECT rsvp_status, promoted_at INTO v_status, v_promoted
+  FROM public.event_rsvps WHERE id = v_w_old;
+  IF v_status <> 'going' OR v_promoted IS NULL THEN
+    RAISE EXCEPTION 'T4 FAIL (arm A): oldest waitlisted did not promote to going (status=%, promoted=%)', v_status, v_promoted;
+  END IF;
+
+  SELECT rsvp_status INTO v_status FROM public.event_rsvps WHERE id = v_w_new;
+  IF v_status <> 'waitlisted' THEN
+    RAISE EXCEPTION 'T4 FAIL (arm A): newer waitlisted wrongly promoted (cap exceeded)';
+  END IF;
+
+  -- Never exceed the cap.
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_confirmed
+  FROM public.event_rsvps WHERE event_id = v_event
+    AND rsvp_status = 'going' AND approval_status = 'approved';
+  IF v_confirmed > 2 THEN
+    RAISE EXCEPTION 'T4 FAIL (arm A): confirmed-attending % exceeds cap 2', v_confirmed;
+  END IF;
+
+  -- Exactly one promote-notify enqueued for the promoted guest.
+  PERFORM 1 FROM public.rsvp_notifications
+   WHERE rsvp_id = v_w_old AND template_key = 'rsvp_waitlist_promoted';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'T4 FAIL (arm A): no rsvp_waitlist_promoted notification enqueued for oldest';
+  END IF;
+
+  -- ── Arm B (A2-NEW host-remove): cap is full again (g2 + w_old). Remove an
+  --    approved/Going guest via approved->denied → the SAME trigger promotes
+  --    the next-oldest waitlisted (w_new). Proves host-remove reuses the drain.
+  UPDATE public.event_rsvps SET approval_status = 'denied' WHERE id = v_g2;
+
+  SELECT rsvp_status, promoted_at INTO v_status, v_promoted
+  FROM public.event_rsvps WHERE id = v_w_new;
+  IF v_status <> 'going' OR v_promoted IS NULL THEN
+    RAISE EXCEPTION 'T4 FAIL (arm B host-remove): w_new did not promote on approved->denied (status=%)', v_status;
+  END IF;
+
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_confirmed
+  FROM public.event_rsvps WHERE event_id = v_event
+    AND rsvp_status = 'going' AND approval_status = 'approved';
+  IF v_confirmed > 2 THEN
+    RAISE EXCEPTION 'T4 FAIL (arm B): confirmed-attending % exceeds cap 2 after host-remove', v_confirmed;
+  END IF;
+
+  RAISE NOTICE 'T4 PASS: oldest-first auto-promote + host-remove(approved->denied) reuses the drain, cap never exceeded';
+END$$;
+ROLLBACK;
+
+-- ===========================================================================
+-- T6 (§9.6) — a LINK guest (user_id IS NULL) MUST carry BOTH guest_email AND
+-- guest_phone; app-user rows (user_id NOT NULL) are exempt. The DB CHECK
+-- event_rsvps_link_guest_contact_required is the last line of defense.
+-- Reverting that CHECK makes this FAIL.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_brand uuid;
+  v_event uuid := gen_random_uuid();
+  v_ok    boolean;
+BEGIN
+  INSERT INTO public.brands (id, slug, name, default_currency, created_at, updated_at)
+  VALUES (gen_random_uuid(), 'orch1150-t6-brand', 'ORCH1150 T6', 'USD', now(), now())
+  RETURNING id INTO v_brand;
+
+  INSERT INTO public.events (id, brand_id, event_type, title, slug, description,
+    status, visibility, currency, timezone, published_at, created_at, updated_at)
+  VALUES (v_event, v_brand, 'rsvp', 'Contact Test', 'contact-t6', 'd',
+    'scheduled', 'public', 'USD', 'UTC', now(), now(), now());
+
+  -- (a) link guest with email but NO phone → REJECTED.
+  v_ok := true;
+  BEGIN
+    INSERT INTO public.event_rsvps (event_id, user_id, guest_name, guest_email, guest_phone)
+    VALUES (v_event, NULL, 'NoPhone', 'a@b.com', NULL);
+  EXCEPTION WHEN check_violation THEN
+    v_ok := false;
+  END;
+  IF v_ok THEN
+    RAISE EXCEPTION 'T6 FAIL: link guest with email but no phone was ACCEPTED (CHECK missing)';
+  END IF;
+
+  -- (b) link guest with phone but NO email → REJECTED.
+  v_ok := true;
+  BEGIN
+    INSERT INTO public.event_rsvps (event_id, user_id, guest_name, guest_email, guest_phone)
+    VALUES (v_event, NULL, 'NoEmail', NULL, '+15551234567');
+  EXCEPTION WHEN check_violation THEN
+    v_ok := false;
+  END;
+  IF v_ok THEN
+    RAISE EXCEPTION 'T6 FAIL: link guest with phone but no email was ACCEPTED (CHECK missing)';
+  END IF;
+
+  -- (c) link guest with BOTH email AND phone → ACCEPTED.
+  BEGIN
+    INSERT INTO public.event_rsvps (event_id, user_id, guest_name, guest_email, guest_phone)
+    VALUES (v_event, NULL, 'BothOK', 'both@b.com', '+15559876543');
+  EXCEPTION WHEN check_violation THEN
+    RAISE EXCEPTION 'T6 FAIL: link guest with BOTH email+phone was wrongly REJECTED';
+  END;
+
+  -- (d) app-user row (user_id NOT NULL) with NEITHER → ACCEPTED (exempt).
+  BEGIN
+    INSERT INTO public.event_rsvps (event_id, user_id, guest_name, guest_email, guest_phone)
+    VALUES (v_event, gen_random_uuid(), 'AppUser', NULL, NULL);
+  EXCEPTION WHEN check_violation THEN
+    RAISE EXCEPTION 'T6 FAIL: app-user row with no contact was wrongly REJECTED (exemption broken)';
+  END;
+
+  RAISE NOTICE 'T6 PASS: link guests require email AND phone; app-user rows exempt';
+END$$;
+ROLLBACK;


### PR DESCRIPTION
## ORCH-1150 — RSVP event (Partiful-style)

A ticketless **RSVP event** type: guests reply **Going / Not going**, no tickets, no checkout. Built as a sibling to the Ticketed event wizard (forked off `events.event_type`), with the live Ticketed path left byte-identical.

### What ships
- **Create chooser fork** — the `+` sheet "Event" row now forks to **Ticketed event** (`/event/create`, untouched) vs **RSVP event** (`/rsvp/create`).
- **6-step RSVP wizard** (Basics → When → Where → Cover → **RSVP setup** → Preview), single-date, money-free; Party Type kept; full host control on the RSVP-setup step (capacity, +1s, waitlist, auto/manual approval, guest-list privacy, discovery toggle).
- **Public Going/Not-going page** on `/e/{slug}` — contact capture (name+email+phone required for link guests), +1s, real waitlist + pending-approval states. Default RSVP = public-page-renders + off-deck (invite-link/Partiful model).
- **Host approve/deny/remove console** (`/rsvp/[id]/guests`) — admit/deny/bulk-approve + remove a Going guest (frees a spot → auto-promote).
- **Full waitlist** — `fn_rsvp_drain_on_capacity_freed` trigger auto-promotes the oldest waitlisted guest + notifies.
- **Tri-channel notify** — `rsvp-notify` edge fn fans out push (OneSignal) + SMS (Twilio) + email (Resend), per-channel non-blocking; reuses existing clients.
- **Consumer deck card** (discoverable RSVPs only) + **Hub "N going"** branch.

### Schema / backend
- Migration `20261004000000_orch_1150_rsvp_events.sql` — `event_type` CHECK widen +`'rsvp'`, `events` RSVP columns, `event_rsvps` table (two-dimension status + contact), RLS, `rsvp_notifications` queue, RPCs (`business_publish_rsvp_draft`/`biz_update_live_rsvp`/`host_set_rsvp_status`/`host_bulk_approve_rsvps`/`submit_event_rsvp`), drain trigger, discover widen.
- New edge fns: `public-submit-rsvp` (verify_jwt=false), `rsvp-notify` (verify_jwt=true).

### Tests
- 24 jest (mingla-business) + 8 Deno (rsvp-notify fanout, deck) green; 3 fails-on-revert proofs.
- 4 SQL regression probes (T1 no-ticket-rows / T2 off-deck-unless-discoverable / T4 waitlist-autopromote+host-remove / T6 link-guest-contact-both-required) — await post-apply DB run.

### DO-NOT-TOUCH
Ticketed publish/checkout byte-identical (RSVP branches are early-returns); only additive changes to the event path (`validateBasics` export, `CreatorStep2When` `lockSingleDate` prop).

Artifacts: spec + investigation + implementation report under `Mingla_Artifacts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)