### PR TITLE
ORCH-1148d: locked-in reservation confirmation card in the Calendar tab

### DIFF
--- a/app-mobile/src/components/activity/ReservationCalendarRow.tsx
+++ b/app-mobile/src/components/activity/ReservationCalendarRow.tsx
@@ -1,20 +1,26 @@
 /**
- * ReservationCalendarRow — META-ORCH-1148 sub-ORCH 2.2b.
+ * ReservationCalendarRow — META-ORCH-1148 sub-ORCH 2.2b + 2.2d.
  * ---------------------------------------------------------------------------
  * Renders one of the signed-in user's venue reservations inside the consumer
- * Calendar tab, alongside calendar entries + business orders (the third
- * UnifiedRow kind). Shows venue · day/time · party · free/deposit, and a Cancel
- * action (honored server-side against cancel_cutoff_hours). Cancellable rows
- * are upcoming + not already cancelled/completed.
+ * Calendar tab, alongside calendar entries + business orders.
+ *
+ * 2.2d [locked-in confirmation card]: the reservation now presents like the
+ * scheduled-experience cards already in the Calendar tab — a tappable card
+ * (venue cover thumbnail · venue · day/time · party · status/fee chips). When
+ * EXPANDED it reveals a prominent "Confirmed — you're locked in" banner plus
+ * the full confirmation: when, party, deposit/payment, occasion, confirmation
+ * reference, and a Cancel action (honored server-side against
+ * cancel_cutoff_hours). Cancellable = upcoming + confirmed/requested.
  *
  * Mirrors BusinessEventCalendarRow's prop/animation shape so it participates in
  * the same staggered Active/Archive entrance.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { Icon } from "../ui/Icon";
+import { ImageWithFallback } from "../figma/ImageWithFallback";
 import type { MyReservationRow } from "../../hooks/useMyReservations";
 
 interface ReservationCalendarRowProps {
@@ -38,6 +44,18 @@ function formatReservedFor(iso: string): string {
   });
 }
 
+function formatReservedForLong(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "Date to be confirmed";
+  return d.toLocaleString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 function formatFee(cents: number | null, currency: string | null): string {
   if (!cents || cents <= 0) return "Free";
   const code = (currency || "USD").toUpperCase();
@@ -51,6 +69,20 @@ function formatFee(cents: number | null, currency: string | null): string {
   }
 }
 
+// Deposit/payment line for the expanded confirmation.
+function formatDeposit(reservation: MyReservationRow): string {
+  const fee = formatFee(reservation.fee_cents, reservation.fee_currency);
+  if (fee === "Free") return "No deposit — free reservation";
+  if (reservation.payment_status === "paid") return `${fee} deposit · Paid`;
+  if (reservation.payment_status === "refunded") return `${fee} deposit · Refunded`;
+  return `${fee} deposit`;
+}
+
+// Short, human confirmation reference from the reservation id.
+function confirmationRef(id: string): string {
+  return `RES-${id.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+}
+
 const STATUS_LABEL: Record<string, string> = {
   requested: "Requested",
   confirmed: "Confirmed",
@@ -62,11 +94,46 @@ const STATUS_LABEL: Record<string, string> = {
   waitlisted: "Waitlisted",
 };
 
+// The expanded banner copy/treatment per status.
+function bannerFor(status: string): {
+  label: string;
+  icon: string;
+  tone: "confirmed" | "pending" | "ended" | "cancelled";
+} {
+  switch (status) {
+    case "confirmed":
+      return { label: "Confirmed — you're locked in", icon: "checkmark-circle", tone: "confirmed" };
+    case "seated":
+      return { label: "Seated — enjoy your visit", icon: "checkmark-circle", tone: "confirmed" };
+    case "requested":
+      return { label: "Requested — awaiting the venue", icon: "time", tone: "pending" };
+    case "waitlisted":
+      return { label: "On the waitlist", icon: "time", tone: "pending" };
+    case "completed":
+      return { label: "Completed", icon: "checkmark-done-circle", tone: "ended" };
+    case "no_show":
+      return { label: "Marked no-show", icon: "close-circle", tone: "cancelled" };
+    case "cancelled_by_guest":
+    case "cancelled_by_venue":
+      return { label: "Reservation cancelled", icon: "close-circle", tone: "cancelled" };
+    default:
+      return { label: STATUS_LABEL[status] ?? status, icon: "information-circle", tone: "pending" };
+  }
+}
+
+function hueColor(hue: string | null): string {
+  const n = Number(hue);
+  if (!Number.isFinite(n)) return "#ea580c";
+  return `hsl(${((n % 360) + 360) % 360}, 55%, 42%)`;
+}
+
 const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
   reservation,
   animation,
   onCancel,
 }) => {
+  const [expanded, setExpanded] = useState(false);
+
   const startMs = Date.parse(reservation.reserved_for);
   const isUpcoming = Number.isFinite(startMs) && startMs > Date.now();
   const isCancellable =
@@ -75,48 +142,135 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
       reservation.status === "requested");
 
   const feeText = formatFee(reservation.fee_cents, reservation.fee_currency);
-  const statusText =
-    STATUS_LABEL[reservation.status] ?? reservation.status;
+  const statusText = STATUS_LABEL[reservation.status] ?? reservation.status;
+  const banner = bannerFor(reservation.status);
+
+  // Cover thumbnail: a real image cover / profile photo when available,
+  // otherwise a hue-tinted placeholder (e.g. when the brand cover is a video,
+  // which we don't play in a list thumbnail — fall back to the brand hue).
+  const imageUri =
+    reservation.brand_cover_type === "image" && reservation.brand_cover_url
+      ? reservation.brand_cover_url
+      : reservation.brand_photo_url ?? null;
+
+  const bannerIconColor =
+    banner.tone === "cancelled"
+      ? "#b91c1c"
+      : banner.tone === "pending"
+      ? "#b45309"
+      : "#047857";
+
+  const bannerToneStyle =
+    banner.tone === "confirmed"
+      ? styles.banner_confirmed
+      : banner.tone === "pending"
+      ? styles.banner_pending
+      : banner.tone === "ended"
+      ? styles.banner_ended
+      : styles.banner_cancelled;
 
   const content = (
     <View style={styles.card}>
-      <View style={styles.iconBadge}>
-        <Icon name="restaurant-outline" size={20} color="#ea580c" />
-      </View>
-      <View style={styles.body}>
-        <Text style={styles.title} numberOfLines={1}>
-          {reservation.brand_name ?? "Reservation"}
-        </Text>
-        <Text style={styles.meta} numberOfLines={1}>
-          {formatReservedFor(reservation.reserved_for)} · Party of{" "}
-          {reservation.party_size}
-        </Text>
-        <View style={styles.chipRow}>
-          <Text style={styles.statusChip}>{statusText}</Text>
-          <Text
-            style={[
-              styles.feeChip,
-              feeText === "Free" ? styles.feeChipFree : styles.feeChipPaid,
-            ]}
-          >
-            {feeText}
-          </Text>
+      <Pressable
+        onPress={() => setExpanded((v) => !v)}
+        accessibilityRole="button"
+        accessibilityLabel={`${expanded ? "Collapse" : "Expand"} reservation at ${reservation.brand_name ?? "venue"}`}
+        style={styles.header}
+      >
+        <View style={styles.thumb}>
+          {imageUri ? (
+            <ImageWithFallback
+              source={{ uri: imageUri }}
+              alt={reservation.brand_name ?? "Venue"}
+              style={{ width: "100%", height: "100%" }}
+            />
+          ) : (
+            <View
+              style={[
+                styles.thumbFallback,
+                { backgroundColor: hueColor(reservation.brand_cover_hue) },
+              ]}
+            >
+              <Icon name="restaurant-outline" size={22} color="#ffffff" />
+            </View>
+          )}
         </View>
-      </View>
-      {isCancellable ? (
-        <Pressable
-          onPress={() => onCancel(reservation)}
-          accessibilityRole="button"
-          accessibilityLabel={`Cancel reservation at ${reservation.brand_name ?? "venue"}`}
-          hitSlop={8}
-          style={({ pressed }) => [
-            styles.cancelBtn,
-            pressed && styles.cancelBtnPressed,
-          ]}
-        >
-          <Text style={styles.cancelText}>Cancel</Text>
-        </Pressable>
-      ) : null}
+
+        <View style={styles.body}>
+          <Text style={styles.title} numberOfLines={1}>
+            {reservation.brand_name ?? "Reservation"}
+          </Text>
+          <Text style={styles.meta} numberOfLines={1}>
+            {formatReservedFor(reservation.reserved_for)} · Party of{" "}
+            {reservation.party_size}
+          </Text>
+          <View style={styles.chipRow}>
+            <Text style={styles.statusChip}>{statusText}</Text>
+            <Text
+              style={[
+                styles.feeChip,
+                feeText === "Free" ? styles.feeChipFree : styles.feeChipPaid,
+              ]}
+            >
+              {feeText === "Free" ? "Free" : `${feeText} deposit`}
+            </Text>
+          </View>
+        </View>
+
+        <Icon
+          name={expanded ? "chevron-up" : "chevron-down"}
+          size={20}
+          color="#9ca3af"
+        />
+      </Pressable>
+
+      {expanded && (
+        <View style={styles.expanded}>
+          {/* Confirmed banner — the "locked in" confirmation. */}
+          <View style={[styles.banner, bannerToneStyle]}>
+            <Icon name={banner.icon} size={18} color={bannerIconColor} />
+            <Text
+              style={[
+                styles.bannerText,
+                banner.tone === "cancelled"
+                  ? styles.bannerTextCancelled
+                  : banner.tone === "pending"
+                  ? styles.bannerTextPending
+                  : styles.bannerTextConfirmed,
+              ]}
+            >
+              {banner.label}
+            </Text>
+          </View>
+
+          <DetailRow icon="calendar-outline" label="When" value={formatReservedForLong(reservation.reserved_for)} />
+          <DetailRow icon="people-outline" label="Party" value={`${reservation.party_size} ${reservation.party_size === 1 ? "guest" : "guests"}`} />
+          <DetailRow icon="card-outline" label="Deposit" value={formatDeposit(reservation)} />
+          {reservation.occasion ? (
+            <DetailRow icon="sparkles-outline" label="Occasion" value={reservation.occasion} />
+          ) : null}
+          {reservation.guest_notes ? (
+            <DetailRow icon="chatbubble-ellipses-outline" label="Notes" value={reservation.guest_notes} />
+          ) : null}
+          <DetailRow icon="pricetag-outline" label="Confirmation" value={confirmationRef(reservation.id)} />
+          <DetailRow icon="storefront-outline" label="Venue" value={reservation.brand_name ?? "Venue"} />
+
+          {isCancellable ? (
+            <Pressable
+              onPress={() => onCancel(reservation)}
+              accessibilityRole="button"
+              accessibilityLabel={`Cancel reservation at ${reservation.brand_name ?? "venue"}`}
+              hitSlop={8}
+              style={({ pressed }) => [
+                styles.cancelBtn,
+                pressed && styles.cancelBtnPressed,
+              ]}
+            >
+              <Text style={styles.cancelText}>Cancel reservation</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      )}
     </View>
   );
 
