### PR TITLE
ORCH-1148 venue e2e validation: 4 on-device fixes (phone blocker, realtime freshness, fee-amount input, table soft-delete)

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1148_CONSUMER_REALTIME_FRESHNESS.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1148_CONSUMER_REALTIME_FRESHNESS.md
@@ -1,0 +1,50 @@
+# IMPLEMENT — ORCH-1148 Consumer realtime freshness (venue reservation config)
+
+**Branch:** `ORCH-1148-venue-e2e-validation` (was exactly at `origin/main` `8d1f5ce94`; no rebase needed)
+**Surface:** consumer app `app-mobile` (runtime 1.1.0). **Scope:** caching/refetch policy ONLY — no engine, edge-fn, or reserve-flow logic touched.
+**Goal (Seth, verbatim):** "make sure changes that the business makes update in real time for the user."
+
+## The gap (proven)
+When an operator changes venue reservation config (enable/disable reservations, fee, currency, tables, availability), the consumer venue card must reflect it promptly. The gate hook `useVenueReservable.ts` — which shows/hides "Reserve a table" and carries `brand_id` + `currency`, calling `pg_venue_reservable_for_place` — cached for **5 minutes** (`staleTime: 5*60*1000`, `gcTime: 10min`). So enabling reservations or changing the fee on the business side was **invisible to the consumer for up to 5 minutes**. This was the main culprit.
+
+`useVenueAvailability.ts` (slots, `pg_venue_available_slots`) was already short-stale (30s) but its "refetch on focus" was only a code comment — the `refetchOnWindowFocus` flag was never actually set.
+
+## Before / after
+
+### `app-mobile/src/hooks/useVenueReservable.ts`
+| setting | before | after |
+|---|---|---|
+| `staleTime` | `5 * 60 * 1000` (5 min) | `0` (always re-check) |
+| `gcTime` | `10 * 60 * 1000` | `60 * 1000` |
+| `refetchOnMount` | (default) | `"always"` |
+| `refetchOnWindowFocus` | (default false) | `true` |
+
+### `app-mobile/src/hooks/useVenueAvailability.ts`
+| setting | before | after |
+|---|---|---|
+| `staleTime` | `30 * 1000` | `30 * 1000` (unchanged) |
+| `gcTime` | `60 * 1000` | `60 * 1000` (unchanged) |
+| `refetchOnWindowFocus` | (comment only, flag missing) | `true` (added) |
+
+## Why this makes business changes propagate
+- `staleTime: 0` + `refetchOnMount: "always"` → **every venue-card expand** re-pulls `pg_venue_reservable_for_place` live, so a just-enabled reservation / new fee / new currency appears immediately (no minutes-long cache). The RPC is cheap and anon-safe (SECURITY DEFINER, returns only `{reservable, brand_id, currency}`), so re-checking on each open is safe.
+- `refetchOnWindowFocus: true` on both hooks → returning to the app (or back to the slot step) re-pulls reservability AND live remaining-capacity slots.
+- A small `gcTime` (60s) keeps memory bounded while still allowing instant re-render of the last value before the fresh fetch resolves.
+
+## Test + fails-on-revert
+New gate: `app-mobile/src/hooks/__tests__/orch_1148_consumer_realtime_freshness.test.ts` (node:assert source-structure idiom, matching `orch_1138_consumer_trip_brand_cover.test.ts`; comments stripped so assertions bite on real code only).
+
+- 6 checks PASS (A1–A4 reservable: staleTime 0, no `N*60*1000` cache, `refetchOnMount:"always"`, `refetchOnWindowFocus:true`; B1–B2 availability: ≤30s stale + `refetchOnWindowFocus:true`).
+- **Fails-on-revert PROVEN**: stashing the two hook edits back to the pre-fix baseline (commit `6074cb19f`, `staleTime: 5*60*1000`) → test exits **1** at `A1` ("must be staleTime 0"). Restored cleanly.
+
+## Gates
+- **eslint** on `useVenueReservable.ts`, `useVenueAvailability.ts`, and the new test → exit 0 (clean).
+- **tsc** (`tsc --noEmit -p tsconfig.json`): 441 errors both at baseline (changes stashed) and with changes — **zero new errors**. All 441 are pre-existing and live in `../packages/phone-input/` (node_modules-symlink artifacts), none reference the touched files.
+- New gate test → 6/6 PASS; fails-on-revert exit 1.
+
+## Files changed (committed)
+- `app-mobile/src/hooks/useVenueReservable.ts`
+- `app-mobile/src/hooks/useVenueAvailability.ts`
+- `app-mobile/src/hooks/__tests__/orch_1148_consumer_realtime_freshness.test.ts`
+
+NOT deployed, NOT merged. No engine/edge/flow logic changed.

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1148_FEE_AMOUNT_AND_TABLE_DELETE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1148_FEE_AMOUNT_AND_TABLE_DELETE.md
@@ -1,0 +1,135 @@
+# IMPLEMENT — META-ORCH-1148 e2e gaps: fee-amount input + table delete
+
+**Status:** implemented and verified (source + jest + deno gates green; fails-on-revert proven). Live SQL engine test + Docker full-chain are operator-runnable (Docker daemon down in this session).
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1148-[venue-e2e-validation]/` on branch `ORCH-1148-venue-e2e-validation`.
+**Comms ledger:** read on entry. No `BLOCK` rows for this skill / ORCH-1148 / `ALL`. WARN/FYI rows (COMMS-0027 EAS-OTA, COMMS-0035 ExpoImageManipulator native drift) noted — neither touches this UI/migration work (no native module, no OTA in this ORCH; OTA is orchestrator/operator-owned at CLOSE).
+
+---
+
+## 1. Summary (plain English)
+
+Two operator gaps in the Venue Suite are closed:
+
+- **GAP 1 — reservation fee never charged.** Settings had the "Charge a reservation fee" toggle but no place to enter the amount, so `fee_amount_cents` stayed null and the engine treated the fee as free. Added a currency-aware amount field that appears when the toggle is on; the fee is treated as active only once an amount above 0 is set, and a clear amber "Set an amount above 0… until you do this fee stays free" line surfaces the broken in-between state. The existing payout fail-close (ORCH-1073/1075) is preserved — the amount field only shows after the toggle clears that gate.
+- **GAP 2 — no way to delete a table.** Added a "Delete table" action in the edit sheet behind a destructive confirm dialog. Delete is **soft** (`deleted_at` column) so reservation history is preserved; the table disappears from the operator list and stops producing availability immediately.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Verified | Commit |
+|----|-----------|----------|--------|
+| SC-1 | Fee amount input, currency-aware, stored as integer cents | ✓ `minorFromMajor(currency)` → `fee_amount_cents`; jest `minorFromMajor` cases (USD/GBP/EUR/JPY) | f41b19d6f |
+| SC-2 | Paid fee cannot be active with null/0 amount; invalid state surfaced, not leaveable as active | ✓ `paidFeeIsActive`/`feeAmountValidForSave` + amber needs-amount state; toggle-OFF clears amount | f41b19d6f |
+| SC-3 | ORCH-1073/1075 payout fail-close preserved (amount only shows/saves once payouts ready) | ✓ `feeBlocked` gate unchanged; amount block renders only when `feeEnabled && !feeBlocked` | f41b19d6f |
+| SC-4 | a11y label + testID on the input | ✓ `accessibilityLabel="Reservation fee amount"` + `testID="venue-settings-fee-amount"` | f41b19d6f |
+| SC-5 | Delete action in edit sheet with confirm dialog (ConfirmDialog reused) | ✓ destructive `ConfirmDialog`, `testID="venue-table-delete"` / `-confirm` | f41b19d6f |
+| SC-6 | Soft-delete: `deleted_at` column, additive monotonic migration | ✓ `20261013000002` (prefix > global max 20261013000001) | f41b19d6f |
+| SC-7 | Soft-deleted excluded from list AND availability engine | ✓ `.is("deleted_at", null)` in `fetchVenueTables` + `AND t.deleted_at IS NULL` in engine v3 | f41b19d6f |
+| SC-8 | Existing reservations referencing a deleted table not broken (FK stays) | ✓ soft-delete = UPDATE; no FK change, `reservations.table_id` untouched | f41b19d6f |
+| SC-9 | Delete RPC SECURITY DEFINER + manager+ gate + REVOKE PUBLIC/anon + audit | ✓ `biz_venue_table_soft_delete` mirrors 2.1b lifecycle RPCs | f41b19d6f |
+
+(`f41b19d6f` = the single squash/close commit on this branch; see §6.)
+
+---
+
+## 3. Files changed
+
+| File | Δ | What |
+|------|---|------|
+| `mingla-business/src/components/venue/VenueSettingsModule.tsx` | ~+70 | fee-amount Input + draft state + cents conversion + needs-amount state + active gating |
+| `mingla-business/src/components/venue/venueFeeGate.ts` | +40 | `paidFeeIsActive` + `feeAmountValidForSave` pure helpers |
+| `mingla-business/src/utils/currency.ts` | +11 | `minorFromMajor` (inverse of `majorFromMinor`, currency-aware, integer-safe) |
+| `mingla-business/src/components/venue/VenueTableSheet.tsx` | ~+55 | Delete button (edit mode) + ConfirmDialog wiring |
+| `mingla-business/src/components/venue/VenueTablesModule.tsx` | ~+25 | `useDeleteVenueTable` wire-up + `handleDelete` + sheet props |
+| `mingla-business/src/hooks/useVenueTables.ts` | ~+30 | list `.is("deleted_at", null)` filter + `useDeleteVenueTable` |
+| `supabase/migrations/20261013000002_orch_1148_venue_table_soft_delete.sql` | NEW | `deleted_at` column + index + engine v3 re-emit + `biz_venue_table_soft_delete` RPC |
+| `mingla-business/src/components/venue/__tests__/venueFeeAmount.test.ts` | NEW | fee-amount validity + cents-conversion happy-path |
+| `mingla-business/src/hooks/__tests__/useVenueTables.softDelete.orch1148.test.ts` | NEW | list deleted_at filter + delete RPC call |
+| `supabase/migrations/__tests__/orch_1148_table_soft_delete_migration.test.ts` | NEW | source-level migration regression (7 assertions) |
+| `supabase/migrations/__tests__/orch_1148_table_soft_delete_engine.test.sql` | NEW | live SQL: soft-deleted table → 0 slots |
+
+---
+
+## 4. Data-model changes
+
+- **`venue_tables.deleted_at timestamptz NULL`** — additive (`ADD COLUMN IF NOT EXISTS`). NULL = live.
+- **Index** `venue_tables_brand_active_idx` recreated as `WHERE is_active AND deleted_at IS NULL` (leaner hot path).
+- **No FK / constraint change.** `reservations.table_id` FK is untouched — soft-delete keeps the row, so historical reservations stay valid.
+
+## 5. Edge functions / RPCs
+
+No edge functions touched. Two SQL functions in the new migration:
+- `pg_venue_available_slots(uuid, date, int)` — engine **v3** re-emit, `STABLE SECURITY DEFINER`, signature + 4-col return FROZEN, only `AND t.deleted_at IS NULL` added. Anon EXECUTE **not** revoked (the 2.2 grant `20261012000000` stands); authenticated re-asserted.
+- `biz_venue_table_soft_delete(uuid)` — `SECURITY DEFINER`, manager+ gate via `biz_brand_effective_rank_for_caller(auth.uid())`, idempotent, audit row, `REVOKE ALL FROM PUBLIC` + `REVOKE EXECUTE FROM anon` + `GRANT authenticated`.
+
+---
+
+## 6. Regression tests + fails-on-revert
+
+- `venueFeeAmount.test.ts` (12 cases) — PASS. **Fails-on-revert verified:** reverting `paidFeeIsActive` to `return feeEnabled;` (true-line deletion of the `&& (feeAmountCents ?? 0) > 0` guard) → 3 cases FAIL; restored → PASS.
+- `useVenueTables.softDelete.orch1148.test.ts` (2 cases) — PASS. **Fails-on-revert verified:** deleting the `.is("deleted_at", null)` line in `fetchVenueTables` → T-DEL-1 FAILs; restored → PASS.
+- `orch_1148_table_soft_delete_migration.test.ts` (7 deno cases) — PASS (T-SD-2 pins the engine `deleted_at` filter; reverting it fails the assertion).
+- `orch_1148_table_soft_delete_engine.test.sql` — live SQL, operator-runnable: asserts a live table yields slots, soft-deleting it yields 0.
+
+`fails-on-revert verified at` the close commit (this branch HEAD).
+
+## 7. Old → New receipts
+
+**VenueSettingsModule.tsx** — *before:* fee toggle wrote `fee_enabled` only; `fee_amount_cents` never set → engine read FREE. *now:* amount Input (currency-aware) on toggle-ON; commits integer cents on blur; fee active only when amount > 0; needs-amount warning otherwise; toggle-OFF clears the amount. *why:* GAP 1.
+
+**venueFeeGate.ts** — *before:* only the payout-readiness gate. *now:* + pure `paidFeeIsActive` / `feeAmountValidForSave`. *why:* fails-on-revert anchor for the amount rule.
+
+**currency.ts** — *before:* `majorFromMinor` only. *now:* + `minorFromMajor` (inverse). *why:* major→cents conversion for the input.
+
+**useVenueTables.ts** — *before:* list returned all rows incl. soft-deleted; no delete path. *now:* list filters `deleted_at IS NULL`; `useDeleteVenueTable` calls the guarded RPC. *why:* GAP 2.
+
+**VenueTableSheet.tsx / VenueTablesModule.tsx** — *before:* add/edit/deactivate only. *now:* destructive Delete + confirm dialog, manager+ gated. *why:* GAP 2.
+
+**migration 20261013000002** — *before:* no `deleted_at`; engine v2 saw all active tables. *now:* column + engine v3 excludes soft-deleted + guarded soft-delete RPC. *why:* GAP 2 server side.
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Parity |
+|---|---|---|
+| Business iOS | YES — Settings amount field + table delete | shared RN code (auto) |
+| Business Android | YES — same | shared RN code (auto); glass via GlassCard/Sheet/Modal (opaque fallback automatic) |
+| Business Web desktop | YES — same | shared RN-on-web (auto) |
+| Business Web phone | YES — same | shared RN-on-web (auto) |
+| Buyer/anon Web | NO — operator-only Settings/Tables | n/a |
+| Consumer iOS/Android | INDIRECT — a soft-deleted table stops appearing in availability (engine v3); no consumer code touched | engine RPC shared |
+| Admin Web | NO | n/a |
+
+## 9. Smoke result
+
+No sim/device run this session (no native change; pure-JS + SQL). Jest + deno gates + strict-grep gates run and pasted (§6, §10). UNVERIFIED-on-device: visual layout of the amount field + delete dialog on a physical phone — tester to confirm.
+
+## 10. Gates run (this session)
+
+- jest (3 suites): 21 passed.
+- deno migration test: 7 passed.
+- tsc `--noEmit`: 0 errors in touched files (358 pre-existing repo-wide, none in changed files).
+- eslint (changed files): 0 errors (2 array-type warnings fixed).
+- strict-grep: `orch-1148-no-buyer-tax-form-in-venue-settings`, `orch-1148-booking-core-engine-and-money-seam`, `orch-1148-reserve-sheet-gate-mirrors-button`, `orch-1075-paid-publish-integrity-guards`, `orch-1130-no-buyer-tax-form`, `i-biz-venue-input-uses-mapbox` — all PASS.
+
+## 11. Operator action required
+
+**Apply the migration** (after REVIEW; from the anchor or linked checkout — the worktree is not linked):
+
+```bash
+cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1148-[venue-e2e-validation]" && /Users/sethogieva/bin/supabase db push --linked
+```
+
+Migration file: `supabase/migrations/20261013000002_orch_1148_venue_table_soft_delete.sql` (prefix `20261013000002`, strictly > global max `20261013000001`). Additive; no `--include-all` needed.
+
+**No edge-function deploy** (none touched). **Optional live-SQL verification** (after apply, against a populated DB):
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/migrations/__tests__/orch_1148_table_soft_delete_engine.test.sql
+```
+
+**Not run this session (Docker daemon down):** the migration Docker full-chain apply. Operator to run the standard local-Postgres apply chain at CLOSE, or rely on the source-level deno test + the live SQL test above.
+
+## 12. Discoveries for orchestrator
+
+- `useVenueReservationFee` already supported `feeAmountCents` in the patch (an earlier sub-ORCH wired the hook but never the UI) — GAP 1 was purely a missing UI control + validity gate; no hook change needed there.
+- The engine v2→v3 re-emit is the **second** byte-copy of the ~200-line `pg_venue_available_slots` body in the migration chain. Future engine edits must remember the body lives in the *latest* migration. Consider extracting to a single canonical re-emittable file if it changes again (registerable follow-up; not in scope here).

