### PR TITLE
META-ORCH-1148 2.2b fix: reserve sheet won't open / card stuck (mount-on-open)

### DIFF
--- a/app-mobile/package.json
+++ b/app-mobile/package.json
@@ -72,7 +72,8 @@
     "test:orch-1054": "node ./scripts/ci/orch-1054-matches-expanded-card-parity-check.mjs",
     "test:orch-1072": "node ./scripts/ci/orch-1072-venue-experiences-check.mjs",
     "test:orch-1125": "node ./scripts/ci/orch-1125-regression-check.mjs && node --experimental-strip-types --test app/__tests__/coldRouteQueryProvider.orch1125.test.ts",
-    "test:orch-1149": "node ./scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs"
+    "test:orch-1149": "node ./scripts/ci/orch-1149-inapp-browser-bottom-anchored.mjs",
+    "test:orch-1148": "node ./scripts/ci/orch-1148-reserve-sheet-mount-on-open-check.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/app-mobile/scripts/ci/orch-1148-reserve-sheet-mount-on-open-check.mjs
+++ b/app-mobile/scripts/ci/orch-1148-reserve-sheet-mount-on-open-check.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * META-ORCH-1148 sub-ORCH 2.2b [consumer venue reserve] structural regression.
+ *
+ * The "Reserve a table" sheet would not visibly open: tapping the CTA flipped
+ * `isReserveSheetOpen` true → `anyChildModalOpen` true → the root card sheet was
+ * gated off (`visible={visible && !anyChildModalOpen}`) and animated closed (the
+ * card collapsed), while the ALWAYS-MOUNTED VenueReserveSheet only toggled its
+ * `visible` prop. Because both share the inline (non-RN-Modal) presentation slot
+ * and the root was closing in the same render, the sub-sheet's open never
+ * presented. Nothing opened → onClose never fired → `isReserveSheetOpen` stayed
+ * true → the root stayed suppressed → the card could not be re-expanded.
+ *
+ * FIX (2026-06-17): mount-on-open, mirroring the proven ConsumerExperienceDetail
+ * sibling (`{selectedVenueExperience !== null && <…>}`). VenueReserveSheet is
+ * rendered ONLY while `isReserveSheetOpen` is true (still behind the reservable
+ * gate), so a freshly mounted BaseBottomSheet performs a clean open animation in
+ * the freed slot; closing it (CTA / pan-down / backdrop → resetAndClose →
+ * onClose) unmounts AND resets the flag, ungating the root so the card restores.
+ *
+ * This check fails-on-revert of commit that introduced the `&& isReserveSheetOpen`
+ * mount-on-open guard on the VenueReserveSheet render block.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const read = (relativePath) =>
+  fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+
+const source = read("app-mobile/src/components/ExpandedCardModal.tsx");
+const reserveSheetSource = read(
+  "app-mobile/src/components/expandedCard/VenueReserveSheet.tsx",
+);
+const checks = [];
+const check = (name, pass, detail) => checks.push({ name, pass, detail });
+
+const mainStart = source.indexOf("export default function ExpandedCardModal");
+const mainBody = mainStart >= 0 ? source.slice(mainStart) : "";
+
+// Locate the VenueReserveSheet render block (gate condition → element).
+const reserveRenderStart = mainBody.indexOf("venueReservable?.reservable === true");
+const reserveRenderEnd = mainBody.indexOf(
+  "/>",
+  mainBody.indexOf("<VenueReserveSheet", reserveRenderStart),
+);
+const reserveRenderBlock =
+  reserveRenderStart >= 0 && reserveRenderEnd > reserveRenderStart
+    ? mainBody.slice(reserveRenderStart, reserveRenderEnd)
+    : "";
+
+check(
+  "G-01 reserve sheet is MOUNT-ON-OPEN (mirrors the experience-detail sibling)",
+  reserveRenderBlock.includes("isReserveSheetOpen && (") &&
+    reserveRenderBlock.includes("<VenueReserveSheet"),
+  "VenueReserveSheet must be rendered only while isReserveSheetOpen is true (mount==open), so a fresh BaseBottomSheet opens in the freed slot instead of toggling visibility on an always-mounted sheet that races the root sheet's close.",
+);
+
+check(
+  "G-02 experience-detail sibling stays mount-on-open (the proven pattern)",
+  /\{selectedVenueExperience !== null && \(/.test(mainBody) &&
+    mainBody.includes("<ConsumerExperienceDetailScreen"),
+  "The reference sibling ConsumerExperienceDetailScreen must remain mount-on-open; the reserve sheet matches it.",
+);
+
+check(
+  "G-03 reserve flag participates in the child-overlay gate and the swallow",
+  /const anyChildModalOpen\s*=\s*[\s\S]*?isReserveSheetOpen;/s.test(mainBody) &&
+    /const handleRootSheetClose = useCallback[\s\S]*?isReserveSheetOpen\) \{[\s\S]*?return;/s.test(
+      mainBody,
+    ),
+  "isReserveSheetOpen must gate the root sheet (anyChildModalOpen) AND be swallowed by handleRootSheetClose so the synthetic root close does not tear the card down while the reserve sheet is open.",
+);
+
+check(
+  "G-04 closing the reserve sheet resets isReserveSheetOpen to false",
+  mainBody.includes("onClose={() => setIsReserveSheetOpen(false)}"),
+  "The reserve sheet's onClose must set isReserveSheetOpen=false so the root ungates and the card restores / can re-expand.",
+);
+
+check(
+  "G-05 VenueReserveSheet dismissal paths all route through onClose",
+  reserveSheetSource.includes("const resetAndClose = (): void => {") &&
+    /const resetAndClose = \(\): void => \{[\s\S]*?onClose\(\);/s.test(
+      reserveSheetSource,
+    ) &&
+    reserveSheetSource.includes("onClose={resetAndClose}"),
+  "BaseBottomSheet pan-down/backdrop dismissal and the close icon must funnel through resetAndClose → onClose so the parent flag always resets on dismissal.",
+);
+
+const failures = checks.filter((item) => !item.pass);
+for (const item of checks) {
+  console.log(`${item.pass ? "PASS" : "FAIL"} ${item.name}`);
+  if (!item.pass) console.log(`  ${item.detail}`);
+}
+
+if (failures.length > 0) {
+  console.error(
+    `ORCH-1148 reserve-sheet mount-on-open regression failed: ${failures.length}/${checks.length}`,
+  );
+  process.exit(1);
+}
+
+console.log("ORCH-1148 reserve-sheet mount-on-open regression passed.");

--- a/app-mobile/src/components/ExpandedCardModal.tsx
+++ b/app-mobile/src/components/ExpandedCardModal.tsx
@@ -2333,9 +2333,22 @@ export default function ExpandedCardModal({
       {/* META-ORCH-1148 2.2b — the 3-step reserve sheet, mounted as a SIBLING of
           the root sheet (same proven sub-sheet pattern as the experience detail
           above). The root sheet is gated off (anyChildModalOpen) while it is
-          open. The reservation attaches to the signed-in user server-side. */}
+          open. The reservation attaches to the signed-in user server-side.
+
+          2.2b reserve-won't-open fix (2026-06-17): MOUNT-ON-OPEN, mirroring the
+          ConsumerExperienceDetailScreen sibling (`selectedVenueExperience !== null
+          && <…>`). The prior always-mounted-when-reservable + `visible`-toggle
+          shape raced the root sheet's simultaneous close (both share the inline,
+          non-RN-Modal presentation slot): flipping `isReserveSheetOpen` true
+          gated the root off (card collapsed) but the already-mounted sub-sheet's
+          open never presented → nothing opened → onClose never fired → the flag
+          stuck true → root stayed suppressed → card couldn't re-expand. Mounting
+          fresh on open gives a clean open animation in the freed slot, exactly
+          like the experience-detail sibling; closing it (CTA/pan-down/backdrop →
+          resetAndClose → onClose) unmounts AND resets isReserveSheetOpen=false,
+          ungating the root so the card restores and re-expands. */}
       {isNightOut && nightOut && venueReservable?.reservable === true &&
-        venueReservable.brand_id !== null && (
+        venueReservable.brand_id !== null && isReserveSheetOpen && (
           <VenueReserveSheet
             visible={isReserveSheetOpen}
             onClose={() => setIsReserveSheetOpen(false)}


### PR DESCRIPTION
Second 2.2b reserve-sheet fix (after the freeze fix). Tapping "Reserve a table" did nothing, collapsed the card, and wedged re-expansion.

**Root cause:** the reserve sheet was MOUNTED-ALWAYS-when-reservable with a toggled `visible` prop, unlike the proven `ConsumerExperienceDetailScreen` sibling which MOUNTS-ONLY-WHEN-OPEN. On tap, the always-mounted inline sub-sheet raced the root sheet's simultaneous close and never presented → nothing opened → onClose never fired → `isReserveSheetOpen` stuck true → root sheet permanently suppressed → card can't re-expand.

**Fix:** add `&& isReserveSheetOpen` to the reserve render gate → mount-on-open, matching the sibling exactly. Fresh BaseBottomSheet opens cleanly; dismiss → unmount → flag reset → card restores + re-expands. Freeze-fix swallow + `anyChildModalOpen` membership preserved. Regression gate `orch-1148-reserve-sheet-mount-on-open-check.mjs` + fails-on-revert. tsc/eslint 0 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)