### PR TITLE
ORCH-1150-R2 D-7c: web-phone parallax — scroll rides over the fixed cover [deploy]

### DIFF
--- a/mingla-business/src/components/trip/__tests__/ParallaxCoverShell_webphone_stacking.test.ts
+++ b/mingla-business/src/components/trip/__tests__/ParallaxCoverShell_webphone_stacking.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ORCH-1150-R2 [rsvp-retest-fixes] D-7c — WEB-PHONE parallax stacking regression test.
+ *
+ * Orchestrator-proven bug (from source): on web at mobile width the public
+ * offering page's scroll content slid UNDER the `position:fixed` cover instead
+ * of over it. The web-phone path never received the zIndex fix the NATIVE path
+ * already had (`styles.nativeScroll` → CONTENT_Z).
+ *
+ * ROOT CAUSE: the web-phone `<Scroll>` element had NO `style` prop, so it was
+ * statically positioned with auto z-index. A static/auto-z element paints in the
+ * flow layer BENEATH every positioned child — including the `position:fixed`
+ * cover at COVER_Z (1). The inner body View carried `zIndex: CONTENT_Z`, but that
+ * only orders the body against the spacer WITHIN the Scroll's own stacking
+ * context — NOT against the host-level fixed cover (a sibling of the Scroll, one
+ * level up). So the entire scroll body rendered behind the cover. This is the
+ * exact stacking trap the shell header documents for native, never applied to
+ * web-phone.
+ *
+ * FIX: give the web-phone `<Scroll>` `position:relative; zIndex:CONTENT_Z` (so it
+ * sits above the fixed cover), and make `webPhoneHost` establish a local stacking
+ * context (`position:relative; zIndex:0`) so the three children resolve
+ * cover(COVER_Z) < Scroll(CONTENT_Z) < chrome(CHROME_Z) deterministically.
+ *
+ * Contract (must hold on BOTH native + react-native-web):
+ *   cover (lowest) < content (middle, opaque, slides over) < chrome (highest).
+ *
+ * Shared-shell note: ParallaxCoverShell backs event / trip / experience / rsvp
+ * public pages alike, so this fix makes the documented "content over cover"
+ * contract hold on web-phone for ALL offering types (the intended behavior).
+ *
+ * Source-structure test (mirrors ParallaxCoverShell_native_stacking.test.ts) so
+ * it runs under the default mingla-business node/ts-jest config without RTL. The
+ * visual parallax itself still needs on-device/browser confirmation.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SHELL_PATH = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "packages",
+  "offering-rendering",
+  "ParallaxCoverShell.tsx",
+);
+const SRC = readFileSync(SHELL_PATH, "utf8");
+
+/** Extract `export const NAME = <int>;` from the shell source. */
+function constValue(name: string): number {
+  const m = SRC.match(new RegExp(`export const ${name} = (\\d+);`));
+  if (m == null) throw new Error(`constant ${name} not exported`);
+  return Number(m[1]);
+}
+
+/** Extract the body of a StyleSheet.create entry `NAME: { ... }`. */
+function styleBlock(name: string): string {
+  const m = SRC.match(new RegExp(`\\b${name}:\\s*\\{([\\s\\S]*?)\\n  \\},`));
+  if (m == null) throw new Error(`style block ${name} not found`);
+  return m[1];
+}
+
+describe("ORCH-1150-R2 ParallaxCoverShell — web-phone z-order contract", () => {
+  it("exports the 3-layer z-index contract ordered cover < content < chrome", () => {
+    const cover = constValue("COVER_Z");
+    const content = constValue("CONTENT_Z");
+    const chrome = constValue("CHROME_Z");
+    expect(cover).toBeLessThan(content);
+    expect(content).toBeLessThan(chrome);
+  });
+
+  it("web-phone Scroll element carries position:relative + zIndex CONTENT_Z above the fixed cover (THE FIX — fails-on-revert)", () => {
+    // The load-bearing fix: the web-phone <Scroll> wires the content-layer style
+    // via the webStyle escape hatch. Without it the Scroll is static + auto-z and
+    // the position:fixed cover (COVER_Z) paints over the scrolling body — the
+    // orchestrator-proven bug. We assert the <Scroll ... style={webStyle({...})}>
+    // shape carries both position:relative and zIndex:CONTENT_Z.
+    expect(SRC).toMatch(
+      /<Scroll\b[\s\S]*?style=\{webStyle\(\{\s*position:\s*"relative",\s*zIndex:\s*CONTENT_Z\s*\}\)\}/,
+    );
+
+    // And the content layer's zIndex MUST be strictly above the cover's.
+    expect(constValue("CONTENT_Z")).toBeGreaterThan(constValue("COVER_Z"));
+  });
+
+  it("webPhoneHost establishes a stacking context so cover/content/chrome resolve against each other", () => {
+    // Without a stacking context on the host, the fixed cover, relative Scroll,
+    // and fixed chrome could resolve at the root rather than locally. position:
+    // relative + an explicit zIndex is the minimal trigger.
+    const host = styleBlock("webPhoneHost");
+    expect(host).toMatch(/position:\s*"relative"/);
+    expect(host).toMatch(/zIndex:\s*0/);
+  });
+
+  it("web-phone cover is the lowest layer (position:fixed, zIndex COVER_Z)", () => {
+    expect(SRC).toMatch(/position:\s*"fixed"[\s\S]*?zIndex:\s*COVER_Z/);
+  });
+
+  it("web-phone chrome is the highest layer (position:fixed, zIndex CHROME_Z)", () => {
+    expect(SRC).toMatch(/position:\s*"fixed"[\s\S]*?zIndex:\s*CHROME_Z/);
+  });
+
+  it("web-phone body keeps the −SEAM overlap + rounded-top seam so it slides up over the cover", () => {
+    // The body still overlaps the cover's bottom edge (negative margin) and the
+    // seam is rounded — unchanged by the stacking fix.
+    expect(SRC).toMatch(/position:\s*"relative",\s*\n\s*zIndex:\s*CONTENT_Z,\s*\n\s*marginTop:\s*-SEAM/);
+    expect(SRC).toMatch(/borderTopLeftRadius:\s*SEAM/);
+  });
+});