--- a/app-mobile/src/components/expandedCard/VenueReserveSheet.tsx
+++ b/app-mobile/src/components/expandedCard/VenueReserveSheet.tsx
@@ -113,7 +113,7 @@ export const VenueReserveSheet: React.FC<VenueReserveSheetProps> = ({
   onReserved,
 }) => {
   const insets = useSafeAreaInsets();
-  const { user } = useAppStore();
+  const { user, profile } = useAppStore();
   const reserve = useReserveTable(user?.id);
 
   const [step, setStep] = useState<Step>("party");
@@ -140,7 +140,14 @@ export const VenueReserveSheet: React.FC<VenueReserveSheetProps> = ({
     step === "slots" || step === "confirm" ? partySize : null,
   );
 
-  const profilePhone = (user?.phone ?? "").trim();
+  // ORCH-1148 [consumer phone blocker] — the signed-in user's phone is sourced
+  // from their profile. The store `user` now mirrors `profiles.phone` (see
+  // appStore.setProfile), but we also read `profile.phone` directly as a
+  // belt-and-suspenders fallback in case the store `user` merge hasn't landed
+  // yet (profile loads asynchronously, possibly after this sheet first reads).
+  // A user WITH a profile phone gets needsPhone=false (no prompt, books with
+  // their phone automatically); a user with NONE gets the contact-phone input.
+  const profilePhone = (user?.phone ?? profile?.phone ?? "").trim();
   const needsPhone = profilePhone.length === 0;
   const composedPhoneE164 = needsPhone
     ? buildPendingCollabPhoneE164(phoneInput, selectedCountry?.dialCode)

--- a/app-mobile/src/hooks/__tests__/orch_1148_consumer_realtime_freshness.test.ts
+++ b/app-mobile/src/hooks/__tests__/orch_1148_consumer_realtime_freshness.test.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1148 [venue-e2e-validation] — consumer realtime freshness gate.
+//
+// Goal (Seth, verbatim): "make sure changes that the business makes update in
+// real time for the user". When a business operator flips reservations on/off or
+// changes the reservation fee/currency, the consumer venue card MUST reflect it
+// the moment they (re)open the card — not after a multi-minute cache.
+//
+// THE GAP THIS PROTECTS: useVenueReservable (the gate that shows/hides "Reserve
+// a table" + carries brand_id/currency) previously used `staleTime: 5*60*1000`
+// (5 min) — so enabling reservations / changing the fee on the business side was
+// invisible to the consumer for up to 5 minutes. The fix makes it re-check on
+// every mount/focus. This gate FAILS if anyone silently regresses it back to a
+// long cache or drops the refetch flags.
+//
+// app-mobile has no jest/RTL runner; the repo convention is node:assert
+// source-assertions (see orch_1138_consumer_trip_brand_cover.test.ts). Every
+// assertion FAILS on a true LINE-DELETION of the policy it protects
+// (fails-on-revert vs the pre-fix commit 6074cb19f / the staleTime:5*60*1000
+// baseline), NOT merely on a comment-out.
+//
+// Run with:
+//   node app-mobile/src/hooks/__tests__/orch_1148_consumer_realtime_freshness.test.ts
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "../../..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+
+const reservableSrc = read("src/hooks/useVenueReservable.ts");
+const availabilitySrc = read("src/hooks/useVenueAvailability.ts");
+
+// Strip block + line comments so every assertion below bites on real CODE only
+// (a regression hidden behind a comment must NOT keep this green).
+const stripComments = (s) =>
+  s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+const reservableCode = stripComments(reservableSrc);
+const availabilityCode = stripComments(availabilitySrc);
+
+let passed = 0;
+function ok(name, cond, detail) {
+  assert.ok(cond, `FAIL ${name}${detail ? " — " + detail : ""}`);
+  console.log(`OK   ${name}`);
+  passed += 1;
+}
+
+// ── A: useVenueReservable re-checks live on every card open ───────────────────
+ok(
+  "A1 useVenueReservable uses staleTime: 0 (always re-check reservability/fee/currency)",
+  /staleTime:\s*0\b/.test(reservableCode),
+  "must be staleTime 0 so business reservation-config changes are seen immediately",
+);
+ok(
+  "A2 useVenueReservable does NOT keep the old 5-minute (or any minutes) stale cache",
+  !/staleTime:\s*5\s*\*\s*60\s*\*\s*1000/.test(reservableCode) &&
+    !/staleTime:\s*[0-9]+\s*\*\s*60\s*\*\s*1000/.test(reservableCode),
+  "regressing to staleTime: N*60*1000 re-hides business changes for minutes — the bug",
+);
+ok(
+  "A3 useVenueReservable sets refetchOnMount: \"always\" (re-pulls on every card expand)",
+  /refetchOnMount:\s*["']always["']/.test(reservableCode),
+  "each venue-card expand must re-pull, even inside the gcTime window",
+);
+ok(
+  "A4 useVenueReservable sets refetchOnWindowFocus: true (re-pulls on app return)",
+  /refetchOnWindowFocus:\s*true/.test(reservableCode),
+);
+
+// ── B: useVenueAvailability re-pulls live slot capacity on focus ──────────────
+ok(
+  "B1 useVenueAvailability keeps a short slot stale window (≤30s)",
+  /staleTime:\s*30\s*\*\s*1000/.test(availabilityCode),
+  "slots go stale fast as other guests book; keep the short window",
+);
+ok(
+  "B2 useVenueAvailability sets refetchOnWindowFocus: true (returning to slot step re-pulls)",
+  /refetchOnWindowFocus:\s*true/.test(availabilityCode),
+  "the prior 'refetch on focus' comment was aspirational — the flag must be real",
+);
+
+console.log(
+  `\n# ORCH-1148 consumer realtime freshness — ${passed} checks PASS`,
+);

--- a/app-mobile/src/hooks/useVenueAvailability.ts
+++ b/app-mobile/src/hooks/useVenueAvailability.ts
@@ -82,7 +82,10 @@ export function useVenueAvailability(
       fetchVenueSlots(brandId as string, date as string, partySize as number),
     enabled,
     // Slots go stale fast — short window, refetch on focus.
+    // ORCH-1148: the focus comment was aspirational — make it real so returning to
+    // the slot step (or back to the app) re-pulls live remaining-capacity.
     staleTime: 30 * 1000,
     gcTime: 60 * 1000,
+    refetchOnWindowFocus: true,
   });
 }

--- a/app-mobile/src/hooks/useVenueReservable.ts
+++ b/app-mobile/src/hooks/useVenueReservable.ts
@@ -57,7 +57,16 @@ export function useVenueReservable(
     queryKey: venueReservableKeys.byPlace(placePoolId ?? "none"),
     queryFn: () => fetchVenueReservable(placePoolId as string),
     enabled,
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
+    // ORCH-1148 consumer realtime freshness: a business operator can flip
+    // reservations on/off or change the reservation fee/currency at any time, and
+    // the consumer MUST see it the moment they (re)open the venue card — never a
+    // multi-minute cache. The RPC is cheap + anon-safe, so re-check on every
+    // mount/focus. staleTime:0 = always considered stale; refetchOnMount:"always"
+    // re-pulls each card expand even within the gcTime window; refetchOnWindowFocus
+    // re-pulls when the user returns to the app. (Was: staleTime 5min — the gap.)
+    staleTime: 0,
+    gcTime: 60 * 1000,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
   });
 }

