### PR TITLE
ORCH-1148e: reservation pass — check-in QR + weather + live-traffic directions

### DIFF
--- a/app-mobile/src/components/activity/ReservationCalendarRow.tsx
+++ b/app-mobile/src/components/activity/ReservationCalendarRow.tsx
@@ -16,11 +16,15 @@
  * the same staggered Active/Archive entrance.
  */
 
-import React, { useState } from "react";
-import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
+import React, { useEffect, useState } from "react";
+import { Animated, Linking, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import QRCode from "react-native-qrcode-svg";
 
 import { Icon } from "../ui/Icon";
 import { ImageWithFallback } from "../figma/ImageWithFallback";
+import WeatherSection from "../expandedCard/WeatherSection";
+import { weatherService, type WeatherData } from "../../services/weatherService";
+import { useAppStore } from "../../store/appStore";
 import type { MyReservationRow } from "../../hooks/useMyReservations";
 
 interface ReservationCalendarRowProps {
@@ -83,6 +87,33 @@ function confirmationRef(id: string): string {
   return `RES-${id.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
 }
 
+// The QR payload the venue scans to check the guest in. Encodes the canonical
+// reservation id under the mingla scheme (stable, scanner-resolvable).
+function reservationQrValue(reservation: MyReservationRow): string {
+  return `mingla://reservation/${reservation.id}`;
+}
+
+// Opens the native maps app with DIRECTIONS to the venue — which surfaces live
+// traffic + ETA from the user's current location. Prefers lat/lng; falls back
+// to the address string. Apple Maps on iOS, Google Maps elsewhere.
+function openDirections(reservation: MyReservationRow): void {
+  const hasCoords =
+    typeof reservation.brand_lat === "number" &&
+    typeof reservation.brand_lng === "number";
+  const dest = hasCoords
+    ? `${reservation.brand_lat},${reservation.brand_lng}`
+    : reservation.brand_address
+    ? encodeURIComponent(reservation.brand_address)
+    : null;
+  if (!dest) return;
+  const label = encodeURIComponent(reservation.brand_name ?? "Venue");
+  const url =
+    Platform.OS === "ios"
+      ? `http://maps.apple.com/?daddr=${dest}&q=${label}&dirflg=d`
+      : `https://www.google.com/maps/dir/?api=1&destination=${dest}&travelmode=driving`;
+  void Linking.openURL(url);
+}
+
 const STATUS_LABEL: Record<string, string> = {
   requested: "Requested",
   confirmed: "Confirmed",
@@ -133,9 +164,53 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
   onCancel,
 }) => {
   const [expanded, setExpanded] = useState(false);
+  const [weather, setWeather] = useState<WeatherData | null>(null);
+  const [weatherLoading, setWeatherLoading] = useState(false);
+  const [weatherTried, setWeatherTried] = useState(false);
+
+  const measurementSystem = useAppStore(
+    (s) => (s.user?.measurement_system === "Metric" ? "Metric" : "Imperial") as
+      | "Metric"
+      | "Imperial",
+  );
 
   const startMs = Date.parse(reservation.reserved_for);
   const isUpcoming = Number.isFinite(startMs) && startMs > Date.now();
+
+  // Lazily fetch the forecast for the venue + reservation date when the card is
+  // first expanded (Open-Meteo, free, no key). Beyond the forecast horizon it
+  // resolves null → the weather block simply hides.
+  useEffect(() => {
+    if (!expanded || weatherTried) return;
+    const lat = reservation.brand_lat;
+    const lng = reservation.brand_lng;
+    if (typeof lat !== "number" || typeof lng !== "number") {
+      setWeatherTried(true);
+      return;
+    }
+    let cancelled = false;
+    setWeatherTried(true);
+    setWeatherLoading(true);
+    const when = Number.isFinite(startMs) ? new Date(startMs) : new Date();
+    weatherService
+      .getWeatherForecast(lat, lng, when)
+      .then((data) => {
+        if (!cancelled) setWeather(data);
+      })
+      .catch(() => {
+        if (!cancelled) setWeather(null);
+      })
+      .finally(() => {
+        if (!cancelled) setWeatherLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [expanded, weatherTried, reservation.brand_lat, reservation.brand_lng, startMs]);
+
+  const hasLocation =
+    typeof reservation.brand_lat === "number" ||
+    !!reservation.brand_address;
   const isCancellable =
     isUpcoming &&
     (reservation.status === "confirmed" ||
@@ -243,6 +318,22 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
             </Text>
           </View>
 
+          {/* Check-in QR — the digital reservation pass (scan at the venue). */}
+          {(banner.tone === "confirmed" || banner.tone === "pending") && (
+            <View style={styles.qrCard}>
+              <View style={styles.qrBox}>
+                <QRCode
+                  value={reservationQrValue(reservation)}
+                  size={132}
+                  backgroundColor="#ffffff"
+                  color="#0c0e12"
+                />
+              </View>
+              <Text style={styles.qrRef}>{confirmationRef(reservation.id)}</Text>
+              <Text style={styles.qrHint}>Show this at the venue to check in</Text>
+            </View>
+          )}
+
           <DetailRow icon="calendar-outline" label="When" value={formatReservedForLong(reservation.reserved_for)} />
           <DetailRow icon="people-outline" label="Party" value={`${reservation.party_size} ${reservation.party_size === 1 ? "guest" : "guests"}`} />
           <DetailRow icon="card-outline" label="Deposit" value={formatDeposit(reservation)} />
@@ -254,6 +345,40 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
           ) : null}
           <DetailRow icon="pricetag-outline" label="Confirmation" value={confirmationRef(reservation.id)} />
           <DetailRow icon="storefront-outline" label="Venue" value={reservation.brand_name ?? "Venue"} />
+          {reservation.brand_address ? (
+            <DetailRow icon="location-outline" label="Address" value={reservation.brand_address} />
+          ) : null}
+
+          {/* Getting there — opens native maps with live traffic + ETA. */}
+          {hasLocation ? (
+            <Pressable
+              onPress={() => openDirections(reservation)}
+              accessibilityRole="button"
+              accessibilityLabel={`Get directions to ${reservation.brand_name ?? "the venue"}`}
+              style={({ pressed }) => [
+                styles.directionsBtn,
+                pressed && styles.directionsBtnPressed,
+              ]}
+            >
+              <Icon name="navigate-outline" size={16} color="#1d4ed8" />
+              <Text style={styles.directionsText}>Directions & live traffic</Text>
+            </Pressable>
+          ) : null}
+
+          {/* Weather forecast for the venue at your reservation time. */}
+          {(weatherLoading || weather) && (
+            <View style={styles.weatherWrap}>
+              <Text style={styles.sectionLabel}>Weather at your visit</Text>
+              <WeatherSection
+                weatherData={weather}
+                loading={weatherLoading}
+                selectedDateTime={
+                  Number.isFinite(startMs) ? new Date(startMs) : undefined
+                }
+                measurementSystem={measurementSystem}
+              />
+            </View>
+          )}
 
           {isCancellable ? (
             <Pressable
@@ -435,6 +560,58 @@ const styles = StyleSheet.create({
     fontSize: 13.5,
     fontWeight: "700",
     color: "#dc2626",
+  },
+  qrCard: {
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 16,
+    backgroundColor: "#f9fafb",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "#eef2f7",
+  },
+  qrBox: {
+    padding: 12,
+    backgroundColor: "#ffffff",
+    borderRadius: 12,
+  },
+  qrRef: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: "#111827",
+    letterSpacing: 1,
+    marginTop: 4,
+  },
+  qrHint: {
+    fontSize: 12,
+    color: "#6b7280",
+  },
+  directionsBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 11,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#bfdbfe",
+    backgroundColor: "#eff6ff",
+  },
+  directionsBtnPressed: {
+    backgroundColor: "#dbeafe",
+  },
+  directionsText: {
+    fontSize: 13.5,
+    fontWeight: "700",
+    color: "#1d4ed8",
+  },
+  weatherWrap: {
+    gap: 6,
+  },
+  sectionLabel: {
+    fontSize: 12.5,
+    fontWeight: "700",
+    color: "#6b7280",
   },
 });
 

--- a/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
+++ b/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
@@ -39,7 +39,7 @@ const hookSrc = stripComments(read(`${APP}/src/hooks/useMyReservations.ts`));
 // ── Data layer — the hook fetches the venue cover/photo + notes ─────────────
 ok(
   "useMyReservations selects the brand cover media + photo + hue",
-  /brands\(name,\s*cover_media_url,\s*cover_media_type,\s*profile_photo_url,\s*cover_hue\)/.test(
+  /brands\(name,\s*cover_media_url,\s*cover_media_type,\s*profile_photo_url,\s*cover_hue/.test(
     hookSrc,
   ),
   "expected brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue)",
@@ -104,6 +104,41 @@ ok(
 ok(
   "Cancel action survives and stays gated on cancellable",
   /isCancellable/.test(rowSrc) && /Cancel reservation/.test(rowSrc),
+);
+
+// ── 2.2e [QR + weather + traffic] — the digital reservation pass ─────────────
+ok(
+  "renders a check-in QR code encoding the reservation id",
+  /from "react-native-qrcode-svg"/.test(rowSrc) &&
+    /reservationQrValue\(/.test(rowSrc) &&
+    /mingla:\/\/reservation\//.test(rowSrc),
+);
+ok(
+  "QR is gated to live reservations (confirmed/pending tone)",
+  /banner\.tone === "confirmed" \|\| banner\.tone === "pending"/.test(rowSrc),
+);
+ok(
+  "shows the venue address row",
+  /label="Address"/.test(rowSrc),
+);
+ok(
+  "Directions opens native maps with driving/live-traffic routing",
+  /openDirections\(/.test(rowSrc) &&
+    /maps\.apple\.com\/\?daddr=/.test(rowSrc) &&
+    /maps\/dir\/\?api=1&destination=/.test(rowSrc) &&
+    /Directions & live traffic/.test(rowSrc),
+);
+ok(
+  "fetches + renders the weather forecast for the venue + reservation time",
+  /weatherService[\s\S]*getWeatherForecast\(/.test(rowSrc) &&
+    /<WeatherSection/.test(rowSrc) &&
+    /brand_lat/.test(rowSrc),
+);
+ok(
+  "hook fetches venue address + coordinates for the pass",
+  /address,\s*city,\s*lat,\s*lng/.test(hookSrc) &&
+    /brand_lat:/.test(hookSrc) &&
+    /brand_address:/.test(hookSrc),
 );
 
 console.log(`\n${passed} assertions passed.`);

--- a/app-mobile/src/hooks/useMyReservations.ts
+++ b/app-mobile/src/hooks/useMyReservations.ts
@@ -22,6 +22,10 @@ export interface MyReservationRow {
   brand_cover_type: string | null;
   brand_photo_url: string | null;
   brand_cover_hue: string | null;
+  brand_address: string | null;
+  brand_city: string | null;
+  brand_lat: number | null;
+  brand_lng: number | null;
   reserved_for: string;
   party_size: number;
   status: string;
@@ -39,6 +43,10 @@ interface RawBrandJoin {
   cover_media_type: string | null;
   profile_photo_url: string | null;
   cover_hue: string | null;
+  address: string | null;
+  city: string | null;
+  lat: number | null;
+  lng: number | null;
 }
 
 interface RawReservationRow {
@@ -67,7 +75,7 @@ async function fetchMyReservations(
   const { data, error } = await supabase
     .from("reservations")
     .select(
-      "id, brand_id, reserved_for, party_size, status, fee_cents, fee_currency, payment_status, occasion, guest_notes, created_at, brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue)",
+      "id, brand_id, reserved_for, party_size, status, fee_cents, fee_currency, payment_status, occasion, guest_notes, created_at, brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue, address, city, lat, lng)",
     )
     .eq("consumer_user_id", userId)
     .order("reserved_for", { ascending: false });
@@ -83,6 +91,10 @@ async function fetchMyReservations(
       brand_cover_type: brand?.cover_media_type ?? null,
       brand_photo_url: brand?.profile_photo_url ?? null,
       brand_cover_hue: brand?.cover_hue ?? null,
+      brand_address: brand?.address ?? null,
+      brand_city: brand?.city ?? null,
+      brand_lat: typeof brand?.lat === "number" ? brand.lat : null,
+      brand_lng: typeof brand?.lng === "number" ? brand.lng : null,
       reserved_for: r.reserved_for,
       party_size: r.party_size,
       status: r.status,


### PR DESCRIPTION
## What
Turns the expanded reservation card into a full **digital reservation pass**:

- **Check-in QR** (`react-native-qrcode-svg`) encoding `mingla://reservation/<id>`, with the `RES-XXXXXX` reference + "show this at the venue" hint. Gated to live (confirmed/pending) reservations.
- **Weather** for the venue + reservation time — fetched lazily on expand via the existing `weatherService` (Open-Meteo, free, no key), rendered through the shared `WeatherSection`. Hidden beyond the forecast horizon.
- **Directions & live traffic** — opens the native maps app (Apple Maps iOS / Google Maps elsewhere) with driving directions to the venue coords/address, surfacing live traffic + ETA.
- Venue **Address** row + all prior details (When, Party, Deposit·Paid, Occasion, Notes, Confirmation, Venue).

`useMyReservations` now joins brand `address/city/lat/lng`.

## Note
QR rendering is client-side; an operator-side reservation **scanner** to validate the QR at check-in is a separate follow-up (tickets already have a scanner pattern to mirror). Inline turn-by-turn traffic is delegated to native maps (reliable, no extra location permission/Directions-API spend).

## Test
`orch_1148d_reservation_confirmation_card` grows to 18 source-assert checks (QR / address / directions / weather / hook-geo), fails-on-revert. `[TEST-MOD-APPROVED ORCH-1148-E]` for the widened cover-SELECT assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)