@@ -135,26 +289,48 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
   return content;
 };
 
+const DetailRow: React.FC<{ icon: string; label: string; value: string }> = ({
+  icon,
+  label,
+  value,
+}) => (
+  <View style={styles.detailRow}>
+    <Icon name={icon} size={16} color="#9ca3af" />
+    <Text style={styles.detailLabel}>{label}</Text>
+    <Text style={styles.detailValue} numberOfLines={2}>
+      {value}
+    </Text>
+  </View>
+);
+
 const styles = StyleSheet.create({
   card: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
     backgroundColor: "#ffffff",
     borderRadius: 16,
-    padding: 14,
     marginHorizontal: 16,
     marginVertical: 6,
     borderWidth: 1,
     borderColor: "#f3f4f6",
+    overflow: "hidden",
   },
-  iconBadge: {
-    width: 44,
-    height: 44,
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 14,
+  },
+  thumb: {
+    width: 52,
+    height: 52,
     borderRadius: 12,
+    overflow: "hidden",
+    backgroundColor: "#fff1e7",
+  },
+  thumbFallback: {
+    width: "100%",
+    height: "100%",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "#fff1e7",
   },
   body: {
     flex: 1,
@@ -201,19 +377,63 @@ const styles = StyleSheet.create({
     color: "#b45309",
     backgroundColor: "#fef3c7",
   },
-  cancelBtn: {
+  expanded: {
+    paddingHorizontal: 14,
+    paddingBottom: 14,
+    paddingTop: 2,
+    gap: 10,
+  },
+  banner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
     paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 10,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  banner_confirmed: { backgroundColor: "#ecfdf5", borderWidth: 1, borderColor: "#a7f3d0" },
+  banner_pending: { backgroundColor: "#fffbeb", borderWidth: 1, borderColor: "#fde68a" },
+  banner_ended: { backgroundColor: "#f3f4f6", borderWidth: 1, borderColor: "#e5e7eb" },
+  banner_cancelled: { backgroundColor: "#fef2f2", borderWidth: 1, borderColor: "#fecaca" },
+  bannerText: {
+    fontSize: 13.5,
+    fontWeight: "700",
+    flex: 1,
+  },
+  bannerTextConfirmed: { color: "#047857" },
+  bannerTextPending: { color: "#b45309" },
+  bannerTextCancelled: { color: "#b91c1c" },
+  detailRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  detailLabel: {
+    fontSize: 12.5,
+    fontWeight: "600",
+    color: "#9ca3af",
+    width: 92,
+  },
+  detailValue: {
+    fontSize: 13.5,
+    color: "#111827",
+    fontWeight: "500",
+    flex: 1,
+  },
+  cancelBtn: {
+    marginTop: 4,
+    paddingVertical: 11,
+    borderRadius: 12,
     borderWidth: 1,
     borderColor: "#fecaca",
+    alignItems: "center",
   },
   cancelBtnPressed: {
     backgroundColor: "#fef2f2",
   },
   cancelText: {
-    fontSize: 13,
-    fontWeight: "600",
+    fontSize: 13.5,
+    fontWeight: "700",
     color: "#dc2626",
   },
 });

--- a/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
+++ b/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
@@ -1,0 +1,109 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// META-ORCH-1148 2.2d [locked-in confirmation card] — after booking, the
+// reservation must surface in the Calendar tab as a tappable card (like the
+// scheduled-experience cards already there) that, when EXPANDED, shows a
+// prominent "Confirmed — you're locked in" banner + the full confirmation
+// details (when, party, deposit/payment, occasion, confirmation ref, venue),
+// and the data layer must fetch the venue cover/photo so the card matches the
+// scheduled-card look.
+//
+// SOURCE-STRING assertions (the RN row/hook can't mount under the node harness
+// — the established ORCH-1138/1148 consumer pattern). fails-on-revert: each
+// ok(...) flips red if the corresponding fix line is removed. Owner:
+// mingla-implementor.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..", "..");
+const read = (rel) => fs.readFileSync(path.join(REPO_ROOT, rel), "utf8");
+const stripComments = (src) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+let passed = 0;
+function ok(name, cond, detail) {
+  assert.ok(cond, `FAIL ${name}${detail ? " — " + detail : ""}`);
+  console.log(`OK   ${name}`);
+  passed += 1;
+}
+
+const APP = "app-mobile";
+const rowSrc = stripComments(
+  read(`${APP}/src/components/activity/ReservationCalendarRow.tsx`),
+);
+const hookSrc = stripComments(read(`${APP}/src/hooks/useMyReservations.ts`));
+
+// ── Data layer — the hook fetches the venue cover/photo + notes ─────────────
+ok(
+  "useMyReservations selects the brand cover media + photo + hue",
+  /brands\(name,\s*cover_media_url,\s*cover_media_type,\s*profile_photo_url,\s*cover_hue\)/.test(
+    hookSrc,
+  ),
+  "expected brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue)",
+);
+ok(
+  "MyReservationRow exposes brand cover fields",
+  /brand_cover_url:/.test(hookSrc) &&
+    /brand_cover_type:/.test(hookSrc) &&
+    /brand_photo_url:/.test(hookSrc) &&
+    /brand_cover_hue:/.test(hookSrc),
+);
+ok(
+  "useMyReservations also reads guest_notes",
+  /guest_notes/.test(hookSrc),
+);
+
+// ── Card — expandable like the scheduled cards ──────────────────────────────
+ok(
+  "row is expandable (collapsed ↔ expanded state)",
+  /useState\(false\)/.test(rowSrc) && /setExpanded\(\(v\)\s*=>\s*!v\)/.test(rowSrc),
+  "expected an `expanded` toggle on tap",
+);
+ok(
+  "collapsed header shows a venue cover thumbnail (image or hue fallback)",
+  /ImageWithFallback/.test(rowSrc) && /hueColor\(/.test(rowSrc),
+);
+ok(
+  "expanded content is gated on `expanded`",
+  /\{expanded\s*&&\s*\(/.test(rowSrc),
+);
+
+// ── The Confirmed banner — the locked-in confirmation ───────────────────────
+ok(
+  "expanded view renders a Confirmed / locked-in banner",
+  /you're locked in/.test(rowSrc) && /bannerFor\(/.test(rowSrc),
+  "expected the `Confirmed — you're locked in` banner",
+);
+ok(
+  "confirmed status maps to the confirmed banner tone",
+  /case "confirmed":[\s\S]*?tone:\s*"confirmed"/.test(rowSrc),
+);
+
+// ── Full confirmation details ───────────────────────────────────────────────
+ok(
+  "expanded view shows When / Party / Deposit / Confirmation / Venue rows",
+  /label="When"/.test(rowSrc) &&
+    /label="Party"/.test(rowSrc) &&
+    /label="Deposit"/.test(rowSrc) &&
+    /label="Confirmation"/.test(rowSrc) &&
+    /label="Venue"/.test(rowSrc),
+);
+ok(
+  "deposit line reflects the paid state",
+  /payment_status === "paid"/.test(rowSrc) && /deposit · Paid/.test(rowSrc),
+);
+ok(
+  "a human confirmation reference is derived from the id",
+  /confirmationRef/.test(rowSrc) && /RES-/.test(rowSrc),
+);
+
+// ── Cancel preserved, gated on upcoming + confirmed/requested ───────────────
+ok(
+  "Cancel action survives and stays gated on cancellable",
+  /isCancellable/.test(rowSrc) && /Cancel reservation/.test(rowSrc),
+);
+
+console.log(`\n${passed} assertions passed.`);

--- a/app-mobile/src/hooks/useMyReservations.ts
+++ b/app-mobile/src/hooks/useMyReservations.ts
@@ -18,6 +18,10 @@ export interface MyReservationRow {
   id: string;
   brand_id: string;
   brand_name: string | null;
+  brand_cover_url: string | null;
+  brand_cover_type: string | null;
+  brand_photo_url: string | null;
+  brand_cover_hue: string | null;
   reserved_for: string;
   party_size: number;
   status: string;
@@ -25,7 +29,16 @@ export interface MyReservationRow {
   fee_currency: string | null;
   payment_status: string;
   occasion: string | null;
+  guest_notes: string | null;
   created_at: string;
+}
+
+interface RawBrandJoin {
+  name: string | null;
+  cover_media_url: string | null;
+  cover_media_type: string | null;
+  profile_photo_url: string | null;
+  cover_hue: string | null;
 }
 
 interface RawReservationRow {
@@ -38,8 +51,9 @@ interface RawReservationRow {
   fee_currency: string | null;
   payment_status: string;
   occasion: string | null;
+  guest_notes: string | null;
   created_at: string;
-  brands: { name: string | null } | { name: string | null }[] | null;
+  brands: RawBrandJoin | RawBrandJoin[] | null;
 }
 
 export const myReservationsKeys = {
@@ -53,7 +67,7 @@ async function fetchMyReservations(
   const { data, error } = await supabase
     .from("reservations")
     .select(
-      "id, brand_id, reserved_for, party_size, status, fee_cents, fee_currency, payment_status, occasion, created_at, brands(name)",
+      "id, brand_id, reserved_for, party_size, status, fee_cents, fee_currency, payment_status, occasion, guest_notes, created_at, brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue)",
     )
     .eq("consumer_user_id", userId)
     .order("reserved_for", { ascending: false });
@@ -65,6 +79,10 @@ async function fetchMyReservations(
       id: r.id,
       brand_id: r.brand_id,
       brand_name: brand?.name ?? null,
+      brand_cover_url: brand?.cover_media_url ?? null,
+      brand_cover_type: brand?.cover_media_type ?? null,
+      brand_photo_url: brand?.profile_photo_url ?? null,
+      brand_cover_hue: brand?.cover_hue ?? null,
       reserved_for: r.reserved_for,
       party_size: r.party_size,
       status: r.status,
@@ -72,6 +90,7 @@ async function fetchMyReservations(
       fee_currency: r.fee_currency,
       payment_status: r.payment_status,
       occasion: r.occasion,
+      guest_notes: r.guest_notes,
       created_at: r.created_at,
     };
   });


### PR DESCRIPTION
## What
After booking, the consumer's reservation showed as a thin one-line row. It now presents like the **scheduled-experience cards** already in the Calendar tab — a tappable card (venue cover thumbnail · venue · day/time · party · status/fee chips) that, when **expanded**, reveals a prominent **"Confirmed — you're locked in" banner** plus the full confirmation:

- **When** (full day + time)
- **Party** size
- **Deposit** + payment status (e.g. "$10 deposit · Paid")
- **Occasion** + guest **Notes** (when set)
- **Confirmation** reference (`RES-XXXXXX`)
- **Venue**
- **Cancel** (preserved, gated on upcoming + confirmed/requested)

Per Seth: reuse the existing scheduled-card pattern, just surface the confirmed banner on expand.

## Data
`useMyReservations` now joins the brand `cover_media_url` / `cover_media_type` / `profile_photo_url` / `cover_hue` (+ `guest_notes`) so the card matches the scheduled-card look. A **video** cover (e.g. Lantern & Vine) falls back to a hue-tinted placeholder — we don't play video in a list thumbnail.

## Placement
Unchanged — confirmed reservations stay **Active until the meal window ends** (already +120 min past start), then archive. (An older test booking aging into Archive is why it looked "missing".)

## Test
`orch_1148d_reservation_confirmation_card` — 12 source-assert checks, fails-on-revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)