--- a/app-mobile/src/store/__tests__/orch_1148_consumer_phone_blocker.test.tsx
+++ b/app-mobile/src/store/__tests__/orch_1148_consumer_phone_blocker.test.tsx
@@ -1,0 +1,132 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1148 [consumer phone blocker] — a signed-in consumer could NOT complete a
+// table reservation: tapping "Confirm reservation" on the VenueReserveSheet
+// review step returned the server `buyer_phone_required` 400, and no phone field
+// was expected because the user HAS a phone on their profile.
+//
+// ROOT CAUSE (sub-bug 1, REAL): the store `user` is seeded from the Supabase
+// AUTH user (`session.user` via setAuth), which does NOT carry `profiles.phone`.
+// The phone lives only on the separately-loaded `profiles` row (`setProfile`).
+// VenueReserveSheet reads `user?.phone` → always empty → `needsPhone` always
+// true; if the (unexpected) prompt is left blank, `composedPhoneE164` is "" and
+// the server rejects with `buyer_phone_required`.
+//
+// FIX (primary): `appStore.setProfile` now mirrors a non-empty `profiles.phone`
+// onto the store `user.phone` (single chokepoint — covers every profile-load
+// path). FIX (secondary/defensive): VenueReserveSheet sources the phone from
+// `user.phone ?? profile.phone` so a user WITH a profile phone gets
+// needsPhone=false (no prompt, books automatically) even before the store merge
+// lands; a user with NONE still gets the contact-phone input block + the
+// client-side `phoneOk` guard that surfaces a friendly message BEFORE the server.
+//
+// These are SOURCE-STRING assertions (the RN store + sheet can't mount under the
+// node harness — the established ORCH-1138/1153 consumer pattern). fails-on-
+// revert: each `ok(...)` below flips red if the corresponding fix line is removed
+// (proven against commit that reverts the two edits). Owner: mingla-implementor.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// REPO_ROOT = up 4 from this dir (…/app-mobile/src/store/__tests__).
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..");
+const read = (rel) => fs.readFileSync(path.join(REPO_ROOT, rel), "utf8");
+const stripComments = (src) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+let passed = 0;
+function ok(name, cond, detail) {
+  assert.ok(cond, `FAIL ${name}${detail ? " — " + detail : ""}`);
+  console.log(`OK   ${name}`);
+  passed += 1;
+}
+
+const APP = "app-mobile";
+const storeSrc = stripComments(read(`${APP}/src/store/appStore.ts`));
+const sheetSrc = stripComments(
+  read(`${APP}/src/components/expandedCard/VenueReserveSheet.tsx`),
+);
+
+// ── Sub-bug 1 fix — appStore.setProfile mirrors profile.phone onto user ──────
+
+// setProfile must use the functional form so it can read the current user.
+ok(
+  "setProfile reads current state (functional set)",
+  /setProfile:\s*\(profile\)\s*=>\s*set\(\s*\(state[^)]*\)\s*=>/.test(storeSrc),
+  "expected `setProfile: (profile) => set((state...) => ...)`",
+);
+
+// It must derive a non-empty phone from the loaded profile.
+ok(
+  "setProfile derives a non-empty phone from the profile",
+  /profile\?\.phone/.test(storeSrc) &&
+    /profile\.phone\.trim\(\)\.length\s*>\s*0/.test(storeSrc),
+  "expected a trimmed non-empty `profile.phone` guard",
+);
+
+// It must merge that phone onto the store user (so user.phone reflects profile).
+ok(
+  "setProfile merges the profile phone onto the store user",
+  /\{\s*\.\.\.state\.user,\s*phone:\s*nextProfilePhone\s*\}/.test(storeSrc),
+  "expected `{ ...state.user, phone: nextProfilePhone }`",
+);
+
+// It must still set `profile` (no regression of the original behavior).
+ok(
+  "setProfile still sets profile",
+  /return\s*\{\s*profile,\s*user:\s*nextUser\s*\}/.test(storeSrc),
+  "expected `return { profile, user: nextUser }`",
+);
+
+// ── Sub-bug 2 fix — VenueReserveSheet phone sourcing + render + guard ────────
+
+// The sheet must read both user and profile from the store.
+ok(
+  "sheet reads { user, profile } from the store",
+  /const\s*\{\s*user,\s*profile\s*\}\s*=\s*useAppStore\(\)/.test(sheetSrc),
+  "expected `const { user, profile } = useAppStore()`",
+);
+
+// profilePhone must fall back to profile.phone when user.phone is empty.
+ok(
+  "profilePhone falls back to user.phone ?? profile.phone",
+  /user\?\.phone\s*\?\?\s*profile\?\.phone/.test(sheetSrc),
+  "expected `user?.phone ?? profile?.phone`",
+);
+
+// needsPhone is derived from the (now profile-aware) phone.
+ok(
+  "needsPhone derives from profilePhone length",
+  /const\s+needsPhone\s*=\s*profilePhone\.length\s*===\s*0/.test(sheetSrc),
+);
+
+// When needsPhone, the sheet builds the E164 from the typed input; otherwise it
+// reuses the profile phone (no prompt for users who already have one).
+ok(
+  "composedPhoneE164 uses the profile phone when not needsPhone",
+  /composedPhoneE164\s*=\s*needsPhone[\s\S]*?:\s*profilePhone/.test(sheetSrc),
+);
+
+// The phone-input block MUST render when needsPhone is true (the secondary path).
+ok(
+  "phone input block renders when needsPhone",
+  /\{needsPhone\s*&&\s*\(/.test(sheetSrc) && /<PhoneInput/.test(sheetSrc),
+  "expected `{needsPhone && ( ... <PhoneInput ... )}`",
+);
+
+// The client-side phoneOk guard must fire BEFORE the server (friendly message).
+ok(
+  "handleConfirm guards on phoneOk before reserving",
+  /if\s*\(!phoneOk\)\s*\{[\s\S]*?Add a phone number[\s\S]*?return;/.test(sheetSrc),
+  "expected the `if (!phoneOk) { ...friendly... return; }` guard before reserve(",
+);
+
+// The reservation must send the composed phone (non-empty when one exists).
+ok(
+  "reserve sends composedPhoneE164 as the buyer phone",
+  /phone:\s*composedPhoneE164/.test(sheetSrc),
+);
+
+console.log(`\n${passed} assertions passed.`);

--- a/app-mobile/src/store/appStore.ts
+++ b/app-mobile/src/store/appStore.ts
@@ -305,7 +305,31 @@ export const useAppStore = create<AppState>()(
       },
 
       // User data actions
-      setProfile: (profile) => set({ profile }),
+      //
+      // ORCH-1148 [consumer phone blocker] — the store `user` is seeded from the
+      // Supabase AUTH user (`session.user`, via setAuth), which does NOT carry
+      // `profiles.phone`. Phone lives only on the separately-loaded `profiles`
+      // row. Consumers that read `user.phone` (e.g. VenueReserveSheet's
+      // `needsPhone`/`composedPhoneE164`) therefore saw an empty phone for a
+      // signed-in user WITH a profile phone → forced phone prompt that, if left
+      // blank, hit the server `buyer_phone_required` 400. Fix: whenever a profile
+      // is loaded, mirror its `phone` (when present) onto the store `user` so
+      // every `user.phone` reader gets the real value. Single chokepoint —
+      // covers useAuthSimple, AppStateManager, OnboardingFlow, AccountSettings,
+      // and authService profile loads alike. Null/absent profile clears nothing
+      // on `user` (logout goes through clearUserData).
+      setProfile: (profile) =>
+        set((state: AppState) => {
+          const nextProfilePhone =
+            typeof profile?.phone === "string" && profile.phone.trim().length > 0
+              ? profile.phone
+              : null;
+          const nextUser =
+            state.user && nextProfilePhone && state.user.phone !== nextProfilePhone
+              ? { ...state.user, phone: nextProfilePhone }
+              : state.user;
+          return { profile, user: nextUser };
+        }),
 
       // Session actions
       setCurrentSession: (currentSession) => set({ currentSession }),

--- a/mingla-business/src/components/venue/VenueSettingsModule.tsx
+++ b/mingla-business/src/components/venue/VenueSettingsModule.tsx
@@ -18,7 +18,7 @@
  *    charge in 2.0).
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Pressable, StyleSheet, Switch, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 
@@ -38,14 +38,24 @@ import {
   useVenueReservationSettings,
 } from "../../hooks/useVenueReservationSettings";
 import { BRAND_ROLE_RANK } from "../../utils/brandRole";
-import { formatCurrency, normalizeCurrency } from "../../utils/currency";
+import {
+  formatCurrency,
+  majorFromMinor,
+  minorFromMajor,
+  normalizeCurrency,
+} from "../../utils/currency";
 import {
   brandStripeOnboardingRoute,
   paidPublishGuardCopy,
 } from "../../utils/paidPublishGuards";
 import { Button } from "../ui/Button";
 import { GlassCard } from "../ui/GlassCard";
-import { brandPayoutReadiness, canEnablePaidReservationFee } from "./venueFeeGate";
+import { Input } from "../ui/Input";
+import {
+  brandPayoutReadiness,
+  canEnablePaidReservationFee,
+  paidFeeIsActive,
+} from "./venueFeeGate";
 
 const MANAGER_PLUS_RANK = BRAND_ROLE_RANK.event_manager; // 40
 
@@ -110,6 +120,31 @@ export function VenueSettingsModule({
   const feeEnabled = settings?.feeEnabled ?? false;
   const feeAmountCents = settings?.feeAmountCents ?? 0;
 
+  // Draft amount in MAJOR units (what the operator types). Hydrated from the
+  // persisted cents; mirrors the table-sheet's string-input pattern. Kept in
+  // sync when the server value changes (e.g. after a successful save / refetch).
+  const [amountDraft, setAmountDraft] = useState<string>("");
+  useEffect(() => {
+    if (feeAmountCents > 0) {
+      setAmountDraft(String(majorFromMinor(feeAmountCents, currency)));
+    } else {
+      setAmountDraft("");
+    }
+  }, [feeAmountCents, currency]);
+
+  // Parse the draft → integer cents (currency-aware; zero-decimal safe). A blank
+  // / non-numeric / non-positive draft → 0 (= "no amount set").
+  const draftCents = useMemo<number>(() => {
+    const major = Number.parseFloat(amountDraft.replace(/,/g, ""));
+    if (!Number.isFinite(major) || major <= 0) return 0;
+    return minorFromMajor(major, currency);
+  }, [amountDraft, currency]);
+
+  // The fee is a broken "paid but charges nothing" config while ON with no
+  // positive amount — surface it and DO NOT treat the fee as active.
+  const feeNeedsAmount = feeEnabled && draftCents <= 0;
+  const feeActive = paidFeeIsActive(feeEnabled, draftCents);
+
   const handleToggleReservations = useCallback(
     (next: boolean): void => {
       if (!canMutate) return;
@@ -127,13 +162,27 @@ export function VenueSettingsModule({
         return;
       }
       setFeeBlocked(false);
+      // Turning the fee ON does NOT set an amount — the operator must enter one
+      // (feeNeedsAmount surfaces until they do). Turning it OFF clears the amount
+      // so it can never settle as a stale paid fee.
       updateFee.mutate({
         feeEnabled: next,
         feeCurrency: next ? currency : null,
+        feeAmountCents: next ? undefined : null,
       });
     },
     [canMutate, payoutReady, updateFee, currency],
   );
+
+  // Commit the typed amount to fee_amount_cents (on blur / explicit save). A
+  // null/0 draft writes null so the fee reads FREE rather than broken-paid.
+  const handleSaveAmount = useCallback((): void => {
+    if (!canMutate || !feeEnabled) return;
+    updateFee.mutate({
+      feeAmountCents: draftCents > 0 ? draftCents : null,
+      feeCurrency: currency,
+    });
+  }, [canMutate, feeEnabled, updateFee, draftCents, currency]);
 
   const handleNoShowPolicy = useCallback(
     (policy: "forfeit" | "none"): void => {
@@ -154,9 +203,9 @@ export function VenueSettingsModule({
   }, [brandId, router]);
 
   const feePreview = useMemo(() => {
-    if (!feeEnabled || feeAmountCents <= 0) return null;
-    return formatCurrency(feeAmountCents, currency, true);
-  }, [feeEnabled, feeAmountCents, currency]);
+    if (!feeActive) return null;
+    return formatCurrency(draftCents, currency, true);
+  }, [feeActive, draftCents, currency]);
 
   return (
     <View style={styles.host} testID={testID ?? "venue-settings-module"}>
@@ -224,8 +273,39 @@ export function VenueSettingsModule({
               </View>
             ) : null}
 
-            {feeEnabled && feePreview !== null ? (
-              <Text style={styles.feePreview}>
+            {feeEnabled && !feeBlocked ? (
+              <View style={styles.amountBlock}>
+                <Text style={styles.fieldLabel}>
+                  Fee amount ({normalizeCurrency(currency)})
+                </Text>
+                <Input
+                  value={amountDraft}
+                  onChangeText={setAmountDraft}
+                  onBlur={handleSaveAmount}
+                  variant="number"
+                  placeholder="0.00"
+                  disabled={!canMutate}
+                  accessibilityLabel="Reservation fee amount"
+                  testID="venue-settings-fee-amount"
+                />
+                {feeNeedsAmount ? (
+                  <Text
+                    style={styles.amountWarn}
+                    accessibilityLabel="Set a fee amount above zero to charge guests"
+                    testID="venue-settings-fee-needs-amount"
+                  >
+                    Set an amount above 0 to charge guests. Until you do, this fee
+                    stays free.
+                  </Text>
+                ) : null}
+              </View>
+            ) : null}
+
+            {feeActive && feePreview !== null ? (
+              <Text
+                style={styles.feePreview}
+                testID="venue-settings-fee-preview"
+              >
                 Guests pay {feePreview} all-in at booking.
               </Text>
             ) : null}
@@ -366,6 +446,18 @@ const styles = StyleSheet.create({
     ...typography.bodySm,
     color: semantic.success,
     marginTop: spacing.xs,
+  },
+  amountBlock: {
+    marginTop: spacing.sm,
+    gap: spacing.xs,
+  },
+  fieldLabel: {
+    ...typography.bodySm,
+    color: textTokens.secondary,
+  },
+  amountWarn: {
+    ...typography.bodySm,
+    color: semantic.warning,
   },
   blockCard: {
     marginTop: spacing.sm,

--- a/mingla-business/src/components/venue/VenueTableSheet.tsx
+++ b/mingla-business/src/components/venue/VenueTableSheet.tsx
@@ -18,6 +18,7 @@ import {
   typography,
 } from "../../constants/designSystem";
 import { Button } from "../ui/Button";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Input } from "../ui/Input";
 import { Sheet } from "../ui/Sheet";
 import type {
@@ -63,6 +64,11 @@ export interface VenueTableSheetProps {
   table: VenueTable | null;
   onSave: (input: VenueTableUpsert) => void;
   saving: boolean;
+  /** Soft-delete the table being edited (edit mode only). Omit to hide delete. */
+  onDelete?: (id: string) => void;
+  deleting?: boolean;
+  /** Only managers+ may delete; the row action is hidden otherwise. */
+  canDelete?: boolean;
   testID?: string;
 }
 
@@ -72,9 +78,25 @@ export function VenueTableSheet({
   table,
   onSave,
   saving,
+  onDelete,
+  deleting = false,
+  canDelete = false,
   testID,
 }: VenueTableSheetProps): React.ReactElement {
   const isEdit = table !== null;
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState<boolean>(false);
+
+  // Close the confirm dialog whenever the sheet (re)opens for a different table.
+  useEffect(() => {
+    if (!visible) setConfirmDeleteOpen(false);
+  }, [visible]);
+
+  const showDelete = isEdit && canDelete && onDelete !== undefined;
+
+  const handleConfirmDelete = useCallback((): void => {
+    if (table === null || onDelete === undefined) return;
+    onDelete(table.id);
+  }, [table, onDelete]);
   const [name, setName] = useState<string>("");
   const [capacity, setCapacity] = useState<string>("");
   const [minParty, setMinParty] = useState<string>("");
@@ -284,8 +306,44 @@ export function VenueTableSheet({
             style={styles.saveBtn}
             testID="venue-table-save"
           />
+
+          {showDelete ? (
+            <Button
+              label="Delete table"
+              onPress={() => setConfirmDeleteOpen(true)}
+              variant="destructive"
+              size="md"
+              fullWidth
+              disabled={deleting}
+              loading={deleting}
+              style={styles.deleteBtn}
+              testID="venue-table-delete"
+            />
+          ) : null}
         </ScrollView>
       </View>
+
+      {showDelete ? (
+        <ConfirmDialog
+          visible={confirmDeleteOpen}
+          onClose={() => setConfirmDeleteOpen(false)}
+          onConfirm={handleConfirmDelete}
+          title="Delete this table?"
+          description={
+            `${table?.name ?? "This table"} will be removed from your floor plan` +
+            " and stop being offered for new bookings. Existing reservations are" +
+            " kept. This can't be undone."
+          }
+          variant="simple"
+          destructive
+          confirmLabel="Delete"
+          cancelLabel="Keep table"
+          confirmLoading={deleting}
+          confirmTestID="venue-table-delete-confirm"
+          cancelTestID="venue-table-delete-cancel"
+          testID="venue-table-delete-dialog"
+        />
+      ) : null}
     </Sheet>
   );
 }
@@ -449,6 +507,9 @@ const styles = StyleSheet.create({
   },
   saveBtn: {
     marginTop: spacing.lg,
+  },
+  deleteBtn: {
+    marginTop: spacing.sm,
   },
 });
 

--- a/mingla-business/src/components/venue/VenueTablesModule.tsx
+++ b/mingla-business/src/components/venue/VenueTablesModule.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../constants/designSystem";
 import { useCurrentBrandRole } from "../../hooks/useCurrentBrandRole";
 import {
+  useDeleteVenueTable,
   useSetVenueTableActive,
   useUpsertVenueTable,
   useVenueTables,
@@ -80,6 +81,7 @@ export function VenueTablesModule({
   const tablesQuery = useVenueTables(brandId);
   const upsert = useUpsertVenueTable(brandId);
   const setActive = useSetVenueTableActive(brandId);
+  const remove = useDeleteVenueTable(brandId);
 
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
   const [editing, setEditing] = useState<VenueTable | null>(null);
@@ -115,6 +117,22 @@ export function VenueTablesModule({
       setActive.mutate({ id: t.id, isActive: !t.isActive });
     },
     [canMutate, setActive],
+  );
+
+  const handleDelete = useCallback(
+    (id: string): void => {
+      if (!canMutate) return;
+      remove.mutate(
+        { id },
+        {
+          onSuccess: () => {
+            setSheetOpen(false);
+            setEditing(null);
+          },
+        },
+      );
+    },
+    [canMutate, remove],
   );
 
   const header = useMemo(
@@ -232,6 +250,9 @@ export function VenueTablesModule({
         table={editing}
         onSave={handleSave}
         saving={upsert.isPending}
+        onDelete={handleDelete}
+        deleting={remove.isPending}
+        canDelete={canMutate}
       />
     </View>
   );

--- a/mingla-business/src/components/venue/__tests__/venueFeeAmount.test.ts
+++ b/mingla-business/src/components/venue/__tests__/venueFeeAmount.test.ts
@@ -1,0 +1,83 @@
+/**
+ * META-ORCH-1148 e2e-validation gap — fee-AMOUNT validity unit tests.
+ *
+ * GAP 1: the Settings module shipped the "Charge a reservation fee" toggle but
+ * NO amount input, so `fee_amount_cents` stayed null and the engine treated the
+ * fee as FREE — enabling it did nothing. The fix adds a currency-aware amount
+ * input and the pure validity helpers tested here.
+ *
+ * Fails-on-revert anchor I-PROPOSED-1148-PAID-FEE-NEEDS-NONZERO-AMOUNT: a paid
+ * fee may NOT read as ACTIVE with a null/0 amount, and is NOT saveable as active
+ * without a positive amount. A revert of `paidFeeIsActive` (e.g. returning
+ * `feeEnabled` alone) flips T-AMT-1 → FAIL.
+ */
+
+import {
+  feeAmountValidForSave,
+  paidFeeIsActive,
+} from "../venueFeeGate";
+import { minorFromMajor } from "../../../utils/currency";
+
+describe("paidFeeIsActive", () => {
+  it("T-AMT-1 — fee ON with null amount is NOT active (the gap bug)", () => {
+    expect(paidFeeIsActive(true, null)).toBe(false);
+  });
+
+  it("T-AMT-2 — fee ON with 0 amount is NOT active", () => {
+    expect(paidFeeIsActive(true, 0)).toBe(false);
+  });
+
+  it("fee ON with a positive amount IS active", () => {
+    expect(paidFeeIsActive(true, 2500)).toBe(true);
+  });
+
+  it("fee OFF is never active regardless of amount", () => {
+    expect(paidFeeIsActive(false, 2500)).toBe(false);
+    expect(paidFeeIsActive(false, null)).toBe(false);
+  });
+});
+
+describe("feeAmountValidForSave", () => {
+  it("fee OFF is always saveable (amount irrelevant)", () => {
+    expect(feeAmountValidForSave(false, null)).toBe(true);
+    expect(feeAmountValidForSave(false, 0)).toBe(true);
+  });
+
+  it("T-AMT-3 — fee ON with null/0 amount is NOT a saveable active state", () => {
+    expect(feeAmountValidForSave(true, null)).toBe(false);
+    expect(feeAmountValidForSave(true, 0)).toBe(false);
+  });
+
+  it("fee ON with a positive amount is saveable", () => {
+    expect(feeAmountValidForSave(true, 1)).toBe(true);
+    expect(feeAmountValidForSave(true, 2500)).toBe(true);
+  });
+});
+
+describe("minorFromMajor — currency-aware cents conversion (input → fee_amount_cents)", () => {
+  it("converts major dollars/pounds to integer cents", () => {
+    expect(minorFromMajor(25, "USD")).toBe(2500);
+    expect(minorFromMajor(10.5, "GBP")).toBe(1050);
+  });
+
+  it("rounds to a whole integer (no fractional cents persisted)", () => {
+    expect(minorFromMajor(9.999, "USD")).toBe(1000);
+    expect(Number.isInteger(minorFromMajor(3.337, "EUR"))).toBe(true);
+  });
+
+  it("zero-decimal currencies (JPY) use a factor of 1", () => {
+    expect(minorFromMajor(2500, "JPY")).toBe(2500);
+  });
+
+  it("blank / non-positive / non-finite input clamps to 0 (= no amount set)", () => {
+    expect(minorFromMajor(0, "USD")).toBe(0);
+    expect(minorFromMajor(-5, "USD")).toBe(0);
+    expect(minorFromMajor(Number.NaN, "USD")).toBe(0);
+  });
+
+  it("end-to-end — a typed amount that converts to 0 cents is NOT an active paid fee", () => {
+    const cents = minorFromMajor(0, "USD");
+    expect(paidFeeIsActive(true, cents)).toBe(false);
+    expect(feeAmountValidForSave(true, cents)).toBe(false);
+  });
+});

--- a/mingla-business/src/components/venue/venueFeeGate.ts
+++ b/mingla-business/src/components/venue/venueFeeGate.ts
@@ -31,6 +31,38 @@ export function canEnablePaidReservationFee(
 }
 
 /**
+ * META-ORCH-1148 e2e-validation gap — a PAID reservation fee is only ACTIVE
+ * (will be charged) when the toggle is ON **and** an amount > 0 is set. The
+ * engine / edge fn already treat `fee_enabled` + null/0 amount as FREE
+ * (venue-reservation-create: `fee_enabled && (fee_amount_cents ?? 0) > 0`).
+ * Surfacing the SAME rule in the Settings UI makes the invalid state
+ * (fee_enabled=true + amount null/0) impossible to leave the screen in as a
+ * silently-broken "paid but charges nothing" config.
+ *
+ * Pure so it is fails-on-revert testable
+ * (I-PROPOSED-1148-PAID-FEE-NEEDS-NONZERO-AMOUNT): a revert that returns true
+ * for a null/0 amount lets the broken config read as active and FAILs the test.
+ */
+export function paidFeeIsActive(
+  feeEnabled: boolean,
+  feeAmountCents: number | null,
+): boolean {
+  return feeEnabled && (feeAmountCents ?? 0) > 0;
+}
+
+/**
+ * True when the fee config is SAVEABLE without leaving the screen in the broken
+ * state: either the fee is OFF (amount irrelevant) OR the fee is ON with a
+ * positive amount. A fee ON with null/0 amount is NOT saveable as active.
+ */
+export function feeAmountValidForSave(
+  feeEnabled: boolean,
+  feeAmountCents: number | null,
+): boolean {
+  return !feeEnabled || (feeAmountCents ?? 0) > 0;
+}
+
+/**
  * Resolve readiness from the (camelCased) brand shape this app already carries.
  * `stripeStatus === "active"` is the canonical "charges enabled" signal.
  */

--- a/mingla-business/src/hooks/__tests__/useVenueTables.softDelete.orch1148.test.ts
+++ b/mingla-business/src/hooks/__tests__/useVenueTables.softDelete.orch1148.test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable import/first */
+/**
+ * META-ORCH-1148 e2e-validation gap — venue table SOFT-DELETE hook tests.
+ *
+ * GAP 2: the Tables module shipped add/edit but NO delete. The fix adds
+ * soft-delete (deleted_at column + guarded RPC). These tests prove:
+ *   (1) fetchVenueTables EXCLUDES soft-deleted rows (`.is("deleted_at", null)`)
+ *       so a deleted table vanishes from the operator list, and
+ *   (2) useDeleteVenueTable calls the guarded RPC `biz_venue_table_soft_delete`
+ *       with the table id.
+ *
+ * Fails-on-revert: deleting the `.is("deleted_at", null)` chain call from
+ * fetchVenueTables makes T-DEL-1 fail (the filter is no longer recorded);
+ * deleting the rpc call makes T-DEL-2 fail (no rpc invocation captured).
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+// --- supabase mock: record the query-builder chain + rpc calls. ----------
+const chainCalls: { method: string; args: unknown[] }[] = [];
+const rpcCalls: { fn: string; params: unknown }[] = [];
+
+const makeBuilder = (): Record<string, unknown> => {
+  const builder: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "is", "order", "returns", "update", "upsert"]) {
+    builder[m] = jest.fn((...args: unknown[]) => {
+      chainCalls.push({ method: m, args });
+      return builder;
+    });
+  }
+  // Terminal `.returns()` resolves to an empty result set.
+  builder.returns = jest.fn((..._args: unknown[]) => {
+    chainCalls.push({ method: "returns", args: _args });
+    return Promise.resolve({ data: [], error: null });
+  });
+  return builder;
+};
+
+jest.mock("../../services/supabase", () => ({
+  supabase: {
+    from: jest.fn(() => makeBuilder()),
+    rpc: jest.fn((fn: string, params: unknown) => {
+      rpcCalls.push({ fn, params });
+      return Promise.resolve({ data: null, error: null });
+    }),
+  },
+}));
+
+jest.mock("../../context/AuthContext", () => ({
+  useAuth: () => ({ isAuthReady: true, user: null, authStatus: "ready" }),
+}));
+
+// Capture the mutation config so we can invoke the real mutationFn body.
+let capturedMutation: { mutationFn: (vars: unknown) => Promise<void> } | null =
+  null;
+jest.mock("@tanstack/react-query", () => {
+  const actual = jest.requireActual<typeof import("@tanstack/react-query")>(
+    "@tanstack/react-query",
+  );
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+    useMutation: (config: { mutationFn: (vars: unknown) => Promise<void> }) => {
+      capturedMutation = config;
+      return { mutate: jest.fn(), isPending: false };
+    },
+  };
+});
+
+import { fetchVenueTables, useDeleteVenueTable } from "../useVenueTables";
+import { supabase } from "../../services/supabase";
+
+describe("META-ORCH-1148 — venue table soft-delete", () => {
+  beforeEach(() => {
+    chainCalls.length = 0;
+    rpcCalls.length = 0;
+    jest.clearAllMocks();
+  });
+
+  test("T-DEL-1 — fetchVenueTables excludes soft-deleted rows (deleted_at IS NULL)", async () => {
+    await fetchVenueTables("brand-1");
+    const isCall = chainCalls.find(
+      (c) => c.method === "is" && c.args[0] === "deleted_at" && c.args[1] === null,
+    );
+    expect(isCall).toBeDefined();
+  });
+
+  test("T-DEL-2 — the delete mutation calls the guarded RPC with the table id", async () => {
+    capturedMutation = null;
+    // Calling the hook outside a renderer is safe: it only invokes the (mocked)
+    // useQueryClient + useMutation — no useState/useEffect/useRef.
+    useDeleteVenueTable("brand-1");
+    const mutation = capturedMutation as
+      | { mutationFn: (vars: unknown) => Promise<void> }
+      | null;
+    if (mutation === null) throw new Error("mutation not captured");
+    await mutation.mutationFn({ id: "table-9" });
+    expect(rpcCalls).toContainEqual({
+      fn: "biz_venue_table_soft_delete",
+      params: { p_table_id: "table-9" },
+    });
+    expect(supabase.rpc).toHaveBeenCalledWith("biz_venue_table_soft_delete", {
+      p_table_id: "table-9",
+    });
+  });
+});

--- a/mingla-business/src/hooks/useVenueTables.ts
+++ b/mingla-business/src/hooks/useVenueTables.ts
@@ -73,6 +73,10 @@ export const fetchVenueTables = async (
     .from("venue_tables")
     .select(TABLE_COLUMNS)
     .eq("brand_id", brandId)
+    // Exclude soft-deleted tables (deleted_at set) — they must vanish from the
+    // operator list AND stop producing availability (the engine excludes them
+    // too). Mirrors the engine's `AND t.deleted_at IS NULL`.
+    .is("deleted_at", null)
     .order("sort_order", { ascending: true })
     .order("name", { ascending: true })
     .returns<VenueTableRow[]>();
@@ -119,6 +123,35 @@ export function useUpsertVenueTable(
       };
       if (input.id !== undefined) row.id = input.id;
       const { error } = await supabase.from("venue_tables").upsert(row);
+      if (error !== null) throw error as unknown as Error;
+    },
+    onSuccess: () => {
+      if (brandId !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: venueTablesKeys.list(brandId),
+        });
+      }
+    },
+  });
+}
+
+/**
+ * Soft-DELETE a table via the guarded RPC (`biz_venue_table_soft_delete`).
+ * Preserves reservation history (the row + FK stay; deleted_at is stamped). The
+ * RPC is SECURITY DEFINER + manager+ gated server-side. Idempotent on the server
+ * (already-deleted → no-op). On success the list (which filters deleted_at) and
+ * the availability engine both stop seeing the table.
+ */
+export function useDeleteVenueTable(
+  brandId: string | null,
+): UseMutationResult<void, Error, { id: string }> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { id: string }>({
+    mutationFn: async ({ id }): Promise<void> => {
+      if (brandId === null) throw new Error("brand_required");
+      const { error } = await supabase.rpc("biz_venue_table_soft_delete", {
+        p_table_id: id,
+      });
       if (error !== null) throw error as unknown as Error;
     },
     onSuccess: () => {

--- a/mingla-business/src/utils/currency.ts
+++ b/mingla-business/src/utils/currency.ts
@@ -145,6 +145,17 @@ export const majorFromMinor = (value: number, currency: string): number =>
   value / minorUnitFactor(normalizeCurrency(currency));
 
 /**
+ * Inverse of `majorFromMinor` — convert a major-unit amount (e.g. 25 dollars)
+ * to integer minor units (e.g. 2500 cents), currency-aware (zero-decimal
+ * currencies like JPY/KRW round to whole units). Always returns an integer.
+ * Negative / non-finite inputs clamp to 0.
+ */
+export const minorFromMajor = (value: number, currency: string): number => {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.round(value * minorUnitFactor(normalizeCurrency(currency)));
+};
+
+/**
  * Sensible-default locale per currency. Avoids requiring callers to know
  * which locale to pair. Defaults to en-GB for unknown codes.
  */

--- a/supabase/migrations/20261013000002_orch_1148_venue_table_soft_delete.sql
+++ b/supabase/migrations/20261013000002_orch_1148_venue_table_soft_delete.sql
@@ -1,0 +1,309 @@
+-- ===========================================================================
+-- META-ORCH-1148 e2e-validation gap — venue_tables SOFT DELETE
+-- ---------------------------------------------------------------------------
+-- The Tables module shipped add/edit/deactivate but NO delete: an operator who
+-- mis-creates a table (or permanently removes one) had no way to remove it. This
+-- migration adds SOFT delete (preserves reservation history; reservations.table_id
+-- stays valid) via a new `deleted_at timestamptz` column + a guarded
+-- `biz_venue_table_soft_delete` RPC, and excludes soft-deleted tables from the
+-- availability engine so a deleted table stops producing bookable slots.
+--
+-- WHY SOFT (not ON DELETE SET NULL hard-delete): a hard delete would NULL the
+-- table_id of every historical reservation that referenced the table (the FK is
+-- ON DELETE SET NULL), losing which table a past guest sat at. Soft delete keeps
+-- the row + the FK intact; existing reservations are untouched. The engine and
+-- the operator list simply stop seeing it.
+--
+-- Three changes, all additive:
+--   (1) ADD COLUMN venue_tables.deleted_at timestamptz NULL  (NULL = live).
+--       Re-create the brand-active partial index to also require deleted_at IS
+--       NULL so the hot path stays lean.
+--   (2) RE-EMIT pg_venue_available_slots (engine v3) with ONLY one line added:
+--       `AND t.deleted_at IS NULL` in the eligible-tables CTE. SIGNATURE +
+--       RETURN shape FROZEN (CREATE OR REPLACE, no DROP). Everything else byte-
+--       for-byte identical to v2 (20261008000001). The 2.2 consumer reserve
+--       surface re-grants anon EXECUTE separately (20261012000000); this re-emit
+--       does NOT re-add the anon grant, so the live anon grant is preserved by
+--       the later migration ordering — see the REVOKE/GRANT block (authenticated
+--       only here; anon untouched-from-2.2 because we don't REVOKE it).
+--   (3) biz_venue_table_soft_delete(p_table_id uuid) — SECURITY DEFINER, manager+
+--       gate via biz_brand_effective_rank_for_caller(auth.uid()), idempotent
+--       (already-deleted → no-op), writes an audit_log row. Mirrors the 2.1b
+--       lifecycle RPC shape. Supabase auto-GRANTs EXECUTE to PUBLIC/anon on every
+--       new fn → REVOKE both explicitly (least-privilege belt; the gate is the
+--       enforcement). $function$ closed BEFORE the GRANT block.
+--
+-- I-PROPOSED-1148-SOFT-DELETED-TABLE-NOT-BOOKABLE: a soft-deleted table is
+-- excluded from the availability engine's eligible-table set. A revert that drops
+-- the `deleted_at IS NULL` engine filter lets a deleted table keep producing slots
+-- and FAILs the engine soft-delete SQL test.
+--
+-- Additive-only. MONOTONIC VERSION 20261013000002 — strictly greater than the
+-- current max prefix across anchor main + every sibling worktree (20261013000001).
+-- Re-confirmed at IMPLEMENT by scanning supabase/migrations/ + ~/Desktop/mingla-orchs/*/.
+--
+-- DO NOT run `supabase db push`. The orchestrator applies via the Supabase
+-- Management API after REVIEW (CLI drift-wedged; MCP read-only).
+-- ===========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (1) deleted_at column + leaner hot-path index.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.venue_tables
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz NULL;
+
+-- The brand-active partial index now also excludes soft-deleted rows so the
+-- engine's eligible-table scan never touches a deleted table.
+DROP INDEX IF EXISTS public.venue_tables_brand_active_idx;
+CREATE INDEX IF NOT EXISTS venue_tables_brand_active_idx
+  ON public.venue_tables (brand_id) WHERE is_active AND deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- (2) Engine v3 — identical to v2 EXCEPT the one `AND t.deleted_at IS NULL`
+--     line in the eligible-tables CTE (marked SOFT-DELETE below). Signature +
+--     RETURN frozen; CREATE OR REPLACE (no DROP). Anon EXECUTE is NOT touched
+--     here (the 2.2 grant in 20261012000000 stands).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.pg_venue_available_slots(
+  p_brand_id   uuid,
+  p_date       date,
+  p_party_size int
+)
+RETURNS TABLE (
+  slot_start_utc   timestamptz,
+  slot_local_label text,
+  remaining        int,
+  is_full          boolean
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_enabled       boolean;
+  v_cfg           public.venue_availability_config%ROWTYPE;
+  v_tz            text;
+  v_dow           int;
+  v_turn_min      int;
+  v_buffer_min    int;
+  v_gran_min      int;
+  v_eligible_cnt  int;
+  v_eligible_ids  uuid[];
+  v_cap_per_slot  int;
+  v_now           timestamptz := now();
+BEGIN
+  IF p_brand_id IS NULL OR p_date IS NULL OR p_party_size IS NULL OR p_party_size < 1 THEN
+    RETURN;
+  END IF;
+
+  SELECT reservations_enabled INTO v_enabled
+  FROM public.venue_reservation_settings
+  WHERE brand_id = p_brand_id;
+  IF v_enabled IS NOT TRUE THEN
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_cfg
+  FROM public.venue_availability_config
+  WHERE brand_id = p_brand_id;
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  v_buffer_min := COALESCE(v_cfg.buffer_minutes, 0);
+  v_gran_min   := COALESCE(v_cfg.slot_granularity_minutes, 15);
+  IF v_gran_min < 1 THEN
+    v_gran_min := 15;
+  END IF;
+
+  v_tz := NULLIF(btrim(COALESCE(v_cfg.iana_timezone, '')), '');
+  IF v_tz IS NULL OR NOT EXISTS (SELECT 1 FROM pg_timezone_names WHERE name = v_tz) THEN
+    v_tz := 'UTC';
+  END IF;
+
+  v_turn_min := public.pg_venue_turn_minutes_for_party(v_cfg.turn_times, p_party_size);
+
+  IF EXISTS (
+    SELECT 1 FROM public.venue_blackouts b
+    WHERE b.brand_id = p_brand_id
+      AND b.applies_to = 'all'
+      AND p_date BETWEEN b.date_start AND b.date_end
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- ELIGIBLE TABLES: active, reservable, party-fitting, not blacked out, and —
+  -- SOFT-DELETE — NOT soft-deleted. A deleted table can never produce a slot.
+  SELECT array_agg(t.id), count(*)::int
+  INTO v_eligible_ids, v_eligible_cnt
+  FROM public.venue_tables t
+  WHERE t.brand_id = p_brand_id
+    AND t.is_active
+    AND t.deleted_at IS NULL                       -- SOFT-DELETE exclusion
+    AND t.reservation_policy = 'reservable'
+    AND p_party_size BETWEEN COALESCE(t.min_party, 1)
+                         AND LEAST(COALESCE(t.max_party, t.capacity), t.capacity)
+    AND NOT EXISTS (
+      SELECT 1 FROM public.venue_blackouts b
+      WHERE b.brand_id = p_brand_id
+        AND p_date BETWEEN b.date_start AND b.date_end
+        AND (
+          (b.applies_to = 'table' AND b.table_id = t.id)
+          OR (b.applies_to = 'zone' AND b.zone IS NOT DISTINCT FROM t.zone)
+        )
+    );
+
+  v_eligible_cnt := COALESCE(v_eligible_cnt, 0);
+  IF v_eligible_cnt = 0 THEN
+    RETURN;
+  END IF;
+
+  v_cap_per_slot := LEAST(COALESCE(v_cfg.max_reservations_per_slot, v_eligible_cnt), v_eligible_cnt);
+
+  v_dow := EXTRACT(dow FROM p_date)::int;
+
+  RETURN QUERY
+  WITH periods AS (
+    SELECT
+      pr.value->>'start' AS p_start,
+      pr.value->>'end'   AS p_end
+    FROM jsonb_array_elements(COALESCE(v_cfg.service_periods, '[]'::jsonb)) AS pr(value)
+    WHERE EXISTS (
+      SELECT 1 FROM jsonb_array_elements_text(COALESCE(pr.value->'days', '[]'::jsonb)) AS d(dow)
+      WHERE d.dow::int = v_dow
+    )
+      AND (pr.value->>'start') ~ '^[0-2][0-9]:[0-5][0-9]$'
+      AND (pr.value->>'end')   ~ '^[0-2][0-9]:[0-5][0-9]$'
+  ),
+  bounds AS (
+    SELECT
+      ((p_date::timestamp) AT TIME ZONE v_tz) AS local_midnight_utc,
+      ((split_part(p.p_start, ':', 1))::int * 60 + (split_part(p.p_start, ':', 2))::int) AS start_min,
+      ((split_part(p.p_end,   ':', 1))::int * 60 + (split_part(p.p_end,   ':', 2))::int) AS end_min
+    FROM periods p
+  ),
+  candidates AS (
+    SELECT
+      (b.local_midnight_utc + make_interval(mins => g.minute_of_day)) AS slot_utc,
+      g.minute_of_day
+    FROM bounds b
+    CROSS JOIN LATERAL generate_series(
+      b.start_min,
+      b.end_min - (v_turn_min + v_buffer_min),
+      v_gran_min
+    ) AS g(minute_of_day)
+    WHERE b.end_min - (v_turn_min + v_buffer_min) >= b.start_min
+  ),
+  windowed AS (
+    SELECT DISTINCT c.slot_utc, c.minute_of_day
+    FROM candidates c
+    WHERE c.slot_utc >= v_now + make_interval(mins => COALESCE(v_cfg.min_notice_minutes, 0))
+      AND p_date <= ((v_now AT TIME ZONE v_tz)::date + COALESCE(v_cfg.advance_window_days, 30))
+  ),
+  scored AS (
+    SELECT
+      w.slot_utc,
+      w.minute_of_day,
+      v_cap_per_slot - (
+        SELECT count(*)::int
+        FROM public.reservations r
+        WHERE r.brand_id = p_brand_id
+          AND r.status IN ('requested', 'confirmed', 'seated')
+          AND (r.table_id IS NULL OR r.table_id = ANY (v_eligible_ids))
+          AND r.reserved_for
+                < (w.slot_utc + make_interval(mins => v_turn_min + v_buffer_min))
+          AND (r.reserved_for
+                + make_interval(mins =>
+                    public.pg_venue_turn_minutes_for_party(v_cfg.turn_times, r.party_size)
+                    + v_buffer_min)) > w.slot_utc
+      ) AS remaining_calc
+    FROM windowed w
+  )
+  SELECT
+    s.slot_utc AS slot_start_utc,
+    to_char(s.slot_utc AT TIME ZONE v_tz, 'HH24:MI') AS slot_local_label,
+    GREATEST(s.remaining_calc, 0) AS remaining,
+    (s.remaining_calc <= 0) AS is_full
+  FROM scored s
+  ORDER BY s.slot_utc;
+END;
+$function$;
+
+-- Preserve the live grants. We do NOT REVOKE anon here — the 2.2 consumer reserve
+-- surface (20261012000000) granted anon EXECUTE intentionally and that stands.
+-- authenticated EXECUTE is re-asserted (idempotent) for safety.
+GRANT EXECUTE ON FUNCTION public.pg_venue_available_slots(uuid, date, int) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- (3) biz_venue_table_soft_delete — the guarded soft-delete RPC.
+-- Manager+ gate via the caller's auth context. Idempotent: an already-deleted
+-- (or non-existent-for-this-caller) table is a clean no-op return of the brand's
+-- live table count. Returns the brand_id so the client can invalidate the right
+-- query key. Writes an audit_log row. NO money/checkout/engine-body change.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.biz_venue_table_soft_delete(
+  p_table_id uuid
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_brand uuid;
+  v_already_deleted boolean;
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+  END IF;
+  IF p_table_id IS NULL THEN
+    RAISE EXCEPTION 'table_id_required' USING ERRCODE = '22004';
+  END IF;
+
+  SELECT brand_id, (deleted_at IS NOT NULL)
+    INTO v_brand, v_already_deleted
+  FROM public.venue_tables
+  WHERE id = p_table_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'table_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Manager+ gate. biz_brand_effective_rank_for_caller is SECURITY DEFINER and
+  -- resolves the caller via auth.uid() — works inside this SECURITY DEFINER fn.
+  IF public.biz_brand_effective_rank_for_caller(v_brand)
+       < public.biz_role_rank('event_manager') THEN
+    RAISE EXCEPTION 'not_authorized' USING ERRCODE = '42501';
+  END IF;
+
+  -- Idempotent: already soft-deleted → no-op (no second audit row).
+  IF v_already_deleted THEN
+    RETURN v_brand;
+  END IF;
+
+  UPDATE public.venue_tables
+     SET deleted_at = now(),
+         updated_at = now()
+   WHERE id = p_table_id;
+
+  INSERT INTO public.audit_log (
+    user_id, brand_id, action, target_type, target_id, after
+  ) VALUES (
+    v_uid, v_brand,
+    'venue_table.soft_delete',
+    'venue_table', p_table_id::text,
+    jsonb_build_object('deleted_at', now())
+  );
+
+  RETURN v_brand;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.biz_venue_table_soft_delete(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.biz_venue_table_soft_delete(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.biz_venue_table_soft_delete(uuid) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/__tests__/orch_1148_table_soft_delete_engine.test.sql
+++ b/supabase/migrations/__tests__/orch_1148_table_soft_delete_engine.test.sql
@@ -1,0 +1,92 @@
+-- ===========================================================================
+-- META-ORCH-1148 e2e-validation gap — soft-deleted table is NOT bookable
+-- ---------------------------------------------------------------------------
+-- Live-SQL test (I-PROPOSED-1148-SOFT-DELETED-TABLE-NOT-BOOKABLE). Run AFTER the
+-- 20261013000002 migration is applied, against a live Supabase Postgres:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f \
+--     supabase/migrations/__tests__/orch_1148_table_soft_delete_engine.test.sql
+--
+-- Self-contained: creates an isolated test brand + venue config + ONE reservable
+-- table inside a transaction, asserts the engine returns slots, then SOFT-DELETES
+-- the table (stamps deleted_at directly — mirrors biz_venue_table_soft_delete's
+-- UPDATE) and asserts the engine now returns ZERO slots. ROLLS BACK (no surviving
+-- rows).
+--
+-- Fails-on-revert: if the engine's eligible-tables CTE drops the
+-- `AND t.deleted_at IS NULL` filter, the soft-deleted table keeps producing slots
+-- and assertion A-DEL-2 RAISEs.
+-- ===========================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $test$
+DECLARE
+  v_brand uuid := gen_random_uuid();
+  v_account uuid;
+  v_table uuid := gen_random_uuid();
+  v_wed date;
+  v_before int;
+  v_after int;
+BEGIN
+  v_wed := date_trunc('week', (now() + interval '120 days'))::date + 2; -- Wednesday
+
+  SELECT id INTO v_account FROM public.creator_accounts LIMIT 1;
+  IF v_account IS NULL THEN
+    RAISE EXCEPTION 'soft-delete test: needs at least one public.creator_accounts row to anchor the test brand';
+  END IF;
+
+  INSERT INTO public.brands (id, account_id, name, slug)
+  VALUES (v_brand, v_account, 'SoftDelete Test Venue',
+          'orch1148-softdel-' || substr(v_brand::text, 1, 8))
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO public.venue_reservation_settings (brand_id, reservations_enabled)
+  VALUES (v_brand, true)
+  ON CONFLICT (brand_id) DO UPDATE SET reservations_enabled = true;
+
+  INSERT INTO public.venue_availability_config (
+    brand_id, service_periods, turn_times, buffer_minutes,
+    max_reservations_per_slot, slot_granularity_minutes, advance_window_days,
+    min_notice_minutes, iana_timezone
+  ) VALUES (
+    v_brand,
+    -- Wednesday 17:00–21:00 service
+    jsonb_build_array(jsonb_build_object('name','Dinner','days',jsonb_build_array(3),'start','17:00','end','21:00')),
+    '{"p2": 90, "p4": 90}'::jsonb,
+    0, 5, 60, 30, 0, 'UTC'
+  )
+  ON CONFLICT (brand_id) DO UPDATE
+    SET service_periods = EXCLUDED.service_periods,
+        turn_times = EXCLUDED.turn_times,
+        slot_granularity_minutes = EXCLUDED.slot_granularity_minutes,
+        advance_window_days = EXCLUDED.advance_window_days,
+        iana_timezone = EXCLUDED.iana_timezone;
+
+  -- ONE reservable, party-fitting, LIVE table.
+  INSERT INTO public.venue_tables (id, brand_id, name, capacity, min_party, max_party, reservation_policy, is_active)
+  VALUES (v_table, v_brand, 'T1', 4, 1, 4, 'reservable', true);
+
+  -- A-DEL-1: with the live table, the engine offers slots.
+  SELECT count(*) INTO v_before
+  FROM public.pg_venue_available_slots(v_brand, v_wed, 2);
+  IF v_before = 0 THEN
+    RAISE EXCEPTION 'A-DEL-1 FAIL: expected slots for a live reservable table, got 0';
+  END IF;
+
+  -- SOFT DELETE the table (mirror biz_venue_table_soft_delete's UPDATE).
+  UPDATE public.venue_tables SET deleted_at = now() WHERE id = v_table;
+
+  -- A-DEL-2: a soft-deleted table produces ZERO slots (the engine excludes it).
+  SELECT count(*) INTO v_after
+  FROM public.pg_venue_available_slots(v_brand, v_wed, 2);
+  IF v_after <> 0 THEN
+    RAISE EXCEPTION 'A-DEL-2 FAIL: soft-deleted table still produced % slots (engine deleted_at filter reverted?)', v_after;
+  END IF;
+
+  RAISE NOTICE 'orch_1148 soft-delete engine test PASSED (before=% after=0)', v_before;
+END;
+$test$;
+
+ROLLBACK;

--- a/supabase/migrations/__tests__/orch_1148_table_soft_delete_migration.test.ts
+++ b/supabase/migrations/__tests__/orch_1148_table_soft_delete_migration.test.ts
@@ -1,0 +1,81 @@
+// META-ORCH-1148 e2e-validation gap — table soft-delete migration regression.
+// Run:
+//   deno test --allow-read supabase/migrations/__tests__/orch_1148_table_soft_delete_migration.test.ts
+//
+// Source-level migration regression (no live SQL harness in the worktree). Pins
+// the soft-delete contract that would FAIL if 20261013000002 is reverted or
+// weakened. Anchors I-PROPOSED-1148-SOFT-DELETED-TABLE-NOT-BOOKABLE +
+// the SECURITY-DEFINER manager+ gate + the Supabase auto-grant REVOKE belt.
+
+import { assert, assertMatch } from "jsr:@std/assert@1";
+
+const FILE =
+  "supabase/migrations/20261013000002_orch_1148_venue_table_soft_delete.sql";
+const sql = Deno.readTextFileSync(FILE);
+
+Deno.test("T-SD-1 — adds deleted_at column additively (IF NOT EXISTS)", () => {
+  assertMatch(
+    sql,
+    /ALTER TABLE public\.venue_tables\s+ADD COLUMN IF NOT EXISTS deleted_at timestamptz/,
+  );
+});
+
+Deno.test("T-SD-2 — engine eligible-table CTE excludes soft-deleted rows", () => {
+  // The single load-bearing line — without it a deleted table keeps producing
+  // slots (the bug the e2e gap reported).
+  assertMatch(sql, /AND t\.deleted_at IS NULL/);
+});
+
+Deno.test("T-SD-3 — soft-delete RPC is SECURITY DEFINER + manager+ gated", () => {
+  assertMatch(
+    sql,
+    /CREATE OR REPLACE FUNCTION public\.biz_venue_table_soft_delete\(/,
+  );
+  assertMatch(sql, /SECURITY DEFINER/);
+  // manager+ gate via the caller's effective rank.
+  assertMatch(
+    sql,
+    /biz_brand_effective_rank_for_caller\([^)]*\)\s*<\s*public\.biz_role_rank\('event_manager'\)/,
+  );
+});
+
+Deno.test("T-SD-4 — RPC REVOKEs PUBLIC + anon, GRANTs authenticated (auto-grant belt)", () => {
+  assertMatch(
+    sql,
+    /REVOKE ALL ON FUNCTION public\.biz_venue_table_soft_delete\(uuid\) FROM PUBLIC/,
+  );
+  assertMatch(
+    sql,
+    /REVOKE EXECUTE ON FUNCTION public\.biz_venue_table_soft_delete\(uuid\) FROM anon/,
+  );
+  assertMatch(
+    sql,
+    /GRANT EXECUTE ON FUNCTION public\.biz_venue_table_soft_delete\(uuid\) TO authenticated/,
+  );
+});
+
+Deno.test("T-SD-5 — RPC writes an audit_log row + is idempotent on already-deleted", () => {
+  assertMatch(sql, /INSERT INTO public\.audit_log/);
+  assertMatch(sql, /venue_table\.soft_delete/);
+  // idempotent: an already-deleted table short-circuits.
+  assertMatch(sql, /IF v_already_deleted THEN/);
+});
+
+Deno.test("T-SD-6 — $function$ closed BEFORE the GRANT block (safe-migration protocol)", () => {
+  const fnIdx = sql.indexOf("biz_venue_table_soft_delete");
+  const tail = sql.slice(fnIdx);
+  const closeIdx = tail.indexOf("$function$;");
+  const revokeIdx = tail.indexOf(
+    "REVOKE ALL ON FUNCTION public.biz_venue_table_soft_delete",
+  );
+  assert(closeIdx !== -1, "function dollar-tag must be closed");
+  assert(
+    closeIdx < revokeIdx,
+    "$function$; must close BEFORE the REVOKE/GRANT block",
+  );
+});
+
+Deno.test("T-SD-7 — monotonic prefix strictly greater than the prior max (20261013000001)", () => {
+  const prefix = Number(FILE.match(/(\d{14})/)?.[1]);
+  assert(prefix > 20261013000001, `prefix ${prefix} must exceed 20261013000001`);
+});


### PR DESCRIPTION
## META-ORCH-1148 — venue e2e validation batch

Autonomous on-device (Samsung) + live-DB validation of the venue reservation loop found and fixed **4 real issues** blocking real users from reserving tables / paying deposits. All additive; based directly on main.

### Fixes
1. **Consumer realtime freshness** (`0dada8ab7`) — `useVenueReservable` cached the reserve gate/fee/currency for 5 min; consumers didn't see operator changes. Now `staleTime:0` + `refetchOnMount:"always"` + `refetchOnWindowFocus:true`; `useVenueAvailability` gets explicit `refetchOnWindowFocus`.
2. **Venue fee-amount input + table soft-delete** (`005c5afc8`) — the "Charge a reservation fee" toggle had **no amount field**, so a "paid" fee resolved to $0 and deposits could never be charged. Added a currency-aware fee-amount input (paid fee can't be active with null/0). Plus table **soft-delete** (`biz_venue_table_soft_delete` RPC + `deleted_at`; deleted tables drop out of availability, reservation history preserved). Migration `20261013000002` already applied to prod.
3. **Consumer reserve phone blocker** (`a75020143`) — a signed-in user with a profile phone hit `buyer_phone_required` because the store `user` (seeded from the auth user) never carried `profiles.phone`. `appStore.setProfile` now mirrors a non-empty `profiles.phone` onto `user.phone` (single chokepoint); `VenueReserveSheet` defensively sources `user.phone ?? profile.phone`.

### Tests (all green locally)
- app-mobile: `orch_1148_consumer_phone_blocker` (11), `orch_1148_consumer_realtime_freshness` (6) — node source-assert, fails-on-revert
- mingla-business: `venueFeeAmount` + `useVenueTables.softDelete.orch1148` (14 jest)
- supabase: `orch_1148_table_soft_delete_migration` (7 deno)

### On-device status
Reserve sheet opens, party/date/real-slots/review all proven on the Samsung. Final Stripe deposit card-entry pending human confirm (blind adb can't type into the native pay sheet reliably).

🤖 Generated with [Claude Code](https://claude.com/claude-code)