### PR TITLE
ORCH-1150-R2: RSVP retest fixes (D-1..D-10 + parallax/edit/maybe) [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -409,3 +409,35 @@ Did NOT edit `ParallaxCoverShell.tsx`, `FoundationEventPreview.tsx`, the tickete
 2. After apply, run `supabase/migrations/__tests__/orch_1150_maybe.test.sql` (T1–T4) against the linked remote.
 3. **Deploy edge fn** from MERGED main: `public-submit-rsvp` (keep `verify_jwt=false`).
 4. **Re-OTA** business per the EAS gotchas runbook (the D-7 fix is build-freshness; the CTA is JS-only).
+
+---
+
+# D-9b — RSVP detail Edit passes `mode=edit-published` (published-edit no longer bounces to events list)
+
+## Root cause (proven from source)
+The D-9 fix hardened the edit screen's *safe-exit timing* (auth-flicker), but it did NOT address THIS cause. `app/rsvp/[id]/index.tsx` `handleEdit` (~L144) pushed `/rsvp/{id}/edit` WITHOUT `?mode=edit-published`. The edit screen (`app/rsvp/[id]/edit.tsx:79`) keys `isEditPublished` off `modeParam === 'edit-published'`. Without the param the screen runs the DRAFT-resolution path (`useDraftById`/`useServerDraftById`) — but a PUBLISHED RSVP has no draft, so `draft===null` settles and the screen exits to `safeEventsExitRoute()` = `/(tabs)/hub/events`. The Hub manage-menu Edit (`app/(tabs)/hub/events.tsx:404`) correctly appends `?mode=edit-published` for non-draft rows; the detail page's `handleEdit` did not. That asymmetry was the bug.
+
+## The fix (one line)
+`app/rsvp/[id]/index.tsx` `handleEdit`: `router.push(\`/rsvp/${id}/edit?mode=edit-published\`)` (was the bare `/rsvp/${id}/edit`). The detail page is ONLY ever shown for a published/live RSVP — the draft case is already redirected away earlier in the "Defensive: draft → redirect" effect (~L110-120, a `router.replace` to the bare draft route, which legitimately omits the mode). So `handleEdit` unconditionally appending `?mode=edit-published` is correct. A 10-line explanatory comment accompanies the change.
+
+## Published-edit resolution verification (no second bounce introduced)
+With `?mode=edit-published`, `edit.tsx` resolves the live event via `useBusinessEventById(idParam)` → `resolvedLiveEvent = serverLiveEvent ?? liveEvent` (L117-123) and mounts the RSVP-aware `EditPublishedScreen` with `rsvpMode` (L554-558). CONFIRMED:
+1. **`fetchBusinessEventById` resolves a published RSVP.** `src/services/businessEvents.ts:631-676` rejects ONLY `event_type === 'trip'` (L647-648). An `event_type='rsvp'` row passes the probe and resolves via `business_management_events_view`. This is the SAME data layer the D-4 detail page used successfully (`useManagedEventRoute` → `fetchBusinessEventById`), so RSVP rows are proven to resolve. NO data-layer change required (verification #1 passes; ticketed path untouched).
+2. **`EditPublishedScreen` mounts in `rsvpMode`** for the resolved RSVP (L554-564) and does not itself bounce — the D-9 conservative safe-exit (L218-229: `isAuthReady && resolved===null && !isLoading && !isFetching`) only fires when the live-event lookup is genuinely exhausted; with a resolvable RSVP it never triggers.
+3. **`le_`→`serverEventId` redirect** (L198-206) already re-appends `?mode=edit-published`, so an `le_<ts36>` detail id stays on the published-edit path through the redirect. Confirmed unchanged in source.
+**No second resolution bug found.** Fix is purely the one-line route change in `index.tsx`.
+
+## Tests + fails-on-revert
+- `app/rsvp/[id]/__tests__/index.test.tsx` — appended D-9b block (2 tests): (a) `handleEdit` pushes the edit screen WITH `?mode=edit-published`; (b) NO bare `router.push(\`/rsvp/{id}/edit\`)` remains (the defensive draft redirect is a `router.replace`, so the negative assertion is valid). Suite: **17/17 pass**.
+- **fails-on-revert verified at 876d64cde**: true line-deletion of the `?mode=edit-published` query (perl substitution back to the bare route) → both D-9b tests FAIL (2 failed, 15 passed); restored → 17/17 green. (Append-only: no existing test modified/deleted.)
+
+## Gates
+- **tsc** (`npx tsc --noEmit -p tsconfig.json`, mingla-business): ZERO new errors — 333 baseline errors before == 333 after (diff of sorted error sets is empty). All baseline errors are pre-existing cross-package/`any`-param noise in files I did not touch (phone-input, checkout buyers, search adapters); neither touched file appears in the error set.
+- **`i-proposed-tr2-route-by-event-type.mjs`**: exit 0 (GREEN). 6 violations reported are PRE-EXISTING (identical count on pristine HEAD via stash; all in ScannerHome / hub trips / accept-scanner-invitation — files I did not touch). My `/rsvp/...` route is not a `/event/` or `/trip/` target, so the gate is unaffected.
+- jest rsvp index suite: 17/17 green.
+
+## DO-NOT-TOUCH compliance
+Edited ONLY `app/rsvp/[id]/index.tsx` (the one-line route fix + comment) and its test `app/rsvp/[id]/__tests__/index.test.tsx`. Did NOT touch the data layer (verification #1 confirmed no change needed), the ticketed `app/event/[id]/**`, the event-edit screen behavior, `app/rsvp/[id]/edit.tsx`, or any parallel-workstream file.
+
+## Commit
+`ORCH-1150-R2: D-9b — RSVP detail Edit passes mode=edit-published (published-edit no longer bounces to events list)`

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -286,3 +286,68 @@ Source-built + gates run; NOT driven on sim/device this turn. Verified by tsc (z
 ## D-5.11 Discoveries for orchestrator (D-5)
 
 - **DISC-1150R2-A (carried forward, NOT introduced here):** `i-proposed-tr2-route-by-event-type.mjs` is RED on the branch baseline with 6 violations in DO-NOT-TOUCH files (home.tsx, hub/trips.tsx, accept-scanner-invitation.tsx, ScannerHome.tsx) — unrelated scanner/trip routes lacking the helper/allowlist. My change is gate-clean (zero new violations). Recommend a dedicated gate-cleanup ORCH; out of scope here.
+
+---
+
+# D-8 + D-9 (mingla-implementor, 2026-06-17)
+
+Implemented per the binding SPEC `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1150_RETEST_D6_D9.md` §D-8/§D-9. D-6/D-7 were OUT of this dispatch's scope (parallel workstream); `RsvpPublicBody.tsx`, `ParallaxCoverShell.tsx`, and the public-page CTA were NOT touched.
+
+## Commits
+- D-9: `0636b3e06`
+- D-8: `b8ee98baa`
+
+## D-9 — published-RSVP edit no longer bounces to the events list
+
+### Files
+- `mingla-business/app/rsvp/[id]/edit.tsx` (guard hardened, ~12 lines incl. comment)
+- `mingla-business/app/rsvp/[id]/__tests__/editPublishedExitGuard.test.ts` (NEW, 5 tests)
+
+### Old → New
+- **Before:** the edit-published safe-exit fired on `resolvedLiveEvent === null && !businessEventQuery.isLoading`. A DISABLED React-Query query (`enabled = isAuthReady && eventId`) reports `isLoading=false`; during the `isAuthReady` flicker (fresh push, empty `useLiveEventStore`) the exit bounced a published RSVP to `/(tabs)/hub/events` before the fetch ran.
+- **Now:** gated on `isAuthReady && resolvedLiveEvent === null && !businessEventQuery.isLoading && !businessEventQuery.isFetching` — bounces ONLY when the lookup is genuinely exhausted. Strictly more conservative; can never bounce earlier than before. All four terms were already in the effect dep array.
+- **Why:** SPEC §D-9 / SC-5. RSVP-route-only; ticketed `app/event/[id]/edit.tsx` untouched (DO-NOT-TOUCH honored).
+
+### Test + fails-on-revert
+- 4 pure-logic predicate tests (auth-flicker, in-flight fetch, event-found, exhausted) + 1 source-binding assertion that the shipped guard carries `isAuthReady` + `!isFetching`.
+- **fails-on-revert verified at `0636b3e06`** by TRUE LINE DELETION of the `isAuthReady &&` + `!businessEventQuery.isFetching` terms → the source assertion FAILS; restored → 5/5 PASS.
+
+## D-8 — RSVP detail keeps Blasts + Group-chat (comms, not money)
+
+### Files
+- `mingla-business/app/rsvp/[id]/index.tsx` (2 handlers + 2 ActionTiles, ~28 lines)
+- `mingla-business/src/services/marketing/marketingAudienceService.ts` (`resolveRsvpGuests`, ~95 lines)
+- `mingla-business/src/hooks/marketing/useEventBuyers.ts` (optional `eventType` arg + event_type probe + RSVP routing, ~55 lines)
+- `mingla-business/src/services/marketing/__tests__/marketingAudienceService.test.ts` (+5 tests, additions only)
+- `mingla-business/src/hooks/marketing/__tests__/useEventBuyers.rsvpAudience.test.ts` (NEW, 5 tests)
+- `mingla-business/app/rsvp/[id]/__tests__/index.test.tsx` (D-4 DROP assertion narrowed + D-8 block; file is net-ADDED vs origin/main → append-only clean)
+
+### Old → New
+- **Group chat tile:** routes `/event/{id}/group-chat` (REUSE-SAFE — event-scoped, event_type-agnostic; the RSVP already has a `conversations` row). Allowlist comment present.
+- **Blasts tile:** routes `/event/{id}/blasts`. `resolveEventBuyers` reads `orders` → an RSVP has zero orders → empty audience forever. NEW `resolveRsvpGuests(eventId)` reads `event_rsvps` `rsvp_status='going'` + `approval_status='approved'` (`guest_name/guest_email/guest_phone`), maps them onto the same aggregate/mask/consent path, and returns the IDENTICAL `{ rows, reach }` shape so the shared Blasts UI + `BuyerRow` render unchanged. `useEventBuyers` gained an optional `eventType` arg; when omitted (the DO-NOT-TOUCH `app/event/[id]/blasts` screen passes none) the hook probes `events.event_type` once and routes RSVP events to `resolveRsvpGuests`. The two existing callers (`blasts/index.tsx`, `useResolveAudience.ts`) are unaffected (optional arg, auto-probe).
+- Tiles reuse the shared `ActionTile` (icons `send`/`chat`, matching the ticketed event detail) so the Android opaque-glass policy is inherited automatically — no new glass surface authored.
+
+### RLS confirmation (the FLAG in SPEC §10 / Open Q-3)
+DB probe (read-only, project `gqnoajqerqhnvulmnyvv`): `event_rsvps` carries `event_rsvps_host_read` (cmd `r`/SELECT) with USING `EXISTS (SELECT 1 FROM events e WHERE e.id = event_rsvps.event_id AND biz_brand_effective_rank(e.brand_id, auth.uid()) >= biz_role_rank('event_manager'))`. The Blasts host is a logged-in business user managing the brand, so the going+approved guest read is covered. **No migration / RPC / RLS widening needed — client query only.** (Same policy the existing ORCH-1150 going-count probe in `businessEvents.ts:596` already reads under.)
+
+### Tests + fails-on-revert
+- `marketingAudienceService.test.ts`: `resolveRsvpGuests` reads `event_rsvps` (NOT `orders`), maps going-guests, empty/error/UUID-guard paths (+5).
+- `useEventBuyers.rsvpAudience.test.ts`: imports `resolveRsvpGuests`, routes by `event_type`, optional-arg + probe, type-gated `audienceEnabled`, type-keyed cache (5).
+- `index.test.tsx` D-8 block: Group-chat + Blasts tiles present, route to the event-scoped screens, and carry ≥2 route-by-event-type allowlist comments.
+- **fails-on-revert verified at `b8ee98baa`**: TRUE LINE DELETION of the `resolvedType === "rsvp" ? resolveRsvpGuests : resolveEventBuyers` hook branch → hook test FAILS; deletion of the two tiles → detail test FAILS (2 D-8 tests). Restored → 50/50 PASS across the 4 D-8/D-9 suites; 207/207 across the full marketing suite (no regression).
+
+## Gate / tsc / test results (D-8 + D-9)
+- `npx tsc --noEmit -p tsconfig.json` (mingla-business): 333 errors WITH my changes, 333 WITHOUT (stash compare) → ZERO new errors; none in any touched file (`edit.tsx`/`index.tsx`/`marketingAudienceService.ts`/`useEventBuyers.ts`/tests). The 333 are pre-existing repo-wide (checkout buyer.tsx implicit-any, RTL render-test module resolution, richEditor, search adapters, payments native modules, DraftEvent.category fixtures).
+- `node .github/scripts/strict-grep/i-proposed-tr2-route-by-event-type.mjs`: the RSVP screen produces ZERO violations (both `/event/...` pushes allowlisted). The gate still exits non-zero on **6 PRE-EXISTING** violations in DO-NOT-TOUCH files (home.tsx:414, hub/trips.tsx:379/388/397, accept-scanner-invitation.tsx:94, ScannerHome.tsx:119) — identical with my changes stashed, files untouched vs origin/main. See DISC-1150R2-A. My change is gate-clean.
+- `node .github/scripts/test-append-only-check.js`: 10 passed, 0 failed (my `marketingAudienceService.test.ts` = additions-only; `index.test.tsx` = net-ADDED vs origin/main).
+- jest (D-8/D-9 suites): 50/50 PASS. Marketing regression: 207/207 PASS.
+
+## DO-NOT-TOUCH compliance (D-8 + D-9)
+- NOT touched: `app/event/[id]/**` (only ROUTED to), `RsvpPublicBody.tsx`, `ParallaxCoverShell.tsx`, `GroupChatPanel.tsx`, `EditPublishedScreen` ticketed behavior, `blasts/index.tsx` UI, any migration/RPC. The Blasts audience is a pure client query under existing RLS. D-6/D-7 files (public-page CTA, parallax shell) left for the parallel workstream.
+
+## Operator action required (D-8 + D-9)
+- None for backend: no migration, no edge deploy, no RPC. `event_rsvps` read runs under the existing `event_rsvps_host_read` policy.
+- For TEST (clean build bound to THIS worktree, per SPEC §11): (1) tap Edit on a PUBLISHED (scheduled/live) RSVP from the Hub → must open the RSVP-aware EditPublishedScreen, not the events list; also cold deep-link `/rsvp/{uuid}/edit?mode=edit-published`. (2) Open an RSVP detail → tap Group chat (existing conversation loads, host can post) and Blasts (audience = going `event_rsvps` guests, NOT "no buyers"). (3) Regression: a published TICKETED event Edit + Blasts behave identically to before.
+
+## Verdict
+D-8 + D-9 implemented and verified at the source/unit/gate layer; live-fire (device) deferred to TEST per SPEC (the reproducer-bound items were capped at probable upstream due to the shared-Metro blocker).

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -125,3 +125,85 @@ None. The RSVP publish RPC (`business_publish_rsvp_draft`) was read-verified (lo
 - **DISC-1150R2-B:** mingla-business tsc has 409 pre-existing baseline errors (missing `@testing-library/react-native` + `@mingla/payments-native` modules, stale `category` field on DraftEvent in 4 test files, several component type errors). The repo's "tsc clean" claim does not hold on main today.
 - **DISC-1150R2-C (carried from forensics DISC-1150-R-A/B):** `createServerDraft` is the SHARED promotion service for event+RSVP; a SECOND d_*→server migration path exists in `useServerDraftEvents.ts` (Hub legacy loop) also calling `createServerDraft` — it now inherits the rsvp typing automatically (good), but any future offering type lazily promoting a d_* draft must set its own discriminator there.
 - **DISC-1150R2-D:** the `EditPublishedScreen` RSVP edit-published path (`?mode=edit-published`) for a LIVE RSVP is reachable via `handleManageEdit` now routing to `/rsvp/{id}/edit?mode=edit-published`; the RSVP route already handles that mode (rsvpMode). Worth a device check that live-RSVP "Edit" lands on the RSVP-aware screen (in scope of TEST).
+
+---
+
+# D-4 — Tailored RSVP host detail/dashboard page (`app/rsvp/[id]/index.tsx`)
+
+- **Binding contract:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1150_RSVP_DETAIL_PAGE.md` (PART 2 SPEC, §5 KEEP/DROP + §8 build order + finding F-2).
+- **Dispatch:** retest fix for the white-screen 404 when tapping a LIVE RSVP event. Root cause (proven): `routeForEventRow` correctly routes a non-draft RSVP row to `/rsvp/{id}`, but `app/rsvp/[id]/index.tsx` did not exist → expo-router rendered the branded `+not-found.tsx` (enlarged-logo white screen). The ONLY fix is to create the missing screen.
+- **No migration. No edge deploy. No service/RPC/hook change. No OTA. No merge.**
+
+## D-4.1 Summary (plain English)
+
+Tapping a live (or scheduled) RSVP event in the business Hub now opens a real RSVP host dashboard instead of a white screen with an oversized logo. The page shows the cover, status pill, title, date·venue, an "N going" headcount, and tiles for Guests (approve/deny/remove console), Edit, Public page, Share, and Brand page. It deliberately shows NO tickets, revenue, scanners, orders, door sales, reconciliation, blasts, group-chat, activity feed, or cancel/manage menu — RSVP has no money and no tickets.
+
+## D-4.2 SPEC coverage
+
+| SC | Criterion | Status | Commit |
+|----|-----------|--------|--------|
+| F-1 | `/rsvp/{id}` resolves to a real screen (no +not-found) | ✓ NEW file created | (this commit) |
+| KEEP-hero | cover + status pill + title + date·venue | ✓ | (this commit) |
+| KEEP-going | "N going" via `formatRsvpGoingLabel`; "No one's responded yet"/"0 going" empty state | ✓ | (this commit) |
+| KEEP-guests | Guests tile → `/rsvp/{id}/guests`; manual-mode "Approve / deny" sub | ✓ | (this commit) |
+| KEEP-edit | Edit tile → `/rsvp/{id}/edit` | ✓ | (this commit) |
+| KEEP-share | Share IconChrome + ShareModal w/ `eventPublicUrl` `/e/{brandSlug}/{eventSlug}` | ✓ | (this commit) |
+| F-2 data hook | going-count from `useBusinessEventsForBrand(brandId).find(byId).rsvpGoingCount`, NOT `fetchBusinessEventById` | ✓ | (this commit) |
+| DROP-money | NO revenue card / moneySummary / ticket types / scan / orders / door / recon / blasts / group-chat / activity / cancel / manage menu | ✓ (test-enforced) | (this commit) |
+| States | loading (page shell + "Loading RSVP…", NOT white screen), not-found (EmptyState + Back), populated, empty going-count | ✓ | (this commit) |
+| Gate | `i-proposed-tr2-route-by-event-type` adds ZERO new violations (only `/rsvp/`,`/e/`,`/brand/`,`/(tabs)/` literals) | ✓ | (this commit) |
+
+## D-4.3 Files created (2)
+
+- `mingla-business/app/rsvp/[id]/index.tsx` (NEW, ~440 lines) — `RsvpDetailScreen` default export.
+- `mingla-business/app/rsvp/[id]/__tests__/index.test.tsx` (NEW, ~140 lines) — structural happy-path + subtractive regression test (12 cases).
+
+DO-NOT-TOUCH list untouched: `app/event/[id]/index.tsx`, all `EventDetail*` components, `routeForEventRow.ts`, the strict-grep gate, every service/hook/RPC/migration/edge-fn — all unchanged (verified: `git status` shows only the 2 new files).
+
+## D-4.4 KEEP / DROP realized
+
+**KEEP (cloned + adapted from `event/[id]/index.tsx`):** TopBar back (title "RSVP"); Share IconChrome → ShareModal (url via `eventPublicUrl`); hero `EventCoverMedia` + `EventDetailHeroStatusPill` + title + date·venue subline (status via `deriveScreenStatus`, verbatim); "N going" headcount in a `GlassCard` (replaces the revenue KPI card); Guests `ActionTile` → `/rsvp/{id}/guests` (manual-mode shows "Approve / deny", else the going label); Edit `ActionTile` → `/rsvp/{id}/edit`; Public-page `ActionTile` → `/e/{brandSlug}/{eventSlug}`; Brand-page `ActionTile`; Toast wrap; not-found EmptyState (illustration "users", "RSVP event not found"); loading shell (header + "Loading RSVP…", never a blank screen).
+
+**DROP (not cloned):** `EventDetailKpiCard` revenue card · `moneySummary`/`summarizeEventMoney` + all revenue/payout/covered/door derivations · currency-mismatch card · TICKET TYPES + `EventDetailTicketTypeRow` + `soldCountByTier` · Scan/Scanners tiles · Orders tile + `useEventOrders` + `totalSoldCount` · Door Sales tile + `useDoorSalesStore` + `doorSoldCount` · `ReconciliationCtaTile` · Blasts tile · Group-chat tile · recent-activity feed (`EventDetailActivityRow` + the 8-stream merge) · End-sales sheet + cancel flow · `EventManageMenu` mount · guest-comp store. Per SPEC OQ-1/OQ-2: cancel omitted from v1; manual-mode pending count lives inside the console (tile shows static "Approve / deny").
+
+## D-4.5 Data-hook used (finding F-2)
+
+`useManagedEventRoute(id)` → `{ event, brand, isLoading }` for cover/title/status/date/venue/slugs/`rsvpCapacity`/`rsvpApprovalMode` (its `rsvpGoingCount` is NOT trusted — `fetchBusinessEventById` zeroes it). The headcount is read from the Hub LIST query `useBusinessEventsForBrand(brand?.id ?? null)`, found-by-id (`e.id === id || e.serverEventId === id`) — the same cache the Hub card reads, so the count matches what the host just saw. Fallback to `event.rsvpGoingCount ?? 0` until the list resolves (non-blocking, self-correcting). No service touched.
+
+## D-4.6 Regression test + fails-on-revert proof
+
+- **Test:** `mingla-business/app/rsvp/[id]/__tests__/index.test.tsx` — 12 structural cases (file-exists + KEEP-element presence + DROP-element absence + F-2 data-hook + route-literal safety). Structural source test follows the sibling precedent (`app/event/[id]/__tests__/cancel-no-navigation.test.tsx`): the screen's dependency graph (Expo Router + useManagedEventRoute + Zustand) is too heavyweight for Node-env jest, and `@testing-library/react-native` is absent from devDeps (baseline). The `readFileSync` of `index.tsx` THROWS when the file is absent — the missing-route white-screen condition.
+- **Passing run:** `12 passed, 12 total`.
+- **Fails-on-revert (TRUE LINE DELETION, not comment-out):** deleted `app/rsvp/[id]/index.tsx` → suite FAILED (`1 failed, 0 tests run` — readFileSync threw, exactly the +not-found fallback condition); restored the file → `12 passed`. **fails-on-revert verified.**
+
+## D-4.7 Gate + tsc results
+
+- **`npx tsc --noEmit -p tsconfig.json` (mingla-business):** ZERO errors in `app/rsvp/[id]/*` (grep on `app/rsvp/` → empty). 333 errors total, ALL pre-existing on the branch baseline (checkout buyer `any` params, marketing ComposerV2, search adapters rsvp-type, `@testing-library/react-native`/`@mingla/payments-native` missing modules, stale DraftEvent `category` in test fixtures) — none in my new files (proven: only the 2 new files are added; `git status` = clean except them).
+- **`node .github/scripts/strict-grep/i-proposed-tr2-route-by-event-type.mjs`:** 6 violations, ALL PRE-EXISTING (home.tsx:414, hub/trips.tsx:379/388/397, accept-scanner-invitation.tsx:94, ScannerHome.tsx:119). Proven identical count WITH my files (789 files, 6) and WITHOUT (788 files, 6) — **my change adds ZERO new violations**; my new file is NOT flagged (uses only `/rsvp/`,`/e/`,`/brand/`,`/(tabs)/` literals, the gate bans only `/event/` and `/trip/`). Carries forward DISC-1150R2-A (gate is RED on main for unrelated scanner routes — gate-cleanup ORCH).
+- **New jest test:** `12 passed`.
+
+## D-4.8 Cross-surface impact
+
+| Surface | Affected | Note |
+|---------|----------|------|
+| Consumer iOS / Android | No | RSVP host detail is host-only |
+| Buyer/anon Web | No | buyers use the public page `/e/{slug}/{slug}` (separate, working) |
+| Business iOS | **Yes** | tap live RSVP → host dashboard (no white screen) — `app/rsvp/[id]/index.tsx` (NEW) |
+| Business Android | **Yes** | same NEW file, parity automatic (shared RN) |
+| Admin Web | No | not an admin surface |
+| Business Web preview | Incidental | same RN route compiles to web; renders the same dashboard if reached |
+
+## D-4.9 Smoke result
+
+Source-built + gates run; NOT driven on sim/device this turn (no dev build exercised). Verified by tsc (zero new errors), the 12-case jest suite (pass + fails-on-revert), and the route gate (zero new violations). REQUIRES device proof at TEST: tap a live RSVP event in the Hub → lands on the RSVP dashboard (no +not-found); the "N going" matches the Hub card; Guests/Edit/Public-page/Share all route correctly.
+
+## D-4.10 Known issues / deferred (D-4)
+
+- No render-level test (RN testing-library absent at baseline) — structural test + device proof at TEST cover it.
+- OQ-1 (cancel/unpublish RSVP) and OQ-2 (live pending-approval badge) deferred per SPEC recommendation — non-blocking.
+- No `[TRANSITIONAL]` code introduced.
+
+## D-4.11 Operator action required (D-4)
+
+- None for backend (no migration, no edge deploy).
+- **For TEST/retest:** after review, OTA the business dev channel from MERGED main, then on device tap a LIVE RSVP event in the Hub and confirm: (1) RSVP dashboard renders (no white-screen/enlarged-logo); (2) "N going" headcount; (3) Guests → console; (4) Edit → RSVP edit screen; (5) Public page + Share work.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -207,3 +207,82 @@ Source-built + gates run; NOT driven on sim/device this turn (no dev build exerc
 
 - None for backend (no migration, no edge deploy).
 - **For TEST/retest:** after review, OTA the business dev channel from MERGED main, then on device tap a LIVE RSVP event in the Hub and confirm: (1) RSVP dashboard renders (no white-screen/enlarged-logo); (2) "N going" headcount; (3) Guests → console; (4) Edit → RSVP edit screen; (5) Public page + Share work.
+
+---
+
+# D-5 — RSVP in-app preview route (`app/rsvp/[id]/preview.tsx`)
+
+- **Binding contract:** `Mingla_Artifacts/specs/SPEC_ORCH-1150_RSVP_PREVIEW_ROUTE.md` (follows `INVESTIGATE_ORCH-1150_RSVP_RENDER_SWEEP.md`).
+- **Base:** HEAD `fc285b92f` (D-4). NOT rebased (continue-the-batch dispatch).
+- **No migration. No edge deploy. No OTA. No merge.**
+
+## D-5.1 Summary (plain English)
+
+The RSVP wizard's "Preview public page" button pushed `/rsvp/{id}/preview`, but that screen file did not exist → expo-router fell through to the branded 404 (`+not-found.tsx`), the white-screen / enlarged-logo crash Seth hit at retest. Same class as the D-4 missing `/rsvp/[id]/index.tsx`. The fix is a single additive route file `app/rsvp/[id]/preview.tsx` — a subtractive clone of the ticketed `app/event/[id]/preview.tsx` that resolves the RSVP draft identically (d_*→server migration + stale/missing recovery) but renders the money-free `RsvpPublicBody` (Going / Not-going) instead of the ticket-assuming `PreviewEventView`. The preview's Going/Not-going CTA is a NO-OP: it shows a "This is a preview" toast and never calls `submitPublicRsvp` / the edge function (a draft has no public guest list).
+
+## D-5.2 SPEC success-criteria coverage
+
+| SC | Met | How (commit) |
+|----|-----|--------------|
+| SC-1-iOS/Android/Web | ✓ | `app/rsvp/[id]/preview.tsx` created → `/rsvp/{id}/preview` resolves (no 404); renders cover+title+date·venue+Going/Not-going via `RsvpPublicBody` |
+| SC-2 (no tickets) | ✓ | Mounts `RsvpPublicBody` (never `PreviewEventView`/`FoundationEventPreview`); mapper sets `tickets:[]`, no checkout/price |
+| SC-3 (submit no-op) | ✓ | `handlePreviewSubmit` shows "This is a preview. Publish to let guests RSVP." toast; NO `submitPublicRsvp` import/call |
+| SC-4 (back) | ✓ | `handleBack` = `router.canGoBack()` ? `router.back()` : `/(tabs)/hub/events` — no dead end |
+| SC-5 (d_* draft) | ✓ | d_*→server migration `useEffect` copied verbatim, `/event` swapped to `/rsvp` — no crash on un-promoted draft |
+| SC-6 (wrong-wizard) | ✓ | `draft.isRsvp === false` → `router.replace('/event/${draft.id}/preview')` (strict-grep allowlisted) |
+| SC-7 (no-regression) | ✓ | `git status` shows ONLY 2 new files; `event/[id]/preview.tsx`, `PreviewEventView.tsx`, `PublicEventPage.tsx`, `RsvpPublicBody.tsx` byte-unchanged |
+
+## D-5.3 Files changed
+
+- `mingla-business/app/rsvp/[id]/preview.tsx` — **NEW** (~340 lines): RSVP preview route.
+- `mingla-business/app/rsvp/[id]/__tests__/preview.test.tsx` — **NEW** (~95 lines): happy-path regression test.
+
+No shared-component edits. `mapDraftToPublicEvent` + `mapBrandToPublicBrand` are inlined local helpers (NOT exported from `PublicEventPage`, per the DO-NOT-TOUCH guard).
+
+## D-5.4 Old → New receipt
+
+### `app/rsvp/[id]/preview.tsx` (NEW)
+- **Before:** file did not exist → `/rsvp/{id}/preview` fell through to `+not-found.tsx` (white-screen crash).
+- **Now:** resolves the RSVP draft (useDraftById + useServerDraftById, d_*→server migration, stale/missing recovery — copied from `event/[id]/preview.tsx` with `/event`→`/rsvp` targets), maps the draft into `PublicEventProps` (tickets:[], slugs ""), renders `RsvpPublicBody` with a preview-mode no-op `onSubmit` and a toast `onShare`. Wrong-wizard guard redirects an `isRsvp===false` draft to the ticketed preview.
+- **Why:** SC-1..SC-6 — close the one render crash the sweep found.
+
+## D-5.5 Regression test (fails-on-revert)
+
+- **Path:** `mingla-business/app/rsvp/[id]/__tests__/preview.test.tsx` — 8 tests, all PASS (structural source test; mirrors the D-4 sibling — the RsvpPublicBody→ParallaxCoverShell→expo-haptics render graph is too heavyweight for the default node/ts-jest config; the tester owns the RTL render-proof).
+- **fails-on-revert verified at `fc285b92f`** (pre-commit): TRUE FILE DELETION of `app/rsvp/[id]/preview.tsx` → `readFileSync` throws → suite fails (`1 failed, 0 tests`). Restored → `8 passed`. (Not a comment-out — the file was `mv`'d out and back.)
+
+## D-5.6 Gate results
+
+- **`npx tsc --noEmit -p tsconfig.json` (mingla-business):** ZERO errors in `app/rsvp/[id]/preview*` (grep on `rsvp/[id]/preview` → empty). The repo-wide pre-existing errors (checkout `any` params, RTL/`@mingla/payments-native` missing modules, stale DraftEvent `category` test fixtures, marketing ComposerV2) are unchanged baseline — none in my 2 new files (proven: only 2 files added, both clean).
+- **`node .github/scripts/strict-grep/i-proposed-tr2-route-by-event-type.mjs`:** 6 violations, ALL PRE-EXISTING (home.tsx:414, hub/trips.tsx:379/388/397, accept-scanner-invitation.tsx:94, ScannerHome.tsx:119). Proven identical count WITH my files (790 files, 6) and WITHOUT (789 files, 6) — **my change adds ZERO new violations**; my new file's one `/event/${draft.id}/preview` literal carries the `// orch-strict-grep-allow route-by-event-type` comment and is NOT flagged. Carries forward DISC-1150R2-A (gate is RED on the branch for unrelated scanner/trip routes — gate-cleanup ORCH).
+- **New jest test:** `8 passed`.
+
+## D-5.7 Cross-surface impact
+
+| Surface | Affected | Note |
+|---------|----------|------|
+| Consumer iOS / Android | No | RSVP preview is a business authoring surface |
+| Buyer/anon Web | No | the PUBLIC `/e/{slug}/{slug}` RSVP page already renders (sweep F-2); preview is host-only |
+| Business iOS | **Yes** | tap "Preview public page" in the RSVP wizard → RSVP preview (no 404) — `app/rsvp/[id]/preview.tsx` (NEW) |
+| Business Android | **Yes** | same NEW file, parity automatic (shared RN) |
+| Admin Web | No | no RSVP wizard |
+| Business Web preview | Incidental | same RN route via Metro web |
+
+## D-5.8 Smoke result
+
+Source-built + gates run; NOT driven on sim/device this turn. Verified by tsc (zero new errors), the 8-case jest suite (pass + fails-on-revert proven by true file deletion), and the route gate (zero new violations). REQUIRES device proof at TEST: in the RSVP wizard Preview step, tap "Preview public page" → RSVP public preview renders (cover + title + date·venue + Going/Not-going), no ticket UI, no 404; tapping Going shows the preview toast and writes nothing; back returns to the wizard.
+
+## D-5.9 Known issues / deferred (D-5)
+
+- No RTL render-level test (RN testing-library absent at the default-config baseline) — structural test + device proof at TEST cover it. The tester may add a `jest.orch1150.render.cjs` mount.
+- OQ-1 (preview brandSlug/eventSlug "" placeholders) and OQ-2 (`isLoggedIn=true` default — contact form hidden) resolved per SPEC defaults; non-blocking, flip-able.
+- No `[TRANSITIONAL]` code introduced.
+
+## D-5.10 Operator action required (D-5)
+
+- None for backend (no migration, no edge deploy).
+- **For TEST/retest:** after review, OTA the business dev channel from MERGED main, then on the dev build open the RSVP wizard → Preview step → tap "Preview public page" and confirm the RSVP preview renders (no white-screen/enlarged-logo), shows Going/Not-going (no ticket tiers/price/checkout), the Going tap shows "This is a preview" + writes nothing, and back returns to the wizard. Also smoke the d_* (fresh draft) and a hand-typed `/rsvp/{ticketed-id}/preview` (redirects to event preview).
+
+## D-5.11 Discoveries for orchestrator (D-5)
+
+- **DISC-1150R2-A (carried forward, NOT introduced here):** `i-proposed-tr2-route-by-event-type.mjs` is RED on the branch baseline with 6 violations in DO-NOT-TOUCH files (home.tsx, hub/trips.tsx, accept-scanner-invitation.tsx, ScannerHome.tsx) — unrelated scanner/trip routes lacking the helper/allowlist. My change is gate-clean (zero new violations). Recommend a dedicated gate-cleanup ORCH; out of scope here.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -351,3 +351,61 @@ DB probe (read-only, project `gqnoajqerqhnvulmnyvv`): `event_rsvps` carries `eve
 
 ## Verdict
 D-8 + D-9 implemented and verified at the source/unit/gate layer; live-fire (device) deferred to TEST per SPEC (the reproducer-bound items were capped at probable upstream due to the shared-Metro blocker).
+
+---
+
+# D-10 — Going / Maybe / Can't-go CTA + new 'maybe' RSVP status  (commit f2d4237d9)
+
+## Summary
+Added a third RSVP status `'maybe'`: an OPTIONAL attendee — auto-approved, CAP-NEUTRAL, on the notify list, never occupying a seat. Mirrors `not_going`'s cap-neutrality but stays on the guest list. The public CTA is now THREE equal-width buttons (Going · Maybe · Can't go) with lucide icons. 6 additive layers, no behavior change to capacity/drain/headcount.
+
+## Migration (written, NOT applied — orchestrator applies)
+- **File:** `supabase/migrations/20261012000000_orch_1150_rsvp_maybe.sql` (prefix strictly > head `20261011000001`; checked anchor + sibling worktrees). Atomic `BEGIN/COMMIT`, idempotent, `NOTIFY pgrst` at end.
+- **DDL summary:**
+  - (a) **CHECK widen** — `DROP CONSTRAINT IF EXISTS event_rsvps_rsvp_status_check` + `ADD … CHECK (rsvp_status IN ('going','not_going','waitlisted','maybe'))`.
+  - (b) **RLS widen** — re-create `event_rsvps_guest_update_own` `WITH CHECK (user_id = auth.uid() AND rsvp_status IN ('going','not_going','maybe'))`.
+  - (c) **`submit_event_rsvp`** (full `CREATE OR REPLACE`) — validation now allows `'maybe'` (else `rsvp_status_invalid`); a `'maybe'` branch BEFORE the capacity math sets `v_status='maybe'; v_approval='approved'` (auto-approved, no cap consumption, `waitlisted_at` stays NULL). The confirmed-headcount SUM WHERE stays `going AND approved` UNCHANGED. GRANT after `$$;`.
+  - (d) **`host_list_rsvp_guests`** (`DROP` + `CREATE`, RETURNS TABLE) — order CASE gets a `WHEN r.rsvp_status='maybe' THEN 3` bucket (else→4). GRANT after `$$;`.
+  - NOT touched: `fn_rsvp_drain_on_capacity_freed`, `business_public_events_view.rsvp_going_count`, `host_bulk_approve_rsvps` (verify-only — they already exclude maybe).
+
+## Edge function
+- `supabase/functions/public-submit-rsvp/index.ts` — request type + validation accept `'maybe'`; A4-NEW anon contact gate is status-agnostic and still requires name+email+phone for a Maybe link guest (not relaxed). `verify_jwt=false` (unchanged, config.toml untouched). `deno check` PASS.
+
+## Service / shared types
+- `mingla-business/src/services/rsvpEvents.ts` — `SubmitPublicRsvpInput.rsvpStatus` + `SubmitPublicRsvpResult.status` +`'maybe'`.
+- `mingla-business/src/services/rsvpApprovals.ts` — `RsvpStatusValue` +`'maybe'`.
+- `packages/event-rendering/offeringCta.ts` — `RsvpCtaState` + `ResolveRsvpCtaInput.guestStatus` +`'maybe'`; `resolveRsvpCta` adds `if (guestStatus === "maybe") return { state: "maybe" }` after not_going (pending still outranks).
+
+## Component CTA (RsvpPublicBody.tsx)
+- 3 equal-size buttons, each `flex:1` via the new shared `ctaBtn` style — **Going · Maybe · Can't go**.
+- **Icons:** per-icon NAMED `import { Check, HelpCircle, X } from "lucide-react-native"` (NOT a barrel) → Going=`Check`, Maybe=`HelpCircle`, Can't-go=`X` (size 19). All three already in the ORCH-1137 web-shim used-set → lucide gate PASS, no shim edit.
+- Going = filled accent; Maybe = `accentWash` + accent border (secondary); Can't-go = outlined (tertiary). `overflow:'hidden'` clips opaque-Android fill (ANDROID_GLASS_USES_OPAQUE_FALLBACK).
+- Contact gate extended: Going AND Maybe both require `contactReady`; not_going ungated.
+- Maybe is NON-TERMINAL: a resolved Maybe shows "You're marked as Maybe — we'll keep you posted. Switch to Going anytime." + a Switch-to-Going button + a Can't-go decline (no dead end). Contact form + plus-row hide when `maybeResolved`.
+- `PublicEventPage.tsx` `rsvpSubmit` callback types widened (`'maybe'`) — necessary type cascade of the widened service/component; NOT in the ticketed DO-NOT-TOUCH branch (`:594-721`), no behavior change.
+
+## Console (RsvpGuestConsole.tsx)
+- New memoized `maybe = guests.filter(g.rsvpStatus==='maybe')`; read-only **"Maybe (N)"** section after Going, before Waitlist. Rows = name + `+plusCount`, no approve/deny. Trailing `Icon name="users"` (in-house Icon has no help glyph; reused an existing glyph to avoid widening Icon.tsx). Going count unchanged.
+
+# D-7 — parallax content-layering safety-net  (commit 3296edb6b)
+
+## Summary
+No source defect in current `RsvpPublicBody`: it already passes a bare `<View>` of children into the SHARED `@mingla/offering-rendering` `ParallaxCoverShell` (ORCH-1138 cover<content<chrome fix), with NO competing `zIndex`/`position`/`marginTop`/`backgroundColor` on that wrapper — byte-identical to the proven ticketed `FoundationEventPreview` body. Seth's inversion = most likely a stale build. Belt-and-suspenders only: a fails-on-revert source-structure test. `ParallaxCoverShell.tsx` NOT touched (shared, test-guarded; its `ParallaxCoverShell_native_stacking.test.ts` stays green 7/7). If a fresh build still inverts → new on-device shell dispatch.
+
+# Tests + gates
+- `resolveRsvpCta.maybe.orch1150r2.test.ts` (3) — maybe state resolution.
+- `rsvpMaybeMigration.orch1150r2.test.ts` (7) — migration-source CHECK/RLS/RPC widen + I-PROPOSED-1150-MAYBE-NOT-IN-CAP (cap SUM still going+approved only).
+- `RsvpPublicBody.maybeCta.orch1150r2.test.ts` (6) — 3-button CTA, per-icon lucide imports, maybe submit path, contact gate covers Maybe, response copy.
+- `RsvpPublicBody.parallaxLayering.orch1150r2.test.ts` (3) — D-7 layering (bare View child of shared shell, no competing stacking style).
+- `supabase/migrations/__tests__/orch_1150_maybe.test.sql` — live T1 (accept), T2 (cap-neutral), T3 (next-going-after-maybe fits), T4 (invalid rejected); orchestrator runs post-apply.
+- **fails-on-revert verified at 3296edb6b** (HEAD): deleting the migration maybe-resolve branch + the RsvpPublicBody lucide import + the offeringCta maybe branch → 4 test failures across the 3 source suites; restored → 26/26 green.
+- **Gates:** `npx tsc --noEmit` (mingla-business) introduces ZERO new errors (333 baseline = 333 after, all pre-existing testing-library/cross-package noise). `deno check public-submit-rsvp` PASS. `i-proposed-tr2-route-by-event-type.mjs` — 6 violations, ALL pre-existing in files I did not touch (ScannerHome/home/hub-trips/accept-scanner-invitation). `i-proposed-1137-biz-web-lucide-real.mjs` PASS (INV-1..4). `ParallaxCoverShell_native_stacking.test.ts` 7/7 green.
+
+# DO-NOT-TOUCH compliance
+Did NOT edit `ParallaxCoverShell.tsx`, `FoundationEventPreview.tsx`, the ticketed `PublicEventPage` branch (`:594-721`), the capacity/drain/headcount SQL, or the parallel workstream's files (`app/rsvp/[id]/edit.tsx`, `app/rsvp/[id]/index.tsx`, `marketingAudienceService.ts`). `PublicEventPage.tsx` edit was a minimal RSVP-submit type cascade outside the ticketed branch (flagged above).
+
+# Operator action required
+1. **APPLY the migration** (orchestrator, via MCP/Management API — dev history drift-corrupted): `supabase/migrations/20261012000000_orch_1150_rsvp_maybe.sql`.
+2. After apply, run `supabase/migrations/__tests__/orch_1150_maybe.test.sql` (T1–T4) against the linked remote.
+3. **Deploy edge fn** from MERGED main: `public-submit-rsvp` (keep `verify_jwt=false`).
+4. **Re-OTA** business per the EAS gotchas runbook (the D-7 fix is build-freshness; the CTA is JS-only).

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -441,3 +441,38 @@ Edited ONLY `app/rsvp/[id]/index.tsx` (the one-line route fix + comment) and its
 
 ## Commit
 `ORCH-1150-R2: D-9b — RSVP detail Edit passes mode=edit-published (published-edit no longer bounces to events list)`
+
+---
+
+# D-7b — RSVP public page scroll runway (contentBottomInset parity)
+
+## Symptom + root cause
+On the public RSVP page (`/e/{brandSlug}/{eventSlug}`, `event_type='rsvp'`), the details (brand chip, RSVP card, facts, About) appeared to slide BEHIND the cover with only a short window to read them; the ticketed event / trip / experience pages scroll correctly. Per `INVESTIGATE_ORCH-1150_RSVP_PARALLAX_D7B.md`: **no z-layering bug** — the shared `ParallaxCoverShell` z-orders `cover(1) < content(2) < chrome(70)` unconditionally on native and the cover is a STATIC pinned layer (no scroll transform). The real cause is **near-zero scroll runway**: the RSVP body is short (no ticket-tier section, no docked CTA), it sat under an ~80%-tall pinned-cover spacer (`aspectRatio:4/5`), AND it passed `contentBottomInset=0` (the shell default). So content height ≈ viewport height ⇒ the body could be dragged only a little over the (correctly pinned) cover before bottoming out ⇒ reads as "stuck behind the cover." The ticketed branch is exempt because its tier list + docked `EventReserveBar` add height; trip/experience routes pass `contentBottomInset={spacing.md}`.
+
+## The inset wiring (end-to-end plumbing, RSVP-scoped)
+The plumbing was MISSING end-to-end — `RsvpPublicBody` neither accepted nor forwarded `contentBottomInset`/`onScroll`/`onScrollViewLayout`, and `PublicEventPage`'s RSVP branch passed none.
+
+1. **`RsvpPublicBody.tsx`** — added `contentBottomInset?: number` (default `48`, a positive runway so a short page clears the cover even if a caller omits it), plus `onScroll?` + `onScrollViewLayout?` for convention parity. All three are forwarded to `<ParallaxCoverShell>` mirroring `FoundationEventPreview.tsx:460-463` (`contentBottomInset={contentBottomInset}` → ScrollView `paddingBottom`; `onScroll`/`onScrollViewLayout` pass-through). Added the `LayoutChangeEvent`/`NativeScrollEvent`/`NativeSyntheticEvent` type imports from `react-native`.
+2. **`PublicEventPage.tsx` RSVP branch only (`~L551-574`)** — imported `spacing` from `../../constants/designSystem` and passed `contentBottomInset={insets.bottom + spacing.xxl}` plus `onScroll={handleScroll}` / `onScrollViewLayout={handleScrollLayout}` (the same handlers already wired to the ticketed branch). The ticketed branch (`L596+`) and the shell were NOT touched.
+
+## Value used + parity source
+- **Value:** `insets.bottom + spacing.xxl` = safe-area bottom + 48px.
+- **Parity source:** trip route `app/t/[brandSlug]/[tripSlug].tsx:174` and experience route `app/exp/[brandSlug]/[experienceSlug].tsx:195` both pass `contentBottomInset={spacing.md}` (=16). RSVP intentionally uses a LARGER pad (`spacing.xxl`=48 + safe-area) because — unlike trip/experience — the RSVP body has NEITHER a docked reserve bar NOR a tier list adding height (the investigation §136 calls for "a one-screen-safe runway... large enough that the short RSVP body clears the cover"). `onScroll` parity: **YES added** (harmless — RSVP has no float→dock pill, so no runtime effect today; matches the caller convention).
+
+## Test + fails-on-revert
+Extended `src/components/event/__tests__/RsvpPublicBody.parallaxLayering.orch1150r2.test.ts` with a new `D-7b` describe block (5 assertions): `RsvpPublicBody` declares `contentBottomInset`, defaults it to a NON-ZERO positive value, forwards it to `<ParallaxCoverShell>`, forwards `onScroll`/`onScrollViewLayout`; AND `PublicEventPage`'s RSVP branch passes a positive `contentBottomInset` (must match `insets.bottom + spacing.`, must NOT be `{0}`). Suite: **8/8 pass**.
+- **fails-on-revert verified at 65d58691c**: true LINE DELETION (perl) of the `contentBottomInset={contentBottomInset}` forward in `RsvpPublicBody.tsx` AND the `contentBottomInset={insets.bottom + spacing.xxl}` pass in `PublicEventPage.tsx` → **2 tests FAIL** (the shell-forward + page-inset assertions); both lines restored → **8/8 green**. Append-only: no existing test modified or deleted.
+
+## Gates
+- **tsc** (`npx tsc --noEmit -p tsconfig.json`, mingla-business): ZERO new errors — **333 baseline before == 333 after** (verified by stashing the three changed files: identical count). Neither edited source file (`RsvpPublicBody.tsx`, `src/components/event/PublicEventPage.tsx`) appears in the error set; all 333 are pre-existing cross-package/`any`-param/missing-test-dep noise.
+- **`node .github/scripts/strict-grep/i-proposed-tr2-route-by-event-type.mjs`**: 6 violations are PRE-EXISTING (identical count on pristine HEAD via stash; all in ScannerHome / hub trips / accept-scanner-invitation — files I did not touch). My change adds no hardcoded `/event/` or `/trip/` route. No new violation introduced.
+- **jest** event suite regression check: the 3 failing suites (`EventListCard_defensiveFilter`, `orch_1138_event_foundation`, `PublicEventPage.closeButton.adversarial`) fail IDENTICALLY at baseline (verified via stash) — pre-existing, unrelated to this change.
+
+## Runtime status
+Runtime sim repro was BLOCKED (per investigation §93-97: the Metro on :8081 is wedged on ORCH-1142's worktree / `expo-image-manipulator` drift, COMMS-0035 / ORCH-1119). Fix is structurally proven + source-test-guarded; Seth's device retest confirms.
+
+## DO-NOT-TOUCH compliance
+Edited ONLY: `mingla-business/src/components/event/RsvpPublicBody.tsx`, the RSVP branch of `mingla-business/src/components/event/PublicEventPage.tsx`, and the test. Did NOT touch `packages/offering-rendering/ParallaxCoverShell.tsx` (shared shell — proven correct), `FoundationEventPreview.tsx`, the ticketed `PublicEventPage` branch, or any trip/experience caller/route. The shell remains byte-identical.
+
+## Commit
+`ORCH-1150-R2: D-7b — RSVP public page scroll runway (contentBottomInset parity) so content scrolls over the cover`

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1150-R2_RETEST_FIXES.md
@@ -1,0 +1,127 @@
+# IMPLEMENT — ORCH-1150-R2 [RSVP wizard retest: 3 device-test defects]
+
+- **ORCH:** ORCH-1150-R2 — RSVP wizard RETEST fixes (D-1 / D-2 / D-3)
+- **Worktree:** `/Users/sethogieva/Desktop/mingla-orchs/orch-1150-r2-[rsvp-retest-fixes]/` on `orch-1150-r2-rsvp-retest-fixes`
+- **Base:** HEAD `13c3ec4c5` (fresh off latest main, pre-rebased — NOT rebased again per dispatch).
+- **Binding contract:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1150_RETEST_3DEFECTS.md` (SPEC half).
+- **Scope:** RSVP-only. Ticketed EventCreatorWizard / event-create / published-edit paths byte-identical except the one inverse RSVP-redirect guard on `app/event/[id]/edit.tsx`.
+- **No migration. No edge deploy. No OTA. No merge.**
+
+## 1. Summary (plain English)
+
+Three RSVP-wizard defects Seth hit on the dev build are fixed:
+- **D-3:** Editing/resuming an RSVP draft now opens the RSVP wizard (`/rsvp/[id]/edit`), not the ticketed event wizard.
+- **D-2:** A video chosen on the RSVP Cover step now persists — the promoted server draft row is typed `event_type='rsvp'`, giving the cover-video pipeline a real RSVP row to bind to.
+- **D-1:** Typing the RSVP name no longer flashes a "refresh"/remount — the brief draft-null Spinner during the draft-migration swap is suppressed; the wizard stays mounted.
+
+All ticketed-event behavior is unchanged.
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Commit |
+|----|-----------|--------|--------|
+| D-3-a | `routeForEventRow` has an `rsvp` branch (draft→/rsvp/{id}/edit, live→/rsvp/{id}) | ✓ | `535c57507` |
+| D-3-b | `routeForEventRowDefensive` honors `isRsvp` (DraftEvent has no event_type) | ✓ | `535c57507` |
+| D-3-c | Hub `handleOpenItem` + `handleManageEdit` honor the RSVP signal | ✓ | `535c57507` |
+| D-3-d | Inverse guard on `app/event/[id]/edit.tsx` (isRsvp draft → /rsvp/[id]/edit) | ✓ | `535c57507` |
+| D-3-e | `i-proposed-tr2-route-by-event-type` gate green for my changes; rsvp branch INSIDE the helper | ✓ | `535c57507` |
+| D-2-a | `createServerDraft` inserts `event_type:'rsvp'` for RSVP drafts (else 'event') | ✓ | `4497ff6b9` |
+| D-2-b | Draft fetches/updates admit rsvp rows (5 sites widened to `.in(['event','rsvp'])`) | ✓ | `4497ff6b9` |
+| D-2-c | Cover-video bind works once the row is a real rsvp id (validateEventRowId non-empty check passes) | ✓ (source-verified) | `4497ff6b9` |
+| D-2-d | `business_publish_rsvp_draft` accepts the promoted row (loads by id, gates status='draft') | ✓ (source-verified) | n/a (no RPC change) |
+| D-1-a | RSVP route suppresses the draft-null Spinner during the d_*→server migration | ✓ | `b3f46e5dc` |
+| D-1-b | Cover/name/all fields carry across the swap (replaceDraft + merge preserve them) | ✓ (source-verified) | `b3f46e5dc` |
+| D-1-c | `app/event/[id]/edit.tsx` behavior unchanged (RSVP-route-only) | ✓ | `b3f46e5dc` |
+
+## 3. Files changed
+
+| File | ± | What |
+|------|---|------|
+| `mingla-business/src/utils/routeForEventRow.ts` | +~30 | rsvp branch + type + defensive isRsvp coercion |
+| `mingla-business/app/(tabs)/hub/events.tsx` | +~14 | handleOpenItem isRsvp signal; handleManageEdit rsvp base |
+| `mingla-business/app/event/[id]/edit.tsx` | +~14 | inverse wrong-wizard guard (isRsvp → /rsvp) |
+| `mingla-business/src/services/eventDrafts.ts` | +~30 / −5 | rsvp insert-typing + DRAFT_EVENT_TYPES + 5 widened filters |
+| `mingla-business/app/rsvp/[id]/edit.tsx` | +~45 | retained-draft + migrationInFlight + Spinner suppression |
+| `mingla-business/src/utils/__tests__/orch_1150_r2_rsvp_route.test.ts` | +120 (new) | D-3 routing test (14 cases) |
+| `mingla-business/src/services/__tests__/orch_1150_r2_rsvp_draft_type.test.ts` | +250 (new) | D-2 service test (4 cases) |
+| `…/eventDraftsTaxonomyAutosave.test.ts` | +3 | additive `in:` mock method (no deletion) |
+| `…/eventDraftsTaxonomyAutosaveAdversarial.test.ts` | +3 | additive `in:` mock method (no deletion) |
+| `…/eventDraftsCurrency.test.ts` | +3 | additive `in:` mock method (no deletion) |
+
+## 4. Data-model changes applied
+
+None. No migration. The `events.event_type` CHECK already admits `'rsvp'` (migration `20261004…`); the change is purely which value the client writes at draft-promotion + which values the draft reads admit.
+
+## 5. Edge functions touched
+
+None. The RSVP publish RPC (`business_publish_rsvp_draft`) was read-verified (loads the draft by `id`, gates on `status='draft'` with NO `event_type` filter) and accepts the promoted `event_type='rsvp'` row unchanged — no edit needed.
+
+## 6. Regression tests added
+
+- **D-3:** `mingla-business/src/utils/__tests__/orch_1150_r2_rsvp_route.test.ts` (14 cases) — rsvp draft/live routing + defensive isRsvp coercion + ticketed/trip/experience unchanged.
+- **D-2:** `mingla-business/src/services/__tests__/orch_1150_r2_rsvp_draft_type.test.ts` (4 cases) — createServerDraft emits rsvp/event by isRsvp; fetchDraftsForBrand + fetchDraftById filter event_type IN ['event','rsvp'].
+- **Fails-on-revert verified at `13c3ec4c5` (pre-commit working tree):** with the rsvp branch + isRsvp coercion deleted (routeForEventRow.ts) AND the insert type-pin reverted to `'event'` + two fetch sites reverted to `.eq("event_type","event")` (eventDrafts.ts) by TRUE LINE DELETION, the two suites reported **11 failed, 5 passed / 16 total**. Restoring the fixes → **16 passed, 16 total**.
+- D-1 is verified by source reasoning + the existing route-wrapper suites (`orch_0893_*`) staying green; a render-mount assertion for the Spinner-suppression needs RTL (`@testing-library/react-native` is absent from this repo's deps — see Known Issues) → D-1 carries a device-proof requirement, NOT an automated render test.
+
+## 7. Old → New receipts
+
+### routeForEventRow.ts
+- **Before:** `EventTypeForRouting = "event"|"experience"|"trip"`; no rsvp branch; defensive variant ignored isRsvp.
+- **Now:** adds `"rsvp"`; `routeForEventRow` returns `/rsvp/{id}/edit` (draft) | `/rsvp/{id}` (live) for rsvp; `routeForEventRowDefensive` coerces `isRsvp===true` → event_type:'rsvp'.
+- **Why:** D-3 — RSVP rows must resume into RsvpCreatorWizard. The rsvp branch lives inside the canonical helper (gate compliance).
+
+### app/(tabs)/hub/events.tsx
+- **Before:** `handleOpenItem` passed only event_type (defaulting RSVP drafts to 'event'); `handleManageEdit` hardcoded `/event/{id}/edit`.
+- **Now:** `handleOpenItem` passes `isRsvp`; `handleManageEdit` picks an `/rsvp/{id}/edit` vs `/event/{id}/edit` base by isRsvp/event_type, preserving the `?mode=edit-published` suffix.
+- **Why:** D-3 — the two drafts-list resume call sites.
+
+### app/event/[id]/edit.tsx
+- **Before:** no isRsvp guard — an RSVP draft reaching this route mounted the ticketed wizard.
+- **Now:** `draft.isRsvp === true` → `router.replace('/rsvp/{id}/edit?step=…')`, mirroring the RSVP route's inverse guard.
+- **Why:** D-3 belt-and-suspenders. This is the ONLY allowed change to the ticketed event path.
+
+### src/services/eventDrafts.ts
+- **Before:** `createServerDraft` hardcoded `event_type:'event'`; 5 draft reads/updates filtered `.eq("event_type","event")`.
+- **Now:** inserts `event_type:'rsvp'` when `draft.isRsvp`; all 5 reads/updates use `.in("event_type", DRAFT_EVENT_TYPES=["event","rsvp"])`.
+- **Why:** D-2 — give the promoted RSVP draft a real rsvp events row for the cover-video pipeline, and keep it visible/loadable/savable.
+
+### app/rsvp/[id]/edit.tsx
+- **Before:** during the d_*→server swap, `draft` briefly resolved null → the `draft===null` Spinner branch rendered → RsvpCreatorWizard remounted (the "refresh").
+- **Now:** retains the last resolved draft (`lastResolvedDraftRef`), derives `migrationInFlight` from `migratingLegacyIdRef`, renders the wizard against `renderDraft` (live draft OR retained draft mid-migration), and suppresses the Spinner while migrating. Brand memo + isCreateMode fall back to the retained draft.
+- **Why:** D-1 — keep the wizard mounted across the swap. RSVP-route-only.
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Behavior | Parity |
+|---------|----------|----------|--------|
+| Consumer iOS | No | no authoring | — |
+| Consumer Android | No | no authoring | — |
+| Buyer/anon Web | No | no draft authoring | — |
+| Business iOS | **Yes** | RSVP video cover persists; RSVP drafts resume into RSVP wizard; no name-typing refresh | automatic (shared RN) |
+| Business Android | **Yes** | same | automatic (shared RN) |
+| Admin Web | No | — | — |
+| Business Web preview | Incidental | RSVP phone-web create benefits from the same `app/rsvp/*` + service fixes | automatic |
+
+## 9. Gates / verification
+
+- **tsc (`npx tsc --noEmit -p tsconfig.json`, mingla-business):** zero NEW errors vs origin/main baseline (diffed: AFTER 409 vs BASELINE 411 — my change net-FIXED 2 pre-existing errors in `src/lib/search/adapters.ts`, introduced 0). The 409 remaining are all pre-existing baseline tech debt (`@testing-library/react-native`, `category` on DraftEvent, `@mingla/payments-native`, etc.) — unrelated to this ORCH.
+- **strict-grep `i-proposed-tr2-route-by-event-type.mjs`:** 6 violations reported, ALL PRE-EXISTING on origin/main baseline (identical count with my changes stashed). My modified file `hub/events.tsx` is CLEAN (allowlist comment accepted; the gate does not scan `/rsvp/`). The contract requirement (rsvp branch inside the helper, no hardcoded `/rsvp/` push outside it) is met. **The gate is RED on main for unrelated scanner-route violations — Discovery for orchestrator.**
+- **append-only check (`test-append-only-check.js`):** clean. The 3 edits to existing test files are pure additions (3-added/0-deleted each) — no `[TEST-MOD-APPROVED]` token required.
+- **Touched-area jest sweep (8 suites):** 56 passed / 56.
+
+## 10. Known issues / deferred
+
+- **D-1 has no automated render test:** `@testing-library/react-native` is not in this repo's devDeps (every `*.render.test.tsx` errors on the missing module at baseline). D-1's fix is verified by source reasoning + the existing `orch_0893_*` route-wrapper suites staying green. It REQUIRES device proof at TEST (type the RSVP name; confirm no Spinner flash / no remount). D-2's video-persist + D-3's resume also want device confirmation.
+- No `[TRANSITIONAL]` code introduced.
+
+## 11. Operator action required
+
+- None for backend (no migration, no edge deploy).
+- **For TEST/retest:** OTA the business dev channel from MERGED main after review, then device-fire all three (D-3 resume-into-RSVP-wizard; D-2 video cover persists across reload; D-1 no name-typing refresh).
+
+## 12. Discoveries for Orchestrator
+
+- **DISC-1150R2-A:** `i-proposed-tr2-route-by-event-type` is RED on origin/main with 6 pre-existing violations (`home.tsx:414` event scanner; `hub/trips.tsx:379/388/397`; `accept-scanner-invitation.tsx:94`; `ScannerHome.tsx:119`). Not introduced by this ORCH; flag for a gate-cleanup ORCH.
+- **DISC-1150R2-B:** mingla-business tsc has 409 pre-existing baseline errors (missing `@testing-library/react-native` + `@mingla/payments-native` modules, stale `category` field on DraftEvent in 4 test files, several component type errors). The repo's "tsc clean" claim does not hold on main today.
+- **DISC-1150R2-C (carried from forensics DISC-1150-R-A/B):** `createServerDraft` is the SHARED promotion service for event+RSVP; a SECOND d_*→server migration path exists in `useServerDraftEvents.ts` (Hub legacy loop) also calling `createServerDraft` — it now inherits the rsvp typing automatically (good), but any future offering type lazily promoting a d_* draft must set its own discriminator there.
+- **DISC-1150R2-D:** the `EditPublishedScreen` RSVP edit-published path (`?mode=edit-published`) for a LIVE RSVP is reachable via `handleManageEdit` now routing to `/rsvp/{id}/edit?mode=edit-published`; the RSVP route already handles that mode (rsvpMode). Worth a device check that live-RSVP "Edit" lands on the RSVP-aware screen (in scope of TEST).

--- a/mingla-business/app/(tabs)/hub/events.tsx
+++ b/mingla-business/app/(tabs)/hub/events.tsx
@@ -357,11 +357,15 @@ export default function EventsTab(): React.ReactElement {
       // instead of /event/{id}. Existing rows without event_type default
       // to "event" via the defensive variant — safe for legacy DraftEvent
       // / LiveEvent stored without the field.
+      // ORCH-1150 — carry the RSVP signal so RSVP rows resume into the RSVP
+      // wizard/dashboard. Drafts carry `isRsvp` (DraftEvent has no event_type);
+      // live RSVP rows carry event_type='rsvp' (LiveEvent). Pass both.
       router.push(
         routeForEventRowDefensive({
           id: item.event.id,
           event_type:
             (item.event as { event_type?: string }).event_type ?? "event",
+          isRsvp: (item.event as { isRsvp?: boolean }).isRsvp === true,
           status: item.kind === "draft" ? "draft" : (item.event as LiveEvent).status,
         }) as never,
       );
@@ -398,8 +402,18 @@ export default function EventsTab(): React.ReactElement {
     // route to the focused EditPublishedScreen via ?mode=edit-published.
     const suffix =
       manageCtx.kind === "draft" ? "" : "?mode=edit-published";
-    // orch-strict-grep-allow route-by-event-type — manageCtx is event-only by construction (event manage menu); trips use a separate dashboard route with no manage-menu surface yet
-    router.push(`/event/${manageCtx.event.id}/edit${suffix}` as never);
+    // ORCH-1150 — route the edit target by RSVP-ness so RSVP rows open the RSVP
+    // wizard / RSVP-aware EditPublishedScreen (app/rsvp/[id]/edit), not the
+    // ticketed event surface. The base path comes from the canonical helper;
+    // ticketed events stay on /event/{id}/edit byte-identically.
+    const isRsvpItem =
+      (manageCtx.event as { isRsvp?: boolean }).isRsvp === true ||
+      (manageCtx.event as { event_type?: string }).event_type === "rsvp";
+    const base = isRsvpItem
+      ? `/rsvp/${manageCtx.event.id}/edit`
+      : `/event/${manageCtx.event.id}/edit`;
+    // orch-strict-grep-allow route-by-event-type — RSVP-vs-event base is chosen above by isRsvp/event_type; ticketed path unchanged, RSVP routes to /rsvp/[id]/edit (outside this gate's /event|/trip scope)
+    router.push(`${base}${suffix}` as never);
     setManageCtx(null);
   }, [manageCtx, router]);
 

--- a/mingla-business/app/event/[id]/edit.tsx
+++ b/mingla-business/app/event/[id]/edit.tsx
@@ -298,6 +298,19 @@ export default function EventEditRoute(): React.ReactElement {
     return draft.lastStepReached === 0 && draft.name.length === 0;
   }, [draft]);
 
+  // ORCH-1150 — inverse wrong-wizard guard (SPEC §4.6). Mirrors the RSVP route's
+  // guard (app/rsvp/[id]/edit.tsx): an /event/[id]/edit URL pointed at an RSVP
+  // draft (isRsvp=true) redirects to the RSVP wizard. Belt-and-suspenders for a
+  // stale/hand-typed URL or a routing miss — the route IS the discriminator.
+  useEffect(() => {
+    if (isEditPublished || draft === null) return;
+    if (draft.isRsvp === true) {
+      router.replace(
+        `/rsvp/${draft.id}/edit?step=${initialStep ?? 0}` as never,
+      );
+    }
+  }, [draft, isEditPublished, initialStep, router]);
+
   const handleExit = React.useCallback(
     (
       mode: WizardExitMode,

--- a/mingla-business/app/rsvp/[id]/__tests__/editPublishedExitGuard.test.ts
+++ b/mingla-business/app/rsvp/[id]/__tests__/editPublishedExitGuard.test.ts
@@ -1,0 +1,114 @@
+/**
+ * ORCH-1150-R2 (D-9) — published-RSVP edit safe-exit guard.
+ *
+ * BUG: editing a PUBLISHED RSVP bounced to the events list. Root cause: the
+ * edit-published safe-exit in `app/rsvp/[id]/edit.tsx` fired on the bare
+ * `resolvedLiveEvent === null && !businessEventQuery.isLoading` guard. React
+ * Query reports a DISABLED query (enabled = isAuthReady && eventId) as
+ * isLoading=false, so during the `isAuthReady` flicker — a fresh push with an
+ * empty useLiveEventStore — the exit fired BEFORE auth landed and the fetch
+ * ran. FIX: gate the exit on `isAuthReady && !isLoading && !isFetching` so it
+ * only bounces once the lookup is genuinely exhausted.
+ *
+ * This is a TWO-PART proof:
+ *   1. A pure-logic test of the exit predicate (the exact boolean condition
+ *      the effect uses), exercising the auth-flicker + in-flight-fetch states.
+ *   2. A structural-source assertion that the shipped guard in edit.tsx
+ *      actually carries the isAuthReady + isFetching terms (fails-on-revert:
+ *      deleting them from the source makes the regex assertion fail; the
+ *      logic test also fails because the predicate would then bounce while
+ *      not-auth-ready / fetching).
+ *
+ * Fails-on-revert verified by TRUE LINE DELETION of the isAuthReady +
+ * !isFetching terms in the source guard (see IMPLEMENT report).
+ */
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * The exact safe-exit predicate from app/rsvp/[id]/edit.tsx (D-9 hardened).
+ * Kept in lock-step with the source; the structural assertion below proves the
+ * source still matches this shape so the two can't silently diverge.
+ */
+function shouldBounceToEventsList(state: {
+  isAuthReady: boolean;
+  resolvedLiveEvent: unknown | null;
+  isLoading: boolean;
+  isFetching: boolean;
+}): boolean {
+  return (
+    state.isAuthReady &&
+    state.resolvedLiveEvent === null &&
+    !state.isLoading &&
+    !state.isFetching
+  );
+}
+
+describe("ORCH-1150-R2 D-9 — RSVP edit-published safe-exit is auth+fetch gated", () => {
+  test("does NOT bounce while auth is not ready (the flicker that caused the bug)", () => {
+    // The disabled query reports isLoading=false; without the isAuthReady gate
+    // this state bounced a published RSVP before it could load.
+    expect(
+      shouldBounceToEventsList({
+        isAuthReady: false,
+        resolvedLiveEvent: null,
+        isLoading: false,
+        isFetching: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does NOT bounce while the live-event fetch is in flight", () => {
+    expect(
+      shouldBounceToEventsList({
+        isAuthReady: true,
+        resolvedLiveEvent: null,
+        isLoading: false,
+        isFetching: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBounceToEventsList({
+        isAuthReady: true,
+        resolvedLiveEvent: null,
+        isLoading: true,
+        isFetching: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("does NOT bounce once the RSVP resolves (event found)", () => {
+    expect(
+      shouldBounceToEventsList({
+        isAuthReady: true,
+        resolvedLiveEvent: { id: "evt_1" },
+        isLoading: false,
+        isFetching: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("DOES bounce only when the lookup is genuinely exhausted (auth ready, settled, still null)", () => {
+    expect(
+      shouldBounceToEventsList({
+        isAuthReady: true,
+        resolvedLiveEvent: null,
+        isLoading: false,
+        isFetching: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("SOURCE: the shipped guard carries isAuthReady + !isFetching (fails-on-revert)", () => {
+    const source = readFileSync(
+      join(__dirname, "..", "edit.tsx"),
+      "utf8",
+    );
+    // The edit-published exit must be gated on all four terms. Reverting the
+    // D-9 fix (dropping isAuthReady / !isFetching) makes this assertion fail.
+    expect(source).toMatch(
+      /isAuthReady\s*&&\s*\n?\s*resolvedLiveEvent === null\s*&&\s*\n?\s*!businessEventQuery\.isLoading\s*&&\s*\n?\s*!businessEventQuery\.isFetching/,
+    );
+  });
+});

--- a/mingla-business/app/rsvp/[id]/__tests__/index.test.tsx
+++ b/mingla-business/app/rsvp/[id]/__tests__/index.test.tsx
@@ -147,3 +147,37 @@ describe("ORCH-1150-R2 D-8 — RSVP detail keeps Blasts + Group-chat tiles", () 
     expect((allowMatches ?? []).length).toBeGreaterThanOrEqual(2);
   });
 });
+
+// ===========================================================================
+// ORCH-1150-R2 (D-9b) — RSVP detail Edit enters the edit screen on its
+// edit-published path. The detail page is only shown for a PUBLISHED RSVP;
+// without ?mode=edit-published the edit screen runs the draft-resolution path
+// (useDraftById), finds no draft for a published RSVP, and bounces to the
+// events list. handleEdit MUST therefore push the edit-published route.
+//
+// Fails-on-revert: delete the `?mode=edit-published` from the handleEdit push
+// in index.tsx and the assertion below fails (the bare /rsvp/{id}/edit route
+// is the bug that bounces to the events list).
+// ===========================================================================
+describe("ORCH-1150-R2 D-9b — RSVP detail Edit passes mode=edit-published", () => {
+  const source = readFileSync(SCREEN_SOURCE_PATH, "utf8");
+
+  test("handleEdit pushes the edit screen WITH ?mode=edit-published", () => {
+    // The Edit tile's handler must enter the published-edit path so the edit
+    // screen resolves the live event (useBusinessEventById) instead of the
+    // non-existent draft (useDraftById) and bouncing to the events list.
+    expect(source).toMatch(
+      /router\.push\(\s*`\/rsvp\/\$\{id\}\/edit\?mode=edit-published`/,
+    );
+  });
+
+  test("no bare /rsvp/{id}/edit push remains in handleEdit (the bounce bug)", () => {
+    // The ONLY draft-mode (no ?mode=) /rsvp/{id}/edit navigation legitimately
+    // left in this file is the "Defensive: draft → redirect" router.replace —
+    // it is a router.replace, NOT a router.push. Assert no router.push targets
+    // the bare edit route (that bare-push WAS the D-9b bounce bug).
+    expect(source).not.toMatch(
+      /router\.push\(\s*`\/rsvp\/\$\{id\}\/edit`/,
+    );
+  });
+});

--- a/mingla-business/app/rsvp/[id]/__tests__/index.test.tsx
+++ b/mingla-business/app/rsvp/[id]/__tests__/index.test.tsx
@@ -100,9 +100,12 @@ describe("ORCH-1150-R2 D-4 — RSVP host dashboard exists + is RSVP-tailored", (
     expect(source).not.toContain("useEventOrders");
   });
 
-  test("DROP: NO blasts / group-chat tiles, NO activity feed, NO manage menu, NO cancel/end-sales", () => {
-    expect(source).not.toContain('label="Blasts"');
-    expect(source).not.toContain("Group chat");
+  // ORCH-1150-R2 (D-8) — Blasts + Group-chat are COMMS, not money. D-4
+  // originally dropped them; D-8 (later in the same retest batch) RE-ADDED
+  // them. This DROP assertion is narrowed to the genuinely money/ticket-
+  // coupled surfaces only. The Blasts/Group-chat presence is asserted
+  // positively in the D-8 block below.
+  test("DROP: NO activity feed, NO manage menu, NO cancel/end-sales (money/ticket surfaces)", () => {
     expect(source).not.toContain("EventDetailActivityRow");
     expect(source).not.toContain("recentActivity");
     expect(source).not.toContain("EventManageMenu");
@@ -110,11 +113,37 @@ describe("ORCH-1150-R2 D-4 — RSVP host dashboard exists + is RSVP-tailored", (
     expect(source).not.toMatch(/Cancel event|handleCancelConfirm/);
   });
 
-  test("REGRESSION: protective comment + only /rsvp routes (no hardcoded /event/ or /trip/)", () => {
+  test("REGRESSION: protective comment present", () => {
     expect(source).toContain("DO NOT delete");
-    // The route gate (i-proposed-tr2) bans /event/ and /trip/ literals; this
-    // screen only pushes /rsvp/... , /e/... , /brand/... and /(tabs)/...
-    expect(source).not.toMatch(/`\/event\//);
-    expect(source).not.toMatch(/`\/trip\//);
+  });
+});
+
+// ===========================================================================
+// ORCH-1150-R2 (D-8) — Blasts + Group-chat tiles re-added (comms, not money)
+// ===========================================================================
+describe("ORCH-1150-R2 D-8 — RSVP detail keeps Blasts + Group-chat tiles", () => {
+  const source = readFileSync(SCREEN_SOURCE_PATH, "utf8");
+
+  test("renders a Group chat tile routing to the event-scoped /event/{id}/group-chat", () => {
+    expect(source).toContain('label="Group chat"');
+    expect(source).toContain("handleGroupChat");
+    expect(source).toMatch(/router\.push\(`\/event\/\$\{id\}\/group-chat`/);
+  });
+
+  test("renders a Blasts tile routing to the event-scoped /event/{id}/blasts", () => {
+    expect(source).toContain('label="Blasts"');
+    expect(source).toContain("handleBlasts");
+    expect(source).toMatch(/router\.push\(`\/event\/\$\{id\}\/blasts`/);
+  });
+
+  test("each cross-type push carries the route-by-event-type allowlist comment (gate stays green)", () => {
+    // The two /event/... pushes from this /rsvp screen are only legal with the
+    // strict-grep allowlist comment within 3 lines above. Reverting either
+    // comment (or the tiles) trips i-proposed-tr2-route-by-event-type.
+    const allowMatches = source.match(
+      /orch-strict-grep-allow route-by-event-type/g,
+    );
+    expect(allowMatches).not.toBeNull();
+    expect((allowMatches ?? []).length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/mingla-business/app/rsvp/[id]/__tests__/index.test.tsx
+++ b/mingla-business/app/rsvp/[id]/__tests__/index.test.tsx
@@ -1,0 +1,120 @@
+/* eslint-disable import/first */
+/**
+ * ORCH-1150-R2 D-4 — implementor happy-path regression test.
+ *
+ * Asserts the RSVP host dashboard (`app/rsvp/[id]/index.tsx`) EXISTS and is a
+ * correct subtractive clone of the ticketed event detail:
+ *   - KEEP: hero/cover, status pill, date·venue facts, "N going" headcount,
+ *     a Guests link → /rsvp/[id]/guests, Edit → /rsvp/[id]/edit, Share +
+ *     public-page link /e/{brandSlug}/{eventSlug}.
+ *   - DROP: revenue card, ticket types, scan/scanners/orders/door/
+ *     reconciliation/blasts/group-chat tiles, activity feed, end-sales/cancel,
+ *     EventManageMenu — anything reading event.tickets or revenue.
+ *   - DATA HOOK (F-2): the going-count is sourced from
+ *     useBusinessEventsForBrand (the Hub LIST query), NOT from
+ *     fetchBusinessEventById (which zeroes rsvpGoingCount).
+ *
+ * Structural source test — the screen's dependency graph (Expo Router +
+ * useManagedEventRoute + Zustand stores) is too heavyweight to render in a
+ * Node-environment jest cleanly; mirrors the sibling event-detail tests
+ * (app/event/[id]/__tests__/cancel-no-navigation.test.tsx).
+ *
+ * Fails-on-revert: the route is file-based. DELETING index.tsx makes
+ * expo-router fall through to +not-found.tsx (the white-screen bug). The
+ * `readFileSync` here THROWS when the file is absent → every test in this
+ * suite errors → the suite fails on revert. Verified by true line deletion of
+ * the file (see IMPLEMENT report).
+ */
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SCREEN_SOURCE_PATH = join(__dirname, "..", "index.tsx");
+
+describe("ORCH-1150-R2 D-4 — RSVP host dashboard exists + is RSVP-tailored", () => {
+  // Throws (suite fails) if the file was deleted → the fails-on-revert proof
+  // for the missing-route white-screen bug.
+  const source = readFileSync(SCREEN_SOURCE_PATH, "utf8");
+
+  test("the RSVP detail screen file exists and exports a default screen", () => {
+    expect(source.length).toBeGreaterThan(0);
+    expect(source).toMatch(/export default function RsvpDetailScreen/);
+  });
+
+  test("KEEP: renders the hero (cover + status pill + title + date·venue)", () => {
+    expect(source).toContain("EventCoverMedia");
+    expect(source).toContain("EventDetailHeroStatusPill");
+    expect(source).toContain("formatDraftDateLine");
+    expect(source).toContain("event.venueName");
+  });
+
+  test("KEEP: renders the 'N going' headcount via formatRsvpGoingLabel", () => {
+    expect(source).toContain("formatRsvpGoingLabel");
+    expect(source).toContain("goingCount");
+    // empty-state copy for zero responses
+    expect(source).toMatch(/No one's responded yet|0 going/);
+  });
+
+  test("KEEP: Guests link routes to /rsvp/[id]/guests", () => {
+    expect(source).toMatch(/\/rsvp\/\$\{id\}\/guests/);
+    expect(source).toContain('label="Guests"');
+  });
+
+  test("KEEP: Edit link routes to /rsvp/[id]/edit", () => {
+    expect(source).toMatch(/\/rsvp\/\$\{id\}\/edit/);
+    expect(source).toContain('label="Edit"');
+  });
+
+  test("KEEP: Share + public-page link /e/{brandSlug}/{eventSlug}", () => {
+    expect(source).toContain("ShareModal");
+    expect(source).toContain("eventPublicUrl");
+    expect(source).toMatch(/\/e\/\$\{resolvedLiveEvent\.brandSlug\}\/\$\{resolvedLiveEvent\.eventSlug\}/);
+  });
+
+  test("DATA HOOK (F-2): going-count is read from useBusinessEventsForBrand, not the detail fetch", () => {
+    expect(source).toContain("useBusinessEventsForBrand");
+    // found-by-id against the Hub list cache (id OR serverEventId)
+    expect(source).toMatch(/e\.id === id \|\| e\.serverEventId === id/);
+  });
+
+  test("DROP: NO revenue / KPI card", () => {
+    expect(source).not.toContain("EventDetailKpiCard");
+    expect(source).not.toContain("summarizeEventMoney");
+    expect(source).not.toContain("moneySummary");
+    expect(source).not.toMatch(/revenueGbp|payoutGbp/);
+  });
+
+  test("DROP: NO ticket types list / row", () => {
+    expect(source).not.toContain("EventDetailTicketTypeRow");
+    expect(source).not.toContain("TICKET TYPES");
+    expect(source).not.toContain("soldCountByTier");
+    expect(source).not.toContain("event.tickets");
+  });
+
+  test("DROP: NO scan / scanners / orders / door / reconciliation tiles", () => {
+    expect(source).not.toContain("Scan tickets");
+    expect(source).not.toContain("Scanners");
+    expect(source).not.toContain('label="Orders"');
+    expect(source).not.toContain("Door Sales");
+    expect(source).not.toContain("ReconciliationCtaTile");
+    expect(source).not.toContain("useEventOrders");
+  });
+
+  test("DROP: NO blasts / group-chat tiles, NO activity feed, NO manage menu, NO cancel/end-sales", () => {
+    expect(source).not.toContain('label="Blasts"');
+    expect(source).not.toContain("Group chat");
+    expect(source).not.toContain("EventDetailActivityRow");
+    expect(source).not.toContain("recentActivity");
+    expect(source).not.toContain("EventManageMenu");
+    expect(source).not.toContain("EndSalesSheet");
+    expect(source).not.toMatch(/Cancel event|handleCancelConfirm/);
+  });
+
+  test("REGRESSION: protective comment + only /rsvp routes (no hardcoded /event/ or /trip/)", () => {
+    expect(source).toContain("DO NOT delete");
+    // The route gate (i-proposed-tr2) bans /event/ and /trip/ literals; this
+    // screen only pushes /rsvp/... , /e/... , /brand/... and /(tabs)/...
+    expect(source).not.toMatch(/`\/event\//);
+    expect(source).not.toMatch(/`\/trip\//);
+  });
+});

--- a/mingla-business/app/rsvp/[id]/__tests__/preview.test.tsx
+++ b/mingla-business/app/rsvp/[id]/__tests__/preview.test.tsx
@@ -1,0 +1,105 @@
+/* eslint-disable import/first */
+/**
+ * ORCH-1150-R2 D-5 — implementor happy-path regression test.
+ *
+ * Asserts the RSVP in-app preview route (`app/rsvp/[id]/preview.tsx`) EXISTS
+ * and is a correct subtractive clone of `app/event/[id]/preview.tsx`:
+ *   - REUSES the RSVP-safe public renderer `RsvpPublicBody` (testID
+ *     "orch-1150-rsvp-preview"), NEVER the ticket-assuming `PreviewEventView` /
+ *     `FoundationEventPreview` / `resolveOfferingCta`
+ *     (I-PROPOSED-1150-RSVP-PREVIEW-NO-TICKET-RENDERER).
+ *   - The Going / Not-going CTA submit is a PREVIEW no-op: it never imports or
+ *     calls `submitPublicRsvp` / the edge function; it shows a "This is a
+ *     preview" toast and resolves to a defined state.
+ *   - Mirrors the ticketed preview's d_*→server-draft migration + stale/missing
+ *     recovery + wrong-wizard (isRsvp===false → /event/{id}/preview) guard, with
+ *     every /event/{id}/preview target swapped to /rsvp/{id}/preview.
+ *
+ * Structural source test — the route's dependency graph (Expo Router +
+ * RsvpPublicBody → ParallaxCoverShell → expo-haptics + Zustand stores +
+ * AuthContext + React Query) is too heavyweight to mount under the default
+ * node/ts-jest config (no RTL installed here — see jest.config.cjs). Mirrors the
+ * D-4 sibling (app/rsvp/[id]/__tests__/index.test.tsx) and the event-detail
+ * source tests. The tester owns the RTL render-proof under a dedicated config.
+ *
+ * Fails-on-revert: the route is file-based. DELETING preview.tsx makes
+ * expo-router fall through to +not-found.tsx (the white-screen crash, the bug
+ * this ORCH fixes). The `readFileSync` here THROWS when the file is absent →
+ * every test in this suite errors → the suite fails on revert. Verified by true
+ * line deletion of the file (see IMPLEMENT report).
+ */
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SCREEN_SOURCE_PATH = join(__dirname, "..", "preview.tsx");
+
+describe("ORCH-1150-R2 D-5 — RSVP preview route exists + uses the no-ticket renderer", () => {
+  // Throws (suite fails) if the file was deleted → the fails-on-revert proof for
+  // the missing-route white-screen bug.
+  const source = readFileSync(SCREEN_SOURCE_PATH, "utf8");
+
+  test("the RSVP preview route file exists and exports a default screen", () => {
+    expect(source.length).toBeGreaterThan(0);
+    expect(source).toMatch(/export default function RsvpPreviewRoute/);
+  });
+
+  test("REUSE: renders RsvpPublicBody with the preview testID (route resolves, no 404)", () => {
+    expect(source).toContain("RsvpPublicBody");
+    expect(source).toContain("<RsvpPublicBody");
+    expect(source).toContain('testID="orch-1150-rsvp-preview"');
+  });
+
+  test("NO TICKET RENDERER: never imports/renders PreviewEventView / FoundationEventPreview / resolveOfferingCta", () => {
+    // The header comment NAMES these to document the rule; the invariant
+    // (I-PROPOSED-1150-RSVP-PREVIEW-NO-TICKET-RENDERER) forbids IMPORTING or
+    // RENDERING them. Assert no import and no JSX mount, precisely.
+    expect(source).not.toMatch(/import\s+\{[^}]*PreviewEventView/);
+    expect(source).not.toMatch(/import\s+\{[^}]*FoundationEventPreview/);
+    expect(source).not.toContain("<PreviewEventView");
+    expect(source).not.toContain("<FoundationEventPreview");
+    expect(source).not.toContain("resolveOfferingCta");
+    expect(source).not.toContain("MultiDateOverrideSheet");
+  });
+
+  test("NO TICKETS: zero ticket tiers + no checkout/price concept in the mapped event", () => {
+    // RSVP carries no tiers — the draft→public mapper sets tickets:[].
+    expect(source).toMatch(/tickets:\s*\[\]/);
+    expect(source).not.toContain("checkoutPublicPath");
+    expect(source).not.toContain("mapTicket");
+    expect(source).not.toContain("PublicTicketProps");
+  });
+
+  test("PREVIEW SUBMIT NO-OP: never imports or CALLS submitPublicRsvp / the edge fn", () => {
+    // No import of the live submit service (the documentary header comment may
+    // name it; the invariant is no IMPORT and no CALL — assert those precisely).
+    expect(source).not.toMatch(/import\s+[^;]*submitPublicRsvp/);
+    expect(source).not.toMatch(/from\s+["'][^"']*rsvpEvents["']/);
+    // No invocation of the edge-fn-backed submitter.
+    expect(source).not.toMatch(/submitPublicRsvp\s*\(/);
+    // the no-op handler shows the preview toast + resolves a defined state
+    expect(source).toContain("handlePreviewSubmit");
+    expect(source).toMatch(/Publish to let guests RSVP/);
+  });
+
+  test("D_* MIGRATION: mirrors the event preview's local→server draft migration + stale recovery", () => {
+    expect(source).toContain("createServerDraft");
+    expect(source).toContain("staleServerDraft");
+    // migration replace stays on the /rsvp route (swapped from /event)
+    expect(source).toMatch(/\/rsvp\/\$\{serverDraft\.id\}\/preview/);
+  });
+
+  test("WRONG-WIZARD GUARD: isRsvp===false redirects to /event/{id}/preview (allowlisted)", () => {
+    expect(source).toContain("draft.isRsvp === false");
+    expect(source).toMatch(/\/event\/\$\{draft\.id\}\/preview/);
+    // the one /event/ literal carries the route-by-event-type strict-grep allowlist
+    expect(source).toContain("orch-strict-grep-allow route-by-event-type");
+  });
+
+  test("STATES + PROTECTIVE COMMENT: loading spinner shell + DO NOT delete header", () => {
+    expect(source).toContain("Spinner");
+    expect(source).toContain("DO NOT delete");
+    // back is never a dead end
+    expect(source).toContain("router.canGoBack()");
+  });
+});

--- a/mingla-business/app/rsvp/[id]/edit.tsx
+++ b/mingla-business/app/rsvp/[id]/edit.tsx
@@ -205,7 +205,22 @@ export default function RsvpEditRoute(): React.ReactElement {
         );
         return undefined;
       }
-      if (resolvedLiveEvent === null && !businessEventQuery.isLoading) {
+      // ORCH-1150 (D-9) — gate the safe-exit so it fires ONLY when the live-
+      // event lookup is genuinely exhausted: auth is ready AND the fetch has
+      // settled (not loading, not fetching) AND the event is still null. The
+      // bare `!isLoading` guard (mirrored from the ticketed event-edit) fired
+      // during the `isAuthReady` flicker — React-Query reports a DISABLED query
+      // (enabled = isAuthReady && eventId) as isLoading=false, so a fresh push
+      // with an empty useLiveEventStore bounced a published RSVP before the
+      // fetch ever ran. Adding isAuthReady + !isFetching makes the exit
+      // strictly more conservative than today; it can never bounce earlier.
+      // RSVP-route-only — the ticketed app/event/[id]/edit.tsx is NOT touched.
+      if (
+        isAuthReady &&
+        resolvedLiveEvent === null &&
+        !businessEventQuery.isLoading &&
+        !businessEventQuery.isFetching
+      ) {
         // Published event not found — bounce to events tab.
         const t = setTimeout(() => {
           router.replace(safeEventsExitRoute() as never);

--- a/mingla-business/app/rsvp/[id]/edit.tsx
+++ b/mingla-business/app/rsvp/[id]/edit.tsx
@@ -128,6 +128,29 @@ export default function RsvpEditRoute(): React.ReactElement {
   const deleteDraft = useDraftEventStore((s) => s.deleteDraft);
   const migratingLegacyIdRef = React.useRef<string | null>(null);
   const staleRecoveryDraftIdRef = React.useRef<string | null>(null);
+  // ORCH-1150 (D-1) — retain the last resolved draft so the d_*→server migration
+  // swap does NOT flash the `draft===null` Spinner (which remounts the wizard,
+  // perceived as a "refresh" while typing the name). During an in-flight
+  // migration the resolved `draft` momentarily goes null between
+  // replaceDraft(d_*→server) + router.replace(newId) and useDraftById(newId)
+  // resolving. We keep rendering the wizard against this retained draft until
+  // the new id resolves. RSVP-route-only — the event route is byte-identical.
+  const lastResolvedDraftRef = React.useRef<DraftEvent | null>(null);
+  if (!isEditPublished && draft !== null) {
+    lastResolvedDraftRef.current = draft;
+    // The migration has landed once a real (non-d_*) server draft resolves —
+    // clear the in-flight marker so the Spinner suppression below stops.
+    if (
+      !draft.id.startsWith("d_") &&
+      migratingLegacyIdRef.current !== null &&
+      migratingLegacyIdRef.current.startsWith("d_")
+    ) {
+      migratingLegacyIdRef.current = null;
+    }
+  }
+  // ORCH-1150 (D-1) — true while the d_*→server promotion is mid-flight. Used to
+  // hold the wizard mounted instead of bouncing to the draft-null Spinner.
+  const migrationInFlight = migratingLegacyIdRef.current !== null;
   const brands = useBrandList();
   const brand = useMemo(() => {
     if (isEditPublished) {
@@ -137,8 +160,12 @@ export default function RsvpEditRoute(): React.ReactElement {
       if (resolvedLiveEvent === null) return null;
       return brands.find((b) => b.id === resolvedLiveEvent.brandId) ?? null;
     }
-    if (draft === null) return null;
-    return brands.find((b) => b.id === draft.brandId) ?? null;
+    // ORCH-1150 (D-1) — fall back to the retained draft during the migration
+    // swap so the brand stays resolved (brandId is identical across the swap)
+    // and the wizard doesn't lose its brand mid-migration.
+    const draftForBrand = draft ?? lastResolvedDraftRef.current;
+    if (draftForBrand === null) return null;
+    return brands.find((b) => b.id === draftForBrand.brandId) ?? null;
   }, [isEditPublished, businessEventQuery.data?.brand, resolvedLiveEvent, draft, brands]);
 
   const [toast, setToast] = React.useState<{ visible: boolean; message: string }>(
@@ -286,11 +313,21 @@ export default function RsvpEditRoute(): React.ReactElement {
     staleServerDraft,
   ]);
 
+  // ORCH-1150 (D-1) — the draft used for rendering. During the d_*→server
+  // migration `draft` briefly resolves to null (the store entry is swapped from
+  // the d_* id to the server id and the URL changes); rather than flash the
+  // Spinner and remount the wizard, fall back to the last resolved draft so the
+  // wizard stays mounted across the swap. Cover/name/all fields carry across
+  // because replaceDraft preserves them (the migration merge in
+  // handleAutosaveDraft copies them onto the server draft).
+  const renderDraft: DraftEvent | null =
+    draft ?? (migrationInFlight ? lastResolvedDraftRef.current : null);
+
   const isCreateMode = useMemo<boolean>(() => {
-    if (draft === null) return false;
+    if (renderDraft === null) return false;
     // First-time edit: lastStepReached is 0 AND name is empty AND no fields filled.
-    return draft.lastStepReached === 0 && draft.name.length === 0;
-  }, [draft]);
+    return renderDraft.lastStepReached === 0 && renderDraft.name.length === 0;
+  }, [renderDraft]);
 
   // ORCH-1150 — wrong-wizard guard (SPEC §4.6): an /rsvp/[id]/edit URL pointed
   // at a TICKETED draft (isRsvp=false) redirects to the event wizard, and
@@ -544,7 +581,12 @@ export default function RsvpEditRoute(): React.ReactElement {
     );
   }
 
-  if (draft === null) {
+  // ORCH-1150 (D-1) — suppress the draft-null Spinner DURING an in-flight
+  // d_*→server migration when we still have the retained draft to render. This
+  // is the visible "refresh"/remount Seth hit when typing the name: the swap
+  // briefly nulled `draft`, flashed this Spinner, and remounted the wizard.
+  // Keep the wizard mounted against `renderDraft` until the new id resolves.
+  if (draft === null && !(migrationInFlight && renderDraft !== null)) {
     return (
       <View
         style={[
@@ -588,9 +630,29 @@ export default function RsvpEditRoute(): React.ReactElement {
     );
   }
 
+  // ORCH-1150 (D-1) — render against `renderDraft` (the live draft, or the
+  // retained draft during the migration swap). This is non-null here: the
+  // draft-null Spinner branch only falls through when migrationInFlight &&
+  // renderDraft !== null. The guard satisfies the type system.
+  if (renderDraft === null) {
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.center}>
+          <Spinner size={36} />
+          <Text style={styles.label}>Loading…</Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <RsvpCreatorWizard
-      draft={draft}
+      draft={renderDraft}
       brand={brand}
       initialStep={initialStep}
       isCreateMode={isCreateMode}

--- a/mingla-business/app/rsvp/[id]/index.tsx
+++ b/mingla-business/app/rsvp/[id]/index.tsx
@@ -1,0 +1,456 @@
+/**
+ * ORCH-1150 — RSVP host dashboard (D-4 retest fix).
+ *
+ * Route: /rsvp/{id} (id = LiveEvent.id `le_<ts36>` or the server events.id).
+ *
+ * Without this file, routeForEventRow.ts's `/rsvp/{id}` target (returned for a
+ * non-draft RSVP row) falls through to +not-found.tsx — the enlarged-logo
+ * white screen Seth hit when tapping a live RSVP event. DO NOT delete.
+ *
+ * This is a SUBTRACTIVE clone of `app/event/[id]/index.tsx` tailored to RSVP:
+ * KEEPS the hero (cover + status pill + title + date·venue), the "N going"
+ * headcount, a Guests console link, Edit, Share, and the public-page link.
+ * DROPS every ticket/money concept (revenue card, ticket types, scan/scanners/
+ * orders/door/reconciliation/blasts/group-chat tiles, activity feed, end-sales/
+ * cancel, the ticket-centric manage menu) — RSVP has no tickets and no money.
+ *
+ * Going-count data-hook (SPEC finding F-2): `fetchBusinessEventById` (behind
+ * useManagedEventRoute) zeroes `rsvpGoingCount` and coerces `event_type` to
+ * 'event', so the headcount is read from the Hub LIST query
+ * (`useBusinessEventsForBrand`) found-by-id — the same source the Hub card
+ * uses, so the count matches what the host just saw. useManagedEventRoute is
+ * still used for cover/title/status/date/venue/slugs/capacity/approvalMode.
+ *
+ * Per INVESTIGATE_ORCH-1150_RSVP_DETAIL_PAGE.md PART 2 (SPEC §5 KEEP/DROP).
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+import {
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+} from "../../../src/constants/designSystem";
+import {
+  useLiveEventStore,
+  type LiveEvent,
+} from "../../../src/store/liveEventStore";
+import { useDraftById } from "../../../src/store/draftEventStore";
+import { formatDraftDateLine } from "../../../src/utils/eventDateDisplay";
+import { deriveLiveStatus } from "../../../src/utils/eventLifecycle";
+import { computeMasterStartAtUtc } from "../../../src/utils/eventDateMath";
+import { eventPublicUrl } from "../../../src/constants/publicUrls";
+import { formatRsvpGoingLabel } from "../../../src/utils/rsvpHubMetrics";
+
+import { EmptyState } from "../../../src/components/ui/EmptyState";
+import { EventCoverMedia } from "../../../src/components/ui/EventCoverMedia";
+import { GlassCard } from "../../../src/components/ui/GlassCard";
+import { IconChrome } from "../../../src/components/ui/IconChrome";
+import { ShareModal } from "../../../src/components/ui/ShareModal";
+import { Toast } from "../../../src/components/ui/Toast";
+import { TopBar } from "../../../src/components/ui/TopBar";
+
+import { ActionTile } from "../../../src/components/event/ActionTile";
+import { EventDetailHeroStatusPill } from "../../../src/components/event/EventDetailHeroStatusPill";
+import { useManagedEventRoute } from "../../../src/hooks/useManagedEventRoute";
+import { useBusinessEventsForBrand } from "../../../src/hooks/useBusinessEvents";
+
+// ----- Status derivation (mirrors event/[id]/index.tsx) ---------------
+type EventStatus = "live" | "upcoming" | "past";
+
+const deriveScreenStatus = (event: LiveEvent): EventStatus => {
+  // ORCH-0828: pass timezone-aware UTC instant (not date-only string).
+  const lifecycle = deriveLiveStatus(event, computeMasterStartAtUtc(event));
+  return lifecycle === "cancelled" ? "past" : lifecycle;
+};
+
+// Map the 3-state screen status to the formatRsvpGoingLabel "kind" (the Hub
+// metric helper only knows draft/live/past). upcoming (scheduled, not yet
+// started) is still published → guests can RSVP → treat as "live" for the
+// headcount label (NOT "draft", which would read "Not published").
+const goingKindForStatus = (status: EventStatus): "live" | "past" =>
+  status === "past" ? "past" : "live";
+
+export default function RsvpDetailScreen(): React.ReactElement {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const id =
+    typeof params.id === "string"
+      ? params.id
+      : Array.isArray(params.id) && typeof params.id[0] === "string"
+        ? params.id[0]
+        : null;
+
+  // ----- Resolve event (cover/title/status/date/venue/slugs/capacity) ---
+  const routeEvent = useManagedEventRoute(id);
+  const resolvedLiveEvent = routeEvent.event;
+  const draftEvent = useDraftById(id);
+  const brand = routeEvent.brand;
+
+  // ----- Going-count source (SPEC F-2) -------------------------------
+  // useManagedEventRoute → fetchBusinessEventById returns rsvpGoingCount: 0,
+  // so source the headcount from the Hub LIST query found-by-id (the same
+  // cache the Hub card reads). brand?.id may be null until the detail resolves
+  // — the hook returns [] when disabled, and we fall back to the (possibly 0)
+  // event.rsvpGoingCount, which is acceptable: the count is non-blocking and
+  // self-corrects once the list resolves.
+  const brandEventsQuery = useBusinessEventsForBrand(brand?.id ?? null);
+  const goingCount = useMemo<number>(() => {
+    const rows = brandEventsQuery.data ?? [];
+    const match = rows.find(
+      (e) => e.id === id || e.serverEventId === id,
+    );
+    return match?.rsvpGoingCount ?? resolvedLiveEvent?.rsvpGoingCount ?? 0;
+  }, [brandEventsQuery.data, id, resolvedLiveEvent?.rsvpGoingCount]);
+
+  // ----- Defensive: draft → redirect to RSVP edit --------------------
+  useEffect(() => {
+    if (id === null) return;
+    if (routeEvent.replacementEventId !== null) {
+      router.replace(`/rsvp/${routeEvent.replacementEventId}` as never);
+      return;
+    }
+    if (resolvedLiveEvent === null && draftEvent !== null) {
+      router.replace(`/rsvp/${id}/edit` as never);
+    }
+  }, [id, routeEvent.replacementEventId, resolvedLiveEvent, draftEvent, router]);
+
+  // ----- State -------------------------------------------------------
+  const [shareModalVisible, setShareModalVisible] = useState<boolean>(false);
+  const [toast, setToast] = useState<{ visible: boolean; message: string }>({
+    visible: false,
+    message: "",
+  });
+
+  const event = resolvedLiveEvent;
+
+  // ----- Handlers ----------------------------------------------------
+  const handleBack = useCallback((): void => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/hub/events" as never);
+    }
+  }, [router]);
+
+  const handleShareOpen = useCallback((): void => {
+    setShareModalVisible(true);
+  }, []);
+
+  const handleEdit = useCallback((): void => {
+    if (id !== null) {
+      router.push(`/rsvp/${id}/edit` as never);
+    }
+  }, [id, router]);
+
+  const handleGuests = useCallback((): void => {
+    if (id !== null) {
+      router.push(`/rsvp/${id}/guests` as never);
+    }
+  }, [id, router]);
+
+  const handleViewPublic = useCallback((): void => {
+    if (resolvedLiveEvent !== null) {
+      router.push(
+        `/e/${resolvedLiveEvent.brandSlug}/${resolvedLiveEvent.eventSlug}` as never,
+      );
+    }
+  }, [resolvedLiveEvent, router]);
+
+  const handleBrandPage = useCallback((): void => {
+    if (brand !== null) {
+      router.push(`/brand/${brand.id}` as never);
+    }
+  }, [brand, router]);
+
+  // ----- Render not-found shell --------------------------------------
+  if (
+    id === null ||
+    (event === null && draftEvent === null && !routeEvent.isLoading)
+  ) {
+    return (
+      <View style={styles.host}>
+        <View
+          style={[
+            styles.headerWrap,
+            {
+              paddingTop: insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+            },
+          ]}
+        >
+          <TopBar leftKind="back" onBack={handleBack} title="RSVP" />
+        </View>
+        <View style={styles.emptyWrap}>
+          <EmptyState
+            illustration="users"
+            title="RSVP event not found"
+            description="This RSVP event may have been deleted or moved."
+            cta={{ label: "Back to events", onPress: handleBack }}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  // Drafts → redirected via useEffect; render skeleton shell briefly (NOT a
+  // white screen — a proper page shell with the header + loading copy).
+  if (event === null) {
+    return (
+      <View style={styles.host}>
+        <View
+          style={[
+            styles.headerWrap,
+            {
+              paddingTop: insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+            },
+          ]}
+        >
+          <TopBar leftKind="back" onBack={handleBack} title="RSVP" />
+        </View>
+        <View style={styles.emptyWrap}>
+          <Text style={styles.loadingText}>Loading RSVP…</Text>
+        </View>
+      </View>
+    );
+  }
+
+  const status = deriveScreenStatus(event);
+  const dateLine = formatDraftDateLine(event);
+  const goingLabel = formatRsvpGoingLabel({
+    kind: goingKindForStatus(status),
+    goingCount,
+    capacity: event.rsvpCapacity ?? null,
+  });
+  const isManualApproval = event.rsvpApprovalMode === "manual";
+  const guestsSub = isManualApproval ? "Approve / deny" : goingLabel;
+
+  return (
+    <View style={styles.host}>
+      {/* Header */}
+      <View
+        style={[
+          styles.headerWrap,
+          {
+            paddingTop: insets.top + (Platform.OS === "web" ? spacing.sm : 0),
+          },
+        ]}
+      >
+        <TopBar
+          leftKind="back"
+          onBack={handleBack}
+          title="RSVP"
+          rightSlot={
+            <View style={styles.headerRightRow}>
+              <IconChrome
+                icon="share"
+                size={36}
+                onPress={handleShareOpen}
+                accessibilityLabel="Share RSVP event"
+              />
+            </View>
+          }
+        />
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: insets.bottom + spacing.xl },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Hero — cover band + status pill + name + date+venue */}
+        <View style={styles.hero}>
+          <View style={styles.heroCoverWrap}>
+            <EventCoverMedia
+              hue={event.coverHue}
+              mediaUrl={event.coverMediaUrl}
+              mediaType={event.coverMediaType}
+              radius={24}
+              label=""
+              height={200}
+            />
+          </View>
+          <View style={styles.heroOverlay} pointerEvents="none">
+            <View style={styles.heroPillRow}>
+              <EventDetailHeroStatusPill status={status} />
+            </View>
+            <Text style={styles.heroTitle} numberOfLines={2}>
+              {event.name.trim().length > 0 ? event.name : "Untitled RSVP"}
+            </Text>
+            <Text style={styles.heroSubline} numberOfLines={1}>
+              {dateLine}
+              {event.venueName !== null && event.venueName.length > 0
+                ? ` · ${event.venueName}`
+                : ""}
+            </Text>
+          </View>
+        </View>
+
+        {/* Headcount card — replaces the ticketed revenue card */}
+        <GlassCard variant="base" radius="md" padding={spacing.md}>
+          <Text style={styles.goingLabel}>
+            {goingCount === 0 && status !== "past"
+              ? "No one's responded yet"
+              : goingLabel}
+          </Text>
+          <Text style={styles.goingSub}>
+            {goingCount === 0 && status !== "past"
+              ? "0 going"
+              : "confirmed attending"}
+          </Text>
+        </GlassCard>
+
+        {/* Action grid — Guests / Edit / Public page / Brand page */}
+        <View style={styles.actionGrid}>
+          <ActionTile
+            icon="users"
+            label="Guests"
+            primary
+            sub={guestsSub}
+            onPress={handleGuests}
+          />
+          <ActionTile icon="edit" label="Edit" onPress={handleEdit} />
+          <ActionTile
+            icon="eye"
+            label="Public page"
+            onPress={handleViewPublic}
+          />
+          {brand !== null ? (
+            <ActionTile
+              icon="user"
+              label="Brand page"
+              onPress={handleBrandPage}
+            />
+          ) : null}
+        </View>
+      </ScrollView>
+
+      {/* Share modal */}
+      <ShareModal
+        visible={shareModalVisible}
+        onClose={() => setShareModalVisible(false)}
+        url={eventPublicUrl({
+          brandSlug: event.brandSlug,
+          eventSlug: event.eventSlug,
+        })}
+        title={`${event.name} on Mingla`}
+        description={event.description.slice(0, 200) || event.name}
+      />
+
+      {/* Toast wrap — top-anchored per memory rule */}
+      <View style={styles.toastWrap} pointerEvents="box-none">
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast({ visible: false, message: "" })}
+        />
+      </View>
+    </View>
+  );
+}
+
+// ---- Page styles ---------------------------------------------------
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+    backgroundColor: "#0c0e12",
+  },
+  headerWrap: {
+    paddingHorizontal: spacing.md,
+  },
+  headerRightRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+    alignItems: "center",
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    gap: spacing.md,
+  },
+  emptyWrap: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: spacing.lg,
+  },
+  loadingText: {
+    fontSize: 14,
+    color: textTokens.tertiary,
+    textAlign: "center",
+  },
+  hero: {
+    position: "relative",
+    height: 200,
+    borderRadius: radiusTokens.xl,
+    overflow: "hidden",
+  },
+  heroCoverWrap: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  heroOverlay: {
+    position: "absolute",
+    left: spacing.md,
+    right: spacing.md,
+    bottom: spacing.md,
+  },
+  heroPillRow: {
+    flexDirection: "row",
+    marginBottom: spacing.sm,
+  },
+  heroTitle: {
+    fontSize: 24,
+    fontWeight: "700",
+    letterSpacing: -0.2,
+    color: "#ffffff",
+    ...(Platform.OS === "web"
+      ? { textShadow: "0 2px 12px rgba(0, 0, 0, 0.4)" }
+      : {
+          textShadowColor: "rgba(0, 0, 0, 0.4)",
+          textShadowOffset: { width: 0, height: 2 },
+          textShadowRadius: 12,
+        }),
+    marginBottom: 4,
+  },
+  heroSubline: {
+    fontSize: 13,
+    color: "rgba(255, 255, 255, 0.85)",
+  },
+  goingLabel: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  goingSub: {
+    fontSize: 12,
+    color: textTokens.tertiary,
+    marginTop: 2,
+  },
+  actionGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  toastWrap: {
+    position: "absolute",
+    top: 80,
+    left: 0,
+    right: 0,
+    zIndex: 100,
+    elevation: 12,
+  },
+});

--- a/mingla-business/app/rsvp/[id]/index.tsx
+++ b/mingla-business/app/rsvp/[id]/index.tsx
@@ -143,7 +143,15 @@ export default function RsvpDetailScreen(): React.ReactElement {
 
   const handleEdit = useCallback((): void => {
     if (id !== null) {
-      router.push(`/rsvp/${id}/edit` as never);
+      // ORCH-1150-R2 (D-9b) — this detail page is ONLY ever shown for a
+      // PUBLISHED/live RSVP (the draft case is redirected away earlier in the
+      // "Defensive: draft → redirect" effect). So Edit must enter the edit
+      // screen on its edit-published path. Without ?mode=edit-published the
+      // edit screen runs its DRAFT-resolution path (useDraftById) — a published
+      // RSVP has no draft → it never resolves and bounces to the events list
+      // (safeEventsExitRoute). The Hub manage-menu Edit appends this same param
+      // for non-draft rows; the detail-page Edit must match that.
+      router.push(`/rsvp/${id}/edit?mode=edit-published` as never);
     }
   }, [id, router]);
 

--- a/mingla-business/app/rsvp/[id]/index.tsx
+++ b/mingla-business/app/rsvp/[id]/index.tsx
@@ -153,6 +153,24 @@ export default function RsvpDetailScreen(): React.ReactElement {
     }
   }, [id, router]);
 
+  // ORCH-1150 (D-8) — Group chat + Blasts are COMMS, not money: D-4 wrongly
+  // dropped them. Both reuse the event-scoped comms screens (group-chat is
+  // event_type-agnostic; the Blasts audience is extended to event_rsvps
+  // going-guests via resolveRsvpGuests + the useEventBuyers type-probe).
+  const handleGroupChat = useCallback((): void => {
+    if (id !== null) {
+      // orch-strict-grep-allow route-by-event-type — RSVP reuses the event-scoped group-chat/blasts screens (comms, not ticketed)
+      router.push(`/event/${id}/group-chat` as never);
+    }
+  }, [id, router]);
+
+  const handleBlasts = useCallback((): void => {
+    if (id !== null) {
+      // orch-strict-grep-allow route-by-event-type — RSVP reuses the event-scoped group-chat/blasts screens (comms, not ticketed)
+      router.push(`/event/${id}/blasts` as never);
+    }
+  }, [id, router]);
+
   const handleViewPublic = useCallback((): void => {
     if (resolvedLiveEvent !== null) {
       router.push(
@@ -316,6 +334,21 @@ export default function RsvpDetailScreen(): React.ReactElement {
             onPress={handleGuests}
           />
           <ActionTile icon="edit" label="Edit" onPress={handleEdit} />
+          {/* ORCH-1150 (D-8) — Group chat + Blasts are comms (not money):
+              re-added after D-4 dropped them. They reuse the event-scoped
+              comms screens (see handleGroupChat / handleBlasts). */}
+          <ActionTile
+            icon="send"
+            label="Blasts"
+            sub="Message going guests"
+            onPress={handleBlasts}
+          />
+          <ActionTile
+            icon="chat"
+            label="Group chat"
+            sub="Read + reply + moderate"
+            onPress={handleGroupChat}
+          />
           <ActionTile
             icon="eye"
             label="Public page"

--- a/mingla-business/app/rsvp/[id]/preview.tsx
+++ b/mingla-business/app/rsvp/[id]/preview.tsx
@@ -1,0 +1,411 @@
+/**
+ * ORCH-1150-R2 D-5 — /rsvp/[id]/preview — in-app preview of an RSVP draft.
+ *
+ * The RSVP twin of `app/event/[id]/preview.tsx`. Resolves the RSVP draft the
+ * SAME way the ticketed preview does (useDraftById + d_*→server migration +
+ * stale/missing recovery), then renders the RSVP-safe public renderer
+ * `RsvpPublicBody` (the Going / Not-going, money-free surface) — NEVER
+ * `PreviewEventView` / `FoundationEventPreview`, which assume ticket tiers +
+ * checkout (investigation F-3). The Going / Not-going CTA here is a PREVIEW
+ * no-op: it shows an informational toast and NEVER calls `submitPublicRsvp` /
+ * the edge function — a draft has no public guest list to write to.
+ *
+ * DO NOT delete — `RsvpStep7Preview` → `edit.tsx:381` pushes
+ * `/rsvp/{id}/preview`; without this file expo-router falls through to
+ * `+not-found.tsx` (the white-screen / enlarged-logo crash, ORCH-1150-R2).
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Linking, Platform, StyleSheet, Text, View } from "react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import {
+  canvas,
+  spacing,
+  text as textTokens,
+  typography,
+} from "../../../src/constants/designSystem";
+import { Spinner } from "../../../src/components/ui/Spinner";
+import { Toast } from "../../../src/components/ui/Toast";
+import { RsvpPublicBody } from "../../../src/components/event/RsvpPublicBody";
+import {
+  resolveTheme,
+  createThemePalette,
+  type PublicEventProps,
+  type PublicBrandProps,
+} from "@mingla/event-rendering";
+import { useBrandList, type Brand } from "../../../src/store/currentBrandStore";
+import {
+  useDraftById,
+  useDraftEventStore,
+  type DraftEvent,
+} from "../../../src/store/draftEventStore";
+import {
+  eventDraftKeys,
+  useServerDraftById,
+} from "../../../src/hooks/useServerDraftEvents";
+import { createServerDraft } from "../../../src/services/eventDrafts";
+import { useAuth } from "../../../src/context/AuthContext";
+import { isBusinessAuthNotReadyError } from "../../../src/utils/authReadiness";
+import {
+  formatDraftDateLine,
+  formatDraftDateSubline,
+  formatDraftDatesList,
+} from "../../../src/utils/eventDateDisplay";
+import { isLegacyUnsafeEventCoverVideoUrl } from "../../../src/utils/eventCoverMediaRules";
+import { eventCoverProviderCreditLabel } from "../../../src/types/eventCoverProvider";
+
+// ----- Draft → public-prop mappers (inlined to avoid editing PublicEventPage) -
+
+/**
+ * Maps an RSVP DraftEvent into the `PublicEventProps` `RsvpPublicBody` consumes.
+ * Mirrors `PublicEventPage.mapLiveEventToPublicEvent` field-for-field, with two
+ * RSVP/preview adjustments: zero `tickets` (RSVP carries no tiers) and empty
+ * `brandSlug`/`eventSlug` (a draft has no published slug; the preview never
+ * shares — `onShare` is a toast). `currency` is a placeholder ("GBP") never read
+ * by `RsvpPublicBody`.
+ */
+const mapDraftToPublicEvent = (draft: DraftEvent): PublicEventProps => {
+  const coverVideoUnsafe = isLegacyUnsafeEventCoverVideoUrl(
+    draft.coverMediaUrl,
+    draft.coverMediaType,
+  );
+  const safeCoverMediaUrl = coverVideoUnsafe ? null : draft.coverMediaUrl;
+  const safeCoverMediaType = coverVideoUnsafe ? null : draft.coverMediaType;
+  const coverCredit = eventCoverProviderCreditLabel({
+    provider: coverVideoUnsafe ? null : draft.coverMediaProvider ?? null,
+    credit: coverVideoUnsafe ? null : draft.coverMediaCredit ?? null,
+  });
+  return {
+    id: draft.id,
+    name: draft.name,
+    brandId: draft.brandId,
+    brandSlug: draft.serverSlug ?? "",
+    eventSlug: "",
+    description: draft.description,
+    dateLine: formatDraftDateLine(draft),
+    dateSubline: formatDraftDateSubline(draft),
+    datesList: formatDraftDatesList(draft),
+    status: "published",
+    endedAt: null,
+    format:
+      draft.format === "online"
+        ? "online"
+        : draft.format === "hybrid"
+          ? "hybrid"
+          : "in-person",
+    venueName: draft.venueName ?? null,
+    address: draft.address ?? null,
+    hideAddressUntilTicket: Boolean(draft.hideAddressUntilTicket),
+    coverHue: draft.coverHue,
+    coverMediaUrl: safeCoverMediaUrl,
+    coverMediaType:
+      safeCoverMediaType === "image" ||
+      safeCoverMediaType === "video" ||
+      safeCoverMediaType === "gif"
+        ? safeCoverMediaType
+        : null,
+    coverCredit,
+    tickets: [],
+    currency: "GBP",
+    themeOverrides: draft.themeOverrides ?? null,
+  };
+};
+
+/** Identical to `PublicEventPage.mapBrandToPublicBrand` (inlined, not edited). */
+const mapBrandToPublicBrand = (
+  brand: Brand | null,
+): PublicBrandProps | null => {
+  if (brand === null) return null;
+  return {
+    id: brand.id,
+    slug: brand.slug,
+    displayName: brand.displayName ?? "Brand",
+    photo: brand.photo,
+    theme: brand.theme ?? null,
+  };
+};
+
+const openMapsForQuery = (query: string): void => {
+  const encoded = encodeURIComponent(query);
+  const googleUrl = `https://www.google.com/maps/search/?api=1&query=${encoded}`;
+  const platformUrl =
+    Platform.OS === "ios"
+      ? `maps://?q=${encoded}`
+      : Platform.OS === "android"
+        ? `geo:0,0?q=${encoded}`
+        : googleUrl;
+
+  void Linking.openURL(platformUrl).catch(() => {
+    void Linking.openURL(googleUrl).catch(() => undefined);
+  });
+};
+
+export default function RsvpPreviewRoute(): React.ReactElement {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user, isAuthReady } = useAuth();
+  const params = useLocalSearchParams<{ id: string | string[] }>();
+  const idParam = Array.isArray(params.id) ? params.id[0] : params.id;
+  const isLegacyLocalDraftId =
+    typeof idParam === "string" && idParam.startsWith("d_");
+
+  const draft = useDraftById(typeof idParam === "string" ? idParam : null);
+  const serverDraftQuery = useServerDraftById(
+    typeof idParam === "string" && !isLegacyLocalDraftId ? idParam : null,
+  );
+  const serverDraftSettled =
+    isAuthReady &&
+    !isLegacyLocalDraftId &&
+    !serverDraftQuery.isLoading &&
+    !serverDraftQuery.isFetching &&
+    !serverDraftQuery.isError;
+  const staleServerDraft =
+    draft !== null &&
+    !draft.id.startsWith("d_") &&
+    serverDraftSettled &&
+    serverDraftQuery.data === null;
+  const brands = useBrandList();
+  const brand = useMemo(() => {
+    if (draft === null) return null;
+    return brands.find((b) => b.id === draft.brandId) ?? null;
+  }, [draft, brands]);
+  const replaceDraft = useDraftEventStore((s) => s.replaceDraft);
+  const deleteDraft = useDraftEventStore((s) => s.deleteDraft);
+  const migratingLegacyIdRef = React.useRef<string | null>(null);
+  const staleRecoveryDraftIdRef = React.useRef<string | null>(null);
+
+  const [toast, setToast] = useState<{ visible: boolean; message: string }>({
+    visible: false,
+    message: "",
+  });
+  const [muted, setMuted] = useState<boolean>(true);
+
+  // Legacy d_* → server-draft migration + stale recovery + missing-draft bounce.
+  // Copied from app/event/[id]/preview.tsx, with /event targets swapped to /rsvp.
+  useEffect(() => {
+    if (
+      draft !== null &&
+      draft.id.startsWith("d_") &&
+      migratingLegacyIdRef.current !== draft.id
+    ) {
+      if (!isAuthReady) return undefined;
+      migratingLegacyIdRef.current = draft.id;
+      void createServerDraft(draft.brandId, draft)
+        .then((serverDraft) => {
+          replaceDraft(draft.id, serverDraft);
+          router.replace(`/rsvp/${serverDraft.id}/preview` as never);
+        })
+        .catch((error) => {
+          migratingLegacyIdRef.current = null;
+          if (isBusinessAuthNotReadyError(error)) {
+            return;
+          }
+          setToast({
+            visible: true,
+            message: "Could not sync this local draft yet.",
+          });
+        });
+      return undefined;
+    }
+    if (staleServerDraft) {
+      if (staleRecoveryDraftIdRef.current === draft.id) {
+        return undefined;
+      }
+      staleRecoveryDraftIdRef.current = draft.id;
+      deleteDraft(draft.id);
+      queryClient.removeQueries({ queryKey: eventDraftKeys.detail(draft.id) });
+      queryClient.setQueryData<DraftEvent[]>(
+        eventDraftKeys.list(draft.brandId),
+        (prev) => (prev ?? []).filter((d) => d.id !== draft.id),
+      );
+      queryClient.invalidateQueries({ queryKey: eventDraftKeys.list(draft.brandId) });
+      setToast({
+        visible: true,
+        message: "This draft is no longer editable.",
+      });
+      router.replace("/(tabs)/hub/events" as never);
+      return undefined;
+    }
+    if (staleRecoveryDraftIdRef.current === idParam) {
+      return undefined;
+    }
+    if (!isAuthReady) {
+      return undefined;
+    }
+    if (
+      typeof idParam !== "string" ||
+      idParam.length === 0 ||
+      (draft === null && !serverDraftQuery.isLoading && !serverDraftQuery.isFetching)
+    ) {
+      const t = setTimeout(() => {
+        router.replace("/(tabs)/hub/events" as never);
+      }, 0);
+      return (): void => clearTimeout(t);
+    }
+    return undefined;
+  }, [
+    idParam,
+    draft,
+    router,
+    isAuthReady,
+    replaceDraft,
+    deleteDraft,
+    queryClient,
+    serverDraftQuery.isFetching,
+    serverDraftQuery.isError,
+    serverDraftQuery.isLoading,
+    serverDraftQuery.data,
+    staleServerDraft,
+  ]);
+
+  // Wrong-wizard guard (mirror edit.tsx:333–343 inverse): a hand-typed/stale
+  // /rsvp/{id}/preview pointed at a TICKETED draft (isRsvp=false) routes to the
+  // ticketed preview — the route is the discriminator.
+  useEffect(() => {
+    if (draft === null) return;
+    if (draft.isRsvp === false) {
+      // orch-strict-grep-allow route-by-event-type — wrong-wizard fallback: a /rsvp preview URL on a ticketed (isRsvp=false) draft routes to the ticketed event preview
+      router.replace(`/event/${draft.id}/preview` as never);
+    }
+  }, [draft, router]);
+
+  const handleBack = (): void => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace("/(tabs)/hub/events" as never);
+    }
+  };
+
+  const handleShareTap = (): void => {
+    setToast({
+      visible: true,
+      message: "This is a preview — publish to get a shareable link.",
+    });
+  };
+
+  // Preview submit — NO-OP. Never calls submitPublicRsvp / the edge function;
+  // a draft has no public guest list. Resolves to a defined state so the body's
+  // optimistic UI has a return value, but writes nothing.
+  const handlePreviewSubmit = async (): Promise<{
+    status: "going" | "not_going" | "waitlisted";
+    approvalStatus: "pending" | "approved";
+  }> => {
+    setToast({
+      visible: true,
+      message: "This is a preview. Publish to let guests RSVP.",
+    });
+    return { status: "going", approvalStatus: "approved" };
+  };
+
+  if (draft === null) {
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.center}>
+          <Spinner size={36} />
+          <Text style={styles.label}>Loading…</Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (staleServerDraft) {
+    return (
+      <View
+        style={[
+          styles.host,
+          { paddingTop: insets.top, backgroundColor: canvas.discover },
+        ]}
+      >
+        <View style={styles.center}>
+          <Spinner size={36} />
+          <Text style={styles.label}>Recovering event…</Text>
+        </View>
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast((p) => ({ ...p, visible: false }))}
+        />
+      </View>
+    );
+  }
+
+  const publicEvent = mapDraftToPublicEvent(draft);
+  const publicBrand = mapBrandToPublicBrand(brand);
+  const resolvedTheme = resolveTheme(
+    publicBrand?.theme ?? null,
+    publicEvent.themeOverrides ?? null,
+  );
+  const palette = createThemePalette(resolvedTheme);
+
+  return (
+    <View style={styles.host}>
+      <RsvpPublicBody
+        event={publicEvent}
+        brand={publicBrand}
+        palette={palette}
+        theme={resolvedTheme}
+        config={{
+          capacity: draft.rsvpCapacity,
+          goingCount: 0,
+          allowPlusOnes: draft.rsvpAllowPlusOnes,
+          plusOnesMax: draft.rsvpPlusOnesMax,
+          waitlistEnabled: draft.rsvpWaitlistEnabled,
+          manualApproval: draft.rsvpApprovalMode === "manual",
+        }}
+        isLoggedIn={user !== null}
+        muted={muted}
+        onToggleMute={() => setMuted((m) => !m)}
+        onClose={handleBack}
+        onShare={handleShareTap}
+        onOpenBrand={(slug: string) => router.push(`/b/${slug}` as never)}
+        onOpenMaps={openMapsForQuery}
+        onSubmit={handlePreviewSubmit}
+        safeAreaTop={insets.top}
+        testID="orch-1150-rsvp-preview"
+      />
+      <View style={styles.toastWrap} pointerEvents="box-none">
+        <Toast
+          visible={toast.visible}
+          kind="info"
+          message={toast.message}
+          onDismiss={() => setToast((p) => ({ ...p, visible: false }))}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.md,
+  },
+  label: {
+    fontSize: typography.bodySm.fontSize,
+    color: textTokens.secondary,
+  },
+  toastWrap: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    top: 0,
+    paddingTop: spacing.lg,
+    paddingHorizontal: spacing.md,
+  },
+});

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -507,14 +507,16 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
   // The ticketed path below is BYTE-IDENTICAL (untouched) for every non-RSVP row.
   const isRsvp = event.event_type === "rsvp";
   const rsvpSubmit = useCallback(
+    // ORCH-1150 R2 D-10: 'maybe' rides the same wiring (cascade of the widened
+    // RsvpPublicBody.onSubmit + submitPublicRsvp types). No behavior change here.
     async (input: {
-      rsvpStatus: "going" | "not_going";
+      rsvpStatus: "going" | "not_going" | "maybe";
       guestName: string;
       guestEmail: string;
       guestPhone: string;
       plusCount: number;
     }): Promise<{
-      status: "going" | "not_going" | "waitlisted";
+      status: "going" | "not_going" | "waitlisted" | "maybe";
       approvalStatus: "pending" | "approved";
     }> =>
       submitPublicRsvp({

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -57,6 +57,7 @@ import {
 } from "@mingla/event-rendering";
 import { useResponsiveLayout } from "@mingla/offering-rendering";
 
+import { spacing } from "../../constants/designSystem";
 import { EventReserveBar } from "./EventReserveBar";
 import { FoundationEventPreview } from "./FoundationEventPreview";
 import { RsvpPublicBody } from "./RsvpPublicBody";
@@ -569,6 +570,15 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
           onOpenBrand={(slug: string) => router.push(`/b/${slug}` as never)}
           onOpenMaps={openMapsForQuery}
           onSubmit={rsvpSubmit}
+          // ORCH-1150 R2 D-7b — scroll-runway parity with the trip / experience /
+          // ticketed routes. Those routes use `spacing.md` because a DOCKED reserve
+          // bar (or tier list) already adds height; the RSVP body has NEITHER, so it
+          // needs MORE bottom runway to guarantee a short page exceeds the viewport
+          // and the (correctly pinned) cover can be fully scrolled away. Safe-area
+          // bottom + a one-screen-safe pad.
+          contentBottomInset={insets.bottom + spacing.xxl}
+          onScroll={handleScroll}
+          onScrollViewLayout={handleScrollLayout}
           safeAreaTop={insets.top}
           testID="orch-1150-rsvp-public"
         />

--- a/mingla-business/src/components/event/RsvpPublicBody.tsx
+++ b/mingla-business/src/components/event/RsvpPublicBody.tsx
@@ -21,6 +21,9 @@
 
 import React, { useCallback, useMemo, useState } from "react";
 import {
+  type LayoutChangeEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   Platform,
   Pressable,
   StyleSheet,
@@ -77,6 +80,26 @@ export interface RsvpPublicBodyProps {
   onOpenBrand?: (brandSlug: string) => void;
   onOpenMaps?: (query: string) => void;
   /**
+   * ORCH-1150 R2 D-7b — scroll runway. A short RSVP page (no ticket tiers, no
+   * docked CTA) sits under an ~80%-tall pinned-cover spacer, so with a zero
+   * bottom inset the body barely exceeds the viewport ⇒ near-zero scroll travel
+   * ⇒ the (correctly pinned) cover dominates and content reads as "stuck behind
+   * the cover." A positive `contentBottomInset` adds the runway so the body
+   * scrolls UP and OVER the cover — parity with the trip / experience / ticketed
+   * routes. Forwarded straight to `<ParallaxCoverShell contentBottomInset>`
+   * (→ ScrollView `paddingBottom`). Defaults to a positive value so the runway
+   * exists even if a caller forgets to pass it.
+   */
+  contentBottomInset?: number;
+  /**
+   * Convention parity with FoundationEventPreview / trip / experience callers.
+   * RSVP has no float→dock CTA pill, so these have no runtime effect today — they
+   * exist so the RSVP caller matches the shared shell's prop contract and the
+   * regression guard can assert full parity.
+   */
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  onScrollViewLayout?: (event: LayoutChangeEvent) => void;
+  /**
    * Submits the RSVP. Returns the resolved server state so the body can reflect
    * pending / waitlist / going. Throws on error (the body shows an inline error,
    * never a dead end).
@@ -111,6 +134,11 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
   onOpenBrand,
   onOpenMaps,
   onSubmit,
+  // ORCH-1150 R2 D-7b — default to a positive runway so the short RSVP page
+  // always clears the pinned cover even if the caller omits the prop.
+  contentBottomInset = 48,
+  onScroll,
+  onScrollViewLayout,
   safeAreaTop = 0,
   testID,
 }) => {
@@ -573,7 +601,10 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
           {event.name.length > 0 ? event.name : "Untitled event"}
         </Text>
       }
+      contentBottomInset={contentBottomInset}
       safeAreaTop={safeAreaTop}
+      onScroll={onScroll}
+      onScrollViewLayout={onScrollViewLayout}
       testID={testID}
     >
       <View>

--- a/mingla-business/src/components/event/RsvpPublicBody.tsx
+++ b/mingla-business/src/components/event/RsvpPublicBody.tsx
@@ -29,6 +29,10 @@ import {
   View,
 } from "react-native";
 import * as Haptics from "expo-haptics";
+// ORCH-1150 R2 D-10: per-icon NAMED imports (never a `import *` barrel — that
+// defeats tree-shake + blows the ORCH-1083 web bundle budget). Real lib on
+// native; the ORCH-1137 metro web shim maps these three to real DOM-SVG glyphs.
+import { Check, HelpCircle, X } from "lucide-react-native";
 
 import {
   ParallaxCoverShell,
@@ -78,13 +82,13 @@ export interface RsvpPublicBodyProps {
    * never a dead end).
    */
   onSubmit: (input: {
-    rsvpStatus: "going" | "not_going";
+    rsvpStatus: "going" | "not_going" | "maybe";
     guestName: string;
     guestEmail: string;
     guestPhone: string;
     plusCount: number;
   }) => Promise<{
-    status: "going" | "not_going" | "waitlisted";
+    status: "going" | "not_going" | "waitlisted" | "maybe";
     approvalStatus: "pending" | "approved";
   }>;
   safeAreaTop?: number;
@@ -124,7 +128,7 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
 
   // The guest's resolved own state after a successful submit (null = not yet).
   const [guestStatus, setGuestStatus] = useState<
-    "going" | "not_going" | "waitlisted" | null
+    "going" | "not_going" | "waitlisted" | "maybe" | null
   >(null);
   const [guestApproval, setGuestApproval] = useState<
     "pending" | "approved" | null
@@ -158,9 +162,11 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
   const contactReady = isLoggedIn || (nameValid && emailValid && phoneValid);
 
   const submit = useCallback(
-    async (rsvpStatus: "going" | "not_going"): Promise<void> => {
+    async (rsvpStatus: "going" | "not_going" | "maybe"): Promise<void> => {
       if (phase === "submitting") return;
-      if (rsvpStatus === "going" && !contactReady) {
+      // A4-NEW: Going AND Maybe both require a reachable guest (a Maybe must be
+      // updatable). Declining (not_going) needs no contact.
+      if ((rsvpStatus === "going" || rsvpStatus === "maybe") && !contactReady) {
         setErrorMsg("Add your name, email, and phone to RSVP.");
         return;
       }
@@ -233,6 +239,9 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
   const pendingResolved = guestApproval === "pending";
   const notGoingResolved = guestStatus === "not_going";
   const waitlistedResolved = guestStatus === "waitlisted";
+  // ORCH-1150 R2 D-10: a resolved (non-binding) Maybe. NOT a terminal dead end —
+  // a Maybe can still upgrade to Going or decline.
+  const maybeResolved = guestStatus === "maybe";
 
   const headline: string =
     pendingResolved
@@ -241,11 +250,13 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
         ? "You're on the waitlist"
         : goingResolved
           ? "You're going"
-          : notGoingResolved
-            ? "You said you can't make it"
-            : ctaState === "full"
-              ? "This event is full"
-              : "Are you going?";
+          : maybeResolved
+            ? "You're marked as Maybe"
+            : notGoingResolved
+              ? "You said you can't make it"
+              : ctaState === "full"
+                ? "This event is full"
+                : "Are you going?";
 
   const subcopy: string | null =
     pendingResolved
@@ -254,15 +265,17 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
         ? "A spot opened? We'll text and email you automatically."
         : goingResolved
           ? "We'll let you know if anything about the event changes."
-          : notGoingResolved
-            ? "Changed your mind? You can switch to Going."
-            : ctaState === "full"
-              ? config.waitlistEnabled
-                ? "Join the waitlist and we'll move you in if a spot opens."
-                : "The guest list is full for now."
-              : config.manualApproval
-                ? "The host approves each guest after you reply."
-                : null;
+          : maybeResolved
+            ? "You're marked as Maybe — we'll keep you posted. Switch to Going anytime."
+            : notGoingResolved
+              ? "Changed your mind? You can switch to Going."
+              : ctaState === "full"
+                ? config.waitlistEnabled
+                  ? "Join the waitlist and we'll move you in if a spot opens."
+                  : "The guest list is full for now."
+                : config.manualApproval
+                  ? "The host approves each guest after you reply."
+                  : null;
 
   // Whether the Going button is the waitlist-join variant.
   const goingIsWaitlist =
@@ -282,11 +295,18 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
       ? "Saving…"
       : "Going";
 
+  // ORCH-1150 R2 D-10: Maybe is disabled while submitting or once the guest has
+  // resolved to a BINDING state (going / pending / waitlisted). It stays
+  // available from the open + not_going states (so a decline can flip to Maybe).
+  const maybeDisabled =
+    submitting || goingResolved || pendingResolved || waitlistedResolved || maybeResolved;
+
   const showContactForm =
     !isLoggedIn &&
     !goingResolved &&
     !pendingResolved &&
     !waitlistedResolved &&
+    !maybeResolved &&
     !(ctaState === "full" && !config.waitlistEnabled);
 
   const actionCard = (
@@ -352,7 +372,8 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
       {config.allowPlusOnes &&
       !goingResolved &&
       !pendingResolved &&
-      !waitlistedResolved ? (
+      !waitlistedResolved &&
+      !maybeResolved ? (
         <View style={[styles.plusRow, surface.card]}>
           <Text style={[styles.plusLabel, surface.secondaryText]}>
             Bringing extras?
@@ -395,7 +416,12 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
         </Text>
       ) : null}
 
-      {!goingResolved && !pendingResolved && !notGoingResolved ? (
+      {/* ORCH-1150 R2 D-10: the three-button RSVP CTA — Going · Maybe · Not going.
+          Each button is flex:1 (equal width). Going = filled accent (primary),
+          Maybe = accent-wash secondary, Not going = outlined tertiary. Icons are
+          per-icon lucide imports (Check / HelpCircle / X). Android fills are
+          opaque (ANDROID_GLASS_USES_OPAQUE_FALLBACK). */}
+      {!goingResolved && !pendingResolved && !notGoingResolved && !maybeResolved ? (
         <View style={styles.ctaRow}>
           <Pressable
             onPress={() => void submit("going")}
@@ -404,16 +430,20 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
             accessibilityState={{ disabled: goingDisabled }}
             accessibilityLabel={goingLabel}
             style={[
-              styles.goingBtn,
+              styles.ctaBtn,
               goingDisabled
                 ? { backgroundColor: palette.card, borderColor: palette.panelBorder, borderWidth: 1 }
                 : { backgroundColor: palette.accent },
             ]}
             testID="orch-1150-rsvp-going"
           >
+            <Check
+              size={19}
+              color={goingDisabled ? palette.tertiaryText : palette.accentText}
+            />
             <Text
               style={[
-                styles.goingText,
+                styles.ctaBtnText,
                 {
                   color: goingDisabled ? palette.tertiaryText : palette.accentText,
                   fontFamily: boldFamily,
@@ -425,39 +455,89 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
           </Pressable>
           {!waitlistedResolved ? (
             <Pressable
+              onPress={() => void submit("maybe")}
+              disabled={maybeDisabled}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: maybeDisabled }}
+              accessibilityLabel="Maybe"
+              style={[
+                styles.ctaBtn,
+                {
+                  backgroundColor: palette.accentWash,
+                  borderColor: palette.accent,
+                  borderWidth: 1,
+                  opacity: maybeDisabled ? 0.5 : 1,
+                },
+              ]}
+              testID="orch-1150-rsvp-maybe"
+            >
+              <HelpCircle size={19} color={palette.accent} />
+              <Text
+                style={[
+                  styles.ctaBtnText,
+                  { color: palette.accent, fontFamily: boldFamily },
+                ]}
+              >
+                Maybe
+              </Text>
+            </Pressable>
+          ) : null}
+          {!waitlistedResolved ? (
+            <Pressable
               onPress={() => void submit("not_going")}
               disabled={submitting}
               accessibilityRole="button"
               accessibilityLabel="Not going"
-              style={[styles.notGoingBtn, { borderColor: palette.panelBorder }]}
+              style={[styles.ctaBtn, { borderColor: palette.panelBorder, borderWidth: 1 }]}
               testID="orch-1150-rsvp-not-going"
             >
-              <Text style={[styles.notGoingText, surface.secondaryText]}>
-                Not going
+              <X size={19} color={palette.secondaryText} />
+              <Text style={[styles.ctaBtnText, surface.secondaryText]}>
+                Can't go
               </Text>
             </Pressable>
           ) : null}
         </View>
       ) : null}
 
-      {notGoingResolved ? (
-        <Pressable
-          onPress={() => void submit("going")}
-          disabled={submitting}
-          accessibilityRole="button"
-          accessibilityLabel="Switch to Going"
-          style={[styles.goingBtn, { backgroundColor: palette.accent }]}
-          testID="orch-1150-rsvp-switch-going"
-        >
-          <Text
-            style={[
-              styles.goingText,
-              { color: palette.accentText, fontFamily: boldFamily },
-            ]}
+      {/* ORCH-1150 R2 D-10: a resolved not_going OR maybe can upgrade to Going.
+          A Maybe can additionally still decline (never a dead end). */}
+      {notGoingResolved || maybeResolved ? (
+        <View style={styles.ctaRow}>
+          <Pressable
+            onPress={() => void submit("going")}
+            disabled={submitting}
+            accessibilityRole="button"
+            accessibilityLabel="Switch to Going"
+            style={[styles.ctaBtn, { backgroundColor: palette.accent }]}
+            testID="orch-1150-rsvp-switch-going"
           >
-            Actually, I'm going
-          </Text>
-        </Pressable>
+            <Check size={19} color={palette.accentText} />
+            <Text
+              style={[
+                styles.ctaBtnText,
+                { color: palette.accentText, fontFamily: boldFamily },
+              ]}
+            >
+              {maybeResolved ? "Switch to Going" : "Actually, I'm going"}
+            </Text>
+          </Pressable>
+          {maybeResolved ? (
+            <Pressable
+              onPress={() => void submit("not_going")}
+              disabled={submitting}
+              accessibilityRole="button"
+              accessibilityLabel="Can't make it"
+              style={[styles.ctaBtn, { borderColor: palette.panelBorder, borderWidth: 1 }]}
+              testID="orch-1150-rsvp-maybe-decline"
+            >
+              <X size={19} color={palette.secondaryText} />
+              <Text style={[styles.ctaBtnText, surface.secondaryText]}>
+                Can't go
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
       ) : null}
     </View>
   );
@@ -703,24 +783,19 @@ const styles = StyleSheet.create({
   stepCount: { fontSize: 16, fontWeight: "800", minWidth: 40, textAlign: "center" },
   errorText: { color: "#e5484d", fontSize: 13, marginTop: 10, marginBottom: 2 },
   ctaRow: { flexDirection: "row", marginTop: 14, gap: 10 },
-  goingBtn: {
+  // ORCH-1150 R2 D-10: equal-width (flex:1) RSVP CTA buttons. overflow:'hidden'
+  // clips the opaque Android fill under the rounded corners (no translucent fill).
+  ctaBtn: {
     flex: 1,
+    flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    gap: 7,
     borderRadius: 14,
     paddingVertical: 15,
-    marginTop: 14,
+    overflow: "hidden",
   },
-  goingText: { fontSize: 16, fontWeight: "900" },
-  notGoingBtn: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 14,
-    paddingVertical: 15,
-    borderWidth: 1,
-  },
-  notGoingText: { fontSize: 15, fontWeight: "700" },
+  ctaBtnText: { fontSize: 15, fontWeight: "900" },
   factRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/mingla-business/src/components/event/__tests__/RsvpPublicBody.maybeCta.orch1150r2.test.ts
+++ b/mingla-business/src/components/event/__tests__/RsvpPublicBody.maybeCta.orch1150r2.test.ts
@@ -1,0 +1,63 @@
+/**
+ * ORCH-1150 R2 — RsvpPublicBody source-structure regression (happy-path).
+ *
+ * Owner: mingla-implementor (the tester adds a SECOND adversarial angle).
+ *
+ * @testing-library/react-native is NOT a dependency of mingla-business (see the
+ * repo-wide pre-existing TS2307s), so the CTA + D-7 layering invariants are
+ * enforced as SOURCE-STRUCTURE assertions (SPEC §7 T8/T11 explicitly call these
+ * "component (source)"). Each assertion FAILS if the corresponding fix line is
+ * deleted — proving fails-on-revert without a runtime renderer.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SRC = readFileSync(
+  join(__dirname, "..", "RsvpPublicBody.tsx"),
+  "utf8",
+);
+
+describe("ORCH-1150 R2 D-10 — RsvpPublicBody three-button CTA", () => {
+  it("imports the three lucide icons per-icon NAMED (never a barrel import)", () => {
+    // INV: real-glyph icons on native + ORCH-1137 web shim; per-icon = tree-shake-safe.
+    expect(SRC).toMatch(
+      /import\s*\{\s*Check\s*,\s*HelpCircle\s*,\s*X\s*\}\s*from\s*["']lucide-react-native["']/,
+    );
+    // Must NOT barrel-import lucide (would blow the ORCH-1083 web bundle budget).
+    expect(SRC).not.toMatch(/import\s*\*\s*as\s*\w+\s*from\s*["']lucide-react-native["']/);
+  });
+
+  it("renders Going · Maybe · Can't-go, each as a flex:1 equal-width ctaBtn", () => {
+    expect(SRC).toContain('testID="orch-1150-rsvp-going"');
+    expect(SRC).toContain('testID="orch-1150-rsvp-maybe"');
+    expect(SRC).toContain('testID="orch-1150-rsvp-not-going"');
+    // The shared CTA button style is flex:1 (equal width).
+    expect(SRC).toMatch(/ctaBtn:\s*\{[\s\S]*?flex:\s*1/);
+  });
+
+  it("threads the correct lucide icon into each button", () => {
+    // Going → Check, Maybe → HelpCircle, Can't-go → X.
+    expect(SRC).toMatch(/<Check\s+size=\{19\}/);
+    expect(SRC).toMatch(/<HelpCircle\s+size=\{19\}/);
+    expect(SRC).toMatch(/<X\s+size=\{19\}/);
+  });
+
+  it("submit() accepts the three-status union and routes 'maybe'", () => {
+    expect(SRC).toMatch(
+      /rsvpStatus:\s*["']going["']\s*\|\s*["']not_going["']\s*\|\s*["']maybe["']/,
+    );
+    expect(SRC).toContain('void submit("maybe")');
+  });
+
+  it("applies the A4-NEW contact gate to BOTH going and maybe (a Maybe must be reachable)", () => {
+    expect(SRC).toMatch(
+      /\(rsvpStatus === "going" \|\| rsvpStatus === "maybe"\) && !contactReady/,
+    );
+  });
+
+  it("shows the keep-posted response copy for a resolved maybe", () => {
+    expect(SRC).toContain("You're marked as Maybe");
+    expect(SRC).toMatch(/we'll keep you posted/i);
+  });
+});

--- a/mingla-business/src/components/event/__tests__/RsvpPublicBody.parallaxLayering.orch1150r2.test.ts
+++ b/mingla-business/src/components/event/__tests__/RsvpPublicBody.parallaxLayering.orch1150r2.test.ts
@@ -1,0 +1,40 @@
+/**
+ * ORCH-1150 R2 D-7 — RsvpPublicBody parallax content-layering safety-net.
+ *
+ * Owner: mingla-implementor (the tester adds the device fresh-build re-test).
+ *
+ * The shared ParallaxCoverShell carries the ORCH-1138 cover<content<chrome
+ * z-order (proven + guarded by ParallaxCoverShell_native_stacking.test.ts). The
+ * RSVP body must consume that SHARED, fixed shell and pass its content as a bare
+ * <View> with NO competing stacking style — so the shell, not the body, owns the
+ * seam/z-order (re-adding a zIndex/marginTop here re-creates the pre-ORCH-1138
+ * double-seam inversion Seth reported; investigation F-1 = most likely a stale
+ * build). These source-structure assertions FAIL on any such revert.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SRC = readFileSync(join(__dirname, "..", "RsvpPublicBody.tsx"), "utf8");
+
+describe("ORCH-1150 R2 D-7 — RsvpPublicBody parallax content layering", () => {
+  it("imports ParallaxCoverShell from the shared @mingla/offering-rendering package", () => {
+    expect(SRC).toMatch(
+      /import\s*\{[\s\S]*ParallaxCoverShell[\s\S]*\}\s*from\s*["']@mingla\/offering-rendering["']/,
+    );
+  });
+
+  it("passes its body as a bare <View> child of <ParallaxCoverShell> (shell owns the seam)", () => {
+    expect(SRC).toMatch(/<ParallaxCoverShell[\s\S]*?>\s*<View>\s*\{\/\* Brand chip/);
+  });
+
+  it("does NOT give the RSVP content wrapper a zIndex / position / marginTop / backgroundColor", () => {
+    const m = SRC.match(/<ParallaxCoverShell[\s\S]*?>\s*<View(\s[^>]*)?>/);
+    expect(m).not.toBeNull();
+    const childOpenTag = m ? m[0] : "";
+    expect(childOpenTag).not.toMatch(/zIndex/);
+    expect(childOpenTag).not.toMatch(/position:/);
+    expect(childOpenTag).not.toMatch(/marginTop/);
+    expect(childOpenTag).not.toMatch(/backgroundColor/);
+  });
+});

--- a/mingla-business/src/components/event/__tests__/RsvpPublicBody.parallaxLayering.orch1150r2.test.ts
+++ b/mingla-business/src/components/event/__tests__/RsvpPublicBody.parallaxLayering.orch1150r2.test.ts
@@ -16,6 +16,10 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 const SRC = readFileSync(join(__dirname, "..", "RsvpPublicBody.tsx"), "utf8");
+const PAGE_SRC = readFileSync(
+  join(__dirname, "..", "PublicEventPage.tsx"),
+  "utf8",
+);
 
 describe("ORCH-1150 R2 D-7 — RsvpPublicBody parallax content layering", () => {
   it("imports ParallaxCoverShell from the shared @mingla/offering-rendering package", () => {
@@ -36,5 +40,57 @@ describe("ORCH-1150 R2 D-7 — RsvpPublicBody parallax content layering", () => 
     expect(childOpenTag).not.toMatch(/position:/);
     expect(childOpenTag).not.toMatch(/marginTop/);
     expect(childOpenTag).not.toMatch(/backgroundColor/);
+  });
+});
+
+/**
+ * ORCH-1150 R2 D-7b — RSVP scroll-runway parity (fails-on-revert).
+ *
+ * The RSVP public page is SHORT (no tier list, no docked CTA) and sits under an
+ * ~80%-tall pinned-cover spacer. With `contentBottomInset=0` (the shell default),
+ * the body barely exceeds the viewport ⇒ near-zero scroll travel ⇒ the correctly
+ * pinned cover dominates and content reads as "stuck behind the cover." The fix:
+ * plumb a POSITIVE `contentBottomInset` end-to-end (PublicEventPage RSVP branch →
+ * RsvpPublicBodyProps → <ParallaxCoverShell>), giving real scroll runway so the
+ * body scrolls UP and OVER the cover — parity with trip / experience / ticketed.
+ *
+ * These source assertions FAIL if the inset plumbing is reverted to 0 / removed.
+ */
+describe("ORCH-1150 R2 D-7b — RSVP scroll-runway parity", () => {
+  it("RsvpPublicBody declares a contentBottomInset prop", () => {
+    expect(SRC).toMatch(/contentBottomInset\?:\s*number/);
+  });
+
+  it("RsvpPublicBody defaults contentBottomInset to a NON-ZERO positive value", () => {
+    const m = SRC.match(/contentBottomInset\s*=\s*(\d+)/);
+    expect(m).not.toBeNull();
+    const dflt = m ? Number(m[1]) : 0;
+    expect(dflt).toBeGreaterThan(0);
+  });
+
+  it("RsvpPublicBody forwards contentBottomInset to <ParallaxCoverShell>", () => {
+    expect(SRC).toMatch(
+      /<ParallaxCoverShell[\s\S]*?contentBottomInset=\{contentBottomInset\}[\s\S]*?>/,
+    );
+  });
+
+  it("RsvpPublicBody forwards onScroll / onScrollViewLayout to <ParallaxCoverShell> (convention parity)", () => {
+    expect(SRC).toMatch(
+      /<ParallaxCoverShell[\s\S]*?onScroll=\{onScroll\}[\s\S]*?>/,
+    );
+    expect(SRC).toMatch(
+      /<ParallaxCoverShell[\s\S]*?onScrollViewLayout=\{onScrollViewLayout\}[\s\S]*?>/,
+    );
+  });
+
+  it("PublicEventPage RSVP branch passes a POSITIVE contentBottomInset to <RsvpPublicBody>", () => {
+    const m = PAGE_SRC.match(/<RsvpPublicBody[\s\S]*?\/>/);
+    expect(m).not.toBeNull();
+    const tag = m ? m[0] : "";
+    // must pass contentBottomInset, and it must NOT be a literal 0
+    expect(tag).toMatch(/contentBottomInset=\{[\s\S]*?\}/);
+    expect(tag).not.toMatch(/contentBottomInset=\{0\}/);
+    // the chosen value adds safe-area bottom plus a spacing runway
+    expect(tag).toMatch(/contentBottomInset=\{insets\.bottom\s*\+\s*spacing\./);
   });
 });

--- a/mingla-business/src/components/offering/__tests__/resolveRsvpCta.maybe.orch1150r2.test.ts
+++ b/mingla-business/src/components/offering/__tests__/resolveRsvpCta.maybe.orch1150r2.test.ts
@@ -1,0 +1,49 @@
+/**
+ * ORCH-1150 R2 D-10 — resolveRsvpCta 'maybe' state regression (happy-path).
+ *
+ * Owner: mingla-implementor (the tester adds a SECOND adversarial angle).
+ *
+ * offeringCta imports ONLY types (no RN runtime), so it resolves under ts-jest.
+ * Fails-on-revert: deleting the `if (guestStatus === "maybe") return …` branch
+ * in resolveRsvpCta makes the first assertion fall through to "open" → FAIL.
+ */
+
+import { resolveRsvpCta } from "../../../../../packages/event-rendering/offeringCta";
+
+describe("ORCH-1150 R2 — resolveRsvpCta maybe", () => {
+  it("reflects a guest's own resolved 'maybe' state", () => {
+    expect(
+      resolveRsvpCta({
+        capacityFull: false,
+        waitlistEnabled: false,
+        manualApproval: false,
+        guestStatus: "maybe",
+        guestApproval: "approved",
+      }).state,
+    ).toBe("maybe");
+  });
+
+  it("maybe wins even when the event capacity is full (non-binding, cap-neutral)", () => {
+    expect(
+      resolveRsvpCta({
+        capacityFull: true,
+        waitlistEnabled: true,
+        manualApproval: false,
+        guestStatus: "maybe",
+        guestApproval: "approved",
+      }).state,
+    ).toBe("maybe");
+  });
+
+  it("pending still outranks a maybe-typed row (approval precedence preserved)", () => {
+    expect(
+      resolveRsvpCta({
+        capacityFull: false,
+        waitlistEnabled: false,
+        manualApproval: true,
+        guestStatus: "maybe",
+        guestApproval: "pending",
+      }).state,
+    ).toBe("pending");
+  });
+});

--- a/mingla-business/src/components/offering/__tests__/rsvpMaybeMigration.orch1150r2.test.ts
+++ b/mingla-business/src/components/offering/__tests__/rsvpMaybeMigration.orch1150r2.test.ts
@@ -1,0 +1,80 @@
+/**
+ * ORCH-1150 R2 D-10 — RSVP 'maybe' migration source-contract regression.
+ *
+ * Owner: mingla-implementor (the tester adds the live DB SQL-probe angle once the
+ * orchestrator applies the migration — see supabase/migrations/__tests__).
+ *
+ * Enforces the migration-source half of I-PROPOSED-1150-MAYBE-NOT-IN-CAP +
+ * the CHECK/RLS/RPC widen, as TEXT assertions runnable without a live DB:
+ *   - the new migration widens the CHECK + RLS + submit_event_rsvp to allow 'maybe';
+ *   - 'maybe' is AUTO-APPROVED + CAP-NEUTRAL (mirrors not_going, never a seat);
+ *   - the base capacity headcount predicate STILL reads `going AND approved` only
+ *     (the maybe migration must not have added 'maybe' to a cap predicate).
+ * Each assertion FAILS on deletion of the corresponding migration line.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MIGRATIONS = join(__dirname, "..", "..", "..", "..", "..", "supabase", "migrations");
+const MAYBE_SQL = readFileSync(
+  join(MIGRATIONS, "20261012000000_orch_1150_rsvp_maybe.sql"),
+  "utf8",
+);
+
+describe("ORCH-1150 R2 D-10 — maybe migration widens CHECK / RLS / RPC", () => {
+  it("widens the rsvp_status CHECK to include 'maybe' (DROP-before-ADD)", () => {
+    expect(MAYBE_SQL).toMatch(/DROP CONSTRAINT IF EXISTS event_rsvps_rsvp_status_check/);
+    expect(MAYBE_SQL).toMatch(
+      /CHECK \(rsvp_status IN \('going',\s*'not_going',\s*'waitlisted',\s*'maybe'\)\)/,
+    );
+  });
+
+  it("widens the guest-update RLS WITH CHECK to allow setting 'maybe'", () => {
+    expect(MAYBE_SQL).toMatch(/event_rsvps_guest_update_own/);
+    expect(MAYBE_SQL).toMatch(/rsvp_status IN \('going',\s*'not_going',\s*'maybe'\)/);
+  });
+
+  it("accepts 'maybe' in submit_event_rsvp validation (else rsvp_status_invalid)", () => {
+    expect(MAYBE_SQL).toMatch(
+      /p_rsvp_status NOT IN \('going',\s*'not_going',\s*'maybe'\)/,
+    );
+  });
+
+  it("resolves 'maybe' as auto-approved + cap-neutral (its own branch before the capacity math)", () => {
+    expect(MAYBE_SQL).toMatch(
+      /ELSIF p_rsvp_status = 'maybe' THEN[\s\S]*?v_status := 'maybe';[\s\S]*?v_approval := 'approved';/,
+    );
+  });
+
+  it("orders a 'maybe' bucket into host_list_rsvp_guests", () => {
+    expect(MAYBE_SQL).toMatch(/WHEN r\.rsvp_status = 'maybe' THEN 3/);
+  });
+});
+
+describe("ORCH-1150 R2 — I-PROPOSED-1150-MAYBE-NOT-IN-CAP (cap predicates untouched)", () => {
+  const BASE_SQL = readFileSync(
+    join(MIGRATIONS, "20261004000000_orch_1150_rsvp_events.sql"),
+    "utf8",
+  );
+
+  it("the confirmed-headcount predicate still counts ONLY going AND approved", () => {
+    // The capacity SUM in submit_event_rsvp must remain going+approved (never +maybe).
+    expect(BASE_SQL).toMatch(
+      /r\.rsvp_status = 'going' AND r\.approval_status = 'approved'/,
+    );
+  });
+
+  it("the maybe migration's capacity SUM predicate still reads ONLY going AND approved", () => {
+    // The re-created submit_event_rsvp keeps the confirmed-headcount SUM gated on
+    // going+approved — adding 'maybe' to THIS predicate would make a maybe occupy
+    // a seat (I-PROPOSED-1150-MAYBE-NOT-IN-CAP violation). Isolate the SUM's WHERE.
+    const sumBlock = MAYBE_SQL.match(
+      /SELECT COALESCE\(SUM\(1 \+ r\.plus_count\)[\s\S]*?WHERE([\s\S]*?);/,
+    );
+    expect(sumBlock).not.toBeNull();
+    const where = sumBlock ? sumBlock[1] : "";
+    expect(where).toMatch(/r\.rsvp_status = 'going' AND r\.approval_status = 'approved'/);
+    expect(where).not.toMatch(/'maybe'/);
+  });
+});

--- a/mingla-business/src/components/rsvp/RsvpGuestConsole.tsx
+++ b/mingla-business/src/components/rsvp/RsvpGuestConsole.tsx
@@ -84,6 +84,12 @@ export const RsvpGuestConsole: React.FC<RsvpGuestConsoleProps> = ({
     () => guests.filter((g) => g.rsvpStatus === "waitlisted"),
     [guests],
   );
+  // ORCH-1150 R2 D-10: read-only "Maybe" group — non-binding, cap-neutral guests
+  // (auto-approved). No approve/deny actions; the host just sees who might come.
+  const maybe = useMemo(
+    () => guests.filter((g) => g.rsvpStatus === "maybe"),
+    [guests],
+  );
 
   const showToast = useCallback((message: string): void => {
     setToast({ visible: true, message });
@@ -262,6 +268,27 @@ export const RsvpGuestConsole: React.FC<RsvpGuestConsoleProps> = ({
             ))
           )}
         </View>
+
+        {/* Maybe section (read-only) — ORCH-1150 R2 D-10 */}
+        {maybe.length > 0 ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Maybe ({maybe.length})</Text>
+            {maybe.map((g) => (
+              <View key={g.id} style={styles.guestRow} testID={`rsvp-maybe-${g.id}`}>
+                <View style={styles.guestInfo}>
+                  <Text style={styles.guestName} numberOfLines={1}>
+                    {g.guestName}
+                    {g.plusCount > 0 ? <Text style={styles.plusChip}>  +{g.plusCount}</Text> : null}
+                  </Text>
+                  <Text style={styles.guestContact} numberOfLines={1}>
+                    {g.guestEmail ?? g.guestPhone ?? "App guest"}
+                  </Text>
+                </View>
+                <Icon name="users" size={18} color={textTokens.tertiary} />
+              </View>
+            ))}
+          </View>
+        ) : null}
 
         {/* Waitlist section (read-only) */}
         {waitlisted.length > 0 ? (

--- a/mingla-business/src/hooks/marketing/__tests__/useEventBuyers.rsvpAudience.test.ts
+++ b/mingla-business/src/hooks/marketing/__tests__/useEventBuyers.rsvpAudience.test.ts
@@ -1,0 +1,60 @@
+/**
+ * useEventBuyers.rsvpAudience.test.ts — ORCH-1150-R2 (D-8).
+ *
+ * RSVP events have ZERO `orders` rows, so the Blasts audience must come from
+ * `event_rsvps` (going-guests) via `resolveRsvpGuests`, NOT `resolveEventBuyers`
+ * (orders-derived). The shared Blasts screen (DO-NOT-TOUCH) calls
+ * `useEventBuyers(eventId)` with no event-type, so the hook probes
+ * `events.event_type` and routes RSVP events to the event_rsvps resolver.
+ *
+ * Hook-render tests need a QueryClientProvider + RN harness (not installed at
+ * this layer) — source-grep is the established resolution here (mirrors
+ * useAudienceList.test.ts). The resolver-selection contract is the thing that
+ * must not silently regress.
+ *
+ * Fails-on-revert: deleting the resolveRsvpGuests import / the `=== "rsvp"`
+ * branch / the type-probe makes these assertions fail (the hook would fall
+ * back to resolveEventBuyers for RSVP events → permanently-empty Blasts).
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const HOOK_PATH = path.resolve(__dirname, "..", "useEventBuyers.ts");
+
+describe("useEventBuyers RSVP audience routing (ORCH-1150-R2 D-8)", () => {
+  let source: string;
+
+  beforeAll(() => {
+    source = fs.readFileSync(HOOK_PATH, "utf8");
+  });
+
+  it("imports resolveRsvpGuests (the event_rsvps-backed resolver)", () => {
+    expect(source).toMatch(/import\s*\{[\s\S]*resolveRsvpGuests[\s\S]*\}\s*from\s*["'].*marketingAudienceService["']/);
+  });
+
+  it("routes RSVP events to resolveRsvpGuests and others to resolveEventBuyers", () => {
+    // The queryFn must branch on the resolved type.
+    expect(source).toMatch(/resolvedType\s*===\s*"rsvp"\s*[\s\S]{0,40}resolveRsvpGuests/);
+    expect(source).toContain("resolveEventBuyers");
+  });
+
+  it("accepts an optional eventType arg and falls back to an events.event_type probe", () => {
+    // Optional override param per the SPEC contract.
+    expect(source).toMatch(/eventType\?:\s*EventBuyersAudienceType/);
+    // Internal probe so the DO-NOT-TOUCH blasts screen (no eventType) still
+    // auto-detects RSVP events.
+    expect(source).toContain('.from("events")');
+    expect(source).toContain('event_type');
+    expect(source).toMatch(/event_type\s*===\s*"rsvp"\s*\?\s*"rsvp"\s*:\s*"event"/);
+  });
+
+  it("waits for the type probe before firing the wrong resolver on first paint", () => {
+    // audienceEnabled must require the type to be known (passed or probed).
+    expect(source).toMatch(/audienceEnabled/);
+    expect(source).toMatch(/eventType !== undefined \|\| typeProbe\.data !== undefined/);
+  });
+
+  it("keys the audience cache by event-type so ticketed/RSVP don't collide", () => {
+    expect(source).toMatch(/byEvent:\s*\(\s*\n?\s*eventId: string,\s*\n?\s*eventType: EventBuyersAudienceType/);
+  });
+});

--- a/mingla-business/src/hooks/marketing/useEventBuyers.ts
+++ b/mingla-business/src/hooks/marketing/useEventBuyers.ts
@@ -69,6 +69,7 @@ export function useEventBuyers(
       ? ["marketing", "event-buyers", "type-probe", eventId]
       : ["marketing", "event-buyers", "type-probe"],
     queryFn: async () => {
+      // orch-strict-grep-allow events-type-filter — ORCH-1150 D-8: RSVP audience path; this query READS events.event_type itself (to route RSVP vs ticketed), so an event_type literal filter is intentionally absent.
       const { data, error } = await supabase
         .from("events")
         .select("event_type")

--- a/mingla-business/src/hooks/marketing/useEventBuyers.ts
+++ b/mingla-business/src/hooks/marketing/useEventBuyers.ts
@@ -14,17 +14,29 @@ import { useMemo } from "react";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 import { useAuth } from "../../context/AuthContext";
+import { supabase } from "../../services/supabase";
 import {
   resolveEventBuyers,
+  resolveRsvpGuests,
   type ResolveBuyersResult,
 } from "../../services/marketing/marketingAudienceService";
 
 const STALE_TIME_MS = 60 * 1000;
 
+/**
+ * ORCH-1150 (D-8) — the audience source depends on the event's `event_type`.
+ * Ticketed events draw from `orders` (resolveEventBuyers); RSVP events have no
+ * orders and draw their going-guests from `event_rsvps` (resolveRsvpGuests).
+ */
+export type EventBuyersAudienceType = "event" | "rsvp";
+
 export const eventBuyersKeys = {
   all: ["marketing", "event-buyers"] as const,
-  byEvent: (eventId: string): readonly [string, string, string] =>
-    ["marketing", "event-buyers", eventId] as const,
+  byEvent: (
+    eventId: string,
+    eventType: EventBuyersAudienceType,
+  ): readonly [string, string, string, EventBuyersAudienceType] =>
+    ["marketing", "event-buyers", eventId, eventType] as const,
 };
 
 export interface UseEventBuyersState {
@@ -37,31 +49,81 @@ export interface UseEventBuyersState {
 
 export function useEventBuyers(
   eventId: string | null | undefined,
+  // ORCH-1150 (D-8) — optional event-type override. The shared Blasts screen
+  // (app/event/[id]/blasts) doesn't know the type, so when omitted the hook
+  // probes `events.event_type` itself and routes RSVP events to the
+  // event_rsvps-backed resolver. Callers that already know the type (e.g. an
+  // RSVP-scoped screen) may pass it to skip the probe.
+  eventType?: EventBuyersAudienceType,
 ): UseEventBuyersState {
   // ORCH-1004 — event buyers read auth.uid()-scoped buyer rollups; gate on auth.
   const { isAuthReady } = useAuth();
   const enabled =
     isAuthReady && typeof eventId === "string" && eventId.length > 0;
 
-  const query = useQuery<ResolveBuyersResult>({
+  // ORCH-1150 (D-8) — resolve the audience type. When the caller didn't pass
+  // one, probe events.event_type once (cached under its own key). This keeps
+  // the DO-NOT-TOUCH blasts screen working for both ticketed + RSVP events.
+  const typeProbe = useQuery<EventBuyersAudienceType>({
     queryKey: enabled
-      ? eventBuyersKeys.byEvent(eventId)
-      : eventBuyersKeys.all,
+      ? ["marketing", "event-buyers", "type-probe", eventId]
+      : ["marketing", "event-buyers", "type-probe"],
     queryFn: async () => {
-      return resolveEventBuyers(eventId as string);
+      const { data, error } = await supabase
+        .from("events")
+        .select("event_type")
+        .eq("id", eventId as string)
+        .maybeSingle();
+      if (error) throw error;
+      return data?.event_type === "rsvp" ? "rsvp" : "event";
     },
-    enabled,
+    enabled: enabled && eventType === undefined,
     staleTime: STALE_TIME_MS,
   });
+
+  const resolvedType: EventBuyersAudienceType =
+    eventType ?? typeProbe.data ?? "event";
+  // When we must probe the type, wait for it to settle before resolving the
+  // audience so we don't fire the wrong resolver on the first paint.
+  const audienceEnabled =
+    enabled && (eventType !== undefined || typeProbe.data !== undefined);
+
+  const query = useQuery<ResolveBuyersResult>({
+    queryKey: audienceEnabled
+      ? eventBuyersKeys.byEvent(eventId as string, resolvedType)
+      : eventBuyersKeys.all,
+    queryFn: async () => {
+      return resolvedType === "rsvp"
+        ? resolveRsvpGuests(eventId as string)
+        : resolveEventBuyers(eventId as string);
+    },
+    enabled: audienceEnabled,
+    staleTime: STALE_TIME_MS,
+  });
+
+  // While the type probe is in flight (caller didn't pass a type), surface a
+  // loading state so the Blasts screen shows its spinner instead of an empty
+  // "no buyers" flash before the correct resolver runs.
+  const probePending =
+    enabled && eventType === undefined && typeProbe.data === undefined;
 
   return useMemo(
     () => ({
       data: query.data,
-      isLoading: query.isLoading,
-      isError: query.isError,
-      error: query.error,
+      isLoading: query.isLoading || probePending,
+      isError: query.isError || typeProbe.isError,
+      error: query.error ?? typeProbe.error,
       refetch: query.refetch,
     }),
-    [query.data, query.isLoading, query.isError, query.error, query.refetch],
+    [
+      query.data,
+      query.isLoading,
+      query.isError,
+      query.error,
+      query.refetch,
+      probePending,
+      typeProbe.isError,
+      typeProbe.error,
+    ],
   );
 }

--- a/mingla-business/src/services/__tests__/eventDraftsCurrency.test.ts
+++ b/mingla-business/src/services/__tests__/eventDraftsCurrency.test.ts
@@ -140,6 +140,9 @@ const queryBuilder = <T,>(
 ) => {
   const builder = {
     eq: jest.fn(() => builder),
+    // ORCH-1150 — additive: draft reads/updates now filter
+    // .in("event_type", ["event","rsvp"]) (RSVP drafts share the pipeline).
+    in: jest.fn(() => builder),
     insert: jest.fn((payload: unknown) => {
       onInsert?.(payload);
       return builder;

--- a/mingla-business/src/services/__tests__/eventDraftsTaxonomyAutosave.test.ts
+++ b/mingla-business/src/services/__tests__/eventDraftsTaxonomyAutosave.test.ts
@@ -92,6 +92,9 @@ const queryBuilder = <T,>(
 ) => {
   const builder = {
     eq: jest.fn(() => builder),
+    // ORCH-1150 — additive: draft reads/updates now filter
+    // .in("event_type", ["event","rsvp"]) (RSVP drafts share the pipeline).
+    in: jest.fn(() => builder),
     insert: jest.fn(() => builder),
     is: jest.fn(() => builder),
     maybeSingle: jest.fn(() =>

--- a/mingla-business/src/services/__tests__/eventDraftsTaxonomyAutosaveAdversarial.test.ts
+++ b/mingla-business/src/services/__tests__/eventDraftsTaxonomyAutosaveAdversarial.test.ts
@@ -101,6 +101,9 @@ const queryBuilder = <T,>(
 ) => {
   const builder = {
     eq: jest.fn(() => builder),
+    // ORCH-1150 — additive: draft reads/updates now filter
+    // .in("event_type", ["event","rsvp"]) (RSVP drafts share the pipeline).
+    in: jest.fn(() => builder),
     insert: jest.fn(() => builder),
     is: jest.fn(() => builder),
     maybeSingle: jest.fn(() =>

--- a/mingla-business/src/services/__tests__/orch_1150_r2_rsvp_draft_type.test.ts
+++ b/mingla-business/src/services/__tests__/orch_1150_r2_rsvp_draft_type.test.ts
@@ -1,0 +1,233 @@
+/**
+ * ORCH-1150-R2 (D-2) [RSVP video cover persists] — service regression test.
+ *
+ * D-2 root cause: `createServerDraft` hardcoded event_type:'event' on the
+ * lazily-promoted server row, so an RSVP draft's server `events` row was
+ * 'event' for its whole draft lifetime — the cover-video pipeline (keyed on the
+ * draft id → its events row) bound to an 'event' row and the processed URL never
+ * persisted. Fix: insert event_type:'rsvp' when sourceDraft.isRsvp === true.
+ *
+ * Paired fetch-widening: the draft reads/updates previously filtered
+ * .eq("event_type","event"); now they .in("event_type", ["event","rsvp"]) so an
+ * rsvp-typed draft still lists/loads/autosaves (without this, the now-'rsvp'
+ * draft vanishes from the Hub and can't be resumed).
+ *
+ * Fails-on-revert:
+ *   - Reverting the insert type pin → the RSVP insert payload's event_type
+ *     becomes 'event' → the first assertion fails.
+ *   - Reverting the fetch widening → the captured .in() filter is gone (the
+ *     query uses .eq("event_type","event")) → the widening assertions fail.
+ */
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const mockGetUser = jest.fn<
+  () => Promise<{ data: { user: { id: string } | null }; error: Error | null }>
+>();
+const mockFrom = jest.fn();
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    auth: { getUser: mockGetUser },
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+// Avoid pulling the real zustand store / RN deps into the node test.
+jest.mock("../../store/draftEventStore", () => ({
+  buildDraftEvent: jest.fn(),
+}));
+
+import {
+  createServerDraft,
+  fetchDraftsForBrand,
+  fetchDraftById,
+} from "../eventDrafts";
+import type { DraftEvent } from "../../store/draftEventStore";
+
+interface InFilter {
+  column: string;
+  values: readonly unknown[];
+}
+
+// A chainable supabase query-builder mock that records `.in(col, values)` and
+// `.insert(payload)`, then resolves at the requested terminal.
+const makeBuilder = (
+  terminal:
+    | { method: "single"; result: { data: unknown; error: Error | null } }
+    | { method: "maybeSingle"; result: { data: unknown; error: Error | null } }
+    | { method: "thenable"; result: { data: unknown; error: Error | null } },
+  capture: { inFilters: InFilter[]; insertPayloads: unknown[] },
+) => {
+  const builder: Record<string, unknown> = {};
+  const ret = () => builder;
+  builder.eq = jest.fn(ret);
+  builder.is = jest.fn(ret);
+  builder.order = jest.fn(() =>
+    terminal.method === "thenable"
+      ? Promise.resolve(terminal.result)
+      : builder,
+  );
+  builder.in = jest.fn((column: string, values: readonly unknown[]) => {
+    capture.inFilters.push({ column, values });
+    return builder;
+  });
+  builder.insert = jest.fn((payload: unknown) => {
+    capture.insertPayloads.push(payload);
+    return builder;
+  });
+  builder.select = jest.fn(ret);
+  builder.single = jest.fn(() =>
+    terminal.method === "single" ? Promise.resolve(terminal.result) : builder,
+  );
+  builder.maybeSingle = jest.fn(() =>
+    terminal.method === "maybeSingle"
+      ? Promise.resolve(terminal.result)
+      : builder,
+  );
+  return builder;
+};
+
+const baseDraft = (patch: Partial<DraftEvent> = {}): DraftEvent =>
+  ({
+    id: "d_abc123",
+    brandId: "00000000-0000-4000-8000-000000000002",
+    serverSlug: null,
+    name: "My event",
+    description: "",
+    format: "in_person",
+    category: null,
+    whenMode: "single",
+    date: null,
+    doorsOpen: null,
+    endsAt: null,
+    timezone: "Europe/London",
+    recurrenceRule: null,
+    multiDates: null,
+    venueName: null,
+    address: null,
+    onlineUrl: null,
+    hideAddressUntilTicket: true,
+    coverHue: 25,
+    coverMediaUrl: null,
+    coverMediaType: null,
+    currency: "USD",
+    tickets: [],
+    visibility: "public",
+    requireApproval: false,
+    allowTransfers: true,
+    hideRemainingCount: false,
+    passwordProtected: false,
+    privateGuestList: false,
+    inPersonPaymentsEnabled: false,
+    lastStepReached: 0,
+    status: "draft",
+    clientRevision: 0,
+    createdAt: "2026-06-16T10:00:00.000Z",
+    updatedAt: "2026-06-16T10:00:00.000Z",
+    isRsvp: false,
+    rsvpCapacity: null,
+    rsvpAllowPlusOnes: false,
+    rsvpPlusOnesMax: 0,
+    rsvpWaitlistEnabled: false,
+    rsvpApprovalMode: "auto",
+    rsvpDiscoverable: true,
+    ...patch,
+  }) as unknown as DraftEvent;
+
+beforeEach(() => {
+  mockFrom.mockReset();
+  mockGetUser.mockReset();
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: "user-1" } },
+    error: null,
+  });
+});
+
+describe("ORCH-1150-R2 D-2 — createServerDraft types the server row by RSVP-ness", () => {
+  const runCreate = async (
+    source: DraftEvent,
+  ): Promise<{ insertPayloads: unknown[] }> => {
+    const capture = { inFilters: [] as InFilter[], insertPayloads: [] as unknown[] };
+    const insertedRow = {
+      id: "00000000-0000-4000-8000-0000000000aa",
+      brand_id: source.brandId,
+      created_by: "user-1",
+      title: source.name,
+      description: "",
+      slug: "draft-xyz",
+      currency: "USD",
+      theme: {},
+      status: "draft",
+      timezone: source.timezone,
+      created_at: source.createdAt,
+      updated_at: source.updatedAt,
+    };
+    mockFrom.mockImplementation((table: unknown) => {
+      if (table === "brands") {
+        return makeBuilder(
+          {
+            method: "maybeSingle",
+            result: { data: { default_currency: "usd" }, error: null },
+          },
+          capture,
+        );
+      }
+      return makeBuilder(
+        { method: "single", result: { data: insertedRow, error: null } },
+        capture,
+      );
+    });
+    await createServerDraft(source.brandId, source);
+    return { insertPayloads: capture.insertPayloads };
+  };
+
+  test("RSVP draft (isRsvp:true) → server row inserted with event_type:'rsvp'", async () => {
+    const { insertPayloads } = await runCreate(baseDraft({ isRsvp: true }));
+    expect(insertPayloads).toHaveLength(1);
+    expect((insertPayloads[0] as { event_type?: string }).event_type).toBe(
+      "rsvp",
+    );
+  });
+
+  test("ticketed draft (isRsvp:false) → server row stays event_type:'event'", async () => {
+    const { insertPayloads } = await runCreate(baseDraft({ isRsvp: false }));
+    expect((insertPayloads[0] as { event_type?: string }).event_type).toBe(
+      "event",
+    );
+  });
+});
+
+describe("ORCH-1150-R2 D-2 — draft fetches admit RSVP rows", () => {
+  test("fetchDraftsForBrand filters event_type IN ['event','rsvp']", async () => {
+    const capture = { inFilters: [] as InFilter[], insertPayloads: [] as unknown[] };
+    mockFrom.mockImplementation(() =>
+      makeBuilder(
+        { method: "thenable", result: { data: [], error: null } },
+        capture,
+      ),
+    );
+    await fetchDraftsForBrand("brand-1");
+    const eventTypeFilter = capture.inFilters.find(
+      (f) => f.column === "event_type",
+    );
+    expect(eventTypeFilter).toBeDefined();
+    expect(eventTypeFilter?.values).toEqual(["event", "rsvp"]);
+  });
+
+  test("fetchDraftById filters event_type IN ['event','rsvp']", async () => {
+    const capture = { inFilters: [] as InFilter[], insertPayloads: [] as unknown[] };
+    mockFrom.mockImplementation(() =>
+      makeBuilder(
+        { method: "maybeSingle", result: { data: null, error: null } },
+        capture,
+      ),
+    );
+    await fetchDraftById("00000000-0000-4000-8000-0000000000aa");
+    const eventTypeFilter = capture.inFilters.find(
+      (f) => f.column === "event_type",
+    );
+    expect(eventTypeFilter).toBeDefined();
+    expect(eventTypeFilter?.values).toEqual(["event", "rsvp"]);
+  });
+});

--- a/mingla-business/src/services/eventDrafts.ts
+++ b/mingla-business/src/services/eventDrafts.ts
@@ -49,6 +49,16 @@ export const isServerDraftLifecycleError = (
     typeof (error as { code?: unknown }).code === "string" &&
     typeof (error as { draftId?: unknown }).draftId === "string");
 
+// ORCH-1150 [RSVP event wizard] — RSVP drafts are stored event_type='rsvp'
+// from promotion onward (see createServerDraft). Every draft READ/UPDATE that
+// previously filtered .eq("event_type","event") must admit 'rsvp' too, or RSVP
+// drafts vanish from the Hub list (fetchDraftsForBrand), can't be resolved
+// (fetchDraftById), can't autosave (autosaveServerDraft), and can't resolve
+// their save context / lifecycle. Trip rows are still excluded (they have their
+// own tripsService draft path). This is the discriminator set for the
+// universal-authoring draft pipeline (event + RSVP share it).
+const DRAFT_EVENT_TYPES = ["event", "rsvp"] as const;
+
 const serverDraftSlug = (): string =>
   generateEventSlug("draft", new Set<string>());
 
@@ -150,13 +160,20 @@ export const createServerDraft = async (
   );
 
   // ORCH-0859 REWORK 3 (events-type-filter audit): explicitly set
-  // event_type='event' on the insert payload. DB default is 'event' per
-  // information_schema probe so this is a no-op today, but pinning it
-  // here future-proofs against the default ever changing and makes the
-  // event vs trip ownership explicit at the call site.
+  // event_type on the insert payload. DB default is 'event' per
+  // information_schema probe so this pin makes the type explicit at the call
+  // site.
+  // ORCH-1150 [RSVP event wizard] — the lazily-promoted server row MUST carry
+  // the RSVP discriminator when the source draft is an RSVP draft (isRsvp:true).
+  // Without this the row is 'event', the cover-video pipeline binds to an
+  // 'event' row (so RSVP video covers never persist — D-2), and the publish
+  // RPC's event_type flip is the ONLY place the row would ever become 'rsvp'.
+  // Setting it at draft-promotion realizes SPEC §4.6:401's explicit instruction.
+  const eventTypeForInsert: "event" | "rsvp" =
+    draft.isRsvp === true ? "rsvp" : "event";
   const { data, error } = await supabase
     .from("events")
-    .insert({ ...insertPayload, event_type: "event" })
+    .insert({ ...insertPayload, event_type: eventTypeForInsert })
     .select(EVENT_DRAFT_SELECT)
     .single();
 
@@ -167,12 +184,13 @@ export const createServerDraft = async (
 export const fetchDraftsForBrand = async (
   brandId: string,
 ): Promise<DraftEvent[]> => {
-  // ORCH-0859 REWORK 3 (events-type-filter audit): event-only drafts list.
+  // ORCH-0859 REWORK 3 (events-type-filter audit): drafts list.
+  // ORCH-1150: include RSVP drafts (DRAFT_EVENT_TYPES) so they don't vanish.
   const { data, error } = await supabase
     .from("events")
     .select(EVENT_DRAFT_SELECT)
     .eq("brand_id", brandId)
-    .eq("event_type", "event")
+    .in("event_type", DRAFT_EVENT_TYPES)
     .eq("status", "draft")
     .is("deleted_at", null)
     .order("updated_at", { ascending: false });
@@ -184,12 +202,13 @@ export const fetchDraftsForBrand = async (
 export const fetchDraftById = async (
   draftId: string,
 ): Promise<DraftEvent | null> => {
-  // ORCH-0859 REWORK 3 (events-type-filter audit): single event-draft read.
+  // ORCH-0859 REWORK 3 (events-type-filter audit): single draft read.
+  // ORCH-1150: include RSVP drafts so resume/edit can resolve them.
   const { data, error } = await supabase
     .from("events")
     .select(EVENT_DRAFT_SELECT)
     .eq("id", draftId)
-    .eq("event_type", "event")
+    .in("event_type", DRAFT_EVENT_TYPES)
     .eq("status", "draft")
     .is("deleted_at", null)
     .maybeSingle();
@@ -207,12 +226,13 @@ const resolveMissingDraftLifecycle = async (
   draftId: string,
 ): Promise<ServerDraftLifecycleError> => {
   // ORCH-0859 REWORK 3 (events-type-filter audit): lifecycle check is for
-  // event-only drafts. Trip-draft lifecycle is handled by tripsService.
+  // event + RSVP drafts (DRAFT_EVENT_TYPES). Trip-draft lifecycle is handled by
+  // tripsService. ORCH-1150: RSVP drafts must resolve their lifecycle too.
   const { data, error } = await supabase
     .from("events")
     .select("status,deleted_at")
     .eq("id", draftId)
-    .eq("event_type", "event")
+    .in("event_type", DRAFT_EVENT_TYPES)
     .maybeSingle();
 
   if (error !== null) throw error;
@@ -229,12 +249,13 @@ const resolveMissingDraftLifecycle = async (
 const fetchExistingDraftSaveContext = async (
   draftId: string,
 ): Promise<ExistingDraftSaveContext> => {
-  // ORCH-0859 REWORK 3 (events-type-filter audit): event-draft save context.
+  // ORCH-0859 REWORK 3 (events-type-filter audit): draft save context.
+  // ORCH-1150: include RSVP drafts so their autosave can resolve theme/currency.
   const { data, error } = await supabase
     .from("events")
     .select("theme,currency")
     .eq("id", draftId)
-    .eq("event_type", "event")
+    .in("event_type", DRAFT_EVENT_TYPES)
     .eq("status", "draft")
     .is("deleted_at", null)
     .maybeSingle();
@@ -260,13 +281,14 @@ export const autosaveServerDraft = async (
     draft.clientRevision ?? 0,
   );
 
-  // ORCH-0859 REWORK 3 (events-type-filter audit): event-draft UPDATE
-  // must not accidentally write to a trip row that shares an id space.
+  // ORCH-0859 REWORK 3 (events-type-filter audit): draft UPDATE must not
+  // accidentally write to a trip row that shares an id space.
+  // ORCH-1150: include RSVP drafts (DRAFT_EVENT_TYPES) so RSVP autosave persists.
   const { data, error } = await supabase
     .from("events")
     .update(updatePayload)
     .eq("id", draft.id)
-    .eq("event_type", "event")
+    .in("event_type", DRAFT_EVENT_TYPES)
     .eq("status", "draft")
     .is("deleted_at", null)
     .select(EVENT_DRAFT_SELECT)

--- a/mingla-business/src/services/eventDrafts.ts
+++ b/mingla-business/src/services/eventDrafts.ts
@@ -171,6 +171,7 @@ export const createServerDraft = async (
   // Setting it at draft-promotion realizes SPEC §4.6:401's explicit instruction.
   const eventTypeForInsert: "event" | "rsvp" =
     draft.isRsvp === true ? "rsvp" : "event";
+  // orch-strict-grep-allow events-type-filter — ORCH-1150 D-2: event_type IS written (event|rsvp) via the eventTypeForInsert variable, not unfiltered; the gate only matches string literals in the payload.
   const { data, error } = await supabase
     .from("events")
     .insert({ ...insertPayload, event_type: eventTypeForInsert })
@@ -186,6 +187,7 @@ export const fetchDraftsForBrand = async (
 ): Promise<DraftEvent[]> => {
   // ORCH-0859 REWORK 3 (events-type-filter audit): drafts list.
   // ORCH-1150: include RSVP drafts (DRAFT_EVENT_TYPES) so they don't vanish.
+  // orch-strict-grep-allow events-type-filter — ORCH-1150 D-2: RSVP drafts are included via .in("event_type", ["event","rsvp"]); event_type IS filtered (event+rsvp), not unfiltered.
   const { data, error } = await supabase
     .from("events")
     .select(EVENT_DRAFT_SELECT)
@@ -204,6 +206,7 @@ export const fetchDraftById = async (
 ): Promise<DraftEvent | null> => {
   // ORCH-0859 REWORK 3 (events-type-filter audit): single draft read.
   // ORCH-1150: include RSVP drafts so resume/edit can resolve them.
+  // orch-strict-grep-allow events-type-filter — ORCH-1150 D-2: RSVP drafts are included via .in("event_type", ["event","rsvp"]); event_type IS filtered (event+rsvp), not unfiltered.
   const { data, error } = await supabase
     .from("events")
     .select(EVENT_DRAFT_SELECT)
@@ -228,6 +231,7 @@ const resolveMissingDraftLifecycle = async (
   // ORCH-0859 REWORK 3 (events-type-filter audit): lifecycle check is for
   // event + RSVP drafts (DRAFT_EVENT_TYPES). Trip-draft lifecycle is handled by
   // tripsService. ORCH-1150: RSVP drafts must resolve their lifecycle too.
+  // orch-strict-grep-allow events-type-filter — ORCH-1150 D-2: RSVP drafts are included via .in("event_type", ["event","rsvp"]); event_type IS filtered (event+rsvp), not unfiltered.
   const { data, error } = await supabase
     .from("events")
     .select("status,deleted_at")
@@ -251,6 +255,7 @@ const fetchExistingDraftSaveContext = async (
 ): Promise<ExistingDraftSaveContext> => {
   // ORCH-0859 REWORK 3 (events-type-filter audit): draft save context.
   // ORCH-1150: include RSVP drafts so their autosave can resolve theme/currency.
+  // orch-strict-grep-allow events-type-filter — ORCH-1150 D-2: RSVP drafts are included via .in("event_type", ["event","rsvp"]); event_type IS filtered (event+rsvp), not unfiltered.
   const { data, error } = await supabase
     .from("events")
     .select("theme,currency")
@@ -284,6 +289,7 @@ export const autosaveServerDraft = async (
   // ORCH-0859 REWORK 3 (events-type-filter audit): draft UPDATE must not
   // accidentally write to a trip row that shares an id space.
   // ORCH-1150: include RSVP drafts (DRAFT_EVENT_TYPES) so RSVP autosave persists.
+  // orch-strict-grep-allow events-type-filter — ORCH-1150 D-2: RSVP-draft UPDATE is scoped via .in("event_type", ["event","rsvp"]); event_type IS filtered (event+rsvp), not unfiltered.
   const { data, error } = await supabase
     .from("events")
     .update(updatePayload)

--- a/mingla-business/src/services/marketing/__tests__/marketingAudienceService.test.ts
+++ b/mingla-business/src/services/marketing/__tests__/marketingAudienceService.test.ts
@@ -26,6 +26,7 @@ import {
   maskPhone,
   resolveBrandBuyers,
   resolveEventBuyers,
+  resolveRsvpGuests,
 } from "../marketingAudienceService";
 import { supabase } from "../../supabase";
 
@@ -308,6 +309,138 @@ describe("marketingAudienceService — consent filtering (T-03 + T-04)", () => {
     });
     const result = await resolveBrandBuyers("00000000-0000-0000-0000-0000000000a1");
     expect(result.rows[0]?.consent.email_marketing_ok).toBe(false);
+  });
+});
+
+// ===========================================================================
+// ORCH-1150-R2 (D-8) — resolveRsvpGuests reads event_rsvps going+approved
+// ===========================================================================
+describe("marketingAudienceService — resolveRsvpGuests (ORCH-1150 D-8)", () => {
+  const EVENT_UUID = "00000000-0000-0000-0000-0000000000c1";
+  const BRAND_UUID = "00000000-0000-0000-0000-0000000000a1";
+
+  interface RsvpGuestFixture {
+    id: string;
+    event_id: string;
+    guest_name: string | null;
+    guest_email: string | null;
+    guest_phone: string | null;
+    created_at: string;
+  }
+
+  function setupRsvpMock(args: {
+    guests: RsvpGuestFixture[];
+    guestsError?: Error;
+    brandId?: string | null;
+  }): { rsvpChain: { eq: jest.Mock } } {
+    const fromMock = supabase.from as jest.Mock;
+    fromMock.mockReset();
+    // event_rsvps chain — assert the going+approved filter is applied.
+    const eqGoing = jest.fn().mockReturnThis();
+    const eqApproved = jest.fn().mockReturnThis();
+    const eqEvent = jest.fn().mockReturnValue({
+      eq: eqGoing,
+    });
+    const rsvpChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: eqEvent,
+    };
+    // We model: .eq(event) -> .eq(going) -> .eq(approved) -> .order(...)
+    eqGoing.mockReturnValue({ eq: eqApproved });
+    eqApproved.mockReturnValue({
+      order: jest.fn().mockResolvedValue({
+        data: args.guestsError ? null : args.guests,
+        error: args.guestsError ?? null,
+      }),
+    });
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === "event_rsvps") return rsvpChain;
+      if (table === "events") {
+        return {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({
+            data:
+              args.brandId === undefined
+                ? { id: EVENT_UUID, brand_id: BRAND_UUID }
+                : args.brandId === null
+                  ? null
+                  : { id: EVENT_UUID, brand_id: args.brandId },
+            error: null,
+          }),
+        };
+      }
+      if (table === "marketing_unsubscribes") {
+        return {
+          select: jest.fn().mockReturnThis(),
+          or: jest.fn().mockResolvedValue({ data: [], error: null }),
+        };
+      }
+      throw new Error(`unexpected supabase.from(${table})`);
+    });
+    return { rsvpChain: { eq: eqEvent } };
+  }
+
+  it("reads going+approved event_rsvps rows and maps them to BuyerRowData", async () => {
+    setupRsvpMock({
+      guests: [
+        {
+          id: "rsvp_1",
+          event_id: EVENT_UUID,
+          guest_name: "Jade R.",
+          guest_email: "jade@example.com",
+          guest_phone: "+15555551111",
+          created_at: "2026-06-15T10:00:00Z",
+        },
+        {
+          id: "rsvp_2",
+          event_id: EVENT_UUID,
+          guest_name: "Kofi A.",
+          guest_email: "kofi@example.com",
+          guest_phone: "+15555552222",
+          created_at: "2026-06-15T11:00:00Z",
+        },
+      ],
+    });
+
+    const result = await resolveRsvpGuests(EVENT_UUID);
+    expect(result.rows).toHaveLength(2);
+    expect(result.reach.total).toBe(2);
+    expect(result.reach.reachable_email).toBe(2);
+    const jade = result.rows.find((r) => r.contact_key === "jade@example.com");
+    expect(jade).toBeDefined();
+    // RSVP guests have no purchase → zero spend; the shared aggregator counts
+    // the single RSVP row as one "membership" and masks the email for display.
+    expect(jade?.total_spend_minor).toBe(0);
+    expect(jade?.masked_email).toBe("jad**@example.com");
+  });
+
+  it("queries the event_rsvps table (NOT orders) — the audience-source contract", async () => {
+    setupRsvpMock({ guests: [] });
+    await resolveRsvpGuests(EVENT_UUID);
+    const fromMock = supabase.from as jest.Mock;
+    const tablesQueried = fromMock.mock.calls.map((c) => c[0]);
+    expect(tablesQueried).toContain("event_rsvps");
+    expect(tablesQueried).not.toContain("orders");
+  });
+
+  it("returns an empty audience without throwing when no one is going", async () => {
+    setupRsvpMock({ guests: [] });
+    const result = await resolveRsvpGuests(EVENT_UUID);
+    expect(result.rows).toEqual([]);
+    expect(result.reach.total).toBe(0);
+  });
+
+  it("throws on RLS/network error (no silent swallow)", async () => {
+    setupRsvpMock({ guests: [], guestsError: new Error("rls_denied") });
+    await expect(resolveRsvpGuests(EVENT_UUID)).rejects.toThrow("rls_denied");
+  });
+
+  it("throws when eventId is empty / not a UUID", async () => {
+    setupRsvpMock({ guests: [] });
+    await expect(resolveRsvpGuests("")).rejects.toThrow(/eventId is required/i);
+    await expect(resolveRsvpGuests("not-a-uuid")).rejects.toThrow(/UUID/);
   });
 });
 

--- a/mingla-business/src/services/marketing/marketingAudienceService.ts
+++ b/mingla-business/src/services/marketing/marketingAudienceService.ts
@@ -205,6 +205,99 @@ export async function resolveEventBuyers(
   return aggregateBuyers(orders, unsubs, brandId);
 }
 
+/**
+ * Resolve "all going (+approved) guests of an RSVP event" audience.
+ *
+ * ORCH-1150 (D-8) — RSVP events have ZERO `orders` rows, so `resolveEventBuyers`
+ * (orders-derived) returns an empty audience forever. RSVP attendees live in
+ * `event_rsvps` (going + approved). This reads them under the host-read RLS
+ * (`event_rsvps_host_read`: brand-scoped, biz_brand_effective_rank >=
+ * event_manager — confirmed covers this SELECT), shapes the result IDENTICALLY
+ * to `resolveEventBuyers` ({ rows, reach }) so the shared Blasts UI + BuyerRow
+ * render with no branching. RSVP guests have no purchase, so order_count = 0,
+ * spend = 0, currency falls back to "USD" purely for the row type (never shown).
+ */
+export async function resolveRsvpGuests(
+  eventId: string,
+): Promise<ResolveBuyersResult> {
+  if (!eventId) {
+    throw new Error("resolveRsvpGuests: eventId is required");
+  }
+  assertUuid(eventId, "resolveRsvpGuests.eventId");
+
+  // Pull every going + approved RSVP guest for this event. Host reads under
+  // event_rsvps_host_read RLS (the brand owner manages the event).
+  const { data, error } = await supabase
+    .from("event_rsvps")
+    .select("id, event_id, guest_name, guest_email, guest_phone, created_at")
+    .eq("event_id", eventId)
+    .eq("rsvp_status", "going")
+    .eq("approval_status", "approved")
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  const guests = (data ?? []) as unknown as Array<{
+    id: string;
+    event_id: string;
+    guest_name: string | null;
+    guest_email: string | null;
+    guest_phone: string | null;
+    created_at: string;
+  }>;
+
+  // The brand-scoped unsubscribe lookup needs a brand_id. Resolve it from the
+  // event row (RLS-gated) so going-guests who unsubscribed are flagged in the
+  // same way buyers are. Failure here is non-fatal to the audience read — but
+  // a thrown query is surfaced (no silent swallow): the brand probe IS allowed
+  // to come back empty (a never-blasted brand), in which case no unsubs apply.
+  let brandId: string | null = null;
+  if (guests.length > 0) {
+    const { data: eventRow, error: eventErr } = await supabase
+      .from("events")
+      .select("id, brand_id")
+      .eq("id", eventId)
+      .maybeSingle();
+    if (eventErr) throw eventErr;
+    brandId =
+      eventRow !== null && typeof eventRow.brand_id === "string"
+        ? eventRow.brand_id
+        : null;
+  }
+
+  let unsubs: UnsubRow[] = [];
+  if (brandId !== null) {
+    assertUuid(brandId, "resolveRsvpGuests.brandId (server-derived)");
+    const { data: unsubData, error: unsubError } = await supabase
+      .from("marketing_unsubscribes")
+      .select("contact_email, channel, scope, brand_id")
+      .or(`scope.eq.global,and(scope.eq.brand,brand_id.eq.${brandId})`);
+
+    if (unsubError) throw unsubError;
+    unsubs = (unsubData ?? []) as unknown as UnsubRow[];
+  }
+
+  // Map RSVP guests onto the same OrderRowForAudience shape aggregateBuyers
+  // expects (zero money), then reuse the identical aggregation + masking +
+  // consent path so the Blasts UI is byte-identical to the buyers surface.
+  const pseudoOrders: OrderRowForAudience[] = guests.map((g) => ({
+    id: g.id,
+    event_id: g.event_id,
+    buyer_email: g.guest_email,
+    buyer_name: g.guest_name,
+    buyer_phone: g.guest_phone,
+    buyer_phone_e164: g.guest_phone,
+    total_cents: 0,
+    currency: "USD",
+    payment_status: "rsvp_going",
+    confirmed_at: g.created_at,
+    created_at: g.created_at,
+    events: brandId !== null ? { id: eventId, title: null, brand_id: brandId } : null,
+  }));
+
+  return aggregateBuyers(pseudoOrders, unsubs, brandId);
+}
+
 // ---------------------------------------------------------------------------
 // Aggregation + masking
 // ---------------------------------------------------------------------------

--- a/mingla-business/src/services/marketing/marketingAudienceService.ts
+++ b/mingla-business/src/services/marketing/marketingAudienceService.ts
@@ -253,6 +253,7 @@ export async function resolveRsvpGuests(
   // to come back empty (a never-blasted brand), in which case no unsubs apply.
   let brandId: string | null = null;
   if (guests.length > 0) {
+    // orch-strict-grep-allow events-type-filter — ORCH-1150 D-8: RSVP blast audience (resolveRsvpGuests) reads event_rsvps for a known rsvp event id; this single-row brand_id lookup is by id on that same RSVP event.
     const { data: eventRow, error: eventErr } = await supabase
       .from("events")
       .select("id, brand_id")

--- a/mingla-business/src/services/rsvpApprovals.ts
+++ b/mingla-business/src/services/rsvpApprovals.ts
@@ -11,7 +11,7 @@
 
 import { supabase } from "./supabase";
 
-export type RsvpStatusValue = "going" | "not_going" | "waitlisted";
+export type RsvpStatusValue = "going" | "not_going" | "waitlisted" | "maybe";
 export type RsvpApprovalValue = "pending" | "approved" | "denied";
 
 export interface RsvpGuest {

--- a/mingla-business/src/services/rsvpEvents.ts
+++ b/mingla-business/src/services/rsvpEvents.ts
@@ -96,7 +96,7 @@ export const updateLiveRsvp = async (
 
 export interface SubmitPublicRsvpInput {
   eventId: string;
-  rsvpStatus: "going" | "not_going";
+  rsvpStatus: "going" | "not_going" | "maybe";
   /** Required for an anon link guest; ignored for a logged-in app user. */
   guestName?: string;
   guestEmail?: string;
@@ -105,7 +105,7 @@ export interface SubmitPublicRsvpInput {
 }
 
 export interface SubmitPublicRsvpResult {
-  status: "going" | "not_going" | "waitlisted";
+  status: "going" | "not_going" | "waitlisted" | "maybe";
   approvalStatus: "pending" | "approved";
 }
 
@@ -129,7 +129,7 @@ export const submitPublicRsvp = async (
     throw new Error(parseRsvpErrorCode(error as RsvpInvokeError));
   }
   const res = (data ?? {}) as {
-    status?: "going" | "not_going" | "waitlisted";
+    status?: "going" | "not_going" | "waitlisted" | "maybe";
     approvalStatus?: "pending" | "approved";
   };
   return {

--- a/mingla-business/src/utils/__tests__/orch_1150_r2_rsvp_route.test.ts
+++ b/mingla-business/src/utils/__tests__/orch_1150_r2_rsvp_route.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ORCH-1150-R2 (D-3) [RSVP event wizard — edit/resume opens the right wizard]
+ * — happy-path regression test for the RSVP routing branch.
+ *
+ * Pins:
+ *   - routeForEventRow event_type='rsvp' → /rsvp/{id}/edit (draft) | /rsvp/{id}.
+ *   - routeForEventRowDefensive honors the camelCase `isRsvp` signal (the
+ *     DraftEvent shape has NO event_type field) and coerces it to event_type
+ *     'rsvp' → /rsvp/{id}/edit.
+ *   - ticketed/event/trip/experience routing stays unchanged (no RSVP leak).
+ *
+ * Fails-on-revert: deleting the `rsvp` branch in routeForEventRow OR the
+ * `isRsvp` coercion in routeForEventRowDefensive flips these assertions to the
+ * ticketed `/event/...` route → the matching expect fails.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  routeForEventRow,
+  routeForEventRowDefensive,
+} from "../routeForEventRow";
+
+describe("ORCH-1150-R2 D-3 — routeForEventRow RSVP branch", () => {
+  test("rsvp draft → /rsvp/{id}/edit (resume RSVP wizard, NOT /event)", () => {
+    expect(
+      routeForEventRow({ id: "r1", event_type: "rsvp", status: "draft" }),
+    ).toBe("/rsvp/r1/edit");
+  });
+
+  test("rsvp scheduled → /rsvp/{id} (RSVP dashboard)", () => {
+    expect(
+      routeForEventRow({ id: "r2", event_type: "rsvp", status: "scheduled" }),
+    ).toBe("/rsvp/r2");
+  });
+
+  test("rsvp live → /rsvp/{id}", () => {
+    expect(
+      routeForEventRow({ id: "r3", event_type: "rsvp", status: "live" }),
+    ).toBe("/rsvp/r3");
+  });
+
+  test("rsvp ended → /rsvp/{id}", () => {
+    expect(
+      routeForEventRow({ id: "r4", event_type: "rsvp", status: "ended" }),
+    ).toBe("/rsvp/r4");
+  });
+
+  // DO-NOT-REGRESS: the ticketed event path is byte-identical.
+  test("ticketed event draft still → /event/{id}/edit (no RSVP leak)", () => {
+    expect(
+      routeForEventRow({ id: "e1", event_type: "event", status: "draft" }),
+    ).toBe("/event/e1/edit");
+  });
+
+  test("trip + experience routing unchanged", () => {
+    expect(
+      routeForEventRow({ id: "t1", event_type: "trip", status: "draft" }),
+    ).toBe("/trip/t1/edit");
+    expect(
+      routeForEventRow({ id: "x1", event_type: "experience", status: "draft" }),
+    ).toBe("/experience/x1");
+  });
+});
+
+describe("ORCH-1150-R2 D-3 — routeForEventRowDefensive honors isRsvp", () => {
+  test("isRsvp:true + draft → /rsvp/{id}/edit (DraftEvent has no event_type)", () => {
+    expect(
+      routeForEventRowDefensive({ id: "r1", isRsvp: true, status: "draft" }),
+    ).toBe("/rsvp/r1/edit");
+  });
+
+  test("isRsvp:true + scheduled → /rsvp/{id}", () => {
+    expect(
+      routeForEventRowDefensive({ id: "r2", isRsvp: true, status: "scheduled" }),
+    ).toBe("/rsvp/r2");
+  });
+
+  test("event_type:'rsvp' (live LiveEvent) + scheduled → /rsvp/{id}", () => {
+    expect(
+      routeForEventRowDefensive({
+        id: "r3",
+        event_type: "rsvp",
+        status: "scheduled",
+      }),
+    ).toBe("/rsvp/r3");
+  });
+
+  test("isRsvp:true wins over a stale event_type='event'", () => {
+    expect(
+      routeForEventRowDefensive({
+        id: "r4",
+        isRsvp: true,
+        event_type: "event",
+        status: "draft",
+      }),
+    ).toBe("/rsvp/r4/edit");
+  });
+
+  // DO-NOT-REGRESS: isRsvp:false / absent routes ticketed exactly as before.
+  test("isRsvp:false + draft → /event/{id}/edit (ticketed unchanged)", () => {
+    expect(
+      routeForEventRowDefensive({ id: "e1", isRsvp: false, status: "draft" }),
+    ).toBe("/event/e1/edit");
+  });
+
+  test("no isRsvp, no event_type → defaults to event", () => {
+    expect(routeForEventRowDefensive({ id: "e2", status: "draft" })).toBe(
+      "/event/e2/edit",
+    );
+  });
+});

--- a/mingla-business/src/utils/routeForEventRow.ts
+++ b/mingla-business/src/utils/routeForEventRow.ts
@@ -28,6 +28,12 @@
  *     own "Continue editing" / "Edit" action is the only path into the wizard.
  *     (META-ORCH-1059 — operator: tapping an experience opened the edit screen
  *     directly; the dashboard must be the landing surface, with Edit deliberate.)
+ *   - event_type='rsvp' + status='draft' → /rsvp/{id}/edit (resume the RSVP wizard)
+ *   - event_type='rsvp' + status anything else → /rsvp/{id} (RSVP dashboard)
+ *     (ORCH-1150 [RSVP event wizard] — RSVP drafts/rows MUST resume into
+ *     RsvpCreatorWizard, never the ticketed EventCreatorWizard. The camelCase
+ *     DraftEvent shape has no `event_type`; it carries `isRsvp` instead, so the
+ *     defensive variant coerces `isRsvp===true` → event_type:'rsvp'.)
  *   - event_type='event' + status='draft' → /event/{id}/edit
  *   - event_type='event' + status anything else → /event/{id}
  *   - status undefined → default to non-edit path
@@ -41,7 +47,7 @@
  *   `.github/workflows/strict-grep-mingla-business.yml`.
  */
 
-export type EventTypeForRouting = "event" | "experience" | "trip";
+export type EventTypeForRouting = "event" | "experience" | "trip" | "rsvp";
 
 export type EventStatusForRouting =
   | "draft"
@@ -69,6 +75,13 @@ export function routeForEventRow(row: EventRowForRouting): string {
       ? `/trip/${row.id}/edit`
       : `/trip/${row.id}`;
   }
+  if (row.event_type === "rsvp") {
+    // ORCH-1150 — RSVP rows resume into the RSVP wizard / dashboard, never the
+    // ticketed event surfaces. Mirrors the event branch's draft-vs-live split.
+    return row.status === "draft"
+      ? `/rsvp/${row.id}/edit`
+      : `/rsvp/${row.id}`;
+  }
   if (row.event_type === "experience") {
     // META-ORCH-1059: the experience DASHBOARD is the single entry point for
     // every status (draft included). Unlike event/trip drafts (which resume the
@@ -92,9 +105,23 @@ export function routeForEventRow(row: EventRowForRouting): string {
  * `routeForEventRow` directly with the raw row shape.
  */
 export function routeForEventRowDefensive(
-  row: { id: string; eventType?: string; event_type?: string; status?: string },
+  row: {
+    id: string;
+    eventType?: string;
+    event_type?: string;
+    status?: string;
+    // ORCH-1150 — the camelCase DraftEvent / LiveEvent shape carries `isRsvp`
+    // (the DraftEvent type has NO `event_type` field at all), so callers route
+    // RSVP rows by passing this flag. It takes precedence over a missing
+    // event_type and coerces to event_type:'rsvp'.
+    isRsvp?: boolean;
+  },
 ): string {
-  const eventType = (row.event_type ?? row.eventType ?? "event") as EventTypeForRouting;
+  const eventType = (
+    row.isRsvp === true
+      ? "rsvp"
+      : row.event_type ?? row.eventType ?? "event"
+  ) as EventTypeForRouting;
   const status = row.status as EventStatusForRouting;
   return routeForEventRow({ id: row.id, event_type: eventType, status });
 }

--- a/packages/event-rendering/offeringCta.ts
+++ b/packages/event-rendering/offeringCta.ts
@@ -279,7 +279,8 @@ export type RsvpCtaState =
   | "waitlist" // capacity hit, waitlist ON → tapping Going joins the waitlist
   | "pending" // manual approval, guest already RSVP'd → "Awaiting host approval"
   | "going" // guest's own current confirmed state
-  | "not_going"; // guest's own current declined state
+  | "not_going" // guest's own current declined state
+  | "maybe"; // ORCH-1150 R2: guest's own non-binding "maybe" state (cap-neutral)
 
 export interface ResolveRsvpCtaInput {
   /** Event-level posture: is the cap full of confirmed-attending guests? */
@@ -289,7 +290,7 @@ export interface ResolveRsvpCtaInput {
   /** events.rsvp_approval_mode === 'manual'. */
   manualApproval: boolean;
   /** The guest's own current row state, when resolvable (else null). */
-  guestStatus?: "going" | "not_going" | "waitlisted" | null;
+  guestStatus?: "going" | "not_going" | "waitlisted" | "maybe" | null;
   guestApproval?: "pending" | "approved" | "denied" | null;
 }
 
@@ -303,6 +304,7 @@ export interface RsvpCtaDescriptor {
  *   guest already pending          → pending
  *   guest already going+approved   → going
  *   guest already not_going        → not_going
+ *   guest already maybe            → maybe (ORCH-1150 R2; non-binding)
  *   guest already waitlisted       → waitlist
  *   cap full + waitlist on         → waitlist
  *   cap full + waitlist off + auto → full
@@ -318,6 +320,8 @@ export const resolveRsvpCta = (input: ResolveRsvpCtaInput): RsvpCtaDescriptor =>
       return { kind: "rsvp", state: "going" };
     }
     if (guestStatus === "not_going") return { kind: "rsvp", state: "not_going" };
+    // ORCH-1150 R2 D-10: a resolved 'maybe' shows the non-binding maybe state.
+    if (guestStatus === "maybe") return { kind: "rsvp", state: "maybe" };
   }
 
   if (capacityFull) {

--- a/supabase/functions/public-submit-rsvp/index.ts
+++ b/supabase/functions/public-submit-rsvp/index.ts
@@ -30,7 +30,7 @@ interface SubmitRsvpRequest {
   guestName?: string;
   guestEmail?: string;
   guestPhone?: string;
-  rsvpStatus?: "going" | "not_going";
+  rsvpStatus?: "going" | "not_going" | "maybe";
   plusCount?: number;
 }
 
@@ -101,7 +101,14 @@ serve(async (req: Request): Promise<Response> => {
   if (eventId.length === 0) {
     return json(400, { error: "event_id_required" });
   }
-  if (rsvpStatus !== "going" && rsvpStatus !== "not_going") {
+  // ORCH-1150 R2 D-10: 'maybe' is an accepted RSVP status (cap-neutral, auto-
+  // approved). The A4-NEW anon-contact gate below is status-agnostic, so a Maybe
+  // link guest still must supply name+email+phone — do NOT relax it for maybe.
+  if (
+    rsvpStatus !== "going" &&
+    rsvpStatus !== "not_going" &&
+    rsvpStatus !== "maybe"
+  ) {
     return json(400, { error: "rsvp_status_invalid" });
   }
 

--- a/supabase/migrations/20261012000000_orch_1150_rsvp_maybe.sql
+++ b/supabase/migrations/20261012000000_orch_1150_rsvp_maybe.sql
@@ -1,0 +1,227 @@
+-- ===========================================================================
+-- ORCH-1150 R2 · D-10 — add a third RSVP status 'maybe'.
+--
+-- A Maybe is an OPTIONAL attendee: auto-approved, CAP-NEUTRAL, on the notify
+-- list, never occupying a seat. It mirrors not_going's cap-neutrality but stays
+-- on the guest list (so the host can plan + we can keep the guest posted).
+--
+-- ORCH-1150: do NOT add 'maybe' to ANY capacity / waitlist-drain / "N going"
+-- headcount predicate — those intentionally count only
+-- (rsvp_status='going' AND approval_status='approved'). 'maybe' being excluded
+-- from those is exactly what makes it cap-neutral (I-PROPOSED-1150-MAYBE-NOT-IN-CAP).
+--
+-- Additive + idempotent. The base RSVP schema is migration
+-- 20261004000000_orch_1150_rsvp_events.sql. Prefix 20261012000000 is strictly
+-- greater than the current head 20261011000001.
+--
+-- DO NOT APPLY from the implementor — the orchestrator applies via MCP /
+-- Management API (dev history is drift-corrupted).
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (a) Widen the rsvp_status CHECK to allow 'maybe' (DROP-before-ADD).
+--     The base constraint is the inline auto-named event_rsvps_rsvp_status_check
+--     from 20261004000000:60-61.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.event_rsvps
+  DROP CONSTRAINT IF EXISTS event_rsvps_rsvp_status_check;
+ALTER TABLE public.event_rsvps
+  ADD CONSTRAINT event_rsvps_rsvp_status_check
+  CHECK (rsvp_status IN ('going', 'not_going', 'waitlisted', 'maybe'));
+
+-- ---------------------------------------------------------------------------
+-- (b) Widen the guest self-update RLS WITH CHECK to allow setting 'maybe'.
+--     Mirrors the base policy from 20261004000000:174-181 + adds 'maybe'.
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS event_rsvps_guest_update_own ON public.event_rsvps;
+CREATE POLICY event_rsvps_guest_update_own ON public.event_rsvps
+  FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (
+    user_id = auth.uid()
+    AND rsvp_status IN ('going', 'not_going', 'maybe')
+  );
+
+-- ---------------------------------------------------------------------------
+-- (c) Widen submit_event_rsvp to accept + resolve 'maybe'.
+--     Latest CREATE OR REPLACE wins. Two precise deltas vs the base
+--     (20261004000000:858-980):
+--       - validation now allows 'maybe' (else still rsvp_status_invalid),
+--       - a 'maybe' attendance branch BEFORE the capacity math: cap-neutral
+--         (like not_going) but AUTO-APPROVED so it never sits in the host's
+--         pending queue (a Maybe is non-binding + never fills a seat).
+--     Everything else (clamp, UPSERT, waitlisted_at) is byte-identical; maybe
+--     never sets waitlisted_at (it is not waitlisted).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.submit_event_rsvp(
+  p_event_id   uuid,
+  p_user_id    uuid,
+  p_guest_name text,
+  p_guest_email text,
+  p_guest_phone text,
+  p_rsvp_status text,
+  p_plus_count  integer DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_event       public.events%ROWTYPE;
+  v_plus        integer;
+  v_confirmed   integer;
+  v_status      text;
+  v_approval    text;
+  v_name        text;
+  v_existing_id uuid;
+BEGIN
+  -- 1. Load + gate the event (FOR UPDATE serializes concurrent submits).
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id FOR UPDATE;
+  IF NOT FOUND
+     OR v_event.event_type <> 'rsvp'
+     OR v_event.status NOT IN ('scheduled', 'live')
+     OR v_event.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'rsvp_not_open';
+  END IF;
+
+  -- ORCH-1150 R2 D-10: 'maybe' joins the accepted set; anything else is invalid.
+  IF p_rsvp_status NOT IN ('going', 'not_going', 'maybe') THEN
+    RAISE EXCEPTION 'rsvp_status_invalid';
+  END IF;
+
+  -- 2. Contact gate for link guests (anon — no user_id).
+  v_name := NULLIF(btrim(COALESCE(p_guest_name, '')), '');
+  IF p_user_id IS NULL THEN
+    IF v_name IS NULL
+       OR NULLIF(btrim(COALESCE(p_guest_email, '')), '') IS NULL
+       OR NULLIF(btrim(COALESCE(p_guest_phone, '')), '') IS NULL THEN
+      RAISE EXCEPTION 'rsvp_contact_required';
+    END IF;
+  END IF;
+  IF v_name IS NULL THEN
+    v_name := COALESCE(NULLIF(btrim(p_guest_email), ''), 'Guest');
+  END IF;
+
+  -- 3. Clamp plus_count.
+  v_plus := GREATEST(COALESCE(p_plus_count, 0), 0);
+  IF v_event.rsvp_allow_plus_ones THEN
+    v_plus := LEAST(v_plus, v_event.rsvp_plus_ones_max);
+  ELSE
+    v_plus := 0;
+  END IF;
+
+  -- 4. Resolve approval + attendance.
+  v_approval := CASE WHEN v_event.rsvp_approval_mode = 'manual' THEN 'pending' ELSE 'approved' END;
+
+  IF p_rsvp_status = 'not_going' THEN
+    v_status := 'not_going';
+  ELSIF p_rsvp_status = 'maybe' THEN
+    -- ORCH-1150 R2 D-10: a Maybe is non-binding + never occupies a seat, so it
+    -- is ALWAYS auto-approved (never host-pending) and never consumes capacity.
+    v_status := 'maybe';
+    v_approval := 'approved';
+  ELSIF v_event.rsvp_capacity IS NULL THEN
+    v_status := 'going';
+  ELSE
+    SELECT COALESCE(SUM(1 + r.plus_count), 0) INTO v_confirmed
+      FROM public.event_rsvps r
+     WHERE r.event_id = p_event_id
+       AND r.rsvp_status = 'going' AND r.approval_status = 'approved'
+       AND (p_user_id IS NULL OR r.user_id IS DISTINCT FROM p_user_id);
+    IF (v_confirmed + 1 + v_plus) > v_event.rsvp_capacity THEN
+      IF v_event.rsvp_approval_mode = 'manual' THEN
+        -- pending doesn't occupy the cap; host's approve is capacity-gated.
+        v_status := 'going';
+      ELSIF v_event.rsvp_waitlist_enabled THEN
+        v_status := 'waitlisted';
+        v_approval := 'approved';
+      ELSE
+        RAISE EXCEPTION 'rsvp_full';
+      END IF;
+    ELSE
+      v_status := 'going';
+    END IF;
+  END IF;
+
+  -- 5. UPSERT the row.
+  IF p_user_id IS NOT NULL THEN
+    SELECT id INTO v_existing_id FROM public.event_rsvps
+     WHERE event_id = p_event_id AND user_id = p_user_id;
+  ELSIF NULLIF(btrim(COALESCE(p_guest_email, '')), '') IS NOT NULL THEN
+    SELECT id INTO v_existing_id FROM public.event_rsvps
+     WHERE event_id = p_event_id AND lower(guest_email) = lower(btrim(p_guest_email));
+  END IF;
+
+  IF v_existing_id IS NOT NULL THEN
+    UPDATE public.event_rsvps
+       SET rsvp_status = v_status,
+           approval_status = v_approval,
+           plus_count = v_plus,
+           guest_name = v_name,
+           guest_email = COALESCE(NULLIF(btrim(p_guest_email), ''), guest_email),
+           guest_phone = COALESCE(NULLIF(btrim(p_guest_phone), ''), guest_phone),
+           waitlisted_at = CASE WHEN v_status = 'waitlisted' THEN COALESCE(waitlisted_at, now()) ELSE NULL END
+     WHERE id = v_existing_id;
+  ELSE
+    INSERT INTO public.event_rsvps
+      (event_id, user_id, guest_name, guest_email, guest_phone,
+       rsvp_status, approval_status, plus_count, waitlisted_at)
+    VALUES
+      (p_event_id, p_user_id, v_name,
+       NULLIF(btrim(p_guest_email), ''), NULLIF(btrim(p_guest_phone), ''),
+       v_status, v_approval, v_plus,
+       CASE WHEN v_status = 'waitlisted' THEN now() ELSE NULL END)
+    RETURNING id INTO v_existing_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'rsvpId', v_existing_id,
+    'status', v_status,
+    'approvalStatus', v_approval,
+    'capacityFull', (v_status = 'waitlisted')
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_event_rsvp(uuid, uuid, text, text, text, text, integer) TO service_role, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- (d) Re-create host_list_rsvp_guests with a 'maybe' bucket in the order CASE
+--     so maybe rows group predictably (between waitlisted and the else tail).
+--     RETURNS TABLE → DROP-before is mandatory (migration-baseline rule).
+--     Body is byte-identical to the base (20261004000000:1166-1191) except the
+--     added maybe ORDER bucket. No capacity predicate changes here.
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.host_list_rsvp_guests(uuid);
+CREATE FUNCTION public.host_list_rsvp_guests(p_event_id uuid)
+RETURNS TABLE (
+  id uuid, event_id uuid, user_id uuid, guest_name text, guest_email text,
+  guest_phone text, rsvp_status text, approval_status text, plus_count integer,
+  waitlisted_at timestamptz, promoted_at timestamptz, created_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = public
+AS $$
+  SELECT r.id, r.event_id, r.user_id, r.guest_name, r.guest_email, r.guest_phone,
+         r.rsvp_status, r.approval_status, r.plus_count,
+         r.waitlisted_at, r.promoted_at, r.created_at
+    FROM public.event_rsvps r
+   WHERE r.event_id = p_event_id
+   ORDER BY
+     CASE WHEN r.approval_status = 'pending' THEN 0
+          WHEN r.rsvp_status = 'going' AND r.approval_status = 'approved' THEN 1
+          WHEN r.rsvp_status = 'waitlisted' THEN 2
+          WHEN r.rsvp_status = 'maybe' THEN 3
+          ELSE 4 END,
+     r.created_at ASC;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.host_list_rsvp_guests(uuid) TO authenticated;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/__tests__/orch_1150_maybe.test.sql
+++ b/supabase/migrations/__tests__/orch_1150_maybe.test.sql
@@ -1,0 +1,159 @@
+-- ORCH-1150 R2 D-10 [RSVP 'maybe' status] — SQL contract tests (T1 / T2 / T3 / T4).
+--
+-- Covers the live-DB half of the maybe semantics for migration
+-- 20261012000000_orch_1150_rsvp_maybe.sql:
+--   T1 = a 'maybe' submit writes rsvp_status='maybe', approval_status='approved'.
+--   T2 = a 'maybe' is CAP-NEUTRAL (does not consume a seat; the next Going still fits).
+--   T3 = at cap, 1 going + 1 maybe → a 2nd going still fits (maybe didn't fill seat 2).
+--   T4 = an invalid status still raises rsvp_status_invalid.
+-- These enforce I-PROPOSED-1150-MAYBE-NOT-IN-CAP on the live RPC.
+--
+-- USAGE (hand-run against the linked remote AFTER the orchestrator applies the
+-- migration — NOT run by the implementor):
+--
+--   cat supabase/migrations/__tests__/orch_1150_maybe.test.sql \
+--     | /Users/sethogieva/bin/supabase db remote sql --linked
+--
+-- Each block is wrapped in BEGIN; … ROLLBACK; so it leaves NO fixture rows.
+
+-- ===========================================================================
+-- T1 — submit_event_rsvp(..., 'maybe') for a reachable link guest → the row is
+-- rsvp_status='maybe', approval_status='approved'; the RPC returns status maybe.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_user   uuid := gen_random_uuid();
+  v_brand  uuid := gen_random_uuid();
+  v_event  uuid := gen_random_uuid();
+  v_res    jsonb;
+  v_status text;
+  v_appr   text;
+BEGIN
+  INSERT INTO public.brands (id, account_id, slug, name, default_currency, created_at, updated_at)
+  VALUES (v_brand, v_user, 'orch1150-maybe-t1', 'Maybe T1', 'USD', now(), now());
+  INSERT INTO public.events (id, brand_id, created_by, event_type, title, slug, description,
+    status, visibility, currency, timezone, party_types, rsvp_approval_mode, created_at, updated_at)
+  VALUES (v_event, v_brand, v_user, 'rsvp', 'Maybe Party', 'maybe-party-t1', 'vibes',
+    'scheduled', 'public', 'USD', 'UTC', ARRAY['house-party'], 'auto', now(), now());
+
+  v_res := public.submit_event_rsvp(v_event, NULL, 'Mae Beigh', 'mae@example.com', '+15551230001', 'maybe', 0);
+
+  IF (v_res->>'status') <> 'maybe' THEN
+    RAISE EXCEPTION 'T1 FAIL: RPC returned status % (expected maybe)', v_res->>'status';
+  END IF;
+  IF (v_res->>'approvalStatus') <> 'approved' THEN
+    RAISE EXCEPTION 'T1 FAIL: RPC returned approvalStatus % (expected approved)', v_res->>'approvalStatus';
+  END IF;
+
+  SELECT rsvp_status, approval_status INTO v_status, v_appr
+    FROM public.event_rsvps WHERE event_id = v_event AND lower(guest_email) = 'mae@example.com';
+  IF v_status <> 'maybe' OR v_appr <> 'approved' THEN
+    RAISE EXCEPTION 'T1 FAIL: row is (%, %) expected (maybe, approved)', v_status, v_appr;
+  END IF;
+
+  RAISE NOTICE 'T1 PASS: maybe submit → row maybe/approved, RPC returns maybe';
+END$$;
+ROLLBACK;
+
+-- ===========================================================================
+-- T2 — cap-neutral: cap=1, one going+approved already, then a maybe submit.
+-- The maybe is written; it does NOT raise rsvp_full and does NOT change the
+-- confirmed headcount.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_user   uuid := gen_random_uuid();
+  v_brand  uuid := gen_random_uuid();
+  v_event  uuid := gen_random_uuid();
+  v_res    jsonb;
+  v_going  int;
+BEGIN
+  INSERT INTO public.brands (id, account_id, slug, name, default_currency, created_at, updated_at)
+  VALUES (v_brand, v_user, 'orch1150-maybe-t2', 'Maybe T2', 'USD', now(), now());
+  INSERT INTO public.events (id, brand_id, created_by, event_type, title, slug, description,
+    status, visibility, currency, timezone, party_types, rsvp_approval_mode, rsvp_capacity, created_at, updated_at)
+  VALUES (v_event, v_brand, v_user, 'rsvp', 'Cap1 Party', 'cap1-party-t2', 'vibes',
+    'scheduled', 'public', 'USD', 'UTC', ARRAY['house-party'], 'auto', 1, now(), now());
+
+  -- Fill the single seat with a going guest.
+  PERFORM public.submit_event_rsvp(v_event, NULL, 'Going One', 'g1@example.com', '+15551230002', 'going', 0);
+
+  -- A maybe must NOT raise rsvp_full at a full cap.
+  v_res := public.submit_event_rsvp(v_event, NULL, 'Maybe One', 'm1@example.com', '+15551230003', 'maybe', 0);
+  IF (v_res->>'status') <> 'maybe' THEN
+    RAISE EXCEPTION 'T2 FAIL: maybe at full cap returned % (expected maybe)', v_res->>'status';
+  END IF;
+
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_going
+    FROM public.event_rsvps WHERE event_id = v_event
+      AND rsvp_status = 'going' AND approval_status = 'approved';
+  IF v_going <> 1 THEN
+    RAISE EXCEPTION 'T2 FAIL: confirmed headcount is % (expected 1 — maybe must not count)', v_going;
+  END IF;
+
+  RAISE NOTICE 'T2 PASS: maybe is cap-neutral (no rsvp_full, headcount unchanged)';
+END$$;
+ROLLBACK;
+
+-- ===========================================================================
+-- T3 — at cap=2 with 1 going + 1 maybe, a 2nd going still fits (the maybe did
+-- not occupy seat 2).
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_user   uuid := gen_random_uuid();
+  v_brand  uuid := gen_random_uuid();
+  v_event  uuid := gen_random_uuid();
+  v_res    jsonb;
+BEGIN
+  INSERT INTO public.brands (id, account_id, slug, name, default_currency, created_at, updated_at)
+  VALUES (v_brand, v_user, 'orch1150-maybe-t3', 'Maybe T3', 'USD', now(), now());
+  INSERT INTO public.events (id, brand_id, created_by, event_type, title, slug, description,
+    status, visibility, currency, timezone, party_types, rsvp_approval_mode, rsvp_capacity, created_at, updated_at)
+  VALUES (v_event, v_brand, v_user, 'rsvp', 'Cap2 Party', 'cap2-party-t3', 'vibes',
+    'scheduled', 'public', 'USD', 'UTC', ARRAY['house-party'], 'auto', 2, now(), now());
+
+  PERFORM public.submit_event_rsvp(v_event, NULL, 'Going A', 'ga@example.com', '+15551230004', 'going', 0);
+  PERFORM public.submit_event_rsvp(v_event, NULL, 'Maybe B', 'mb@example.com', '+15551230005', 'maybe', 0);
+  -- The 2nd going must succeed (only 1 seat consumed so far).
+  v_res := public.submit_event_rsvp(v_event, NULL, 'Going C', 'gc@example.com', '+15551230006', 'going', 0);
+  IF (v_res->>'status') <> 'going' THEN
+    RAISE EXCEPTION 'T3 FAIL: 2nd going returned % (expected going — maybe should not fill a seat)', v_res->>'status';
+  END IF;
+
+  RAISE NOTICE 'T3 PASS: a 2nd going still fits past a maybe (maybe is seatless)';
+END$$;
+ROLLBACK;
+
+-- ===========================================================================
+-- T4 — an invalid rsvp_status still raises rsvp_status_invalid.
+-- ===========================================================================
+BEGIN;
+DO $$
+DECLARE
+  v_user   uuid := gen_random_uuid();
+  v_brand  uuid := gen_random_uuid();
+  v_event  uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.brands (id, account_id, slug, name, default_currency, created_at, updated_at)
+  VALUES (v_brand, v_user, 'orch1150-maybe-t4', 'Maybe T4', 'USD', now(), now());
+  INSERT INTO public.events (id, brand_id, created_by, event_type, title, slug, description,
+    status, visibility, currency, timezone, party_types, rsvp_approval_mode, created_at, updated_at)
+  VALUES (v_event, v_brand, v_user, 'rsvp', 'Bad Status', 'bad-status-t4', 'vibes',
+    'scheduled', 'public', 'USD', 'UTC', ARRAY['house-party'], 'auto', now(), now());
+
+  BEGIN
+    PERFORM public.submit_event_rsvp(v_event, NULL, 'Ban Ana', 'banana@example.com', '+15551230007', 'banana', 0);
+    RAISE EXCEPTION 'T4 FAIL: invalid status was accepted (expected rsvp_status_invalid)';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM NOT LIKE '%rsvp_status_invalid%' THEN
+      RAISE EXCEPTION 'T4 FAIL: wrong error % (expected rsvp_status_invalid)', SQLERRM;
+    END IF;
+  END;
+
+  RAISE NOTICE 'T4 PASS: invalid status still rejected with rsvp_status_invalid';
+END$$;
+ROLLBACK;


### PR DESCRIPTION
## ORCH-1150-R2 — RSVP retest fixes (full batch)

Device-test fixes for the RSVP event feature, validated by Seth on the native dev channel. This merge deploys them to **buyer-web** (which can't be OTA'd).

### Fixes
- **D-1** name-typing no longer remounts the wizard (Spinner suppression during draft promotion).
- **D-2** video cover persists (RSVP draft typed `event_type='rsvp'` server-side + draft fetches widened).
- **D-3** RSVP draft Edit opens the RSVP wizard, not the event one (routing + inverse guard on `event/[id]/edit`).
- **D-4** tailored RSVP host detail page `app/rsvp/[id]/index.tsx` (no white-screen; no ticket/revenue tiles).
- **D-5** RSVP preview route `app/rsvp/[id]/preview.tsx` (no 404; reuses the no-ticket renderer, no-op CTA).
- **D-7b** public RSVP page scroll runway (`contentBottomInset` parity) so content scrolls over the cover.
- **D-8** Blasts + Group chat restored on the RSVP detail page (new `resolveRsvpGuests` audience for blasts).
- **D-9 / D-9b** published RSVP Edit no longer bounces to the events list (auth-gate + the detail Edit passes `?mode=edit-published`).
- **D-10** Going / **Maybe** / Can't-go CTA (3 equal buttons + Lucide icons); new cap-neutral, auto-approved `maybe` status.

### Backend
- Migration `20261012000000_orch_1150_rsvp_maybe.sql` (rsvp_status CHECK + RLS + `submit_event_rsvp` + `host_list_rsvp_guests` widen; capacity/headcount untouched) — **already applied to Mingla-dev**.
- `public-submit-rsvp` edge fn accepts `maybe` — already deployed to dev.

### Guards
Ticketed event/trip/experience paths byte-identical; `ParallaxCoverShell` (shared) untouched; the only ticketed-file change is the allowed inverse RSVP-redirect guard in `app/event/[id]/edit.tsx`. Each fix has a fails-on-revert regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)