### PR TITLE
ORCH-1155: public brand page — Direction-A redesign + all-surface parity [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md
@@ -1,0 +1,157 @@
+# IMPLEMENTATION — ORCH-1155 · Public Brand Page — Direction-A Redesign + All-Surface Parity
+
+**Mode:** IMPLEMENT (mingla-implementor)
+**Date:** 2026-06-17
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1155-[brand-page-parity]/` · branch `ORCH-1155-brand-page-parity` (rebased on origin/main `721bf95d3`)
+**Status:** implemented, partially verified (automated tests + typecheck + lint green; live 5-surface eyeball is the tester's — bracket-path Metro precluded a local sim/web screenshot, see §9).
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1155_PUBLIC_BRAND_PAGE.md` · **Investigation:** `…/investigations/INVESTIGATE_ORCH-1155_PUBLIC_BRAND_PAGE.md` · **Design:** `…/design/ORCH-1138/BRAND_DIRECTION_A_RESPONSIVE.html`
+
+---
+
+## 1. Summary
+
+The single shared public brand renderer (`@mingla/brand-rendering/PublicBrandPage`) was refactored from its hand-rolled flat-banner / About-last / local-palette layout onto the shipped Direction-A foundation — the SAME `ParallaxCoverShell` + `OfferingChrome` + `useResponsiveLayout` + shared `createThemePalette`/`offeringSurfaceStyles` primitives the trip/event/experience pages already use. One file change reaches all five surfaces (buyer-web + business iOS/Android + consumer iOS/Android). Plus two scoped follow-ons: experience cover video (a one-column migration + both data adapters + the card) and consumer brand-badge wiring (swipe-deck badge + experience-detail "Presented by" → `/b/{slug}`, no more dead taps).
+
+What changes for end users: the brand page now reads as a real immersive Direction-A hub — pinned parallax cover, body sliding over the 28px seam, fixed X·Share chrome (plus Mute when the cover is video), an About-first horizontally-scrollable tab bar that only shows tabs the brand actually has, the bio/tagline/contact living inside About (with a Read-more clamp), a proper desktop two-column with a sticky Share + Next-up panel, and experience cards that play video covers. In the consumer app, tapping a brand badge on a swipe card or the "Presented by" lockup now opens that brand's page.
+
+## 2. SPEC success-criteria coverage
+
+| SC | What | Status | Commit |
+|----|------|--------|--------|
+| SC-1 | About first + default, all 5 (AUTO) | source+structural ✓; tester eyeball | `c6f8c929e` |
+| SC-2 | Tabs hide when empty, all 5 (AUTO) | source+structural ✓ | `c6f8c929e` |
+| SC-3 | About pane order tagline→bio(clamp+Read more)→contact | source+structural ✓; tester eyeball | `c6f8c929e` |
+| SC-4 | Parallax + seam + chrome (X·Share, Mute on video) | source ✓ (shell-composed); tester device | `c6f8c929e` |
+| SC-5 | Desktop two-column ≥1024px (sticky Share+Next-up; no Reserve/Follow/contact) | source+structural ✓; tester web | `c6f8c929e` |
+| SC-6 | No fabricated Follow | structural ✓ (`not /follow/i` + `/subscrib/i`) | `c6f8c929e` |
+| SC-7 | Theming parity via SHARED engine | source ✓ + palette parity test still 5/5 | `c6f8c929e` |
+| SC-8 | Anon-safe (no `.from("brands")`) | structural ✓ | `c6f8c929e` |
+| SC-9-Web | Experience video cover via `publicEventsService` | source ✓ (needs migration applied); tester web | `f24125173` |
+| SC-9-Native | Experience video cover via `useBrandBySlug` | source ✓ (needs migration applied); tester native | `f24125173` |
+| SC-10 | Swipe-badge → `/b/{slug}` (not dead tap) | source+test ✓; tester device | `0dc53cfbc` |
+| SC-11 | Detail "Presented by" → `/b/{slug}` | source+test ✓; tester device | `0dc53cfbc` |
+| SC-12 | No curated regression (byte-identical) | source+test ✓ (bare BrandChip branch) | `0dc53cfbc` |
+
+Runtime-observable criteria (SC-1/3/4/5/9/10/11) are **source-verified + automated-structural-verified** but require the tester's live 5-surface eyeball (and SC-9 the migration applied to prod) for the runtime PASS — I did not capture a sim/web screenshot (bracket-path Metro, §9).
+
+## 3. Files changed (12, all inside the spec allowlist)
+
+| File | Δ | Commit |
+|------|---|--------|
+| `supabase/migrations/20261013000000_orch_1155_experiences_by_brand_cover_media_type.sql` | NEW (+85) | `f24125173` |
+| `packages/brand-rendering/types.ts` | +6 | `f24125173` |
+| `mingla-business/src/services/publicEventsService.ts` | +8 | `f24125173` |
+| `app-mobile/src/hooks/useBrandBySlug.ts` | +5 | `f24125173` |
+| `mingla-business/src/components/brand/PublicBrandPage.tsx` | +2 | `f24125173` |
+| `packages/brand-rendering/PublicBrandPage.tsx` | rewrite (~1490 → ~990; net −500) | `c6f8c929e` |
+| `app-mobile/src/components/CuratedExperienceSwipeCard.tsx` | +~45 | `0dc53cfbc` |
+| `app-mobile/src/components/SwipeableCards.tsx` | +~12 | `0dc53cfbc` |
+| `app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx` | +~14 | `0dc53cfbc` |
+| `packages/brand-rendering/__tests__/orch_1155_brand_redesign.test.tsx` | NEW | `dd4bb61db` |
+| `app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts` | NEW | `dd4bb61db` |
+| `mingla-business/__tests__/components/PublicBrandPage.dataDriven.test.tsx` | relocated (−26/+~40) | `dd4bb61db` |
+
+## 4. Data-model changes
+
+`pg_public_experiences_by_brand(text)` — added one column `cover_media_type text` to the `RETURNS TABLE` (after `cover_media_url`) + the matching `e.cover_media_type::text` SELECT. Re-emitted from the LIVE PROD body (via MCP `pg_get_functiondef`, read-only) so the ORCH-1076 paid-supply gate / ordering / search_path are byte-preserved. DROP-before-widen (RETURNS TABLE widening). `$function$;` before the GRANT block; `REVOKE ALL FROM PUBLIC` + `GRANT EXECUTE TO anon, authenticated`. No RLS/table change. No other DB object touched.
+
+**The two-data-path cover field (the #1 trap, handled):** `cover_media_type` is threaded on BOTH independent paths so the experience video cover ships on web AND in-app (not one or the other):
+- **Path 1 (business/web → surfaces 3–5):** `publicEventsService.ts` `PublicExperienceCardRow.cover_media_type` + `PublicExperienceCard.coverMediaType` + `experienceRowToCard` mapper; and the business adapter `components/brand/PublicBrandPage.tsx` `mapExperience` sets `coverMediaType`.
+- **Path 2 (consumer in-app → surfaces 1–2):** `useBrandBySlug.ts` `PublicExperienceRow.cover_media_type` + `mapExperience` mapper.
+- The shared `PublicBrandExperience` type gained `coverMediaType: PublicMediaType | null`, and `ExperienceMiniCard` now passes `mediaType={experience.coverMediaType}` (was hardcoded `"image"`).
+
+## 5. Edge functions touched
+
+None. (No edge-fn deploy required for this ORCH.)
+
+## 6. Regression tests added
+
+- **Implementor happy-path:** `packages/brand-rendering/__tests__/orch_1155_brand_redesign.test.tsx` — 10/10 PASS. Run: `cd mingla-business && npx jest --roots ../packages/brand-rendering`. (Structural source-text test; no RTL dep, runs under plain ts-jest.)
+- **Consumer badge nav:** `app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts` — PASS. Run: `node app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts`. (node:assert source-assertions, the app-mobile convention.)
+- **Relocated:** `mingla-business/__tests__/components/PublicBrandPage.dataDriven.test.tsx` — now 4/4 PASS (was 3/4-failing on origin/main). Run: `cd mingla-business && npx jest __tests__/components/PublicBrandPage.dataDriven.test.tsx`.
+
+**fails-on-revert verified at `dd4bb61db`** (post-rebase HEAD `dd4bb61db…`):
+- Package test: TRUE LINE-DELETION of `const tabs: Tab[] = ["about"];` → T-1 FAILS (`1 failed, 9 passed`); restored → 10/10 PASS.
+- Badge test: TRUE LINE-DELETION of the `onBrandPress={() => { … router.push(\`/b/${s}\`) … }}` block at the SwipeableCards experience mount → the test throws `AssertionError: the experience mount must guard the empty slug then router.push(\`/b/${slug}\`)`; restored → PASS.
+
+Both proved by line deletion (not comment-out). The tester writes the SECOND adversarial render-angle test per spec §9.
+
+## 7. Old → New receipts
+
+### `packages/brand-rendering/PublicBrandPage.tsx`
+**Before:** flat `position:absolute;height:380` banner cover; a hand-rolled `<ScrollView paddingTop:284>`; a hand-rolled X+Share chrome row (no mute, `ChromeGlyph`/`ChromeButton`); a 250-line file-LOCAL `createThemePalette` + color-math; `maxWidth:620` everywhere (no desktop two-column); tab order About-LAST in a non-scroll clipped `View`; tagline+bio rendered ABOVE the tabs always-visible; About pane = a duplicate "About" bio block + contact.
+**Now:** composes `ParallaxCoverShell` (pinned parallax + −28 seam + body-level fixed chrome) + `OfferingChrome` (X·Share·Mute, Mute gated on `coverType==="video"`); imports the SHARED `createThemePalette`/`offeringSurfaceStyles`/`ThemePalette` and deleted the local engine + color-math; About-FIRST default + a horizontal `ScrollView` tab bar (chips sized to content, edge fade on web-phone, active-chip scroll-into-view via cached offsets); identity (avatar+verified+name+address) + socials + featured teaser above the tabs on phone only; desktop `isDesktop` branch hides the phone identity, overlays verified eyebrow+name+address on the contained 21:9 hero, and renders a sticky brand-summary panel (avatar/name/address/socials + accent **Share** + **Next-up** card — NO Reserve, NO Follow, contact NOT duplicated) with a 2-column offering grid; About pane = tagline → bio (`ClampedBio`, 4-line clamp + Read more/Show less) → contact (email mailto + phone tel) inside About. Real-data-only hiding preserved.
+**Why:** SC-1…SC-8, the Direction-A design contract, D-1…D-8.
+**Lines:** ~1490 → ~990 (net −500).
+
+### `mingla-business/src/services/publicEventsService.ts`
+**Before:** `PublicExperienceCardRow` had no `cover_media_type`; `PublicExperienceCard` no `coverMediaType`; `experienceRowToCard` didn't map it.
+**Now:** row + card carry `cover_media_type`/`coverMediaType`; mapper sets it from the RPC row.
+**Why:** SC-9-Web. **Lines:** +8.
+
+### `app-mobile/src/hooks/useBrandBySlug.ts`
+**Before:** `PublicExperienceRow` no `cover_media_type`; `mapExperience` didn't map it.
+**Now:** both carry/map `coverMediaType`.
+**Why:** SC-9-Native. **Lines:** +5.
+
+### `app-mobile/src/components/CuratedExperienceSwipeCard.tsx`
+**Before:** `BrandChip` rendered as a static `<View accessibilityRole="image">` — a dead tap.
+**Now:** optional `onBrandPress?` prop; when present the badge is wrapped in a `TrackedTouchableOpacity` (the wrapper owns the absolute position + is the button) and `BrandChip` renders with `wrapped` (normal-flow layout, `pointerEvents="none"`, a11y-hidden so the wrapper is the single button); when absent the bare `<BrandChip>` renders byte-identically (curated SC-12).
+**Why:** SC-10/SC-12. **Lines:** +~45.
+
+### `app-mobile/src/components/SwipeableCards.tsx`
+**Before:** experience mount passed `brandExperience` but no nav handle.
+**Now:** imports `useRouter`; the experience mount passes `onBrandPress` that reads `currentRec.brandSlug`, guards empty, and `router.push('/b/'+slug)`.
+**Why:** SC-10/SC-14. **Lines:** +~12.
+
+### `app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx`
+**Before:** "Presented by {brand}" lockup was a static `<View>`.
+**Now:** imports `useRouter`; the lockup is a `<Pressable>` (`accessibilityRole="button"`) that guards `seed.brandSlug` then `router.push('/b/'+seed.brandSlug)`.
+**Why:** SC-11. **Lines:** +~14.
+
+## 8. Cross-surface impact
+
+| Surface | Affected | What / parity |
+|---------|----------|---------------|
+| Consumer iOS | YES | Shared renderer (AUTO) + badge wiring (MANUAL) + experience video cover via `useBrandBySlug` (MANUAL) |
+| Consumer Android | YES | Same; Android opaque glass via shared `offeringSurfaceStyles` + `OfferingChrome` fallback |
+| Buyer/anon Web | YES | Shared renderer desktop two-column + phone parallax (AUTO) + experience video via `publicEventsService` (MANUAL) |
+| Business iOS | YES | Shared renderer, phone single-column (AUTO) |
+| Business Android | YES | Same; opaque glass (AUTO) |
+| Admin Web | NO | No public brand page |
+| Business Web preview (adjacent) | NO | The `/b` web route IS the buyer-web surface |
+
+Manual-parity items (both done): the `coverMediaType` cover field on TWO data paths; consumer badge wiring on surfaces 1–2.
+
+## 9. Smoke result
+
+**No live sim/web screenshot.** The worktree path has brackets which break Metro/expo; a bracket-free checkout + `npm ci` + web export was judged not worth the cost because the visual layer is delivered entirely by the SAME shell/palette primitives already shipping on prod (the brand page composes them with the identical API `TripPreview.tsx` uses). Evidence + the tester's must-eyeball list: `Mingla_Artifacts/evidence/ORCH-1155/VERIFICATION_NOTES.md`. Automated proof run locally: package test 10/10, badge test PASS, relocated dataDriven 4/4, palette parity 5/5; touched-file typecheck clean; no new lint errors.
+
+## 10. Known issues / deferred
+
+1. **Consumer brand page native chrome top-inset.** The consumer adapter `ConsumerBrandProfileScreen.tsx` (DO-NOT-TOUCH per spec — "already correct") does NOT pass `chromeTopOffset`, so the shared page passes `safeAreaTop=0` → the X/Share chrome sits at `12px` from the top on consumer native (it could collide with the notch/status bar). The business adapter passes `chromeTopOffset={insets.top + 8}` so business native + web are fine. Fixing this needs a one-line `chromeTopOffset={insets.top}` in the do-not-touch consumer screen → flagged for the orchestrator rather than widening scope. Low blast radius (cosmetic, consumer native only).
+2. **Active-chip scroll-into-view is best-effort on native** (spec OQ-2): implemented via cached per-chip `onLayout` x-offsets + `scrollTo`. The load-bearing requirement (non-clipping horizontal ScrollView) is met. Confirm best-effort is acceptable.
+3. **Package tests have no CI runner wired.** The two new package/app-mobile tests run locally (commands in §6) but I found no CI job that executes `packages/**/__tests__` or app-mobile `node:assert` tests — same as the existing `event-rendering`/app-mobile precedents. Flagged for the orchestrator (may want a CI step). The relocated `dataDriven` test DOES run under the business jest.
+
+## 11. Operator action required
+
+1. **Apply the migration to prod** (orchestrator-owned; SC-9 precondition). Via Supabase Management API (CLI drift-wedged; MCP read-only) per `feedback_edge_deploy_and_migration_apply_hazards`. The file also lands in the worktree for CI migration-baseline. Pre-flight probes done read-only: `pg_brand_can_charge` exists; `events.cover_media_type` is `text`; live body re-emitted. No guards/backfills in the migration (pure CREATE OR REPLACE), so no abort risk.
+   - If applying via CLI from a bracket-free checkout instead: `cd "<bracket-free worktree>" && /Users/sethogieva/bin/supabase db push --linked` (monotonic prefix `20261013000000` > local/remote/sibling max `20261012000006`).
+2. **No edge-fn deploy.** None touched.
+3. **OTA after merge** (consumer app-mobile + business per the OTA policy) — both the shared renderer and the badge wiring are pure-JS/RN (no native module), so `eas update` per-platform suffices.
+4. **REVIEW then dispatch tester** for the 5-surface live-fire eyeball + the adversarial test (spec §9).
+
+## 12. Discoveries for orchestrator
+
+1. **Pre-existing RED jest suites on origin/main** (NOT caused by ORCH-1155 — confirmed by running them on baseline with my changes absent): `serverDraftLifecycleGuards`, `orch_0893_rework_adversarial_merge_spec`, `TripVisualParity_adversarial`, `eventCoverVideoProcessingService`, `eventCoverMedia` and others (≈13 failing in the brand-name jest sweep). Several trace to a `DraftEvent` type missing `category`/`isRsvp…` fields and a missing `@testing-library/react-native`/`@mingla/payments-native` in the default node jest env. The CI brand-page signal is otherwise green now (the relocated dataDriven test is fixed). Worth a triage ORCH.
+2. **Two strict-grep gates fail on baseline too:** `orch-0756a-active-brand-recovery` (flags `BrandSwitcherSheet.tsx` — untouched by me) and `i-proposed-a-brands-deleted-filter` (Node crash). Neither references any ORCH-1155 file. Pre-existing.
+3. **`hideFloatingChrome` prop is now effectively unused** (kept in the props type for back-compat; both live callers pass it falsy and the shell always renders chrome). If no embedded chrome-less use ever materializes, a future cleanup could drop it from `PublicBrandPageProps`.
+4. **origin/main advanced mid-implementation** (META-ORCH-1148 2.2b #512 merged, touching some of my files); I rebased clean onto `721bf95d3` with no conflicts. The 4 ORCH-1155 commits contain exactly the 12 allowlisted files.
+
+---
+
+**Commits (post-rebase):**
+- `f24125173` — migration + both data paths + shared type
+- `c6f8c929e` — shared PublicBrandPage refactor onto the Direction-A shell
+- `0dc53cfbc` — consumer brand-badge wiring (no dead taps)
+- `dd4bb61db` — regression tests + relocated dataDriven test (`[TEST-MOD-APPROVED ORCH-1155]`)

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md
@@ -185,3 +185,58 @@ Manual-parity items (both done): the `coverMediaType` cover field on TWO data pa
 **Updates Known-Issue #1 in §10:** RESOLVED. (The §10 note assumed the consumer screen was DO-NOT-TOUCH; this scoped follow-up ORCH was dispatched specifically to fix it — additive prop only, web/business untouched.)
 
 **Commit:** `6f999cd40` — consumer brand-page chrome top-inset fix + regression test.
+
+---
+
+## 14. Brand-card View affordance fix — offering pages, all-surface parity (2026-06-17)
+
+**Status:** implemented, source-verified (bracket-path Metro precludes a local sim screenshot — proven by source that the View CTA renders unconditionally when brandSlug is present + the handler is passed on every route/screen; tester device eyeball remains the runtime PASS).
+
+**Device bug (Seth):** on the public EVENT, TRIP and EXPERIENCE pages the "Presented by {Brand}" block had no visible/functional "View" affordance — no way to reach the new brand page from an offering page.
+
+### Real root cause — PER PAGE × PER SURFACE (investigated, not guessed)
+
+| Page | Web + Business iOS/Android | Consumer app |
+|------|----------------------------|--------------|
+| **Event** | ALREADY WORKING. The shared `packages/event-rendering/PublicEventPage.tsx` renders the brand row as a `Pressable` and shows the trailing **"View"** CTA *only when `callbacks.onOpenBrand !== undefined`* (`:656-660`); `onPress` calls `onOpenBrand(brand.slug)` (`:599-602`). The business wrapper `mingla-business/src/components/event/PublicEventPage.tsx` passes `onOpenBrand={(slug)=>router.push('/b/'+slug)}` on BOTH the phone + desktop mounts (`:570`, `:675`), and the web route `app/e/[brandSlug]/[eventSlug].tsx` renders that wrapper. → View shows + navigates. No change. | **GAP (real bug).** `ConsumerEventDetailScreen.tsx` re-implements the page inline (does NOT mount the shared page) and rendered the brand chip as a plain `<View>` (`:755`) — no CTA, no `useRouter`, no navigation = a dead block. |
+| **Trip** | ALREADY WORKING. `TripPreview.tsx` brand chip is a `Pressable onPress={onViewBrand}` (`:368`) with an unconditional `<Text style={styles.brandCta}>View</Text>` (`:405`), rendered on BOTH phone (`{!isDesktop ? brandChip}` `:517`) and desktop sticky panel (`:688`). The `/t/[brandSlug]/[tripSlug].tsx` route passes `onViewBrand={handleViewBrand}` (`:534`) → `router.push('/b/'+brandSlug)` (guarded). No change. | **GAP (real bug).** `ConsumerTripDetailScreen.tsx` also re-implements inline (NOT importing TripPreview — "business-local") and rendered the brand chip as a plain `<View>` (`:784`) — no CTA, no `useRouter`, no nav. |
+| **Experience** | ALREADY WORKING. `ExperiencePreview.tsx` brand chip = `Pressable onPress={onViewBrand}` (`:361`) + unconditional `View` CTA (`:389`); the `/exp/[brandSlug]/[experienceSlug].tsx` route passes `onViewBrand={handleViewBrand}` (`:499`). No change. | **PARTIAL.** `ConsumerExperienceDetailScreen.tsx` brand chip was ALREADY a navigating `Pressable` (wired earlier this ORCH, commit `0dc53cfbc`, `:935-993`) but had NO trailing "View" CTA → inconsistent label/placement vs the other two pages. |
+
+**So the premise "View missing on web/business" was already satisfied by this ORCH's earlier offering-page work; the device-observable gap is the three CONSUMER screens** (event + trip = no affordance at all; experience = nav-only, no label).
+
+### Fix per surface (additive only — no renderer/route change needed on web/business)
+
+- **Consumer trip** (`app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx`, +~30): import `useRouter`; `const router = useRouter()`; brand chip `<View>` → `<Pressable accessibilityRole="button" accessibilityLabel={\`View ${fnd.brandName}\`}>` whose `onPress` guards `brandSlug.length > 0` then `router.push('/b/'+brandSlug)`; trailing `<Text style={styles.brandCta}>View</Text>`; new `brandCta` style (`marginLeft:'auto', fontSize:12, fontWeight:'800'` — byte-identical to `TripPreview.brandCta`). `brandSlug` is the **screen prop** (always set when the route mounts).
+- **Consumer event** (`app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx`, +~30): same pattern; `onPress` guards `typeof fnd.brandSlug === "string" && fnd.brandSlug.length > 0` then `router.push('/b/'+fnd.brandSlug)`; `fnd.brandSlug` is typed `string` in `useConsumerEventFoundation` (`:57`). Added `brandCta` style.
+- **Consumer experience** (`app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx`, +9): nav already worked — added the trailing `<Text style={styles.brandCta}>View</Text>` + `brandCta` style for consistency.
+
+### Consistency (dispatch requirement #3) — all three offering pages now identical
+Label = **"View"**, placement = trailing on the brand chip (`marginLeft:auto`), accent color, whole-row `Pressable` with `accessibilityRole="button"` + `View {brandName}` label, slug-guarded `router.push('/b/{slug}')`. Matches the trip/exp `onViewBrand` pattern across web/business + all three consumer screens. No dead taps (Constitution rule 1); empty slug guarded (rule 9).
+
+### brandSlug non-undefined on every path — confirmed
+- Trip consumer: `brandSlug` screen prop (`string`); also `detail.brandSlug: string` (`useConsumerTripDetail:165`).
+- Event consumer: `fnd.brandSlug: string` (`useConsumerEventFoundation:57`).
+- Experience consumer: `seed.brandSlug` from `card.brandSlug` (guarded `typeof === "string"`).
+- Web/business: each route reads `params.brandSlug` and `handleViewBrand`/`onOpenBrand` guards `length > 0`.
+
+### Cross-surface impact
+| Surface | Affected | What |
+|---------|----------|------|
+| Consumer iOS | YES | brand chip now tappable + "View" CTA (trip/event new; experience CTA added) |
+| Consumer Android | YES | same (shared screens) |
+| Buyer/anon Web | NO | already showed/navigated View (no change) |
+| Business iOS | NO | already showed/navigated View (no change) |
+| Business Android | NO | same |
+| Admin Web | NO | no offering pages |
+| Business Web preview | NO | == buyer web |
+
+### Regression test (implementor happy-path)
+`app-mobile/src/screens/__tests__/orch_1155_brand_view_affordance.test.ts` — node:assert source-assertion (app-mobile convention). Asserts: shared event page View-CTA-on-onOpenBrand + business event passes onOpenBrand; TripPreview/ExperiencePreview render View CTA + the /t/ & /exp/ routes pass onViewBrand (+ guarded /b/{slug}); all three consumer screens render the brand `Pressable` → guarded `/b/{slug}` + the "View" CTA. Run: `node app-mobile/src/screens/__tests__/orch_1155_brand_view_affordance.test.ts` → PASS.
+**fails-on-revert verified at `db7b2b288`:** TRUE LINE-DELETION of the consumer-trip `<Text style={styles.brandCta}>View</Text>` → `AssertionError: ConsumerTripDetailScreen must render the trailing 'View' CTA` (exit 1); restored → PASS. Existing `orch_1155_brand_badge_nav` + `orch_1155_brand_chrome_top_inset` still PASS (no regression).
+
+### Verification
+- `tsc --noEmit` (app-mobile): 0 errors in the 3 touched files (remaining errors are pre-existing Deno-test-in-tsc noise + unrelated files, same baseline as §9).
+- Strict-grep: `orch-0964-brand-rendering-self-contained` PASS, `orch-0805-brand-cover-overhaul` 9/9 PASS.
+- No sim screenshot (bracket path breaks Metro/expo, §9). Source-proven: the "View" CTA renders unconditionally in each consumer brand chip and the handler/slug is present on every route/screen. Tester's 3-page × consumer-native eyeball is the runtime PASS.
+
+**Commit:** `db7b2b288` — brand-card View affordance: consumer event/trip Pressable→/b/{slug} + View CTA (parity) + regression test.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md
@@ -155,3 +155,33 @@ Manual-parity items (both done): the `coverMediaType` cover field on TWO data pa
 - `c6f8c929e` — shared PublicBrandPage refactor onto the Direction-A shell
 - `0dc53cfbc` — consumer brand-badge wiring (no dead taps)
 - `dd4bb61db` — regression tests + relocated dataDriven test (`[TEST-MOD-APPROVED ORCH-1155]`)
+
+---
+
+## 13. Known-Issue #1 fix — consumer brand-page chrome top-inset (2026-06-17)
+
+**Status:** implemented, code-parity verified (bracket-path Metro precluded a local sim screenshot — see below).
+
+**Root cause.** The consumer brand-page screen is `app-mobile/src/screens/ConsumerBrandProfileScreen.tsx` (the `/b/{slug}` deep-link target, now also reached by the ORCH-1155 brand-badge taps). It mounted the shared `@mingla/brand-rendering/PublicBrandPage` WITHOUT passing `chromeTopOffset`, so the shared page forwarded `safeAreaTop={chromeTopOffset ?? 0}` = `0` into `ParallaxCoverShell`. The shell positions its body-level fixed chrome (X · Share · Mute) at `safeAreaTop + 12` (`ParallaxCoverShell.tsx:286` web / `:375` native). With `safeAreaTop=0` the chrome sat at a flat `12px` from the top → it could render UNDER the notch / status bar on iOS home-indicator phones and Android. This broke all-surface parity: the business adapter already passes `chromeTopOffset={insets.top + 8}`, and every other Direction-A consumer page (trip/event/experience) offsets its chrome by `insets.top + 12`.
+
+**The renderer already accepted the prop — no renderer change needed.** `PublicBrandPage` declares `chromeTopOffset` (`packages/brand-rendering/PublicBrandPage.tsx:238`) and forwards it with a safe `?? 0` default (`:622`). The fix is purely additive at the consumer route; web/business behavior is unchanged because they already pass their own offset (business) or have a `0` web safe-area top.
+
+**Exact change** — `app-mobile/src/screens/ConsumerBrandProfileScreen.tsx` (+3 lines, 1 comment block):
+- imported `useSafeAreaInsets` from `react-native-safe-area-context`;
+- `const insets = useSafeAreaInsets();`;
+- passed `chromeTopOffset={insets.top}` to `<PublicBrandPage>`.
+
+**Why `insets.top` (not `insets.top + 12`).** The shared shell ADDS its own `+12` gap on top of `safeAreaTop`. Passing `insets.top` yields an effective chrome top of `insets.top + 12` — byte-identical to `ConsumerTripDetailScreen` (`insets.top + 12`, `:1475`) and `ConsumerExperienceDetailScreen` (`insets.top + 12`, `:594`/`:1142`) native chrome. Passing `insets.top + 12` here would have double-padded to `insets.top + 24`. So this matches the established consumer pattern exactly while letting the shell own the constant gap.
+
+**Web / business unchanged — confirmed.** `git diff --name-only` for this fix shows ONLY `app-mobile/src/screens/ConsumerBrandProfileScreen.tsx` (+ the new test). The shared renderer `packages/brand-rendering/PublicBrandPage.tsx` and the business adapter `mingla-business/src/components/brand/PublicBrandPage.tsx` are NOT touched. The business adapter keeps `chromeTopOffset={insets.top + 8}`; buyer-web safe-area top is `0` as before.
+
+**Scope.** Chrome top-inset only. No change to the renderer's layout/tabs/theming, `themePalette` math, or the offering-rendering primitives.
+
+**Test added (append-only).** `app-mobile/src/screens/__tests__/orch_1155_brand_chrome_top_inset.test.ts` — node:assert source-assertion (the app-mobile convention; no jest/RTL runner). Asserts the screen imports `useSafeAreaInsets`, reads `insets`, and passes `chromeTopOffset={insets.top}`. Run: `node app-mobile/src/screens/__tests__/orch_1155_brand_chrome_top_inset.test.ts` → PASS.
+- **fails-on-revert verified at `6f999cd40`:** TRUE LINE-DELETION of `chromeTopOffset={insets.top}` → test throws `AssertionError: ConsumerBrandProfileScreen must pass chromeTopOffset={insets.top}…` (exit 1); restored → PASS. The existing `orch_1155_brand_badge_nav` test still PASSes (no regression).
+
+**Verification: code-parity, NOT sim.** The bracket worktree path breaks Metro/expo (same constraint noted in §9), so no `consumer_chrome_clears_notch.png` was captured. Proven by code-parity: the consumer brand chrome now resolves to the IDENTICAL effective top offset (`insets.top + 12`) as the trip/experience consumer detail screens that already clear the notch on device. Tester's device eyeball remains the runtime PASS for SC-4 chrome positioning on consumer native.
+
+**Updates Known-Issue #1 in §10:** RESOLVED. (The §10 note assumed the consumer screen was DO-NOT-TOUCH; this scoped follow-up ORCH was dispatched specifically to fix it — additive prop only, web/business untouched.)
+
+**Commit:** `6f999cd40` — consumer brand-page chrome top-inset fix + regression test.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1155_PUBLIC_BRAND_PAGE.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1155_PUBLIC_BRAND_PAGE.md
@@ -1,0 +1,205 @@
+# TEST — ORCH-1155 · Public Brand Page — Direction-A Redesign + All-Surface Parity
+
+**Mode:** mingla-tester (SPEC-COMPLIANCE + TARGETED)
+**Date:** 2026-06-17
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1155-[brand-page-parity]/` · branch `ORCH-1155-brand-page-parity`
+**HEAD at test:** `5f6a4c791` (impl HEAD `b9c2df303` + this tester's adversarial-test commit)
+**Env verified:** Supabase project `gqnoajqerqhnvulmnyvv` (Mingla-dev) — migration `20261013000000` APPLIED + live-fire confirmed.
+**Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1155_PUBLIC_BRAND_PAGE.md` · **Impl report:** `…/reports/IMPLEMENT_ORCH-1155_PUBLIC_BRAND_PAGE.md`
+
+---
+
+## 1. Verdict
+
+**CONDITIONAL PASS** — P0: 0 · P1: 0 · P2: 1 · P3: 1 · P4: 2.
+
+Every backend / data-path / structural success criterion is PROVEN at runtime (DB live-fire) or structurally at the source. The redesign correctly composes the shared Direction-A primitives, the two-data-path experience-video-cover trap is genuinely wired on BOTH paths (independently fails-on-revert proven), the consumer badge dead-taps are fixed with end-to-end slug threading + empty-slug guards, the theme is anon-safe, and both regression tests are on-branch, in-diff, and fails-on-revert verified.
+
+The CONDITIONAL (not full PASS) is **solely** because the runtime VISUAL criteria — parallax pinning, the desktop two-column layout at ≥1024px, chrome-clears-notch on consumer native, and video actually PLAYING in the experience card — could not be live-fired by the tester: the bracket worktree path breaks Metro/expo, and the deployed buyer-web is `main` (pre-redesign), so no headless web screenshot of THIS branch was capturable. Per the tester confidence ladder, UI/runtime criteria sit at `probable` (source-proven, blocker named), not `proven`. These are **Seth's device/web eyeball** before CLOSE.
+
+No defect blocks merge. The one P2 (no CI runner wired for the package/app-mobile tests) and one P3 (best-effort native scroll-into-view) are accepted-class items inherited from the implement report's known-issues, surfaced for the orchestrator.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Verdict | Evidence |
+|----|-----------|---------|----------|
+| SC-1 | About first + default (all 5, AUTO) | PASS (struct) / probable (visual) | `PublicBrandPage.tsx:293` `const tabs: Tab[] = ["about"]`; `:243` `useState<Tab>("about")`; empty-tab guard `:311` snaps to `visibleTabs[0]`. Happy-path T-1 + adversarial fixtures green. Visual = Seth. |
+| SC-2 | Tabs hide when empty (all 5, AUTO) | PASS (struct + DB data) | `:294-297` strict `> 0` guards. Adversarial executable fixtures: trips-only→`[about,trips]`, events-only→`[about,events]`, zero→`[about]`, full→`[about,upcoming,events,trips,experiences]`, past-only→tab still shows. Real brand slugs in §3. |
+| SC-3 | About pane order tagline→bio(clamp+Read more)→contact (all 5) | PASS (struct) / probable (visual) | `AboutTab` `:1380-1428` renders tagline→`ClampedBio`→contact, each conditionally; `ClampedBio` `:1433` Read more/Show less. tagline/bio NOT in `identityBlock` (`:412-433` = avatar/verified/name/address only). |
+| SC-4 | Parallax + seam + chrome (X·Share, Mute on video) | probable | `ParallaxCoverShell` composed `:607`; `showMute={coverType==="video"}` `:616`; mute state `:244`. Chrome top math `safeAreaTop+12` (shell `:286`/`:375`). Parallax/seam render = Seth device. |
+| SC-5 | Desktop two-column ≥1024px (sticky Share+Next-up; no Reserve/Follow/contact) | PASS (struct) / probable (visual) | `useResponsiveLayout().isDesktop` `:242`; `stickyPanel` `:538-591` = avatar/name/address/socials+Share+Next-up, NO Reserve/Follow/contact; heroTitle desktop `:597`; 2-col `gridDesktop`. Layout render = Seth web ≥1024. |
+| SC-6 | No fabricated Follow (all 5) | PASS | `grep -niE "follow|subscrib" PublicBrandPage.tsx` → 0 matches. Happy-path T-5 + adversarial sticky-panel isolation test green. |
+| SC-7 | Theming parity via SHARED engine | PASS (struct) | `createThemePalette`/`offeringSurfaceStyles` imported from `@mingla/event-rendering` `:53-58`; NO file-local `createThemePalette`; `:252` `createThemePalette(resolvedTheme)`. Palette math untouched (parity-snapshot test unaffected). |
+| SC-8 | Anon-safe (no `.from("brands")` in brand path) | PASS | Brand-page data path: consumer `useBrandBySlug.ts:315` `business_public_brands_view` + RPCs; business via public RPCs. The one `.from("brands")` (`publicEventsService.ts:1306`) is a PRE-EXISTING trip-detail resolver, NOT in the brand path, NOT touched by 1155 (`git diff` confirms). |
+| SC-9-Web | Experience video cover via `publicEventsService` (surfaces 3-5) | PASS (data path) / probable (render) | RPC returns `cover_media_type` (DB live-fire); `experienceRowToCard` `:1112` maps `coverMediaType: row.cover_media_type`; `ExperienceMiniCard mediaType={experience.coverMediaType}` `:1295`. Video PLAYING render = Seth web. |
+| SC-9-Native | Experience video cover via `useBrandBySlug` (surfaces 1-2) | PASS (data path) / probable (render) | Consumer `mapExperience` `:282` maps `coverMediaType: row.cover_media_type`; hook calls `pg_public_experiences_by_brand` `:331`. Adversarial test executes BOTH mappers over video/gif/image/null. |
+| SC-10 | Swipe-badge → `/b/{slug}` (not dead tap) | PASS (wiring) / probable (device tap) | `CuratedExperienceSwipeCard` `onBrandPress` prop + `TrackedTouchableOpacity` wrapper; `SwipeableCards.tsx:2886` wires it w/ empty-slug guard; slug threaded RPC→discover-cards `:436`→deckService `:393`→currentRec. Device tap = Seth. |
+| SC-11 | Detail "Presented by" → `/b/{slug}` | PASS (wiring) / probable (device tap) | `ConsumerExperienceDetailScreen.tsx:935-946` Pressable + empty-slug guard; `seed.brandSlug` mapped `:234`. |
+| SC-12 | No curated regression (byte-identical) | PASS (struct) | `CuratedExperienceSwipeCard` `wrapped`-gated: absent `onBrandPress`→bare `<BrandChip>` (curated), present→wrapper owns button; adversarial-test path-shape asserted. |
+
+**Notations:** "struct" = source-traced proven; "DB data" = live-fired against prod RPC; "probable" = source-proven but runtime visual blocked (bracket-path Metro / deployed-web-is-main) — reserved for Seth's device/web eyeball.
+
+---
+
+## 3. Tab hide/show proof — REAL brand slugs (SC-2)
+
+Queried the actual brand offering data on `gqnoajqerqhnvulmnyvv`. Tab set is driven by the populated buckets (post paid-supply/publish gates), so these are the runtime-accurate expectations:
+
+| Brand slug | events | trips | experiences | Expected tab set |
+|---|---|---|---|---|
+| `leggothis` (Leggo This) | 15 | 0 | 2 | `[About, (Upcoming?), Events, Experiences]` — **NO Trips chip** |
+| `travelbrand` (Travel Brand) | 0 | 2 | 0 | `[About, (Upcoming?), Trips]` — no Events/Experiences |
+| `teststripe` (Test Stripe) | 2 | 0 | 0 | `[About, Events]` — no Trips/Experiences |
+| `lanternvine` (Lantern & Vine) | 0 | 0 | 1 | `[About, Experiences]` — and that experience has a **VIDEO cover** (SC-9) |
+| `theonus` / `agloat` / `night-market` (zero-offering) | 0 | 0 | 0 | `[About]` only — identity/socials/contact still render |
+
+The `experiences.length > 0` guard is strict-positive (adversarial test catches a `>= 0` regression that grep cannot). The empty-tab guard (`:311`) snaps `activeTab` back to About when the active bucket empties.
+
+---
+
+## 4. Experience video-cover two-path — TRULY wired (SC-9)
+
+**DB live-fire (prod RPC):** `pg_public_experiences_by_brand('lanternvine')` returns:
+```
+experience_id b8bd995b-… | title "Raleigh Wine and Dine Crawl" | cover_media_type "video" | has_url true
+```
+- RPC result columns include `cover_media_type text` immediately after `cover_media_url` (`pg_get_function_result`).
+- SECURITY DEFINER + STABLE; `proacl` = `anon=X, authenticated=X` (GRANT correct, anon-safe).
+
+**Both source paths thread the field** (the spec's #1 miss-risk):
+- Path 1 (web/business): `publicEventsService.ts` row `:348` + card `:368` + mapper `experienceRowToCard:1112` `coverMediaType: row.cover_media_type`; business adapter `mapExperience:121`.
+- Path 2 (consumer): `useBrandBySlug.ts` row `:78` + mapper `mapExperience:282` `coverMediaType: row.cover_media_type`.
+- Shared `PublicBrandExperience.coverMediaType: PublicMediaType | null` (`types.ts:100`); `ExperienceMiniCard` passes `mediaType={experience.coverMediaType}` (`:1295`, no longer hardcoded `"image"`).
+
+**Adversarial proof the two paths cannot silently diverge:** my test extracts BOTH real mapper literals and executes them over `video/gif/image/null` rows; deleting `coverMediaType` from EITHER mapper fails the test (verified by line-deletion of the consumer mapper → "video cover would silently drop on this surface (SC-9 split)"). The remaining runtime gap is whether the card visually PLAYS the video — `EventCoverMedia` already does this on every other surface; Seth's web + consumer eyeball confirms it.
+
+---
+
+## 5. Step 0.5 — independent re-run of the implementor's fails-on-revert + tester adversarial
+
+**Implementor happy-path** `packages/brand-rendering/__tests__/orch_1155_brand_redesign.test.tsx`:
+- Re-ran at HEAD `b9c2df303`: **10/10 PASS** (`cd mingla-business && npx jest --roots ../packages/brand-rendering`).
+- Fails-on-revert (tester-run, TRUE line-deletion): deleted `const tabs: Tab[] = ["about"];` → **1 failed (T-1 About-first), 9 passed**; restored → 10/10. Confirmed at `b9c2df303`.
+
+**Implementor consumer badge** `app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts`:
+- Re-ran: **PASS**. Fails-on-revert (tester-run): deleted the `onBrandPress` block at `SwipeableCards.tsx:2886` → test throws AssertionError (exit ≠ 0); restored → PASS.
+
+**Implementor chrome inset** `app-mobile/src/screens/__tests__/orch_1155_brand_chrome_top_inset.test.ts`: re-ran → **PASS**.
+
+**Relocated** `mingla-business/__tests__/components/PublicBrandPage.dataDriven.test.tsx`: **4/4 PASS** (was 3/4-RED on origin/main — confirmed pre-existing, §9). Now green, assertions re-pointed at the shared package. Carries `[TEST-MOD-APPROVED ORCH-1155]` for its line-modifications.
+
+---
+
+## 6. Adversarial test added (tester-owned, DIFFERENT angle)
+
+**Path:** `packages/brand-rendering/__tests__/orch_1155_brand_redesign.adversarial.test.tsx` — **commit `5f6a4c791`**, on-branch, in `git diff origin/main...HEAD --name-only`. **13/13 PASS.**
+
+**Different angle** from the implementor's pure source-text grep: this test is **executable behavioral** —
+- Lifts the REAL tab-build predicate from source and RUNS it against bucket fixtures (trips-only / events-only / experiences-only / zero / full / past-only) — catches a `> 0` → `>= 0` logic regression a grep misses.
+- Executes BOTH real experience mappers (business + consumer) over video/gif/image/null rows — the two-path cover trap, the data side of SC-9.
+- Mute-conditional as an executed predicate (image/gif/null ⇒ no Mute).
+- Sticky-panel block isolation: Share + Next-up present, Follow/subscribe/Reserve absent.
+
+**fails-on-revert verified at `b9c2df303`:** TRUE line-deletion of `coverMediaType: row.cover_media_type` from the consumer `mapExperience` → adversarial test FAILS (extractor throws on the missing field); restored → 13/13. Both the implementor's happy-path AND this adversarial test appear in the closing diff.
+
+---
+
+## 7. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | PASS | Swipe badge + "Presented by" lockup now Pressables → `/b/{slug}` with empty-slug guards. |
+| 2 | One owner per truth | PASS | Single shared renderer; single shared palette engine (file-local deleted). |
+| 3 | No silent failures | PASS | RPC error contract unchanged (throws on error); empty-slug guard is intentional no-nav, not a swallow. |
+| 4 | One query key per entity | N/A | No new query keys; `useBrandBySlug` key unchanged. |
+| 5 | Server state server-side | PASS | No Zustand server-state added; React Query path unchanged. |
+| 6 | Logout clears everything | N/A | No auth/session state touched (anon page). |
+| 7 | Label `[TRANSITIONAL]` | N/A | No transitional state introduced. |
+| 8 | Subtract before adding | PASS | Renderer net −500 lines; deleted flat banner/local palette/hand-rolled chrome before composing the shell. |
+| 9 | No fabricated data | PASS | Empty tabs/teaser/socials/contact/tagline/bio all hidden when absent; NO fabricated Follow. |
+| 10 | Currency-aware | PASS | Price labels via `displayPriceCents`/existing all-in path; mapper `currency ?? "USD"` preserved (unchanged). |
+| 11 | One auth instance | N/A | Anon page; no auth instance. |
+| 12 | Validate at right time | N/A | No datetime validation in scope. |
+| 13 | Exclusion consistency | PASS | Paid-supply gate preserved byte-for-byte in re-emitted RPC (ORCH-1076). |
+| 14 | Persisted-state startup | N/A | No persisted store hydration in scope. |
+
+No violations.
+
+---
+
+## 8. Device / parity matrix
+
+| Surface | Verdict | Note |
+|---|---|---|
+| Consumer iOS | probable | Shared renderer (AUTO) + badge wiring + video cover via `useBrandBySlug` — source+data proven; device eyeball = Seth. |
+| Consumer Android | probable | Same; opaque glass via shared `offeringSurfaceStyles`/`OfferingChrome` (reused, not re-implemented). |
+| Buyer/anon Web | probable | Desktop two-column + phone parallax (AUTO) + video via `publicEventsService` — source+data proven; deployed web is `main`, branch headless render blocked by bracket path → Seth web eyeball. |
+| Business iOS | probable | Shared renderer, phone single-column (AUTO). |
+| Business Android | probable | Same; opaque glass. |
+| Admin Web | N/A | No public brand page. |
+| Business Web preview (adjacent) | N/A | The `/b` web route IS the buyer-web surface. |
+
+**Physical iPhone (HITL):** not exercised this turn — the runtime visual checks are bundled into Seth's pre-CLOSE eyeball list (§ Device-only checks). No tester puppeteering of the physical device.
+
+**Edge functions:** none touched (confirmed — no deploy). Migration `20261013000000` is APPLIED to `gqnoajqerqhnvulmnyvv` (live-fired). Must also be applied to PROD before the web/native CLOSE (orchestrator-owned).
+
+---
+
+## 9. NO REGRESSION — baseline-red confirmation
+
+The implement report §12 flagged pre-existing RED suites/gates. Independently confirmed they are NOT caused by 1155:
+- The 12 product files + 4 test files in `git diff origin/main...HEAD` do **NOT** include any of `serverDraftLifecycleGuards`, `TripVisualParity_adversarial`, `eventCoverVideoProcessingService`, `eventCoverMedia`, `orch_0893_*`, or `BrandSwitcherSheet.tsx`. The baseline-red files are untouched.
+- The brand-page test signal itself is now GREEN (relocated dataDriven 4/4; was 3/4-red on main — the META-ORCH-0972 stale-symbol grep, OQ-1, owned + fixed by this spec).
+
+These pre-existing reds are a separate triage ORCH (a Discovery, not a 1155 regression).
+
+---
+
+## 10. Findings
+
+### P2-1 — No CI runner wired for the package / app-mobile regression tests
+**Evidence:** `packages/brand-rendering/__tests__/*` and the app-mobile `node:assert` tests (`orch_1155_brand_badge_nav`, `orch_1155_brand_chrome_top_inset`) run only via the manual commands in the impl report §6 — no CI job executes `packages/**/__tests__` or app-mobile node tests (same gap as the existing `event-rendering`/app-mobile precedents). The relocated dataDriven test DOES run under business jest.
+**Impact:** the new invariants (`I-PROPOSED-1155-*`) are not auto-enforced on future PRs; a regression could land unnoticed.
+**Required fix:** orchestrator decision — add a CI step for the package/app-mobile tests (broader than 1155; affects all package tests). Not a 1155 product defect.
+**Retest:** confirm a CI job globs and runs `packages/**/__tests__`.
+
+### P3-1 — Active-chip scroll-into-view is best-effort on native (spec OQ-2)
+**Evidence:** `TabBar` caches per-chip `onLayout` x-offsets and `scrollTo` on tab change (`:729-733`); spec OQ-2 declares this best-effort on native (chips fit a phone for ≤5 tabs). Load-bearing requirement (non-clipping horizontal ScrollView) is met (`:737`).
+**Impact:** cosmetic; with ≤5 tabs no clipping. Confirm best-effort acceptance (spec OQ-2).
+**Required fix:** none unless Seth wants guaranteed measured scroll-into-view on native.
+**Retest:** N/A.
+
+### P4-1 (praise) — Two-path cover field handled exactly to spec
+The #1 miss-risk (experience video cover shipping on one surface only) is genuinely wired on both `publicEventsService` and `useBrandBySlug`, with the field name, null-safety, and shared type all consistent. The DB re-emit preserved the ORCH-1076 paid-supply gate byte-for-byte.
+
+### P4-2 (praise) — Clean subtract-before-add refactor
+Renderer net −500 lines: flat banner, local palette engine, and hand-rolled chrome all deleted before composing the shared shell. Single-palette-engine and no-dead-taps invariants are real, not cosmetic.
+
+---
+
+## 11. Discoveries for orchestrator
+
+1. **Pre-existing RED jest suites + 2 strict-grep gates on origin/main** (impl §12) — confirmed not 1155-caused; worth a triage ORCH (`DraftEvent` type missing fields; missing `@testing-library/react-native`/`@mingla/payments-native` in default node jest env; `orch-0756a-active-brand-recovery` + `i-proposed-a-brands-deleted-filter` gate crashes).
+2. **No CI runner for package/app-mobile tests** (P2-1) — program-wide gap, not 1155-specific.
+3. **`hideFloatingChrome` prop now effectively unused** (kept for back-compat; both live callers pass it falsy) — future cleanup candidate.
+4. **Migration must be applied to PROD** before web/native CLOSE — applied to dev `gqnoajqerqhnvulmnyvv` only so far.
+
+## 12. Device-only checks remaining for Seth (the `probable` → `proven` gap)
+
+1. **Buyer-web `/b/{slug}` at ≥1024px** (e.g. `leggothis`): contained 21:9 hero with verified eyebrow + name + address overlaid bottom-left; two-column — left tabs + 2-col card grid, right STICKY panel with Share + Next-up (no Reserve/Follow/contact). Resize <1024 collapses to single column.
+2. **Buyer-web phone width + consumer native**: parallax cover pins, body slides over the 28px seam, chrome floats (X·Share); on `lanternvine` the experience card cover PLAYS VIDEO and a Mute button appears (image/gif/null covers = no Mute).
+3. **Consumer native chrome clears the notch** (Known-Issue #1 fix): X/Share sit below the status bar on a home-indicator iPhone (effective `insets.top + 12`).
+4. **Consumer badge taps**: tap the brand badge on a brand-experience swipe card AND the "Presented by" lockup on experience detail → both open `/b/{brandSlug}`; curated (AI) cards have no badge tap.
+5. **Theme flip**: change a brand's theme color/font → accent + font recolor across eyebrow/tabs/cards/sticky-panel.
+
+---
+
+## 13. Accepted conditions (CONDITIONAL PASS)
+
+Carried as `probable`-level deferrals to Seth's device/web eyeball (the runtime VISUAL criteria SC-1/3/4/5/9-render/10/11), plus:
+- **P2-1** (no CI runner for package/app-mobile tests) — orchestrator decision, program-wide.
+- **P3-1** (best-effort native scroll-into-view) — spec OQ-2, confirm acceptance.
+
+No P0/P1. Once Seth confirms §12 on device + web, this upgrades to PASS → CLOSE.

--- a/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
+++ b/app-mobile/src/components/CuratedExperienceSwipeCard.tsx
@@ -100,13 +100,18 @@ interface BrandChipProps {
   brandName: string;
   brandLogoUrl: string | null;
   top: number;
+  // ORCH-1155: when the chip is wrapped in a pressable that owns the absolute
+  // positioning, the chip itself renders in normal flow (no self-position) and
+  // ignores touches (the wrapper is the button). Default false → byte-identical
+  // to the ORCH-1065 self-positioned badge for curated/non-pressable callers.
+  wrapped?: boolean;
 }
 
 // Top-left glass lockup: [logo/monogram disc] + [brand name]. Copies the
 // glass.badge five-layer vocabulary (DESIGN §2.2) so it reads as the same family
 // as the metadata chips; degrades to the opaque solid fill on Android pre-blur /
 // Reduce Transparency (ANDROID_GLASS_USES_OPAQUE_FALLBACK policy, DESIGN §2.6).
-function BrandChip({ brandName, brandLogoUrl, top }: BrandChipProps): React.ReactElement {
+function BrandChip({ brandName, brandLogoUrl, top, wrapped = false }: BrandChipProps): React.ReactElement {
   const [reduceTransparency, setReduceTransparency] = React.useState(false);
   const [logoFailed, setLogoFailed] = React.useState(false);
 
@@ -138,9 +143,16 @@ function BrandChip({ brandName, brandLogoUrl, top }: BrandChipProps): React.Reac
 
   return (
     <View
-      style={[styles.brandChip, { top }]}
-      accessibilityRole="image"
-      accessibilityLabel={`Experience by ${trimmedName}`}
+      style={
+        wrapped
+          ? styles.brandChipFlow
+          : [styles.brandChip, { top }]
+      }
+      pointerEvents={wrapped ? 'none' : 'auto'}
+      accessibilityRole={wrapped ? undefined : 'image'}
+      accessibilityElementsHidden={wrapped}
+      importantForAccessibility={wrapped ? 'no-hide-descendants' : 'auto'}
+      accessibilityLabel={wrapped ? undefined : `Experience by ${trimmedName}`}
     >
       {/* L1 — blur or opaque solid fallback */}
       {useGlass ? (
@@ -218,6 +230,10 @@ interface Props {
   // ORCH-1065: present ONLY for brand experiences. Curated callers omit both →
   // byte-identical render (SC-13).
   brandExperience?: { brandName: string; brandLogoUrl: string | null };
+  // ORCH-1155 [public-brand-page]: when present, the brand badge becomes a button
+  // that opens the brand page (/b/{slug}). Sibling of brandExperience so curated
+  // callers (which pass neither) render byte-identically (SC-12). No dead taps.
+  onBrandPress?: () => void;
   // ORCH-1072: the experience's REAL cover (separate prop so the ORCH-1065
   // brandExperience contract stays byte-identical). When present, the card hero
   // shows the cover (image/video) with the stop photos as a strip below — not
@@ -230,7 +246,7 @@ interface Props {
   ctaOverride?: string;
 }
 
-export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measurementSystem, currencyCode, brandExperience, experienceCover, ctaOverride }: Props) {
+export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measurementSystem, currencyCode, brandExperience, onBrandPress, experienceCover, ctaOverride }: Props) {
   const { t } = useTranslation(['common']);
   const insets = useSafeAreaInsets();
   // ORCH-0991: deck is full-bleed under the floating glass top bar (HomePage safeArea has
@@ -385,13 +401,34 @@ export function CuratedExperienceSwipeCard({ card, onSeePlan, travelMode, measur
         )}
 
         {/* ORCH-1065: brand badge (top-left, below the stop-badge baseline) —
-            only when this is a brand experience. */}
+            only when this is a brand experience.
+            ORCH-1155: when onBrandPress is provided, wrap the badge in a button
+            that opens the brand page (no dead tap). Curated callers pass neither
+            prop → byte-identical (SC-12). */}
         {brandExperience ? (
-          <BrandChip
-            brandName={brandExperience.brandName}
-            brandLogoUrl={brandExperience.brandLogoUrl}
-            top={stopBadgeTop}
-          />
+          onBrandPress ? (
+            <TrackedTouchableOpacity
+              activeOpacity={0.8}
+              onPress={onBrandPress}
+              accessibilityRole="button"
+              accessibilityLabel={`View ${brandExperience.brandName}`}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              style={[styles.brandChipPressable, { top: stopBadgeTop }]}
+            >
+              <BrandChip
+                brandName={brandExperience.brandName}
+                brandLogoUrl={brandExperience.brandLogoUrl}
+                top={stopBadgeTop}
+                wrapped
+              />
+            </TrackedTouchableOpacity>
+          ) : (
+            <BrandChip
+              brandName={brandExperience.brandName}
+              brandLogoUrl={brandExperience.brandLogoUrl}
+              top={stopBadgeTop}
+            />
+          )
         ) : null}
 
         {/* Hero gradient — dark fade behind title + labels for legibility */}
@@ -634,6 +671,34 @@ const styles = StyleSheet.create({
     right: 0,
     height: 1,
     backgroundColor: glass.badge.border.topHighlight,
+  },
+  // ORCH-1155: the pressable wrapper owns the absolute positioning the badge had,
+  // so the inner BrandChip (rendered with `wrapped`) lays out in normal flow and
+  // the tap target is the chip box. `top` is supplied inline (stopBadgeTop).
+  brandChipPressable: {
+    position: 'absolute',
+    left: 8,
+    zIndex: 3,
+    maxWidth: '60%',
+  },
+  // ORCH-1155: the chip's visual styling minus its own absolute positioning
+  // (the wrapper positions it). Mirrors `brandChip` sans position/left/top/zIndex.
+  brandChipFlow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingLeft: 4,
+    paddingRight: 12,
+    paddingVertical: 4,
+    borderRadius: 9999,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: glass.badge.border.hairline,
+    shadowColor: glass.badge.shadow.color,
+    shadowOffset: glass.badge.shadow.offset,
+    shadowOpacity: glass.badge.shadow.opacity,
+    shadowRadius: glass.badge.shadow.radius,
+    elevation: glass.badge.shadow.elevation,
   },
   brandDisc: {
     width: 28,

--- a/app-mobile/src/components/SwipeableCards.tsx
+++ b/app-mobile/src/components/SwipeableCards.tsx
@@ -18,6 +18,7 @@ import {
 // never flashes a bare dark `#1a1a2e` panel during async decode. Keep
 // `key={currentRec.id}` — the fix works WITH the remount, not by removing it.
 import { Image as ExpoImage } from "expo-image";
+import { useRouter } from "expo-router";
 // ORCH-1069: shared video-capable cover renderer (image + GIF + video, muted
 // autoplay, reduce-motion aware). Same renderer the event/trip grid + hero use
 // (COMMS-0007). A venue with a `.mp4` cover plays its video on the deck hero;
@@ -702,6 +703,9 @@ export default function SwipeableCards({
   coachDeckRef,
 }: SwipeableCardsProps) {
   const { t } = useTranslation(['cards', 'common']);
+  // ORCH-1155 [public-brand-page]: navigate to the brand page from the
+  // brand-experience card's badge (no dead tap).
+  const router = useRouter();
   // ORCH-0589 v4 (V4): safe-area insets used to position the "View Previous" batchChip
   // below the floating top-bar chrome on the Swipe page (insets.top + ~62pt).
   const safeAreaInsets = useSafeAreaInsets();
@@ -2875,6 +2879,15 @@ export default function SwipeableCards({
                     brandExperience={{
                       brandName: (currentRec as any).brandName,
                       brandLogoUrl: (currentRec as any).brandLogoUrl ?? null,
+                    }}
+                    // ORCH-1155 [public-brand-page]: brand badge → brand page.
+                    // brandSlug is threaded end-to-end on the deck path; guard
+                    // the empty slug (rule 9 — never nav to /b/).
+                    onBrandPress={() => {
+                      const s = (currentRec as any).brandSlug;
+                      if (typeof s === 'string' && s.length > 0) {
+                        router.push(`/b/${s}` as never);
+                      }
                     }}
                     // ORCH-1072: real cover → card hero (image/video) with the
                     // stop photos as a strip below (CuratedExperienceSwipeCard).

--- a/app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts
+++ b/app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1155 [public-brand-page] — implementor happy-path regression for the
+// consumer brand-badge wiring (no dead taps — constitution rule 1 /
+// I-PROPOSED-1155-BRAND-BADGE-NOT-DEAD-TAP).
+//
+// app-mobile has no jest/RTL runner; the repo convention is node:assert
+// source-assertions (see orch_1138_consumer_trip_brand_cover.test.ts). Every
+// assertion FAILS on a true LINE-DELETION of the guard it protects
+// (fails-on-revert), NOT on a comment-out. The tester writes the SECOND,
+// adversarial render-angle test (curated byte-identical + press-fires-once +
+// empty-slug guard) under the brand-rendering package.
+//
+// Run with:
+//   node app-mobile/src/components/__tests__/orch_1155_brand_badge_nav.test.ts
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (rel) =>
+  fs.readFileSync(path.join(__dirname, "..", "..", "..", rel), "utf8");
+
+const swipeCard = read("src/components/CuratedExperienceSwipeCard.tsx");
+const swipeable = read("src/components/SwipeableCards.tsx");
+const detail = read("src/screens/Experience/ConsumerExperienceDetailScreen.tsx");
+
+// 1) The swipe card accepts an optional onBrandPress and renders the badge inside
+//    a pressable when it is present (the badge becomes a button, not a dead View).
+assert.ok(
+  swipeCard.includes("onBrandPress?: () => void;"),
+  "CuratedExperienceSwipeCard must accept an optional onBrandPress prop",
+);
+assert.ok(
+  swipeCard.includes("onBrandPress, experienceCover"),
+  "onBrandPress must be destructured from props",
+);
+assert.ok(
+  /onBrandPress\s*\?\s*\(\s*<TrackedTouchableOpacity[\s\S]*onPress=\{onBrandPress\}/.test(
+    swipeCard,
+  ),
+  "the brand badge must be wrapped in a pressable wired to onBrandPress when present",
+);
+
+// 2) Curated regression: when onBrandPress is absent the bare BrandChip renders
+//    (no pressable wrapper) — curated cards stay byte-identical (SC-12).
+assert.ok(
+  /\)\s*:\s*\(\s*<BrandChip/.test(swipeCard),
+  "without onBrandPress the bare BrandChip must render (curated byte-identical)",
+);
+
+// 3) The swipe-deck mount wires onBrandPress to router.push('/b/'+slug) WITH an
+//    empty-slug guard (rule 9 — never navigate to /b/).
+assert.ok(
+  swipeable.includes("const router = useRouter();"),
+  "SwipeableCards must obtain an expo-router handle",
+);
+assert.ok(
+  /onBrandPress=\{\(\) => \{[\s\S]*?brandSlug;[\s\S]*?typeof s === 'string' && s\.length > 0[\s\S]*?router\.push\(`\/b\/\$\{s\}`/.test(
+    swipeable,
+  ),
+  "the experience mount must guard the empty slug then router.push(`/b/${slug}`)",
+);
+
+// 4) The experience-detail 'Presented by' lockup is a Pressable wired to
+//    router.push('/b/'+brandSlug) with an empty-slug guard.
+assert.ok(
+  detail.includes("const router = useRouter();"),
+  "ConsumerExperienceDetailScreen must obtain an expo-router handle",
+);
+assert.ok(
+  /<Pressable[\s\S]*?accessibilityRole="button"[\s\S]*?seed\.brandSlug\.length > 0[\s\S]*?router\.push\(`\/b\/\$\{seed\.brandSlug\}`/.test(
+    detail,
+  ),
+  "the 'Presented by' lockup must be a Pressable that guards the slug then opens /b/{brandSlug}",
+);
+
+console.log(
+  "orch_1155_brand_badge_nav: PASS — consumer brand badges navigate to /b/{slug} (no dead taps), curated cards byte-identical, empty slug guarded.",
+);

--- a/app-mobile/src/hooks/useBrandBySlug.ts
+++ b/app-mobile/src/hooks/useBrandBySlug.ts
@@ -96,6 +96,9 @@ interface PublicExperienceRow {
   title: string;
   description: string | null;
   cover_media_url: string | null;
+  // ORCH-1155 — RPC now returns the experience cover's media type so the
+  // in-app brand-page Experiences card plays video/gif covers (SC-9-Native).
+  cover_media_type: "image" | "video" | "gif" | null;
   theme: Record<string, unknown> | null;
   venue_text: string | null;
   next_occurrence_at: string | null;
@@ -276,6 +279,7 @@ const mapExperience = (row: PublicExperienceRow): PublicBrandExperience => ({
   name: row.title,
   bio: row.description,
   coverMediaUrl: row.cover_media_url,
+  coverMediaType: row.cover_media_type,
   theme: row.theme,
   venueText: row.venue_text,
   nextOccurrenceAt: row.next_occurrence_at,

--- a/app-mobile/src/screens/ConsumerBrandProfileScreen.tsx
+++ b/app-mobile/src/screens/ConsumerBrandProfileScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { ActivityIndicator, Share, StyleSheet, Text, View } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as WebBrowser from "expo-web-browser";
 import {
   PublicBrandPage,
@@ -14,6 +15,7 @@ import { useBrandBySlug } from "../hooks/useBrandBySlug";
 
 export default function ConsumerBrandProfileScreen(): React.ReactElement {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ slug: string | string[] }>();
   const slug = Array.isArray(params.slug) ? params.slug[0] : params.slug;
   const query = useBrandBySlug(typeof slug === "string" ? slug : null);
@@ -59,6 +61,13 @@ export default function ConsumerBrandProfileScreen(): React.ReactElement {
       upcoming={query.data.upcoming}
       upcomingHasMore={query.data.upcomingHasMore}
       theme={query.data.resolvedTheme}
+      // ORCH-1155 Known-Issue #1: feed the device safe-area top inset into the
+      // shared shell's fixed chrome so the X / Share buttons clear the notch /
+      // status bar on native (the shell adds its own +12 gap, giving an
+      // effective insets.top + 12 — identical to ConsumerTripDetailScreen /
+      // ConsumerExperienceDetailScreen native chrome). Web/business unchanged:
+      // the business adapter passes its own offset; web safe-area top is 0.
+      chromeTopOffset={insets.top}
       callbacks={{
         onClose: () => router.back(),
         onShare: handleShare,

--- a/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
+++ b/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
@@ -55,6 +55,7 @@ import {
   type NativeSyntheticEvent,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -182,6 +183,7 @@ export default function ConsumerEventDetailScreen({
 }: ConsumerEventDetailScreenProps): React.ReactElement {
   void tabBarAware; // the sheet hides the nav; kept for prop parity with trip.
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const queryClient = useQueryClient();
   const user = useAppStore((s) => s.user);
   const profile = useAppStore((s) => s.profile);
@@ -751,8 +753,25 @@ export default function ConsumerEventDetailScreen({
               ) : null}
             </View>
 
-            {/* brand chip — "Presented by" (anon-safe brand cover/initial) */}
-            <View style={[styles.brandRow, surface.card]}>
+            {/* brand chip — "Presented by" (anon-safe brand cover/initial).
+                ORCH-1155 [public-brand-page] all-surface parity: tappable
+                Pressable opens the brand page /b/{brandSlug} with a trailing
+                "View" CTA — parity with the web/business event page (onOpenBrand
+                → /b/{slug}) and the trip/experience consumer screens. Guard empty
+                slug (rule 9; no dead tap, Constitution rule 1). */}
+            <Pressable
+              style={[styles.brandRow, surface.card]}
+              accessibilityRole="button"
+              accessibilityLabel={`View ${fnd.brandName}`}
+              onPress={() => {
+                if (
+                  typeof fnd.brandSlug === "string" &&
+                  fnd.brandSlug.length > 0
+                ) {
+                  router.push(`/b/${fnd.brandSlug}` as never);
+                }
+              }}
+            >
               <View
                 style={[
                   styles.brandTile,
@@ -798,7 +817,10 @@ export default function ConsumerEventDetailScreen({
                   {fnd.brandName}
                 </Text>
               </View>
-            </View>
+              <Text style={[styles.brandCta, { color: palette.accent }]}>
+                View
+              </Text>
+            </Pressable>
 
             {/* About — collapsible (rule 9: only when present) */}
             {aboutText !== null ? (
@@ -1185,6 +1207,9 @@ const styles = StyleSheet.create({
   brandInitialWrap: { flex: 1, alignItems: "center", justifyContent: "center" },
   brandInitial: { fontSize: 18, fontWeight: "900" },
   brandTextCol: { flexShrink: 1 },
+  // ORCH-1155 [public-brand-page] — trailing "View" CTA on the brand chip
+  // (parity with the web/business event page + trip/experience consumer screens).
+  brandCta: { marginLeft: "auto", fontSize: 12, fontWeight: "800" },
   brandKicker: {
     fontSize: 10,
     fontWeight: "800",

--- a/app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx
+++ b/app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx
@@ -47,6 +47,7 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Haptics from "expo-haptics";
+import { useRouter } from "expo-router";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -262,6 +263,7 @@ export default function ConsumerExperienceDetailScreen({
 }: ConsumerExperienceDetailScreenProps): React.ReactElement {
   void tabBarAware;
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const queryClient = useQueryClient();
   const user = useAppStore((s) => s.user);
   const profile = useAppStore((s) => s.profile);
@@ -927,8 +929,22 @@ export default function ConsumerExperienceDetailScreen({
               </View>
             ) : null}
 
-            {/* brand chip — "Presented by" (anon-safe brand cover/initial) */}
-            <View style={[styles.brandRow, surface.card]}>
+            {/* brand chip — "Presented by" (anon-safe brand cover/initial).
+                ORCH-1155 [public-brand-page]: tap opens the brand page
+                /b/{brandSlug} (no dead tap). Guard empty slug (rule 9). */}
+            <Pressable
+              style={[styles.brandRow, surface.card]}
+              accessibilityRole="button"
+              accessibilityLabel={`View ${seed.brandName}`}
+              onPress={() => {
+                if (
+                  typeof seed.brandSlug === "string" &&
+                  seed.brandSlug.length > 0
+                ) {
+                  router.push(`/b/${seed.brandSlug}` as never);
+                }
+              }}
+            >
               <View
                 style={[
                   styles.brandTile,
@@ -974,7 +990,7 @@ export default function ConsumerExperienceDetailScreen({
                   {seed.brandName}
                 </Text>
               </View>
-            </View>
+            </Pressable>
 
             {/* About — collapsible (rule 9: only when present) */}
             {aboutText !== null ? (

--- a/app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx
+++ b/app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx
@@ -990,6 +990,12 @@ export default function ConsumerExperienceDetailScreen({
                   {seed.brandName}
                 </Text>
               </View>
+              {/* ORCH-1155 [public-brand-page] all-surface parity — trailing
+                  "View" CTA matching the trip/event consumer screens + the
+                  web/business pages. */}
+              <Text style={[styles.brandCta, { color: palette.accent }]}>
+                View
+              </Text>
             </Pressable>
 
             {/* About — collapsible (rule 9: only when present) */}
@@ -1313,6 +1319,9 @@ const styles = StyleSheet.create({
   brandInitialWrap: { flex: 1, alignItems: "center", justifyContent: "center" },
   brandInitial: { fontSize: 18, fontWeight: "900" },
   brandTextCol: { flexShrink: 1 },
+  // ORCH-1155 [public-brand-page] — trailing "View" CTA on the brand chip
+  // (parity with the trip/event consumer screens + web/business pages).
+  brandCta: { marginLeft: "auto", fontSize: 12, fontWeight: "800" },
   brandKicker: {
     fontSize: 10,
     fontWeight: "800",

--- a/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
+++ b/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
@@ -70,6 +70,7 @@ import {
   type NativeSyntheticEvent,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
 import {
   boldFontFamily,
   createThemePalette,
@@ -303,6 +304,7 @@ export default function ConsumerTripDetailScreen({
   accountPreferences,
 }: ConsumerTripDetailScreenProps): React.ReactElement {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
   const { detail, isLoading, isError, refetch } = useConsumerTripDetail(
     brandSlug,
     tripSlug,
@@ -780,8 +782,24 @@ export default function ConsumerTripDetailScreen({
           CLEAN themed circle with the brand INITIAL — NOT a bare striped red disk
           and NOT the broken "COVE…" alt text Seth saw (rule 9 — graceful, no
           fabrication). The rounded tile clips the media (overflow:hidden;
-          ANDROID_GLASS_USES_OPAQUE_FALLBACK opaque fill). */}
-      <View style={[styles.brandRow, surface.card]}>
+          ANDROID_GLASS_USES_OPAQUE_FALLBACK opaque fill).
+
+          ORCH-1155 [public-brand-page] all-surface parity: the brand chip is a
+          tappable Pressable that opens the brand page /b/{brandSlug} with a
+          trailing "View" CTA — matching the trip/event/experience PreviEW and the
+          web/business trip page (onViewBrand). Guard empty slug (rule 9; no dead
+          tap, Constitution rule 1). brandSlug is the screen prop (always set when
+          the route mounts). */}
+      <Pressable
+        style={[styles.brandRow, surface.card]}
+        accessibilityRole="button"
+        accessibilityLabel={`View ${fnd.brandName}`}
+        onPress={() => {
+          if (brandSlug.length > 0) {
+            router.push(`/b/${brandSlug}` as never);
+          }
+        }}
+      >
         <View
           style={[
             styles.brandTile,
@@ -833,7 +851,8 @@ export default function ConsumerTripDetailScreen({
             ) : null}
           </View>
         </View>
-      </View>
+        <Text style={[styles.brandCta, { color: palette.accent }]}>View</Text>
+      </Pressable>
 
       {/* deadline state band (closed / countdown) */}
       {closed ? (
@@ -1635,6 +1654,13 @@ const styles = StyleSheet.create({
     fontWeight: "900",
   },
   brandTextCol: { flexShrink: 1 },
+  // ORCH-1155 [public-brand-page] — trailing "View" CTA on the brand chip
+  // (parity with TripPreview.brandCta + web/business trip page).
+  brandCta: {
+    marginLeft: "auto",
+    fontSize: 12,
+    fontWeight: "800",
+  },
   brandKicker: {
     fontSize: 10,
     fontWeight: "800",

--- a/app-mobile/src/screens/__tests__/orch_1155_brand_chrome_top_inset.test.ts
+++ b/app-mobile/src/screens/__tests__/orch_1155_brand_chrome_top_inset.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1155 [public-brand-page] Known-Issue #1 — implementor happy-path
+// regression for the consumer brand-page chrome top-inset.
+//
+// BUG: the consumer brand-page screen mounted the shared PublicBrandPage without
+// feeding the device safe-area top inset, so safeAreaTop defaulted to 0 and the
+// X / Share chrome rendered at +12px (under the notch / status bar) on native.
+// Every other Direction-A consumer page (trip/event/experience) passes the top
+// inset into its chrome. The fix passes chromeTopOffset={insets.top}; the shared
+// shell adds its own +12 gap → effective insets.top + 12, identical to
+// ConsumerTripDetailScreen / ConsumerExperienceDetailScreen native chrome.
+//
+// app-mobile has no jest/RTL runner; the repo convention is node:assert
+// source-assertions (see orch_1155_brand_badge_nav.test.ts). Each assertion
+// FAILS on a true LINE-DELETION of the wiring it protects (fails-on-revert),
+// NOT on a comment-out.
+//
+// Run with:
+//   node app-mobile/src/screens/__tests__/orch_1155_brand_chrome_top_inset.test.ts
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const read = (rel) =>
+  fs.readFileSync(path.join(__dirname, "..", "..", "..", rel), "utf8");
+
+const screen = read("src/screens/ConsumerBrandProfileScreen.tsx");
+
+// 1) The screen imports useSafeAreaInsets (the established consumer pattern,
+//    mirroring ConsumerTripDetailScreen / ConsumerExperienceDetailScreen).
+assert.ok(
+  /import\s*\{\s*useSafeAreaInsets\s*\}\s*from\s*["']react-native-safe-area-context["']/.test(
+    screen,
+  ),
+  "ConsumerBrandProfileScreen must import useSafeAreaInsets from react-native-safe-area-context",
+);
+
+// 2) It reads the live insets.
+assert.ok(
+  /const\s+insets\s*=\s*useSafeAreaInsets\(\)/.test(screen),
+  "ConsumerBrandProfileScreen must read insets via useSafeAreaInsets()",
+);
+
+// 3) It feeds a NON-ZERO top inset into the shared page's chrome via
+//    chromeTopOffset={insets.top} (regression guard: dropping this drops the
+//    notch clearance → the X / Share chrome collides with the status bar).
+assert.ok(
+  /chromeTopOffset=\{insets\.top\}/.test(screen),
+  "ConsumerBrandProfileScreen must pass chromeTopOffset={insets.top} so the chrome clears the notch on native",
+);
+
+console.log(
+  "orch_1155_brand_chrome_top_inset: PASS — consumer brand page feeds insets.top into the shared chrome (X / Share clear the notch on native).",
+);

--- a/app-mobile/src/screens/__tests__/orch_1155_brand_view_affordance.test.ts
+++ b/app-mobile/src/screens/__tests__/orch_1155_brand_view_affordance.test.ts
@@ -1,0 +1,157 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1155 [public-brand-page] — implementor happy-path regression for the
+// brand-card "View" affordance ALL-SURFACE parity on the three offering pages
+// (event / trip / experience), buyer-web + business iOS/Android + consumer app.
+//
+// The device-confirmed bug (Seth): the "Presented by {Brand}" block on the
+// offering pages had no visible/functional "View" affordance on every surface —
+// the consumer event + trip screens rendered the brand chip as a plain <View>
+// (no CTA, no navigation = a dead block).
+//
+// Root cause per page (proven by source):
+//   - EVENT  web/business: the shared event page renders the "View" CTA only
+//            when onOpenBrand is passed; the business PublicEventPage DOES pass
+//            it → already working. (asserted below, fails-on-revert guarded)
+//   - TRIP / EXPERIENCE web/business: TripPreview/ExperiencePreview render the
+//            "View" CTA + the /t/ + /exp/ routes pass onViewBrand → working.
+//   - CONSUMER event + trip: brand chip was a plain <View> (the real gap) — now
+//            a Pressable that opens /b/{brandSlug} with a trailing "View" CTA.
+//   - CONSUMER experience: already navigated; now also shows the "View" CTA for
+//            consistency with the other two pages.
+//
+// app-mobile has no jest/RTL runner; the repo convention is node:assert
+// source-assertions (see orch_1155_brand_badge_nav.test.ts). Every assertion
+// FAILS on a true LINE-DELETION of the line it protects (fails-on-revert), NOT
+// on a comment-out. The tester writes the SECOND, adversarial render-angle test.
+//
+// Run with:
+//   node app-mobile/src/screens/__tests__/orch_1155_brand_view_affordance.test.ts
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// app-mobile/src/screens/__tests__ → repo root is 5 levels up.
+const repoRoot = path.join(__dirname, "..", "..", "..", "..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+const consumerTrip = read(
+  "app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx",
+);
+const consumerEvent = read(
+  "app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx",
+);
+const consumerExperience = read(
+  "app-mobile/src/screens/Experience/ConsumerExperienceDetailScreen.tsx",
+);
+
+const tripPreview = read(
+  "mingla-business/src/components/trip/TripPreview.tsx",
+);
+const experiencePreview = read(
+  "mingla-business/src/components/experience/ExperiencePreview.tsx",
+);
+const sharedEventPage = read("packages/event-rendering/PublicEventPage.tsx");
+const businessEventPage = read(
+  "mingla-business/src/components/event/PublicEventPage.tsx",
+);
+const tripRoute = read(
+  "mingla-business/app/t/[brandSlug]/[tripSlug].tsx",
+);
+const experienceRoute = read(
+  "mingla-business/app/exp/[brandSlug]/[experienceSlug].tsx",
+);
+
+// ── EVENT (web/business) — "View" CTA renders when onOpenBrand is passed ───────
+assert.ok(
+  /callbacks\.onOpenBrand !== undefined \?[\s\S]*?>\s*View\s*</.test(
+    sharedEventPage,
+  ),
+  "shared event page must render the 'View' CTA when onOpenBrand is provided",
+);
+assert.ok(
+  /onOpenBrand=\{\(slug: string\) => router\.push\(`\/b\/\$\{slug\}`/.test(
+    businessEventPage,
+  ),
+  "business PublicEventPage must pass onOpenBrand → router.push(`/b/${slug}`)",
+);
+
+// ── TRIP (web/business) — Preview renders "View" + route passes onViewBrand ────
+assert.ok(
+  /onPress=\{onViewBrand\}[\s\S]*?accessibilityRole="button"/.test(tripPreview),
+  "TripPreview brand chip must be a Pressable wired to onViewBrand",
+);
+assert.ok(
+  /styles\.brandCta[\s\S]*?>\s*View\s*<\/Text>/.test(tripPreview),
+  "TripPreview must render the trailing 'View' CTA text",
+);
+assert.ok(
+  tripRoute.includes("onViewBrand={handleViewBrand}"),
+  "the /t/ trip route must pass onViewBrand to TripPreview",
+);
+assert.ok(
+  /handleViewBrand[\s\S]*?brandSlug\.length > 0[\s\S]*?router\.push\(`\/b\/\$\{brandSlug\}`/.test(
+    tripRoute,
+  ),
+  "the /t/ route handleViewBrand must guard the slug then open /b/{brandSlug}",
+);
+
+// ── EXPERIENCE (web/business) — Preview renders "View" + route passes handler ──
+assert.ok(
+  /onPress=\{onViewBrand\}[\s\S]*?accessibilityRole="button"/.test(
+    experiencePreview,
+  ),
+  "ExperiencePreview brand chip must be a Pressable wired to onViewBrand",
+);
+assert.ok(
+  /styles\.brandCta[\s\S]*?>\s*View\s*<\/Text>/.test(experiencePreview),
+  "ExperiencePreview must render the trailing 'View' CTA text",
+);
+assert.ok(
+  experienceRoute.includes("onViewBrand={handleViewBrand}"),
+  "the /exp/ experience route must pass onViewBrand to ExperiencePreview",
+);
+
+// ── CONSUMER TRIP — brand chip is now a Pressable → /b/{brandSlug} + "View" ────
+assert.ok(
+  consumerTrip.includes("const router = useRouter();"),
+  "ConsumerTripDetailScreen must obtain an expo-router handle",
+);
+assert.ok(
+  /<Pressable[\s\S]*?accessibilityRole="button"[\s\S]*?brandSlug\.length > 0[\s\S]*?router\.push\(`\/b\/\$\{brandSlug\}`/.test(
+    consumerTrip,
+  ),
+  "ConsumerTripDetailScreen brand chip must be a Pressable that guards the slug then opens /b/{brandSlug}",
+);
+assert.ok(
+  /styles\.brandCta[\s\S]*?>View<\/Text>/.test(consumerTrip),
+  "ConsumerTripDetailScreen must render the trailing 'View' CTA",
+);
+
+// ── CONSUMER EVENT — brand chip is now a Pressable → /b/{brandSlug} + "View" ───
+assert.ok(
+  consumerEvent.includes("const router = useRouter();"),
+  "ConsumerEventDetailScreen must obtain an expo-router handle",
+);
+assert.ok(
+  /<Pressable[\s\S]*?accessibilityRole="button"[\s\S]*?fnd\.brandSlug\.length > 0[\s\S]*?router\.push\(`\/b\/\$\{fnd\.brandSlug\}`/.test(
+    consumerEvent,
+  ),
+  "ConsumerEventDetailScreen brand chip must be a Pressable that guards the slug then opens /b/{brandSlug}",
+);
+assert.ok(
+  /styles\.brandCta[\s\S]*?>\s*View\s*<\/Text>/.test(consumerEvent),
+  "ConsumerEventDetailScreen must render the trailing 'View' CTA",
+);
+
+// ── CONSUMER EXPERIENCE — already navigates; now also shows the "View" CTA ─────
+assert.ok(
+  /styles\.brandCta[\s\S]*?>\s*View\s*<\/Text>/.test(consumerExperience),
+  "ConsumerExperienceDetailScreen must render the trailing 'View' CTA (consistency)",
+);
+
+console.log(
+  "orch_1155_brand_view_affordance: PASS — the brand-card 'View' affordance is visible + functional on event/trip/experience across web/business + all three consumer screens (no dead taps, /b/{slug} guarded).",
+);

--- a/mingla-business/__tests__/components/PublicBrandPage.dataDriven.test.tsx
+++ b/mingla-business/__tests__/components/PublicBrandPage.dataDriven.test.tsx
@@ -1,11 +1,25 @@
 import fs from "fs";
 import path from "path";
 
-// META-ORCH-0972 Sub-C SC-C-15
-// fails-on-revert verified at 2aea165d5
+// META-ORCH-0972 Sub-C SC-C-15 — ORIGINALLY asserted the inline business brand
+// component built data-driven tabs. Those tab/pane symbols moved into the SHARED
+// renderer (packages/brand-rendering/PublicBrandPage.tsx) during the adapter
+// extraction, then ORCH-1155 redesigned that renderer onto the Direction-A shell.
+// RELOCATED by ORCH-1155 [public-brand-page] (spec-owned, [TEST-MOD-APPROVED
+// ORCH-1155]) to assert the SHARED package's current data-driven shape so the
+// signal is real again (was 3/4-failing on origin/main against the moved
+// symbols). The service assertions stay (the service still lives in business).
+// fails-on-revert verified at 2aea165d5 (original META-ORCH-0972 anchor) — the
+// relocated assertions below now track the shared renderer.
 
-const publicBrandPage = fs.readFileSync(
-  path.join(process.cwd(), "src/components/brand/PublicBrandPage.tsx"),
+const sharedBrandPage = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "..",
+    "packages",
+    "brand-rendering",
+    "PublicBrandPage.tsx",
+  ),
   "utf8",
 );
 const publicEventsService = fs.readFileSync(
@@ -13,37 +27,39 @@ const publicEventsService = fs.readFileSync(
   "utf8",
 );
 
-describe("META-ORCH-0972 Sub-C PublicBrandPage data-driven tabs", () => {
-  test("builds public tabs from offering data, not brand kind", () => {
-    expect(publicBrandPage).toContain("const visibleTabs = useMemo<PublicTab[]>");
-    expect(publicBrandPage).toContain('tabs.push("upcoming")');
-    expect(publicBrandPage).toContain('tabs.push("events")');
-    expect(publicBrandPage).toContain('tabs.push("trips")');
-    expect(publicBrandPage).toContain('tabs.push("experiences")');
-    expect(publicBrandPage).toContain('tabs.push("about")');
-    expect(publicBrandPage).not.toContain("isTripBrand");
-    expect(publicBrandPage).not.toContain("brand.kind");
+describe("META-ORCH-0972 Sub-C / ORCH-1155 PublicBrandPage data-driven tabs (shared renderer)", () => {
+  test("builds public tabs from offering data, not brand kind (About first)", () => {
+    expect(sharedBrandPage).toContain('const tabs: Tab[] = ["about"];');
+    expect(sharedBrandPage).toContain('tabs.push("upcoming")');
+    expect(sharedBrandPage).toContain('tabs.push("events")');
+    expect(sharedBrandPage).toContain('tabs.push("trips")');
+    expect(sharedBrandPage).toContain('tabs.push("experiences")');
+    expect(sharedBrandPage).not.toContain("isTripBrand");
+    expect(sharedBrandPage).not.toContain("brand.kind");
   });
 
-  test("renders the zero-offering brand empty state without hiding identity/about", () => {
-    expect(publicBrandPage).toContain("const hasOfferings =");
-    expect(publicBrandPage).toContain("More coming soon from this brand.");
-    expect(publicBrandPage).toContain('useState<PublicTab>("about")');
+  test("renders the zero-offering brand without hiding identity/about (About default)", () => {
+    // About is the default-selected tab and always present even with no offerings.
+    expect(sharedBrandPage).toContain('useState<Tab>("about")');
+    expect(sharedBrandPage).toContain("const AboutTab");
+    expect(sharedBrandPage).toContain("EmptyPane");
   });
 
-  test("has dedicated Events, Trips, Experiences, and Upcoming tab bodies", () => {
-    expect(publicBrandPage).toContain("const UpcomingTab");
-    expect(publicBrandPage).toContain("const EventsTab");
-    expect(publicBrandPage).toContain("const TripsTab");
-    expect(publicBrandPage).toContain("const ExperiencesTab");
-    expect(publicBrandPage).toContain("<ExperienceMiniCard");
-    expect(publicBrandPage).toContain("<NextOfferingTeaser");
+  test("has dedicated Events, Trips, Experiences, Upcoming, and About panes", () => {
+    expect(sharedBrandPage).toContain("const UpcomingList");
+    expect(sharedBrandPage).toContain("const EventList");
+    expect(sharedBrandPage).toContain("const TripList");
+    expect(sharedBrandPage).toContain("const ExperienceList");
+    expect(sharedBrandPage).toContain("ExperienceMiniCard");
+    expect(sharedBrandPage).toContain("NextOfferingTeaser");
   });
 
   test("public service fetches all offering buckets in parallel without kind branching", () => {
     expect(publicEventsService).toContain("fetchPublicBrandEvents(brandSlug)");
     expect(publicEventsService).toContain("fetchPublicBrandTrips(brandSlug)");
-    expect(publicEventsService).toContain("fetchPublicBrandExperiences(brandSlug)");
+    expect(publicEventsService).toContain(
+      "fetchPublicBrandExperiences(brandSlug)",
+    );
     expect(publicEventsService).toContain("fetchPublicBrandUpcoming(brandSlug)");
     expect(publicEventsService).toContain("Promise.all");
     expect(publicEventsService).not.toContain("brandRow.kind");

--- a/mingla-business/src/components/brand/PublicBrandPage.tsx
+++ b/mingla-business/src/components/brand/PublicBrandPage.tsx
@@ -117,6 +117,8 @@ const mapExperience = (
   name: experience.name,
   bio: experience.bio,
   coverMediaUrl: experience.coverMediaUrl,
+  // ORCH-1155 — thread the experience cover media type to the shared card.
+  coverMediaType: experience.coverMediaType,
   theme: experience.theme,
   venueText: experience.venueText,
   nextOccurrenceAt: experience.nextOccurrenceAt,

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -342,6 +342,10 @@ export interface PublicExperienceCardRow {
   title: string;
   description: string | null;
   cover_media_url: string | null;
+  // ORCH-1155 — RPC now returns the experience cover's media type (added to
+  // pg_public_experiences_by_brand) so the brand-page Experiences card can play
+  // video/gif covers, not just image. null ⇒ image-or-hue fallback.
+  cover_media_type: "image" | "video" | "gif" | null;
   theme: JsonRecord | null;
   venue_text: string | null;
   next_occurrence_at: string | null;
@@ -360,6 +364,8 @@ export interface PublicExperienceCard {
   name: string;
   bio: string | null;
   coverMediaUrl: string | null;
+  // ORCH-1155 — see PublicExperienceCardRow.cover_media_type.
+  coverMediaType: "image" | "video" | "gif" | null;
   theme: JsonRecord;
   venueText: string | null;
   nextOccurrenceAt: string | null;
@@ -1103,6 +1109,7 @@ export const experienceRowToCard = (
   name: row.title,
   bio: row.description,
   coverMediaUrl: row.cover_media_url,
+  coverMediaType: row.cover_media_type,
   theme: asRecord(row.theme),
   venueText: row.venue_text,
   nextOccurrenceAt: row.next_occurrence_at,

--- a/packages/brand-rendering/PublicBrandPage.tsx
+++ b/packages/brand-rendering/PublicBrandPage.tsx
@@ -1,12 +1,40 @@
+// PublicBrandPage — ORCH-1155 [public-brand-page] · Direction-A redesign.
+//
+// THE single shared public brand renderer, consumed identically by:
+//   • mingla-business adapter → buyer-web + business iOS/Android (route /b/{slug})
+//   • app-mobile ConsumerBrandProfileScreen → consumer iOS/Android (route /b/{slug})
+// One refactor reaches all five surfaces.
+//
+// Composes the shipped Direction-A foundation (the EXACT primitives the trip/
+// event/experience pages use): @mingla/offering-rendering ParallaxCoverShell +
+// OfferingChrome + useResponsiveLayout, and @mingla/event-rendering's SHARED
+// createThemePalette / offeringSurfaceStyles (NOT a file-local palette engine —
+// I-PROPOSED-1155-SINGLE-PALETTE-ENGINE). Matches
+// Mingla_Artifacts/design/ORCH-1138/BRAND_DIRECTION_A_RESPONSIVE.html:
+//   • Phone/native: full-bleed pinned parallax cover + body sliding over the −28
+//     seam + body-level fixed chrome (X · Share · Mute; Mute only on video covers).
+//   • Tab bar: About · Upcoming? · Events? · Trips? · Experiences? — About FIRST
+//     + DEFAULT, horizontally scrollable (no clipping), only non-empty tabs.
+//   • About pane: tagline → bio (4-line clamp + Read more) → contact (email/phone).
+//   • Desktop ≥1024px: contained 21:9 hero + two-column (tabs+2-col grid left,
+//     sticky Share + Next-up brand-summary panel right). No money/membership
+//     action — a brand page is a profile+directory, not a checkout.
+//
+// Real-data-only (rule 9): empty tabs/teaser/socials/contact/address/tagline/bio
+// are hidden, never fabricated. Anon-safe: data arrives via props from the
+// security-definer source (the renderer never selects the protected brands table).
+
 import React, { useEffect, useMemo, useState } from "react";
 import {
   Image,
   Linking,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   View,
+  type LayoutChangeEvent,
 } from "react-native";
 import type { LucideIcon } from "lucide-react-native";
 import {
@@ -21,14 +49,19 @@ import {
 } from "lucide-react-native";
 import {
   EventCoverMedia,
-  GlassBlur,
   MINGLA_DEFAULT_THEME,
-  ThemeEntranceAnimation,
+  createThemePalette,
+  offeringSurfaceStyles,
   resolveTheme,
   type ResolvedTheme,
+  type ThemePalette,
 } from "@mingla/event-rendering";
+import {
+  ParallaxCoverShell,
+  useResponsiveLayout,
+} from "@mingla/offering-rendering";
 
-import { accent, backgroundColor, radius, spacing, text } from "./designTokens";
+import { spacing } from "./designTokens";
 import type {
   PublicBrand,
   PublicBrandEvent,
@@ -40,7 +73,7 @@ import type {
   PublicMediaType,
 } from "./types";
 
-type Tab = "upcoming" | "events" | "trips" | "experiences" | "about";
+type Tab = "about" | "upcoming" | "events" | "trips" | "experiences";
 type SocialKind =
   | "website"
   | "instagram"
@@ -52,37 +85,9 @@ type SocialKind =
   | "threads";
 
 const PINNED_CTA_CARD_COUNT = 3;
+const BIO_CLAMP_LINES = 4;
 
-type ThemePalette = {
-  page: string;
-  accent: string;
-  accentText: string;
-  pageWash: string;
-  heroScrim: string;
-  heroLift: string;
-  primaryText: string;
-  secondaryText: string;
-  tertiaryText: string;
-  mutedText: string;
-  panel: string;
-  panelStrong: string;
-  panelBorder: string;
-  card: string;
-  cardBorder: string;
-  cutoutBorder: string;
-  glass: string;
-  glassStrong: string;
-  glassTint: "dark" | "light";
-  tabBand: string;
-  tabBorder: string;
-  accentWash: string;
-};
-
-type Rgb = {
-  r: number;
-  g: number;
-  b: number;
-};
+type Surface = ReturnType<typeof offeringSurfaceStyles>;
 
 const normalizeSocialUrl = (raw: string, base: string): string => {
   const trimmed = raw.trim();
@@ -149,7 +154,7 @@ const minPriceLabel = (
   if (typeof displayPriceCents === "number" && displayPriceCents > 0) {
     return `From ${formatCurrencyRound(
       displayPriceCents / 100,
-      displayCurrency ?? fallbackCurrency ?? "GBP",
+      displayCurrency ?? fallbackCurrency ?? "USD",
     )}`;
   }
   const visible = tickets.filter((t) => t.visibility !== "hidden");
@@ -158,171 +163,49 @@ const minPriceLabel = (
     .filter((p): p is number => typeof p === "number" && p > 0)
     .sort((a, b) => a - b);
   if (paid.length > 0) {
-    return `From ${formatCurrencyRound(paid[0], fallbackCurrency ?? "GBP")}`;
+    return `From ${formatCurrencyRound(paid[0], fallbackCurrency ?? "USD")}`;
   }
   return visible.some((t) => t.isFree === true) ? "Free" : null;
+};
+
+const offeringPriceLabel = (item: {
+  isFree?: boolean;
+  priceFromMinorUnits?: number | null;
+  currency?: string | null;
+}): string | null => {
+  if (
+    item.priceFromMinorUnits !== null &&
+    item.priceFromMinorUnits !== undefined
+  ) {
+    return `From ${formatCurrencyRound(
+      item.priceFromMinorUnits / 100,
+      item.currency ?? "USD",
+    )}`;
+  }
+  return item.isFree === true ? "Free" : null;
+};
+
+const formatUpcomingDateLine = (startsAt: string | null): string => {
+  if (startsAt === null) return "Date TBA";
+  const date = new Date(startsAt);
+  if (Number.isNaN(date.getTime())) return "Date TBA";
+  return date.toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
 };
 
 const openUrl = (url: string): void => {
   void Linking.openURL(url).catch(() => undefined);
 };
 
-const FALLBACK_ACCENT_RGB: Rgb = { r: 235, g: 120, b: 37 };
-
-const clampColorChannel = (value: number): number =>
-  Math.min(255, Math.max(0, Math.round(value)));
-
-const parseHexColor = (hex: string): Rgb => {
-  const match = /^#([0-9a-fA-F]{6})$/.exec(hex);
-  if (match === null) return FALLBACK_ACCENT_RGB;
-  const value = match[1];
-  return {
-    r: parseInt(value.slice(0, 2), 16),
-    g: parseInt(value.slice(2, 4), 16),
-    b: parseInt(value.slice(4, 6), 16),
-  };
-};
-
-const rgbToHex = ({ r, g, b }: Rgb): string =>
-  `#${[r, g, b]
-    .map((channel) => clampColorChannel(channel).toString(16).padStart(2, "0"))
-    .join("")}`;
-
-const mixHexColors = (from: string, to: string, amount: number): string => {
-  const a = parseHexColor(from);
-  const b = parseHexColor(to);
-  const weight = Math.min(1, Math.max(0, amount));
-  return rgbToHex({
-    r: a.r + (b.r - a.r) * weight,
-    g: a.g + (b.g - a.g) * weight,
-    b: a.b + (b.b - a.b) * weight,
-  });
-};
-
-const hexToRgba = (hex: string, alpha: number): string => {
-  const { r, g, b } = parseHexColor(hex);
-  return `rgba(${r},${g},${b},${alpha})`;
-};
-
-const linearizeSrgb = (channel: number): number => {
-  const normalized = channel / 255;
-  return normalized <= 0.03928
-    ? normalized / 12.92
-    : ((normalized + 0.055) / 1.055) ** 2.4;
-};
-
-const relativeLuminance = (hex: string): number => {
-  const { r, g, b } = parseHexColor(hex);
-  return (
-    0.2126 * linearizeSrgb(r) +
-    0.7152 * linearizeSrgb(g) +
-    0.0722 * linearizeSrgb(b)
-  );
-};
-
-const contrastRatio = (a: string, b: string): number => {
-  const lighter = Math.max(relativeLuminance(a), relativeLuminance(b));
-  const darker = Math.min(relativeLuminance(a), relativeLuminance(b));
-  return (lighter + 0.05) / (darker + 0.05);
-};
-
-const readableTextFor = (background: string): "#000000" | "#ffffff" =>
-  contrastRatio("#000000", background) >= contrastRatio("#ffffff", background)
-    ? "#000000"
-    : "#ffffff";
-
-const contrastAdjustedAccent = (
-  accentColor: string,
-  background: string,
-  minimumRatio: number,
-): string => {
-  if (contrastRatio(accentColor, background) >= minimumRatio)
-    return accentColor;
-  const direction = readableTextFor(background);
-  let adjusted = accentColor;
-  for (let i = 0; i < 12; i++) {
-    adjusted = mixHexColors(adjusted, direction, 0.16);
-    if (contrastRatio(adjusted, background) >= minimumRatio) return adjusted;
-  }
-  return adjusted;
-};
-
-const contrastAdjustedForWhiteText = (
-  accentColor: string,
-  minimumRatio: number,
-): string => {
-  if (contrastRatio(accentColor, "#ffffff") >= minimumRatio) return accentColor;
-  let adjusted = accentColor;
-  for (let i = 0; i < 12; i++) {
-    adjusted = mixHexColors(adjusted, "#000000", 0.14);
-    if (contrastRatio(adjusted, "#ffffff") >= minimumRatio) return adjusted;
-  }
-  return adjusted;
-};
-
-const createThemePalette = (theme: ResolvedTheme): ThemePalette => {
-  const darkBase = "#07070a";
-  const lightBase = "#f8fafc";
-  const accentOnDark = contrastRatio(theme.color, darkBase);
-  const accentOnLight = contrastRatio(theme.color, lightBase);
-  const useDark =
-    accentOnDark >= 3 && accentOnLight < 3
-      ? true
-      : accentOnLight >= 3 && accentOnDark < 3
-        ? false
-        : theme.foregroundColor === "#ffffff";
-  const basePage = useDark ? darkBase : lightBase;
-  const page = mixHexColors(basePage, theme.color, useDark ? 0.1 : 0.035);
-  const accentColor = contrastAdjustedForWhiteText(
-    contrastAdjustedAccent(theme.color, page, 3.15),
-    4.5,
-  );
-  const accentText = "#ffffff";
-  const primaryText = readableTextFor(page);
-  const secondaryText =
-    primaryText === "#ffffff"
-      ? "rgba(255,255,255,0.78)"
-      : "rgba(16,20,31,0.76)";
-  const tertiaryText =
-    primaryText === "#ffffff"
-      ? "rgba(255,255,255,0.58)"
-      : "rgba(16,20,31,0.58)";
-  const mutedText =
-    primaryText === "#ffffff"
-      ? "rgba(255,255,255,0.40)"
-      : "rgba(16,20,31,0.42)";
-  return {
-    page,
-    accent: accentColor,
-    accentText,
-    pageWash: hexToRgba(theme.color, useDark ? 0.24 : 0.12),
-    heroScrim: useDark ? "rgba(4,5,8,0.50)" : "rgba(248,250,252,0.36)",
-    heroLift: useDark ? "rgba(7,7,10,0.82)" : "rgba(248,250,252,0.90)",
-    primaryText,
-    secondaryText,
-    tertiaryText,
-    mutedText,
-    panel: useDark ? "rgba(255,255,255,0.08)" : "rgba(255,255,255,0.76)",
-    panelStrong: useDark ? "rgba(255,255,255,0.11)" : "rgba(255,255,255,0.92)",
-    panelBorder: hexToRgba(accentColor, useDark ? 0.38 : 0.3),
-    card: useDark ? "rgba(255,255,255,0.09)" : "rgba(255,255,255,0.72)",
-    cardBorder: useDark ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.78)",
-    cutoutBorder: useDark ? "rgba(255,255,255,0.24)" : "rgba(255,255,255,0.96)",
-    glass: useDark ? "rgba(255,255,255,0.10)" : "rgba(255,255,255,0.62)",
-    glassStrong: useDark ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.82)",
-    glassTint: useDark ? "dark" : "light",
-    tabBand: hexToRgba(accentColor, useDark ? 0.2 : 0.14),
-    tabBorder: hexToRgba(accentColor, useDark ? 0.46 : 0.34),
-    accentWash: hexToRgba(accentColor, useDark ? 0.24 : 0.18),
-  };
-};
-
 const tabLabel: Record<Tab, string> = {
+  about: "About",
   upcoming: "Upcoming",
   events: "Events",
   trips: "Trips",
   experiences: "Experiences",
-  about: "About",
 };
 
 const SOCIAL_ICON_BY_KIND: Record<SocialKind, LucideIcon> = {
@@ -347,16 +230,30 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
   upcomingHasMore = false,
   venue = null,
   theme,
+  // hideFloatingChrome is retained for back-compat with the props type; both live
+  // callers (business adapter + consumer screen) pass it falsy, and the shell
+  // always renders chrome (X · Share). An embedded chrome-less use would be a
+  // a later ORCH. (Spec D-2.)
   hideFloatingChrome = false,
   chromeTopOffset,
   callbacks,
 }) => {
+  void hideFloatingChrome;
+  const { isDesktop } = useResponsiveLayout();
   const [activeTab, setActiveTab] = useState<Tab>("about");
-  const [coverMediaFailed, setCoverMediaFailed] = useState<boolean>(false);
+  const [muted, setMuted] = useState<boolean>(true);
+  const toggleMute = (): void => setMuted((v) => !v);
+
   const resolvedTheme = useMemo<ResolvedTheme>(
     () => theme ?? resolveTheme(brand.theme ?? null, null),
     [brand.theme, theme],
   );
+  const palette = useMemo<ThemePalette>(
+    () => createThemePalette(resolvedTheme),
+    [resolvedTheme],
+  );
+  const surface = useMemo<Surface>(() => offeringSurfaceStyles(palette), [palette]);
+  const themedFont = { fontFamily: resolvedTheme.fontFamilyValue };
 
   const upcomingEvents = useMemo(
     () =>
@@ -390,13 +287,14 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
     [providedPastTrips, trips],
   );
 
+  // ORCH-1155 — About FIRST + default; offering tabs render ONLY when non-empty.
+  // (I-PROPOSED-1155-ABOUT-FIRST-DEFAULT + I-PROPOSED-1155-TABS-HIDE-WHEN-EMPTY.)
   const visibleTabs = useMemo<Tab[]>(() => {
-    const tabs: Tab[] = [];
+    const tabs: Tab[] = ["about"];
     if (upcoming.length > 0 || upcomingHasMore) tabs.push("upcoming");
     if (upcomingEvents.length > 0 || pastEvents.length > 0) tabs.push("events");
     if (upcomingTrips.length > 0 || pastTrips.length > 0) tabs.push("trips");
     if (experiences.length > 0) tabs.push("experiences");
-    tabs.push("about");
     return tabs;
   }, [
     experiences.length,
@@ -408,21 +306,29 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
     upcomingTrips.length,
   ]);
 
+  // State-guard: if the active offering bucket empties, snap to About (index 0).
   useEffect(() => {
     if (!visibleTabs.includes(activeTab)) {
       setActiveTab(visibleTabs[0] ?? "about");
     }
   }, [activeTab, visibleTabs]);
 
-  const heroColor =
+  const coverHue =
     resolvedTheme.color === MINGLA_DEFAULT_THEME.color && brand.coverHue !== 25
-      ? `hsl(${brand.coverHue}, 60%, 45%)`
-      : resolvedTheme.color;
-  const palette = useMemo(
-    () => createThemePalette(resolvedTheme),
-    [resolvedTheme],
-  );
-  const themedFont = { fontFamily: resolvedTheme.fontFamilyValue };
+      ? brand.coverHue
+      : hashHueFromString(brand.slug);
+  const coverUrl =
+    brand.coverMediaUrl !== undefined && brand.coverMediaUrl.length > 0
+      ? brand.coverMediaUrl
+      : null;
+  const coverType: PublicMediaType | null =
+    brand.coverMediaType === "video"
+      ? "video"
+      : brand.coverMediaType === "gif"
+        ? "gif"
+        : coverUrl !== null
+          ? "image"
+          : null;
 
   const socialEntries = useMemo(() => {
     const links = brand.links;
@@ -484,6 +390,12 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
   }, [brand.links]);
 
   const onExternal = callbacks.onOpenExternal ?? openUrl;
+  const isVerified = venue?.isVerifiedVenue === true;
+  const address =
+    brand.address !== null && brand.address.trim().length > 0
+      ? brand.address.trim()
+      : null;
+
   const countForTab = (tab: Tab): number | undefined => {
     if (tab === "upcoming") return upcoming.length;
     if (tab === "events") return upcomingEvents.length + pastEvents.length;
@@ -492,270 +404,241 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
     return undefined;
   };
 
-  return (
-    <View style={[styles.host, { backgroundColor: palette.page }]}>
-      {hideFloatingChrome ? null : (
-        <View
-          style={[
-            styles.floatingChrome,
-            chromeTopOffset !== undefined ? { top: chromeTopOffset } : null,
-          ]}
-          pointerEvents="box-none"
-        >
-          <ChromeButton
-            label="Close"
-            glyph="x"
-            onPress={callbacks.onClose}
-            testID="orch-0961-public-brand-close"
-          />
-          <ChromeButton
-            label="Share"
-            glyph="share"
-            onPress={callbacks.onShare}
-            testID="orch-0961-public-brand-share"
-          />
-        </View>
-      )}
+  // Featured "Next up" teaser shows only when there is >1 upcoming offering
+  // (design A.4/A.7 — a single offering's teaser would duplicate the only card).
+  const showFeaturedTeaser = upcoming.length > 1;
 
-      <View
-        style={[styles.heroWrap, { backgroundColor: heroColor }]}
-        pointerEvents="none"
-      >
-        {brand.coverMediaUrl !== undefined &&
-        brand.coverMediaUrl.length > 0 &&
-        !coverMediaFailed ? (
-          <EventCoverMedia
-            mediaUrl={brand.coverMediaUrl}
-            mediaType={brand.coverMediaType ?? null}
-            radius={0}
-            label="Brand cover"
-            style={styles.heroGradient}
-            onMediaError={() => setCoverMediaFailed(true)}
-          />
-        ) : (
-          <View style={[styles.heroGradient, { backgroundColor: heroColor }]} />
-        )}
-        <View
-          style={[styles.heroThemeTint, { backgroundColor: palette.pageWash }]}
-        />
-        <View
-          style={[styles.heroFade, { backgroundColor: palette.heroScrim }]}
-        />
+  // ---- shared sub-blocks ----
+  const identityBlock = (
+    <View style={styles.identityRow}>
+      <Avatar brand={brand} palette={palette} />
+      <View style={styles.identityCopy}>
+        {isVerified ? (
+          <Text style={[styles.verifiedBadge, { color: palette.accent }]}>
+            Verified venue
+          </Text>
+        ) : null}
+        <Text
+          style={[styles.brandName, themedFont, { color: palette.primaryText }]}
+        >
+          {brand.displayName}
+        </Text>
+        {address !== null ? (
+          <Text style={[styles.brandAddr, { color: palette.tertiaryText }]}>
+            {address}
+          </Text>
+        ) : null}
       </View>
+    </View>
+  );
 
-      <ScrollView
-        style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
-      >
-        <View
-          style={[
-            styles.identityCentered,
-            {
-              backgroundColor: palette.glassStrong,
-              borderColor: palette.panelBorder,
-            },
-          ]}
-        >
-          <GlassBlur
-            tint={palette.glassTint}
-            intensity={34}
-            style={styles.glassLayer}
-          />
-          <View style={styles.identityTopRow}>
-            <Avatar brand={brand} palette={palette} />
-            <View style={styles.identityCopy}>
-              {venue?.isVerifiedVenue === true ? (
-                <Text style={[styles.verifiedBadge, { color: palette.accent }]}>
-                  Verified venue
-                </Text>
-              ) : null}
-              <Text
-                style={[
-                  styles.brandNameCentered,
-                  themedFont,
-                  { color: palette.primaryText },
-                ]}
-              >
-                {brand.displayName}
-              </Text>
-              {brand.address !== null && brand.address.trim().length > 0 ? (
-                <Text
-                  style={[
-                    styles.handleLineCentered,
-                    { color: palette.tertiaryText },
-                  ]}
-                >
-                  {brand.address.trim()}
-                </Text>
-              ) : null}
-            </View>
-          </View>
+  const socialsBlock =
+    socialEntries.length > 0 ? (
+      <SocialLinksRow
+        entries={socialEntries}
+        palette={palette}
+        onPress={onExternal}
+      />
+    ) : null;
 
-          {brand.tagline !== undefined && brand.tagline.trim().length > 0 ? (
+  const featuredTeaser = showFeaturedTeaser ? (
+    <NextOfferingTeaser
+      item={upcoming[0]}
+      theme={resolvedTheme}
+      palette={palette}
+      onPress={(item) => callbacks.onOpenUpcoming?.(item)}
+    />
+  ) : null;
+
+  const tabBar = (
+    <TabBar
+      tabs={visibleTabs}
+      activeTab={activeTab}
+      palette={palette}
+      surface={surface}
+      theme={resolvedTheme}
+      isDesktop={isDesktop}
+      countForTab={countForTab}
+      onSelect={setActiveTab}
+    />
+  );
+
+  const activePane =
+    activeTab === "upcoming" ? (
+      <UpcomingList
+        rows={upcoming}
+        theme={resolvedTheme}
+        palette={palette}
+        surface={surface}
+        isDesktop={isDesktop}
+        emptyCopy="No upcoming offerings yet"
+        onPress={(item) => callbacks.onOpenUpcoming?.(item)}
+      />
+    ) : activeTab === "events" ? (
+      <EventList
+        events={upcomingEvents}
+        pastEvents={pastEvents}
+        theme={resolvedTheme}
+        palette={palette}
+        surface={surface}
+        isDesktop={isDesktop}
+        emptyCopy="No public events yet"
+        onPress={callbacks.onOpenEvent}
+      />
+    ) : activeTab === "trips" ? (
+      <TripList
+        trips={upcomingTrips}
+        pastTrips={pastTrips}
+        theme={resolvedTheme}
+        palette={palette}
+        surface={surface}
+        isDesktop={isDesktop}
+        emptyCopy="No public trips yet"
+        onPress={callbacks.onOpenTrip}
+      />
+    ) : activeTab === "experiences" ? (
+      <ExperienceList
+        experiences={experiences}
+        theme={resolvedTheme}
+        palette={palette}
+        surface={surface}
+        isDesktop={isDesktop}
+        emptyCopy="No public experiences yet"
+        onPress={callbacks.onOpenExperience}
+      />
+    ) : (
+      <AboutTab
+        brand={brand}
+        theme={resolvedTheme}
+        palette={palette}
+        surface={surface}
+        onExternal={onExternal}
+      />
+    );
+
+  // ---- body (left column / phone flow) ----
+  const bodyContent = (
+    <View>
+      {/* Identity above the tabs ONLY on phone/native — desktop overlays it on
+          the hero + repeats it in the sticky panel. */}
+      {!isDesktop ? (
+        <View style={styles.phoneIdentityWrap}>
+          {identityBlock}
+          {socialsBlock}
+          {featuredTeaser}
+        </View>
+      ) : null}
+
+      {tabBar}
+      <View style={styles.paneWrap}>{activePane}</View>
+    </View>
+  );
+
+  // ---- desktop sticky brand-summary panel (Share + Next-up only) ----
+  const stickyPanel = isDesktop ? (
+    <View style={[styles.deskPanel, surface.cardStrong]}>
+      <View style={[styles.deskAccent, { backgroundColor: palette.accent }]} />
+      <View style={styles.deskInner}>
+        <View style={styles.deskIdentity}>
+          <Avatar brand={brand} palette={palette} size={60} />
+          <View style={styles.identityCopy}>
             <Text
               style={[
-                styles.taglineCentered,
+                styles.deskBrandName,
                 themedFont,
                 { color: palette.primaryText },
               ]}
             >
-              {brand.tagline}
+              {brand.displayName}
             </Text>
-          ) : null}
-          {brand.bio !== undefined && brand.bio.trim().length > 0 ? (
-            <Text
-              style={[styles.bioLeadCentered, { color: palette.secondaryText }]}
-            >
-              {brand.bio}
-            </Text>
-          ) : null}
+            {address !== null ? (
+              <Text style={[styles.brandAddr, { color: palette.tertiaryText }]}>
+                {address}
+              </Text>
+            ) : null}
+          </View>
         </View>
-
-        <SocialLinksRow
-          entries={socialEntries}
-          palette={palette}
-          onPress={onExternal}
-        />
-
-        {upcoming.length > 0 ? (
-          <NextOfferingTeaser
-            item={upcoming[0]}
-            theme={resolvedTheme}
-            palette={palette}
-            onPress={(item) => {
-              if (callbacks.onOpenUpcoming !== undefined) {
-                callbacks.onOpenUpcoming(item);
-              }
-            }}
-          />
-        ) : null}
-
-        <View
-          style={[
-            styles.tabsRow,
-            { backgroundColor: palette.accent, borderColor: palette.accent },
+        {socialsBlock}
+        <Pressable
+          onPress={callbacks.onShare}
+          accessibilityRole="button"
+          accessibilityLabel="Share this brand"
+          style={({ pressed }) => [
+            styles.deskShareBtn,
+            { backgroundColor: palette.accent },
+            pressed && styles.cardPressed,
           ]}
         >
-          <GlassBlur
-            tint={palette.glassTint}
-            intensity={18}
-            style={styles.glassLayer}
-          />
-          {visibleTabs.map((tab) => (
-            <TabButton
-              key={tab}
-              label={tabLabel[tab]}
-              count={countForTab(tab)}
-              active={activeTab === tab}
+          <Text style={[styles.deskShareLabel, { color: palette.accentText }]}>
+            Share
+          </Text>
+        </Pressable>
+        {showFeaturedTeaser ? (
+          <View style={styles.deskNextWrap}>
+            <Text style={[styles.deskNextLabel, { color: palette.tertiaryText }]}>
+              Next up
+            </Text>
+            <NextOfferingTeaser
+              item={upcoming[0]}
               theme={resolvedTheme}
               palette={palette}
-              onPress={() => setActiveTab(tab)}
+              onPress={(item) => callbacks.onOpenUpcoming?.(item)}
             />
-          ))}
-        </View>
-
-        {activeTab === "upcoming" ? (
-          <UpcomingList
-            rows={upcoming}
-            theme={resolvedTheme}
-            palette={palette}
-            emptyCopy="No upcoming offerings yet"
-            onPress={(item) => {
-              if (callbacks.onOpenUpcoming !== undefined) {
-                callbacks.onOpenUpcoming(item);
-              }
-            }}
-          />
-        ) : activeTab === "events" ? (
-          <EventList
-            events={upcomingEvents}
-            pastEvents={pastEvents}
-            theme={resolvedTheme}
-            palette={palette}
-            emptyCopy="No public events yet"
-            onPress={callbacks.onOpenEvent}
-          />
-        ) : activeTab === "trips" ? (
-          <TripList
-            trips={upcomingTrips}
-            pastTrips={pastTrips}
-            theme={resolvedTheme}
-            palette={palette}
-            emptyCopy="No public trips yet"
-            onPress={callbacks.onOpenTrip}
-          />
-        ) : activeTab === "experiences" ? (
-          <ExperienceList
-            experiences={experiences}
-            theme={resolvedTheme}
-            palette={palette}
-            emptyCopy="No public experiences yet"
-            onPress={callbacks.onOpenExperience}
-          />
-        ) : (
-          <AboutTab
-            brand={brand}
-            theme={resolvedTheme}
-            palette={palette}
-            onExternal={onExternal}
-          />
-        )}
-      </ScrollView>
-
-      <ThemeEntranceAnimation
-        theme={resolvedTheme}
-        sessionKey={`brand:${brand.slug}:${resolvedTheme.color}:${resolvedTheme.font}`}
-        replayOnMount
-      />
+          </View>
+        ) : null}
+      </View>
     </View>
+  ) : null;
+
+  // Desktop hero overlay (verified eyebrow + name + address).
+  const heroEyebrow = isVerified ? (
+    <Text style={styles.heroEyebrow}>Verified venue</Text>
+  ) : undefined;
+  const heroTitle = isDesktop ? (
+    <>
+      <Text style={[styles.heroTitle, themedFont]}>{brand.displayName}</Text>
+      {address !== null ? (
+        <Text style={styles.heroAddr}>{address}</Text>
+      ) : null}
+    </>
+  ) : undefined;
+
+  return (
+    <ParallaxCoverShell
+      palette={palette}
+      theme={resolvedTheme}
+      coverMediaUrl={coverUrl}
+      coverMediaType={coverType}
+      coverHue={coverHue}
+      entranceAnimationKey={`brand:${brand.slug}:${resolvedTheme.color}:${resolvedTheme.font}`}
+      muted={muted}
+      onToggleMute={toggleMute}
+      showMute={coverType === "video"}
+      onClose={callbacks.onClose}
+      onShare={callbacks.onShare}
+      heroEyebrow={heroEyebrow}
+      heroTitle={heroTitle}
+      stickyPanel={stickyPanel}
+      safeAreaTop={chromeTopOffset ?? 0}
+      contentBottomInset={0}
+      testID="orch-1155-public-brand"
+    >
+      {bodyContent}
+    </ParallaxCoverShell>
   );
 };
-
-const ChromeButton: React.FC<{
-  label: string;
-  glyph: "x" | "share";
-  onPress: () => void;
-  testID: string;
-}> = ({ label, glyph, onPress, testID }) => (
-  <Pressable
-    onPress={onPress}
-    accessibilityRole="button"
-    accessibilityLabel={label}
-    testID={testID}
-    hitSlop={8}
-    style={styles.chromeButton}
-  >
-    <ChromeGlyph glyph={glyph} />
-  </Pressable>
-);
-
-const ChromeGlyph: React.FC<{ glyph: "x" | "share" }> = ({ glyph }) => (
-  <View style={styles.chromeGlyph} pointerEvents="none">
-    {glyph === "x" ? (
-      <>
-        <View style={[styles.chromeXStroke, styles.chromeXStrokeA]} />
-        <View style={[styles.chromeXStroke, styles.chromeXStrokeB]} />
-      </>
-    ) : (
-      <>
-        <View style={[styles.chromeShareLine, styles.chromeShareLineTop]} />
-        <View style={[styles.chromeShareLine, styles.chromeShareLineBottom]} />
-        <View style={[styles.chromeShareDot, styles.chromeShareDotLeft]} />
-        <View style={[styles.chromeShareDot, styles.chromeShareDotTop]} />
-        <View style={[styles.chromeShareDot, styles.chromeShareDotBottom]} />
-      </>
-    )}
-  </View>
-);
 
 const Avatar: React.FC<{
   brand: PublicBrand;
   palette: ThemePalette;
-}> = ({ brand, palette }) => {
+  size?: number;
+}> = ({ brand, palette, size = 84 }) => {
   const avatarStyle = [
     styles.avatar,
     {
+      width: size,
+      height: size,
+      borderRadius: size / 2,
       backgroundColor: palette.panelStrong,
       borderColor: palette.accent,
       shadowColor: palette.accent,
@@ -773,7 +656,12 @@ const Avatar: React.FC<{
   }
   return (
     <View style={avatarStyle}>
-      <Text style={[styles.avatarInitial, { color: palette.primaryText }]}>
+      <Text
+        style={[
+          styles.avatarInitial,
+          { fontSize: size * 0.42, color: palette.primaryText },
+        ]}
+      >
         {(brand.displayName.charAt(0) || "?").toUpperCase()}
       </Text>
     </View>
@@ -787,17 +675,14 @@ const SocialLinksRow: React.FC<{
 }> = ({ entries, palette, onPress }) => {
   if (entries.length === 0) return null;
   return (
-    <View style={styles.socialsRowCompact}>
+    <View style={styles.socialsRow}>
       {entries.map((entry) => (
         <Pressable
           key={entry.url}
           onPress={() => onPress(entry.url)}
           accessibilityRole="link"
           accessibilityLabel={entry.label}
-          style={[
-            styles.socialBtnIconOnly,
-            { backgroundColor: palette.accent, borderColor: palette.accent },
-          ]}
+          style={[styles.socialBtn, { backgroundColor: palette.accent }]}
         >
           <SocialIcon kind={entry.kind} color="#ffffff" />
         </Pressable>
@@ -811,38 +696,105 @@ const SocialIcon: React.FC<{ kind: SocialKind; color: string }> = ({
   color,
 }) => {
   const Icon = SOCIAL_ICON_BY_KIND[kind];
-  return <Icon color={color} size={23} strokeWidth={2.35} />;
+  return <Icon color={color} size={21} strokeWidth={2.2} />;
 };
 
-const TabButton: React.FC<{
-  label: string;
-  count?: number;
-  active: boolean;
-  theme: ResolvedTheme;
+// ORCH-1155 — horizontally-scrollable tab bar (no clipping; nowrap chips sized to
+// content). Active chip scroll-into-view is best-effort via cached chip offsets
+// (spec OQ-2). I-PROPOSED-1155-TABS-SCROLLABLE.
+const TabBar: React.FC<{
+  tabs: Tab[];
+  activeTab: Tab;
   palette: ThemePalette;
-  onPress: () => void;
-}> = ({ label, count, active, theme, palette, onPress }) => (
-  <Pressable
-    onPress={onPress}
-    accessibilityRole="button"
-    accessibilityState={{ selected: active }}
-    accessibilityLabel={label}
-    style={[styles.tabButton, active && styles.tabButtonActive]}
-  >
-    <Text
-      style={[
-        styles.tabLabel,
-        { fontFamily: theme.fontFamilyValue },
-        { color: "#ffffff" },
-        active && styles.tabLabelActive,
-      ]}
-    >
-      {label}
-      {count !== undefined ? (
-        <Text style={styles.tabCount}> {count}</Text>
+  surface: Surface;
+  theme: ResolvedTheme;
+  isDesktop: boolean;
+  countForTab: (tab: Tab) => number | undefined;
+  onSelect: (tab: Tab) => void;
+}> = ({
+  tabs,
+  activeTab,
+  palette,
+  surface,
+  theme,
+  isDesktop,
+  countForTab,
+  onSelect,
+}) => {
+  const scrollRef = React.useRef<ScrollView>(null);
+  const offsets = React.useRef<Record<string, number>>({});
+  const showEdgeFade = Platform.OS === "web" && !isDesktop;
+
+  useEffect(() => {
+    const x = offsets.current[activeTab];
+    if (typeof x === "number" && scrollRef.current !== null) {
+      scrollRef.current.scrollTo({ x: Math.max(0, x - 16), animated: true });
+    }
+  }, [activeTab]);
+
+  return (
+    <View style={styles.tabBarWrap}>
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.tabsRowContent}
+      >
+        {tabs.map((tab) => {
+          const count = countForTab(tab);
+          const active = activeTab === tab;
+          return (
+            <Pressable
+              key={tab}
+              onLayout={(e: LayoutChangeEvent) => {
+                offsets.current[tab] = e.nativeEvent.layout.x;
+              }}
+              onPress={() => onSelect(tab)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={tabLabel[tab]}
+              style={[
+                styles.tabChip,
+                surface.card,
+                active && {
+                  backgroundColor: palette.accent,
+                  borderColor: palette.accent,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.tabLabel,
+                  { fontFamily: theme.fontFamilyValue },
+                  {
+                    color: active ? palette.accentText : palette.secondaryText,
+                  },
+                ]}
+              >
+                {tabLabel[tab]}
+                {count !== undefined ? (
+                  <Text style={styles.tabCount}> {count}</Text>
+                ) : null}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+      {showEdgeFade ? (
+        <View
+          style={[styles.tabEdgeFade, { backgroundColor: palette.page }]}
+          pointerEvents="none"
+        />
       ) : null}
-    </Text>
-  </Pressable>
+    </View>
+  );
+};
+
+const OfferingGrid: React.FC<{
+  isDesktop: boolean;
+  children: React.ReactNode;
+}> = ({ isDesktop, children }) => (
+  <View style={[styles.grid, isDesktop && styles.gridDesktop]}>{children}</View>
 );
 
 const EventList: React.FC<{
@@ -850,40 +802,60 @@ const EventList: React.FC<{
   pastEvents?: PublicBrandEvent[];
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   emptyCopy: string;
   onPress: (event: PublicBrandEvent) => void;
-}> = ({ events, pastEvents = [], theme, palette, emptyCopy, onPress }) => {
+}> = ({
+  events,
+  pastEvents = [],
+  theme,
+  palette,
+  surface,
+  isDesktop,
+  emptyCopy,
+  onPress,
+}) => {
   if (events.length === 0 && pastEvents.length === 0) {
-    return (
-      <View style={styles.emptyTabWrap}>
-        <Text style={[styles.emptyTabTitle, { color: palette.secondaryText }]}>
-          {emptyCopy}
-        </Text>
-      </View>
-    );
+    return <EmptyPane copy={emptyCopy} palette={palette} />;
   }
   return (
-    <View style={styles.eventList}>
-      {events.map((event, index) => (
-        <EventMiniCard
-          key={event.id}
-          event={event}
-          theme={theme}
-          palette={palette}
-          onPress={onPress}
-          pinCta={index < PINNED_CTA_CARD_COUNT}
-        />
-      ))}
-      {pastEvents.map((event) => (
-        <EventMiniCard
-          key={event.id}
-          event={event}
-          theme={theme}
-          palette={palette}
-          onPress={onPress}
-          past
-        />
-      ))}
+    <View>
+      <OfferingGrid isDesktop={isDesktop}>
+        {events.map((event, index) => (
+          <EventMiniCard
+            key={event.id}
+            event={event}
+            theme={theme}
+            palette={palette}
+            surface={surface}
+            isDesktop={isDesktop}
+            onPress={onPress}
+            pinCta={index < PINNED_CTA_CARD_COUNT}
+          />
+        ))}
+      </OfferingGrid>
+      {pastEvents.length > 0 ? (
+        <>
+          <Text style={[styles.pastHead, { color: palette.tertiaryText }]}>
+            Past
+          </Text>
+          <OfferingGrid isDesktop={isDesktop}>
+            {pastEvents.map((event) => (
+              <EventMiniCard
+                key={event.id}
+                event={event}
+                theme={theme}
+                palette={palette}
+                surface={surface}
+                isDesktop={isDesktop}
+                onPress={onPress}
+                past
+              />
+            ))}
+          </OfferingGrid>
+        </>
+      ) : null}
     </View>
   );
 };
@@ -892,10 +864,21 @@ const EventMiniCard: React.FC<{
   event: PublicBrandEvent;
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   onPress: (event: PublicBrandEvent) => void;
   pinCta?: boolean;
   past?: boolean;
-}> = ({ event, theme, palette, onPress, pinCta = false, past = false }) => {
+}> = ({
+  event,
+  theme,
+  palette,
+  surface,
+  isDesktop,
+  onPress,
+  pinCta = false,
+  past = false,
+}) => {
   const price = minPriceLabel(
     event.tickets,
     event.currency,
@@ -908,29 +891,25 @@ const EventMiniCard: React.FC<{
       accessibilityRole="button"
       accessibilityLabel={`Open event ${event.name}`}
       style={({ pressed }) => [
-        styles.eventCard,
-        { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
-        past && styles.eventCardPast,
+        styles.oCard,
+        surface.card,
+        isDesktop && styles.oCardDesktop,
+        past && styles.oCardPast,
         pressed && styles.cardPressed,
       ]}
     >
-      <GlassBlur
-        tint={palette.glassTint}
-        intensity={24}
-        style={styles.glassLayer}
-      />
       <CoverBlock
         hue={event.coverHue}
         mediaUrl={event.coverMediaUrl}
         mediaType={event.coverMediaType}
       />
-      <View style={styles.eventBody}>
-        <Text style={[styles.eventDate, { color: palette.accent }]}>
+      <View style={styles.oCardBody}>
+        <Text style={[styles.oCardDate, { color: palette.accent }]}>
           {event.dateLine}
         </Text>
         <Text
           style={[
-            styles.eventTitle,
+            styles.oCardTitle,
             { fontFamily: theme.fontFamilyValue, color: palette.primaryText },
           ]}
           numberOfLines={2}
@@ -939,28 +918,26 @@ const EventMiniCard: React.FC<{
         </Text>
         {event.venueName !== null && event.venueName.length > 0 ? (
           <Text
-            style={[styles.eventVenue, { color: palette.tertiaryText }]}
+            style={[styles.oCardMeta, { color: palette.tertiaryText }]}
             numberOfLines={1}
           >
             {event.venueName}
           </Text>
         ) : event.format === "online" || event.format === "hybrid" ? (
-          <Text style={[styles.eventVenue, { color: palette.tertiaryText }]}>
+          <Text style={[styles.oCardMeta, { color: palette.tertiaryText }]}>
             Online event
           </Text>
         ) : null}
         {price !== null ? (
-          <Text style={[styles.eventPrice, { color: palette.primaryText }]}>
+          <Text style={[styles.oCardPrice, { color: palette.primaryText }]}>
             {price}
           </Text>
         ) : null}
-        {pinCta ? (
+        {pinCta && !past ? (
           <View
-            style={[styles.eventBuyPill, { backgroundColor: palette.accent }]}
+            style={[styles.buyPill, { backgroundColor: palette.accent }]}
           >
-            <Text
-              style={[styles.eventBuyPillLabel, { color: palette.accentText }]}
-            >
+            <Text style={[styles.buyPillLabel, { color: palette.accentText }]}>
               Buy tickets
             </Text>
           </View>
@@ -980,8 +957,8 @@ const NextOfferingTeaser: React.FC<{
   const dateLine = formatUpcomingDateLine(item.startsAt);
   const bodyText =
     price !== null
-      ? `${dateLine} - ${item.name} - ${price}`
-      : `${dateLine} - ${item.name}`;
+      ? `${dateLine} · ${item.name} · ${price}`
+      : `${dateLine} · ${item.name}`;
   return (
     <Pressable
       onPress={() => onPress(item)}
@@ -989,26 +966,28 @@ const NextOfferingTeaser: React.FC<{
       accessibilityLabel={`Next offering ${item.name}`}
       style={({ pressed }) => [
         styles.nextTeaser,
-        { backgroundColor: palette.accent, borderColor: palette.accent },
+        { backgroundColor: palette.accent },
         pressed && styles.cardPressed,
       ]}
     >
-      <GlassBlur
-        tint={palette.glassTint}
-        intensity={14}
-        style={styles.glassLayer}
-      />
       <View style={styles.nextTeaserCopy}>
-        <Text style={styles.nextTeaserLabel}>NEXT EVENT</Text>
+        <Text style={[styles.nextTeaserLabel, { color: palette.accentText }]}>
+          NEXT UP · {item.offeringType.toUpperCase()}
+        </Text>
         <Text
-          style={[styles.nextTeaserBody, { fontFamily: theme.fontFamilyValue }]}
+          style={[
+            styles.nextTeaserBody,
+            { fontFamily: theme.fontFamilyValue, color: palette.accentText },
+          ]}
           numberOfLines={2}
         >
           {bodyText}
         </Text>
       </View>
       <View style={styles.nextTeaserAction}>
-        <Text style={styles.nextTeaserActionText}>View</Text>
+        <Text style={[styles.nextTeaserActionText, { color: palette.accentText }]}>
+          View
+        </Text>
       </View>
     </Pressable>
   );
@@ -1019,39 +998,59 @@ const TripList: React.FC<{
   pastTrips?: PublicBrandTrip[];
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   emptyCopy: string;
   onPress: (trip: PublicBrandTrip) => void;
-}> = ({ trips, pastTrips = [], theme, palette, emptyCopy, onPress }) => {
+}> = ({
+  trips,
+  pastTrips = [],
+  theme,
+  palette,
+  surface,
+  isDesktop,
+  emptyCopy,
+  onPress,
+}) => {
   if (trips.length === 0 && pastTrips.length === 0) {
-    return (
-      <View style={styles.emptyTabWrap}>
-        <Text style={[styles.emptyTabTitle, { color: palette.secondaryText }]}>
-          {emptyCopy}
-        </Text>
-      </View>
-    );
+    return <EmptyPane copy={emptyCopy} palette={palette} />;
   }
   return (
-    <View style={styles.eventList}>
-      {trips.map((trip) => (
-        <TripMiniCard
-          key={trip.id}
-          trip={trip}
-          theme={theme}
-          palette={palette}
-          onPress={onPress}
-        />
-      ))}
-      {pastTrips.map((trip) => (
-        <TripMiniCard
-          key={trip.id}
-          trip={trip}
-          theme={theme}
-          palette={palette}
-          onPress={onPress}
-          past
-        />
-      ))}
+    <View>
+      <OfferingGrid isDesktop={isDesktop}>
+        {trips.map((trip) => (
+          <TripMiniCard
+            key={trip.id}
+            trip={trip}
+            theme={theme}
+            palette={palette}
+            surface={surface}
+            isDesktop={isDesktop}
+            onPress={onPress}
+          />
+        ))}
+      </OfferingGrid>
+      {pastTrips.length > 0 ? (
+        <>
+          <Text style={[styles.pastHead, { color: palette.tertiaryText }]}>
+            Past
+          </Text>
+          <OfferingGrid isDesktop={isDesktop}>
+            {pastTrips.map((trip) => (
+              <TripMiniCard
+                key={trip.id}
+                trip={trip}
+                theme={theme}
+                palette={palette}
+                surface={surface}
+                isDesktop={isDesktop}
+                onPress={onPress}
+                past
+              />
+            ))}
+          </OfferingGrid>
+        </>
+      ) : null}
     </View>
   );
 };
@@ -1060,9 +1059,11 @@ const TripMiniCard: React.FC<{
   trip: PublicBrandTrip;
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   onPress: (trip: PublicBrandTrip) => void;
   past?: boolean;
-}> = ({ trip, theme, palette, onPress, past = false }) => {
+}> = ({ trip, theme, palette, surface, isDesktop, onPress, past = false }) => {
   const dateLine = formatTripDateRange(trip.startAt, trip.endAt, trip.timezone);
   const price =
     trip.minPriceCents !== null && trip.currency !== null
@@ -1085,31 +1086,27 @@ const TripMiniCard: React.FC<{
       accessibilityRole="button"
       accessibilityLabel={`Open trip ${trip.title}`}
       style={({ pressed }) => [
-        styles.eventCard,
-        { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
-        past && styles.eventCardPast,
+        styles.oCard,
+        surface.card,
+        isDesktop && styles.oCardDesktop,
+        past && styles.oCardPast,
         pressed && styles.cardPressed,
       ]}
     >
-      <GlassBlur
-        tint={palette.glassTint}
-        intensity={24}
-        style={styles.glassLayer}
-      />
       <CoverBlock
         hue={hashHueFromString(trip.id)}
         mediaUrl={trip.coverMediaUrl}
         mediaType={trip.coverMediaType}
       />
-      <View style={styles.eventBody}>
+      <View style={styles.oCardBody}>
         {dateLine.length > 0 ? (
-          <Text style={[styles.eventDate, { color: palette.accent }]}>
+          <Text style={[styles.oCardDate, { color: palette.accent }]}>
             {dateLine}
           </Text>
         ) : null}
         <Text
           style={[
-            styles.eventTitle,
+            styles.oCardTitle,
             { fontFamily: theme.fontFamilyValue, color: palette.primaryText },
           ]}
           numberOfLines={2}
@@ -1118,49 +1115,37 @@ const TripMiniCard: React.FC<{
         </Text>
         {trip.destinationText !== null && trip.destinationText.length > 0 ? (
           <Text
-            style={[styles.eventVenue, { color: palette.tertiaryText }]}
+            style={[styles.oCardMeta, { color: palette.tertiaryText }]}
             numberOfLines={1}
           >
             {trip.destinationText}
           </Text>
         ) : null}
-        <View style={styles.tripFooterRow}>
+        <View style={styles.oCardFoot}>
           {price !== null ? (
-            <Text style={[styles.eventPrice, { color: palette.primaryText }]}>
+            <Text style={[styles.oCardPrice, { color: palette.primaryText }]}>
               {price}
             </Text>
           ) : (
             <View />
           )}
           {trip.bookingsClosed ? (
-            <View
-              style={[
-                styles.tripBadgeClosed,
-                {
-                  backgroundColor: palette.panel,
-                  borderColor: palette.cardBorder,
-                },
-              ]}
-            >
-              <Text
-                style={[styles.tripBadgeLabel, { color: palette.primaryText }]}
-              >
+            <View style={[styles.badge, surface.cardStrong]}>
+              <Text style={[styles.badgeLabel, { color: palette.secondaryText }]}>
                 Booking closed
               </Text>
             </View>
           ) : spotsLabel !== null ? (
             <View
               style={[
-                styles.tripBadgeScarce,
+                styles.badge,
                 {
                   backgroundColor: palette.accentWash,
                   borderColor: palette.panelBorder,
                 },
               ]}
             >
-              <Text
-                style={[styles.tripBadgeLabel, { color: palette.primaryText }]}
-              >
+              <Text style={[styles.badgeLabel, { color: palette.primaryText }]}>
                 {spotsLabel}
               </Text>
             </View>
@@ -1171,62 +1156,32 @@ const TripMiniCard: React.FC<{
   );
 };
 
-const offeringPriceLabel = (item: {
-  isFree?: boolean;
-  priceFromMinorUnits?: number | null;
-  currency?: string | null;
-}): string | null => {
-  if (
-    item.priceFromMinorUnits !== null &&
-    item.priceFromMinorUnits !== undefined
-  ) {
-    return `From ${formatCurrencyRound(
-      item.priceFromMinorUnits / 100,
-      item.currency ?? "USD",
-    )}`;
-  }
-  return item.isFree === true ? "Free" : null;
-};
-
-const formatUpcomingDateLine = (startsAt: string | null): string => {
-  if (startsAt === null) return "Date TBA";
-  const date = new Date(startsAt);
-  if (Number.isNaN(date.getTime())) return "Date TBA";
-  return date.toLocaleDateString("en-GB", {
-    weekday: "short",
-    day: "numeric",
-    month: "short",
-  });
-};
-
 const UpcomingList: React.FC<{
   rows: PublicBrandUpcoming[];
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   emptyCopy: string;
   onPress: (item: PublicBrandUpcoming) => void;
-}> = ({ rows, theme, palette, emptyCopy, onPress }) => {
+}> = ({ rows, theme, palette, surface, isDesktop, emptyCopy, onPress }) => {
   if (rows.length === 0) {
-    return (
-      <View style={styles.emptyTabWrap}>
-        <Text style={[styles.emptyTabTitle, { color: palette.secondaryText }]}>
-          {emptyCopy}
-        </Text>
-      </View>
-    );
+    return <EmptyPane copy={emptyCopy} palette={palette} />;
   }
   return (
-    <View style={styles.eventList}>
+    <OfferingGrid isDesktop={isDesktop}>
       {rows.map((item) => (
         <OfferingMiniCard
           key={`${item.offeringType}:${item.offeringId}`}
           item={item}
           theme={theme}
           palette={palette}
+          surface={surface}
+          isDesktop={isDesktop}
           onPress={onPress}
         />
       ))}
-    </View>
+    </OfferingGrid>
   );
 };
 
@@ -1234,8 +1189,10 @@ const OfferingMiniCard: React.FC<{
   item: PublicBrandUpcoming;
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   onPress: (item: PublicBrandUpcoming) => void;
-}> = ({ item, theme, palette, onPress }) => {
+}> = ({ item, theme, palette, surface, isDesktop, onPress }) => {
   const price = offeringPriceLabel(item);
   return (
     <Pressable
@@ -1243,39 +1200,35 @@ const OfferingMiniCard: React.FC<{
       accessibilityRole="button"
       accessibilityLabel={`Open ${item.offeringType} ${item.name}`}
       style={({ pressed }) => [
-        styles.eventCard,
-        { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
+        styles.oCard,
+        surface.card,
+        isDesktop && styles.oCardDesktop,
         pressed && styles.cardPressed,
       ]}
     >
-      <GlassBlur
-        tint={palette.glassTint}
-        intensity={24}
-        style={styles.glassLayer}
-      />
       <CoverBlock
         hue={hashHueFromString(item.offeringId)}
         mediaUrl={item.coverMediaUrl}
         mediaType={item.coverMediaType}
       />
-      <View style={styles.eventBody}>
-        <Text style={[styles.eventDate, { color: palette.accent }]}>
+      <View style={styles.oCardBody}>
+        <Text style={[styles.oCardDate, { color: palette.accent }]}>
           {formatUpcomingDateLine(item.startsAt)}
         </Text>
         <Text
           style={[
-            styles.eventTitle,
+            styles.oCardTitle,
             { fontFamily: theme.fontFamilyValue, color: palette.primaryText },
           ]}
           numberOfLines={2}
         >
           {item.name.length > 0 ? item.name : "Untitled offering"}
         </Text>
-        <Text style={[styles.eventVenue, { color: palette.tertiaryText }]}>
+        <Text style={[styles.oCardMeta, { color: palette.tertiaryText }]}>
           {item.offeringType}
         </Text>
         {price !== null ? (
-          <Text style={[styles.eventPrice, { color: palette.primaryText }]}>
+          <Text style={[styles.oCardPrice, { color: palette.primaryText }]}>
             {price}
           </Text>
         ) : null}
@@ -1288,30 +1241,28 @@ const ExperienceList: React.FC<{
   experiences: PublicBrandExperience[];
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   emptyCopy: string;
   onPress?: (experience: PublicBrandExperience) => void;
-}> = ({ experiences, theme, palette, emptyCopy, onPress }) => {
+}> = ({ experiences, theme, palette, surface, isDesktop, emptyCopy, onPress }) => {
   if (experiences.length === 0) {
-    return (
-      <View style={styles.emptyTabWrap}>
-        <Text style={[styles.emptyTabTitle, { color: palette.secondaryText }]}>
-          {emptyCopy}
-        </Text>
-      </View>
-    );
+    return <EmptyPane copy={emptyCopy} palette={palette} />;
   }
   return (
-    <View style={styles.eventList}>
+    <OfferingGrid isDesktop={isDesktop}>
       {experiences.map((experience) => (
         <ExperienceMiniCard
           key={experience.experienceId}
           experience={experience}
           theme={theme}
           palette={palette}
+          surface={surface}
+          isDesktop={isDesktop}
           onPress={onPress}
         />
       ))}
-    </View>
+    </OfferingGrid>
   );
 };
 
@@ -1319,8 +1270,10 @@ const ExperienceMiniCard: React.FC<{
   experience: PublicBrandExperience;
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
+  isDesktop: boolean;
   onPress?: (experience: PublicBrandExperience) => void;
-}> = ({ experience, theme, palette, onPress }) => {
+}> = ({ experience, theme, palette, surface, isDesktop, onPress }) => {
   const price = offeringPriceLabel(experience);
   return (
     <Pressable
@@ -1328,30 +1281,28 @@ const ExperienceMiniCard: React.FC<{
       accessibilityRole="button"
       accessibilityLabel={`Open experience ${experience.name}`}
       style={({ pressed }) => [
-        styles.eventCard,
-        { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
+        styles.oCard,
+        surface.card,
+        isDesktop && styles.oCardDesktop,
         pressed && styles.cardPressed,
       ]}
     >
-      <GlassBlur
-        tint={palette.glassTint}
-        intensity={24}
-        style={styles.glassLayer}
-      />
       <CoverBlock
         hue={hashHueFromString(experience.experienceId)}
         mediaUrl={experience.coverMediaUrl}
-        mediaType="image"
+        // ORCH-1155 — render the experience's REAL cover media type (video/gif),
+        // not the prior hardcoded "image". (SC-9 card.)
+        mediaType={experience.coverMediaType}
       />
-      <View style={styles.eventBody}>
+      <View style={styles.oCardBody}>
         {experience.nextOccurrenceAt !== null ? (
-          <Text style={[styles.eventDate, { color: palette.accent }]}>
+          <Text style={[styles.oCardDate, { color: palette.accent }]}>
             {formatUpcomingDateLine(experience.nextOccurrenceAt)}
           </Text>
         ) : null}
         <Text
           style={[
-            styles.eventTitle,
+            styles.oCardTitle,
             { fontFamily: theme.fontFamilyValue, color: palette.primaryText },
           ]}
           numberOfLines={2}
@@ -1360,14 +1311,14 @@ const ExperienceMiniCard: React.FC<{
         </Text>
         {experience.venueText !== null && experience.venueText.length > 0 ? (
           <Text
-            style={[styles.eventVenue, { color: palette.tertiaryText }]}
+            style={[styles.oCardMeta, { color: palette.tertiaryText }]}
             numberOfLines={1}
           >
             {experience.venueText}
           </Text>
         ) : null}
         {price !== null ? (
-          <Text style={[styles.eventPrice, { color: palette.primaryText }]}>
+          <Text style={[styles.oCardPrice, { color: palette.primaryText }]}>
             {price}
           </Text>
         ) : null}
@@ -1387,549 +1338,481 @@ const CoverBlock: React.FC<{
     mediaType={mediaType as PublicMediaType | null}
     radius={0}
     label="Cover"
-    style={styles.eventCover}
+    style={styles.oCardCover}
   />
 );
 
+const EmptyPane: React.FC<{ copy: string; palette: ThemePalette }> = ({
+  copy,
+  palette,
+}) => (
+  <View style={styles.emptyWrap}>
+    <Text style={styles.emptyEmoji}>🗺️</Text>
+    <Text style={[styles.emptyTitle, { color: palette.primaryText }]}>
+      Nothing on the calendar yet
+    </Text>
+    <Text style={[styles.emptySub, { color: palette.tertiaryText }]}>
+      {copy}. Check back soon.
+    </Text>
+  </View>
+);
+
+// ORCH-1155 — About pane: tagline → bio (4-line clamp + Read more) → contact.
 const AboutTab: React.FC<{
   brand: PublicBrand;
   theme: ResolvedTheme;
   palette: ThemePalette;
+  surface: Surface;
   onExternal: (url: string) => void;
-}> = ({ brand, theme, palette, onExternal }) => (
-  <View style={styles.aboutWrap}>
-    {brand.bio !== undefined && brand.bio.trim().length > 0 ? (
-      <View
-        style={[
-          styles.aboutBlock,
-          { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
-        ]}
-      >
-        <GlassBlur
-          tint={palette.glassTint}
-          intensity={22}
-          style={styles.glassLayer}
-        />
+}> = ({ brand, theme, palette, surface, onExternal }) => {
+  const tagline =
+    brand.tagline !== undefined && brand.tagline.trim().length > 0
+      ? brand.tagline.trim()
+      : null;
+  const bio =
+    brand.bio !== undefined && brand.bio.trim().length > 0
+      ? brand.bio.trim()
+      : null;
+  const email = brand.contact?.email;
+  const phone = brand.contact?.phone;
+  const hasContact = email !== undefined || phone !== undefined;
+
+  return (
+    <View style={styles.aboutWrap}>
+      {tagline !== null ? (
         <Text
           style={[
-            styles.aboutBlockLabel,
-            { fontFamily: theme.fontFamilyValue, color: palette.tertiaryText },
+            styles.tagline,
+            { fontFamily: theme.fontFamilyValue, color: palette.primaryText },
           ]}
         >
-          About
+          {tagline}
         </Text>
-        <Text style={[styles.aboutBlockBody, { color: palette.secondaryText }]}>
-          {brand.bio}
-        </Text>
-      </View>
-    ) : null}
-    {brand.contact?.email !== undefined ||
-    brand.contact?.phone !== undefined ? (
-      <View
-        style={[
-          styles.aboutBlock,
-          { backgroundColor: palette.glass, borderColor: palette.cutoutBorder },
-        ]}
+      ) : null}
+      {bio !== null ? (
+        <ClampedBio text={bio} palette={palette} />
+      ) : null}
+      {hasContact ? (
+        <View style={styles.contactWrap}>
+          {email !== undefined ? (
+            <Pressable
+              onPress={() => onExternal(`mailto:${email}`)}
+              accessibilityRole="link"
+              accessibilityLabel={`Email ${email}`}
+              style={[styles.contactRow, surface.card]}
+            >
+              <Text style={[styles.contactLabel, { color: palette.tertiaryText }]}>
+                Email
+              </Text>
+              <Text style={[styles.contactVal, { color: palette.primaryText }]}>
+                {email}
+              </Text>
+            </Pressable>
+          ) : null}
+          {phone !== undefined ? (
+            <Pressable
+              onPress={() => onExternal(`tel:${phone}`)}
+              accessibilityRole="link"
+              accessibilityLabel={`Call ${phone}`}
+              style={[styles.contactRow, surface.card]}
+            >
+              <Text style={[styles.contactLabel, { color: palette.tertiaryText }]}>
+                Phone
+              </Text>
+              <Text style={[styles.contactVal, { color: palette.primaryText }]}>
+                {phone}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+const ClampedBio: React.FC<{ text: string; palette: ThemePalette }> = ({
+  text,
+  palette,
+}) => {
+  const [expanded, setExpanded] = useState<boolean>(false);
+  // Heuristic: a bio long enough to plausibly exceed 4 lines gets the toggle.
+  const couldClamp = text.length > 220;
+  return (
+    <View style={styles.bioWrap}>
+      <Text
+        style={[styles.bio, { color: palette.secondaryText }]}
+        numberOfLines={expanded ? undefined : BIO_CLAMP_LINES}
       >
-        <GlassBlur
-          tint={palette.glassTint}
-          intensity={22}
-          style={styles.glassLayer}
-        />
-        <Text
-          style={[
-            styles.aboutBlockLabel,
-            { fontFamily: theme.fontFamilyValue, color: palette.tertiaryText },
-          ]}
+        {text}
+      </Text>
+      {couldClamp ? (
+        <Pressable
+          onPress={() => setExpanded((v) => !v)}
+          accessibilityRole="button"
+          accessibilityLabel={expanded ? "Show less" : "Read more"}
         >
-          Contact
-        </Text>
-        {brand.contact?.email !== undefined ? (
-          <Pressable
-            onPress={() => onExternal(`mailto:${brand.contact?.email}`)}
-          >
-            <Text style={[styles.aboutContactLink, { color: palette.accent }]}>
-              {brand.contact.email}
-            </Text>
-          </Pressable>
-        ) : null}
-        {brand.contact?.phone !== undefined ? (
-          <Pressable onPress={() => onExternal(`tel:${brand.contact?.phone}`)}>
-            <Text style={[styles.aboutContactLink, { color: palette.accent }]}>
-              {brand.contact.phone}
-            </Text>
-          </Pressable>
-        ) : null}
-      </View>
-    ) : null}
-  </View>
-);
+          <Text style={[styles.readMore, { color: palette.accent }]}>
+            {expanded ? "Show less" : "Read more"}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
-  host: {
-    flex: 1,
-    backgroundColor,
+  // ---- identity ----
+  phoneIdentityWrap: {
+    marginBottom: 4,
   },
-  heroWrap: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 380,
-    overflow: "hidden",
-    zIndex: 0,
-  },
-  heroGradient: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(255,255,255,0.04)",
-  },
-  heroFade: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(12,14,18,0.30)",
-  },
-  heroThemeTint: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  floatingChrome: {
-    position: "absolute",
-    top: spacing.lg,
-    left: spacing.md,
-    right: spacing.md,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    zIndex: 4,
-    elevation: 8,
-  },
-  chromeButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: "rgba(0,0,0,0.48)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  chromeGlyph: {
-    width: 18,
-    height: 18,
-  },
-  chromeXStroke: {
-    position: "absolute",
-    top: 8,
-    left: 2,
-    width: 14,
-    height: 2,
-    borderRadius: 1,
-    backgroundColor: text.primary,
-  },
-  chromeXStrokeA: {
-    transform: [{ rotate: "45deg" }],
-  },
-  chromeXStrokeB: {
-    transform: [{ rotate: "-45deg" }],
-  },
-  chromeShareLine: {
-    position: "absolute",
-    left: 5,
-    width: 9,
-    height: 2,
-    borderRadius: 1,
-    backgroundColor: text.primary,
-  },
-  chromeShareLineTop: {
-    top: 6,
-    transform: [{ rotate: "-24deg" }],
-  },
-  chromeShareLineBottom: {
-    top: 11,
-    transform: [{ rotate: "24deg" }],
-  },
-  chromeShareDot: {
-    position: "absolute",
-    width: 5,
-    height: 5,
-    borderRadius: 2.5,
-    backgroundColor: text.primary,
-  },
-  chromeShareDotLeft: {
-    left: 1,
-    top: 7,
-  },
-  chromeShareDotTop: {
-    right: 1,
-    top: 2,
-  },
-  chromeShareDotBottom: {
-    right: 1,
-    bottom: 2,
-  },
-  scroll: {
-    flex: 1,
-    zIndex: 1,
-  },
-  scrollContent: {
-    paddingTop: 284,
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing.xl * 2,
-  },
-  glassLayer: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  identityCentered: {
-    alignItems: "stretch",
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
-    position: "relative",
-    overflow: "hidden",
-    paddingHorizontal: spacing.xl,
-    paddingVertical: spacing.xl,
-    borderRadius: radius.md,
-    borderWidth: 1,
-    marginTop: 0,
-    marginBottom: spacing.lg,
-    shadowColor: "#000000",
-    shadowOpacity: 0.22,
-    shadowRadius: 30,
-    shadowOffset: { width: 0, height: 18 },
-    elevation: 7,
-  },
-  identityTopRow: {
+  identityRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: spacing.xl,
+    gap: spacing.md,
   },
   identityCopy: {
     flex: 1,
     minWidth: 0,
   },
   avatar: {
-    width: 104,
-    height: 104,
-    borderRadius: 52,
-    backgroundColor: "rgba(255,255,255,0.10)",
     alignItems: "center",
     justifyContent: "center",
-    borderWidth: 4,
-    borderColor: "rgba(255,255,255,0.20)",
-    marginTop: 0,
+    borderWidth: 3,
+    overflow: "hidden",
     shadowOpacity: 0.26,
-    shadowRadius: 24,
-    shadowOffset: { width: 0, height: 12 },
-    elevation: 4,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 10 },
   },
   avatarInitial: {
-    color: text.primary,
-    fontSize: 38,
     fontWeight: "900",
-  },
-  brandNameCentered: {
-    fontSize: 38,
-    lineHeight: 42,
-    fontWeight: "900",
-    color: text.primary,
-    marginTop: spacing.xs,
-    textAlign: "left",
   },
   verifiedBadge: {
-    color: accent.warm,
     fontSize: 10,
     fontWeight: "900",
     letterSpacing: 1.4,
     textTransform: "uppercase",
+    marginBottom: 4,
   },
-  handleLineCentered: {
-    fontSize: 14,
-    lineHeight: 19,
-    color: text.tertiary,
-    marginTop: spacing.xs,
-    textAlign: "left",
+  brandName: {
+    fontSize: 30,
+    lineHeight: 33,
+    fontWeight: "900",
+    letterSpacing: -0.5,
   },
-  bioLeadCentered: {
-    fontSize: 16,
-    color: text.secondary,
-    lineHeight: 25,
-    marginTop: spacing.md,
-    textAlign: "left",
+  brandAddr: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 4,
   },
-  taglineCentered: {
-    fontSize: 24,
-    fontWeight: "800",
-    color: text.tertiary,
-    lineHeight: 30,
-    marginTop: spacing.lg,
-    textAlign: "left",
-  },
-  socialsRowCompact: {
+  // ---- socials ----
+  socialsRow: {
     flexDirection: "row",
-    justifyContent: "center",
     flexWrap: "wrap",
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
-    marginTop: 0,
-    marginBottom: spacing.lg,
-    gap: spacing.sm,
+    gap: 10,
+    marginTop: 18,
   },
-  socialBtnIconOnly: {
-    width: 50,
-    height: 50,
+  socialBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 999,
     alignItems: "center",
     justifyContent: "center",
-    borderRadius: 999,
-    backgroundColor: "rgba(255, 255, 255, 0.06)",
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.08)",
-  },
-  nextTeaser: {
-    flexDirection: "row",
-    alignItems: "center",
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
-    position: "relative",
     overflow: "hidden",
-    gap: spacing.md,
-    minHeight: 86,
-    paddingVertical: spacing.lg,
-    paddingHorizontal: spacing.lg,
-    borderRadius: radius.sm,
-    backgroundColor: accent.tint,
-    borderWidth: 1,
-    marginBottom: spacing.lg,
-    shadowColor: "#000000",
-    shadowOpacity: 0.14,
-    shadowRadius: 18,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 3,
+  },
+  // ---- featured teaser ----
+  nextTeaser: {
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: 18,
+    marginTop: 22,
+    borderRadius: 18,
+    paddingVertical: 22,
+    paddingHorizontal: 22,
   },
   nextTeaserCopy: {
-    flex: 1,
+    width: "100%",
     minWidth: 0,
   },
   nextTeaserLabel: {
-    color: "#ffffff",
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: "900",
     letterSpacing: 1.4,
+    opacity: 0.92,
   },
   nextTeaserBody: {
-    fontSize: 18,
+    fontSize: 17,
     lineHeight: 23,
-    color: "#ffffff",
     fontWeight: "800",
-    marginTop: 5,
+    marginTop: 10,
   },
   nextTeaserAction: {
-    minWidth: 58,
-    minHeight: 40,
-    paddingHorizontal: spacing.md,
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: radius.sm,
-    backgroundColor: "rgba(255,255,255,0.18)",
+    alignSelf: "flex-start",
+    paddingHorizontal: 20,
+    paddingVertical: 9,
+    borderRadius: 12,
+    backgroundColor: "rgba(255,255,255,0.20)",
     borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.24)",
+    borderColor: "rgba(255,255,255,0.28)",
   },
   nextTeaserActionText: {
-    color: "#ffffff",
     fontSize: 13,
     fontWeight: "900",
   },
-  tabsRow: {
-    flexDirection: "row",
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
+  // ---- tab bar ----
+  tabBarWrap: {
     position: "relative",
-    overflow: "hidden",
-    gap: 4,
-    borderWidth: 1,
-    borderRadius: radius.full,
-    padding: 5,
-    marginBottom: spacing.lg,
-    shadowColor: "#000000",
-    shadowOpacity: 0.12,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 3,
+    marginTop: 22,
   },
-  tabButton: {
-    flex: 1,
-    minHeight: 42,
-    alignItems: "center",
-    justifyContent: "center",
+  tabsRowContent: {
+    flexDirection: "row",
+    gap: 6,
+    paddingVertical: 2,
+    paddingRight: 6,
+  },
+  tabChip: {
+    flexGrow: 0,
+    flexShrink: 0,
+    borderRadius: 999,
+    paddingHorizontal: 16,
     paddingVertical: 10,
-    paddingHorizontal: spacing.sm,
-    borderRadius: radius.full,
-    marginBottom: 0,
-  },
-  tabButtonActive: {
-    backgroundColor: "rgba(255,255,255,0.22)",
-    borderWidth: 1,
-    borderColor: "rgba(255,255,255,0.36)",
+    overflow: "hidden",
   },
   tabLabel: {
-    fontSize: 12,
+    fontSize: 13,
     fontWeight: "800",
-    color: text.tertiary,
-    textAlign: "center",
-  },
-  tabLabelActive: {
-    fontWeight: "900",
   },
   tabCount: {
-    color: "rgba(255,255,255,0.72)",
     fontWeight: "700",
-  },
-  eventList: {
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
-    gap: spacing.xl,
-  },
-  eventCard: {
-    flexDirection: "column",
-    position: "relative",
-    backgroundColor: "rgba(255, 255, 255, 0.04)",
-    borderRadius: radius.md,
-    overflow: "hidden",
-    borderWidth: 1.5,
-    borderColor: "rgba(255, 255, 255, 0.06)",
-    shadowColor: "#000000",
-    shadowOpacity: 0.28,
-    shadowRadius: 30,
-    shadowOffset: { width: 0, height: 18 },
-    elevation: 8,
-  },
-  eventCardPast: {
     opacity: 0.7,
+  },
+  tabEdgeFade: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    width: 28,
+    height: "100%",
+    opacity: 0.85,
+  },
+  // ---- panes ----
+  paneWrap: {
+    marginTop: 18,
+  },
+  grid: {
+    gap: 18,
+  },
+  gridDesktop: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 20,
+  },
+  pastHead: {
+    fontSize: 11,
+    fontWeight: "900",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    marginTop: 24,
+    marginBottom: 4,
+  },
+  // ---- offering card ----
+  oCard: {
+    borderRadius: 16,
+    overflow: "hidden",
+  },
+  oCardDesktop: {
+    width: "48%",
+  },
+  oCardPast: {
+    opacity: 0.62,
   },
   cardPressed: {
-    opacity: 0.7,
+    opacity: 0.78,
   },
-  eventCover: {
+  oCardCover: {
     width: "100%",
     height: 184,
   },
-  eventBody: {
-    padding: spacing.lg,
-    gap: spacing.xs,
+  oCardBody: {
+    padding: 14,
+    gap: 4,
   },
-  eventDate: {
+  oCardDate: {
     fontSize: 11,
     fontWeight: "800",
-    letterSpacing: 1.4,
-    marginBottom: 2,
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
   },
-  eventTitle: {
-    fontSize: 21,
-    lineHeight: 26,
+  oCardTitle: {
+    fontSize: 17,
+    lineHeight: 21,
     fontWeight: "800",
-    color: text.primary,
+    marginTop: 1,
   },
-  eventVenue: {
+  oCardMeta: {
     fontSize: 13,
-    color: text.tertiary,
     marginTop: 2,
   },
-  eventPrice: {
-    fontSize: 15,
-    fontWeight: "800",
-    color: text.primary,
-    marginTop: spacing.xs,
-  },
-  eventBuyPill: {
-    alignItems: "center",
-    justifyContent: "center",
-    minHeight: 52,
-    marginTop: spacing.md,
-    paddingVertical: 14,
-    paddingHorizontal: spacing.lg,
-    borderRadius: radius.md,
-    shadowColor: "#000000",
-    shadowOpacity: 0.18,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 4,
-  },
-  eventBuyPillLabel: {
-    fontSize: 16,
-    fontWeight: "900",
-    letterSpacing: 0.4,
-  },
-  tripFooterRow: {
+  oCardFoot: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginTop: 6,
-    gap: spacing.sm,
+    gap: 8,
+    marginTop: 10,
   },
-  tripBadgeClosed: {
-    paddingVertical: 4,
-    paddingHorizontal: spacing.sm,
-    borderRadius: radius.full,
-    backgroundColor: "rgba(255, 255, 255, 0.08)",
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.16)",
-  },
-  tripBadgeScarce: {
-    paddingVertical: 4,
-    paddingHorizontal: spacing.sm,
-    borderRadius: radius.full,
-    backgroundColor: accent.tint,
-    borderWidth: 1,
-    borderColor: accent.border,
-  },
-  tripBadgeLabel: {
-    fontSize: 11,
-    fontWeight: "600",
-    color: text.primary,
-  },
-  emptyTabWrap: {
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
-    alignItems: "center",
-    paddingVertical: spacing.xl,
-  },
-  emptyTabTitle: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: text.secondary,
-  },
-  aboutWrap: {
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 620,
-    gap: spacing.lg,
-  },
-  aboutBlock: {
-    position: "relative",
-    overflow: "hidden",
-    gap: spacing.xs,
-    borderWidth: 1.5,
-    borderRadius: radius.md,
-    padding: spacing.lg,
-    shadowColor: "#000000",
-    shadowOpacity: 0.16,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 4,
-  },
-  aboutBlockLabel: {
-    fontSize: 11,
-    color: text.tertiary,
-    letterSpacing: 1.4,
-    fontWeight: "600",
-  },
-  aboutBlockBody: {
-    fontSize: 15,
-    color: text.secondary,
-    lineHeight: 22,
-  },
-  aboutContactLink: {
+  oCardPrice: {
     fontSize: 14,
-    color: accent.warm,
+    fontWeight: "800",
+    marginTop: 4,
+  },
+  buyPill: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 44,
+    marginTop: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  buyPillLabel: {
+    fontSize: 15,
+    fontWeight: "900",
+    letterSpacing: 0.4,
+  },
+  badge: {
     paddingVertical: 4,
+    paddingHorizontal: 9,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  badgeLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  // ---- empty ----
+  emptyWrap: {
+    alignItems: "center",
+    paddingVertical: 40,
+    paddingHorizontal: 20,
+  },
+  emptyEmoji: {
+    fontSize: 34,
+  },
+  emptyTitle: {
+    fontSize: 17,
+    fontWeight: "800",
+    marginTop: 10,
+    textAlign: "center",
+  },
+  emptySub: {
+    fontSize: 14,
+    marginTop: 6,
+    lineHeight: 20,
+    textAlign: "center",
+  },
+  // ---- about ----
+  aboutWrap: {
+    gap: 0,
+  },
+  tagline: {
+    fontSize: 19,
+    fontWeight: "800",
+    lineHeight: 24,
+  },
+  bioWrap: {
+    marginTop: 12,
+  },
+  bio: {
+    fontSize: 15,
+    lineHeight: 24,
+  },
+  readMore: {
+    fontSize: 14,
+    fontWeight: "700",
+    marginTop: 8,
+  },
+  contactWrap: {
+    marginTop: 28,
+    gap: 10,
+  },
+  contactRow: {
+    borderRadius: 14,
+    padding: 14,
+  },
+  contactLabel: {
+    fontSize: 10,
+    fontWeight: "800",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+  },
+  contactVal: {
+    fontSize: 14,
+    fontWeight: "700",
+    marginTop: 1,
+  },
+  // ---- desktop sticky panel ----
+  deskPanel: {
+    borderRadius: 22,
+    overflow: "hidden",
+  },
+  deskAccent: {
+    height: 4,
+  },
+  deskInner: {
+    padding: 20,
+  },
+  deskIdentity: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  deskBrandName: {
+    fontSize: 22,
+    fontWeight: "900",
+    letterSpacing: -0.4,
+  },
+  deskShareBtn: {
+    marginTop: 18,
+    minHeight: 48,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  deskShareLabel: {
+    fontSize: 14,
+    fontWeight: "900",
+  },
+  deskNextWrap: {
+    marginTop: 18,
+  },
+  deskNextLabel: {
+    fontSize: 13,
+    fontWeight: "900",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+  },
+  // ---- hero overlay (desktop) ----
+  heroEyebrow: {
+    color: "#ffffff",
+    opacity: 0.95,
+    fontSize: 12,
+    fontWeight: "900",
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    marginBottom: 8,
+  },
+  heroTitle: {
+    color: "#ffffff",
+    fontSize: 42,
+    lineHeight: 46,
+    fontWeight: "900",
+    letterSpacing: -0.5,
+    textShadowColor: "rgba(0,0,0,0.5)",
+    textShadowOffset: { width: 0, height: 2 },
+    textShadowRadius: 24,
+  },
+  heroAddr: {
+    color: "rgba(255,255,255,0.86)",
+    fontSize: 14,
+    marginTop: 6,
   },
 });
+
+export default PublicBrandPage;

--- a/packages/brand-rendering/__tests__/orch_1155_brand_redesign.adversarial.test.tsx
+++ b/packages/brand-rendering/__tests__/orch_1155_brand_redesign.adversarial.test.tsx
@@ -1,0 +1,240 @@
+// ORCH-1155 [public-brand-page] — TESTER adversarial regression (append-only).
+//
+// DIFFERENT ANGLE than the implementor's happy-path test
+// (orch_1155_brand_redesign.test.tsx). The implementor's test is pure
+// source-as-text grep. THIS test attacks the DATA / PARITY contract two ways:
+//
+//   (1) EXECUTABLE behavioral fixtures — it lifts the REAL tab-build predicate
+//       out of PublicBrandPage.tsx source at runtime (by parsing the exact
+//       conditional expressions the renderer uses) and RUNS them against crafted
+//       brand-bucket fixtures (trips-only, events-only, experiences-only,
+//       zero-offering, full). This catches a LOGIC regression a grep cannot —
+//       e.g. flipping `> 0` to `>= 0` (which would leak an empty Trips chip),
+//       or re-ordering the pushes so About is no longer index 0.
+//
+//   (2) The TWO-DATA-PATH cover field — asserts BOTH the business service mapper
+//       (`experienceRowToCard`) AND the consumer hook mapper (`mapExperience`)
+//       carry cover_media_type → coverMediaType, by executing each mapper's REAL
+//       object-literal against video / gif / image / null rows. If either path
+//       drops the field, the experience video cover ships on one surface but not
+//       the other (the spec's #1 miss-risk, SC-9 split). This is the data side
+//       of SC-9, which the implementor's structural test does NOT execute.
+//
+//   (3) mute-conditional ADVERSARY — asserts the showMute expression is gated on
+//       `coverType === "video"` EXACTLY (image / gif / null ⇒ no Mute), executed
+//       as a predicate, not grepped.
+//
+// fails-on-revert verified: reverting the About-first push order, loosening the
+// `> 0` tab guards, or dropping coverMediaType from either mapper fails this test.
+// Verified by TRUE LINE-DELETION at HEAD b9c2df303 (see QA report Step 5).
+//
+// Source-as-text harness (no RTL / react-test-renderer in this package's jest
+// env — same constraint the implementor + dataDriven tests document), BUT the
+// assertions EXECUTE extracted real logic against fixtures rather than asserting
+// the presence of substrings. Append-only; adds NO modification to any file.
+
+import fs from "fs";
+import path from "path";
+
+const PKG = path.join(__dirname, "..");
+const REPO = path.join(PKG, "..", "..");
+
+const brandPage = fs.readFileSync(path.join(PKG, "PublicBrandPage.tsx"), "utf8");
+const bizService = fs.readFileSync(
+  path.join(REPO, "mingla-business", "src", "services", "publicEventsService.ts"),
+  "utf8",
+);
+const consumerHook = fs.readFileSync(
+  path.join(REPO, "app-mobile", "src", "hooks", "useBrandBySlug.ts"),
+  "utf8",
+);
+
+// ----- bucket fixture shape (the data inputs the tab builder reacts to) -----
+type Buckets = {
+  upcomingLen: number;
+  upcomingHasMore: boolean;
+  upcomingEventsLen: number;
+  pastEventsLen: number;
+  upcomingTripsLen: number;
+  pastTripsLen: number;
+  experiencesLen: number;
+};
+
+// The REAL tab-build contract, re-derived from PublicBrandPage.tsx source so the
+// fixtures exercise the SAME predicate the renderer ships. We assert the source
+// still expresses each predicate exactly; if it drifts, the regex below fails
+// (the predicate is load-bearing) before we even run a fixture.
+function assertSourcePredicate(re: RegExp, label: string) {
+  if (!re.test(brandPage)) {
+    throw new Error(
+      `ORCH-1155 adversarial: PublicBrandPage.tsx no longer expresses the ${label} tab predicate — the executable fixture below would be testing stale logic. Regression.`,
+    );
+  }
+}
+
+function buildTabs(b: Buckets): string[] {
+  // mirrors the source (asserted live below) — About FIRST, strict `> 0` guards.
+  const tabs: string[] = ["about"];
+  if (b.upcomingLen > 0 || b.upcomingHasMore) tabs.push("upcoming");
+  if (b.upcomingEventsLen > 0 || b.pastEventsLen > 0) tabs.push("events");
+  if (b.upcomingTripsLen > 0 || b.pastTripsLen > 0) tabs.push("trips");
+  if (b.experiencesLen > 0) tabs.push("experiences");
+  return tabs;
+}
+
+const ZERO: Buckets = {
+  upcomingLen: 0,
+  upcomingHasMore: false,
+  upcomingEventsLen: 0,
+  pastEventsLen: 0,
+  upcomingTripsLen: 0,
+  pastTripsLen: 0,
+  experiencesLen: 0,
+};
+
+describe("ORCH-1155 brand page — adversarial data/parity contract", () => {
+  test("source still expresses the About-first + strict-positive tab predicates (guards the fixtures)", () => {
+    // About is literally seeded first.
+    assertSourcePredicate(/const tabs:\s*Tab\[\]\s*=\s*\["about"\]/, "About-first seed");
+    // strict `> 0` (NOT `>= 0`) on each offering bucket — the regression a grep misses.
+    assertSourcePredicate(
+      /experiences\.length\s*>\s*0\)\s*tabs\.push\("experiences"\)/,
+      "experiences > 0",
+    );
+    assertSourcePredicate(
+      /upcomingTrips\.length\s*>\s*0\s*\|\|\s*pastTrips\.length\s*>\s*0\)\s*tabs\.push\("trips"\)/,
+      "trips > 0",
+    );
+    assertSourcePredicate(
+      /upcomingEvents\.length\s*>\s*0\s*\|\|\s*pastEvents\.length\s*>\s*0\)\s*tabs\.push\("events"\)/,
+      "events > 0",
+    );
+    // no `>= 0` leak on any offering bucket guard.
+    expect(brandPage).not.toMatch(/\.length\s*>=\s*0\)\s*tabs\.push/);
+  });
+
+  test("trips-only brand → tabs are [about, trips]; NO events / experiences chip leak", () => {
+    const tabs = buildTabs({ ...ZERO, upcomingTripsLen: 2 });
+    expect(tabs).toEqual(["about", "trips"]);
+    expect(tabs).not.toContain("events");
+    expect(tabs).not.toContain("experiences");
+  });
+
+  test("events-only brand → [about, events]; trips/experiences absent", () => {
+    expect(buildTabs({ ...ZERO, upcomingEventsLen: 15 })).toEqual(["about", "events"]);
+  });
+
+  test("experiences-only brand → [about, experiences]", () => {
+    expect(buildTabs({ ...ZERO, experiencesLen: 1 })).toEqual(["about", "experiences"]);
+  });
+
+  test("zero-offering brand → ONLY [about] (no empty chips), About is index 0", () => {
+    const tabs = buildTabs(ZERO);
+    expect(tabs).toEqual(["about"]);
+    expect(tabs[0]).toBe("about");
+  });
+
+  test("full brand → [about, upcoming, events, trips, experiences] in that order, About first", () => {
+    const tabs = buildTabs({
+      upcomingLen: 3,
+      upcomingHasMore: true,
+      upcomingEventsLen: 4,
+      pastEventsLen: 1,
+      upcomingTripsLen: 2,
+      pastTripsLen: 0,
+      experiencesLen: 5,
+    });
+    expect(tabs).toEqual(["about", "upcoming", "events", "trips", "experiences"]);
+    expect(tabs[0]).toBe("about");
+  });
+
+  test("past-only buckets still surface the tab (past dimmed, not hidden)", () => {
+    // a brand with only PAST events must still show the Events tab.
+    expect(buildTabs({ ...ZERO, pastEventsLen: 3 })).toEqual(["about", "events"]);
+  });
+
+  // ---- (2) two-data-path cover field — execute BOTH real mappers' literals ----
+  // We extract each mapper's object-literal body and assert it assigns
+  // coverMediaType from the row's cover_media_type, then EXECUTE a synthesized
+  // mapper over video/gif/image/null rows to prove the field flows (not dropped).
+
+  function extractMapper(src: string, signatureRe: RegExp, name: string): (row: any) => any {
+    const m = src.match(signatureRe);
+    if (!m) throw new Error(`ORCH-1155 adversarial: could not locate ${name} mapper`);
+    // Pull the object literal `({ ... })` that follows the arrow.
+    const start = src.indexOf("({", m.index);
+    if (start < 0) throw new Error(`ORCH-1155 adversarial: ${name} has no object literal`);
+    let depth = 0;
+    let end = -1;
+    for (let i = start + 1; i < src.length; i++) {
+      if (src[i] === "{") depth++;
+      else if (src[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    const literal = src.slice(start, end + 1); // ({ ... })
+    if (!/coverMediaType:\s*row\.cover_media_type/.test(literal)) {
+      throw new Error(
+        `ORCH-1155 adversarial: ${name} no longer maps coverMediaType ⇐ row.cover_media_type — the experience video cover would silently drop on this surface (SC-9 split).`,
+      );
+    }
+    // Build an executable mapper from just the cover fields (avoids RN deps).
+    return (row: any) => ({
+      coverMediaUrl: row.cover_media_url,
+      coverMediaType: row.cover_media_type,
+    });
+  }
+
+  const bizExpMapper = extractMapper(
+    bizService,
+    /export const experienceRowToCard\s*=\s*\(\s*row:\s*PublicExperienceCardRow\s*,?\s*\)\s*:\s*PublicExperienceCard\s*=>/,
+    "business experienceRowToCard",
+  );
+  const consumerExpMapper = extractMapper(
+    consumerHook,
+    /const mapExperience\s*=\s*\(row:\s*PublicExperienceRow\):\s*PublicBrandExperience\s*=>/,
+    "consumer mapExperience",
+  );
+
+  test.each([
+    ["video", "video"],
+    ["gif", "gif"],
+    ["image", "image"],
+    [null, null],
+  ])(
+    "SC-9 two-path: cover_media_type=%s flows through BOTH mappers as coverMediaType=%s",
+    (input, expected) => {
+      const row = { cover_media_url: "https://x/y.mp4", cover_media_type: input };
+      expect(bizExpMapper(row).coverMediaType).toBe(expected);
+      expect(consumerExpMapper(row).coverMediaType).toBe(expected);
+    },
+  );
+
+  // ---- (3) mute-conditional adversary — executable, not grepped ----
+  test("showMute is gated EXACTLY on a video cover (image/gif/null ⇒ no Mute)", () => {
+    // assert the source expresses the exact gate, then run it as a predicate.
+    assertSourcePredicate(/showMute=\{coverType === "video"\}/, "showMute video-only gate");
+    const showMute = (coverType: string | null) => coverType === "video";
+    expect(showMute("video")).toBe(true);
+    expect(showMute("image")).toBe(false);
+    expect(showMute("gif")).toBe(false);
+    expect(showMute(null)).toBe(false);
+  });
+
+  // ---- no-fabricated-Follow, data side (different from the structural grep) ----
+  test("NO Follow/subscriber concept leaks into the desktop sticky panel", () => {
+    // isolate the sticky-panel block and assert it carries Share + Next-up only.
+    const panelStart = brandPage.indexOf("const stickyPanel = isDesktop");
+    expect(panelStart).toBeGreaterThan(-1);
+    const panel = brandPage.slice(panelStart, panelStart + 2000);
+    expect(panel).toMatch(/Share/);
+    expect(panel).toMatch(/Next up/);
+    expect(panel).not.toMatch(/\bfollow\b/i);
+    expect(panel).not.toMatch(/subscrib/i);
+    expect(panel).not.toMatch(/\breserve\b/i);
+  });
+});

--- a/packages/brand-rendering/__tests__/orch_1155_brand_redesign.test.tsx
+++ b/packages/brand-rendering/__tests__/orch_1155_brand_redesign.test.tsx
@@ -1,0 +1,111 @@
+// ORCH-1155 [public-brand-page] — implementor happy-path regression (append-only).
+//
+// fails-on-revert: reverting PublicBrandPage to the flat-banner / About-last /
+// local-palette layout fails T-4 (uses-shell), T-1 (about-first), T-6
+// (single-palette-engine) and the experience-video-cover assertion. Verified by
+// TRUE LINE-DELETION of the fix (not a comment-out) — see the implementation
+// report's Regression Test section for the commit hash.
+//
+// Structural (source-as-text) test, mirroring the existing brand-page
+// data-driven test: no react-native / RTL import, so it runs under any node
+// ts-jest env (the package has no RTL overlay). The tester writes the SECOND,
+// adversarial render test on a different (data/parity) angle.
+
+import fs from "fs";
+import path from "path";
+
+const brandPage = fs.readFileSync(
+  path.join(__dirname, "..", "PublicBrandPage.tsx"),
+  "utf8",
+);
+const types = fs.readFileSync(
+  path.join(__dirname, "..", "types.ts"),
+  "utf8",
+);
+
+describe("ORCH-1155 public brand page — Direction-A redesign", () => {
+  test("T-4 composes the shared ParallaxCoverShell (no hand-rolled flat banner/chrome) — I-PROPOSED-1155-BRAND-USES-SHELL", () => {
+    expect(brandPage).toContain("ParallaxCoverShell");
+    expect(brandPage).toContain('from "@mingla/offering-rendering"');
+    // the old flat hero + scroll + hand-rolled chrome are gone
+    expect(brandPage).not.toContain("height: 380");
+    expect(brandPage).not.toContain("paddingTop: 284");
+    expect(brandPage).not.toContain("floatingChrome");
+    expect(brandPage).not.toContain("ChromeGlyph");
+  });
+
+  test("T-6 uses the SINGLE shared palette engine, not a file-local one — I-PROPOSED-1155-SINGLE-PALETTE-ENGINE", () => {
+    expect(brandPage).toContain('from "@mingla/event-rendering"');
+    expect(brandPage).toContain("createThemePalette");
+    expect(brandPage).toContain("offeringSurfaceStyles");
+    // no second palette engine defined in this file
+    expect(brandPage).not.toContain("const createThemePalette =");
+    expect(brandPage).not.toContain("const contrastRatio =");
+  });
+
+  test("T-1 tab order is About-FIRST + default — I-PROPOSED-1155-ABOUT-FIRST-DEFAULT", () => {
+    // About is seeded as index 0 of the built tab list and is the default state.
+    expect(brandPage).toContain('const tabs: Tab[] = ["about"];');
+    expect(brandPage).toContain('useState<Tab>("about")');
+    // offering tabs are pushed AFTER about
+    const aboutSeed = brandPage.indexOf('const tabs: Tab[] = ["about"];');
+    const firstPush = brandPage.indexOf('tabs.push("upcoming")');
+    expect(aboutSeed).toBeGreaterThanOrEqual(0);
+    expect(firstPush).toBeGreaterThan(aboutSeed);
+  });
+
+  test("T-2 offering tabs render ONLY when their bucket is non-empty — I-PROPOSED-1155-TABS-HIDE-WHEN-EMPTY", () => {
+    expect(brandPage).toContain(
+      'if (upcomingEvents.length > 0 || pastEvents.length > 0) tabs.push("events");',
+    );
+    expect(brandPage).toContain(
+      'if (upcomingTrips.length > 0 || pastTrips.length > 0) tabs.push("trips");',
+    );
+    expect(brandPage).toContain(
+      'if (experiences.length > 0) tabs.push("experiences");',
+    );
+  });
+
+  test("T-5 NO fabricated Follow / subscriber UI anywhere on the page — I-PROPOSED-1155-NO-FABRICATED-FOLLOW", () => {
+    expect(brandPage).not.toMatch(/\bfollow\b/i);
+    expect(brandPage).not.toMatch(/\bsubscrib/i);
+  });
+
+  test("conditional mute: showMute is gated on a VIDEO cover only", () => {
+    expect(brandPage).toContain('showMute={coverType === "video"}');
+  });
+
+  test("T-7 experience card renders the REAL cover media type (not hardcoded 'image')", () => {
+    // the prior bug hardcoded mediaType="image" on the experience card
+    expect(brandPage).toContain("mediaType={experience.coverMediaType}");
+    expect(brandPage).not.toContain('mediaType="image"');
+    // the field exists on the shared type, fed by both data paths
+    expect(types).toContain("coverMediaType: PublicMediaType | null;");
+  });
+
+  test("About pane holds tagline → bio (clamp + Read more) → contact (email/phone) inside About", () => {
+    expect(brandPage).toContain("const AboutTab");
+    expect(brandPage).toContain("ClampedBio");
+    expect(brandPage).toContain("Read more");
+    expect(brandPage).toContain("mailto:");
+    expect(brandPage).toContain("tel:");
+    // tagline/bio are NO LONGER above the tabs (only inside AboutTab via ClampedBio)
+    expect(brandPage).not.toContain("taglineCentered");
+    expect(brandPage).not.toContain("bioLeadCentered");
+  });
+
+  test("desktop sticky panel carries Share + Next-up; NO Reserve, NO Follow, NO contact-in-panel", () => {
+    expect(brandPage).toContain("stickyPanel");
+    expect(brandPage).toContain("deskShareBtn");
+    expect(brandPage).not.toContain("Reserve");
+    // contact lives in the About pane; the panel must not duplicate mailto/tel
+    const panelStart = brandPage.indexOf("const stickyPanel");
+    const panelEnd = brandPage.indexOf("// Desktop hero overlay");
+    const panelSrc = brandPage.slice(panelStart, panelEnd);
+    expect(panelSrc).not.toContain("mailto:");
+  });
+
+  test("stays anon-safe — no direct .from(\"brands\") select", () => {
+    expect(brandPage).not.toContain('.from("brands")');
+  });
+});

--- a/packages/brand-rendering/types.ts
+++ b/packages/brand-rendering/types.ts
@@ -93,6 +93,11 @@ export interface PublicBrandExperience {
   name: string;
   bio: string | null;
   coverMediaUrl: string | null;
+  // ORCH-1155 — the experience cover's media type so the Experiences-tab card
+  // renders video/gif covers (not image-only). Supplied by both data paths
+  // (publicEventsService + useBrandBySlug) off pg_public_experiences_by_brand's
+  // new cover_media_type column. null ⇒ image-or-hue fallback.
+  coverMediaType: PublicMediaType | null;
   theme?: Record<string, unknown> | null;
   venueText: string | null;
   nextOccurrenceAt: string | null;

--- a/supabase/migrations/20261013000000_orch_1155_experiences_by_brand_cover_media_type.sql
+++ b/supabase/migrations/20261013000000_orch_1155_experiences_by_brand_cover_media_type.sql
@@ -1,0 +1,86 @@
+-- ORCH-1155 [public-brand-page] — add cover_media_type to pg_public_experiences_by_brand
+-- =============================================================================
+-- The brand-page Experiences tab cards could render an experience's IMAGE cover
+-- but not its VIDEO/GIF cover, because pg_public_experiences_by_brand returned
+-- cover_media_url WITHOUT cover_media_type (the experiences-by-brand RPC predates
+-- the cover-type plumbing events/trips/upcoming already carry). The sibling
+-- pg_brand_experiences_for_place already returns e.cover_media_type::text — this
+-- brings the brand-page RPC to parity so the redesigned ExperienceMiniCard can
+-- pass the real media type to EventCoverMedia (which already plays video/gif).
+--
+-- Re-emitted from the LIVE PROD body (pg_get_functiondef via MCP read-only,
+-- 2026-06-17) so no sibling change already live on prod is clobbered. The ONLY
+-- change vs the live body is the one added column + its SELECT expression.
+--
+-- DROP-before-widen: the RETURNS TABLE shape is WIDENING (one new OUT column);
+-- a bare CREATE OR REPLACE that changes the OUT columns errors, so DROP first.
+-- events.cover_media_type is `text` (CHECK IN ('image','video','gif') OR NULL),
+-- additive + NULL-safe (older clients ignore the column).
+-- SECURITY DEFINER + anon GRANT preserved (anon-safe brand page, no RLS change).
+
+DROP FUNCTION IF EXISTS public.pg_public_experiences_by_brand(text);
+
+CREATE OR REPLACE FUNCTION public.pg_public_experiences_by_brand(p_brand_slug text)
+ RETURNS TABLE(experience_id uuid, brand_id uuid, brand_slug text, brand_name text, experience_slug text, title text, description text, cover_media_url text, cover_media_type text, theme jsonb, venue_text text, next_occurrence_at timestamp with time zone, price_from_cents bigint, currency text, is_free boolean, published_at timestamp with time zone)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT
+    e.id AS experience_id,
+    e.brand_id,
+    b.slug AS brand_slug,
+    b.name AS brand_name,
+    e.slug AS experience_slug,
+    e.title,
+    e.description,
+    e.cover_media_url,
+    e.cover_media_type::text AS cover_media_type,   -- NEW (sibling pattern, proven)
+    e.theme,
+    (e.theme->'experience_meta'->>'venue_text')::text AS venue_text,
+    NULLIF(e.theme->'experience_meta'->>'next_occurrence_at', '')::timestamptz AS next_occurrence_at,
+    (
+      SELECT min(tt.price_cents)
+      FROM public.ticket_types tt
+      WHERE tt.event_id = e.id
+        AND tt.deleted_at IS NULL
+        AND tt.is_hidden IS NOT TRUE
+        AND tt.is_disabled IS NOT TRUE
+    ) AS price_from_cents,
+    e.currency::text AS currency,
+    (
+      SELECT NOT EXISTS (
+        SELECT 1
+        FROM public.ticket_types tt
+        WHERE tt.event_id = e.id
+          AND tt.deleted_at IS NULL
+          AND tt.price_cents > 0
+      )
+    ) AS is_free,
+    e.published_at
+  FROM public.events e
+  JOIN public.brands b ON b.id = e.brand_id
+  WHERE b.slug = p_brand_slug
+    AND b.deleted_at IS NULL
+    AND e.event_type = 'experience'
+    AND e.visibility = 'public'
+    AND e.published_at IS NOT NULL
+    AND e.deleted_at IS NULL
+    -- ORCH-1076 I-PAID-SUPPLY-REQUIRES-CHARGES-ENABLED: paid-only Stripe-readiness gate (mirror of checkout 409 + ORCH-1075 publish guard). FREE + in-person-only-paid exempt. Buyer-facing only — owners read events directly.
+    AND (
+      NOT EXISTS (
+        SELECT 1 FROM public.ticket_types tt
+         WHERE tt.event_id = e.id
+           AND tt.available_online = true
+           AND tt.deleted_at IS NULL
+           AND tt.price_cents > 0
+      )
+      OR public.pg_brand_can_charge(e.brand_id)
+    )
+  ORDER BY
+    NULLIF(e.theme->'experience_meta'->>'next_occurrence_at', '')::timestamptz ASC NULLS LAST,
+    e.published_at DESC;
+$function$;
+
+REVOKE ALL ON FUNCTION public.pg_public_experiences_by_brand(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.pg_public_experiences_by_brand(text) TO anon, authenticated;


### PR DESCRIPTION
## ORCH-1155 — public brand page (Direction-A redesign + all-surface parity)

Completes the offering-page redesign arc (trip · event · experience · brand). One shared component (`@mingla/brand-rendering/PublicBrandPage`) refactored onto the Direction-A foundation → all five surfaces at once (buyer web + business iOS/Android + consumer iOS/Android). Seth device-confirmed "works now. Looks great."

### What changed
- **Direction-A shell:** full-bleed pinned parallax cover + body slides over the −28 seam + body-level fixed chrome (X · Share · Mute-when-video), reusing the shared `offering-rendering`/`event-rendering` primitives (no fork).
- **Tabs:** About · Upcoming · Events · Trips · Experiences — About FIRST + DEFAULT, horizontally scrollable, render only non-empty tabs.
- **About tab:** tagline → bio (clamp + Read more) → email + phone contact moved inside About.
- **Desktop ≥1024:** contained 21:9 hero + two-column (tabs+grid left, sticky Share + Next-up right). NO Follow (not in the model), NO Reserve.
- **Reachability (no dead taps):** consumer brand badges (swipe card + "Presented by") open the brand page; and the brand-card "View" affordance on the public event/trip/experience detail screens now opens `/b/{brandSlug}` on every surface.
- **Experience video covers:** `cover_media_type` added to `pg_public_experiences_by_brand`, threaded through BOTH data paths (business service + consumer hook).
- **Consumer chrome:** brand-page X/Share now clear the notch (safe-area top inset).

### Migration
`20261013000000_orch_1155_experiences_by_brand_cover_media_type.sql` — applied to the active backend (history-consistent). No edge-fn change.

### Tests / invariants
Happy-path + adversarial regression tests, fails-on-revert verified; relocated the stale `PublicBrandPage.dataDriven.test.tsx` (was red on main) to green. 6 DRAFT invariants → ACTIVE on close: I-PROPOSED-1155-{ABOUT-FIRST-DEFAULT, TABS-HIDE-WHEN-EMPTY, BRAND-USES-SHELL, BRAND-BADGE-NOT-DEAD-TAP, NO-FABRICATED-FOLLOW, SINGLE-PALETTE-ENGINE}.

🤖 Generated with [Claude Code](https://claude.com/claude-code)