--- a/packages/offering-rendering/ParallaxCoverShell.tsx
+++ b/packages/offering-rendering/ParallaxCoverShell.tsx
@@ -294,6 +294,17 @@ export const ParallaxCoverShell: React.FC<ParallaxCoverShellProps> = ({
         </View>
 
         <Scroll
+          // WEB-PHONE STACKING FIX (ORCH-1150-R2 D-7c): the Scroll element MUST
+          // carry an explicit position+zIndex so the scrolling body paints OVER
+          // the `position:fixed` cover (COVER_Z) instead of behind it. Without a
+          // `style` the Scroll was statically positioned + auto-z, so it sat in
+          // the flow layer BENEATH every positioned child (the fixed cover at
+          // COVER_Z). Mirrors how the native branch z-indexes `styles.nativeScroll`
+          // to CONTENT_Z. The host (`webPhoneHost`) establishes the shared stacking
+          // context (position:relative + zIndex:0) so cover(1) < Scroll(2) <
+          // chrome(70) resolves deterministically. Contract: COVER_Z < CONTENT_Z
+          // < CHROME_Z (shell header §Z-INDEX CONTRACT).
+          style={webStyle({ position: "relative", zIndex: CONTENT_Z })}
           contentContainerStyle={[
             styles.webPhoneScrollContent,
             { paddingBottom: contentBottomInset },
@@ -434,6 +445,15 @@ const styles = StyleSheet.create({
   // ---- web phone ----
   webPhoneHost: {
     flex: 1,
+    // WEB-PHONE STACKING FIX (ORCH-1150-R2 D-7c): establish a local stacking
+    // context so the host's three children — the `position:fixed` cover
+    // (COVER_Z), the `position:relative` Scroll (CONTENT_Z), and the
+    // `position:fixed` chrome (CHROME_Z) — resolve their z-order against EACH
+    // OTHER (cover < content < chrome) rather than independently at the root.
+    // `position:relative` + an explicit `zIndex` is the minimal trigger; without
+    // it the body could not reliably paint over the fixed cover.
+    position: "relative",
+    zIndex: 0,
   },
   webPhoneScrollContent: {
     flexGrow: 1,


### PR DESCRIPTION
## D-7c — web-phone ParallaxCoverShell stacking fix

On a mobile-width browser, public offering pages scrolled their content UNDER the fixed cover instead of over it. The shared shell's web-phone `<Scroll>` was missing the zIndex the native path already has, so it sat below the `position:fixed` cover.

**Fix (web-phone branch only):** the web-phone Scroll now carries `position:relative; zIndex:CONTENT_Z` and its host establishes a stacking context, so the documented contract holds: cover(1) < content(2) < chrome(70). Native + desktop branches byte-identical.

Shared shell → fixes web-phone parallax for **event, trip, experience, and rsvp** public pages alike (the intended contract). Fails-on-revert web-phone stacking test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)