### PR TITLE
ORCH-1148b: non-US reserve phone blocker — coerce bare-E164 auth phone to +E164

### DIFF
--- a/app-mobile/src/components/expandedCard/VenueReserveSheet.tsx
+++ b/app-mobile/src/components/expandedCard/VenueReserveSheet.tsx
@@ -141,13 +141,28 @@ export const VenueReserveSheet: React.FC<VenueReserveSheetProps> = ({
   );
 
   // ORCH-1148 [consumer phone blocker] — the signed-in user's phone is sourced
-  // from their profile. The store `user` now mirrors `profiles.phone` (see
-  // appStore.setProfile), but we also read `profile.phone` directly as a
+  // from their profile / auth user. The store `user` now mirrors `profiles.phone`
+  // (see appStore.setProfile); we also read `profile.phone` directly as a
   // belt-and-suspenders fallback in case the store `user` merge hasn't landed
   // yet (profile loads asynchronously, possibly after this sheet first reads).
-  // A user WITH a profile phone gets needsPhone=false (no prompt, books with
-  // their phone automatically); a user with NONE gets the contact-phone input.
-  const profilePhone = (user?.phone ?? profile?.phone ?? "").trim();
+  // A user WITH a phone gets needsPhone=false (no prompt, books automatically);
+  // a user with NONE gets the contact-phone input.
+  //
+  // ORCH-1148b [non-US phone blocker] — Supabase Auth stores the onboarding phone
+  // in E.164 WITHOUT the leading '+' (e.g. "32466178389"), while the profile /
+  // public buyer form store it WITH '+'. The server `normalizePhoneE164` only
+  // re-prefixes US numbers (10-digit → +1, 11-digit "1…" → +…), so a bare
+  // international number ("32466178389") normalized to null → buyer_phone_required
+  // for EVERY non-US consumer. Coerce a bare all-digits stored phone to '+digits'
+  // here so the server accepts it. (Already-'+'-prefixed values pass through.)
+  const rawStoredPhone = (profile?.phone ?? user?.phone ?? "").trim();
+  const profilePhone = rawStoredPhone.startsWith("+")
+    ? rawStoredPhone // already E.164 (profile / public buyer form)
+    : /^\d{10}$/.test(rawStoredPhone) || /^1\d{10}$/.test(rawStoredPhone)
+    ? rawStoredPhone // US national (10) / US E.164 "1…" (11) — let the server add +1
+    : /^\d{6,15}$/.test(rawStoredPhone)
+    ? `+${rawStoredPhone}` // full international E.164 missing its '+' (Supabase Auth)
+    : rawStoredPhone;
   const needsPhone = profilePhone.length === 0;
   const composedPhoneE164 = needsPhone
     ? buildPendingCollabPhoneE164(phoneInput, selectedCountry?.dialCode)

--- a/app-mobile/src/store/__tests__/orch_1148_consumer_phone_blocker.test.tsx
+++ b/app-mobile/src/store/__tests__/orch_1148_consumer_phone_blocker.test.tsx
@@ -91,9 +91,20 @@ ok(
 
 // profilePhone must fall back to profile.phone when user.phone is empty.
 ok(
-  "profilePhone falls back to user.phone ?? profile.phone",
-  /user\?\.phone\s*\?\?\s*profile\?\.phone/.test(sheetSrc),
-  "expected `user?.phone ?? profile?.phone`",
+  "rawStoredPhone sources from profile.phone and user.phone",
+  /profile\?\.phone\s*\?\?\s*user\?\.phone/.test(sheetSrc) ||
+    /user\?\.phone\s*\?\?\s*profile\?\.phone/.test(sheetSrc),
+  "expected `profile?.phone ?? user?.phone` (or the reverse)",
+);
+
+// ── ORCH-1148b fix — bare-E164 (no '+') stored phone is coerced to '+digits' ──
+// Supabase Auth stores the onboarding phone without '+'; the server's
+// normalizePhoneE164 only re-prefixes US numbers, so a bare international number
+// must be '+'-coerced client-side or it normalizes to null → buyer_phone_required.
+ok(
+  "bare all-digits stored phone is coerced to +E164",
+  /\.test\(rawStoredPhone\)\s*\?\s*`\+\$\{rawStoredPhone\}`/.test(sheetSrc),
+  "expected the `/^\\d{6,15}$/.test(rawStoredPhone) ? `+${rawStoredPhone}`` coercion",
 );
 
 // needsPhone is derived from the (now profile-aware) phone.
@@ -127,6 +138,45 @@ ok(
 ok(
   "reserve sends composedPhoneE164 as the buyer phone",
   /phone:\s*composedPhoneE164/.test(sheetSrc),
+);
+
+// ── Behavioral proof: the client coercion + the SERVER normalizePhoneE164 ─────
+// together accept a non-US onboarding phone. Mirrors the two functions exactly.
+const coerce = (raw) => {
+  const r = (raw ?? "").trim();
+  if (r.startsWith("+")) return r;
+  if (/^\d{10}$/.test(r) || /^1\d{10}$/.test(r)) return r; // US national / US E.164
+  return /^\d{6,15}$/.test(r) ? `+${r}` : r; // bare international E.164 → restore '+'
+};
+const serverNormalize = (raw) => {
+  if (typeof raw !== "string") return null;
+  const t = raw.trim();
+  if (/^\+[1-9][0-9]{1,14}$/.test(t)) return t;
+  const d = t.replace(/[^\d]/g, "");
+  if (d.length === 10) return `+1${d}`;
+  if (d.length === 11 && d.startsWith("1")) return `+${d}`;
+  return null;
+};
+// Belgium auth phone (no '+') — the exact bug repro.
+ok(
+  "non-US bare auth phone survives coerce → server-normalize (was buyer_phone_required)",
+  serverNormalize(coerce("32466178389")) === "+32466178389",
+  `got ${serverNormalize(coerce("32466178389"))}`,
+);
+// Already-'+' profile phone passes through unchanged.
+ok(
+  "already-+E164 profile phone is unchanged through coerce → normalize",
+  serverNormalize(coerce("+32466178389")) === "+32466178389",
+);
+// US 10-digit still works (no regression).
+ok(
+  "US 10-digit still normalizes to +1 (no regression)",
+  serverNormalize(coerce("2025551234")) === "+12025551234",
+);
+// Proves the OLD path was broken (coercion is load-bearing).
+ok(
+  "without coercion the bare non-US phone normalized to null (regression guard)",
+  serverNormalize("32466178389") === null,
 );
 
 console.log(`\n${passed} assertions passed.`);


### PR DESCRIPTION
## The bug
Every **non-US** consumer hit `buyer_phone_required` when reserving a table, even though their phone was captured at onboarding.

**Root cause:** the signed-in user's phone comes from the Supabase Auth session in E.164 **without** the leading `+` (e.g. Belgium `32466178389`). The server `normalizePhoneE164` only re-prefixes US numbers (10-digit→`+1`, 11-digit `1…`→`+…`), so a bare international number normalized to `null` → 400. (Repro: Ethan Bennett's BE number `32466178389`.)

The prior ORCH-1148 fix mirrored the phone onto `user.phone` but didn't address the missing `+`.

## The fix
`VenueReserveSheet` coerces a bare full-international E.164 to `+digits` before sending, while preserving US national (10-digit) / US E.164 (`1…`) inputs so the server's `+1` heuristic still applies. Already-`+` values (profile / public buyer form) pass through unchanged.

## Tests
Extends `orch_1148_consumer_phone_blocker` (16 assertions) with a behavioral proof (`coerce → server-normalize`) for BE/US/`+E164`, plus a regression guard proving the bare non-US phone **was** normalizing to `null` without the coercion.

## Related (NOT in this PR)
`ConsumerEventDetailScreen` (event/experience/trip ticket checkout) reads only `profile?.phone` with no `user.phone` fallback and no `+`-coercion — same latent risk for non-US buyers on a different flow. Flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)