### PR TITLE
META-ORCH-1148 2.1b: Reservations lifecycle + Waitlist + Twilio table-ready SMS [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1148_SUBB_2_1B.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1148_SUBB_2_1B.md
@@ -170,3 +170,110 @@ All reverts restored with zero residual diff.
 NEXT = **mingla-tester** (business iOS + Android + web-desktop + web-phone device/sim proof of the Reservations + Waitlist modules + manual create + lifecycle actions + realtime + the SMS notify path on a Twilio test number; confirm the money seam + the engine-frozen contract held). Then **mingla-orchestrator CLOSE** — apply the 4 migrations via Management API from MERGED main, run `get_advisors`, set the Twilio secrets, deploy `send-venue-sms`, flip the 4 DRAFT invariants ACTIVE, register 2.1b on the World Map. Then **2.2** (consumer/web booking surface + the engine's `anon` GRANT seam).
 
 *No deploy / no migration applied to prod / no edge-fn deploy / no merge performed by this implementor.*
+
+---
+
+## 10. D-1 + D-2 fix (RETEST rework, post-tester CONDITIONAL PASS)
+
+Fixing the two P2 defects from `TEST_META-ORCH-1148_SUBB_2_1B.md`. Scope NOT widened; money seam + engine frozen untouched. Comms Ledger read on entry — no OPEN BLOCK row addressed to ALL / ORCH-1148 / mingla-implementor; the prior report's "no COMMS_LEDGER.md exists" claim (tester D-3) is corrected — it DOES exist at the worktree/main root and was read this pass.
+
+**New files (touched on the branch):**
+- `supabase/migrations/20261011000000_orch_1148_2_1b_table_brand_scope.sql` — D-1 (CREATE OR REPLACE the 3 RPCs with the same-brand guard).
+- `supabase/migrations/20261011000001_orch_1148_2_1b_sms_optout_rpc.sql` — D-2 (partial-index-safe global opt-out RPC).
+- `supabase/functions/send-venue-sms/index.ts` — D-2 (call the RPC + try/catch).
+- `supabase/functions/__tests__/send_venue_sms.test.ts` — D-2 fails-on-revert assertion.
+- `supabase/migrations/__tests__/orch_1148_2_1b_lifecycle_adversarial.tester.sql` — D-1/D-2 hard fails-on-revert assertions (B1-B4, C4, C5, H1-H3).
+
+Migration versions monotonic: true global max across anchor main (`20261002000000`) + every sibling worktree (2.1b chain through `20261010000003`) was `20261010000003`; the two new migrations are `20261011000000` / `…001`, strictly above. No duplicate prefixes introduced (two pre-existing dup prefixes `20260612000000` / `20260615000000` are in git HEAD, not mine).
+
+### D-1 — cross-brand `table_id` assignment (P2, data integrity)
+
+**Before** (all three RPCs accepted `p_table_id` with NO brand check):
+```sql
+-- biz_reservation_transition
+UPDATE public.reservations SET status = p_to_status,
+       table_id = COALESCE(p_table_id, table_id), updated_at = now() WHERE id = p_reservation_id ...
+-- biz_reservation_create
+INSERT INTO public.reservations (..., table_id, ...) VALUES (..., p_table_id, ...);
+-- biz_waitlist_convert_to_reservation
+INSERT INTO public.reservations (brand_id, ..., table_id, ...) VALUES (v_brand, ..., p_table_id, ...);
+```
+`reservations.table_id` FKs `venue_tables(id)` GLOBALLY (not brand-scoped) → a Brand-A manager could stamp Brand-B's `table_id`.
+
+**After** — in each RPC, before the write, when `p_table_id IS NOT NULL`:
+```sql
+IF p_table_id IS NOT NULL
+   AND NOT EXISTS (
+     SELECT 1 FROM public.venue_tables
+      WHERE id = p_table_id AND brand_id = v_brand   -- (p_brand_id in create)
+   ) THEN
+  RAISE EXCEPTION 'table_brand_mismatch: table % does not belong to brand %',
+    p_table_id, v_brand USING ERRCODE = '23514';
+END IF;
+```
+NULL `p_table_id` stays allowed. SECURITY DEFINER + manager+ gate + audit + lifecycle matrix + convert atomicity preserved verbatim; REVOKE FROM PUBLIC + FROM anon re-emitted for every function (auto-grant gotcha).
+
+**Live proof** (Docker `supabase/postgres:17.4.1.075`, all 239 migrations applied clean in version order):
+- `B1 PASS` — cross-brand `table_id` on `biz_reservation_transition` REJECTED (`check_violation`).
+- `B2 PASS` — same-brand table on transition ACCEPTED + persisted.
+- `B3 PASS` — NULL `table_id` transition still allowed.
+- `B4 PASS` — cross-brand `table_id` on `biz_reservation_create` REJECTED.
+- `C4 PASS` — cross-brand table on `biz_waitlist_convert_to_reservation` REJECTED, NO orphan reservation, waitlist stays `waiting` (atomic abort before INSERT).
+- `C5 PASS` — same-brand table on convert ACCEPTED + linked.
+
+**Fails-on-revert (D-1), proven live:** re-applied the pre-D-1 RPC bodies (`20261010000001` / `…002`) into the live container, re-ran the cross-brand attack → `FAILS-ON-REVERT CONFIRMED (D-1): cross-brand Brand-B table_id bbbbbbbb-0000-0000-0000-000000000001 ACCEPTED onto Brand-A reservation once the guard is reverted`. Restoring the guard → rejected. The B1/B4/C4 assertions also RAISE `FAILS-ON-REVERT CONFIRMED` on a reverted guard. Cited at the commit below.
+
+### D-2 — defensive 21610 opt-out upsert throws (P2, runtime crash)
+
+**Before** (`send-venue-sms/index.ts`): on a Twilio 21610 the fn did
+```ts
+await admin.from("venue_sms_opt_out").upsert(
+  { phone_e164: toPhone, brand_id: null, reason: "twilio_blacklist" },
+  { onConflict: "phone_e164", ignoreDuplicates: true },
+);
+```
+`venue_sms_opt_out` has ONLY PARTIAL unique indexes (`WHERE brand_id IS NULL` global / `WHERE brand_id IS NOT NULL` per-brand) — no plain `UNIQUE(phone_e164)` — so `ON CONFLICT (phone_e164)` errors `42P10` at runtime; the defensive opt-out never persisted, and the unguarded `await` could 500 the response before `logSend("failed")`.
+
+**After** — option (c): a SECURITY DEFINER RPC whose ON CONFLICT targets the GLOBAL partial index's exact predicate, called inside a try/catch:
+```sql
+-- 20261011000001
+CREATE OR REPLACE FUNCTION public.biz_sms_record_global_opt_out(p_phone_e164 text, p_reason text DEFAULT 'twilio_blacklist')
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $function$
+BEGIN
+  IF p_reason NOT IN ('stop_keyword','manual','twilio_blacklist') THEN p_reason := 'twilio_blacklist'; END IF;
+  INSERT INTO public.venue_sms_opt_out (phone_e164, brand_id, reason)
+  VALUES (p_phone_e164, NULL, p_reason)
+  ON CONFLICT (phone_e164) WHERE brand_id IS NULL DO NOTHING;   -- partial-index-safe + idempotent
+END; $function$;
+REVOKE ALL ... FROM PUBLIC; REVOKE EXECUTE ... FROM anon; REVOKE EXECUTE ... FROM authenticated;
+GRANT EXECUTE ... TO service_role;   -- internal helper; edge fn runs service role
+```
+```ts
+if (result.blacklisted) {
+  try {
+    const { error: optErr } = await admin.rpc("biz_sms_record_global_opt_out",
+      { p_phone_e164: toPhone, p_reason: "twilio_blacklist" });
+    if (optErr) console.warn("[send-venue-sms] defensive opt-out persist failed (non-fatal)", optErr.message);
+  } catch (optThrow) { console.warn("[send-venue-sms] defensive opt-out persist threw (non-fatal)", String(optThrow)); }
+}
+```
+Per-brand opt-out rows preserved (no plain UNIQUE added); partial-index semantics untouched. The persist can no longer mask the `logSend("failed")` / response.
+
+**Live proof:**
+- `H1 PASS` — RPC persists exactly ONE global (`brand_id IS NULL`) row, and is idempotent on a repeat 21610 (no `23505` throw).
+- `H2 PASS` — a per-brand opt-out for the same phone coexists; the RPC touches only the global row.
+- `H3 PASS(by-error)` — the OLD broken `ON CONFLICT (phone_e164)` spec errors live `42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification` — i.e. the bug, proven, and the RPC avoids it.
+
+**Fails-on-revert (D-2):** H3 proves the broken arbiter throws against the real schema (revert to the `.upsert(onConflict:"phone_e164")` path → runtime `42P10`). The deno `T-SMS-4` adds a source fails-on-revert assertion: it now requires the `biz_sms_record_global_opt_out` RPC call AND forbids a plain `onConflict:'phone_e164'` upsert against `venue_sms_opt_out` (reverting to the old upsert fails the test), plus asserts the try/catch wrap.
+
+### Gate results (all green)
+- **Live adversarial harness** `orch_1148_2_1b_lifecycle_adversarial.tester.sql` on PG 17.4.1: `== ALL 2.1b ADVERSARIAL ASSERTIONS PASSED ==` (E1-E4, F1-F4, B1-B4, A, C1-C5, D1-D3, G, H1-H3).
+- **deno SMS contract** `send_venue_sms.test.ts`: 8/8 (T-SMS-4 updated to the RPC path + fails-on-revert + try/catch assertion).
+- **deno migration** `orch_1148_venue_suite_migration.test.ts`: 30/30 (T-MIG-30 band-scoped to `20261010000xxx`, unaffected by the new `…11…` band).
+- **edge fn type-check** `deno check supabase/functions/send-venue-sms/index.ts`: clean (exit 0).
+- **money-seam gate** `orch-1148-booking-core-engine-and-money-seam.mjs`: PASS (engine sole slot source; no checkout/pricing in the booking core).
+- **venue jest** `capacityRules` / `venueModules` / `venueShellScroll`: 14/14. ZERO `mingla-business` files touched → tsc/eslint/jest baselines unchanged by construction; the broad-pattern jest failures (`PublicBrandPage.ve4` etc.) reproduce IDENTICALLY on the base with this pass's diff stashed → pre-existing, NOT a regression.
+
+Money seam + engine-frozen contract unchanged (no checkout/Stripe/Paystack/`pg_venue_available_slots` file touched). Migration versions monotonic; origin/main has NOT moved past the branch base (`git rev-list --count HEAD..origin/main` = 0) → no rebase needed.
+
+*No deploy / no migration applied to prod / no edge-fn deploy / no merge performed by this implementor.*

--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1148_SUBB_2_1B.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1148_SUBB_2_1B.md
@@ -1,0 +1,172 @@
+# IMPLEMENT — META-ORCH-1148 sub-ORCH 2.1b (Reservations lifecycle + Waitlist + Twilio "table's ready" SMS)
+
+- **Skill:** mingla-implementor
+- **Sub-ORCH:** META-ORCH-1148 / **2.1b** (the second/final slice of the OPERATOR booking core).
+- **Branch / worktree:** `ORCH-1148-venue-reservations-waitlist` @ `~/Desktop/mingla-orchs/ORCH-1148-[venue-reservations-waitlist]/`
+- **HEAD after this implementation:** **`7eeb41d6f328b11def80273463b7be396370c11b`** (rebased onto current origin/main — already up to date, no rebase movement).
+- **Binding inputs read on entry:** PRD `PRD_META-ORCH-1148_FIRSTSHIP_BOOKING_LOOP.md`, Journey Map `JOURNEY_MAP_META-ORCH-1148_RESERVATION_E2E.md` (incl. the LOCKED DECISIONS: Twilio SMS in ship 1, auto-forfeit no-show), Vision, Design IA, the SHIPPED 2.0 schema + 2.1a engine + suite shell. (No `COMMS_LEDGER.md` exists at the cited path in this worktree or main; the closest ledger artifacts were reviewed — none carry an open BLOCK relevant to 2.1b.)
+- **NOT done (per directive):** no deploy, no migration applied to prod, no edge-fn deploy, no merge. Migrations authored only.
+
+---
+
+## 1. Changed files (21; all committed, scoped allowlist only)
+
+### Migrations (additive-only; base `20261010*`, monotonic above the 2.1a max `20261008000003`)
+| File | Purpose |
+|------|---------|
+| `supabase/migrations/20261010000000_orch_1148_sms_consent_and_log.sql` | `venue_sms_opt_out` (STOP ledger, service-role-only, partial-unique global+per-brand) + `venue_sms_log` (append-only send attempts, brand-member READ / service-role WRITE). |
+| `supabase/migrations/20261010000001_orch_1148_reservation_lifecycle_rpcs.sql` | `pg_reservation_transition_is_legal(text,text)` (the legal-transition matrix), `biz_reservation_transition(...)` (the SINGLE guarded+audited lifecycle mutator), `biz_reservation_create(...)` (manual FREE operator create). |
+| `supabase/migrations/20261010000002_orch_1148_waitlist_rpcs_and_indexes.sql` | `biz_waitlist_mark_notified(...)`, `biz_waitlist_convert_to_reservation(...)` (ATOMIC create+mark), the list-view index `reservations_brand_status_reserved_idx` + active-queue index. |
+| `supabase/migrations/20261010000003_orch_1148_reservation_lifecycle_probes.sql` | Read-only invariant probe (fails-on-revert at the DB layer). |
+| `supabase/migrations/__tests__/orch_1148_venue_suite_migration.test.ts` | **Extended** (T-MIG-21..30) + corrected the pre-existing stale T-MIG-20 (see §6). |
+
+### Edge function
+| File | Purpose |
+|------|---------|
+| `supabase/functions/send-venue-sms/index.ts` | NEW — operator-triggered "table's ready" Twilio SMS (auth + manager-plus brand gate + E.164 validation + opt-out gate + locked copy + approved-toll-free Messaging Service + send-log + mark-notified). |
+| `supabase/functions/__tests__/send_venue_sms.test.ts` | NEW — source-contract test (T-SMS-1..8: locked copy, toll-free-only, opt-out honored, E.164, env creds, brand gate, log). |
+| `supabase/config.toml` | **Modified (add-only)** — registered `[functions.send-venue-sms] verify_jwt = true`. |
+
+### Business app
+| File | Purpose |
+|------|---------|
+| `mingla-business/src/types/venueReservation.ts` | **Modified (add-only)** — 2.1b domain shapes (`Reservation`, `ReservationStatus/Source/View/Action/Tag`, `WaitlistEntry`, create/add inputs). 2.0/2.1a shapes untouched. |
+| `mingla-business/src/hooks/useVenueReservations.ts` | NEW — list + brand-scoped realtime + guarded create + transition. |
+| `mingla-business/src/hooks/useVenueWaitlist.ts` | NEW — list + realtime + add/notify(edge fn)/convert/mark-lost. |
+| `mingla-business/src/components/venue/reservationViews.ts` | NEW pure helper — view filtering + the CLIENT lifecycle-transition mirror + status presentation (fails-on-revert anchor). |
+| `mingla-business/src/components/venue/ReservationCard.tsx` | NEW — the Design-IA reservation card. |
+| `mingla-business/src/components/venue/ReservationDetailSheet.tsx` | NEW — lifecycle actions (legal-only; destructive reach+confirm). |
+| `mingla-business/src/components/venue/ReservationCreateSheet.tsx` | NEW — manual create (party/date/engine-slots/table/source/occasion/tags/contact). |
+| `mingla-business/src/components/venue/VenueReservationsModule.tsx` | NEW — the module (segmented views + list + detail + create). |
+| `mingla-business/src/components/venue/WaitlistAddSheet.tsx` | NEW — add-to-waitlist form. |
+| `mingla-business/src/components/venue/WaitlistConvertSheet.tsx` | NEW — convert (engine slots + table → atomic RPC). |
+| `mingla-business/src/components/venue/VenueWaitlistModule.tsx` | NEW — the queue + Notify/Seat/Lost. |
+| `mingla-business/src/components/venue/VenueSuiteShell.tsx` | **Modified (surgical)** — dispatch swap ONLY (reservations→module, waitlist→module; ComingSoon import removed; unused `goToSettings` removed; stale docstring updated). All shell machine/layout/scroll preserved. |
+| `mingla-business/src/components/venue/__tests__/reservationViews.test.ts` | NEW unit test (T-RES-1..9). |
+
+> `VenueModuleComingSoon.tsx` is now orphaned but intentionally **left in place** (2.0 artifact, harmless, not deleted).
+
+---
+
+## 2. RPC signatures (the guarded contract 2.2 / the operator UI call)
+
+```
+pg_reservation_transition_is_legal(p_from text, p_to text) RETURNS boolean
+  LANGUAGE sql IMMUTABLE  -- the single legal-transition matrix
+
+biz_reservation_transition(
+  p_reservation_id uuid, p_to_status text,
+  p_table_id uuid DEFAULT NULL, p_reason text DEFAULT NULL
+) RETURNS public.reservations
+  SECURITY DEFINER · manager+ gate · enforces pg_reservation_transition_is_legal · audited
+  · no_show records the venue's no_show_fee_policy DECISION (NO Stripe capture — 2.2 seam)
+
+biz_reservation_create(
+  p_brand_id uuid, p_reserved_for timestamptz, p_party_size int,
+  p_source text='phone', p_guest_name/p_guest_phone_e164/p_guest_email,
+  p_table_id, p_occasion, p_guest_notes, p_tags text[], p_status text='confirmed'
+) RETURNS public.reservations
+  SECURITY DEFINER · manager+ gate · FREE (no fee) · created_via='operator' · audited
+
+biz_waitlist_mark_notified(p_waitlist_id uuid, p_expire_minutes int=15, p_notify_via text='sms')
+  RETURNS public.venue_waitlist · SECURITY DEFINER · manager+ gate · audited
+
+biz_waitlist_convert_to_reservation(p_waitlist_id uuid, p_reserved_for timestamptz, p_table_id uuid=NULL)
+  RETURNS public.reservations · SECURITY DEFINER · manager+ gate · ATOMIC (insert reservation + mark
+  waitlist converted+linked in ONE txn) · audited
+```
+
+**Legal-transition matrix (server-authoritative):** requested→{confirmed,cancel\*}; confirmed→{seated,no_show,completed,cancel\*}; seated→{completed,no_show,cancelled_by_venue}; waitlisted→{confirmed,cancel\*}; completed/no_show/cancelled\* = terminal. `no_show` is reachable ONLY from confirmed/seated.
+
+**Grant boundary (all 5 fns):** `REVOKE ALL … FROM PUBLIC` + `REVOKE EXECUTE … FROM anon` + `GRANT EXECUTE … TO authenticated`. The `REVOKE … FROM PUBLIC` is **required** — the Supabase Postgres image auto-grants EXECUTE to PUBLIC on every new function; without it the fns are PUBLIC/anon-callable (the live probe caught this; see §6).
+
+---
+
+## 3. Edge fn design + Twilio secrets
+
+**`send-venue-sms`** (`verify_jwt = true`): POST `{ waitlistId }`. Flow: (1) authenticate caller's JWT; (2) resolve waitlist row → brand → phone; (3) gate on `biz_brand_effective_rank_for_caller >= 40` (event_manager); (4) validate E.164 (`/^\+[1-9][0-9]{1,14}$/`); (5) **opt-out gate** — read `venue_sms_opt_out`, block on a global (`brand_id IS NULL`) OR per-brand match; (6) send the LOCKED copy via the **approved toll-free Messaging Service** (never a raw `From`); (7) log every attempt to `venue_sms_log`; (8) on success call `biz_waitlist_mark_notified`. A Twilio `21610` (blacklisted) persists a defensive global opt-out.
+
+**LOCKED copy (verbatim, no link):** `Your table's ready at {VenueName}. Reply STOP to opt out.`
+
+**Twilio Supabase secrets the orchestrator MUST set at deploy** (read from Deno env, NEVER hardcoded):
+- `TWILIO_ACCOUNT_SID`
+- `TWILIO_AUTH_TOKEN`
+- `TWILIO_MESSAGING_SERVICE_SID` (the Messaging Service bound to the approved toll-free **+1 888-250-5351**)
+- (optional, reused) `TWILIO_STATUS_CALLBACK_SECRET` — wires the existing `twilio-message-status` delivery callback.
+
+**Consent / STOP:** the primary STOP path is Twilio's native Advanced Opt-Out on the Messaging Service (carrier-level; no inbound webhook required). The edge fn's pre-send `venue_sms_opt_out` check + the `21610` defensive persistence + the consent ledger together honor "never send to an opted-out number." (No new inbound-STOP webhook is added — Twilio's Messaging Service handles STOP natively; flagged for the tester.)
+
+---
+
+## 4. Gate results
+
+| Gate | Result |
+|------|--------|
+| `deno test orch_1148_venue_suite_migration.test.ts` | **30 passed / 0 failed** (9 carried 2.0 + 6 carried 2.1a + 5 carried P3 + the new T-MIG-21..30; T-MIG-20 corrected — see §6). |
+| `deno test send_venue_sms.test.ts` (T-SMS-1..8) | **8 passed / 0 failed**. |
+| `reservationViews.test.ts` (jest, T-RES-1..9) | **9 passed**. |
+| Full venue jest suite (`src/components/venue`) | **48 passed / 48** (9 suites — incl. the 2.0 `venueSuiteLeakAndExit.tester.adversarial` + `venueModules` + `venueShellScroll` + 2.1a `capacityRules` all still green). |
+| `orch-1148-booking-core-engine-and-money-seam.mjs` `--self-test` + live | **PASS** — engine sole-source held (no venue component names the RPC; slots flow via the existing `useAvailableSlots` owner hook) + money seam clean (zero checkout/pricing/Stripe/Paystack in any new venue file). |
+| I-39 a11y (`i39-pressable-label.mjs`) | **PASS** — 469 .tsx scanned, **0 violations** (every new Pressable carries an a11y label). |
+| `tsc --noEmit` (mingla-business) | **334 → 334 (DELTA 0)** — pre-existing baseline confirmed via stash-and-rerun; **0 errors in any new file**. |
+| `eslint` (all 13 changed business files) | **0 errors** (the 2 initial warnings — unused import + exhaustive-deps — fixed → clean). |
+| **Live full-chain migration apply** (Docker `supabase/postgres:17.4.1.075`) | **PASS** — all 236 prior migrations + the 4 new 2.1b applied in version order on a seeded container; the 2.1b probe fired its PASS NOTICE. |
+| **Live behavioral (real fixtures)** | create→seat→complete works; illegal `seated→requested` + terminal `completed→seated` REJECTED (`check_violation`); atomic convert (waitlist converted+linked AND reservation created, both = 1); non-member create REJECTED (`42501`). |
+| **Live RLS brand-scoping** | a stranger reads **0** reservations + **0** waitlist rows for a brand they don't belong to; the owner reads their own. |
+| **Live grant boundary** | post-fix ACLs = `{postgres, authenticated, service_role}` only (no PUBLIC, no anon); `has_function_privilege('anon', biz_reservation_transition…)` = **false**. |
+
+---
+
+## 5. Fails-on-revert proofs (cited @ commit `4854e590d` / final `7eeb41d6f`)
+
+| Invariant | Test | Revert applied | Result |
+|-----------|------|----------------|--------|
+| Client lifecycle guard rejects illegal transitions | `reservationViews.test.ts` T-RES-1/2/3/5/6 | made `isTransitionLegal` `return true` | **T-RES-1/2/3/5/6 FAIL**, happy-path T-RES-4/7/8/9 stay PASS (the test discriminates); restore → 9 pass. |
+| Server legal-transition matrix locks terminal states | `T-MIG-22` (deno) | changed the matrix `ELSE false` → `ELSE true` | **FAIL**; restore → pass. |
+| SMS uses the exact LOCKED copy | `T-SMS-1` (deno) | replaced the copy with `Table ready: … https://…` | **FAIL**; restore → pass. |
+| SMS honors the opt-out ledger | `T-SMS-3` (deno) | replaced the `brand_id===null \|\| brand_id===brandId` match with `false` | **FAIL**; restore → pass. |
+
+All reverts restored with zero residual diff.
+
+---
+
+## 6. Decisions / ambiguities flagged
+
+1. **Pre-existing stale test T-MIG-20 corrected.** At branch HEAD (before my work), `T-MIG-20` already FAILED — it asserted the 2.1a P3 probe (`…002`) was the "highest" prefix, but a later 2.1a follow-up (`20261008000003_orch_1148_revoke_anon_turn_helper.sql`) sits above it. Proven pre-existing via stash-and-rerun against HEAD. I corrected it to assert **ordering** (P3 probe > engine-v2 + tz-column) rather than strict-max, preserving the original intent. This is a 2.1a-owned test; flag for the tester / 2.1a owner.
+2. **Supabase PUBLIC auto-grant (same class as the 2.1a anon gotcha).** The live full-chain apply caught that the new RPCs were PUBLIC/anon-callable despite `REVOKE … FROM anon`, because the image auto-grants EXECUTE to **PUBLIC** on every new function. Fixed by adding `REVOKE ALL … FROM PUBLIC` before each anon revoke (mirrors the 2.1a engine). The 2.1b probe asserts the transition fn is not anon/PUBLIC-callable; tester should confirm on the prod project's default-privilege config.
+3. **STOP handled by Twilio's Messaging Service natively (no inbound webhook added).** The consent loop = native carrier-level STOP + the edge fn's pre-send opt-out check + the `21610` defensive persistence + the `venue_sms_opt_out` ledger. No new inbound-message webhook was added (out of scope; Twilio's Messaging Service Advanced Opt-Out is the primary path). Flagged for the tester.
+4. **`approval_required` / the `requested→approve` consumer UI is NOT in 2.1b** (PRD §9 Q2 deferred); the matrix supports `requested` as a starting state for completeness, and the operator can confirm a `requested` row, but no consumer-facing request flow is built (that's 2.2).
+5. **Reservation `reason` note** is recorded in `audit_log.after` (no new column) — the 2.0 `reservations` table carries no cancellation-reason column and the directive forbade non-essential schema; the audit trail is the system of record for cancellation reasons.
+6. **`no_show` fee enforcement** records the policy decision only (per the LOCKED auto-forfeit decision, the actual Stripe capture is 2.2's seam — no money path touched here, enforced by the strict-grep gate B).
+
+---
+
+## 7. Hard-guard compliance
+
+- **Money seam HELD:** zero reference to `ticket-checkout-create` / `allInPricingEngine` / Stripe / Paystack in any 2.1b file (gate B + the migration no-money test + grep verified). Manual bookings are FREE; no charge path touched.
+- **Engine FROZEN:** `pg_venue_available_slots` / `pg_venue_turn_minutes_for_party` READ only (via the existing `useAvailableSlots` owner hook); no venue component names the RPC (gate A verified). The manual-create + convert pickers reuse the 2.1a engine for slot truth.
+- **DO-NOT-TOUCH respected:** `git show --stat` confirms NONE of the 2.1a engine migrations, Tables/Availability modules, `VenueSettingsModule`/`useVenueReservationSettings`/`venueFeeGate`/`venueModules`/`VenueModulePillRow`/`venueShellScroll`/`venueSuiteStore`, `VenueListingContent`, the hub nav (`hub/_layout`/`HubSubNav`/`useHubTabs`), `ticket-checkout-create`/`allInPricingEngine`, `app-mobile/`, buyer-web, or `mingla-admin/` were touched. Only `VenueSuiteShell.tsx` (the permitted dispatch swap), the migration test, `config.toml`, and the add-only 2.0 types file are modified existing files.
+- **Realtime (locked Q4):** brand-scoped `postgres_changes` on `reservations` + `venue_waitlist`, filtered by `brand_id` (NOT a PK → no ORCH-0931 silent-drop), `event:'*'`, cleanup on unmount.
+- **Android opaque glass:** all cards/sheets use `GlassCard`/`Sheet` (opaque Android fallback automatic). No bespoke translucent fills.
+- **Tokens only · currency-aware:** spacing/radius/typography/text/accent/semantic; no money rendered in 2.1b (free bookings) → no GBP-fallback risk.
+- **a11y / no dead taps:** every Pressable carries `accessibilityRole` + `accessibilityLabel` (I-39 = 0). Read-only (below-manager) states render explicit notes, not disabled mysteries. Destructive actions (no-show/cancel) require a reach + a second confirming tap.
+- **`_hasHydrated`:** N/A — 2.1b adds no persisted Zustand store; all server data lives in React Query.
+- **No native deps / runtime bump:** zero new `expo-*`/native modules; OTA-safe.
+- **`[TRANSITIONAL]` exit conditions:** the 4 DRAFT invariants carry their flip-ACTIVE-on-CLOSE condition (the probe + tests are the anchors).
+
+---
+
+## 8. Pre-staged DRAFT invariants (flip ACTIVE on CLOSE)
+
+- `I-PROPOSED-1148-RESERVATION-LIFECYCLE-TRANSITIONS-GUARDED-SERVER-SIDE` — illegal transitions rejected in the DB (the matrix + `biz_reservation_transition`), not just hidden in the client. Anchor: T-MIG-22/23 + T-RES-1/2/3 + the live behavioral proof + the 2.1b probe.
+- `I-PROPOSED-1148-WAITLIST-CONVERT-ATOMIC` — convert creates the reservation AND marks the waitlist converted+linked in one txn. Anchor: T-MIG-25 + the live atomic proof + the probe.
+- `I-PROPOSED-1148-SMS-FROM-APPROVED-TOLLFREE-ONLY` — `send-venue-sms` sends ONLY via `TWILIO_MESSAGING_SERVICE_SID` (the approved toll-free), never a raw `From`. Anchor: T-SMS-2.
+- `I-PROPOSED-1148-SMS-OPT-OUT-HONORED` — never send to a phone with a matching opt-out row; the consent ledger exists + is RLS-protected. Anchor: T-SMS-3 + T-MIG-27 + the probe.
+
+---
+
+## 9. Downstream
+
+NEXT = **mingla-tester** (business iOS + Android + web-desktop + web-phone device/sim proof of the Reservations + Waitlist modules + manual create + lifecycle actions + realtime + the SMS notify path on a Twilio test number; confirm the money seam + the engine-frozen contract held). Then **mingla-orchestrator CLOSE** — apply the 4 migrations via Management API from MERGED main, run `get_advisors`, set the Twilio secrets, deploy `send-venue-sms`, flip the 4 DRAFT invariants ACTIVE, register 2.1b on the World Map. Then **2.2** (consumer/web booking surface + the engine's `anon` GRANT seam).
+
+*No deploy / no migration applied to prod / no edge-fn deploy / no merge performed by this implementor.*

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1148_SUBB_2_1B.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1148_SUBB_2_1B.md
@@ -1,0 +1,88 @@
+# TEST — META-ORCH-1148 sub-ORCH 2.1b (Reservations lifecycle + Waitlist + Twilio "table's ready" SMS)
+
+- **Skill:** mingla-tester (claude) — brutal production gatekeeper. Assumed BROKEN until proven.
+- **Branch / worktree:** `ORCH-1148-venue-reservations-waitlist` @ `~/Desktop/mingla-orchs/ORCH-1148-[venue-reservations-waitlist]/`
+- **Implementation under test:** HEAD `7eeb41d6f` (report `29ca7fd72`).
+- **Comms Ledger:** READ on entry (`/Users/.../COMMS_LEDGER.md` — it DOES exist; the implementor report §entry claimed "no COMMS_LEDGER.md exists at the cited path", which is INCORRECT — flagged below). No OPEN `BLOCK` row addressed to tester / ALL / ORCH-1148. Acked **COMMS-0002** (C7 no-new-backend gate) — N/A: ORCH-1141 re-scoped C7 to fire ONLY on PRs citing ORCH-0863; the 2.1b PR cites META-ORCH-1148 → C7 is skipped, no backend-allowlist entry required (verified in `orch-0863-marketing-hub-phase-b.mjs:220-238`). Acked **COMMS-0018/0015** — deploy/migration-apply only from MERGED main (close-time concern).
+
+---
+
+## VERDICT: **CONDITIONAL PASS**
+
+The 2.1b lifecycle/convert/RLS/grant/money-seam contract is **proven correct LIVE on Postgres 17.4.1** with the full 237-migration chain applied. The locked SMS copy, toll-free-only send, E.164 validation, and opt-out *gate* are correct at source. **Two real defects found** (neither a launch-blocker, neither in the money/auth-escalation class), gating the verdict to CONDITIONAL:
+
+- **D-1 (P2 · data integrity):** `biz_reservation_transition` and `biz_waitlist_convert_to_reservation` assign `p_table_id` with **NO same-brand validation** → a Brand A manager can stamp **Brand B's `table_id`** onto a Brand A reservation. PROVEN LIVE (findings B + C4). Cross-tenant data corruption of occupancy state that the 2.1a engine reads.
+- **D-2 (P2 · runtime crash on a cold path):** the edge fn's defensive 21610-blacklist `upsert(..., { onConflict: "phone_e164" })` **throws at runtime** — `venue_sms_opt_out` has ONLY *partial* unique indexes (`WHERE brand_id IS NULL` / `WHERE brand_id IS NOT NULL`), never a plain `UNIQUE(phone_e164)`, so `ON CONFLICT (phone_e164)` errors `there is no unique or exclusion constraint matching the ON CONFLICT specification`. PROVEN LIVE. The source-grep deno test (T-SMS-4) is GREEN yet cannot see this — exactly why a different-angle live test was required.
+
+Neither defect blocks the lifecycle/convert/SMS-gate happy paths. Conditions to clear to full PASS listed at the end.
+
+---
+
+## Per-criterion result
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Lifecycle transition matrix enforced SERVER-SIDE | **PASS (live)** | Full 237-mig chain on `supabase/postgres:17.4.1.075`. Adversarial harness F1/F2/F3/F4 + A + E1-E4 all PASS: same-state rejected (F1), terminal `completed→seated` rejected (F2), `no_show` not reachable from `requested` (F3), `no_show` records forfeit policy w/ NO money path (F4), second transition on a terminal row rejected via fresh `FOR UPDATE` re-read (A), non-member create 42501 (E1), scanner-rank (10<40) create rejected (E2), event_manager create allowed (E3), create-into-terminal rejected (E4). |
+| 2 | Atomic waitlist convert | **PASS (live)** | C1 atomic (reservation created + waitlist `converted`+linked in one txn); C2 double-convert rejected `23505` with NO orphan reservation; C3 forced mid-convert FK failure → full rollback, NO orphan, waitlist stays `waiting`. |
+| 3 | SMS path (copy / toll-free-only / E.164 / opt-out / log / manager gate) | **PASS w/ D-2** | Locked copy exact, no link (source + T-SMS-1). Sends ONLY via `TWILIO_MESSAGING_SERVICE_SID`, never raw `From` (T-SMS-2, source read). E.164 `^\+[1-9][0-9]{1,14}$` gate before send. Opt-out *gate* reads `venue_sms_opt_out`, blocks global (`brand_id IS NULL`) OR per-brand, BEFORE send — correct. Every attempt logged with `triggered_by`. Manager+ gate via `biz_brand_effective_rank_for_caller`. **BUT** the defensive 21610 persistence is broken (D-2). STOP-honoring assessed below. |
+| 4 | RPCs NOT anon/PUBLIC-callable | **PASS (live)** | Live ACL on all 5 RPCs: `anon=false, public=false, authenticated=true`. 2.1b probe `…003` fires its PASS NOTICE asserting non-anon. |
+| 5 | Money seam intact + engine frozen | **PASS** | `orch-1148-booking-core-engine-and-money-seam.mjs` self-test + live = PASS. `git diff` confirms `pg_venue_available_slots` / any engine/checkout/Stripe/Paystack file NOT touched. `no_show` records policy only (no capture). |
+| 6 | No regressions (shell / 2.1a / hub / listing) | **PASS** | 2.1b diff touches only NEW files + `VenueSuiteShell.tsx` (23-line dispatch swap, machine/layout/scroll preserved) + `config.toml` (+8, verify_jwt reg) + add-only types + extended mig test. 48/48 venue jest green (incl. 2.0 leak/exit adversarial + capacityRules + venueModules + venueShellScroll). Forbidden/engine files: NONE touched. |
+| 7 | OWN adversarial test, different angle, fails-on-revert | **PASS** | `supabase/migrations/__tests__/orch_1148_2_1b_lifecycle_adversarial.tester.sql` — a LIVE-FIRE psql harness (the implementor shipped only source-grep deno tests + an uncommitted behavioral note). Fails-on-revert proven (below). |
+| 8 | Gates (jest / deno / I-39 / I-PROPOSED-N / money-seam / tsc / eslint) | **PASS** | deno mig 30/30; deno SMS 8/8; venue jest 48/48; money-seam gate PASS; no-buyer-tax-form gate PASS; I-39 = 0 violations (469 .tsx); tsc 334→334 DELTA 0 (pre-existing baseline confirmed via checkout of 2.1a base `488db83c4` = also 334), ZERO tsc errors in any 2.1b file. |
+
+---
+
+## Runtime evidence (live, not source-only)
+
+- **Environment:** Docker `supabase/postgres:17.4.1.075` (matched the implementor's PG17 — note PG15 fails the baseline squash on the `MAINTAIN` privilege, PG17-only). All **237** migrations (incl. the 4 new 2.1b) applied clean in version order; the 2.1b probe `…003` emitted its PASS NOTICE.
+- **Grant boundary (live ACL):** all 5 RPCs `has_function_privilege('anon', …, 'EXECUTE') = false`, `public = false`, `authenticated = true`.
+- **Lifecycle / convert / RLS / gate:** all assertions in the adversarial harness ran against REAL seeded rows (two brands, two owners, an event_manager, a scanner, a stranger) with `auth.uid()` simulated via `request.jwt.claim.sub`; RLS proven by `SET ROLE authenticated` (postgres bypasses RLS — the test drops to the non-superuser role for D1-D3).
+- **Deterministic:** re-ran the full harness on a SECOND fresh PG17 container → identical PASS + identical two FINDINGs.
+
+### My adversarial test (different angle)
+`supabase/migrations/__tests__/orch_1148_2_1b_lifecycle_adversarial.tester.sql` (untracked; commit alongside CLOSE). Angle = **live execution** of the RPCs (implementor's tests are source-grep only), attacking: concurrent/double-transition serialization (A), **cross-brand `p_table_id` injection on BOTH transition and convert (B + C4 — the two FINDINGs)**, convert-then-reconvert + forced mid-convert rollback (C1-C3), RLS cross-brand read isolation under the `authenticated` role (D1-D3), manager+ gate at scanner/non-member/manager ranks (E1-E4), same-state + terminal-lock + no_show-source matrix (F1-F4), audit trail (G). A renamed copy of the implementor's deno grep tests it is NOT.
+
+**Fails-on-revert (cited @ `7eeb41d6f`):** reverted `pg_reservation_transition_is_legal` to `SELECT true` (permissive matrix) live → the terminal-lock attack (`completed→seated`) SUCCEEDED, i.e. assertion F2 RAISEs `FAILS-ON-REVERT CONFIRMED`. Restoring the matrix → F2 passes. (Container discarded after the destructive probe; the clean run was re-proven on a fresh container.)
+
+### SMS STOP-honoring assessment (criterion 3 deep-dive)
+The implementor relies on Twilio Messaging-Service **Advanced Opt-Out** (carrier-level STOP, no inbound webhook) + the pre-send `venue_sms_opt_out` ledger check + the 21610 defensive persistence. Assessment:
+- The **primary** "never send to an opted-out number" guarantee is genuinely honored by Twilio's native STOP at the carrier (a STOPped number is blocked by Twilio regardless of our ledger) AND our pre-send gate (which blocks numbers already in our ledger).
+- **GAP (informational, accepted-by-design):** with NO inbound-STOP webhook, our OWN `venue_sms_opt_out` ledger is NEVER populated from organic STOP replies — it only fills from the (broken, D-2) 21610 path or manual rows. So our pre-send gate is effectively a no-op for organically-opted-out numbers until they first bounce a 21610. Twilio still blocks them, so no SMS actually reaches an opted-out user — but the operator UI ("Notified ✓") may mislead, and D-2 means even the 21610 backfill never lands. Recommend wiring the inbound-STOP webhook to write `venue_sms_opt_out` (the migration comment already anticipates `twilio-message-status` doing this) post-2.1b.
+
+---
+
+## Defects (report only; do NOT fix)
+
+### D-1 — Cross-brand `table_id` injection (P2 · data integrity, cross-tenant)
+- **Where:** `supabase/migrations/20261010000001_…rpcs.sql` `biz_reservation_transition` (`table_id = COALESCE(p_table_id, table_id)`, line ~117) and `20261010000002_…waitlist_rpcs…sql` `biz_waitlist_convert_to_reservation` (`VALUES (…, p_table_id, …)`, line ~148).
+- **Proven:** harness findings B + C4 — a Brand A manager seated/converted a Brand A reservation while passing **Brand B's** `table_id`; the value was ACCEPTED and persisted. The `reservations.table_id` FK references `venue_tables` globally and does NOT scope by brand.
+- **Impact:** corrupts the occupancy/table model the 2.1a availability engine reads; leaks one tenant's table identity onto another's reservation. Not auth-escalation (the caller is already a Brand A manager) and no money path — hence P2 not P0.
+- **Fix direction:** in both RPCs, when `p_table_id IS NOT NULL`, validate `EXISTS (SELECT 1 FROM venue_tables WHERE id = p_table_id AND brand_id = v_brand)` → RAISE on mismatch.
+
+### D-2 — Defensive 21610 opt-out upsert throws at runtime (P2 · cold-path crash)
+- **Where:** `supabase/functions/send-venue-sms/index.ts:247-252` — `.upsert({ phone_e164, brand_id: null, … }, { onConflict: "phone_e164", ignoreDuplicates: true })`.
+- **Proven:** the emitted `INSERT … ON CONFLICT (phone_e164) DO NOTHING` errors live: `there is no unique or exclusion constraint matching the ON CONFLICT specification`, because `venue_sms_opt_out` has only the two PARTIAL unique indexes. The correct arbiter (`ON CONFLICT (phone_e164) WHERE brand_id IS NULL`) works + is idempotent (proven live) — but the Supabase JS `.upsert()` API cannot express a partial-index predicate.
+- **Impact:** only on the Twilio-21610 path (recipient already opted out at Twilio). The unawaited-in-try upsert rejection happens AFTER the SMS already failed; the `await admin…upsert` is NOT wrapped in try/catch and the `serve` body has no outer catch → the request likely 500s and the subsequent `logSend("failed")` never runs. Net: the defensive global opt-out is NEVER persisted, so the operator can keep re-tapping Notify and re-hitting Twilio 21610 each time. Low blast radius (cold path), but a real runtime fault hidden behind a green source-grep test.
+- **Fix direction:** persist via a SECURITY-DEFINER RPC doing `INSERT … ON CONFLICT (phone_e164) WHERE brand_id IS NULL DO NOTHING`, or add a non-partial `UNIQUE(phone_e164)` only if the per-brand rows are dropped (they aren't — so the RPC path is correct). Also wrap in try/catch regardless.
+
+### D-3 — Implementor report inaccuracy (P4 · doc)
+- The report's entry stanza states "No `COMMS_LEDGER.md` exists at the cited path in this worktree or main." It DOES exist at the worktree/main root and is reachable. No functional impact; flag so the CLOSE record doesn't propagate the claim.
+
+### Observations (not defects)
+- `biz_reservation_transition` keeps a no-show's `table_id` (COALESCE preserves it) — table stays "occupied" by a no-show until separately cleared. Matches "records policy decision only"; noting for 2.2 occupancy semantics.
+- `p_reason` is stored only in `audit_log.after` (no column) — per the implementor's flagged decision §5; acceptable.
+
+---
+
+## Conditions to clear CONDITIONAL → PASS
+1. Fix **D-1** (same-brand `table_id` validation in both RPCs) — data-integrity, should land before the engine consumes occupancy in 2.2.
+2. Fix **D-2** (partial-index-safe opt-out persistence + try/catch) — or explicitly accept the cold-path gap with a tracked follow-on, given Twilio still blocks the send.
+3. Device/sim visual leg (business iOS + Android + web) for the Reservations + Waitlist modules + realtime + the live Twilio send on a test number — **DEFERRED to post-merge dev-OTA** per the runtime-evidence allowance (no safe Twilio test number wired in this pass; the send was proven by source-contract + the opt-out/copy/E.164/toll-free logic proven, the lifecycle/convert/RLS proven live on PG17).
+
+---
+
+## Downstream
+NEXT = **mingla-implementor** to fix D-1 + D-2 (small, surgical), then a RETEST of just those two paths, then **mingla-orchestrator CLOSE** (apply 4 migrations from MERGED main via Management API, `get_advisors`, set Twilio secrets, deploy `send-venue-sms`, wire inbound-STOP→`venue_sms_opt_out`, flip the 4 DRAFT invariants ACTIVE, register 2.1b on the World Map) + the post-merge device/SMS-test-number visual leg.
+
+*No code fixed by this tester. Defects reported only. Adversarial test committed as `orch_1148_2_1b_lifecycle_adversarial.tester.sql`.*

--- a/mingla-business/src/components/venue/ReservationCard.tsx
+++ b/mingla-business/src/components/venue/ReservationCard.tsx
@@ -1,0 +1,196 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — reservation list card.
+ *
+ * The Design IA §4.4 exemplar: time (lead) · guest · status pill · party ·
+ * table · occasion · source/tags row. Reuses the OfferingListCard structural DNA
+ * (status pill → title → subline → metric), recolored — NOT a parallel card.
+ * Color is never the only signal (pill pairs label + tone). a11y label on the
+ * pressable. Android glass via GlassCard (opaque fallback automatic).
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  radius,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { GlassCard } from "../ui/GlassCard";
+import { Icon } from "../ui/Icon";
+import { STATUS_PRESENTATION } from "./reservationViews";
+import type { Reservation } from "../../types/venueReservation";
+
+const SOURCE_LABEL: Record<Reservation["source"], string> = {
+  mingla: "From Mingla",
+  phone: "Phone",
+  walk_in: "Walk-in",
+  website: "Website",
+  instagram: "Instagram",
+};
+
+const TAG_LABEL: Record<string, string> = {
+  vip: "VIP",
+  birthday: "Birthday",
+  first_time: "First-time",
+  regular: "Regular",
+  high_risk_no_show: "High no-show risk",
+};
+
+const TONE_COLOR: Record<string, string> = {
+  neutral: textTokens.secondary,
+  success: semantic.success,
+  warm: "#eb7825",
+  muted: textTokens.tertiary,
+  error: semantic.error,
+  faded: textTokens.tertiary,
+};
+
+function localTimeLabel(iso: string): string {
+  const d = new Date(iso);
+  let h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h >= 12 ? "PM" : "AM";
+  h = h % 12;
+  if (h === 0) h = 12;
+  return `${h}:${m.toString().padStart(2, "0")} ${ampm}`;
+}
+
+export interface ReservationCardProps {
+  reservation: Reservation;
+  tableName: string | null;
+  onPress: (r: Reservation) => void;
+  testID?: string;
+}
+
+export function ReservationCard({
+  reservation,
+  tableName,
+  onPress,
+  testID,
+}: ReservationCardProps): React.ReactElement {
+  const pres = STATUS_PRESENTATION[reservation.status];
+  const toneColor = TONE_COLOR[pres.tone] ?? textTokens.secondary;
+  const subParts: string[] = [`Party of ${reservation.partySize}`];
+  if (tableName != null) subParts.push(`Table ${tableName}`);
+  if (reservation.occasion != null) subParts.push(reservation.occasion);
+
+  return (
+    <GlassCard variant="base" style={styles.card}>
+      <Pressable
+        onPress={() => onPress(reservation)}
+        accessibilityRole="button"
+        accessibilityLabel={`Reservation for ${reservation.guestName ?? "guest"}, ${pres.label}, party of ${reservation.partySize}`}
+        style={styles.pressable}
+        testID={testID ?? `reservation-card-${reservation.id}`}
+      >
+        <View style={styles.topRow}>
+          <Text style={styles.time}>{localTimeLabel(reservation.reservedFor)}</Text>
+          <Text style={styles.guest} numberOfLines={1}>
+            {reservation.guestName ?? "Guest"}
+          </Text>
+          <View style={styles.pill}>
+            <View style={[styles.pillDot, { backgroundColor: toneColor }]} />
+            <Text style={[styles.pillLabel, { color: toneColor }]}>
+              {pres.label}
+            </Text>
+          </View>
+        </View>
+        <Text style={styles.subline} numberOfLines={1}>
+          {subParts.join(" · ")}
+        </Text>
+        <View style={styles.metaRow}>
+          <Text style={styles.source}>{SOURCE_LABEL[reservation.source]}</Text>
+          {reservation.paymentStatus === "paid" ? (
+            <Text style={styles.metaChip}>Deposit paid</Text>
+          ) : null}
+          {reservation.tags.map((t) => (
+            <Text key={t} style={styles.tagChip}>
+              {TAG_LABEL[t] ?? t}
+            </Text>
+          ))}
+        </View>
+      </Pressable>
+      <Icon name="chevR" size={18} color={textTokens.tertiary} />
+    </GlassCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  pressable: {
+    flex: 1,
+    gap: spacing.xxs,
+  },
+  topRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  time: {
+    ...typography.bodyLg,
+    color: textTokens.primary,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  guest: {
+    ...typography.body,
+    color: textTokens.primary,
+    flex: 1,
+  },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.05)",
+  },
+  pillDot: {
+    width: 7,
+    height: 7,
+    borderRadius: radius.full,
+  },
+  pillLabel: {
+    ...typography.caption,
+    fontWeight: "700",
+  },
+  subline: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  metaRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginTop: spacing.xxs,
+  },
+  source: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+    fontWeight: "600",
+  },
+  metaChip: {
+    ...typography.caption,
+    color: semantic.success,
+    fontWeight: "600",
+  },
+  tagChip: {
+    ...typography.caption,
+    color: textTokens.secondary,
+    paddingHorizontal: spacing.xs,
+    paddingVertical: 1,
+    borderRadius: radius.sm,
+    backgroundColor: "rgba(255,255,255,0.05)",
+  },
+});
+
+export default ReservationCard;

--- a/mingla-business/src/components/venue/ReservationCreateSheet.tsx
+++ b/mingla-business/src/components/venue/ReservationCreateSheet.tsx
@@ -1,0 +1,527 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — manual reservation create sheet.
+ *
+ * Guest · party · date · time (from the engine slots — the SAME availability
+ * truth the consumer picker uses; NO client slot fabrication) · table · source ·
+ * occasion · tags · contact · note. Writes via the guarded biz_reservation_create
+ * RPC (FREE; created_via='operator'). Slots come from useAvailableSlots (the sole
+ * engine caller — the strict-grep gate forbids any component naming the RPC).
+ * a11y labels on every Pressable. Android glass via Sheet.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useAvailableSlots } from "../../hooks/useVenueAvailability";
+import { useVenueTables } from "../../hooks/useVenueTables";
+import { isValidE164 } from "../../utils/phone";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Sheet } from "../ui/Sheet";
+import {
+  RESERVATION_TAGS,
+  type ReservationCreateInput,
+  type ReservationSource,
+  type ReservationTag,
+} from "../../types/venueReservation";
+
+const SOURCES: readonly { value: ReservationSource; label: string }[] = [
+  { value: "phone", label: "Phone" },
+  { value: "walk_in", label: "Walk-in" },
+  { value: "website", label: "Website" },
+  { value: "instagram", label: "Instagram" },
+  { value: "mingla", label: "Mingla" },
+];
+
+const TAG_LABEL: Record<ReservationTag, string> = {
+  vip: "VIP",
+  birthday: "Birthday",
+  first_time: "First-time",
+  regular: "Regular",
+  high_risk_no_show: "High no-show risk",
+};
+
+/** Next `count` dates as YYYY-MM-DD (venue-local-ish; the engine resolves tz). */
+function nextDates(count: number): { iso: string; label: string }[] {
+  const out: { iso: string; label: string }[] = [];
+  const base = new Date();
+  for (let i = 0; i < count; i += 1) {
+    const d = new Date(base);
+    d.setDate(base.getDate() + i);
+    const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    const label =
+      i === 0
+        ? "Today"
+        : i === 1
+          ? "Tomorrow"
+          : d.toLocaleDateString(undefined, {
+              weekday: "short",
+              month: "short",
+              day: "numeric",
+            });
+    out.push({ iso, label });
+  }
+  return out;
+}
+
+export interface ReservationCreateSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  brandId: string | null;
+  onSave: (input: ReservationCreateInput) => void;
+  saving: boolean;
+  testID?: string;
+}
+
+export function ReservationCreateSheet({
+  visible,
+  onClose,
+  brandId,
+  onSave,
+  saving,
+  testID,
+}: ReservationCreateSheetProps): React.ReactElement {
+  const [guestName, setGuestName] = useState<string>("");
+  const [partySize, setPartySize] = useState<number>(2);
+  const [date, setDate] = useState<string | null>(null);
+  const [slotIso, setSlotIso] = useState<string | null>(null);
+  const [tableId, setTableId] = useState<string | null>(null);
+  const [source, setSource] = useState<ReservationSource>("phone");
+  const [occasion, setOccasion] = useState<string>("");
+  const [tags, setTags] = useState<ReservationTag[]>([]);
+  const [phone, setPhone] = useState<string>("");
+  const [notes, setNotes] = useState<string>("");
+
+  const dates = useMemo(() => nextDates(14), []);
+
+  useEffect(() => {
+    if (!visible) return;
+    setGuestName("");
+    setPartySize(2);
+    setDate(dates[0]?.iso ?? null);
+    setSlotIso(null);
+    setTableId(null);
+    setSource("phone");
+    setOccasion("");
+    setTags([]);
+    setPhone("");
+    setNotes("");
+  }, [visible, dates]);
+
+  const tablesQuery = useVenueTables(brandId);
+  const tables = (tablesQuery.data ?? []).filter((t) => t.isActive);
+
+  // The SOLE slot source — engine RPC via the owner hook. No fabrication.
+  const slotsQuery = useAvailableSlots(brandId, date, partySize);
+  const slots = slotsQuery.data ?? [];
+
+  const phoneValid = phone.trim().length === 0 || isValidE164(phone.trim());
+  const canSave =
+    guestName.trim().length > 0 &&
+    slotIso !== null &&
+    phoneValid &&
+    !saving;
+
+  const handleSave = useCallback((): void => {
+    if (!canSave || slotIso === null) return;
+    onSave({
+      reservedFor: slotIso,
+      partySize,
+      source,
+      guestName: guestName.trim(),
+      guestPhoneE164: phone.trim().length > 0 ? phone.trim() : null,
+      guestEmail: null,
+      tableId,
+      occasion: occasion.trim().length > 0 ? occasion.trim() : null,
+      guestNotes: notes.trim().length > 0 ? notes.trim() : null,
+      tags,
+    });
+  }, [
+    canSave,
+    slotIso,
+    partySize,
+    source,
+    guestName,
+    phone,
+    tableId,
+    occasion,
+    notes,
+    tags,
+    onSave,
+  ]);
+
+  const toggleTag = useCallback((t: ReservationTag): void => {
+    setTags((prev) =>
+      prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t],
+    );
+  }, []);
+
+  return (
+    <Sheet
+      visible={visible}
+      onClose={onClose}
+      snapPoint={0.92}
+      testID={testID ?? "reservation-create-sheet"}
+    >
+      <View style={styles.body}>
+        <Text style={styles.heading}>New reservation</Text>
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={styles.groupLabel}>Guest</Text>
+          <Input
+            value={guestName}
+            onChangeText={setGuestName}
+            placeholder="Guest name"
+            accessibilityLabel="Guest name"
+            testID="reservation-guest-name"
+          />
+
+          <Text style={styles.groupLabel}>Party size</Text>
+          <View style={styles.stepper}>
+            <Pressable
+              onPress={() => setPartySize((p) => Math.max(1, p - 1))}
+              accessibilityRole="button"
+              accessibilityLabel="Decrease party size"
+              style={styles.stepBtn}
+              testID="reservation-party-minus"
+            >
+              <Text style={styles.stepBtnLabel}>−</Text>
+            </Pressable>
+            <Text style={styles.stepValue}>{partySize}</Text>
+            <Pressable
+              onPress={() => setPartySize((p) => Math.min(100, p + 1))}
+              accessibilityRole="button"
+              accessibilityLabel="Increase party size"
+              style={styles.stepBtn}
+              testID="reservation-party-plus"
+            >
+              <Text style={styles.stepBtnLabel}>+</Text>
+            </Pressable>
+          </View>
+
+          <Text style={styles.groupLabel}>Date</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.chipRow}
+          >
+            {dates.map((d) => {
+              const active = d.iso === date;
+              return (
+                <Pressable
+                  key={d.iso}
+                  onPress={() => {
+                    setDate(d.iso);
+                    setSlotIso(null);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={`Date ${d.label}`}
+                  style={[styles.chip, active ? styles.chipActive : null]}
+                  testID={`reservation-date-${d.iso}`}
+                >
+                  <Text
+                    style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                  >
+                    {d.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+
+          <Text style={styles.groupLabel}>Time</Text>
+          {slotsQuery.isLoading ? (
+            <Text style={styles.helper}>Loading times…</Text>
+          ) : slots.length === 0 ? (
+            <Text style={styles.helper}>
+              No bookable times for this date and party size. Try another date.
+            </Text>
+          ) : (
+            <View style={styles.slotGrid}>
+              {slots.map((s) => {
+                const active = s.slotStartUtc === slotIso;
+                return (
+                  <Pressable
+                    key={s.slotStartUtc}
+                    onPress={() => (s.isFull ? undefined : setSlotIso(s.slotStartUtc))}
+                    disabled={s.isFull}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active, disabled: s.isFull }}
+                    accessibilityLabel={
+                      s.isFull
+                        ? `${s.slotLocalLabel}, full`
+                        : `Select ${s.slotLocalLabel}`
+                    }
+                    style={[
+                      styles.slot,
+                      active ? styles.slotActive : null,
+                      s.isFull ? styles.slotFull : null,
+                    ]}
+                    testID={`reservation-slot-${s.slotStartUtc}`}
+                  >
+                    <Text
+                      style={[styles.slotLabel, active ? styles.slotLabelActive : null]}
+                    >
+                      {s.slotLocalLabel}
+                    </Text>
+                    {s.isFull ? <Text style={styles.slotFullText}>full</Text> : null}
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
+
+          {tables.length > 0 ? (
+            <>
+              <Text style={styles.groupLabel}>Table (optional)</Text>
+              <View style={styles.chipRowWrap}>
+                {tables.map((t) => {
+                  const active = t.id === tableId;
+                  return (
+                    <Pressable
+                      key={t.id}
+                      onPress={() => setTableId(active ? null : t.id)}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: active }}
+                      accessibilityLabel={`Table ${t.name}`}
+                      style={[styles.chip, active ? styles.chipActive : null]}
+                      testID={`reservation-table-${t.id}`}
+                    >
+                      <Text
+                        style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                      >
+                        {t.name}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </>
+          ) : null}
+
+          <Text style={styles.groupLabel}>Source</Text>
+          <View style={styles.chipRowWrap}>
+            {SOURCES.map((s) => {
+              const active = s.value === source;
+              return (
+                <Pressable
+                  key={s.value}
+                  onPress={() => setSource(s.value)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={`Source ${s.label}`}
+                  style={[styles.chip, active ? styles.chipActive : null]}
+                  testID={`reservation-source-${s.value}`}
+                >
+                  <Text
+                    style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                  >
+                    {s.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={styles.groupLabel}>Tags</Text>
+          <View style={styles.chipRowWrap}>
+            {RESERVATION_TAGS.map((t) => {
+              const active = tags.includes(t);
+              return (
+                <Pressable
+                  key={t}
+                  onPress={() => toggleTag(t)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={`Tag ${TAG_LABEL[t]}`}
+                  style={[styles.chip, active ? styles.chipActive : null]}
+                  testID={`reservation-tag-${t}`}
+                >
+                  <Text
+                    style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                  >
+                    {TAG_LABEL[t]}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={styles.groupLabel}>Contact &amp; details (optional)</Text>
+          <Input
+            value={phone}
+            onChangeText={setPhone}
+            placeholder="+1 555 123 4567"
+            accessibilityLabel="Guest phone, E.164 format"
+            testID="reservation-phone"
+          />
+          {!phoneValid ? (
+            <Text style={styles.errorText} testID="reservation-phone-error">
+              Enter a valid phone like +15551234567.
+            </Text>
+          ) : null}
+          <Input
+            value={occasion}
+            onChangeText={setOccasion}
+            placeholder="Occasion (birthday, anniversary…)"
+            accessibilityLabel="Occasion"
+            testID="reservation-occasion"
+          />
+          <Input
+            value={notes}
+            onChangeText={setNotes}
+            placeholder="Notes for the host"
+            accessibilityLabel="Guest notes"
+            testID="reservation-notes"
+          />
+
+          <Button
+            label="Create reservation"
+            onPress={handleSave}
+            variant="primary"
+            size="lg"
+            fullWidth
+            loading={saving}
+            disabled={!canSave}
+            style={styles.saveBtn}
+            testID="reservation-create-save"
+          />
+        </ScrollView>
+      </View>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+  },
+  heading: {
+    ...typography.h3,
+    color: textTokens.primary,
+    marginBottom: spacing.sm,
+  },
+  scroll: {
+    paddingBottom: spacing.xxl,
+    gap: spacing.xs,
+  },
+  groupLabel: {
+    ...typography.labelCap,
+    color: textTokens.tertiary,
+    marginTop: spacing.md,
+    marginBottom: spacing.xxs,
+  },
+  helper: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  errorText: {
+    ...typography.bodySm,
+    color: "#ff6b6b",
+    marginTop: spacing.xxs,
+  },
+  stepper: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.lg,
+  },
+  stepBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.06)",
+  },
+  stepBtnLabel: {
+    ...typography.h3,
+    color: textTokens.primary,
+  },
+  stepValue: {
+    ...typography.h3,
+    color: textTokens.primary,
+    minWidth: 32,
+    textAlign: "center",
+    fontVariant: ["tabular-nums"],
+  },
+  chipRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+    paddingVertical: spacing.xxs,
+  },
+  chipRowWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  chip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  chipActive: {
+    backgroundColor: accent.warm,
+  },
+  chipLabel: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+    fontWeight: "600",
+  },
+  chipLabelActive: {
+    color: "#0c0e12",
+  },
+  slotGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  slot: {
+    minWidth: 72,
+    minHeight: 44,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.05)",
+  },
+  slotActive: {
+    borderWidth: 2,
+    borderColor: accent.warm,
+  },
+  slotFull: {
+    opacity: 0.4,
+  },
+  slotLabel: {
+    ...typography.bodySm,
+    color: textTokens.primary,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+  },
+  slotLabelActive: {
+    color: accent.warm,
+  },
+  slotFullText: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+  },
+  saveBtn: {
+    marginTop: spacing.lg,
+  },
+});
+
+export default ReservationCreateSheet;

--- a/mingla-business/src/components/venue/ReservationDetailSheet.tsx
+++ b/mingla-business/src/components/venue/ReservationDetailSheet.tsx
@@ -1,0 +1,289 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — reservation detail + lifecycle actions.
+ *
+ * Shows the reservation summary + the LEGAL lifecycle actions (computed from the
+ * status via legalActionsFor — the client mirror of the server guard). Safe
+ * actions are primary chips; destructive (Cancel / No-show) require a reach +
+ * confirm (Design IA §4.4). The server RPC re-enforces legality (the client only
+ * hides illegal buttons). a11y label on every Pressable. Android glass via Sheet.
+ */
+
+import React, { useCallback, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  radius,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { Sheet } from "../ui/Sheet";
+import {
+  ACTION_LABEL,
+  DESTRUCTIVE_ACTIONS,
+  STATUS_PRESENTATION,
+  legalActionsFor,
+} from "./reservationViews";
+import type {
+  Reservation,
+  ReservationAction,
+} from "../../types/venueReservation";
+
+function localLabel(iso: string): string {
+  const d = new Date(iso);
+  let h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h >= 12 ? "PM" : "AM";
+  h = h % 12;
+  if (h === 0) h = 12;
+  const day = d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  return `${day} · ${h}:${m.toString().padStart(2, "0")} ${ampm}`;
+}
+
+export interface ReservationDetailSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  reservation: Reservation | null;
+  tableName: string | null;
+  /** Apply a lifecycle action (maps to a server transition). */
+  onAction: (r: Reservation, action: ReservationAction) => void;
+  acting: boolean;
+  testID?: string;
+}
+
+export function ReservationDetailSheet({
+  visible,
+  onClose,
+  reservation,
+  tableName,
+  onAction,
+  acting,
+  testID,
+}: ReservationDetailSheetProps): React.ReactElement | null {
+  const [confirmingAction, setConfirmingAction] =
+    useState<ReservationAction | null>(null);
+
+  const handlePress = useCallback(
+    (action: ReservationAction): void => {
+      if (reservation === null) return;
+      if (DESTRUCTIVE_ACTIONS.includes(action) && confirmingAction !== action) {
+        // First tap on a destructive action arms the confirm.
+        setConfirmingAction(action);
+        return;
+      }
+      setConfirmingAction(null);
+      onAction(reservation, action);
+    },
+    [reservation, confirmingAction, onAction],
+  );
+
+  if (reservation === null) return null;
+  const pres = STATUS_PRESENTATION[reservation.status];
+  const actions = legalActionsFor(reservation.status);
+  const safe = actions.filter((a) => !DESTRUCTIVE_ACTIONS.includes(a));
+  const destructive = actions.filter((a) => DESTRUCTIVE_ACTIONS.includes(a));
+
+  const summaryParts: string[] = [
+    `Party of ${reservation.partySize}`,
+  ];
+  if (tableName != null) summaryParts.push(`Table ${tableName}`);
+
+  return (
+    <Sheet
+      visible={visible}
+      onClose={onClose}
+      snapPoint={0.7}
+      testID={testID ?? "reservation-detail-sheet"}
+    >
+      <View style={styles.body}>
+        <Text style={styles.guest}>{reservation.guestName ?? "Guest"}</Text>
+        <Text style={styles.when}>{localLabel(reservation.reservedFor)}</Text>
+        <Text style={styles.summary}>{summaryParts.join(" · ")}</Text>
+        <View style={styles.statusRow}>
+          <Text style={styles.statusLabel}>Status:</Text>
+          <Text style={styles.statusValue}>{pres.label}</Text>
+        </View>
+        {reservation.guestNotes != null ? (
+          <Text style={styles.note}>“{reservation.guestNotes}”</Text>
+        ) : null}
+        {reservation.guestPhoneE164 != null ? (
+          <Text style={styles.contact}>{reservation.guestPhoneE164}</Text>
+        ) : null}
+
+        {actions.length === 0 ? (
+          <Text style={styles.terminalNote}>
+            This reservation is {pres.label.toLowerCase()} — no further actions.
+          </Text>
+        ) : (
+          <>
+            {safe.length > 0 ? (
+              <View style={styles.actionRow}>
+                {safe.map((a) => (
+                  <ActionButton
+                    key={a}
+                    action={a}
+                    armed={false}
+                    onPress={handlePress}
+                    disabled={acting}
+                  />
+                ))}
+              </View>
+            ) : null}
+            {destructive.length > 0 ? (
+              <View style={styles.destructiveRow}>
+                {destructive.map((a) => (
+                  <ActionButton
+                    key={a}
+                    action={a}
+                    armed={confirmingAction === a}
+                    onPress={handlePress}
+                    disabled={acting}
+                  />
+                ))}
+              </View>
+            ) : null}
+          </>
+        )}
+      </View>
+    </Sheet>
+  );
+}
+
+interface ActionButtonProps {
+  action: ReservationAction;
+  armed: boolean;
+  onPress: (a: ReservationAction) => void;
+  disabled: boolean;
+}
+
+function ActionButton({
+  action,
+  armed,
+  onPress,
+  disabled,
+}: ActionButtonProps): React.ReactElement {
+  const isDestructive = DESTRUCTIVE_ACTIONS.includes(action);
+  const label = armed ? "Tap again to confirm" : ACTION_LABEL[action];
+  return (
+    <Pressable
+      onPress={() => onPress(action)}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={
+        armed ? `Confirm ${ACTION_LABEL[action]}` : ACTION_LABEL[action]
+      }
+      style={[
+        styles.actionBtn,
+        isDestructive ? styles.destructiveBtn : styles.safeBtn,
+        armed ? styles.armedBtn : null,
+        disabled ? styles.disabledBtn : null,
+      ]}
+      testID={`reservation-action-${action}`}
+    >
+      <Text
+        style={[
+          styles.actionLabel,
+          isDestructive ? styles.destructiveLabel : styles.safeLabel,
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    gap: spacing.xs,
+  },
+  guest: {
+    ...typography.h3,
+    color: textTokens.primary,
+  },
+  when: {
+    ...typography.body,
+    color: textTokens.secondary,
+  },
+  summary: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginTop: spacing.xxs,
+  },
+  statusLabel: {
+    ...typography.bodySm,
+    color: textTokens.tertiary,
+  },
+  statusValue: {
+    ...typography.bodySm,
+    color: textTokens.primary,
+    fontWeight: "600",
+  },
+  note: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+    fontStyle: "italic",
+    marginTop: spacing.xxs,
+  },
+  contact: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  terminalNote: {
+    ...typography.bodySm,
+    color: textTokens.tertiary,
+    marginTop: spacing.md,
+  },
+  actionRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  destructiveRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  actionBtn: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  safeBtn: {
+    backgroundColor: "rgba(255,255,255,0.07)",
+  },
+  destructiveBtn: {
+    backgroundColor: semantic.errorTint,
+  },
+  armedBtn: {
+    backgroundColor: semantic.error,
+  },
+  disabledBtn: {
+    opacity: 0.5,
+  },
+  actionLabel: {
+    ...typography.bodySm,
+    fontWeight: "700",
+  },
+  safeLabel: {
+    color: textTokens.primary,
+  },
+  destructiveLabel: {
+    color: semantic.error,
+  },
+});
+
+export default ReservationDetailSheet;

--- a/mingla-business/src/components/venue/VenueReservationsModule.tsx
+++ b/mingla-business/src/components/venue/VenueReservationsModule.tsx
@@ -1,0 +1,296 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — Reservations module (real operator UI).
+ *
+ * Replaces the Reservations ComingSoon slot. Segmented views (Today / Upcoming /
+ * Waitlist / Completed / No-shows / Canceled — a control INSIDE the module, not a
+ * 3rd nav level), a live list of ReservationCards (realtime via useVenueReservations),
+ * a detail sheet with guarded lifecycle actions, and manual create. Manager-plus
+ * gates the controls in the UI (the RPCs re-enforce server-side). a11y labels on
+ * every Pressable. Android glass via GlassCard.
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useCurrentBrandRole } from "../../hooks/useCurrentBrandRole";
+import {
+  useCreateReservation,
+  useTransitionReservation,
+  useVenueReservations,
+} from "../../hooks/useVenueReservations";
+import { useVenueTables } from "../../hooks/useVenueTables";
+import { BRAND_ROLE_RANK } from "../../utils/brandRole";
+import { Button } from "../ui/Button";
+import { GlassCard } from "../ui/GlassCard";
+import { Icon } from "../ui/Icon";
+import { ReservationCard } from "./ReservationCard";
+import { ReservationCreateSheet } from "./ReservationCreateSheet";
+import { ReservationDetailSheet } from "./ReservationDetailSheet";
+import {
+  ACTION_TARGET,
+  RESERVATION_VIEWS,
+  filterReservationsForView,
+} from "./reservationViews";
+import type {
+  Reservation,
+  ReservationAction,
+  ReservationCreateInput,
+  ReservationView,
+} from "../../types/venueReservation";
+
+const MANAGER_PLUS_RANK = BRAND_ROLE_RANK.event_manager;
+
+const VIEW_EMPTY: Record<ReservationView, string> = {
+  today: "No reservations today yet.",
+  upcoming: "No upcoming reservations yet.",
+  waitlist: "No waitlisted reservations.",
+  completed: "No completed reservations yet.",
+  no_shows: "No no-shows. Nice.",
+  canceled: "No canceled reservations.",
+};
+
+export interface VenueReservationsModuleProps {
+  brandId: string | null;
+  testID?: string;
+}
+
+export function VenueReservationsModule({
+  brandId,
+  testID,
+}: VenueReservationsModuleProps): React.ReactElement {
+  const { rank } = useCurrentBrandRole(brandId);
+  const canMutate = rank >= MANAGER_PLUS_RANK;
+
+  const reservationsQuery = useVenueReservations(brandId);
+  const tablesQuery = useVenueTables(brandId);
+  const create = useCreateReservation(brandId);
+  const transition = useTransitionReservation(brandId);
+
+  const [view, setView] = useState<ReservationView>("today");
+  const [createOpen, setCreateOpen] = useState<boolean>(false);
+  const [selected, setSelected] = useState<Reservation | null>(null);
+
+  const tableNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const t of tablesQuery.data ?? []) map.set(t.id, t.name);
+    return map;
+  }, [tablesQuery.data]);
+
+  const reservations = reservationsQuery.data;
+  const visible = useMemo(
+    () => filterReservationsForView(reservations ?? [], view),
+    [reservations, view],
+  );
+
+  const handleSave = useCallback(
+    (input: ReservationCreateInput): void => {
+      create.mutate(input, {
+        onSuccess: () => setCreateOpen(false),
+      });
+    },
+    [create],
+  );
+
+  const handleAction = useCallback(
+    (r: Reservation, action: ReservationAction): void => {
+      transition.mutate(
+        { reservationId: r.id, toStatus: ACTION_TARGET[action] },
+        { onSuccess: () => setSelected(null) },
+      );
+    },
+    [transition],
+  );
+
+  return (
+    <View style={styles.host} testID={testID ?? "venue-reservations-module"}>
+      <View style={styles.headerRow}>
+        <View style={styles.headerText}>
+          <Text style={styles.title}>Reservations</Text>
+          <Text style={styles.subtitle}>
+            Bookings from Mingla and your own — all in one list.
+          </Text>
+        </View>
+        {canMutate ? (
+          <Button
+            label="New"
+            onPress={() => setCreateOpen(true)}
+            variant="primary"
+            size="sm"
+            leadingIcon="plus"
+            testID="venue-reservations-new"
+          />
+        ) : null}
+      </View>
+
+      {/* Segmented views (inside the module — not a 3rd nav level). */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.segRow}
+        accessibilityRole="tablist"
+      >
+        {RESERVATION_VIEWS.map((v) => {
+          const active = v.id === view;
+          return (
+            <Pressable
+              key={v.id}
+              onPress={() => setView(v.id)}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={`${v.label} reservations`}
+              style={[styles.seg, active ? styles.segActive : null]}
+              testID={`venue-reservations-view-${v.id}`}
+            >
+              <Text style={[styles.segLabel, active ? styles.segLabelActive : null]}>
+                {v.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+
+      {reservationsQuery.isLoading ? (
+        <Text style={styles.helper}>Loading reservations…</Text>
+      ) : visible.length === 0 ? (
+        <GlassCard variant="elevated" style={styles.emptyCard}>
+          <Icon name="calendar" size={26} color={textTokens.primary} />
+          <Text style={styles.emptyTitle}>{VIEW_EMPTY[view]}</Text>
+          {view === "today" || view === "upcoming" ? (
+            <Text style={styles.emptyBody}>
+              When guests book — from Mingla or here — they land in this list.
+            </Text>
+          ) : null}
+          {canMutate && (view === "today" || view === "upcoming") ? (
+            <Button
+              label="Add one to test"
+              onPress={() => setCreateOpen(true)}
+              variant="secondary"
+              size="md"
+              testID="venue-reservations-empty-add"
+            />
+          ) : null}
+        </GlassCard>
+      ) : (
+        <View style={styles.list}>
+          {visible.map((r) => (
+            <ReservationCard
+              key={r.id}
+              reservation={r}
+              tableName={r.tableId != null ? (tableNameById.get(r.tableId) ?? null) : null}
+              onPress={setSelected}
+            />
+          ))}
+        </View>
+      )}
+
+      {reservationsQuery.isError ? (
+        <Text style={styles.errorNote}>
+          Couldn&apos;t load reservations. Pull to refresh.
+        </Text>
+      ) : null}
+
+      <ReservationCreateSheet
+        visible={createOpen}
+        onClose={() => setCreateOpen(false)}
+        brandId={brandId}
+        onSave={handleSave}
+        saving={create.isPending}
+      />
+      <ReservationDetailSheet
+        visible={selected !== null}
+        onClose={() => setSelected(null)}
+        reservation={selected}
+        tableName={
+          selected?.tableId != null
+            ? (tableNameById.get(selected.tableId) ?? null)
+            : null
+        }
+        onAction={handleAction}
+        acting={transition.isPending}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    gap: spacing.md,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: spacing.md,
+  },
+  headerText: {
+    flex: 1,
+    gap: spacing.xxs,
+  },
+  title: {
+    ...typography.h3,
+    color: textTokens.primary,
+  },
+  subtitle: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  segRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+    paddingVertical: spacing.xxs,
+  },
+  seg: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  segActive: {
+    backgroundColor: accent.warm,
+  },
+  segLabel: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+    fontWeight: "600",
+  },
+  segLabelActive: {
+    color: "#0c0e12",
+  },
+  helper: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  emptyCard: {
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  emptyTitle: {
+    ...typography.h3,
+    color: textTokens.primary,
+    textAlign: "center",
+  },
+  emptyBody: {
+    ...typography.body,
+    color: textTokens.secondary,
+    textAlign: "center",
+  },
+  list: {
+    gap: spacing.sm,
+  },
+  errorNote: {
+    ...typography.bodySm,
+    color: semantic.error,
+  },
+});
+
+export default VenueReservationsModule;

--- a/mingla-business/src/components/venue/VenueSuiteShell.tsx
+++ b/mingla-business/src/components/venue/VenueSuiteShell.tsx
@@ -17,7 +17,8 @@
  *  - overview  → <VenueListingContent> (the ORCH-1145 listing, VERBATIM) + an
  *                invitation card when the toggle is OFF.
  *  - settings  → <VenueSettingsModule>.
- *  - booking   → <VenueModuleComingSoon> (honest "set up next", not a dead tap).
+ *  - booking   → live operator modules: Tables (2.1a) · Availability (2.1a) ·
+ *                Reservations (2.1b) · Waitlist (2.1b). No ComingSoon left.
  *
  * Bands C/D are not in the module union → cannot be selected → cannot dead-tap.
  */
@@ -47,9 +48,10 @@ import { Button } from "../ui/Button";
 import { GlassCard } from "../ui/GlassCard";
 import { VenueAvailabilityModule } from "./VenueAvailabilityModule";
 import { VenueListingContent } from "./VenueListingContent";
-import { VenueModuleComingSoon } from "./VenueModuleComingSoon";
+import { VenueReservationsModule } from "./VenueReservationsModule";
 import { VenueSettingsModule } from "./VenueSettingsModule";
 import { VenueTablesModule } from "./VenueTablesModule";
+import { VenueWaitlistModule } from "./VenueWaitlistModule";
 import { moduleSelfScrolls, venueScrollBottomPad } from "./venueShellScroll";
 import {
   VENUE_MODULES,
@@ -113,9 +115,6 @@ export function VenueSuiteShell({
     });
   }, [setEnabled]);
 
-  const goToSettings = useCallback((): void => {
-    setActiveModule("settings");
-  }, []);
 
   // Overview mounts <VenueListingContent>, which OWNS its own ScrollView (with
   // its own `insets.bottom + 120` clearance) — so the shell must NOT wrap it in
@@ -166,19 +165,19 @@ export function VenueSuiteShell({
     if (activeModule === "settings") {
       return <VenueSettingsModule brandId={brandId} />;
     }
-    // 2.1a — Tables + Availability are now LIVE operator modules (replacing
-    // ComingSoon). Reservations + Waitlist stay ComingSoon until 2.1b.
+    // 2.1a — Tables + Availability LIVE. 2.1b — Reservations + Waitlist LIVE.
+    // The whole booking band is now real operator UI (no ComingSoon left).
     if (activeModule === "tables") {
       return <VenueTablesModule brandId={brandId} />;
     }
     if (activeModule === "availability") {
       return <VenueAvailabilityModule brandId={brandId} />;
     }
-    // Remaining booking band (reservations / waitlist) → honest ComingSoon
-    // (never a dead tap). Real CRUD lands in 2.1b.
-    return (
-      <VenueModuleComingSoon module={activeModule} onGoToSettings={goToSettings} />
-    );
+    if (activeModule === "reservations") {
+      return <VenueReservationsModule brandId={brandId} />;
+    }
+    // The remaining booking module: waitlist.
+    return <VenueWaitlistModule brandId={brandId} />;
   };
 
   // ----- Web desktop: two-column master rail + workspace. -----

--- a/mingla-business/src/components/venue/VenueWaitlistModule.tsx
+++ b/mingla-business/src/components/venue/VenueWaitlistModule.tsx
@@ -1,0 +1,357 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — Waitlist module (real operator UI).
+ *
+ * Replaces the Waitlist ComingSoon slot. A live queue (realtime via
+ * useVenueWaitlist) of waiting/notified guests with position, party, est wait,
+ * preferred seating + Notify (Twilio "table's ready" via send-venue-sms) +
+ * Convert-to-reservation (atomic RPC) + mark-lost. Manager-plus gates the
+ * controls. a11y labels on every Pressable. Android glass via GlassCard.
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import {
+  radius,
+  semantic,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useCurrentBrandRole } from "../../hooks/useCurrentBrandRole";
+import {
+  useAddToWaitlist,
+  useConvertWaitlist,
+  useMarkWaitlistLost,
+  useNotifyWaitlist,
+  useVenueWaitlist,
+} from "../../hooks/useVenueWaitlist";
+import { BRAND_ROLE_RANK } from "../../utils/brandRole";
+import { Button } from "../ui/Button";
+import { GlassCard } from "../ui/GlassCard";
+import { Icon } from "../ui/Icon";
+import { WaitlistAddSheet } from "./WaitlistAddSheet";
+import { WaitlistConvertSheet } from "./WaitlistConvertSheet";
+import type {
+  VenueTableZone,
+  WaitlistAddInput,
+  WaitlistEntry,
+} from "../../types/venueReservation";
+
+const MANAGER_PLUS_RANK = BRAND_ROLE_RANK.event_manager;
+
+const ZONE_LABEL: Record<VenueTableZone, string> = {
+  indoor: "Indoor",
+  outdoor: "Outdoor",
+  private_room: "Private room",
+  bar: "Bar",
+  patio: "Patio",
+};
+
+export interface VenueWaitlistModuleProps {
+  brandId: string | null;
+  testID?: string;
+}
+
+export function VenueWaitlistModule({
+  brandId,
+  testID,
+}: VenueWaitlistModuleProps): React.ReactElement {
+  const { rank } = useCurrentBrandRole(brandId);
+  const canMutate = rank >= MANAGER_PLUS_RANK;
+
+  const waitlistQuery = useVenueWaitlist(brandId);
+  const add = useAddToWaitlist(brandId);
+  const notify = useNotifyWaitlist(brandId);
+  const convert = useConvertWaitlist(brandId);
+  const markLost = useMarkWaitlistLost(brandId);
+
+  const [addOpen, setAddOpen] = useState<boolean>(false);
+  const [converting, setConverting] = useState<WaitlistEntry | null>(null);
+
+  // The ACTIVE queue (waiting + notified), FIFO by created order.
+  const queue = useMemo(
+    () =>
+      (waitlistQuery.data ?? []).filter(
+        (w) => w.status === "waiting" || w.status === "notified",
+      ),
+    [waitlistQuery.data],
+  );
+
+  const handleAdd = useCallback(
+    (input: WaitlistAddInput): void => {
+      add.mutate(input, { onSuccess: () => setAddOpen(false) });
+    },
+    [add],
+  );
+
+  const handleConvert = useCallback(
+    (reservedFor: string, tableId: string | null): void => {
+      if (converting === null) return;
+      convert.mutate(
+        { waitlistId: converting.id, reservedFor, tableId },
+        { onSuccess: () => setConverting(null) },
+      );
+    },
+    [convert, converting],
+  );
+
+  return (
+    <View style={styles.host} testID={testID ?? "venue-waitlist-module"}>
+      <View style={styles.headerRow}>
+        <View style={styles.headerText}>
+          <Text style={styles.title}>
+            Waitlist{queue.length > 0 ? ` · ${queue.length} waiting` : ""}
+          </Text>
+          <Text style={styles.subtitle}>
+            Drop walk-ins here and text them when a table opens.
+          </Text>
+        </View>
+        {canMutate ? (
+          <Button
+            label="Add"
+            onPress={() => setAddOpen(true)}
+            variant="primary"
+            size="sm"
+            leadingIcon="plus"
+            testID="venue-waitlist-add"
+          />
+        ) : null}
+      </View>
+
+      {waitlistQuery.isLoading ? (
+        <Text style={styles.helper}>Loading waitlist…</Text>
+      ) : queue.length === 0 ? (
+        <GlassCard variant="elevated" style={styles.emptyCard}>
+          <Icon name="clock" size={26} color={textTokens.primary} />
+          <Text style={styles.emptyTitle}>Nobody&apos;s waiting</Text>
+          <Text style={styles.emptyBody}>
+            When you&apos;re full, add walk-ins here and notify them when a table
+            opens.
+          </Text>
+          {canMutate ? (
+            <Button
+              label="Add to waitlist"
+              onPress={() => setAddOpen(true)}
+              variant="secondary"
+              size="md"
+              testID="venue-waitlist-empty-add"
+            />
+          ) : null}
+        </GlassCard>
+      ) : (
+        <View style={styles.list}>
+          {queue.map((w, i) => {
+            const parts: string[] = [`Party ${w.partySize}`];
+            if (w.quotedWaitMinutes != null) parts.push(`~${w.quotedWaitMinutes}m`);
+            if (w.preferredZone != null) parts.push(ZONE_LABEL[w.preferredZone]);
+            const notified = w.status === "notified";
+            return (
+              <GlassCard key={w.id} variant="base" style={styles.card}>
+                <View style={styles.cardMain}>
+                  <Text style={styles.pos}>{i + 1}</Text>
+                  <View style={styles.cardText}>
+                    <Text style={styles.guest} numberOfLines={1}>
+                      {w.guestName ?? "Guest"}
+                    </Text>
+                    <Text style={styles.meta}>{parts.join(" · ")}</Text>
+                    {notified ? (
+                      <Text style={styles.notified}>Notified ✓</Text>
+                    ) : null}
+                  </View>
+                </View>
+                {canMutate ? (
+                  <View style={styles.actions}>
+                    {w.guestPhoneE164 != null ? (
+                      <Pressable
+                        onPress={() => notify.mutate(w.id)}
+                        disabled={notify.isPending}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Text ${w.guestName ?? "guest"} their table is ready`}
+                        style={styles.notifyBtn}
+                        testID={`venue-waitlist-notify-${w.id}`}
+                      >
+                        <Icon name="sms" size={15} color="#0c0e12" />
+                        <Text style={styles.notifyLabel}>Notify</Text>
+                      </Pressable>
+                    ) : null}
+                    <Pressable
+                      onPress={() => setConverting(w)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Seat ${w.guestName ?? "guest"} as a reservation`}
+                      style={styles.seatBtn}
+                      testID={`venue-waitlist-seat-${w.id}`}
+                    >
+                      <Text style={styles.seatLabel}>Seat</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => markLost.mutate(w.id)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Mark ${w.guestName ?? "guest"} as left`}
+                      style={styles.lostBtn}
+                      testID={`venue-waitlist-lost-${w.id}`}
+                    >
+                      <Icon name="close" size={15} color={textTokens.tertiary} />
+                    </Pressable>
+                  </View>
+                ) : null}
+              </GlassCard>
+            );
+          })}
+        </View>
+      )}
+
+      {notify.isError ? (
+        <Text style={styles.errorNote}>
+          Couldn&apos;t send the text. Check the guest&apos;s phone number.
+        </Text>
+      ) : null}
+      {waitlistQuery.isError ? (
+        <Text style={styles.errorNote}>
+          Couldn&apos;t load the waitlist. Pull to refresh.
+        </Text>
+      ) : null}
+
+      <WaitlistAddSheet
+        visible={addOpen}
+        onClose={() => setAddOpen(false)}
+        onSave={handleAdd}
+        saving={add.isPending}
+      />
+      <WaitlistConvertSheet
+        visible={converting !== null}
+        onClose={() => setConverting(null)}
+        brandId={brandId}
+        entry={converting}
+        onConvert={handleConvert}
+        converting={convert.isPending}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    gap: spacing.md,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: spacing.md,
+  },
+  headerText: {
+    flex: 1,
+    gap: spacing.xxs,
+  },
+  title: {
+    ...typography.h3,
+    color: textTokens.primary,
+  },
+  subtitle: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  helper: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  emptyCard: {
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  emptyTitle: {
+    ...typography.h3,
+    color: textTokens.primary,
+    textAlign: "center",
+  },
+  emptyBody: {
+    ...typography.body,
+    color: textTokens.secondary,
+    textAlign: "center",
+  },
+  list: {
+    gap: spacing.sm,
+  },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  cardMain: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  pos: {
+    ...typography.h3,
+    color: textTokens.tertiary,
+    fontVariant: ["tabular-nums"],
+    minWidth: 22,
+  },
+  cardText: {
+    flex: 1,
+    gap: spacing.xxs,
+  },
+  guest: {
+    ...typography.bodyLg,
+    color: textTokens.primary,
+    fontWeight: "600",
+  },
+  meta: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  notified: {
+    ...typography.caption,
+    color: semantic.success,
+    fontWeight: "700",
+  },
+  actions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
+  notifyBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: "#eb7825",
+  },
+  notifyLabel: {
+    ...typography.caption,
+    color: "#0c0e12",
+    fontWeight: "700",
+  },
+  seatBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.07)",
+  },
+  seatLabel: {
+    ...typography.caption,
+    color: textTokens.primary,
+    fontWeight: "700",
+  },
+  lostBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.full,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  errorNote: {
+    ...typography.bodySm,
+    color: semantic.error,
+  },
+});
+
+export default VenueWaitlistModule;

--- a/mingla-business/src/components/venue/WaitlistAddSheet.tsx
+++ b/mingla-business/src/components/venue/WaitlistAddSheet.tsx
@@ -1,0 +1,274 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — add-to-waitlist sheet.
+ *
+ * Guest · party · preferred seating · quoted wait · contact (E.164 phone for the
+ * "table's ready" SMS). Writes via the RLS-gated insert (useAddToWaitlist).
+ * a11y labels on every Pressable. Android glass via Sheet.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { isValidE164 } from "../../utils/phone";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Sheet } from "../ui/Sheet";
+import type {
+  VenueTableZone,
+  WaitlistAddInput,
+} from "../../types/venueReservation";
+
+const ZONES: readonly { value: VenueTableZone; label: string }[] = [
+  { value: "indoor", label: "Indoor" },
+  { value: "outdoor", label: "Outdoor" },
+  { value: "private_room", label: "Private room" },
+  { value: "bar", label: "Bar" },
+  { value: "patio", label: "Patio" },
+];
+
+const parseIntOrNull = (raw: string): number | null => {
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+};
+
+export interface WaitlistAddSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (input: WaitlistAddInput) => void;
+  saving: boolean;
+  testID?: string;
+}
+
+export function WaitlistAddSheet({
+  visible,
+  onClose,
+  onSave,
+  saving,
+  testID,
+}: WaitlistAddSheetProps): React.ReactElement {
+  const [guestName, setGuestName] = useState<string>("");
+  const [partySize, setPartySize] = useState<number>(2);
+  const [zone, setZone] = useState<VenueTableZone | null>(null);
+  const [quotedWait, setQuotedWait] = useState<string>("");
+  const [phone, setPhone] = useState<string>("");
+
+  useEffect(() => {
+    if (!visible) return;
+    setGuestName("");
+    setPartySize(2);
+    setZone(null);
+    setQuotedWait("");
+    setPhone("");
+  }, [visible]);
+
+  const phoneValid = phone.trim().length === 0 || isValidE164(phone.trim());
+  const canSave = guestName.trim().length > 0 && phoneValid && !saving;
+
+  const handleSave = useCallback((): void => {
+    if (!canSave) return;
+    onSave({
+      guestName: guestName.trim(),
+      guestPhoneE164: phone.trim().length > 0 ? phone.trim() : null,
+      guestEmail: null,
+      partySize,
+      preferredZone: zone,
+      quotedWaitMinutes: parseIntOrNull(quotedWait),
+    });
+  }, [canSave, guestName, phone, partySize, zone, quotedWait, onSave]);
+
+  return (
+    <Sheet
+      visible={visible}
+      onClose={onClose}
+      snapPoint={0.8}
+      testID={testID ?? "waitlist-add-sheet"}
+    >
+      <View style={styles.body}>
+        <Text style={styles.heading}>Add to waitlist</Text>
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={styles.groupLabel}>Guest</Text>
+          <Input
+            value={guestName}
+            onChangeText={setGuestName}
+            placeholder="Guest name"
+            accessibilityLabel="Guest name"
+            testID="waitlist-guest-name"
+          />
+
+          <Text style={styles.groupLabel}>Party size</Text>
+          <View style={styles.stepper}>
+            <Pressable
+              onPress={() => setPartySize((p) => Math.max(1, p - 1))}
+              accessibilityRole="button"
+              accessibilityLabel="Decrease party size"
+              style={styles.stepBtn}
+              testID="waitlist-party-minus"
+            >
+              <Text style={styles.stepBtnLabel}>−</Text>
+            </Pressable>
+            <Text style={styles.stepValue}>{partySize}</Text>
+            <Pressable
+              onPress={() => setPartySize((p) => Math.min(100, p + 1))}
+              accessibilityRole="button"
+              accessibilityLabel="Increase party size"
+              style={styles.stepBtn}
+              testID="waitlist-party-plus"
+            >
+              <Text style={styles.stepBtnLabel}>+</Text>
+            </Pressable>
+          </View>
+
+          <Text style={styles.groupLabel}>Preferred seating (optional)</Text>
+          <View style={styles.chipRow}>
+            {ZONES.map((z) => {
+              const active = z.value === zone;
+              return (
+                <Pressable
+                  key={z.value}
+                  onPress={() => setZone(active ? null : z.value)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={`Preferred seating ${z.label}`}
+                  style={[styles.chip, active ? styles.chipActive : null]}
+                  testID={`waitlist-zone-${z.value}`}
+                >
+                  <Text
+                    style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                  >
+                    {z.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={styles.groupLabel}>Quoted wait (minutes, optional)</Text>
+          <Input
+            value={quotedWait}
+            onChangeText={setQuotedWait}
+            variant="number"
+            placeholder="20"
+            accessibilityLabel="Quoted wait in minutes"
+            testID="waitlist-quoted-wait"
+          />
+
+          <Text style={styles.groupLabel}>Phone for the “table’s ready” text</Text>
+          <Input
+            value={phone}
+            onChangeText={setPhone}
+            placeholder="+1 555 123 4567"
+            accessibilityLabel="Guest phone, E.164 format"
+            testID="waitlist-phone"
+          />
+          {!phoneValid ? (
+            <Text style={styles.errorText} testID="waitlist-phone-error">
+              Enter a valid phone like +15551234567.
+            </Text>
+          ) : null}
+
+          <Button
+            label="Add to waitlist"
+            onPress={handleSave}
+            variant="primary"
+            size="lg"
+            fullWidth
+            loading={saving}
+            disabled={!canSave}
+            style={styles.saveBtn}
+            testID="waitlist-add-save"
+          />
+        </ScrollView>
+      </View>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+  },
+  heading: {
+    ...typography.h3,
+    color: textTokens.primary,
+    marginBottom: spacing.sm,
+  },
+  scroll: {
+    paddingBottom: spacing.xxl,
+    gap: spacing.xs,
+  },
+  groupLabel: {
+    ...typography.labelCap,
+    color: textTokens.tertiary,
+    marginTop: spacing.md,
+    marginBottom: spacing.xxs,
+  },
+  errorText: {
+    ...typography.bodySm,
+    color: "#ff6b6b",
+    marginTop: spacing.xxs,
+  },
+  stepper: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.lg,
+  },
+  stepBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.06)",
+  },
+  stepBtnLabel: {
+    ...typography.h3,
+    color: textTokens.primary,
+  },
+  stepValue: {
+    ...typography.h3,
+    color: textTokens.primary,
+    minWidth: 32,
+    textAlign: "center",
+    fontVariant: ["tabular-nums"],
+  },
+  chipRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  chip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  chipActive: {
+    backgroundColor: accent.warm,
+  },
+  chipLabel: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+    fontWeight: "600",
+  },
+  chipLabelActive: {
+    color: "#0c0e12",
+  },
+  saveBtn: {
+    marginTop: spacing.lg,
+  },
+});
+
+export default WaitlistAddSheet;

--- a/mingla-business/src/components/venue/WaitlistConvertSheet.tsx
+++ b/mingla-business/src/components/venue/WaitlistConvertSheet.tsx
@@ -1,0 +1,316 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — convert-waitlist-to-reservation sheet.
+ *
+ * Pick a date + time (from the engine slots — the SAME availability truth, no
+ * client fabrication) + optional table, then convert atomically via the guarded
+ * biz_waitlist_convert_to_reservation RPC. a11y labels. Android glass via Sheet.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../constants/designSystem";
+import { useAvailableSlots } from "../../hooks/useVenueAvailability";
+import { useVenueTables } from "../../hooks/useVenueTables";
+import { Button } from "../ui/Button";
+import { Sheet } from "../ui/Sheet";
+import type { WaitlistEntry } from "../../types/venueReservation";
+
+function nextDates(count: number): { iso: string; label: string }[] {
+  const out: { iso: string; label: string }[] = [];
+  const base = new Date();
+  for (let i = 0; i < count; i += 1) {
+    const d = new Date(base);
+    d.setDate(base.getDate() + i);
+    const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    const label =
+      i === 0
+        ? "Today"
+        : i === 1
+          ? "Tomorrow"
+          : d.toLocaleDateString(undefined, {
+              weekday: "short",
+              month: "short",
+              day: "numeric",
+            });
+    out.push({ iso, label });
+  }
+  return out;
+}
+
+export interface WaitlistConvertSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  brandId: string | null;
+  entry: WaitlistEntry | null;
+  onConvert: (reservedFor: string, tableId: string | null) => void;
+  converting: boolean;
+  testID?: string;
+}
+
+export function WaitlistConvertSheet({
+  visible,
+  onClose,
+  brandId,
+  entry,
+  onConvert,
+  converting,
+  testID,
+}: WaitlistConvertSheetProps): React.ReactElement | null {
+  const [date, setDate] = useState<string | null>(null);
+  const [slotIso, setSlotIso] = useState<string | null>(null);
+  const [tableId, setTableId] = useState<string | null>(null);
+
+  const dates = useMemo(() => nextDates(7), []);
+
+  useEffect(() => {
+    if (!visible) return;
+    setDate(dates[0]?.iso ?? null);
+    setSlotIso(null);
+    setTableId(null);
+  }, [visible, dates]);
+
+  const partySize = entry?.partySize ?? 2;
+  const slotsQuery = useAvailableSlots(brandId, date, partySize);
+  const slots = slotsQuery.data ?? [];
+  const tablesQuery = useVenueTables(brandId);
+  const tables = (tablesQuery.data ?? []).filter((t) => t.isActive);
+
+  const handleConvert = useCallback((): void => {
+    if (slotIso === null) return;
+    onConvert(slotIso, tableId);
+  }, [slotIso, tableId, onConvert]);
+
+  if (entry === null) return null;
+
+  return (
+    <Sheet
+      visible={visible}
+      onClose={onClose}
+      snapPoint={0.85}
+      testID={testID ?? "waitlist-convert-sheet"}
+    >
+      <View style={styles.body}>
+        <Text style={styles.heading}>Seat {entry.guestName ?? "guest"}</Text>
+        <Text style={styles.sub}>Party of {entry.partySize}</Text>
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={styles.groupLabel}>Date</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.chipRow}
+          >
+            {dates.map((d) => {
+              const active = d.iso === date;
+              return (
+                <Pressable
+                  key={d.iso}
+                  onPress={() => {
+                    setDate(d.iso);
+                    setSlotIso(null);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: active }}
+                  accessibilityLabel={`Date ${d.label}`}
+                  style={[styles.chip, active ? styles.chipActive : null]}
+                  testID={`waitlist-convert-date-${d.iso}`}
+                >
+                  <Text
+                    style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                  >
+                    {d.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+
+          <Text style={styles.groupLabel}>Time</Text>
+          {slotsQuery.isLoading ? (
+            <Text style={styles.helper}>Loading times…</Text>
+          ) : slots.length === 0 ? (
+            <Text style={styles.helper}>No open times for this date.</Text>
+          ) : (
+            <View style={styles.slotGrid}>
+              {slots.map((s) => {
+                const active = s.slotStartUtc === slotIso;
+                return (
+                  <Pressable
+                    key={s.slotStartUtc}
+                    onPress={() => (s.isFull ? undefined : setSlotIso(s.slotStartUtc))}
+                    disabled={s.isFull}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active, disabled: s.isFull }}
+                    accessibilityLabel={
+                      s.isFull ? `${s.slotLocalLabel}, full` : `Select ${s.slotLocalLabel}`
+                    }
+                    style={[
+                      styles.slot,
+                      active ? styles.slotActive : null,
+                      s.isFull ? styles.slotFull : null,
+                    ]}
+                    testID={`waitlist-convert-slot-${s.slotStartUtc}`}
+                  >
+                    <Text
+                      style={[styles.slotLabel, active ? styles.slotLabelActive : null]}
+                    >
+                      {s.slotLocalLabel}
+                    </Text>
+                    {s.isFull ? <Text style={styles.slotFullText}>full</Text> : null}
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
+
+          {tables.length > 0 ? (
+            <>
+              <Text style={styles.groupLabel}>Table (optional)</Text>
+              <View style={styles.chipRowWrap}>
+                {tables.map((t) => {
+                  const active = t.id === tableId;
+                  return (
+                    <Pressable
+                      key={t.id}
+                      onPress={() => setTableId(active ? null : t.id)}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: active }}
+                      accessibilityLabel={`Table ${t.name}`}
+                      style={[styles.chip, active ? styles.chipActive : null]}
+                      testID={`waitlist-convert-table-${t.id}`}
+                    >
+                      <Text
+                        style={[styles.chipLabel, active ? styles.chipLabelActive : null]}
+                      >
+                        {t.name}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </>
+          ) : null}
+
+          <Button
+            label="Seat as reservation"
+            onPress={handleConvert}
+            variant="primary"
+            size="lg"
+            fullWidth
+            loading={converting}
+            disabled={slotIso === null || converting}
+            style={styles.saveBtn}
+            testID="waitlist-convert-save"
+          />
+        </ScrollView>
+      </View>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+  },
+  heading: {
+    ...typography.h3,
+    color: textTokens.primary,
+  },
+  sub: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+    marginBottom: spacing.sm,
+  },
+  scroll: {
+    paddingBottom: spacing.xxl,
+    gap: spacing.xs,
+  },
+  groupLabel: {
+    ...typography.labelCap,
+    color: textTokens.tertiary,
+    marginTop: spacing.md,
+    marginBottom: spacing.xxs,
+  },
+  helper: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  chipRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+    paddingVertical: spacing.xxs,
+  },
+  chipRowWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  chip: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.04)",
+  },
+  chipActive: {
+    backgroundColor: accent.warm,
+  },
+  chipLabel: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+    fontWeight: "600",
+  },
+  chipLabelActive: {
+    color: "#0c0e12",
+  },
+  slotGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  slot: {
+    minWidth: 72,
+    minHeight: 44,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.05)",
+  },
+  slotActive: {
+    borderWidth: 2,
+    borderColor: accent.warm,
+  },
+  slotFull: {
+    opacity: 0.4,
+  },
+  slotLabel: {
+    ...typography.bodySm,
+    color: textTokens.primary,
+    fontWeight: "600",
+    fontVariant: ["tabular-nums"],
+  },
+  slotLabelActive: {
+    color: accent.warm,
+  },
+  slotFullText: {
+    ...typography.caption,
+    color: textTokens.tertiary,
+  },
+  saveBtn: {
+    marginTop: spacing.lg,
+  },
+});
+
+export default WaitlistConvertSheet;

--- a/mingla-business/src/components/venue/__tests__/reservationViews.test.ts
+++ b/mingla-business/src/components/venue/__tests__/reservationViews.test.ts
@@ -1,0 +1,129 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — reservationViews unit tests (T-RES).
+ *
+ * Fails-on-revert anchors:
+ *  - I-PROPOSED-1148-RESERVATION-LIFECYCLE-TRANSITIONS-GUARDED-SERVER-SIDE
+ *    (the CLIENT mirror isTransitionLegal must reject illegal moves — terminal
+ *    states locked, no_show only from confirmed/seated). If isTransitionLegal is
+ *    loosened these flip to FAIL.
+ *  - view filtering correctness (segmented Today/Upcoming/Completed/etc.).
+ */
+
+import type { Reservation, ReservationStatus } from "../../../types/venueReservation";
+import {
+  ACTION_TARGET,
+  filterReservationsForView,
+  isTransitionLegal,
+  legalActionsFor,
+} from "../reservationViews";
+
+const baseRes = (over: Partial<Reservation>): Reservation => ({
+  id: "r1",
+  brandId: "b1",
+  placePoolId: null,
+  tableId: null,
+  reservedFor: new Date().toISOString(),
+  partySize: 2,
+  status: "confirmed",
+  source: "phone",
+  createdVia: "operator",
+  guestName: "Guest",
+  guestPhoneE164: null,
+  guestEmail: null,
+  consumerUserId: null,
+  occasion: null,
+  guestNotes: null,
+  tags: [],
+  feeCents: null,
+  feeCurrency: null,
+  paymentStatus: "none",
+  createdAt: new Date().toISOString(),
+  ...over,
+});
+
+describe("reservation lifecycle guard (client mirror)", () => {
+  it("T-RES-1 — terminal states allow NO transition", () => {
+    const terminal: ReservationStatus[] = [
+      "completed",
+      "no_show",
+      "cancelled_by_guest",
+      "cancelled_by_venue",
+    ];
+    for (const from of terminal) {
+      expect(legalActionsFor(from)).toHaveLength(0);
+      expect(isTransitionLegal(from, "seated")).toBe(false);
+      expect(isTransitionLegal(from, "confirmed")).toBe(false);
+    }
+  });
+
+  it("T-RES-2 — a cancelled reservation can NOT be seated or completed", () => {
+    expect(isTransitionLegal("cancelled_by_venue", "seated")).toBe(false);
+    expect(isTransitionLegal("cancelled_by_guest", "completed")).toBe(false);
+  });
+
+  it("T-RES-3 — no_show is ONLY reachable from confirmed or seated", () => {
+    expect(isTransitionLegal("confirmed", "no_show")).toBe(true);
+    expect(isTransitionLegal("seated", "no_show")).toBe(true);
+    expect(isTransitionLegal("requested", "no_show")).toBe(false);
+    expect(isTransitionLegal("waitlisted", "no_show")).toBe(false);
+  });
+
+  it("T-RES-4 — the happy path confirmed→seated→completed is legal", () => {
+    expect(isTransitionLegal("confirmed", "seated")).toBe(true);
+    expect(isTransitionLegal("seated", "completed")).toBe(true);
+    expect(isTransitionLegal("requested", "confirmed")).toBe(true);
+  });
+
+  it("T-RES-5 — seated can NOT regress to confirmed", () => {
+    expect(isTransitionLegal("seated", "confirmed")).toBe(false);
+  });
+
+  it("T-RES-6 — legalActionsFor maps to legal targets only", () => {
+    for (const a of legalActionsFor("confirmed")) {
+      expect(isTransitionLegal("confirmed", ACTION_TARGET[a])).toBe(true);
+    }
+    // confirmed → seat/no_show/complete/cancel are all legal (4 actions).
+    expect(legalActionsFor("confirmed").sort()).toEqual(
+      ["cancel", "complete", "no_show", "seat"].sort(),
+    );
+    // requested → confirm + cancel (no seat/no_show/complete).
+    expect(legalActionsFor("requested").sort()).toEqual(["cancel", "confirm"].sort());
+  });
+});
+
+describe("reservation view filtering", () => {
+  const now = new Date("2026-06-16T12:00:00Z");
+
+  it("T-RES-7 — today shows only LIVE reservations dated today", () => {
+    const list = [
+      baseRes({ id: "a", status: "confirmed", reservedFor: "2026-06-16T19:00:00Z" }),
+      baseRes({ id: "b", status: "completed", reservedFor: "2026-06-16T13:00:00Z" }),
+      baseRes({ id: "c", status: "confirmed", reservedFor: "2026-06-17T19:00:00Z" }),
+    ];
+    const today = filterReservationsForView(list, "today", now).map((r) => r.id);
+    expect(today).toEqual(["a"]);
+  });
+
+  it("T-RES-8 — upcoming shows future LIVE reservations not today", () => {
+    const list = [
+      baseRes({ id: "a", status: "confirmed", reservedFor: "2026-06-16T19:00:00Z" }),
+      baseRes({ id: "c", status: "confirmed", reservedFor: "2026-06-18T19:00:00Z" }),
+    ];
+    const up = filterReservationsForView(list, "upcoming", now).map((r) => r.id);
+    expect(up).toEqual(["c"]);
+  });
+
+  it("T-RES-9 — terminal buckets route by status", () => {
+    const list = [
+      baseRes({ id: "d", status: "completed" }),
+      baseRes({ id: "e", status: "no_show" }),
+      baseRes({ id: "f", status: "cancelled_by_guest" }),
+      baseRes({ id: "g", status: "cancelled_by_venue" }),
+      baseRes({ id: "h", status: "waitlisted" }),
+    ];
+    expect(filterReservationsForView(list, "completed", now).map((r) => r.id)).toEqual(["d"]);
+    expect(filterReservationsForView(list, "no_shows", now).map((r) => r.id)).toEqual(["e"]);
+    expect(filterReservationsForView(list, "canceled", now).map((r) => r.id).sort()).toEqual(["f", "g"]);
+    expect(filterReservationsForView(list, "waitlist", now).map((r) => r.id)).toEqual(["h"]);
+  });
+});

--- a/mingla-business/src/components/venue/reservationViews.ts
+++ b/mingla-business/src/components/venue/reservationViews.ts
@@ -1,0 +1,174 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — reservation view filtering + lifecycle map.
+ *
+ * Pure, dependency-free. The single source of truth for (a) which statuses each
+ * segmented view shows, (b) which lifecycle actions are legal from a given
+ * status (the CLIENT mirror of the server guard pg_reservation_transition_is_legal
+ * — the server is authoritative, this just hides illegal buttons), and (c) the
+ * status pill presentation. Unit-tested (reservationViews.test.ts) as the
+ * fails-on-revert anchor for the client lifecycle map.
+ */
+
+import type {
+  Reservation,
+  ReservationAction,
+  ReservationStatus,
+  ReservationView,
+} from "../../types/venueReservation";
+
+/** The 6 segmented views in display order (Design IA §4.4). */
+export const RESERVATION_VIEWS: readonly {
+  id: ReservationView;
+  label: string;
+}[] = [
+  { id: "today", label: "Today" },
+  { id: "upcoming", label: "Upcoming" },
+  { id: "waitlist", label: "Waitlist" },
+  { id: "completed", label: "Completed" },
+  { id: "no_shows", label: "No-shows" },
+  { id: "canceled", label: "Canceled" },
+];
+
+const LIVE_STATUSES: readonly ReservationStatus[] = [
+  "requested",
+  "confirmed",
+  "seated",
+];
+
+const isSameLocalDay = (iso: string, ref: Date): boolean => {
+  const d = new Date(iso);
+  return (
+    d.getFullYear() === ref.getFullYear() &&
+    d.getMonth() === ref.getMonth() &&
+    d.getDate() === ref.getDate()
+  );
+};
+
+/**
+ * Filter the full reservation list for a given view.
+ *  - today: LIVE statuses whose reserved_for is today.
+ *  - upcoming: LIVE statuses reserved AFTER today (later than now's end-of-day).
+ *  - waitlist: status='waitlisted'.
+ *  - completed / no_shows / canceled: terminal-status buckets.
+ */
+export function filterReservationsForView(
+  reservations: readonly Reservation[],
+  view: ReservationView,
+  now: Date = new Date(),
+): Reservation[] {
+  switch (view) {
+    case "today":
+      return reservations.filter(
+        (r) =>
+          LIVE_STATUSES.includes(r.status) && isSameLocalDay(r.reservedFor, now),
+      );
+    case "upcoming":
+      return reservations.filter(
+        (r) =>
+          LIVE_STATUSES.includes(r.status) &&
+          new Date(r.reservedFor).getTime() > now.getTime() &&
+          !isSameLocalDay(r.reservedFor, now),
+      );
+    case "waitlist":
+      return reservations.filter((r) => r.status === "waitlisted");
+    case "completed":
+      return reservations.filter((r) => r.status === "completed");
+    case "no_shows":
+      return reservations.filter((r) => r.status === "no_show");
+    case "canceled":
+      return reservations.filter(
+        (r) =>
+          r.status === "cancelled_by_guest" || r.status === "cancelled_by_venue",
+      );
+    default:
+      return [];
+  }
+}
+
+/**
+ * The CLIENT mirror of the legal-transition matrix (server is authoritative via
+ * pg_reservation_transition_is_legal). Maps an action → its target status, and
+ * whether it's legal from the current status. Used to hide illegal buttons.
+ */
+export const ACTION_TARGET: Record<ReservationAction, ReservationStatus> = {
+  confirm: "confirmed",
+  seat: "seated",
+  no_show: "no_show",
+  complete: "completed",
+  cancel: "cancelled_by_venue",
+};
+
+/** Mirrors pg_reservation_transition_is_legal exactly. */
+export function isTransitionLegal(
+  from: ReservationStatus,
+  to: ReservationStatus,
+): boolean {
+  switch (from) {
+    case "requested":
+      return ["confirmed", "cancelled_by_venue", "cancelled_by_guest"].includes(
+        to,
+      );
+    case "confirmed":
+      return [
+        "seated",
+        "no_show",
+        "completed",
+        "cancelled_by_venue",
+        "cancelled_by_guest",
+      ].includes(to);
+    case "seated":
+      return ["completed", "no_show", "cancelled_by_venue"].includes(to);
+    case "waitlisted":
+      return ["confirmed", "cancelled_by_venue", "cancelled_by_guest"].includes(
+        to,
+      );
+    default:
+      // completed / no_show / cancelled_* are terminal.
+      return false;
+  }
+}
+
+/** Which actions are legal from a status (for rendering the action buttons). */
+export function legalActionsFor(
+  status: ReservationStatus,
+): ReservationAction[] {
+  return (Object.keys(ACTION_TARGET) as ReservationAction[]).filter((a) =>
+    isTransitionLegal(status, ACTION_TARGET[a]),
+  );
+}
+
+/** Status pill presentation (color is NEVER the only signal — pairs label + glyph). */
+export interface StatusPresentation {
+  label: string;
+  /** semantic token key the component maps to a color. */
+  tone: "neutral" | "success" | "warm" | "muted" | "error" | "faded";
+}
+
+export const STATUS_PRESENTATION: Record<
+  ReservationStatus,
+  StatusPresentation
+> = {
+  requested: { label: "Pending", tone: "neutral" },
+  confirmed: { label: "Confirmed", tone: "success" },
+  seated: { label: "Seated", tone: "warm" },
+  completed: { label: "Completed", tone: "muted" },
+  no_show: { label: "No-show", tone: "error" },
+  cancelled_by_guest: { label: "Canceled", tone: "faded" },
+  cancelled_by_venue: { label: "Canceled", tone: "faded" },
+  waitlisted: { label: "Waitlisted", tone: "neutral" },
+};
+
+/** The action button labels (Design IA §4.4). */
+export const ACTION_LABEL: Record<ReservationAction, string> = {
+  confirm: "Confirm",
+  seat: "Mark seated",
+  no_show: "Mark no-show",
+  complete: "Mark completed",
+  cancel: "Cancel",
+};
+
+/** Destructive actions require a reach + confirm (Design IA §4.4). */
+export const DESTRUCTIVE_ACTIONS: readonly ReservationAction[] = [
+  "no_show",
+  "cancel",
+];

--- a/mingla-business/src/hooks/useVenueReservations.ts
+++ b/mingla-business/src/hooks/useVenueReservations.ts
@@ -1,0 +1,206 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — reservations list + realtime + lifecycle.
+ *
+ * Reads the brand's reservations (server state in React Query — Const #5), keeps
+ * the list live via a brand-scoped postgres_changes subscription (locked Q4;
+ * filters by brand_id, NOT a PK, so no ORCH-0931 silent-drop), and exposes the
+ * guarded create + transition mutations (both call the SECURITY DEFINER RPCs —
+ * legal transitions enforced server-side). Manual bookings are FREE.
+ */
+
+import { useEffect } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import { useAuth } from "../context/AuthContext";
+import { supabase } from "../services/supabase";
+import type {
+  Reservation,
+  ReservationCreateInput,
+} from "../types/venueReservation";
+
+interface ReservationRow {
+  id: string;
+  brand_id: string;
+  place_pool_id: string | null;
+  table_id: string | null;
+  reserved_for: string;
+  party_size: number;
+  status: Reservation["status"];
+  source: Reservation["source"];
+  created_via: Reservation["createdVia"];
+  guest_name: string | null;
+  guest_phone_e164: string | null;
+  guest_email: string | null;
+  consumer_user_id: string | null;
+  occasion: string | null;
+  guest_notes: string | null;
+  tags: string[] | null;
+  fee_cents: number | null;
+  fee_currency: string | null;
+  payment_status: Reservation["paymentStatus"];
+  created_at: string;
+}
+
+const RESERVATION_COLUMNS =
+  "id, brand_id, place_pool_id, table_id, reserved_for, party_size, status, source, created_via, guest_name, guest_phone_e164, guest_email, consumer_user_id, occasion, guest_notes, tags, fee_cents, fee_currency, payment_status, created_at";
+
+const mapRow = (row: ReservationRow): Reservation => ({
+  id: row.id,
+  brandId: row.brand_id,
+  placePoolId: row.place_pool_id,
+  tableId: row.table_id,
+  reservedFor: row.reserved_for,
+  partySize: row.party_size,
+  status: row.status,
+  source: row.source,
+  createdVia: row.created_via,
+  guestName: row.guest_name,
+  guestPhoneE164: row.guest_phone_e164,
+  guestEmail: row.guest_email,
+  consumerUserId: row.consumer_user_id,
+  occasion: row.occasion,
+  guestNotes: row.guest_notes,
+  tags: row.tags ?? [],
+  feeCents: row.fee_cents,
+  feeCurrency: row.fee_currency,
+  paymentStatus: row.payment_status,
+  createdAt: row.created_at,
+});
+
+export const venueReservationsKeys = {
+  list: (brandId: string): readonly ["venueReservations", string] =>
+    ["venueReservations", brandId] as const,
+};
+
+export const fetchVenueReservations = async (
+  brandId: string,
+): Promise<Reservation[]> => {
+  const { data, error } = await supabase
+    .from("reservations")
+    .select(RESERVATION_COLUMNS)
+    .eq("brand_id", brandId)
+    .order("reserved_for", { ascending: true })
+    .returns<ReservationRow[]>();
+  if (error !== null) throw error;
+  return (data ?? []).map(mapRow);
+};
+
+export function useVenueReservations(
+  brandId: string | null,
+): UseQueryResult<Reservation[]> {
+  const { isAuthReady } = useAuth();
+  const queryClient = useQueryClient();
+  const enabled = isAuthReady && brandId !== null && brandId.length > 0;
+
+  const query = useQuery<Reservation[]>({
+    queryKey: enabled
+      ? venueReservationsKeys.list(brandId)
+      : (["venueReservations", "disabled"] as const),
+    enabled,
+    staleTime: 15_000,
+    queryFn: () =>
+      enabled ? fetchVenueReservations(brandId) : Promise.resolve([]),
+  });
+
+  // Realtime (locked Q4): a brand-scoped postgres_changes subscription so an
+  // inbound source='mingla' booking (2.2) and any operator change land live.
+  // Filter on brand_id (NOT a PK) — avoids the ORCH-0931 PK-filter silent-drop;
+  // event:'*' catches insert/update/delete. Cleanup on unmount.
+  useEffect(() => {
+    if (!enabled) return;
+    const channel = supabase
+      .channel(`venue:reservations:${brandId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "reservations",
+          filter: `brand_id=eq.${brandId}`,
+        },
+        () => {
+          void queryClient.invalidateQueries({
+            queryKey: venueReservationsKeys.list(brandId),
+          });
+        },
+      )
+      .subscribe();
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [enabled, brandId, queryClient]);
+
+  return query;
+}
+
+/** Manual create via the guarded RPC (FREE; created_via='operator'). */
+export function useCreateReservation(
+  brandId: string | null,
+): UseMutationResult<void, Error, ReservationCreateInput> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, ReservationCreateInput>({
+    mutationFn: async (input: ReservationCreateInput): Promise<void> => {
+      if (brandId === null) throw new Error("brand_required");
+      const { error } = await supabase.rpc("biz_reservation_create", {
+        p_brand_id: brandId,
+        p_reserved_for: input.reservedFor,
+        p_party_size: input.partySize,
+        p_source: input.source,
+        p_guest_name: input.guestName,
+        p_guest_phone_e164: input.guestPhoneE164,
+        p_guest_email: input.guestEmail,
+        p_table_id: input.tableId,
+        p_occasion: input.occasion,
+        p_guest_notes: input.guestNotes,
+        p_tags: input.tags,
+        p_status: "confirmed",
+      });
+      if (error !== null) throw error as unknown as Error;
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueReservationsKeys.list(brandId),
+        });
+      }
+    },
+  });
+}
+
+export interface ReservationTransitionVars {
+  reservationId: string;
+  toStatus: Reservation["status"];
+  tableId?: string | null;
+  reason?: string | null;
+}
+
+/** Lifecycle transition via the guarded RPC (legal transitions enforced server-side). */
+export function useTransitionReservation(
+  brandId: string | null,
+): UseMutationResult<void, Error, ReservationTransitionVars> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, ReservationTransitionVars>({
+    mutationFn: async (vars: ReservationTransitionVars): Promise<void> => {
+      const { error } = await supabase.rpc("biz_reservation_transition", {
+        p_reservation_id: vars.reservationId,
+        p_to_status: vars.toStatus,
+        p_table_id: vars.tableId ?? null,
+        p_reason: vars.reason ?? null,
+      });
+      if (error !== null) throw error as unknown as Error;
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueReservationsKeys.list(brandId),
+        });
+      }
+    },
+  });
+}

--- a/mingla-business/src/hooks/useVenueWaitlist.ts
+++ b/mingla-business/src/hooks/useVenueWaitlist.ts
@@ -1,0 +1,245 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — waitlist list + realtime + add/notify/convert.
+ *
+ * Reads the brand's live waitlist (server state in React Query), keeps it live
+ * via a brand-scoped postgres_changes subscription (filter brand_id, not PK —
+ * no ORCH-0931 silent-drop), and exposes add (direct RLS insert), mark-lost
+ * (direct update), notify (the send-venue-sms edge fn → Twilio + mark notified),
+ * and convert-to-reservation (the atomic guarded RPC).
+ */
+
+import { useEffect } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import { useAuth } from "../context/AuthContext";
+import { supabase } from "../services/supabase";
+import { venueReservationsKeys } from "./useVenueReservations";
+import type {
+  WaitlistAddInput,
+  WaitlistEntry,
+} from "../types/venueReservation";
+
+interface WaitlistRow {
+  id: string;
+  brand_id: string;
+  guest_name: string | null;
+  guest_phone_e164: string | null;
+  guest_email: string | null;
+  party_size: number;
+  preferred_zone: WaitlistEntry["preferredZone"];
+  quoted_wait_minutes: number | null;
+  status: WaitlistEntry["status"];
+  notify_via: WaitlistEntry["notifyVia"];
+  notified_at: string | null;
+  expires_at: string | null;
+  converted_reservation_id: string | null;
+  consumer_user_id: string | null;
+  created_at: string;
+}
+
+const WAITLIST_COLUMNS =
+  "id, brand_id, guest_name, guest_phone_e164, guest_email, party_size, preferred_zone, quoted_wait_minutes, status, notify_via, notified_at, expires_at, converted_reservation_id, consumer_user_id, created_at";
+
+const mapRow = (row: WaitlistRow): WaitlistEntry => ({
+  id: row.id,
+  brandId: row.brand_id,
+  guestName: row.guest_name,
+  guestPhoneE164: row.guest_phone_e164,
+  guestEmail: row.guest_email,
+  partySize: row.party_size,
+  preferredZone: row.preferred_zone,
+  quotedWaitMinutes: row.quoted_wait_minutes,
+  status: row.status,
+  notifyVia: row.notify_via,
+  notifiedAt: row.notified_at,
+  expiresAt: row.expires_at,
+  convertedReservationId: row.converted_reservation_id,
+  consumerUserId: row.consumer_user_id,
+  createdAt: row.created_at,
+});
+
+export const venueWaitlistKeys = {
+  list: (brandId: string): readonly ["venueWaitlist", string] =>
+    ["venueWaitlist", brandId] as const,
+};
+
+export const fetchVenueWaitlist = async (
+  brandId: string,
+): Promise<WaitlistEntry[]> => {
+  const { data, error } = await supabase
+    .from("venue_waitlist")
+    .select(WAITLIST_COLUMNS)
+    .eq("brand_id", brandId)
+    .order("created_at", { ascending: true })
+    .returns<WaitlistRow[]>();
+  if (error !== null) throw error;
+  return (data ?? []).map(mapRow);
+};
+
+export function useVenueWaitlist(
+  brandId: string | null,
+): UseQueryResult<WaitlistEntry[]> {
+  const { isAuthReady } = useAuth();
+  const queryClient = useQueryClient();
+  const enabled = isAuthReady && brandId !== null && brandId.length > 0;
+
+  const query = useQuery<WaitlistEntry[]>({
+    queryKey: enabled
+      ? venueWaitlistKeys.list(brandId)
+      : (["venueWaitlist", "disabled"] as const),
+    enabled,
+    staleTime: 15_000,
+    queryFn: () =>
+      enabled ? fetchVenueWaitlist(brandId) : Promise.resolve([]),
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    const channel = supabase
+      .channel(`venue:waitlist:${brandId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "venue_waitlist",
+          filter: `brand_id=eq.${brandId}`,
+        },
+        () => {
+          void queryClient.invalidateQueries({
+            queryKey: venueWaitlistKeys.list(brandId),
+          });
+        },
+      )
+      .subscribe();
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [enabled, brandId, queryClient]);
+
+  return query;
+}
+
+/** Add a guest to the waitlist (direct RLS-gated insert — manager+ enforced server-side). */
+export function useAddToWaitlist(
+  brandId: string | null,
+): UseMutationResult<void, Error, WaitlistAddInput> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, WaitlistAddInput>({
+    mutationFn: async (input: WaitlistAddInput): Promise<void> => {
+      if (brandId === null) throw new Error("brand_required");
+      const { error } = await supabase.from("venue_waitlist").insert({
+        brand_id: brandId,
+        guest_name: input.guestName,
+        guest_phone_e164: input.guestPhoneE164,
+        guest_email: input.guestEmail,
+        party_size: input.partySize,
+        preferred_zone: input.preferredZone,
+        quoted_wait_minutes: input.quotedWaitMinutes,
+        status: "waiting",
+      });
+      if (error !== null) throw error as unknown as Error;
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueWaitlistKeys.list(brandId),
+        });
+      }
+    },
+  });
+}
+
+/** Mark a waitlist entry lost (guest left) — direct RLS-gated update. */
+export function useMarkWaitlistLost(
+  brandId: string | null,
+): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: async (id: string): Promise<void> => {
+      if (brandId === null) throw new Error("brand_required");
+      const { error } = await supabase
+        .from("venue_waitlist")
+        .update({ status: "lost", updated_at: new Date().toISOString() })
+        .eq("id", id)
+        .eq("brand_id", brandId);
+      if (error !== null) throw error as unknown as Error;
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueWaitlistKeys.list(brandId),
+        });
+      }
+    },
+  });
+}
+
+/**
+ * Notify a waitlist guest their table is ready — invokes the send-venue-sms edge
+ * fn (Twilio "table's ready" via the approved toll-free + opt-out gate + the
+ * mark-notified RPC). The fn handles E.164 validation + consent server-side.
+ */
+export function useNotifyWaitlist(
+  brandId: string | null,
+): UseMutationResult<{ ok: boolean }, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation<{ ok: boolean }, Error, string>({
+    mutationFn: async (waitlistId: string): Promise<{ ok: boolean }> => {
+      const { data, error } = await supabase.functions.invoke("send-venue-sms", {
+        body: { waitlistId },
+      });
+      if (error !== null) throw error as unknown as Error;
+      return { ok: (data as { ok?: boolean } | null)?.ok ?? false };
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueWaitlistKeys.list(brandId),
+        });
+      }
+    },
+  });
+}
+
+export interface WaitlistConvertVars {
+  waitlistId: string;
+  reservedFor: string;
+  tableId?: string | null;
+}
+
+/** Convert a waitlist entry → reservation atomically (the guarded RPC). */
+export function useConvertWaitlist(
+  brandId: string | null,
+): UseMutationResult<void, Error, WaitlistConvertVars> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, WaitlistConvertVars>({
+    mutationFn: async (vars: WaitlistConvertVars): Promise<void> => {
+      const { error } = await supabase.rpc(
+        "biz_waitlist_convert_to_reservation",
+        {
+          p_waitlist_id: vars.waitlistId,
+          p_reserved_for: vars.reservedFor,
+          p_table_id: vars.tableId ?? null,
+        },
+      );
+      if (error !== null) throw error as unknown as Error;
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueWaitlistKeys.list(brandId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: venueReservationsKeys.list(brandId),
+        });
+      }
+    },
+  });
+}

--- a/mingla-business/src/types/venueReservation.ts
+++ b/mingla-business/src/types/venueReservation.ts
@@ -224,3 +224,136 @@ export interface AvailableSlot {
   /** true → returned but full (show "full", don't hide). */
   isFull: boolean;
 }
+
+/* ===========================================================================
+ * 2.1b (Reservations lifecycle + Waitlist) domain types. camelCase mapped from
+ * the snake_case `reservations` / `venue_waitlist` tables.
+ * ========================================================================= */
+
+/** The 8-state reservation lifecycle (matches the reservations.status CHECK). */
+export type ReservationStatus =
+  | "requested"
+  | "confirmed"
+  | "seated"
+  | "completed"
+  | "no_show"
+  | "cancelled_by_guest"
+  | "cancelled_by_venue"
+  | "waitlisted";
+
+/** Where a reservation came from (matches reservations.source CHECK). */
+export type ReservationSource =
+  | "mingla"
+  | "phone"
+  | "walk_in"
+  | "website"
+  | "instagram";
+
+/** payment_status (manual bookings are FREE → 'none'). */
+export type ReservationPaymentStatus = "none" | "paid" | "refunded";
+
+/**
+ * The segmented list views (Design IA §4.4) — NOT a 3rd nav level; a segmented
+ * control inside the Reservations module. Each maps to a status filter.
+ */
+export type ReservationView =
+  | "today"
+  | "upcoming"
+  | "waitlist"
+  | "completed"
+  | "no_shows"
+  | "canceled";
+
+/** A `reservations` row, camelCased. */
+export interface Reservation {
+  id: string;
+  brandId: string;
+  placePoolId: string | null;
+  tableId: string | null;
+  /** Slot start, UTC ISO. */
+  reservedFor: string;
+  partySize: number;
+  status: ReservationStatus;
+  source: ReservationSource;
+  createdVia: "operator" | "consumer";
+  guestName: string | null;
+  guestPhoneE164: string | null;
+  guestEmail: string | null;
+  consumerUserId: string | null;
+  occasion: string | null;
+  guestNotes: string | null;
+  tags: string[];
+  feeCents: number | null;
+  feeCurrency: string | null;
+  paymentStatus: ReservationPaymentStatus;
+  createdAt: string;
+}
+
+/** Manual-create payload for biz_reservation_create. */
+export interface ReservationCreateInput {
+  reservedFor: string;
+  partySize: number;
+  source: ReservationSource;
+  guestName: string | null;
+  guestPhoneE164: string | null;
+  guestEmail: string | null;
+  tableId: string | null;
+  occasion: string | null;
+  guestNotes: string | null;
+  tags: string[];
+}
+
+/** The lifecycle actions the operator can take (UI labels → transition target). */
+export type ReservationAction =
+  | "confirm"
+  | "seat"
+  | "no_show"
+  | "complete"
+  | "cancel";
+
+/** The canonical reservation tags (Design IA §4.4). */
+export const RESERVATION_TAGS = [
+  "vip",
+  "birthday",
+  "first_time",
+  "regular",
+  "high_risk_no_show",
+] as const;
+export type ReservationTag = (typeof RESERVATION_TAGS)[number];
+
+/** venue_waitlist status (matches the CHECK). */
+export type WaitlistStatus =
+  | "waiting"
+  | "notified"
+  | "converted"
+  | "expired"
+  | "lost";
+
+/** A `venue_waitlist` row, camelCased. */
+export interface WaitlistEntry {
+  id: string;
+  brandId: string;
+  guestName: string | null;
+  guestPhoneE164: string | null;
+  guestEmail: string | null;
+  partySize: number;
+  preferredZone: VenueTableZone | null;
+  quotedWaitMinutes: number | null;
+  status: WaitlistStatus;
+  notifyVia: "push" | "sms" | "none";
+  notifiedAt: string | null;
+  expiresAt: string | null;
+  convertedReservationId: string | null;
+  consumerUserId: string | null;
+  createdAt: string;
+}
+
+/** Add-to-waitlist payload (direct RLS-gated insert). */
+export interface WaitlistAddInput {
+  guestName: string | null;
+  guestPhoneE164: string | null;
+  guestEmail: string | null;
+  partySize: number;
+  preferredZone: VenueTableZone | null;
+  quotedWaitMinutes: number | null;
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -220,3 +220,11 @@ verify_jwt = false
 # It is NOT a public anon route.
 [functions.rsvp-notify]
 verify_jwt = true
+
+# META-ORCH-1148 2.1b — send-venue-sms is the OPERATOR-triggered "table's ready"
+# waitlist SMS. verify_jwt=true: the gateway verifies the caller's user JWT; the
+# fn ADDITIONALLY gates on manager-plus brand membership, validates E.164, honors
+# the SMS opt-out (STOP) ledger, and sends ONLY via the approved toll-free
+# Messaging Service. Twilio creds are Supabase secrets (set at deploy).
+[functions.send-venue-sms]
+verify_jwt = true

--- a/supabase/functions/__tests__/send_venue_sms.test.ts
+++ b/supabase/functions/__tests__/send_venue_sms.test.ts
@@ -1,0 +1,102 @@
+// META-ORCH-1148 sub-ORCH 2.1b — send-venue-sms edge fn source contract test.
+//
+// Run:
+//   deno test --allow-read supabase/functions/__tests__/send_venue_sms.test.ts
+//
+// Source-level contract regression (the repo convention — no live edge harness
+// in the worktree). Pins the invariants that would FAIL on revert:
+//   - SMS-FROM-APPROVED-TOLLFREE-ONLY: sends ONLY via the Messaging Service SID
+//     (the approved toll-free); NEVER a raw `From` number.
+//   - SMS-OPT-OUT-HONORED: checks venue_sms_opt_out BEFORE sending; skips on a
+//     global (brand_id NULL) or per-brand opt-out; persists the 21610 blacklist.
+//   - LOCKED COPY: the exact "Your table's ready at {VenueName}. Reply STOP to
+//     opt out." string, with no link.
+//   - E.164 validation before send.
+//   - Twilio creds read from Deno env (NEVER hardcoded).
+//   - manager-plus brand gate.
+
+import { assert, assertMatch } from "jsr:@std/assert@1";
+
+const SRC = Deno.readTextFileSync(
+  "supabase/functions/send-venue-sms/index.ts",
+);
+
+Deno.test("T-SMS-1 — the LOCKED copy is exact, with no link", () => {
+  assertMatch(
+    SRC,
+    /Your table's ready at \$\{venueName\}\. Reply STOP to opt out\./,
+    "the locked table-ready copy must be present verbatim",
+  );
+  // No URL in the SMS body builder.
+  assert(
+    !/https?:\/\//.test(
+      SRC.slice(
+        SRC.indexOf("function tableReadyCopy"),
+        SRC.indexOf("function tableReadyCopy") + 200,
+      ),
+    ),
+    "the table-ready copy must NOT contain a link",
+  );
+});
+
+Deno.test("T-SMS-2 — sends ONLY via the approved toll-free Messaging Service (no raw From)", () => {
+  assertMatch(
+    SRC,
+    /TWILIO_MESSAGING_SERVICE_SID/,
+    "must use the Messaging Service SID (approved toll-free)",
+  );
+  assertMatch(SRC, /MessagingServiceSid/, "the Twilio param must be MessagingServiceSid");
+  // NEVER a raw From param (which would bypass the approved toll-free).
+  assert(
+    !/params\.set\(["']From["']/.test(SRC) && !/From:\s*[^M]/.test(SRC),
+    "must NOT send with a raw From number",
+  );
+});
+
+Deno.test("T-SMS-3 — opt-out is checked BEFORE send and honored", () => {
+  assertMatch(SRC, /from\(["']venue_sms_opt_out["']\)/, "must read the opt-out ledger");
+  assertMatch(SRC, /skipped_opt_out/, "must log a skipped_opt_out outcome");
+  // Global (brand_id NULL) OR per-brand opt-out blocks the send.
+  assertMatch(
+    SRC,
+    /r\.brand_id === null \|\| r\.brand_id === brandId/,
+    "must honor BOTH global and per-brand opt-out rows",
+  );
+  // The opt-out check returns BEFORE the Twilio send.
+  const optIdx = SRC.indexOf("skipped_opt_out");
+  const sendIdx = SRC.indexOf("sendTwilioSms(toPhone, copy)");
+  assert(optIdx > -1 && sendIdx > -1 && optIdx < sendIdx, "opt-out gate must precede the send");
+});
+
+Deno.test("T-SMS-4 — a 21610 (blacklist) persists a global opt-out (defensive)", () => {
+  assertMatch(SRC, /21610/, "must recognize the Twilio blacklist error code");
+  assertMatch(
+    SRC,
+    /from\(["']venue_sms_opt_out["']\)[\s\S]*?upsert/,
+    "a blacklist response must persist a global opt-out",
+  );
+});
+
+Deno.test("T-SMS-5 — E.164 validation gates the send", () => {
+  assertMatch(SRC, /\^\\\+\[1-9\]\[0-9\]\{1,14\}\$/, "must validate E.164 with the canonical regex");
+  assertMatch(SRC, /skipped_invalid_phone/, "must log a skipped_invalid_phone outcome");
+});
+
+Deno.test("T-SMS-6 — Twilio creds come from Deno env, never hardcoded", () => {
+  assertMatch(SRC, /Deno\.env\.get\("TWILIO_ACCOUNT_SID"\)/);
+  assertMatch(SRC, /Deno\.env\.get\("TWILIO_AUTH_TOKEN"\)/);
+  assertMatch(SRC, /Deno\.env\.get\("TWILIO_MESSAGING_SERVICE_SID"\)/);
+  // No literal Twilio SID/token pattern hardcoded.
+  assert(!/AC[0-9a-f]{32}/i.test(SRC), "no hardcoded Twilio Account SID");
+});
+
+Deno.test("T-SMS-7 — the caller is gated on manager-plus brand membership", () => {
+  assertMatch(SRC, /biz_brand_effective_rank_for_caller/, "must check brand-member rank");
+  assertMatch(SRC, /not_authorized/, "must 403 a non-member");
+  assertMatch(SRC, /auth\.getUser\(\)/, "must authenticate the caller's JWT");
+});
+
+Deno.test("T-SMS-8 — every send attempt is logged to venue_sms_log", () => {
+  assertMatch(SRC, /from\("venue_sms_log"\)/);
+  assertMatch(SRC, /triggered_by: userId/, "the log must record the triggering operator");
+});

--- a/supabase/functions/__tests__/send_venue_sms.test.ts
+++ b/supabase/functions/__tests__/send_venue_sms.test.ts
@@ -70,10 +70,29 @@ Deno.test("T-SMS-3 — opt-out is checked BEFORE send and honored", () => {
 
 Deno.test("T-SMS-4 — a 21610 (blacklist) persists a global opt-out (defensive)", () => {
   assertMatch(SRC, /21610/, "must recognize the Twilio blacklist error code");
+  // D-2 fix: the defensive persist routes through the partial-index-safe
+  // SECURITY DEFINER RPC (NOT a plain .upsert({ onConflict: "phone_e164" }),
+  // which errors at runtime against the table's PARTIAL unique indexes).
   assertMatch(
     SRC,
-    /from\(["']venue_sms_opt_out["']\)[\s\S]*?upsert/,
-    "a blacklist response must persist a global opt-out",
+    /\.rpc\(\s*["']biz_sms_record_global_opt_out["']/,
+    "a blacklist response must persist a global opt-out via the partial-index-safe RPC",
+  );
+  // FAILS-ON-REVERT (D-2): reverting to the broken `.upsert({ onConflict:
+  // "phone_e164" })` on venue_sms_opt_out (the runtime-throwing path) makes this
+  // assertion FAIL. The defensive persist must NOT use a plain onConflict upsert
+  // against venue_sms_opt_out — that table only has PARTIAL unique indexes.
+  assert(
+    !/from\(["']venue_sms_opt_out["']\)[\s\S]{0,200}?\.upsert\([\s\S]{0,200}?onConflict:\s*["']phone_e164["']/
+      .test(SRC),
+    "must NOT use a plain onConflict:'phone_e164' upsert (errors against the partial unique indexes)",
+  );
+  // The defensive persist is guarded so it never masks the failure response.
+  const blIdx = SRC.indexOf("result.blacklisted");
+  const tryIdx = SRC.indexOf("try {", blIdx);
+  assert(
+    blIdx > -1 && tryIdx > -1 && tryIdx - blIdx < 400,
+    "the defensive opt-out persist must be wrapped in try/catch",
   );
 });
 

--- a/supabase/functions/send-venue-sms/index.ts
+++ b/supabase/functions/send-venue-sms/index.ts
@@ -1,0 +1,275 @@
+/**
+ * META-ORCH-1148 sub-ORCH 2.1b — send-venue-sms
+ *
+ * The operator-triggered "table's ready" Twilio SMS for the venue waitlist.
+ * verify_jwt=true (config.toml): the gateway verifies the caller's Supabase JWT;
+ * this fn ADDITIONALLY gates on brand membership (manager+) before sending.
+ *
+ * Request: POST { waitlistId: string }
+ *   Resolves the waitlist row → brand → guest phone, gates the caller on
+ *   manager-plus rank for that brand, validates E.164, honors the SMS opt-out
+ *   ledger (STOP), then sends EXACTLY the locked copy via the APPROVED toll-free
+ *   Messaging Service, logs the attempt to venue_sms_log, and (on success) marks
+ *   the waitlist row notified via biz_waitlist_mark_notified.
+ *
+ * Locked SMS copy (NO link, do NOT paraphrase):
+ *   "Your table's ready at {VenueName}. Reply STOP to opt out."
+ *
+ * Twilio creds from Deno env (Supabase secrets — NEVER hardcoded; the
+ * orchestrator sets them at deploy):
+ *   TWILIO_ACCOUNT_SID · TWILIO_AUTH_TOKEN · TWILIO_MESSAGING_SERVICE_SID
+ * (the Messaging Service is bound to the approved toll-free +1 888-250-5351).
+ *
+ * Twilio send clones the proven pattern from ticket-confirmation-dispatch /
+ * rsvp-notify (the Messaging Service path), with the StatusCallback wired so
+ * inbound STOP keywords land an opt-out (handled by twilio-message-status).
+ *
+ * I-PROPOSED invariants this fn upholds:
+ *   - SMS-FROM-APPROVED-TOLLFREE-ONLY: send ONLY via TWILIO_MESSAGING_SERVICE_SID
+ *     (the approved toll-free), never a raw From number.
+ *   - SMS-OPT-OUT-HONORED: never send to a phone with a matching opt-out row.
+ */
+
+// @ts-ignore — Deno ESM import
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+// @ts-ignore — Deno ESM import
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Mirror the server-side validator (utils/phone.ts + _shared/ticketCheckout.ts).
+const E164_RE = /^\+[1-9][0-9]{1,14}$/;
+
+const isValidE164 = (v: string): boolean => E164_RE.test(v.trim());
+
+/** The LOCKED copy — exact, no link. */
+function tableReadyCopy(venueName: string): string {
+  return `Your table's ready at ${venueName}. Reply STOP to opt out.`;
+}
+
+function json(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+// Twilio send via the Messaging Service (the approved toll-free) — cloned from
+// rsvp-notify/ticket-confirmation-dispatch. NEVER uses a raw From number.
+async function sendTwilioSms(
+  to: string,
+  body: string,
+): Promise<{ ok: boolean; sid?: string; error?: string; blacklisted?: boolean }> {
+  const accountSid = Deno.env.get("TWILIO_ACCOUNT_SID");
+  const authToken = Deno.env.get("TWILIO_AUTH_TOKEN");
+  const messagingServiceSid = Deno.env.get("TWILIO_MESSAGING_SERVICE_SID");
+  if (!accountSid || !authToken || !messagingServiceSid) {
+    return { ok: false, error: "twilio_env_missing" };
+  }
+  const statusSecret = Deno.env.get("TWILIO_STATUS_CALLBACK_SECRET");
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const statusCallback =
+    statusSecret && supabaseUrl
+      ? `${supabaseUrl}/functions/v1/twilio-message-status?secret=${encodeURIComponent(statusSecret)}`
+      : undefined;
+  const params = new URLSearchParams({
+    To: to,
+    MessagingServiceSid: messagingServiceSid,
+    Body: body,
+  });
+  if (statusCallback) params.set("StatusCallback", statusCallback);
+  try {
+    const res = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Basic ${btoa(`${accountSid}:${authToken}`)}`,
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: params,
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      // Twilio 21610 = recipient has opted out (blacklisted).
+      const blacklisted = text.includes("21610");
+      return { ok: false, error: `Twilio ${res.status}: ${text}`, blacklisted };
+    }
+    const data = (await res.json()) as { sid?: string };
+    return { ok: true, sid: data.sid };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json(405, { error: "method_not_allowed" });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseUrl || !serviceKey || !anonKey) {
+    console.error("[send-venue-sms] missing supabase env");
+    return json(500, { error: "server_misconfigured" });
+  }
+
+  // 1. Authenticate the caller (user JWT).
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) return json(401, { error: "missing_authorization" });
+  const userClient = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+  const { data: authData, error: authErr } = await userClient.auth.getUser();
+  if (authErr || !authData?.user) {
+    return json(401, { error: "not_authenticated" });
+  }
+  const userId = authData.user.id;
+
+  // 2. Parse body.
+  let reqBody: { waitlistId?: string };
+  try {
+    reqBody = (await req.json()) as { waitlistId?: string };
+  } catch {
+    return json(400, { error: "invalid_json" });
+  }
+  const waitlistId =
+    typeof reqBody.waitlistId === "string" ? reqBody.waitlistId : "";
+  if (!UUID_RE.test(waitlistId)) {
+    return json(400, { error: "waitlist_id_required" });
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  // 3. Resolve the waitlist row + brand.
+  const { data: wait, error: waitErr } = await admin
+    .from("venue_waitlist")
+    .select("id, brand_id, guest_name, guest_phone_e164, status")
+    .eq("id", waitlistId)
+    .maybeSingle();
+  if (waitErr || !wait) {
+    return json(404, { error: "waitlist_not_found" });
+  }
+  const brandId: string = wait.brand_id;
+  const toPhone: string | null = wait.guest_phone_e164 ?? null;
+
+  // 4. Brand-member gate (manager+). Use the caller's auth context against the
+  // SECURITY DEFINER rank helper (the same gate the lifecycle RPCs use).
+  const { data: rankData, error: rankErr } = await userClient.rpc(
+    "biz_brand_effective_rank_for_caller",
+    { p_brand_id: brandId },
+  );
+  if (rankErr) {
+    console.error("[send-venue-sms] rank check failed", rankErr.message);
+    return json(500, { error: "rank_check_failed" });
+  }
+  const rank = typeof rankData === "number" ? rankData : 0;
+  const EVENT_MANAGER_RANK = 40;
+  if (rank < EVENT_MANAGER_RANK) {
+    return json(403, { error: "not_authorized" });
+  }
+
+  // Resolve the venue name for the copy.
+  let venueName = "the venue";
+  const { data: brandRow } = await admin
+    .from("brands")
+    .select("name")
+    .eq("id", brandId)
+    .maybeSingle();
+  if (brandRow?.name && typeof brandRow.name === "string") {
+    venueName = brandRow.name;
+  }
+
+  // Helper to append to the send log (service-role; append-only).
+  const logSend = async (
+    status: string,
+    extra: { sid?: string | null; error?: string | null },
+  ): Promise<void> => {
+    await admin.from("venue_sms_log").insert({
+      brand_id: brandId,
+      waitlist_id: waitlistId,
+      to_phone_e164: toPhone ?? "",
+      template: "table_ready",
+      status,
+      twilio_message_sid: extra.sid ?? null,
+      error: extra.error ?? null,
+      triggered_by: userId,
+    });
+  };
+
+  // 5. Validate E.164.
+  if (toPhone === null || !isValidE164(toPhone)) {
+    await logSend("skipped_invalid_phone", { error: "invalid_or_missing_e164" });
+    return json(422, { error: "invalid_phone", reason: "not_e164" });
+  }
+
+  // 6. Opt-out gate (SMS-OPT-OUT-HONORED) — a global (brand_id IS NULL) OR a
+  // per-brand opt-out row for this phone blocks the send.
+  const { data: optRows } = await admin
+    .from("venue_sms_opt_out")
+    .select("id, brand_id")
+    .eq("phone_e164", toPhone);
+  const optedOut =
+    Array.isArray(optRows) &&
+    optRows.some(
+      (r: { brand_id: string | null }) =>
+        r.brand_id === null || r.brand_id === brandId,
+    );
+  if (optedOut) {
+    await logSend("skipped_opt_out", { error: "recipient_opted_out" });
+    return json(409, { error: "opted_out" });
+  }
+
+  // 7. Send the locked copy via the approved toll-free Messaging Service.
+  const copy = tableReadyCopy(venueName);
+  const result = await sendTwilioSms(toPhone, copy);
+
+  if (!result.ok) {
+    // A 21610 (blacklisted) means Twilio knows the recipient opted out — persist
+    // a global opt-out so we never try again (defensive; the inbound STOP webhook
+    // is the primary path).
+    if (result.blacklisted) {
+      await admin
+        .from("venue_sms_opt_out")
+        .upsert(
+          { phone_e164: toPhone, brand_id: null, reason: "twilio_blacklist" },
+          { onConflict: "phone_e164", ignoreDuplicates: true },
+        );
+    }
+    await logSend("failed", { error: result.error ?? "twilio_error" });
+    console.error("[send-venue-sms] twilio send failed", result.error);
+    return json(502, { error: "sms_send_failed", detail: result.error });
+  }
+
+  await logSend("sent", { sid: result.sid });
+
+  // 8. Mark the waitlist row notified (atomic + audited via the RPC, in the
+  // caller's auth context so the RPC's own brand gate applies).
+  try {
+    await userClient.rpc("biz_waitlist_mark_notified", {
+      p_waitlist_id: waitlistId,
+      p_expire_minutes: 15,
+      p_notify_via: "sms",
+    });
+  } catch (markErr) {
+    // Non-fatal: the SMS already went out + is logged. Surface a soft warning.
+    console.warn("[send-venue-sms] mark-notified failed (non-fatal)", String(markErr));
+  }
+
+  return json(200, { ok: true, sid: result.sid });
+});

--- a/supabase/functions/send-venue-sms/index.ts
+++ b/supabase/functions/send-venue-sms/index.ts
@@ -243,13 +243,33 @@ serve(async (req: Request): Promise<Response> => {
     // A 21610 (blacklisted) means Twilio knows the recipient opted out — persist
     // a global opt-out so we never try again (defensive; the inbound STOP webhook
     // is the primary path).
+    //
+    // D-2: venue_sms_opt_out has ONLY PARTIAL unique indexes (global brand_id IS
+    // NULL / per-brand brand_id IS NOT NULL) — never a plain UNIQUE(phone_e164) —
+    // so a plain `.upsert({ onConflict: "phone_e164" })` errors at runtime
+    // ("no unique or exclusion constraint matching the ON CONFLICT specification")
+    // and never persists. Route through the SECURITY DEFINER RPC, whose
+    // ON CONFLICT (phone_e164) WHERE brand_id IS NULL DO NOTHING matches the GLOBAL
+    // partial index exactly and is idempotent. Guard with try/catch so a failure
+    // here NEVER masks the subsequent logSend("failed") / response.
     if (result.blacklisted) {
-      await admin
-        .from("venue_sms_opt_out")
-        .upsert(
-          { phone_e164: toPhone, brand_id: null, reason: "twilio_blacklist" },
-          { onConflict: "phone_e164", ignoreDuplicates: true },
+      try {
+        const { error: optErr } = await admin.rpc(
+          "biz_sms_record_global_opt_out",
+          { p_phone_e164: toPhone, p_reason: "twilio_blacklist" },
         );
+        if (optErr) {
+          console.warn(
+            "[send-venue-sms] defensive opt-out persist failed (non-fatal)",
+            optErr.message,
+          );
+        }
+      } catch (optThrow) {
+        console.warn(
+          "[send-venue-sms] defensive opt-out persist threw (non-fatal)",
+          String(optThrow),
+        );
+      }
     }
     await logSend("failed", { error: result.error ?? "twilio_error" });
     console.error("[send-venue-sms] twilio send failed", result.error);

--- a/supabase/migrations/20261010000000_orch_1148_sms_consent_and_log.sql
+++ b/supabase/migrations/20261010000000_orch_1148_sms_consent_and_log.sql
@@ -1,0 +1,100 @@
+-- ===========================================================================
+-- META-ORCH-1148 sub-ORCH 2.1b — SMS consent (opt-out) + send log
+-- ---------------------------------------------------------------------------
+-- The "table's ready" Twilio SMS path (send-venue-sms edge fn) needs two
+-- additive primitives the 2.0 schema did not ship:
+--
+--   1. public.venue_sms_opt_out — the STOP-honoring opt-out ledger, keyed by
+--      E.164 phone (+ optional brand_id for per-venue opt-out; a NULL brand_id
+--      row is a GLOBAL opt-out). The edge fn MUST NOT send to a phone that has a
+--      matching opt-out row. Written by the Twilio inbound-STOP webhook
+--      (twilio-message-status already exists for status callbacks; the STOP keyword
+--      lands a global opt-out row) and, defensively, by the edge fn when Twilio
+--      returns a 21610 (blacklisted) error.
+--
+--   2. public.venue_sms_log — append-only send attempts (to_phone, brand_id,
+--      waitlist_id, template, twilio_sid/status, error). Mirrors the audit_log
+--      posture (service-role INSERT only; no UPDATE/DELETE for non-service-role).
+--      The operator surfaces "Notified" / "SMS failed" off the latest log row.
+--
+-- Both are service-role-write (the edge fn runs service role); brand members can
+-- READ their own brand's log (RLS) so the Waitlist UI can show send state.
+-- Consent rows are service-role-only (PII + cross-brand global rows).
+--
+-- Additive-only; idempotent (IF NOT EXISTS). MONOTONIC VERSION 20261010000000
+-- (above the 2.1a max 20261008000003 + all sibling worktrees). Apply via the
+-- Supabase Management API after REVIEW. NOT applied to prod by the implementor.
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. venue_sms_opt_out — STOP ledger.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.venue_sms_opt_out (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- E.164 (+ country code, digits only after the +). NOT brand-FK-scoped on its
+  -- own; a NULL brand_id = a GLOBAL opt-out (the carrier-level STOP), a non-NULL
+  -- brand_id = opted out of one venue only.
+  phone_e164 text NOT NULL,
+  brand_id uuid NULL REFERENCES public.brands(id) ON DELETE CASCADE,
+  -- 'stop_keyword' (inbound STOP), 'manual' (operator), 'twilio_blacklist' (21610).
+  reason text NOT NULL DEFAULT 'stop_keyword'
+    CHECK (reason IN ('stop_keyword','manual','twilio_blacklist')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One opt-out row per (phone, brand) pair — a NULL brand_id is a distinct global
+-- row. The partial unique indexes make the upsert idempotent across re-deliveries.
+CREATE UNIQUE INDEX IF NOT EXISTS venue_sms_opt_out_phone_global_uniq
+  ON public.venue_sms_opt_out (phone_e164)
+  WHERE brand_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS venue_sms_opt_out_phone_brand_uniq
+  ON public.venue_sms_opt_out (phone_e164, brand_id)
+  WHERE brand_id IS NOT NULL;
+
+ALTER TABLE public.venue_sms_opt_out ENABLE ROW LEVEL SECURITY;
+-- No SELECT/WRITE policy for authenticated → only service_role (which bypasses
+-- RLS) can read/write. Consent rows carry PII + cross-brand global rows; the
+-- edge fn (service role) is the sole reader/writer.
+
+GRANT SELECT, INSERT ON public.venue_sms_opt_out TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. venue_sms_log — append-only send attempts.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.venue_sms_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  brand_id uuid NOT NULL REFERENCES public.brands(id) ON DELETE CASCADE,
+  waitlist_id uuid NULL REFERENCES public.venue_waitlist(id) ON DELETE SET NULL,
+  to_phone_e164 text NOT NULL,
+  template text NOT NULL DEFAULT 'table_ready'
+    CHECK (template IN ('table_ready')),
+  -- 'sent' | 'failed' | 'skipped_opt_out' | 'skipped_invalid_phone'.
+  status text NOT NULL
+    CHECK (status IN ('sent','failed','skipped_opt_out','skipped_invalid_phone')),
+  twilio_message_sid text NULL,
+  error text NULL,
+  -- who triggered it (operator user id resolved from JWT in the edge fn).
+  triggered_by uuid NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS venue_sms_log_brand_created_idx
+  ON public.venue_sms_log (brand_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS venue_sms_log_waitlist_idx
+  ON public.venue_sms_log (waitlist_id) WHERE waitlist_id IS NOT NULL;
+
+ALTER TABLE public.venue_sms_log ENABLE ROW LEVEL SECURITY;
+
+-- Brand members can READ their own brand's send log (drives the Waitlist
+-- "Notified ✓" / "SMS failed" surface). No write policy → service_role only.
+DROP POLICY IF EXISTS "venue_sms_log brand member can read" ON public.venue_sms_log;
+CREATE POLICY "venue_sms_log brand member can read" ON public.venue_sms_log
+  FOR SELECT TO authenticated
+  USING (public.biz_is_brand_member_for_read_for_caller(brand_id));
+
+GRANT SELECT ON public.venue_sms_log TO authenticated;
+GRANT SELECT, INSERT ON public.venue_sms_log TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20261010000001_orch_1148_reservation_lifecycle_rpcs.sql
+++ b/supabase/migrations/20261010000001_orch_1148_reservation_lifecycle_rpcs.sql
@@ -1,0 +1,221 @@
+-- ===========================================================================
+-- META-ORCH-1148 sub-ORCH 2.1b — reservation LIFECYCLE RPCs (guarded + audited)
+-- ---------------------------------------------------------------------------
+-- The 2.0 `reservations` table shipped the 8-state CHECK; 2.1b ships ONLY the
+-- transitions. Lifecycle changes flow through a SINGLE guarded transition RPC
+-- (`biz_reservation_transition`) plus a manual-create RPC (`biz_reservation_create`).
+-- Both are SECURITY DEFINER, gate on brand-member rank >= event_manager via the
+-- caller's auth context (biz_brand_effective_rank_for_caller reads auth.uid()),
+-- and write an audit_log row. This is the SERVER-SIDE enforcement of legal
+-- transitions — the UI is convenience only.
+--
+-- I-PROPOSED-1148-RESERVATION-LIFECYCLE-TRANSITIONS-GUARDED-SERVER-SIDE: illegal
+-- transitions are REJECTED in the database (RAISE EXCEPTION), not just hidden in
+-- the client. A revert that allows e.g. seating a cancelled reservation fails the
+-- transition-guard test.
+--
+-- Money: manual operator bookings are FREE (fee_cents stays NULL/0). A no_show
+-- RECORDS the forfeit-policy DECISION (copies venue_reservation_settings.no_show_fee_policy
+-- onto the row's payment context) but performs NO Stripe capture — the actual
+-- charge/capture is 2.2's seam. NO checkout/charge path is touched here.
+--
+-- Additive-only; $function$ closed BEFORE each GRANT. MONOTONIC 20261010000001.
+-- DROP FUNCTION not needed (new identities). Apply via Management API after REVIEW.
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Legal-transition matrix (pure, IMMUTABLE) — the single source of truth.
+--   requested  -> confirmed | cancelled_by_venue | cancelled_by_guest
+--   confirmed  -> seated | no_show | completed | cancelled_by_venue | cancelled_by_guest
+--   seated     -> completed | no_show | cancelled_by_venue
+--   waitlisted -> confirmed | cancelled_by_venue | cancelled_by_guest
+--   completed / no_show / cancelled_by_guest / cancelled_by_venue -> (terminal)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.pg_reservation_transition_is_legal(
+  p_from text,
+  p_to text
+) RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $function$
+  SELECT CASE p_from
+    WHEN 'requested'  THEN p_to IN ('confirmed','cancelled_by_venue','cancelled_by_guest')
+    WHEN 'confirmed'  THEN p_to IN ('seated','no_show','completed','cancelled_by_venue','cancelled_by_guest')
+    WHEN 'seated'     THEN p_to IN ('completed','no_show','cancelled_by_venue')
+    WHEN 'waitlisted' THEN p_to IN ('confirmed','cancelled_by_venue','cancelled_by_guest')
+    ELSE false  -- completed / no_show / cancelled_* are terminal
+  END;
+$function$;
+
+-- Supabase's public-schema default privileges auto-GRANT EXECUTE to PUBLIC (and
+-- anon) on every new function. These RPCs are operator-only (manager+), so REVOKE
+-- both PUBLIC and anon explicitly — the gate is enforced inside the fn, but the
+-- least-privilege ACL is the belt (mirrors the 2.1a engine).
+REVOKE ALL ON FUNCTION public.pg_reservation_transition_is_legal(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.pg_reservation_transition_is_legal(text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.pg_reservation_transition_is_legal(text, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- biz_reservation_transition — the SINGLE guarded lifecycle mutator.
+-- Confirm / seat / no_show / complete / cancel all route through here.
+-- Returns the updated reservation row (so the client refreshes optimistically).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_reservation_transition(
+  p_reservation_id uuid,
+  p_to_status text,
+  p_table_id uuid DEFAULT NULL,      -- optional table (re)assignment on seat
+  p_reason text DEFAULT NULL          -- optional operator note (cancellation reason)
+) RETURNS public.reservations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_row public.reservations;
+  v_from text;
+  v_brand uuid;
+  v_policy text;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT * INTO v_row FROM public.reservations WHERE id = p_reservation_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'reservation_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  v_from := v_row.status;
+  v_brand := v_row.brand_id;
+
+  -- Brand-member gate (manager+). biz_brand_effective_rank_for_caller is
+  -- SECURITY DEFINER and resolves the caller via auth.uid() — works inside this
+  -- SECURITY DEFINER fn because the JWT is still on the request.
+  IF public.biz_brand_effective_rank_for_caller(v_brand)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Legal-transition enforcement (server-side; the heart of the invariant).
+  IF NOT public.pg_reservation_transition_is_legal(v_from, p_to_status) THEN
+    RAISE EXCEPTION 'illegal_transition_%_to_%', v_from, p_to_status
+      USING ERRCODE = '23514';
+  END IF;
+
+  -- no_show RECORDS the forfeit-policy DECISION (NO Stripe capture here — 2.2 seam).
+  IF p_to_status = 'no_show' THEN
+    SELECT no_show_fee_policy INTO v_policy
+      FROM public.venue_reservation_settings WHERE brand_id = v_brand;
+  END IF;
+
+  UPDATE public.reservations
+     SET status = p_to_status,
+         -- table assignment is allowed on seat (or any non-cancel transition).
+         table_id = COALESCE(p_table_id, table_id),
+         -- preserve a free-form operator note in guest_notes-adjacent column;
+         -- we DO NOT clobber guest_notes — the reason is appended as a tag-free
+         -- audit detail only (kept in audit_log.after). No new column needed.
+         updated_at = now()
+   WHERE id = p_reservation_id
+   RETURNING * INTO v_row;
+
+  -- Audit (append-only; service-defined fn runs as definer = privileged).
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, before, after
+  ) VALUES (
+    v_uid, v_brand,
+    'venue_reservation.transition',
+    'reservation', p_reservation_id::text,
+    jsonb_build_object('status', v_from),
+    jsonb_build_object(
+      'status', p_to_status,
+      'table_id', v_row.table_id,
+      'reason', p_reason,
+      'no_show_fee_policy', v_policy
+    )
+  );
+
+  RETURN v_row;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_reservation_transition(uuid, text, uuid, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_reservation_transition(uuid, text, uuid, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_reservation_transition(uuid, text, uuid, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- biz_reservation_create — manual operator create (phone/walk-in/etc.).
+-- FREE (no fee). created_via='operator'. status defaults 'confirmed' (a manual
+-- booking is already confirmed) unless the caller passes a starting status.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_reservation_create(
+  p_brand_id uuid,
+  p_reserved_for timestamptz,
+  p_party_size int,
+  p_source text DEFAULT 'phone',
+  p_guest_name text DEFAULT NULL,
+  p_guest_phone_e164 text DEFAULT NULL,
+  p_guest_email text DEFAULT NULL,
+  p_table_id uuid DEFAULT NULL,
+  p_occasion text DEFAULT NULL,
+  p_guest_notes text DEFAULT NULL,
+  p_tags text[] DEFAULT '{}'::text[],
+  p_status text DEFAULT 'confirmed'
+) RETURNS public.reservations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_row public.reservations;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+  IF public.biz_brand_effective_rank_for_caller(p_brand_id)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+  -- A manual booking starts in a non-terminal, sensible state only.
+  IF p_status NOT IN ('requested','confirmed','seated') THEN
+    RAISE EXCEPTION 'invalid_initial_status_%', p_status USING ERRCODE = '23514';
+  END IF;
+  IF p_source NOT IN ('mingla','phone','walk_in','website','instagram') THEN
+    RAISE EXCEPTION 'invalid_source_%', p_source USING ERRCODE = '23514';
+  END IF;
+
+  INSERT INTO public.reservations (
+    brand_id, reserved_for, party_size, status, source, created_via,
+    guest_name, guest_phone_e164, guest_email, table_id, occasion,
+    guest_notes, tags
+  ) VALUES (
+    p_brand_id, p_reserved_for, p_party_size, p_status, p_source, 'operator',
+    p_guest_name, p_guest_phone_e164, p_guest_email, p_table_id, p_occasion,
+    p_guest_notes, COALESCE(p_tags, '{}'::text[])
+  ) RETURNING * INTO v_row;
+
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, after
+  ) VALUES (
+    v_uid, p_brand_id,
+    'venue_reservation.create',
+    'reservation', v_row.id::text,
+    jsonb_build_object(
+      'source', p_source, 'party_size', p_party_size,
+      'reserved_for', p_reserved_for, 'status', p_status, 'created_via', 'operator'
+    )
+  );
+
+  RETURN v_row;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_reservation_create(uuid, timestamptz, int, text, text, text, text, uuid, text, text, text[], text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_reservation_create(uuid, timestamptz, int, text, text, text, text, uuid, text, text, text[], text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_reservation_create(uuid, timestamptz, int, text, text, text, text, uuid, text, text, text[], text) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20261010000002_orch_1148_waitlist_rpcs_and_indexes.sql
+++ b/supabase/migrations/20261010000002_orch_1148_waitlist_rpcs_and_indexes.sql
@@ -1,0 +1,180 @@
+-- ===========================================================================
+-- META-ORCH-1148 sub-ORCH 2.1b — waitlist RPCs (notify/convert) + list indexes
+-- ---------------------------------------------------------------------------
+-- The waitlist add/edit happens via direct RLS-gated INSERT/UPDATE (the table
+-- ships manager-plus-write RLS in 2.0). Two operations need server-side
+-- ATOMICITY + audit and so are RPCs:
+--
+--   biz_waitlist_mark_notified — flip a waitlist row to status='notified',
+--     stamp notified_at + expires_at (now + p_expire_minutes). The
+--     "table's ready" SMS is sent by the send-venue-sms edge fn; this RPC only
+--     records the notify state. Guarded + audited.
+--
+--   biz_waitlist_convert_to_reservation — ATOMICALLY create a reservations row
+--     from a waitlist row + mark the waitlist row converted (status='converted',
+--     converted_reservation_id = the new row). Both in ONE transaction so a
+--     half-convert can never happen (I-PROPOSED-1148-WAITLIST-CONVERT-ATOMIC).
+--
+-- Plus the list-view indexes the Reservations module's Today/Upcoming/etc.
+-- filters need (brand_id + status + reserved_for) and the source-badge read.
+--
+-- Manual operator bookings are FREE; the converted reservation carries no fee.
+-- Additive-only; $function$ before GRANT. MONOTONIC 20261010000002.
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- List-view indexes (Reservations module Today / Upcoming / Completed / ...).
+-- The 2.0 reservations table already has (brand_id, reserved_for) and
+-- (brand_id, status); add the combined (brand_id, status, reserved_for) for the
+-- segmented views that filter on BOTH status-set AND order by time.
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS reservations_brand_status_reserved_idx
+  ON public.reservations (brand_id, status, reserved_for);
+
+-- Waitlist FIFO already indexed in 2.0 (venue_waitlist_queue_idx). Add an index
+-- for the "active queue" read (waiting + notified, by creation order).
+CREATE INDEX IF NOT EXISTS venue_waitlist_active_idx
+  ON public.venue_waitlist (brand_id, created_at)
+  WHERE status IN ('waiting','notified');
+
+-- ---------------------------------------------------------------------------
+-- biz_waitlist_mark_notified — record the notify state (SMS sent separately).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_waitlist_mark_notified(
+  p_waitlist_id uuid,
+  p_expire_minutes int DEFAULT 15,
+  p_notify_via text DEFAULT 'sms'
+) RETURNS public.venue_waitlist
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_row public.venue_waitlist;
+  v_brand uuid;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+  SELECT * INTO v_row FROM public.venue_waitlist WHERE id = p_waitlist_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'waitlist_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  v_brand := v_row.brand_id;
+  IF public.biz_brand_effective_rank_for_caller(v_brand)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+  IF v_row.status NOT IN ('waiting','notified') THEN
+    RAISE EXCEPTION 'waitlist_not_active_%', v_row.status USING ERRCODE = '23514';
+  END IF;
+  IF p_notify_via NOT IN ('push','sms','none') THEN
+    RAISE EXCEPTION 'invalid_notify_via_%', p_notify_via USING ERRCODE = '23514';
+  END IF;
+
+  UPDATE public.venue_waitlist
+     SET status = 'notified',
+         notify_via = p_notify_via,
+         notified_at = now(),
+         expires_at = now() + make_interval(mins => GREATEST(p_expire_minutes, 0)),
+         updated_at = now()
+   WHERE id = p_waitlist_id
+   RETURNING * INTO v_row;
+
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, after
+  ) VALUES (
+    v_uid, v_brand,
+    'venue_waitlist.notified',
+    'venue_waitlist', p_waitlist_id::text,
+    jsonb_build_object('notify_via', p_notify_via, 'expires_at', v_row.expires_at)
+  );
+
+  RETURN v_row;
+END;
+$function$;
+
+-- Operator-only (manager+); REVOKE the Supabase auto PUBLIC+anon grants.
+REVOKE ALL ON FUNCTION public.biz_waitlist_mark_notified(uuid, int, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_waitlist_mark_notified(uuid, int, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_waitlist_mark_notified(uuid, int, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- biz_waitlist_convert_to_reservation — ATOMIC: create reservation + mark
+-- the waitlist row converted, in one transaction.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_waitlist_convert_to_reservation(
+  p_waitlist_id uuid,
+  p_reserved_for timestamptz,
+  p_table_id uuid DEFAULT NULL
+) RETURNS public.reservations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_wait public.venue_waitlist;
+  v_res public.reservations;
+  v_brand uuid;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+  SELECT * INTO v_wait FROM public.venue_waitlist WHERE id = p_waitlist_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'waitlist_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  v_brand := v_wait.brand_id;
+  IF public.biz_brand_effective_rank_for_caller(v_brand)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+  IF v_wait.status = 'converted' THEN
+    RAISE EXCEPTION 'waitlist_already_converted' USING ERRCODE = '23505';
+  END IF;
+  IF v_wait.status NOT IN ('waiting','notified') THEN
+    RAISE EXCEPTION 'waitlist_not_active_%', v_wait.status USING ERRCODE = '23514';
+  END IF;
+
+  -- Create the reservation (FREE; created_via=operator; carries the waitlist
+  -- guest identity + party + preferred-zone-as-occasion-less note).
+  INSERT INTO public.reservations (
+    brand_id, place_pool_id, table_id, reserved_for, party_size, status,
+    source, created_via, guest_name, guest_phone_e164, guest_email,
+    consumer_user_id
+  ) VALUES (
+    v_brand, v_wait.place_pool_id, p_table_id, p_reserved_for, v_wait.party_size,
+    'confirmed', 'walk_in', 'operator',
+    v_wait.guest_name, v_wait.guest_phone_e164, v_wait.guest_email,
+    v_wait.consumer_user_id
+  ) RETURNING * INTO v_res;
+
+  -- Mark the waitlist row converted + link.
+  UPDATE public.venue_waitlist
+     SET status = 'converted',
+         converted_reservation_id = v_res.id,
+         updated_at = now()
+   WHERE id = p_waitlist_id;
+
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, after
+  ) VALUES (
+    v_uid, v_brand,
+    'venue_waitlist.converted',
+    'venue_waitlist', p_waitlist_id::text,
+    jsonb_build_object('reservation_id', v_res.id, 'reserved_for', p_reserved_for)
+  );
+
+  RETURN v_res;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_waitlist_convert_to_reservation(uuid, timestamptz, uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_waitlist_convert_to_reservation(uuid, timestamptz, uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_waitlist_convert_to_reservation(uuid, timestamptz, uuid) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20261010000003_orch_1148_reservation_lifecycle_probes.sql
+++ b/supabase/migrations/20261010000003_orch_1148_reservation_lifecycle_probes.sql
@@ -1,0 +1,113 @@
+-- ===========================================================================
+-- META-ORCH-1148 sub-ORCH 2.1b — lifecycle/waitlist/consent probes (read-only)
+-- ---------------------------------------------------------------------------
+-- A read-only DO block (NO writes) asserting the 2.1b invariants are physically
+-- present, so a future migration that drops/weakens them trips this probe
+-- (fails-on-revert at the DB layer). Runs LAST in the 2.1b version order.
+--
+-- Fails-on-revert anchors (DRAFT, flip ACTIVE on CLOSE):
+--   I-PROPOSED-1148-RESERVATION-LIFECYCLE-TRANSITIONS-GUARDED-SERVER-SIDE
+--   I-PROPOSED-1148-WAITLIST-CONVERT-ATOMIC
+--   I-PROPOSED-1148-SMS-OPT-OUT-HONORED (the consent ledger exists)
+--
+-- MONOTONIC VERSION 20261010000003. Apply via the Supabase Management API.
+-- ===========================================================================
+
+BEGIN;
+
+DO $probe$
+DECLARE
+  v_oid      oid;
+  v_secdef   boolean;
+  v_has_anon boolean;
+  v_acl      aclitem[];
+  v_def      text;
+BEGIN
+  -- (1) The legal-transition matrix fn exists + rejects terminal-state moves.
+  IF public.pg_reservation_transition_is_legal('completed', 'seated') THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: a completed reservation must NOT be seatable (terminal)';
+  END IF;
+  IF public.pg_reservation_transition_is_legal('cancelled_by_venue', 'confirmed') THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: a cancelled reservation must NOT be re-confirmable (terminal)';
+  END IF;
+  IF NOT public.pg_reservation_transition_is_legal('confirmed', 'seated') THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: confirmed -> seated must be legal';
+  END IF;
+  IF NOT public.pg_reservation_transition_is_legal('confirmed', 'no_show') THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: confirmed -> no_show must be legal';
+  END IF;
+  -- no_show only from confirmed/seated (NOT from requested or waitlisted).
+  IF public.pg_reservation_transition_is_legal('requested', 'no_show') THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: no_show must NOT be reachable from requested';
+  END IF;
+
+  -- (2) The guarded transition RPC exists, is SECURITY DEFINER, references the
+  -- legal-transition guard (so a revert that bypasses it trips the probe), and
+  -- is NOT anon-callable.
+  SELECT p.oid, p.prosecdef INTO v_oid, v_secdef
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'biz_reservation_transition'
+  LIMIT 1;
+  IF v_oid IS NULL THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: biz_reservation_transition is missing';
+  END IF;
+  IF v_secdef IS NOT TRUE THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: biz_reservation_transition must be SECURITY DEFINER';
+  END IF;
+  v_def := pg_get_functiondef(v_oid);
+  IF position('pg_reservation_transition_is_legal' in v_def) = 0 THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: biz_reservation_transition must enforce legality via pg_reservation_transition_is_legal';
+  END IF;
+  IF position('biz_brand_effective_rank_for_caller' in v_def) = 0 THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: biz_reservation_transition must gate on brand-member rank';
+  END IF;
+  SELECT p.proacl INTO v_acl FROM pg_proc p WHERE p.oid = v_oid;
+  v_has_anon := EXISTS (
+    SELECT 1 FROM aclexplode(v_acl) a
+    WHERE a.grantee IN ('anon'::regrole, 0) AND a.privilege_type = 'EXECUTE'
+  );
+  IF v_has_anon THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: biz_reservation_transition must NOT be anon-callable';
+  END IF;
+
+  -- (3) The atomic convert RPC exists, inserts a reservation AND marks the
+  -- waitlist converted (both literals present → single-txn convert).
+  SELECT p.oid INTO v_oid
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'biz_waitlist_convert_to_reservation'
+  LIMIT 1;
+  IF v_oid IS NULL THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: biz_waitlist_convert_to_reservation is missing';
+  END IF;
+  v_def := pg_get_functiondef(v_oid);
+  IF position('INSERT INTO public.reservations' in v_def) = 0
+     OR position($q$status = 'converted'$q$ in v_def) = 0
+     OR position('converted_reservation_id' in v_def) = 0 THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: convert RPC must atomically create the reservation AND mark the waitlist row converted+linked';
+  END IF;
+
+  -- (4) The SMS consent ledger + send log exist (opt-out honored seam).
+  IF to_regclass('public.venue_sms_opt_out') IS NULL THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: venue_sms_opt_out (the STOP ledger) is missing';
+  END IF;
+  IF to_regclass('public.venue_sms_log') IS NULL THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: venue_sms_log is missing';
+  END IF;
+  -- The opt-out ledger must be RLS-enabled (no authenticated read of PII).
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname = 'venue_sms_opt_out' AND c.relrowsecurity
+  ) THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: venue_sms_opt_out must have RLS enabled';
+  END IF;
+
+  -- (5) The list-view index for the segmented Reservations views exists.
+  IF to_regclass('public.reservations_brand_status_reserved_idx') IS NULL THEN
+    RAISE EXCEPTION 'ORCH-1148 2.1b probe: reservations_brand_status_reserved_idx (list-view index) is missing';
+  END IF;
+
+  RAISE NOTICE 'ORCH-1148 2.1b invariant probe passed: legal-transition guard enforced (terminal states locked, no_show only from confirmed/seated), guarded+SECURITY DEFINER+non-anon lifecycle RPCs, atomic waitlist convert, SMS consent ledger + log present (RLS), list-view index present.';
+END;
+$probe$;
+
+COMMIT;

--- a/supabase/migrations/20261011000000_orch_1148_2_1b_table_brand_scope.sql
+++ b/supabase/migrations/20261011000000_orch_1148_2_1b_table_brand_scope.sql
@@ -1,0 +1,306 @@
+-- ===========================================================================
+-- META-ORCH-1148 sub-ORCH 2.1b — D-1 fix: same-brand table_id validation
+-- ---------------------------------------------------------------------------
+-- The 2.1b lifecycle RPCs (biz_reservation_transition, biz_reservation_create)
+-- and the waitlist convert (biz_waitlist_convert_to_reservation) accepted a
+-- p_table_id with NO check that the target venue_tables row belongs to the SAME
+-- brand as the reservation/caller. The reservations.table_id FK references
+-- venue_tables GLOBALLY (not brand-scoped), so a Brand-A manager could stamp
+-- Brand-B's table_id onto a Brand-A reservation → cross-tenant corruption of the
+-- occupancy/table model the 2.1a availability engine reads. PROVEN LIVE by the
+-- tester (TEST_META-ORCH-1148_SUBB_2_1B.md findings B + C4).
+--
+-- FIX: in every RPC that sets/updates reservations.table_id, when p_table_id IS
+-- NOT NULL, validate EXISTS(venue_tables WHERE id = p_table_id AND brand_id =
+-- <the reservation's brand>). RAISE 'table_brand_mismatch' (ERRCODE 23514,
+-- check_violation) otherwise. NULL p_table_id (unassigned) stays allowed.
+--
+-- These are CREATE OR REPLACE re-emits of the EXACT 2.1b bodies with ONLY the
+-- brand-scope guard added. SECURITY DEFINER + manager+ gate + audit + the
+-- lifecycle matrix + atomicity are all preserved verbatim. The Supabase
+-- auto-GRANT-to-PUBLIC/anon gotcha is re-handled (REVOKE PUBLIC + anon, GRANT
+-- authenticated) for every re-emitted function. No money/checkout/engine file
+-- touched. Manual operator bookings remain FREE.
+--
+-- I-PROPOSED-1148-RESERVATION-TABLE-SAME-BRAND: a table_id from a DIFFERENT brand
+-- is REJECTED in create / transition / convert. A revert of any guard lets the
+-- cross-brand injection succeed and FAILs the adversarial harness (findings B/C4).
+--
+-- Additive-only (CREATE OR REPLACE, no DROP needed — same identities/signatures).
+-- $function$ closed BEFORE each GRANT. MONOTONIC VERSION 20261011000000 — strictly
+-- greater than the current max prefix across anchor main (20261002000000) + every
+-- sibling worktree (the 2.1b chain through 20261010000003). Apply via the Supabase
+-- Management API after REVIEW. NOT applied to prod by the implementor.
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- biz_reservation_transition — adds the same-brand table_id guard on (re)assign.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_reservation_transition(
+  p_reservation_id uuid,
+  p_to_status text,
+  p_table_id uuid DEFAULT NULL,      -- optional table (re)assignment on seat
+  p_reason text DEFAULT NULL          -- optional operator note (cancellation reason)
+) RETURNS public.reservations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_row public.reservations;
+  v_from text;
+  v_brand uuid;
+  v_policy text;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT * INTO v_row FROM public.reservations WHERE id = p_reservation_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'reservation_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  v_from := v_row.status;
+  v_brand := v_row.brand_id;
+
+  -- Brand-member gate (manager+). biz_brand_effective_rank_for_caller is
+  -- SECURITY DEFINER and resolves the caller via auth.uid() — works inside this
+  -- SECURITY DEFINER fn because the JWT is still on the request.
+  IF public.biz_brand_effective_rank_for_caller(v_brand)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Legal-transition enforcement (server-side; the heart of the invariant).
+  IF NOT public.pg_reservation_transition_is_legal(v_from, p_to_status) THEN
+    RAISE EXCEPTION 'illegal_transition_%_to_%', v_from, p_to_status
+      USING ERRCODE = '23514';
+  END IF;
+
+  -- D-1: cross-brand table_id injection guard. A (re)assigned table MUST belong
+  -- to the SAME brand as the reservation. NULL p_table_id (unassigned) is allowed.
+  IF p_table_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM public.venue_tables
+        WHERE id = p_table_id AND brand_id = v_brand
+     ) THEN
+    RAISE EXCEPTION 'table_brand_mismatch: table % does not belong to brand %',
+      p_table_id, v_brand USING ERRCODE = '23514';
+  END IF;
+
+  -- no_show RECORDS the forfeit-policy DECISION (NO Stripe capture here — 2.2 seam).
+  IF p_to_status = 'no_show' THEN
+    SELECT no_show_fee_policy INTO v_policy
+      FROM public.venue_reservation_settings WHERE brand_id = v_brand;
+  END IF;
+
+  UPDATE public.reservations
+     SET status = p_to_status,
+         -- table assignment is allowed on seat (or any non-cancel transition).
+         table_id = COALESCE(p_table_id, table_id),
+         -- preserve a free-form operator note in guest_notes-adjacent column;
+         -- we DO NOT clobber guest_notes — the reason is appended as a tag-free
+         -- audit detail only (kept in audit_log.after). No new column needed.
+         updated_at = now()
+   WHERE id = p_reservation_id
+   RETURNING * INTO v_row;
+
+  -- Audit (append-only; service-defined fn runs as definer = privileged).
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, before, after
+  ) VALUES (
+    v_uid, v_brand,
+    'venue_reservation.transition',
+    'reservation', p_reservation_id::text,
+    jsonb_build_object('status', v_from),
+    jsonb_build_object(
+      'status', p_to_status,
+      'table_id', v_row.table_id,
+      'reason', p_reason,
+      'no_show_fee_policy', v_policy
+    )
+  );
+
+  RETURN v_row;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_reservation_transition(uuid, text, uuid, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_reservation_transition(uuid, text, uuid, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_reservation_transition(uuid, text, uuid, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- biz_reservation_create — adds the same-brand table_id guard on initial assign.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_reservation_create(
+  p_brand_id uuid,
+  p_reserved_for timestamptz,
+  p_party_size int,
+  p_source text DEFAULT 'phone',
+  p_guest_name text DEFAULT NULL,
+  p_guest_phone_e164 text DEFAULT NULL,
+  p_guest_email text DEFAULT NULL,
+  p_table_id uuid DEFAULT NULL,
+  p_occasion text DEFAULT NULL,
+  p_guest_notes text DEFAULT NULL,
+  p_tags text[] DEFAULT '{}'::text[],
+  p_status text DEFAULT 'confirmed'
+) RETURNS public.reservations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_row public.reservations;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+  IF public.biz_brand_effective_rank_for_caller(p_brand_id)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+  -- A manual booking starts in a non-terminal, sensible state only.
+  IF p_status NOT IN ('requested','confirmed','seated') THEN
+    RAISE EXCEPTION 'invalid_initial_status_%', p_status USING ERRCODE = '23514';
+  END IF;
+  IF p_source NOT IN ('mingla','phone','walk_in','website','instagram') THEN
+    RAISE EXCEPTION 'invalid_source_%', p_source USING ERRCODE = '23514';
+  END IF;
+
+  -- D-1: cross-brand table_id injection guard. An assigned table MUST belong to
+  -- the SAME brand as the reservation being created. NULL p_table_id is allowed.
+  IF p_table_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM public.venue_tables
+        WHERE id = p_table_id AND brand_id = p_brand_id
+     ) THEN
+    RAISE EXCEPTION 'table_brand_mismatch: table % does not belong to brand %',
+      p_table_id, p_brand_id USING ERRCODE = '23514';
+  END IF;
+
+  INSERT INTO public.reservations (
+    brand_id, reserved_for, party_size, status, source, created_via,
+    guest_name, guest_phone_e164, guest_email, table_id, occasion,
+    guest_notes, tags
+  ) VALUES (
+    p_brand_id, p_reserved_for, p_party_size, p_status, p_source, 'operator',
+    p_guest_name, p_guest_phone_e164, p_guest_email, p_table_id, p_occasion,
+    p_guest_notes, COALESCE(p_tags, '{}'::text[])
+  ) RETURNING * INTO v_row;
+
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, after
+  ) VALUES (
+    v_uid, p_brand_id,
+    'venue_reservation.create',
+    'reservation', v_row.id::text,
+    jsonb_build_object(
+      'source', p_source, 'party_size', p_party_size,
+      'reserved_for', p_reserved_for, 'status', p_status, 'created_via', 'operator'
+    )
+  );
+
+  RETURN v_row;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_reservation_create(uuid, timestamptz, int, text, text, text, text, uuid, text, text, text[], text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_reservation_create(uuid, timestamptz, int, text, text, text, text, uuid, text, text, text[], text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_reservation_create(uuid, timestamptz, int, text, text, text, text, uuid, text, text, text[], text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- biz_waitlist_convert_to_reservation — adds the same-brand table_id guard on
+-- the convert's table assignment (the converted reservation's brand = waitlist
+-- brand). Atomicity (single txn: create reservation + mark waitlist converted)
+-- preserved verbatim.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_waitlist_convert_to_reservation(
+  p_waitlist_id uuid,
+  p_reserved_for timestamptz,
+  p_table_id uuid DEFAULT NULL
+) RETURNS public.reservations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_wait public.venue_waitlist;
+  v_res public.reservations;
+  v_brand uuid;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+  SELECT * INTO v_wait FROM public.venue_waitlist WHERE id = p_waitlist_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'waitlist_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  v_brand := v_wait.brand_id;
+  IF public.biz_brand_effective_rank_for_caller(v_brand)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+  IF v_wait.status = 'converted' THEN
+    RAISE EXCEPTION 'waitlist_already_converted' USING ERRCODE = '23505';
+  END IF;
+  IF v_wait.status NOT IN ('waiting','notified') THEN
+    RAISE EXCEPTION 'waitlist_not_active_%', v_wait.status USING ERRCODE = '23514';
+  END IF;
+
+  -- D-1: cross-brand table_id injection guard. The assigned table MUST belong to
+  -- the SAME brand as the waitlist row (= the converted reservation's brand).
+  -- NULL p_table_id (no table assigned at convert) is allowed. This check runs
+  -- BEFORE the INSERT so a mismatch aborts the whole convert atomically.
+  IF p_table_id IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM public.venue_tables
+        WHERE id = p_table_id AND brand_id = v_brand
+     ) THEN
+    RAISE EXCEPTION 'table_brand_mismatch: table % does not belong to brand %',
+      p_table_id, v_brand USING ERRCODE = '23514';
+  END IF;
+
+  -- Create the reservation (FREE; created_via=operator; carries the waitlist
+  -- guest identity + party + preferred-zone-as-occasion-less note).
+  INSERT INTO public.reservations (
+    brand_id, place_pool_id, table_id, reserved_for, party_size, status,
+    source, created_via, guest_name, guest_phone_e164, guest_email,
+    consumer_user_id
+  ) VALUES (
+    v_brand, v_wait.place_pool_id, p_table_id, p_reserved_for, v_wait.party_size,
+    'confirmed', 'walk_in', 'operator',
+    v_wait.guest_name, v_wait.guest_phone_e164, v_wait.guest_email,
+    v_wait.consumer_user_id
+  ) RETURNING * INTO v_res;
+
+  -- Mark the waitlist row converted + link.
+  UPDATE public.venue_waitlist
+     SET status = 'converted',
+         converted_reservation_id = v_res.id,
+         updated_at = now()
+   WHERE id = p_waitlist_id;
+
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, after
+  ) VALUES (
+    v_uid, v_brand,
+    'venue_waitlist.converted',
+    'venue_waitlist', p_waitlist_id::text,
+    jsonb_build_object('reservation_id', v_res.id, 'reserved_for', p_reserved_for)
+  );
+
+  RETURN v_res;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_waitlist_convert_to_reservation(uuid, timestamptz, uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_waitlist_convert_to_reservation(uuid, timestamptz, uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_waitlist_convert_to_reservation(uuid, timestamptz, uuid) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20261011000001_orch_1148_2_1b_sms_optout_rpc.sql
+++ b/supabase/migrations/20261011000001_orch_1148_2_1b_sms_optout_rpc.sql
@@ -1,0 +1,74 @@
+-- ===========================================================================
+-- META-ORCH-1148 sub-ORCH 2.1b — D-2 fix: partial-index-safe global opt-out write
+-- ---------------------------------------------------------------------------
+-- The send-venue-sms edge fn's defensive Twilio-21610 (blacklisted) write used
+--   .upsert({ phone_e164, brand_id: null, ... }, { onConflict: "phone_e164" })
+-- which emits INSERT ... ON CONFLICT (phone_e164) DO NOTHING. But venue_sms_opt_out
+-- has ONLY PARTIAL unique indexes:
+--   venue_sms_opt_out_phone_global_uniq  ON (phone_e164)            WHERE brand_id IS NULL
+--   venue_sms_opt_out_phone_brand_uniq   ON (phone_e164, brand_id)  WHERE brand_id IS NOT NULL
+-- There is NO plain UNIQUE(phone_e164), so ON CONFLICT (phone_e164) errors at
+-- runtime: "there is no unique or exclusion constraint matching the ON CONFLICT
+-- specification". The Supabase JS .upsert() API cannot express a partial-index
+-- predicate, so the defensive global opt-out NEVER persisted (PROVEN LIVE by the
+-- tester, TEST_META-ORCH-1148_SUBB_2_1B.md D-2).
+--
+-- FIX (option c): a SECURITY DEFINER RPC that runs the CORRECT, partial-index-safe
+-- arbiter — ON CONFLICT (phone_e164) WHERE brand_id IS NULL DO NOTHING — which
+-- matches the GLOBAL partial unique index exactly and is idempotent (a repeat
+-- 21610 for the same number is a no-op, never a duplicate-key crash). The edge fn
+-- (service role) calls this instead of the broken .upsert(). The per-brand opt-out
+-- rows are PRESERVED (no plain UNIQUE added), so the existing partial-index
+-- semantics are untouched.
+--
+-- GRANT EXECUTE to service_role ONLY (the edge fn runs service role; this is an
+-- internal persistence helper, never operator/anon-callable). The Supabase
+-- auto-GRANT-to-PUBLIC/anon gotcha is handled: REVOKE PUBLIC + anon explicitly.
+--
+-- I-PROPOSED-1148-SMS-21610-OPTOUT-PERSISTS: a simulated Twilio 21610 defensive
+-- global opt-out PERSISTS (one row, brand_id IS NULL) without throwing, and is
+-- idempotent on repeat. A revert to the .upsert(onConflict:"phone_e164") path
+-- throws "no unique or exclusion constraint matching the ON CONFLICT spec".
+--
+-- Additive-only. $function$ closed BEFORE each GRANT. MONOTONIC VERSION
+-- 20261011000001 (immediately above the D-1 fix 20261011000000). Apply via the
+-- Supabase Management API after REVIEW. NOT applied to prod by the implementor.
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- biz_sms_record_global_opt_out — partial-index-safe, idempotent global opt-out.
+-- Writes a brand_id-NULL (GLOBAL) opt-out row for the phone if one does not
+-- already exist. Used by send-venue-sms on a Twilio 21610 (blacklist) response.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_sms_record_global_opt_out(
+  p_phone_e164 text,
+  p_reason text DEFAULT 'twilio_blacklist'
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+BEGIN
+  -- Defensive: only the three allowed reasons (CHECK on the table mirrors this).
+  IF p_reason NOT IN ('stop_keyword','manual','twilio_blacklist') THEN
+    p_reason := 'twilio_blacklist';
+  END IF;
+
+  -- ON CONFLICT targets the GLOBAL partial unique index's predicate exactly, so
+  -- the arbiter resolves and a repeat is a no-op (idempotent, never a 23505 crash).
+  INSERT INTO public.venue_sms_opt_out (phone_e164, brand_id, reason)
+  VALUES (p_phone_e164, NULL, p_reason)
+  ON CONFLICT (phone_e164) WHERE brand_id IS NULL
+  DO NOTHING;
+END;
+$function$;
+
+-- service_role only (the edge fn runs service role); never operator/anon-callable.
+REVOKE ALL ON FUNCTION public.biz_sms_record_global_opt_out(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_sms_record_global_opt_out(text, text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.biz_sms_record_global_opt_out(text, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.biz_sms_record_global_opt_out(text, text) TO service_role;
+
+COMMIT;

--- a/supabase/migrations/__tests__/orch_1148_2_1b_lifecycle_adversarial.tester.sql
+++ b/supabase/migrations/__tests__/orch_1148_2_1b_lifecycle_adversarial.tester.sql
@@ -1,0 +1,481 @@
+-- =====================================================================================
+-- TEST_META-ORCH-1148 sub-ORCH 2.1b — ADVERSARIAL LIFECYCLE / CONVERT / RLS / GRANT
+-- mingla-tester (claude). A DIFFERENT angle than the implementor's source-grep deno
+-- tests: this is a LIVE-FIRE psql harness that EXECUTES the RPCs against real seeded
+-- rows on Postgres 17 with the full 237-migration chain applied, and attacks:
+--   A. concurrent / double-transition race serialization (FOR UPDATE)
+--   B. cross-brand p_table_id injection (transition + convert)  [suspected defect]
+--   C. convert-then-reconvert + convert from non-active states
+--   D. RLS cross-brand read isolation (stranger reads 0)
+--   E. manual-create gate (non-member + scanner-rank denied; manager allowed)
+--   F. same-state transition rejected; terminal locked; no_show only from confirmed/seated
+--   G. audit_log rows written for every mutation
+--
+-- Run (after applying all migrations to a fresh supabase/postgres:17.4.1.075):
+--   psql -v ON_ERROR_STOP=1 -f orch_1148_2_1b_lifecycle_adversarial.tester.sql
+--
+-- Each assertion RAISEs EXCEPTION on failure (so ON_ERROR_STOP aborts + the harness
+-- reports the first defect). A clean run ends '== ALL 2.1b ADVERSARIAL ASSERTIONS PASSED =='.
+--
+-- Fails-on-revert anchor: a revert of biz_reservation_transition's legal-matrix guard,
+-- the FOR UPDATE lock, the convert already-converted guard, or the manager+ gate makes
+-- the corresponding assert RAISE. Cited @ commit 7eeb41d6f.
+-- =====================================================================================
+
+\set ON_ERROR_STOP on
+\timing off
+
+-- -------------------------------------------------------------------------------------
+-- FIXTURES: two brands owned by two different users + a manager + a scanner-rank member.
+-- -------------------------------------------------------------------------------------
+INSERT INTO auth.users (id, instance_id, aud, role, email) VALUES
+  ('11111111-1111-1111-1111-111111111111','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ownerA@tester.com'),
+  ('22222222-2222-2222-2222-222222222222','00000000-0000-0000-0000-000000000000','authenticated','authenticated','ownerB@tester.com'),
+  ('33333333-3333-3333-3333-333333333333','00000000-0000-0000-0000-000000000000','authenticated','authenticated','managerA@tester.com'),
+  ('44444444-4444-4444-4444-444444444444','00000000-0000-0000-0000-000000000000','authenticated','authenticated','scannerA@tester.com'),
+  ('55555555-5555-5555-5555-555555555555','00000000-0000-0000-0000-000000000000','authenticated','authenticated','stranger@tester.com')
+ON CONFLICT (id) DO NOTHING;
+
+-- brands.account_id FKs creator_accounts(id), where creator_accounts.id = auth.users.id.
+INSERT INTO public.creator_accounts (id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.brands (id, account_id, name, slug) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','11111111-1111-1111-1111-111111111111','Brand A','tester-brand-a'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','22222222-2222-2222-2222-222222222222','Brand B','tester-brand-b')
+ON CONFLICT (id) DO NOTHING;
+
+-- managerA is an accepted event_manager on Brand A; scannerA is an accepted scanner on Brand A.
+INSERT INTO public.brand_team_members (brand_id, user_id, role, accepted_at) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','33333333-3333-3333-3333-333333333333','event_manager', now()),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','44444444-4444-4444-4444-444444444444','scanner', now())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.venue_reservation_settings (brand_id, no_show_fee_policy) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','forfeit'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','forfeit')
+ON CONFLICT (brand_id) DO NOTHING;
+
+-- A table that belongs to Brand B (the cross-brand injection target).
+INSERT INTO public.venue_tables (id, brand_id, name, capacity) VALUES
+  ('bbbbbbbb-0000-0000-0000-000000000001','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','B-Table-1',4),
+  ('aaaaaaaa-0000-0000-0000-000000000001','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','A-Table-1',4)
+ON CONFLICT (id) DO NOTHING;
+
+-- =====================================================================================
+-- E. MANUAL-CREATE GATE
+-- =====================================================================================
+
+-- E1: a non-member (stranger) cannot create on Brand A → 42501.
+DO $$
+DECLARE ok boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','55555555-5555-5555-5555-555555555555', true);
+  BEGIN
+    PERFORM public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '2 hours', 2);
+  EXCEPTION WHEN insufficient_privilege THEN ok := true;
+  END;
+  IF NOT ok THEN RAISE EXCEPTION 'E1 FAIL: a non-member was allowed to create a reservation'; END IF;
+  RAISE NOTICE 'E1 PASS: non-member create rejected (42501)';
+END $$;
+
+-- E2: a scanner-rank member (rank 10 < 40) cannot create → 42501.
+DO $$
+DECLARE ok boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','44444444-4444-4444-4444-444444444444', true);
+  BEGIN
+    PERFORM public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '2 hours', 2);
+  EXCEPTION WHEN insufficient_privilege THEN ok := true;
+  END;
+  IF NOT ok THEN RAISE EXCEPTION 'E2 FAIL: a scanner-rank member was allowed to create (gate must be manager+)'; END IF;
+  RAISE NOTICE 'E2 PASS: scanner-rank create rejected (manager+ gate holds)';
+END $$;
+
+-- E3: an event_manager (rank 40) CAN create.
+DO $$
+DECLARE v_id uuid;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','33333333-3333-3333-3333-333333333333', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '2 hours', 2,
+            'phone','Manager Made','+15555550100')).id;
+  IF v_id IS NULL THEN RAISE EXCEPTION 'E3 FAIL: manager create returned NULL'; END IF;
+  RAISE NOTICE 'E3 PASS: event_manager create allowed (%).', v_id;
+END $$;
+
+-- E4: invalid initial status rejected (e.g. cannot create directly into 'completed').
+DO $$
+DECLARE ok boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  BEGIN
+    PERFORM public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '2 hours', 2,
+      'phone',NULL,NULL,NULL,NULL,NULL,NULL,'{}'::text[],'completed');
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  IF NOT ok THEN RAISE EXCEPTION 'E4 FAIL: create into terminal status completed was allowed'; END IF;
+  RAISE NOTICE 'E4 PASS: create into a terminal status rejected';
+END $$;
+
+-- =====================================================================================
+-- F. TRANSITION MATRIX (terminal locked, same-state rejected, no_show source-gated)
+-- =====================================================================================
+
+-- Set up a confirmed reservation on Brand A owned by ownerA.
+DO $$
+DECLARE v_id uuid; ok boolean := false; ok2 boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '3 hours', 2)).id;
+  -- F1: same-state transition (confirmed->confirmed) must be REJECTED.
+  BEGIN
+    PERFORM public.biz_reservation_transition(v_id, 'confirmed');
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  IF NOT ok THEN RAISE EXCEPTION 'F1 FAIL: same-state confirmed->confirmed was allowed'; END IF;
+  RAISE NOTICE 'F1 PASS: same-state transition rejected';
+  -- F2: confirmed -> seated -> completed legal; then completed is terminal.
+  PERFORM public.biz_reservation_transition(v_id, 'seated');
+  PERFORM public.biz_reservation_transition(v_id, 'completed');
+  BEGIN
+    PERFORM public.biz_reservation_transition(v_id, 'seated');
+  EXCEPTION WHEN check_violation THEN ok2 := true;
+  END;
+  IF NOT ok2 THEN RAISE EXCEPTION 'F2 FAIL: a completed (terminal) reservation was re-seatable'; END IF;
+  RAISE NOTICE 'F2 PASS: terminal completed cannot transition out';
+END $$;
+
+-- F3: no_show is NOT reachable from 'requested' (only confirmed/seated).
+DO $$
+DECLARE v_id uuid; ok boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '4 hours', 2,
+            'phone',NULL,NULL,NULL,NULL,NULL,NULL,'{}'::text[],'requested')).id;
+  BEGIN
+    PERFORM public.biz_reservation_transition(v_id, 'no_show');
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  IF NOT ok THEN RAISE EXCEPTION 'F3 FAIL: no_show was reachable from requested'; END IF;
+  RAISE NOTICE 'F3 PASS: no_show not reachable from requested';
+END $$;
+
+-- F4: no_show DOES record the venue forfeit policy in audit_log.after (from confirmed).
+DO $$
+DECLARE v_id uuid; v_policy text;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '5 hours', 2)).id;
+  PERFORM public.biz_reservation_transition(v_id, 'no_show', NULL, 'guest never showed');
+  SELECT (after->>'no_show_fee_policy') INTO v_policy
+    FROM public.audit_log
+    WHERE target_id = v_id::text AND action='venue_reservation.transition'
+    ORDER BY created_at DESC LIMIT 1;
+  IF v_policy IS DISTINCT FROM 'forfeit' THEN
+    RAISE EXCEPTION 'F4 FAIL: no_show did not record the venue forfeit policy (got %)', v_policy;
+  END IF;
+  RAISE NOTICE 'F4 PASS: no_show records forfeit policy decision (no money path)';
+END $$;
+
+-- =====================================================================================
+-- B. CROSS-BRAND p_table_id INJECTION on biz_reservation_transition  [D-1 FIX]
+--    The RPC assigns COALESCE(p_table_id, table_id). D-1 added a same-brand guard:
+--    a table from a DIFFERENT brand MUST be REJECTED. A same-brand table MUST work,
+--    and NULL (unassigned) MUST stay allowed. These are HARD fails-on-revert now.
+--    (Revert the D-1 guard → B1 RAISEs FAILS-ON-REVERT CONFIRMED.)
+-- =====================================================================================
+
+-- B1: cross-brand table_id on TRANSITION is REJECTED (check_violation 23514).
+DO $$
+DECLARE v_id uuid; ok boolean := false; v_injected uuid := 'bbbbbbbb-0000-0000-0000-000000000001';
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '6 hours', 2)).id;
+  BEGIN
+    PERFORM public.biz_reservation_transition(v_id, 'seated', v_injected, 'inject cross-brand table');
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  IF NOT ok THEN
+    RAISE EXCEPTION 'B1 FAIL [FAILS-ON-REVERT CONFIRMED]: cross-brand Brand-B table was ASSIGNED onto a Brand-A reservation via transition (D-1 guard missing). reservation=%', v_id;
+  END IF;
+  RAISE NOTICE 'B1 PASS: cross-brand table_id on transition REJECTED (same-brand guard)';
+END $$;
+
+-- B2: a SAME-BRAND table on transition is ACCEPTED + persisted (positive control).
+DO $$
+DECLARE v_id uuid; v_assigned uuid; v_same uuid := 'aaaaaaaa-0000-0000-0000-000000000001';
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '6 hours 30 minutes', 2)).id;
+  v_assigned := (public.biz_reservation_transition(v_id, 'seated', v_same, 'same-brand table ok')).table_id;
+  IF v_assigned IS DISTINCT FROM v_same THEN
+    RAISE EXCEPTION 'B2 FAIL: same-brand table not assigned (got %, want %)', v_assigned, v_same;
+  END IF;
+  RAISE NOTICE 'B2 PASS: same-brand table assigned on transition (%).', v_assigned;
+END $$;
+
+-- B3: a NULL table_id (unassigned) transition is still allowed (no regression).
+DO $$
+DECLARE v_id uuid; v_status text;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '6 hours 45 minutes', 2)).id;
+  v_status := (public.biz_reservation_transition(v_id, 'seated', NULL, 'no table')).status;
+  IF v_status <> 'seated' THEN RAISE EXCEPTION 'B3 FAIL: NULL-table transition did not seat (got %)', v_status; END IF;
+  RAISE NOTICE 'B3 PASS: NULL table_id transition still allowed (unassigned)';
+END $$;
+
+-- B4: cross-brand table_id on biz_reservation_create is REJECTED (D-1, create path).
+DO $$
+DECLARE ok boolean := false; v_injected uuid := 'bbbbbbbb-0000-0000-0000-000000000001';
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  BEGIN
+    PERFORM public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '6 hours', 2,
+      'phone',NULL,NULL,NULL, v_injected);
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  IF NOT ok THEN
+    RAISE EXCEPTION 'B4 FAIL [FAILS-ON-REVERT CONFIRMED]: biz_reservation_create accepted a CROSS-BRAND table_id (D-1 guard missing)';
+  END IF;
+  RAISE NOTICE 'B4 PASS: cross-brand table_id on create REJECTED (same-brand guard)';
+END $$;
+
+-- =====================================================================================
+-- A. CONCURRENT / DOUBLE-TRANSITION RACE (serialization via FOR UPDATE)
+--    Single-connection proxy: the matrix guard re-reads status FOR UPDATE each call, so
+--    the SECOND terminal transition on an already-terminal row must be rejected. (A true
+--    2-connection race is run separately by the harness; here we prove the guard re-reads
+--    fresh state rather than a stale snapshot.)
+-- =====================================================================================
+DO $$
+DECLARE v_id uuid; ok boolean := false;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_id := (public.biz_reservation_create('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now()+interval '7 hours', 2)).id;
+  PERFORM public.biz_reservation_transition(v_id, 'cancelled_by_venue', NULL, 'first cancel');
+  -- a second mutation on the now-terminal row must be rejected (proves fresh re-read).
+  BEGIN
+    PERFORM public.biz_reservation_transition(v_id, 'completed');
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  IF NOT ok THEN RAISE EXCEPTION 'A FAIL: a second transition on a terminal (cancelled) row succeeded — stale-state guard'; END IF;
+  RAISE NOTICE 'A PASS: second transition on terminal row rejected (guard re-reads fresh status FOR UPDATE)';
+END $$;
+
+-- =====================================================================================
+-- C. WAITLIST CONVERT — atomicity, reconvert, non-active rejection, cross-brand table
+-- =====================================================================================
+
+-- Seed a waitlist row on Brand A.
+INSERT INTO public.venue_waitlist (id, brand_id, party_size, guest_name, guest_phone_e164, status)
+VALUES ('aaaaaaaa-eeee-eeee-eeee-000000000001','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 3, 'Wait Guest', '+15555550111', 'waiting')
+ON CONFLICT (id) DO NOTHING;
+
+-- C1: convert is ATOMIC — reservation created AND waitlist marked converted+linked.
+DO $$
+DECLARE v_res uuid; v_wstatus text; v_link uuid;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_res := (public.biz_waitlist_convert_to_reservation('aaaaaaaa-eeee-eeee-eeee-000000000001', now()+interval '8 hours', NULL)).id;
+  SELECT status, converted_reservation_id INTO v_wstatus, v_link
+    FROM public.venue_waitlist WHERE id='aaaaaaaa-eeee-eeee-eeee-000000000001';
+  IF v_res IS NULL THEN RAISE EXCEPTION 'C1 FAIL: convert returned no reservation'; END IF;
+  IF v_wstatus <> 'converted' THEN RAISE EXCEPTION 'C1 FAIL: waitlist not marked converted (got %)', v_wstatus; END IF;
+  IF v_link IS DISTINCT FROM v_res THEN RAISE EXCEPTION 'C1 FAIL: converted_reservation_id not linked (got % want %)', v_link, v_res; END IF;
+  RAISE NOTICE 'C1 PASS: atomic convert (reservation % created + waitlist converted+linked)', v_res;
+END $$;
+
+-- C2: a converted waitlist row CANNOT be converted again → 23505.
+DO $$
+DECLARE ok boolean := false; res_before bigint; res_after bigint;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  SELECT count(*) INTO res_before FROM public.reservations;
+  BEGIN
+    PERFORM public.biz_waitlist_convert_to_reservation('aaaaaaaa-eeee-eeee-eeee-000000000001', now()+interval '9 hours', NULL);
+  EXCEPTION WHEN unique_violation THEN ok := true;
+  END;
+  SELECT count(*) INTO res_after FROM public.reservations;
+  IF NOT ok THEN RAISE EXCEPTION 'C2 FAIL: a converted waitlist row was converted twice'; END IF;
+  IF res_after <> res_before THEN RAISE EXCEPTION 'C2 FAIL: a 2nd-convert attempt left an ORPHAN reservation (% -> %)', res_before, res_after; END IF;
+  RAISE NOTICE 'C2 PASS: double-convert rejected (23505), no orphan reservation';
+END $$;
+
+-- C3: a forced mid-convert failure (bad table_id) leaves NO orphan + NO converted
+--     flag (atomic rollback). NOTE post-D-1: a non-existent table_id is rejected by
+--     the D-1 same-brand guard (check_violation) BEFORE the FK ever fires — earlier
+--     and cleaner. The atomicity proof is unchanged: either error aborts the whole
+--     txn with no orphan reservation + waitlist still 'waiting'.
+INSERT INTO public.venue_waitlist (id, brand_id, party_size, guest_name, status)
+VALUES ('aaaaaaaa-eeee-eeee-eeee-000000000002','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 2, 'Atomic Guest', 'waiting')
+ON CONFLICT (id) DO NOTHING;
+DO $$
+DECLARE ok boolean := false; res_before bigint; res_after bigint; v_wstatus text;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  SELECT count(*) INTO res_before FROM public.reservations;
+  BEGIN
+    -- a non-existent table_id: rejected by the D-1 same-brand guard (check_violation),
+    -- or — absent the guard — by the reservations.table_id FK (foreign_key_violation).
+    -- Either way the whole txn rolls back.
+    PERFORM public.biz_waitlist_convert_to_reservation('aaaaaaaa-eeee-eeee-eeee-000000000002', now()+interval '2 hours',
+      '00000000-dead-dead-dead-000000000000');
+  EXCEPTION
+    WHEN check_violation THEN ok := true;        -- D-1 guard (current behavior)
+    WHEN foreign_key_violation THEN ok := true;  -- pre-D-1 FK (still atomic)
+  END;
+  SELECT count(*) INTO res_after FROM public.reservations;
+  SELECT status INTO v_wstatus FROM public.venue_waitlist WHERE id='aaaaaaaa-eeee-eeee-eeee-000000000002';
+  IF NOT ok THEN RAISE EXCEPTION 'C3 FAIL: a bad table_id did not error'; END IF;
+  IF res_after <> res_before THEN RAISE EXCEPTION 'C3 FAIL: ORPHAN reservation left after mid-convert failure (% -> %)', res_before, res_after; END IF;
+  IF v_wstatus <> 'waiting' THEN RAISE EXCEPTION 'C3 FAIL: waitlist row partially mutated after failed convert (got %)', v_wstatus; END IF;
+  RAISE NOTICE 'C3 PASS: forced mid-convert failure left NO orphan + waitlist still waiting (atomic rollback)';
+END $$;
+
+-- C4: cross-brand table injection on CONVERT (Brand B table onto a Brand A convert)
+--     is REJECTED (D-1), the waitlist row stays 'waiting', and NO orphan reservation
+--     is left (atomic abort BEFORE the INSERT). HARD fails-on-revert.
+DO $$
+DECLARE ok boolean := false; v_injected uuid := 'bbbbbbbb-0000-0000-0000-000000000001';
+  res_before bigint; res_after bigint; v_wstatus text;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  SELECT count(*) INTO res_before FROM public.reservations;
+  BEGIN
+    PERFORM public.biz_waitlist_convert_to_reservation('aaaaaaaa-eeee-eeee-eeee-000000000002', now()+interval '2 hours', v_injected);
+  EXCEPTION WHEN check_violation THEN ok := true;
+  END;
+  SELECT count(*) INTO res_after FROM public.reservations;
+  SELECT status INTO v_wstatus FROM public.venue_waitlist WHERE id='aaaaaaaa-eeee-eeee-eeee-000000000002';
+  IF NOT ok THEN
+    RAISE EXCEPTION 'C4 FAIL [FAILS-ON-REVERT CONFIRMED]: convert assigned a CROSS-BRAND (Brand B) table onto a Brand A reservation (D-1 guard missing)';
+  END IF;
+  IF res_after <> res_before THEN RAISE EXCEPTION 'C4 FAIL: cross-brand convert left an ORPHAN reservation (% -> %)', res_before, res_after; END IF;
+  IF v_wstatus <> 'waiting' THEN RAISE EXCEPTION 'C4 FAIL: waitlist row mutated after rejected cross-brand convert (got %)', v_wstatus; END IF;
+  RAISE NOTICE 'C4 PASS: cross-brand table on convert REJECTED, no orphan, waitlist still waiting';
+END $$;
+
+-- C5: a SAME-BRAND table on convert is ACCEPTED + linked (positive control).
+DO $$
+DECLARE v_res uuid; v_tbl uuid; v_same uuid := 'aaaaaaaa-0000-0000-0000-000000000001';
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub','11111111-1111-1111-1111-111111111111', true);
+  v_res := (public.biz_waitlist_convert_to_reservation('aaaaaaaa-eeee-eeee-eeee-000000000002', now()+interval '2 hours', v_same)).id;
+  SELECT table_id INTO v_tbl FROM public.reservations WHERE id = v_res;
+  IF v_tbl IS DISTINCT FROM v_same THEN
+    RAISE EXCEPTION 'C5 FAIL: same-brand table not assigned on convert (got %, want %)', v_tbl, v_same;
+  END IF;
+  RAISE NOTICE 'C5 PASS: same-brand table assigned on convert (reservation %, table %).', v_res, v_tbl;
+END $$;
+
+-- =====================================================================================
+-- D. RLS CROSS-BRAND READ ISOLATION (the stranger reads 0 of Brand A's rows)
+--    Run as a NON-superuser role so RLS is enforced (postgres bypasses RLS).
+-- =====================================================================================
+-- Grant authenticated role membership so we can SET ROLE authenticated with a jwt claim.
+DO $$ BEGIN
+  -- ownerA can read their own reservations; stranger reads 0.
+  NULL;
+END $$;
+
+SET ROLE authenticated;
+SET request.jwt.claim.sub = '55555555-5555-5555-5555-555555555555';   -- stranger
+SELECT CASE WHEN count(*) = 0 THEN 'D1 PASS: stranger reads 0 Brand A reservations (RLS)'
+            ELSE 'D1 FAIL: stranger read '||count(*)||' Brand A reservations' END AS d1
+FROM public.reservations WHERE brand_id='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+SELECT CASE WHEN count(*) = 0 THEN 'D2 PASS: stranger reads 0 Brand A waitlist rows (RLS)'
+            ELSE 'D2 FAIL: stranger read '||count(*)||' Brand A waitlist rows' END AS d2
+FROM public.venue_waitlist WHERE brand_id='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+SET request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';   -- ownerA
+SELECT CASE WHEN count(*) > 0 THEN 'D3 PASS: ownerA reads their own Brand A reservations'
+            ELSE 'D3 FAIL: ownerA reads 0 of their own reservations' END AS d3
+FROM public.reservations WHERE brand_id='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+RESET ROLE;
+
+-- =====================================================================================
+-- G. AUDIT TRAIL — every mutation wrote an audit_log row.
+-- =====================================================================================
+DO $$
+DECLARE n_create int; n_trans int; n_conv int;
+BEGIN
+  SELECT count(*) INTO n_create FROM public.audit_log WHERE action='venue_reservation.create';
+  SELECT count(*) INTO n_trans  FROM public.audit_log WHERE action='venue_reservation.transition';
+  SELECT count(*) INTO n_conv   FROM public.audit_log WHERE action='venue_waitlist.converted';
+  IF n_create < 1 THEN RAISE EXCEPTION 'G FAIL: no venue_reservation.create audit rows'; END IF;
+  IF n_trans  < 1 THEN RAISE EXCEPTION 'G FAIL: no venue_reservation.transition audit rows'; END IF;
+  IF n_conv   < 1 THEN RAISE EXCEPTION 'G FAIL: no venue_waitlist.converted audit rows'; END IF;
+  RAISE NOTICE 'G PASS: audit rows written (create=%, transition=%, convert=%)', n_create, n_trans, n_conv;
+END $$;
+
+-- =====================================================================================
+-- H. D-2 — defensive 21610 global opt-out persistence (partial-index-safe RPC).
+--    The edge fn calls biz_sms_record_global_opt_out on a Twilio 21610. It MUST
+--    persist a single GLOBAL (brand_id IS NULL) row WITHOUT throwing, and be
+--    idempotent on repeat (no 23505). HARD fails-on-revert: the broken
+--    .upsert(onConflict:"phone_e164") path errors against the PARTIAL unique
+--    indexes — proven below by attacking that exact spec directly.
+-- =====================================================================================
+
+-- H1: the RPC persists a global opt-out without throwing, and is IDEMPOTENT.
+DO $$
+DECLARE n int; n_nonnull int;
+BEGIN
+  -- first call inserts the global row.
+  PERFORM public.biz_sms_record_global_opt_out('+15555559999', 'twilio_blacklist');
+  -- repeat call is a no-op (idempotent) — must NOT raise 23505.
+  PERFORM public.biz_sms_record_global_opt_out('+15555559999', 'twilio_blacklist');
+  SELECT count(*) INTO n
+    FROM public.venue_sms_opt_out WHERE phone_e164='+15555559999';
+  SELECT count(*) INTO n_nonnull
+    FROM public.venue_sms_opt_out WHERE phone_e164='+15555559999' AND brand_id IS NOT NULL;
+  IF n <> 1 THEN RAISE EXCEPTION 'H1 FAIL: expected exactly 1 global opt-out row, got %', n; END IF;
+  IF n_nonnull <> 0 THEN RAISE EXCEPTION 'H1 FAIL: opt-out row is not GLOBAL (a non-NULL brand_id row exists)'; END IF;
+  RAISE NOTICE 'H1 PASS: 21610 global opt-out persists once + idempotent on repeat (no throw)';
+END $$;
+
+-- H2: a per-brand opt-out for the SAME phone coexists with the global row
+--     (the partial indexes are distinct; the RPC only touches the global one).
+DO $$
+DECLARE n_global int; n_brand int;
+BEGIN
+  INSERT INTO public.venue_sms_opt_out (phone_e164, brand_id, reason)
+    VALUES ('+15555559999', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'manual')
+    ON CONFLICT (phone_e164, brand_id) WHERE brand_id IS NOT NULL DO NOTHING;
+  -- RPC again — still no-op on the global row, brand row untouched.
+  PERFORM public.biz_sms_record_global_opt_out('+15555559999', 'twilio_blacklist');
+  SELECT count(*) INTO n_global FROM public.venue_sms_opt_out WHERE phone_e164='+15555559999' AND brand_id IS NULL;
+  SELECT count(*) INTO n_brand  FROM public.venue_sms_opt_out WHERE phone_e164='+15555559999' AND brand_id IS NOT NULL;
+  IF n_global <> 1 THEN RAISE EXCEPTION 'H2 FAIL: global row count drifted (got %)', n_global; END IF;
+  IF n_brand  <> 1 THEN RAISE EXCEPTION 'H2 FAIL: per-brand row count drifted (got %)', n_brand; END IF;
+  RAISE NOTICE 'H2 PASS: global + per-brand opt-out rows coexist; RPC touches only global';
+END $$;
+
+-- H3: FAILS-ON-REVERT for D-2 — the OLD broken arbiter spec
+--     `ON CONFLICT (phone_e164)` (a NON-partial target) errors against the table,
+--     which has ONLY partial unique indexes. This is exactly what the JS
+--     .upsert({ onConflict: "phone_e164" }) emitted. Proving it RAISEs documents
+--     the bug the RPC fix avoids.
+DO $$
+DECLARE ok boolean := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.venue_sms_opt_out (phone_e164, brand_id, reason)
+      VALUES ('+15555558888', NULL, 'twilio_blacklist')
+      ON CONFLICT (phone_e164) DO NOTHING;   -- the BROKEN (D-2) spec.
+  EXCEPTION WHEN others THEN
+    -- 42P10 invalid_column_reference: "no unique or exclusion constraint matching..."
+    ok := true;
+    RAISE NOTICE 'H3 PASS(by-error): broken ON CONFLICT (phone_e164) spec rejected by % (%)', SQLSTATE, SQLERRM;
+  END;
+  IF NOT ok THEN
+    RAISE EXCEPTION 'H3 FAIL: ON CONFLICT (phone_e164) unexpectedly succeeded — a non-partial UNIQUE(phone_e164) must have been added (D-2 fix uses the partial-index RPC, NOT a widened constraint)';
+  END IF;
+END $$;
+
+\echo '== ALL 2.1b ADVERSARIAL ASSERTIONS PASSED (see NOTICE/WARNING lines above for findings) =='

--- a/supabase/migrations/__tests__/orch_1148_venue_suite_migration.test.ts
+++ b/supabase/migrations/__tests__/orch_1148_venue_suite_migration.test.ts
@@ -500,9 +500,14 @@ Deno.test("T-MIG-20 — the P3 fix migration versions are monotonic above all pr
     .filter((n) => /^20261008000\d{3}_orch_1148/.test(n))
     .map((n) => n.slice(0, 14));
   assert(present.length >= 3, "the three P3 fix migrations must exist");
+  // The P3 probe must come AFTER the engine v2 + tz column (so the probe runs
+  // against the v2 engine). NOTE: a later 2.1a follow-up (revoke_anon_turn_helper
+  // at ...003) legitimately sits above the probe, so this asserts ordering, not
+  // strict-max (the original "is the highest" assertion was stale post that add).
   assert(
-    Math.max(...present.map(Number)) === Number(P3_PROBE_FILE.slice(0, 14)),
-    "the P3 probe migration must be the highest (last) prefix",
+    Number(P3_PROBE_FILE.slice(0, 14)) > Number(ENGINE_V2_FILE.slice(0, 14)) &&
+      Number(P3_PROBE_FILE.slice(0, 14)) > Number(TZ_COLUMN_FILE.slice(0, 14)),
+    "the P3 probe must order after the engine v2 + tz-column migrations",
   );
 });
 
@@ -533,5 +538,159 @@ Deno.test("T-MIG-15 — the 2.1a probe asserts the engine contract, the grant bo
     sql,
     /must enforce party_fit/,
     "probe must assert party_fit is enforced server-side",
+  );
+});
+
+/* =========================================================================
+ * 2.1b — reservation lifecycle + waitlist RPCs + SMS consent (T-MIG-21..30).
+ * Fails-on-revert anchors:
+ *   I-PROPOSED-1148-RESERVATION-LIFECYCLE-TRANSITIONS-GUARDED-SERVER-SIDE
+ *   I-PROPOSED-1148-WAITLIST-CONVERT-ATOMIC
+ *   I-PROPOSED-1148-SMS-OPT-OUT-HONORED
+ * ======================================================================= */
+const CONSENT_FILE = "20261010000000_orch_1148_sms_consent_and_log.sql";
+const LIFECYCLE_RPC_FILE = "20261010000001_orch_1148_reservation_lifecycle_rpcs.sql";
+const WAITLIST_RPC_FILE = "20261010000002_orch_1148_waitlist_rpcs_and_indexes.sql";
+const LIFECYCLE_PROBE_FILE = "20261010000003_orch_1148_reservation_lifecycle_probes.sql";
+
+Deno.test("T-MIG-21 — the 2.1b migrations exist and are ADDITIVE (no DROP TABLE/COLUMN)", () => {
+  for (const f of [CONSENT_FILE, LIFECYCLE_RPC_FILE, WAITLIST_RPC_FILE, LIFECYCLE_PROBE_FILE]) {
+    const sql = read(f);
+    assert(sql.length > 0, `${f} must exist`);
+    assert(
+      !/DROP\s+TABLE/i.test(sql) && !/DROP\s+COLUMN/i.test(sql),
+      `${f} must be additive (no DROP TABLE/COLUMN)`,
+    );
+  }
+});
+
+Deno.test("T-MIG-22 — the legal-transition matrix locks terminal states + no_show source", () => {
+  const sql = read(LIFECYCLE_RPC_FILE);
+  // The matrix fn exists.
+  assertMatch(
+    sql,
+    /FUNCTION public\.pg_reservation_transition_is_legal/,
+    "the legal-transition matrix fn must exist",
+  );
+  // requested can confirm; confirmed can seat/no_show; seated can complete/no_show.
+  assertMatch(sql, /WHEN 'confirmed'\s+THEN p_to IN \([^)]*'no_show'[^)]*\)/);
+  assertMatch(sql, /WHEN 'seated'\s+THEN p_to IN \([^)]*'completed'[^)]*\)/);
+  // The ELSE branch returns false → terminal states are locked.
+  assertMatch(sql, /ELSE false/);
+});
+
+Deno.test("T-MIG-23 — biz_reservation_transition is SECURITY DEFINER, gated, audited, enforces legality", () => {
+  const sql = read(LIFECYCLE_RPC_FILE);
+  assertMatch(sql, /FUNCTION public\.biz_reservation_transition/);
+  assertMatch(sql, /SECURITY DEFINER/);
+  assertMatch(
+    sql,
+    /biz_brand_effective_rank_for_caller/,
+    "transition must gate on brand-member rank",
+  );
+  assertMatch(
+    sql,
+    /pg_reservation_transition_is_legal\(v_from, p_to_status\)/,
+    "transition must enforce server-side legality",
+  );
+  assertMatch(sql, /INSERT INTO public\.audit_log/, "transition must be audited");
+  assertMatch(
+    sql,
+    /REVOKE EXECUTE ON FUNCTION public\.biz_reservation_transition[\s\S]*FROM anon/,
+    "transition must NOT be anon-callable",
+  );
+});
+
+Deno.test("T-MIG-24 — biz_reservation_create is guarded + creates FREE operator bookings", () => {
+  const sql = read(LIFECYCLE_RPC_FILE);
+  assertMatch(sql, /FUNCTION public\.biz_reservation_create/);
+  assertMatch(sql, /SECURITY DEFINER/);
+  assertMatch(sql, /biz_brand_effective_rank_for_caller/);
+  assertMatch(sql, /'operator'/, "manual create must set created_via='operator'");
+  // No checkout/charge CODE in the lifecycle RPC migration (money seam stays
+  // 2.2). Strip SQL comments first — the header prose names the 2.2 Stripe seam.
+  const noComments = sql
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/--.*$/gm, "");
+  assert(
+    !/ticket-checkout-create|allInPricingEngine|stripe_charges|payment_intent_id\s*=|stripe\.|paystack\./i.test(
+      noComments,
+    ),
+    "the lifecycle RPC migration must NOT touch any money path",
+  );
+});
+
+Deno.test("T-MIG-25 — waitlist convert is ATOMIC (create reservation + mark converted in one fn)", () => {
+  const sql = read(WAITLIST_RPC_FILE);
+  assertMatch(sql, /FUNCTION public\.biz_waitlist_convert_to_reservation/);
+  assertMatch(sql, /INSERT INTO public\.reservations/);
+  assertMatch(sql, /status = 'converted'/);
+  assertMatch(sql, /converted_reservation_id = v_res\.id/);
+  assertMatch(sql, /SECURITY DEFINER/);
+  assertMatch(sql, /biz_brand_effective_rank_for_caller/);
+});
+
+Deno.test("T-MIG-26 — waitlist mark-notified RPC exists, guarded, audited", () => {
+  const sql = read(WAITLIST_RPC_FILE);
+  assertMatch(sql, /FUNCTION public\.biz_waitlist_mark_notified/);
+  assertMatch(sql, /status = 'notified'/);
+  assertMatch(sql, /INSERT INTO public\.audit_log/);
+});
+
+Deno.test("T-MIG-27 — the SMS consent ledger exists, RLS-enabled, NOT authenticated-readable", () => {
+  const sql = read(CONSENT_FILE);
+  assertMatch(sql, /CREATE TABLE IF NOT EXISTS public\.venue_sms_opt_out/);
+  assertMatch(sql, /ALTER TABLE public\.venue_sms_opt_out ENABLE ROW LEVEL SECURITY/);
+  // No SELECT policy for `authenticated` on the opt-out PII ledger.
+  assert(
+    !/CREATE POLICY[^;]*ON public\.venue_sms_opt_out[\s\S]*?FOR SELECT TO authenticated/i.test(sql),
+    "the opt-out ledger must NOT be authenticated-readable (service-role only)",
+  );
+});
+
+Deno.test("T-MIG-28 — the SMS send log exists + is brand-member-readable + service-write only", () => {
+  const sql = read(CONSENT_FILE);
+  assertMatch(sql, /CREATE TABLE IF NOT EXISTS public\.venue_sms_log/);
+  assertMatch(
+    sql,
+    /CREATE POLICY[^;]*ON public\.venue_sms_log[\s\S]*?biz_is_brand_member_for_read_for_caller/,
+    "the send log must be brand-member-readable",
+  );
+  // No INSERT/ALL policy for authenticated → service_role inserts only.
+  assert(
+    !/CREATE POLICY[^;]*ON public\.venue_sms_log[\s\S]*?FOR (INSERT|ALL) TO authenticated/i.test(sql),
+    "the send log must NOT be authenticated-writable",
+  );
+});
+
+Deno.test("T-MIG-29 — the 2.1b probe asserts transitions guarded, atomic convert, consent (read-only)", () => {
+  const sql = read(LIFECYCLE_PROBE_FILE);
+  // Strip comments AND single-quoted SQL string literals — the probe READS
+  // function defs that CONTAIN write keywords (via position('INSERT …' in v_def)),
+  // but performs no actual writes. The real read-only guard is: no unquoted
+  // INSERT INTO / UPDATE public. statement.
+  const body = sql
+    .replace(/--.*$/gm, "")
+    .replace(/\$q\$[\s\S]*?\$q\$/g, "''") // dollar-quoted literals
+    .replace(/'[^']*'/g, "''"); // single-quoted literals
+  assert(
+    !/\bINSERT\s+INTO\b/i.test(body) && !/\bUPDATE\s+public\./i.test(body),
+    "the 2.1b probe must be read-only (no unquoted writes)",
+  );
+  assertMatch(sql, /pg_reservation_transition_is_legal\('completed', 'seated'\)/);
+  assertMatch(sql, /biz_reservation_transition must enforce legality/);
+  assertMatch(sql, /atomically create the reservation AND mark/);
+  assertMatch(sql, /venue_sms_opt_out.*is missing/);
+});
+
+Deno.test("T-MIG-30 — the 2.1b probe is the new highest migration prefix", () => {
+  const present = [...Deno.readDirSync(DIR)]
+    .map((e) => e.name)
+    .filter((n) => /^20261010000\d{3}_orch_1148/.test(n))
+    .map((n) => n.slice(0, 14));
+  assert(present.length >= 4, "the four 2.1b migrations must exist");
+  assert(
+    Math.max(...present.map(Number)) === Number(LIFECYCLE_PROBE_FILE.slice(0, 14)),
+    "the 2.1b probe migration must be the highest (last) prefix",
   );
 });


### PR DESCRIPTION
Sub-ORCH 2.1b — completes the OPERATOR booking core (operator-side; no consumer surface, no money capture).

- **Reservations module**: list (Today/Upcoming/Waitlist/Completed/No-shows/Canceled + realtime) + manual FREE create/edit + guarded lifecycle (`biz_reservation_transition`, 8-state legal-transition matrix, manager+ gate, audited). No-show records the forfeit policy (Stripe capture is 2.2's seam).
- **Waitlist module**: add/estimate/auto-expire + **atomic** convert-to-reservation (`biz_waitlist_convert_to_reservation`).
- **Twilio SMS** `send-venue-sms`: locked copy "Your table's ready at {Venue}. Reply STOP to opt out." via the approved toll-free Messaging Service only; E.164 + opt-out ledger + audit log; STOP via Twilio Advanced Opt-Out.
- Replaces the Reservations + Waitlist ComingSoon slots.

**Tester CONDITIONAL PASS → cleared:** 2 P2 defects found live + FIXED — D-1 cross-brand `table_id` guard (same-brand check in all 3 RPCs), D-2 defensive opt-out upsert crash (partial-index-safe RPC). Re-verified live.

Migrations `20261010000000..03` + `20261011000000..01` applied to prod via Management API (additive, RLS, REVOKE PUBLIC+anon). Engine FROZEN (read-only), money seam grep-gated (zero checkout/charge). Twilio secrets set. Gates: deno 30/30 + SMS 8/8, venue jest 48/48, I-39, money-seam — green; full-chain Docker apply PASS; fails-on-revert proven. Step 0.5: implementor tests + tester adversarial SQL (cross-brand/terminal-lock/atomic-convert/opt-out) tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)