### PR TITLE
ORCH-1148f: reservation pass inside the existing ExpandedCardModal (QR + details)

### DIFF
--- a/app-mobile/src/components/ExpandedCardModal.tsx
+++ b/app-mobile/src/components/ExpandedCardModal.tsx
@@ -38,6 +38,7 @@ import CardInfoSection from "./expandedCard/CardInfoSection";
 import WeatherSection from "./expandedCard/WeatherSection";
 import BusynessSection from "./expandedCard/BusynessSection";
 import PracticalDetailsSection from "./expandedCard/PracticalDetailsSection";
+import ReservationPassSection from "./expandedCard/ReservationPassSection";
 import TimelineSection from "./expandedCard/TimelineSection";
 import EventDetailLayout from "./expandedCard/EventDetailLayout";
 import CompanionStopsSection from "./expandedCard/CompanionStopsSection";
@@ -1399,6 +1400,7 @@ export default function ExpandedCardModal({
   navigationTotal,
   onPaywallRequired,
   canAccessCurated = true,
+  reservationPass,
 }: ExpandedCardModalProps) {
   // ORCH-0828: project the union back to the legacy `card` / `businessEvent`
   // local bindings used throughout the rest of this large component. The
@@ -1916,6 +1918,11 @@ export default function ExpandedCardModal({
       >
             {/* ORCH-0908: locked-in banner — renders for ANY card type (curated/event/place) when shared via lock-and-schedule */}
             {card && <LockedInBanner card={card} />}
+
+            {/* META-ORCH-1148 2.2f: when opened from a booked reservation, the
+                injected Confirmed pass (banner + check-in QR + details) sits at
+                the top of the existing expanded card design. */}
+            {reservationPass && <ReservationPassSection pass={reservationPass} />}
 
             {/* ===== Curated Experience Plan ===== */}
             {isCuratedCard && curatedCard && Array.isArray(curatedCard.stops) && (

--- a/app-mobile/src/components/activity/CalendarTab.tsx
+++ b/app-mobile/src/components/activity/CalendarTab.tsx
@@ -26,7 +26,7 @@ import ExpandedCardModal from "../ExpandedCardModal";
 import { mixpanelService } from "../../services/mixpanelService";
 import { logAppsFlyerEvent } from "../../services/appsFlyerService";
 import { recordCardExpand } from "../../services/cardEngagementService";
-import { ExpandedCardData } from "../../types/expandedCardTypes";
+import { ExpandedCardData, ReservationPass } from "../../types/expandedCardTypes";
 import { useAppStore } from "../../store/appStore";
 import { useQueryClient } from "@tanstack/react-query";
 import { toastManager } from "../ui/Toast";
@@ -224,6 +224,10 @@ const CalendarTab = ({
   const lastModalCloseAtRef = useRef(0);
   const [selectedCardForExpansion, setSelectedCardForExpansion] =
     useState<ExpandedCardData | null>(null);
+  // META-ORCH-1148 2.2f — the Confirmed reservation pass injected into the
+  // ExpandedCardModal when a reservation row is tapped (null for normal cards).
+  const [reservationPassForModal, setReservationPassForModal] =
+    useState<ReservationPass | null>(null);
   const [isScheduling, setIsScheduling] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedWhen, setSelectedWhen] = useState<WhenFilter>('all');
@@ -1725,7 +1729,91 @@ const CalendarTab = ({
   const handleCloseExpandedModal = () => {
     setIsExpandedModalVisible(false);
     setSelectedCardForExpansion(null);
+    setReservationPassForModal(null);
     lastModalCloseAtRef.current = Date.now(); // ORCH-1064: re-open guard window
+  };
+
+  // META-ORCH-1148 2.2f — tapping a reservation opens the SAME ExpandedCardModal
+  // the app uses for venues (its weather / directions / gallery), with the
+  // Confirmed reservation pass (banner + check-in QR + details) injected on top.
+  const handleReservationPress = (reservation: MyReservationRow) => {
+    if (Date.now() - lastModalCloseAtRef.current < 500) return; // re-open guard
+    HapticFeedback.buttonPress();
+
+    const image =
+      reservation.brand_cover_type === "image" && reservation.brand_cover_url
+        ? reservation.brand_cover_url
+        : reservation.brand_photo_url ?? "";
+    const hasCoords =
+      typeof reservation.brand_lat === "number" &&
+      typeof reservation.brand_lng === "number";
+    const startMs = Date.parse(reservation.reserved_for);
+
+    // Minimal venue ExpandedCardData → renders the modal's place branch with
+    // weather (from location) + directions (from address) + gallery.
+    const venueCard: ExpandedCardData = {
+      id: `reservation:${reservation.id}`,
+      placeId: reservation.brand_id,
+      title: reservation.brand_name ?? "Your reservation",
+      category: "Restaurant",
+      categoryIcon: getIconComponent("restaurant"),
+      description: "",
+      fullDescription: "",
+      image,
+      images: image ? [image] : [],
+      rating: 0,
+      reviewCount: 0,
+      priceRange: undefined,
+      distance: "",
+      travelTime: undefined,
+      address: reservation.brand_address ?? "",
+      openingHours: undefined,
+      phone: undefined,
+      website: undefined,
+      highlights: [],
+      tags: [],
+      matchScore: 0,
+      matchFactors: { location: 0, budget: 0, category: 0, time: 0, popularity: 0 },
+      socialStats: { views: 0, likes: 0, saves: 0, shares: 0 },
+      priceTier: undefined,
+      location: hasCoords
+        ? { lat: reservation.brand_lat as number, lng: reservation.brand_lng as number }
+        : undefined,
+      selectedDateTime: Number.isFinite(startMs)
+        ? new Date(startMs)
+        : new Date(),
+    };
+
+    const cancellable =
+      Number.isFinite(startMs) &&
+      startMs > Date.now() &&
+      (reservation.status === "confirmed" || reservation.status === "requested");
+
+    const pass: ReservationPass = {
+      reservationId: reservation.id,
+      status: reservation.status,
+      reservedForUtc: reservation.reserved_for,
+      partySize: reservation.party_size,
+      feeCents: reservation.fee_cents,
+      feeCurrency: reservation.fee_currency,
+      paymentStatus: reservation.payment_status,
+      occasion: reservation.occasion,
+      guestNotes: reservation.guest_notes,
+      venueName: reservation.brand_name,
+      address: reservation.brand_address,
+      confirmationRef: `RES-${reservation.id.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      cancellable,
+      onCancel: cancellable
+        ? () => {
+            handleCloseExpandedModal();
+            handleCancelReservation(reservation);
+          }
+        : undefined,
+    };
+
+    setSelectedCardForExpansion(venueCard);
+    setReservationPassForModal(pass);
+    setIsExpandedModalVisible(true);
   };
 
   const handleSaveFromModal = async (card: ExpandedCardData) => {
@@ -2420,7 +2508,7 @@ const CalendarTab = ({
                         key={row.key}
                         reservation={row.reservation}
                         animation={animation}
-                        onCancel={handleCancelReservation}
+                        onPress={handleReservationPress}
                       />
                     );
                   }
@@ -2492,7 +2580,7 @@ const CalendarTab = ({
                         key={row.key}
                         reservation={row.reservation}
                         animation={animation}
-                        onCancel={handleCancelReservation}
+                        onPress={handleReservationPress}
                       />
                     );
                   }
@@ -2540,6 +2628,7 @@ const CalendarTab = ({
           visible={isExpandedModalVisible}
           // ORCH-0828: discriminated-union target.
           target={{ kind: "nightOut", data: selectedCardForExpansion }}
+          reservationPass={reservationPassForModal}
           onClose={handleCloseExpandedModal}
           onSave={handleSaveFromModal}
           onPurchase={handlePurchaseFromModal}

--- a/app-mobile/src/components/activity/ReservationCalendarRow.tsx
+++ b/app-mobile/src/components/activity/ReservationCalendarRow.tsx
@@ -1,22 +1,21 @@
 /**
- * ReservationCalendarRow — META-ORCH-1148 sub-ORCH 2.2b + 2.2d.
+ * ReservationCalendarRow — META-ORCH-1148 sub-ORCH 2.2b + 2.2f.
  * ---------------------------------------------------------------------------
  * Renders one of the signed-in user's venue reservations inside the consumer
  * Calendar tab, alongside calendar entries + business orders.
  *
- * 2.2d [locked-in confirmation card]: the reservation now presents like the
- * scheduled-experience cards already in the Calendar tab — a tappable card
- * (venue cover thumbnail · venue · day/time · party · status/fee chips). When
- * EXPANDED it reveals a prominent "Confirmed — you're locked in" banner plus
- * the full confirmation: when, party, deposit/payment, occasion, confirmation
- * reference, and a Cancel action (honored server-side against
- * cancel_cutoff_hours). Cancellable = upcoming + confirmed/requested.
+ * 2.2f [open the existing expanded card]: the row is a compact, tappable card
+ * (venue cover thumbnail · venue · day/time · party · status/fee chips). Tapping
+ * it opens the SAME ExpandedCardModal the app already uses for venues — which
+ * carries the weather / directions / gallery — and that modal renders the
+ * injected "Confirmed" reservation pass (banner + details + check-in QR). The
+ * row no longer expands in place; we don't reinvent the expanded design.
  *
  * Mirrors BusinessEventCalendarRow's prop/animation shape so it participates in
  * the same staggered Active/Archive entrance.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { Icon } from "../ui/Icon";
@@ -29,7 +28,7 @@ interface ReservationCalendarRowProps {
     opacity: Animated.Value;
     slide: Animated.Value;
   };
-  onCancel: (reservation: MyReservationRow) => void;
+  onPress: (reservation: MyReservationRow) => void;
 }
 
 function formatReservedFor(iso: string): string {
@@ -38,18 +37,6 @@ function formatReservedFor(iso: string): string {
   return d.toLocaleString(undefined, {
     weekday: "short",
     month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
-function formatReservedForLong(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "Date to be confirmed";
-  return d.toLocaleString(undefined, {
-    weekday: "long",
-    month: "long",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
@@ -69,20 +56,6 @@ function formatFee(cents: number | null, currency: string | null): string {
   }
 }
 
-// Deposit/payment line for the expanded confirmation.
-function formatDeposit(reservation: MyReservationRow): string {
-  const fee = formatFee(reservation.fee_cents, reservation.fee_currency);
-  if (fee === "Free") return "No deposit — free reservation";
-  if (reservation.payment_status === "paid") return `${fee} deposit · Paid`;
-  if (reservation.payment_status === "refunded") return `${fee} deposit · Refunded`;
-  return `${fee} deposit`;
-}
-
-// Short, human confirmation reference from the reservation id.
-function confirmationRef(id: string): string {
-  return `RES-${id.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
-}
-
 const STATUS_LABEL: Record<string, string> = {
   requested: "Requested",
   confirmed: "Confirmed",
@@ -94,33 +67,6 @@ const STATUS_LABEL: Record<string, string> = {
   waitlisted: "Waitlisted",
 };
 
-// The expanded banner copy/treatment per status.
-function bannerFor(status: string): {
-  label: string;
-  icon: string;
-  tone: "confirmed" | "pending" | "ended" | "cancelled";
-} {
-  switch (status) {
-    case "confirmed":
-      return { label: "Confirmed — you're locked in", icon: "checkmark-circle", tone: "confirmed" };
-    case "seated":
-      return { label: "Seated — enjoy your visit", icon: "checkmark-circle", tone: "confirmed" };
-    case "requested":
-      return { label: "Requested — awaiting the venue", icon: "time", tone: "pending" };
-    case "waitlisted":
-      return { label: "On the waitlist", icon: "time", tone: "pending" };
-    case "completed":
-      return { label: "Completed", icon: "checkmark-done-circle", tone: "ended" };
-    case "no_show":
-      return { label: "Marked no-show", icon: "close-circle", tone: "cancelled" };
-    case "cancelled_by_guest":
-    case "cancelled_by_venue":
-      return { label: "Reservation cancelled", icon: "close-circle", tone: "cancelled" };
-    default:
-      return { label: STATUS_LABEL[status] ?? status, icon: "information-circle", tone: "pending" };
-  }
-}
-
 function hueColor(hue: string | null): string {
   const n = Number(hue);
   if (!Number.isFinite(n)) return "#ea580c";
@@ -130,20 +76,10 @@ function hueColor(hue: string | null): string {
 const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
   reservation,
   animation,
-  onCancel,
+  onPress,
 }) => {
-  const [expanded, setExpanded] = useState(false);
-
-  const startMs = Date.parse(reservation.reserved_for);
-  const isUpcoming = Number.isFinite(startMs) && startMs > Date.now();
-  const isCancellable =
-    isUpcoming &&
-    (reservation.status === "confirmed" ||
-      reservation.status === "requested");
-
   const feeText = formatFee(reservation.fee_cents, reservation.fee_currency);
   const statusText = STATUS_LABEL[reservation.status] ?? reservation.status;
-  const banner = bannerFor(reservation.status);
 
   // Cover thumbnail: a real image cover / profile photo when available,
   // otherwise a hue-tinted placeholder (e.g. when the brand cover is a video,
@@ -153,125 +89,55 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
       ? reservation.brand_cover_url
       : reservation.brand_photo_url ?? null;
 
-  const bannerIconColor =
-    banner.tone === "cancelled"
-      ? "#b91c1c"
-      : banner.tone === "pending"
-      ? "#b45309"
-      : "#047857";
-
-  const bannerToneStyle =
-    banner.tone === "confirmed"
-      ? styles.banner_confirmed
-      : banner.tone === "pending"
-      ? styles.banner_pending
-      : banner.tone === "ended"
-      ? styles.banner_ended
-      : styles.banner_cancelled;
-
   const content = (
-    <View style={styles.card}>
-      <Pressable
-        onPress={() => setExpanded((v) => !v)}
-        accessibilityRole="button"
-        accessibilityLabel={`${expanded ? "Collapse" : "Expand"} reservation at ${reservation.brand_name ?? "venue"}`}
-        style={styles.header}
-      >
-        <View style={styles.thumb}>
-          {imageUri ? (
-            <ImageWithFallback
-              source={{ uri: imageUri }}
-              alt={reservation.brand_name ?? "Venue"}
-              style={{ width: "100%", height: "100%" }}
-            />
-          ) : (
-            <View
-              style={[
-                styles.thumbFallback,
-                { backgroundColor: hueColor(reservation.brand_cover_hue) },
-              ]}
-            >
-              <Icon name="restaurant-outline" size={22} color="#ffffff" />
-            </View>
-          )}
-        </View>
-
-        <View style={styles.body}>
-          <Text style={styles.title} numberOfLines={1}>
-            {reservation.brand_name ?? "Reservation"}
-          </Text>
-          <Text style={styles.meta} numberOfLines={1}>
-            {formatReservedFor(reservation.reserved_for)} · Party of{" "}
-            {reservation.party_size}
-          </Text>
-          <View style={styles.chipRow}>
-            <Text style={styles.statusChip}>{statusText}</Text>
-            <Text
-              style={[
-                styles.feeChip,
-                feeText === "Free" ? styles.feeChipFree : styles.feeChipPaid,
-              ]}
-            >
-              {feeText === "Free" ? "Free" : `${feeText} deposit`}
-            </Text>
+    <Pressable
+      onPress={() => onPress(reservation)}
+      accessibilityRole="button"
+      accessibilityLabel={`Open reservation at ${reservation.brand_name ?? "venue"}`}
+      style={styles.card}
+    >
+      <View style={styles.thumb}>
+        {imageUri ? (
+          <ImageWithFallback
+            source={{ uri: imageUri }}
+            alt={reservation.brand_name ?? "Venue"}
+            style={{ width: "100%", height: "100%" }}
+          />
+        ) : (
+          <View
+            style={[
+              styles.thumbFallback,
+              { backgroundColor: hueColor(reservation.brand_cover_hue) },
+            ]}
+          >
+            <Icon name="restaurant-outline" size={22} color="#ffffff" />
           </View>
+        )}
+      </View>
+
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={1}>
+          {reservation.brand_name ?? "Reservation"}
+        </Text>
+        <Text style={styles.meta} numberOfLines={1}>
+          {formatReservedFor(reservation.reserved_for)} · Party of{" "}
+          {reservation.party_size}
+        </Text>
+        <View style={styles.chipRow}>
+          <Text style={styles.statusChip}>{statusText}</Text>
+          <Text
+            style={[
+              styles.feeChip,
+              feeText === "Free" ? styles.feeChipFree : styles.feeChipPaid,
+            ]}
+          >
+            {feeText === "Free" ? "Free" : `${feeText} deposit`}
+          </Text>
         </View>
+      </View>
 
-        <Icon
-          name={expanded ? "chevron-up" : "chevron-down"}
-          size={20}
-          color="#9ca3af"
-        />
-      </Pressable>
-
-      {expanded && (
-        <View style={styles.expanded}>
-          {/* Confirmed banner — the "locked in" confirmation. */}
-          <View style={[styles.banner, bannerToneStyle]}>
-            <Icon name={banner.icon} size={18} color={bannerIconColor} />
-            <Text
-              style={[
-                styles.bannerText,
-                banner.tone === "cancelled"
-                  ? styles.bannerTextCancelled
-                  : banner.tone === "pending"
-                  ? styles.bannerTextPending
-                  : styles.bannerTextConfirmed,
-              ]}
-            >
-              {banner.label}
-            </Text>
-          </View>
-
-          <DetailRow icon="calendar-outline" label="When" value={formatReservedForLong(reservation.reserved_for)} />
-          <DetailRow icon="people-outline" label="Party" value={`${reservation.party_size} ${reservation.party_size === 1 ? "guest" : "guests"}`} />
-          <DetailRow icon="card-outline" label="Deposit" value={formatDeposit(reservation)} />
-          {reservation.occasion ? (
-            <DetailRow icon="sparkles-outline" label="Occasion" value={reservation.occasion} />
-          ) : null}
-          {reservation.guest_notes ? (
-            <DetailRow icon="chatbubble-ellipses-outline" label="Notes" value={reservation.guest_notes} />
-          ) : null}
-          <DetailRow icon="pricetag-outline" label="Confirmation" value={confirmationRef(reservation.id)} />
-          <DetailRow icon="storefront-outline" label="Venue" value={reservation.brand_name ?? "Venue"} />
-
-          {isCancellable ? (
-            <Pressable
-              onPress={() => onCancel(reservation)}
-              accessibilityRole="button"
-              accessibilityLabel={`Cancel reservation at ${reservation.brand_name ?? "venue"}`}
-              hitSlop={8}
-              style={({ pressed }) => [
-                styles.cancelBtn,
-                pressed && styles.cancelBtnPressed,
-              ]}
-            >
-              <Text style={styles.cancelText}>Cancel reservation</Text>
-            </Pressable>
-          ) : null}
-        </View>
-      )}
-    </View>
+      <Icon name="chevron-forward" size={20} color="#9ca3af" />
+    </Pressable>
   );
 
   if (animation) {
@@ -289,35 +155,18 @@ const ReservationCalendarRow: React.FC<ReservationCalendarRowProps> = ({
   return content;
 };
 
-const DetailRow: React.FC<{ icon: string; label: string; value: string }> = ({
-  icon,
-  label,
-  value,
-}) => (
-  <View style={styles.detailRow}>
-    <Icon name={icon} size={16} color="#9ca3af" />
-    <Text style={styles.detailLabel}>{label}</Text>
-    <Text style={styles.detailValue} numberOfLines={2}>
-      {value}
-    </Text>
-  </View>
-);
-
 const styles = StyleSheet.create({
   card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
     backgroundColor: "#ffffff",
     borderRadius: 16,
+    padding: 14,
     marginHorizontal: 16,
     marginVertical: 6,
     borderWidth: 1,
     borderColor: "#f3f4f6",
-    overflow: "hidden",
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    padding: 14,
   },
   thumb: {
     width: 52,
@@ -376,65 +225,6 @@ const styles = StyleSheet.create({
   feeChipPaid: {
     color: "#b45309",
     backgroundColor: "#fef3c7",
-  },
-  expanded: {
-    paddingHorizontal: 14,
-    paddingBottom: 14,
-    paddingTop: 2,
-    gap: 10,
-  },
-  banner: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: 12,
-  },
-  banner_confirmed: { backgroundColor: "#ecfdf5", borderWidth: 1, borderColor: "#a7f3d0" },
-  banner_pending: { backgroundColor: "#fffbeb", borderWidth: 1, borderColor: "#fde68a" },
-  banner_ended: { backgroundColor: "#f3f4f6", borderWidth: 1, borderColor: "#e5e7eb" },
-  banner_cancelled: { backgroundColor: "#fef2f2", borderWidth: 1, borderColor: "#fecaca" },
-  bannerText: {
-    fontSize: 13.5,
-    fontWeight: "700",
-    flex: 1,
-  },
-  bannerTextConfirmed: { color: "#047857" },
-  bannerTextPending: { color: "#b45309" },
-  bannerTextCancelled: { color: "#b91c1c" },
-  detailRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  detailLabel: {
-    fontSize: 12.5,
-    fontWeight: "600",
-    color: "#9ca3af",
-    width: 92,
-  },
-  detailValue: {
-    fontSize: 13.5,
-    color: "#111827",
-    fontWeight: "500",
-    flex: 1,
-  },
-  cancelBtn: {
-    marginTop: 4,
-    paddingVertical: 11,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: "#fecaca",
-    alignItems: "center",
-  },
-  cancelBtnPressed: {
-    backgroundColor: "#fef2f2",
-  },
-  cancelText: {
-    fontSize: 13.5,
-    fontWeight: "700",
-    color: "#dc2626",
   },
 });
 

--- a/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
+++ b/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
@@ -1,18 +1,21 @@
 // @ts-nocheck
 /* eslint-disable @typescript-eslint/no-require-imports */
 //
-// META-ORCH-1148 2.2d [locked-in confirmation card] — after booking, the
-// reservation must surface in the Calendar tab as a tappable card (like the
-// scheduled-experience cards already there) that, when EXPANDED, shows a
-// prominent "Confirmed — you're locked in" banner + the full confirmation
-// details (when, party, deposit/payment, occasion, confirmation ref, venue),
-// and the data layer must fetch the venue cover/photo so the card matches the
-// scheduled-card look.
+// META-ORCH-1148 2.2f [reservation pass in the existing expanded card] —
+// REWRITE of the 2.2d test. Per Seth, we do NOT reinvent an expanded design in
+// the calendar row. Instead:
+//   • the reservation row is a COMPACT, TAPPABLE card (cover · venue · time ·
+//     party · chips) that calls onPress — it no longer expands in place;
+//   • tapping opens the SAME ExpandedCardModal the app already uses for venues
+//     (its weather / directions / gallery), into which a Confirmed reservation
+//     PASS is injected: a status banner, a check-in QR code, the full details,
+//     and Cancel. That pass lives in ReservationPassSection and is rendered by
+//     ExpandedCardModal when `reservationPass` is provided;
+//   • CalendarTab builds a venue ExpandedCardData + the pass from the tapped
+//     reservation and opens the modal.
 //
-// SOURCE-STRING assertions (the RN row/hook can't mount under the node harness
-// — the established ORCH-1138/1148 consumer pattern). fails-on-revert: each
-// ok(...) flips red if the corresponding fix line is removed. Owner:
-// mingla-implementor.
+// SOURCE-STRING assertions (RN can't mount under node — the established
+// ORCH-1138/1148 consumer pattern). fails-on-revert. Owner: mingla-implementor.
 
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
@@ -34,76 +37,104 @@ const APP = "app-mobile";
 const rowSrc = stripComments(
   read(`${APP}/src/components/activity/ReservationCalendarRow.tsx`),
 );
+const passSrc = stripComments(
+  read(`${APP}/src/components/expandedCard/ReservationPassSection.tsx`),
+);
+const modalSrc = stripComments(
+  read(`${APP}/src/components/ExpandedCardModal.tsx`),
+);
+const calSrc = stripComments(
+  read(`${APP}/src/components/activity/CalendarTab.tsx`),
+);
 const hookSrc = stripComments(read(`${APP}/src/hooks/useMyReservations.ts`));
 
-// ── Data layer — the hook fetches the venue cover/photo + notes ─────────────
+// ── Data layer — hook fetches cover + notes + venue geo/address ──────────────
 ok(
-  "useMyReservations selects the brand cover media + photo + hue",
-  /brands\(name,\s*cover_media_url,\s*cover_media_type,\s*profile_photo_url,\s*cover_hue\)/.test(
+  "useMyReservations selects cover + address + coordinates",
+  /brands\(name,\s*cover_media_url,\s*cover_media_type,\s*profile_photo_url,\s*cover_hue,\s*address,\s*city,\s*lat,\s*lng\)/.test(
     hookSrc,
   ),
-  "expected brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue)",
 );
 ok(
-  "MyReservationRow exposes brand cover fields",
-  /brand_cover_url:/.test(hookSrc) &&
-    /brand_cover_type:/.test(hookSrc) &&
-    /brand_photo_url:/.test(hookSrc) &&
-    /brand_cover_hue:/.test(hookSrc),
-);
-ok(
-  "useMyReservations also reads guest_notes",
-  /guest_notes/.test(hookSrc),
+  "MyReservationRow exposes venue address + lat/lng",
+  /brand_address:/.test(hookSrc) &&
+    /brand_lat:/.test(hookSrc) &&
+    /brand_lng:/.test(hookSrc),
 );
 
-// ── Card — expandable like the scheduled cards ──────────────────────────────
+// ── Row — compact + tappable, NOT an in-place expanded card ──────────────────
 ok(
-  "row is expandable (collapsed ↔ expanded state)",
-  /useState\(false\)/.test(rowSrc) && /setExpanded\(\(v\)\s*=>\s*!v\)/.test(rowSrc),
-  "expected an `expanded` toggle on tap",
+  "row is a tappable card that calls onPress (no inline expand)",
+  /onPress:\s*\(reservation/.test(rowSrc) &&
+    /onPress\(reservation\)/.test(rowSrc) &&
+    !/setExpanded/.test(rowSrc),
+  "row should delegate to onPress and not manage its own expanded state",
 );
 ok(
-  "collapsed header shows a venue cover thumbnail (image or hue fallback)",
+  "row keeps the venue cover thumbnail + chips",
   /ImageWithFallback/.test(rowSrc) && /hueColor\(/.test(rowSrc),
 );
+
+// ── ExpandedCardModal — injects the reservation pass (reuse, not reinvent) ────
 ok(
-  "expanded content is gated on `expanded`",
-  /\{expanded\s*&&\s*\(/.test(rowSrc),
+  "modal accepts a reservationPass prop",
+  /reservationPass,/.test(modalSrc) || /reservationPass\b/.test(modalSrc),
+);
+ok(
+  "modal renders ReservationPassSection when a pass is present",
+  /import ReservationPassSection/.test(modalSrc) &&
+    /\{reservationPass\s*&&\s*<ReservationPassSection\s+pass=\{reservationPass\}/.test(
+      modalSrc,
+    ),
 );
 
-// ── The Confirmed banner — the locked-in confirmation ───────────────────────
+// ── ReservationPassSection — banner + QR + full details + cancel ─────────────
 ok(
-  "expanded view renders a Confirmed / locked-in banner",
-  /you're locked in/.test(rowSrc) && /bannerFor\(/.test(rowSrc),
-  "expected the `Confirmed — you're locked in` banner",
+  "pass renders a check-in QR encoding the reservation id",
+  /from "react-native-qrcode-svg"/.test(passSrc) &&
+    /mingla:\/\/reservation\/\$\{pass\.reservationId\}/.test(passSrc),
 );
 ok(
-  "confirmed status maps to the confirmed banner tone",
-  /case "confirmed":[\s\S]*?tone:\s*"confirmed"/.test(rowSrc),
+  "pass renders the Confirmed / locked-in banner",
+  /you're locked in/.test(passSrc) && /bannerFor\(/.test(passSrc),
+);
+ok(
+  "pass shows When / Party / Deposit / Confirmation / Venue",
+  /label="When"/.test(passSrc) &&
+    /label="Party"/.test(passSrc) &&
+    /label="Deposit"/.test(passSrc) &&
+    /label="Confirmation"/.test(passSrc) &&
+    /label="Venue"/.test(passSrc),
+);
+ok(
+  "pass deposit line reflects the paid state",
+  /paymentStatus === "paid"/.test(passSrc) && /deposit · Paid/.test(passSrc),
+);
+ok(
+  "pass exposes a gated Cancel action",
+  /pass\.cancellable\s*&&\s*pass\.onCancel/.test(passSrc) &&
+    /Cancel reservation/.test(passSrc),
 );
 
-// ── Full confirmation details ───────────────────────────────────────────────
+// ── CalendarTab — taps build a venue card + pass and open the modal ──────────
 ok(
-  "expanded view shows When / Party / Deposit / Confirmation / Venue rows",
-  /label="When"/.test(rowSrc) &&
-    /label="Party"/.test(rowSrc) &&
-    /label="Deposit"/.test(rowSrc) &&
-    /label="Confirmation"/.test(rowSrc) &&
-    /label="Venue"/.test(rowSrc),
+  "tapping a reservation opens the modal via handleReservationPress",
+  /handleReservationPress/.test(calSrc) &&
+    /onPress=\{handleReservationPress\}/.test(calSrc),
 );
 ok(
-  "deposit line reflects the paid state",
-  /payment_status === "paid"/.test(rowSrc) && /deposit · Paid/.test(rowSrc),
+  "the venue card carries location (weather) + address (directions)",
+  /location:\s*hasCoords/.test(calSrc) &&
+    /address:\s*reservation\.brand_address/.test(calSrc),
 );
 ok(
-  "a human confirmation reference is derived from the id",
-  /confirmationRef/.test(rowSrc) && /RES-/.test(rowSrc),
+  "the modal is passed the built reservationPass",
+  /reservationPass=\{reservationPassForModal\}/.test(calSrc) &&
+    /setReservationPassForModal\(pass\)/.test(calSrc),
 );
-
-// ── Cancel preserved, gated on upcoming + confirmed/requested ───────────────
 ok(
-  "Cancel action survives and stays gated on cancellable",
-  /isCancellable/.test(rowSrc) && /Cancel reservation/.test(rowSrc),
+  "the pass cancel routes through the existing cancel handler",
+  /handleCancelReservation\(reservation\)/.test(calSrc),
 );
 
 console.log(`\n${passed} assertions passed.`);

--- a/app-mobile/src/components/expandedCard/ReservationPassSection.tsx
+++ b/app-mobile/src/components/expandedCard/ReservationPassSection.tsx
@@ -1,0 +1,224 @@
+/**
+ * ReservationPassSection — META-ORCH-1148 sub-ORCH 2.2f.
+ * ---------------------------------------------------------------------------
+ * The "Confirmed reservation pass" injected at the TOP of the existing
+ * ExpandedCardModal when it is opened from a booked reservation. Renders the
+ * status banner, a check-in QR code (the digital pass the venue scans), the
+ * full confirmation details, and a Cancel action. The rest of the expanded
+ * card (weather / directions / gallery) is the modal's own existing design —
+ * this is purely the additive reservation overlay.
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import QRCode from "react-native-qrcode-svg";
+
+import { Icon } from "../ui/Icon";
+import type { ReservationPass } from "../../types/expandedCardTypes";
+
+function formatReservedForLong(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "Date to be confirmed";
+  return d.toLocaleString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatFee(cents: number | null, currency: string | null): string {
+  if (!cents || cents <= 0) return "Free";
+  const code = (currency || "USD").toUpperCase();
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: code,
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${code}`;
+  }
+}
+
+function formatDeposit(pass: ReservationPass): string {
+  const fee = formatFee(pass.feeCents, pass.feeCurrency);
+  if (fee === "Free") return "No deposit — free reservation";
+  if (pass.paymentStatus === "paid") return `${fee} deposit · Paid`;
+  if (pass.paymentStatus === "refunded") return `${fee} deposit · Refunded`;
+  return `${fee} deposit`;
+}
+
+function bannerFor(status: string): {
+  label: string;
+  icon: string;
+  tone: "confirmed" | "pending" | "ended" | "cancelled";
+} {
+  switch (status) {
+    case "confirmed":
+      return { label: "Confirmed — you're locked in", icon: "checkmark-circle", tone: "confirmed" };
+    case "seated":
+      return { label: "Seated — enjoy your visit", icon: "checkmark-circle", tone: "confirmed" };
+    case "requested":
+      return { label: "Requested — awaiting the venue", icon: "time", tone: "pending" };
+    case "waitlisted":
+      return { label: "On the waitlist", icon: "time", tone: "pending" };
+    case "completed":
+      return { label: "Completed", icon: "checkmark-done-circle", tone: "ended" };
+    case "no_show":
+      return { label: "Marked no-show", icon: "close-circle", tone: "cancelled" };
+    case "cancelled_by_guest":
+    case "cancelled_by_venue":
+      return { label: "Reservation cancelled", icon: "close-circle", tone: "cancelled" };
+    default:
+      return { label: status, icon: "information-circle", tone: "pending" };
+  }
+}
+
+const DetailRow: React.FC<{ icon: string; label: string; value: string }> = ({
+  icon,
+  label,
+  value,
+}) => (
+  <View style={styles.detailRow}>
+    <Icon name={icon} size={16} color="#9ca3af" />
+    <Text style={styles.detailLabel}>{label}</Text>
+    <Text style={styles.detailValue} numberOfLines={2}>
+      {value}
+    </Text>
+  </View>
+);
+
+const ReservationPassSection: React.FC<{ pass: ReservationPass }> = ({ pass }) => {
+  const banner = bannerFor(pass.status);
+  const isLive = banner.tone === "confirmed" || banner.tone === "pending";
+
+  const bannerIconColor =
+    banner.tone === "cancelled"
+      ? "#b91c1c"
+      : banner.tone === "pending"
+      ? "#b45309"
+      : "#047857";
+  const bannerToneStyle =
+    banner.tone === "confirmed"
+      ? styles.banner_confirmed
+      : banner.tone === "pending"
+      ? styles.banner_pending
+      : banner.tone === "ended"
+      ? styles.banner_ended
+      : styles.banner_cancelled;
+
+  return (
+    <View style={styles.wrap}>
+      {/* Status banner */}
+      <View style={[styles.banner, bannerToneStyle]}>
+        <Icon name={banner.icon} size={18} color={bannerIconColor} />
+        <Text
+          style={[
+            styles.bannerText,
+            banner.tone === "cancelled"
+              ? styles.bannerTextCancelled
+              : banner.tone === "pending"
+              ? styles.bannerTextPending
+              : styles.bannerTextConfirmed,
+          ]}
+        >
+          {banner.label}
+        </Text>
+      </View>
+
+      {/* Check-in QR — the digital reservation pass (scan at the venue). */}
+      {isLive && (
+        <View style={styles.qrCard}>
+          <View style={styles.qrBox}>
+            <QRCode
+              value={`mingla://reservation/${pass.reservationId}`}
+              size={140}
+              backgroundColor="#ffffff"
+              color="#0c0e12"
+            />
+          </View>
+          <Text style={styles.qrRef}>{pass.confirmationRef}</Text>
+          <Text style={styles.qrHint}>Show this at the venue to check in</Text>
+        </View>
+      )}
+
+      {/* Full confirmation details */}
+      <DetailRow icon="calendar-outline" label="When" value={formatReservedForLong(pass.reservedForUtc)} />
+      <DetailRow icon="people-outline" label="Party" value={`${pass.partySize} ${pass.partySize === 1 ? "guest" : "guests"}`} />
+      <DetailRow icon="card-outline" label="Deposit" value={formatDeposit(pass)} />
+      {pass.occasion ? (
+        <DetailRow icon="sparkles-outline" label="Occasion" value={pass.occasion} />
+      ) : null}
+      {pass.guestNotes ? (
+        <DetailRow icon="chatbubble-ellipses-outline" label="Notes" value={pass.guestNotes} />
+      ) : null}
+      <DetailRow icon="pricetag-outline" label="Confirmation" value={pass.confirmationRef} />
+      <DetailRow icon="storefront-outline" label="Venue" value={pass.venueName ?? "Venue"} />
+
+      {pass.cancellable && pass.onCancel ? (
+        <Pressable
+          onPress={pass.onCancel}
+          accessibilityRole="button"
+          accessibilityLabel={`Cancel reservation at ${pass.venueName ?? "venue"}`}
+          hitSlop={8}
+          style={({ pressed }) => [styles.cancelBtn, pressed && styles.cancelBtnPressed]}
+        >
+          <Text style={styles.cancelText}>Cancel reservation</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: {
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+  },
+  banner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  banner_confirmed: { backgroundColor: "#ecfdf5", borderWidth: 1, borderColor: "#a7f3d0" },
+  banner_pending: { backgroundColor: "#fffbeb", borderWidth: 1, borderColor: "#fde68a" },
+  banner_ended: { backgroundColor: "#f3f4f6", borderWidth: 1, borderColor: "#e5e7eb" },
+  banner_cancelled: { backgroundColor: "#fef2f2", borderWidth: 1, borderColor: "#fecaca" },
+  bannerText: { fontSize: 14, fontWeight: "700", flex: 1 },
+  bannerTextConfirmed: { color: "#047857" },
+  bannerTextPending: { color: "#b45309" },
+  bannerTextCancelled: { color: "#b91c1c" },
+  qrCard: {
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 16,
+    backgroundColor: "#f9fafb",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "#eef2f7",
+  },
+  qrBox: { padding: 12, backgroundColor: "#ffffff", borderRadius: 12 },
+  qrRef: { fontSize: 14, fontWeight: "800", color: "#111827", letterSpacing: 1, marginTop: 4 },
+  qrHint: { fontSize: 12, color: "#6b7280" },
+  detailRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  detailLabel: { fontSize: 12.5, fontWeight: "600", color: "#9ca3af", width: 92 },
+  detailValue: { fontSize: 13.5, color: "#111827", fontWeight: "500", flex: 1 },
+  cancelBtn: {
+    marginTop: 4,
+    paddingVertical: 11,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#fecaca",
+    alignItems: "center",
+  },
+  cancelBtnPressed: { backgroundColor: "#fef2f2" },
+  cancelText: { fontSize: 13.5, fontWeight: "700", color: "#dc2626" },
+});
+
+export default ReservationPassSection;

--- a/app-mobile/src/hooks/useMyReservations.ts
+++ b/app-mobile/src/hooks/useMyReservations.ts
@@ -22,6 +22,10 @@ export interface MyReservationRow {
   brand_cover_type: string | null;
   brand_photo_url: string | null;
   brand_cover_hue: string | null;
+  brand_address: string | null;
+  brand_city: string | null;
+  brand_lat: number | null;
+  brand_lng: number | null;
   reserved_for: string;
   party_size: number;
   status: string;
@@ -39,6 +43,10 @@ interface RawBrandJoin {
   cover_media_type: string | null;
   profile_photo_url: string | null;
   cover_hue: string | null;
+  address: string | null;
+  city: string | null;
+  lat: number | null;
+  lng: number | null;
 }
 
 interface RawReservationRow {
@@ -67,7 +75,7 @@ async function fetchMyReservations(
   const { data, error } = await supabase
     .from("reservations")
     .select(
-      "id, brand_id, reserved_for, party_size, status, fee_cents, fee_currency, payment_status, occasion, guest_notes, created_at, brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue)",
+      "id, brand_id, reserved_for, party_size, status, fee_cents, fee_currency, payment_status, occasion, guest_notes, created_at, brands(name, cover_media_url, cover_media_type, profile_photo_url, cover_hue, address, city, lat, lng)",
     )
     .eq("consumer_user_id", userId)
     .order("reserved_for", { ascending: false });
@@ -83,6 +91,10 @@ async function fetchMyReservations(
       brand_cover_type: brand?.cover_media_type ?? null,
       brand_photo_url: brand?.profile_photo_url ?? null,
       brand_cover_hue: brand?.cover_hue ?? null,
+      brand_address: brand?.address ?? null,
+      brand_city: brand?.city ?? null,
+      brand_lat: typeof brand?.lat === "number" ? brand.lat : null,
+      brand_lng: typeof brand?.lng === "number" ? brand.lng : null,
       reserved_for: r.reserved_for,
       party_size: r.party_size,
       status: r.status,

--- a/app-mobile/src/types/expandedCardTypes.ts
+++ b/app-mobile/src/types/expandedCardTypes.ts
@@ -294,4 +294,29 @@ export interface ExpandedCardModalProps {
   navigationTotal?: number;
   onPaywallRequired?: () => void;
   canAccessCurated?: boolean;
+  /**
+   * META-ORCH-1148 2.2f — when the modal is opened from a booked reservation,
+   * this renders the injected "Confirmed" reservation pass (banner + full
+   * details + a check-in QR) at the top of the existing expanded card design.
+   * Null / absent for every other card. Structural shape (no hook coupling);
+   * the Calendar tab maps its MyReservationRow into this.
+   */
+  reservationPass?: ReservationPass | null;
+}
+
+export interface ReservationPass {
+  reservationId: string;
+  status: string;
+  reservedForUtc: string;
+  partySize: number;
+  feeCents: number | null;
+  feeCurrency: string | null;
+  paymentStatus: string;
+  occasion: string | null;
+  guestNotes: string | null;
+  venueName: string | null;
+  address: string | null;
+  confirmationRef: string;
+  cancellable: boolean;
+  onCancel?: () => void;
 }


### PR DESCRIPTION
## What (per Seth — reuse, don't reinvent)
Tapping a reservation in the Calendar now opens the **same `ExpandedCardModal`** the app already uses for venues (its weather / directions / gallery), with a **Confirmed reservation pass injected** — instead of a parallel in-row expanded card.

- **Row** → compact tappable card (cover · venue · time · party · chips → chevron) that calls `onPress`; the in-place expand is removed.
- **`ReservationPassSection`** (new) renders at the top of the modal: status banner, **check-in QR** (`mingla://reservation/<id>` + `RES-XXXXXX`), full details (When / Party / Deposit·Paid / Occasion / Notes / Confirmation / Venue), and a gated **Cancel**.
- **`ExpandedCardModal`** gains an optional `reservationPass` prop; weather/directions/gallery come from its existing design for free.
- **CalendarTab** builds a minimal venue `ExpandedCardData` (location→weather, address→directions) + the pass from the tapped reservation; cancel routes through the existing handler.
- `useMyReservations` also joins brand `address/city/lat/lng`.

Supersedes the closed #522 (parallel mini-card). Builds on the shipped #521.

## Test
`orch_1148d` rewritten for this architecture — 15 source-assert checks, fails-on-revert. `[TEST-MOD-APPROVED ORCH-1148-F]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)