### PR TITLE
ORCH-1148g: cancel executes the deposit refund + video covers render in the reservation pass

### DIFF
--- a/app-mobile/src/components/activity/CalendarTab.tsx
+++ b/app-mobile/src/components/activity/CalendarTab.tsx
@@ -287,18 +287,31 @@ const CalendarTab = ({
             onPress: () => {
               void (async () => {
                 try {
-                  const { refundEligible } = await cancelMyReservation(
-                    reservation.id,
-                  );
+                  const { refundEligible, refunded, refundAmountCents } =
+                    await cancelMyReservation(reservation.id);
                   if (user?.id) {
                     await queryClient.invalidateQueries({
                       queryKey: myReservationsKeys.byUser(user.id),
                     });
                   }
+                  const amount =
+                    refundAmountCents > 0
+                      ? new Intl.NumberFormat(undefined, {
+                          style: "currency",
+                          currency: (reservation.fee_currency || "USD").toUpperCase(),
+                        }).format(refundAmountCents / 100)
+                      : null;
+                  const hadDeposit =
+                    (reservation.fee_cents ?? 0) > 0 &&
+                    reservation.payment_status === "paid";
                   Alert.alert(
                     "Reservation cancelled",
-                    refundEligible
-                      ? "You cancelled before the cutoff. Any deposit refund will follow."
+                    refunded && amount
+                      ? `Your ${amount} deposit has been refunded.`
+                      : refundEligible
+                      ? "Your deposit refund is being processed and will follow shortly."
+                      : hadDeposit
+                      ? "Your reservation has been cancelled. Your deposit is non-refundable after the venue's cancellation cutoff."
                       : "Your reservation has been cancelled.",
                   );
                 } catch (err) {
@@ -1740,10 +1753,12 @@ const CalendarTab = ({
     if (Date.now() - lastModalCloseAtRef.current < 500) return; // re-open guard
     HapticFeedback.buttonPress();
 
+    // Cover media for the modal's ImageGallery — which plays VIDEO covers via
+    // isVideoUrl/EventCoverMedia, so pass the cover URL regardless of type
+    // (image OR video); fall back to the profile photo. (Earlier this dropped
+    // video covers → the "no images" placeholder.)
     const image =
-      reservation.brand_cover_type === "image" && reservation.brand_cover_url
-        ? reservation.brand_cover_url
-        : reservation.brand_photo_url ?? "";
+      reservation.brand_cover_url || reservation.brand_photo_url || "";
     const hasCoords =
       typeof reservation.brand_lat === "number" &&
       typeof reservation.brand_lng === "number";

--- a/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
+++ b/app-mobile/src/components/activity/__tests__/orch_1148d_reservation_confirmation_card.test.tsx
@@ -137,4 +137,22 @@ ok(
   /handleCancelReservation\(reservation\)/.test(calSrc),
 );
 
+// ── 2.2g [video cover + real cancel/refund] ─────────────────────────────────
+ok(
+  "the venue card passes the cover URL regardless of type (video plays)",
+  /const image =\s*\n?\s*reservation\.brand_cover_url \|\| reservation\.brand_photo_url \|\| ""/.test(
+    calSrc,
+  ),
+  "video covers must reach ImageGallery, not be dropped to the placeholder",
+);
+ok(
+  "cancelMyReservation calls the venue-reservation-cancel edge fn (executes refund)",
+  /functions\.invoke\(\s*\n?\s*["']venue-reservation-cancel["']/.test(hookSrc),
+);
+ok(
+  "cancel surfaces the actual refund outcome to the guest",
+  /refunded,\s*refundAmountCents/.test(calSrc) &&
+    /deposit has been refunded/.test(calSrc),
+);
+
 console.log(`\n${passed} assertions passed.`);

--- a/app-mobile/src/hooks/useMyReservations.ts
+++ b/app-mobile/src/hooks/useMyReservations.ts
@@ -121,29 +121,39 @@ export function useMyReservations(
 }
 
 /**
- * Cancel one of the caller's OWN reservations via pg_cancel_my_reservation
- * (2.2a, SECURITY DEFINER authenticated — asserts consumer_user_id = auth.uid(),
- * honors cancel_cutoff_hours, transitions to cancelled_by_guest). Returns
- * { refundEligible } so the UI can surface refund eligibility.
- *
- * [TRANSITIONAL] Refund EXECUTION is not wired here — the RPC only FLAGS
- * refund_eligible (paid + refundable + before cutoff). When a deposit was paid
- * and eligible, the actual refund (reuse refund-order) is the 2.2c/edge-cancel
- * seam. Exit: once the edge cancel endpoint executes the refund, this caller
- * routes through it instead of the bare RPC. Tracked in the 2.2b report.
+ * Cancel one of the caller's OWN reservations via the venue-reservation-cancel
+ * edge function (META-ORCH-1148 2.2g). The fn calls the SECURITY DEFINER
+ * pg_cancel_my_reservation AS THE USER (auth.uid() enforces ownership + a legal
+ * transition + computes refund eligibility), then — when eligible (paid &&
+ * fee_refundable && before the venue's cancel cutoff) — EXECUTES the Stripe
+ * deposit refund on the brand's connected account and flips payment_status to
+ * 'refunded'. Cancellation is always allowed for an upcoming reservation; the
+ * cutoff governs only the refund (Seth 2026-06-17). A refund-side failure still
+ * returns cancelled:true (the seat is freed) with refunded:false + refundError.
  */
 export async function cancelMyReservation(
   reservationId: string,
-): Promise<{ refundEligible: boolean; status: string }> {
-  const { data, error } = await supabase.rpc("pg_cancel_my_reservation", {
-    p_reservation_id: reservationId,
-  });
+): Promise<{
+  refundEligible: boolean;
+  refunded: boolean;
+  refundAmountCents: number;
+  status: string;
+}> {
+  const { data, error } = await supabase.functions.invoke(
+    "venue-reservation-cancel",
+    { body: { reservationId } },
+  );
   if (error !== null) throw error;
-  const row = (Array.isArray(data) ? data[0] : data) as
-    | { reservation?: { status?: string } | null; refund_eligible?: boolean }
-    | null;
+  const res = (data ?? {}) as {
+    status?: string;
+    refundEligible?: boolean;
+    refunded?: boolean;
+    refundAmountCents?: number;
+  };
   return {
-    refundEligible: row?.refund_eligible === true,
-    status: row?.reservation?.status ?? "cancelled_by_guest",
+    refundEligible: res.refundEligible === true,
+    refunded: res.refunded === true,
+    refundAmountCents: typeof res.refundAmountCents === "number" ? res.refundAmountCents : 0,
+    status: res.status ?? "cancelled",
   };
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -242,3 +242,12 @@ verify_jwt = false
 # verify_jwt=false: callable from the anon web redirect-return + the app.
 [functions.venue-reservation-confirm]
 verify_jwt = false
+
+# META-ORCH-1148 2.2g — venue-reservation-cancel: the signed-in guest cancels
+# their OWN reservation; the SECURITY DEFINER pg_cancel_my_reservation (called as
+# the user) enforces ownership + legal transition + computes refund eligibility
+# (paid && fee_refundable && before cancel cutoff). When eligible, this fn
+# EXECUTES the Stripe deposit refund on the connected account (mirrors
+# refund-order). verify_jwt=false: the fn validates the JWT + auth.uid() itself.
+[functions.venue-reservation-cancel]
+verify_jwt = false

--- a/supabase/functions/__tests__/orch_1148g_venue_reservation_cancel.test.ts
+++ b/supabase/functions/__tests__/orch_1148g_venue_reservation_cancel.test.ts
@@ -1,0 +1,66 @@
+// META-ORCH-1148 2.2g — venue-reservation-cancel contract regression.
+// Run:
+//   deno test --allow-read supabase/functions/__tests__/orch_1148g_venue_reservation_cancel.test.ts
+//
+// Source-level contract pins (no live Stripe/SQL harness in the worktree). The
+// cancel fn must: cancel as the user (auth.uid() ownership), then — ONLY when
+// the RPC says refund_eligible — execute the Stripe deposit refund on the
+// brand's CONNECTED account, idempotent on the reservation id, and flip
+// payment_status to 'refunded'. A refund-side failure must keep the cancel
+// (200, refunded:false) — never un-cancel a freed seat.
+
+import { assert, assertMatch } from "jsr:@std/assert@1";
+
+const FILE =
+  "supabase/functions/venue-reservation-cancel/index.ts";
+const SRC = Deno.readTextFileSync(FILE);
+const CONFIG = Deno.readTextFileSync("supabase/config.toml");
+
+Deno.test("G-1 cancels via pg_cancel_my_reservation called AS THE USER", () => {
+  assertMatch(SRC, /userClient\(req\)/);
+  assertMatch(SRC, /\.rpc\(\s*["']pg_cancel_my_reservation["']/);
+});
+
+Deno.test("G-2 owner-only: rejects unauthenticated callers", () => {
+  assertMatch(SRC, /userIdFromAuthHeader\(req\)/);
+  assertMatch(SRC, /not_authenticated/);
+});
+
+Deno.test("G-3 refund runs ONLY when eligible + a real paid charge exists", () => {
+  // The guard short-circuits (returns refunded:false) unless eligible + fee + PI.
+  assertMatch(
+    SRC,
+    /if\s*\(!refundEligible\s*\|\|\s*feeCents\s*<=\s*0\s*\|\|\s*!paymentIntentId\)/,
+  );
+});
+
+Deno.test("G-4 refund is a direct-charge refund on the CONNECTED account", () => {
+  assertMatch(SRC, /stripe_connect_id/);
+  assertMatch(SRC, /refunds\.create/);
+  assertMatch(SRC, /stripeAccount:\s*connectedAccountId/);
+  assertMatch(SRC, /payment_intent:\s*paymentIntentId/);
+  assertMatch(SRC, /amount:\s*feeCents/);
+});
+
+Deno.test("G-5 refund is idempotent on the reservation id", () => {
+  assertMatch(SRC, /idempotencyKey:\s*`venue_resv_refund:\$\{reservation\.id\}`/);
+});
+
+Deno.test("G-6 success flips payment_status to refunded + returns the amount", () => {
+  assertMatch(SRC, /payment_status:\s*["']refunded["']/);
+  assertMatch(SRC, /refunded:\s*true/);
+  assertMatch(SRC, /refundAmountCents:\s*feeCents/);
+});
+
+Deno.test("G-7 a refund failure keeps the cancel (200, refunded:false, refundError)", () => {
+  // No 502 on the refund arm — the seat is already freed; only the money retries.
+  assert(!/refunds\.create[\s\S]*?502/.test(SRC), "refund failure must not 502");
+  assertMatch(SRC, /refundError/);
+});
+
+Deno.test("G-8 registered verify_jwt=false (the fn enforces auth itself)", () => {
+  assertMatch(
+    CONFIG,
+    /\[functions\.venue-reservation-cancel\][\s\S]*?verify_jwt = false/,
+  );
+});

--- a/supabase/functions/venue-reservation-cancel/index.ts
+++ b/supabase/functions/venue-reservation-cancel/index.ts
@@ -1,0 +1,242 @@
+// ===========================================================================
+// META-ORCH-1148 sub-ORCH 2.2g — venue-reservation-cancel
+// ---------------------------------------------------------------------------
+// The signed-in consumer cancels their OWN venue reservation. Two responsibili-
+// ties, in order:
+//
+//   1. CANCEL (authoritative, atomic) — call the SECURITY DEFINER
+//      pg_cancel_my_reservation AS THE USER so auth.uid() inside it enforces
+//      ownership, asserts the status transition is legal, flips the row to
+//      cancelled_by_guest + writes the audit row, and returns refund_eligible
+//      (= payment_status='paid' AND venue fee_refundable AND before the venue's
+//      cancel cutoff). Cancellation itself is always allowed for a legal-state
+//      (upcoming, confirmed/requested) reservation — the cutoff only governs the
+//      REFUND, never the ability to cancel (Seth, 2026-06-17: "cancel any
+//      upcoming; refund before cutoff, else forfeit").
+//
+//   2. REFUND (only when eligible) — execute the Stripe deposit refund on the
+//      brand's CONNECTED account (direct-charge refund, mirrors refund-order
+//      ORCH-0843), idempotent on the reservation id, then flip payment_status
+//      to 'refunded'. A refund failure does NOT un-cancel the reservation (the
+//      seat is already freed) — it returns cancelled:true, refunded:false with
+//      the detail so the client can tell the guest the refund will be retried.
+//
+// Auth: the caller MUST be the owner — there is no anon path. verify_jwt=false
+// in config.toml (the fn validates the JWT itself); the RPC's auth.uid() is the
+// real gate.
+//
+// Contract:
+//   POST { reservationId }
+//   → 200 { status:"cancelled", cancelled:true, refundEligible, refunded,
+//           refundAmountCents }
+//   → 400 invalid input · 401 not authenticated · 404 unknown/not-owned
+//   → 409 { error:"cancel_not_allowed" } when the state can't transition
+//   → 200 { cancelled:true, refunded:false, refundError } refund-side failure
+//          (the cancel SUCCEEDED; only the deposit refund is pending retry)
+//   → 500 internal
+// ===========================================================================
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { wrapEdgeHandler } from "../_shared/structuredLog.ts";
+import { stripeTicketRefund } from "../_shared/stripe.ts";
+import {
+  jsonResponse,
+  serviceClient,
+  ticketCorsHeaders,
+  userClient,
+  userIdFromAuthHeader,
+} from "../_shared/ticketCheckout.ts";
+
+interface CancelledReservation {
+  id: string;
+  brand_id: string;
+  status: string;
+  payment_status: string;
+  payment_intent_id: string | null;
+  fee_cents: number | null;
+  fee_currency: string | null;
+}
+
+serve(
+  wrapEdgeHandler("venue-reservation-cancel", async (req: Request) => {
+    if (req.method === "OPTIONS") {
+      return new Response("ok", { headers: ticketCorsHeaders });
+    }
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "method_not_allowed" }, 405);
+    }
+
+    // ── input ────────────────────────────────────────────────────────────
+    let body: { reservationId?: unknown };
+    try {
+      body = await req.json();
+    } catch {
+      return jsonResponse({ error: "invalid_json" }, 400);
+    }
+    const reservationId =
+      typeof body.reservationId === "string" ? body.reservationId.trim() : "";
+    if (reservationId.length === 0) {
+      return jsonResponse({ error: "reservation_id_required" }, 400);
+    }
+
+    // ── auth (owner only) ─────────────────────────────────────────────────
+    const userId = await userIdFromAuthHeader(req);
+    if (!userId) {
+      return jsonResponse({ error: "not_authenticated" }, 401);
+    }
+
+    // ── 1. cancel (as the user → auth.uid() enforces ownership + transition) ─
+    const asUser = userClient(req);
+    const { data: cancelData, error: cancelErr } = await asUser.rpc(
+      "pg_cancel_my_reservation",
+      { p_reservation_id: reservationId },
+    );
+    if (cancelErr !== null) {
+      const msg = cancelErr.message ?? "";
+      if (msg.includes("not_authenticated")) {
+        return jsonResponse({ error: "not_authenticated" }, 401);
+      }
+      if (msg.includes("reservation_not_found")) {
+        return jsonResponse({ error: "reservation_not_found" }, 404);
+      }
+      if (msg.includes("cancel_not_allowed")) {
+        return jsonResponse(
+          { error: "cancel_not_allowed", detail: msg },
+          409,
+        );
+      }
+      console.error("[venue-reservation-cancel] cancel RPC failed", cancelErr);
+      return jsonResponse({ error: "cancel_failed", detail: msg }, 500);
+    }
+
+    const row = (Array.isArray(cancelData) ? cancelData[0] : cancelData) as
+      | { reservation?: CancelledReservation | null; refund_eligible?: boolean }
+      | null;
+    const reservation = row?.reservation ?? null;
+    const refundEligible = row?.refund_eligible === true;
+    if (!reservation) {
+      console.error("[venue-reservation-cancel] RPC returned no reservation");
+      return jsonResponse({ error: "cancel_failed" }, 500);
+    }
+
+    const feeCents = Number(reservation.fee_cents ?? 0);
+    const paymentIntentId = reservation.payment_intent_id ?? null;
+
+    // ── 2. refund (only when eligible + a real charge exists) ─────────────
+    if (!refundEligible || feeCents <= 0 || !paymentIntentId) {
+      return jsonResponse({
+        status: "cancelled",
+        cancelled: true,
+        refundEligible,
+        refunded: false,
+        refundAmountCents: 0,
+      });
+    }
+
+    // Resolve the connected account that owns the PI (direct-charge refund).
+    const svc = serviceClient();
+    const { data: brandRow, error: brandErr } = await svc
+      .from("brands")
+      .select("stripe_connect_id")
+      .eq("id", reservation.brand_id)
+      .maybeSingle();
+    const connectedAccountId =
+      typeof brandRow?.stripe_connect_id === "string" &&
+      brandRow.stripe_connect_id.length > 0
+        ? brandRow.stripe_connect_id
+        : null;
+    if (brandErr || !connectedAccountId) {
+      console.error(
+        "[venue-reservation-cancel] connected-account lookup failed",
+        brandErr,
+      );
+      // Cancelled, but we can't refund right now — surface for retry.
+      return jsonResponse(
+        {
+          status: "cancelled",
+          cancelled: true,
+          refundEligible: true,
+          refunded: false,
+          refundAmountCents: 0,
+          refundError: "missing_connected_account",
+        },
+        200,
+      );
+    }
+
+    try {
+      const stripe = stripeTicketRefund();
+      // @ts-ignore — Stripe SDK namespace is runtime-provided in Deno.
+      const created = await stripe.refunds.create(
+        {
+          payment_intent: paymentIntentId,
+          amount: feeCents,
+          reason: "requested_by_customer",
+          refund_application_fee: true,
+          metadata: {
+            mingla_reservation_id: reservation.id,
+            mingla_kind: "venue_reservation_deposit",
+          },
+        },
+        {
+          idempotencyKey: `venue_resv_refund:${reservation.id}`,
+          stripeAccount: connectedAccountId,
+        },
+      );
+      const status = String(created.status ?? "");
+      if (status === "failed" || status === "canceled") {
+        // Cancellation already succeeded (seat freed); only the money retry is
+        // pending → 200 so the client doesn't read a freed-seat cancel as a hard
+        // failure. refundError tells the guest the refund will follow.
+        return jsonResponse(
+          {
+            status: "cancelled",
+            cancelled: true,
+            refundEligible: true,
+            refunded: false,
+            refundAmountCents: 0,
+            refundError: `stripe refund status=${status}`,
+          },
+          200,
+        );
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      console.error("[venue-reservation-cancel] refunds.create failed", detail);
+      return jsonResponse(
+        {
+          status: "cancelled",
+          cancelled: true,
+          refundEligible: true,
+          refunded: false,
+          refundAmountCents: 0,
+          refundError: detail,
+        },
+        200,
+      );
+    }
+
+    // Refund succeeded → reflect it on the row (service role; the guest already
+    // cancelled, this is the money-state bookkeeping).
+    const { error: updErr } = await svc
+      .from("reservations")
+      .update({ payment_status: "refunded", updated_at: new Date().toISOString() })
+      .eq("id", reservation.id);
+    if (updErr) {
+      // The money moved; a stale payment_status is non-fatal (webhook/retry can
+      // reconcile). Log + still report the refund as done.
+      console.error(
+        "[venue-reservation-cancel] payment_status update failed (refund DID succeed)",
+        updErr,
+      );
+    }
+
+    return jsonResponse({
+      status: "cancelled",
+      cancelled: true,
+      refundEligible: true,
+      refunded: true,
+      refundAmountCents: feeCents,
+    });
+  }),
+);


### PR DESCRIPTION
## Two fixes on the reservation pass + the chosen cancel behavior

### 1. Video/image cover now renders
Opening a reservation built a venue card that only included **image**-type covers, so a brand with a **video** cover (e.g. Lantern & Vine) fell through to the "no images" placeholder. The modal's `ImageGallery` already plays video (`isVideoUrl`/`EventCoverMedia`) — the card now passes the cover URL **regardless of type**, with a profile-photo fallback.

### 2. Cancel now actually refunds the deposit
Cancel previously only **flagged** `refund_eligible` and never moved money. New edge fn **`venue-reservation-cancel`**:
- Calls `pg_cancel_my_reservation` **as the user** (`auth.uid()` ownership + legal transition + eligibility = `paid && fee_refundable && before the venue's cancel cutoff`).
- When eligible, **executes the Stripe deposit refund** on the brand's **connected account** (direct-charge, mirrors `refund-order`), idempotent on the reservation id, then flips `payment_status='refunded'`.
- A refund-side failure **keeps the cancel** (200, `refunded:false`, `refundError`) — never un-cancels a freed seat.

Per Seth: **cancel is allowed for any upcoming reservation**; the cutoff governs only the **refund** (before → refunded, after → forfeit). The client routes through the edge fn and tells the guest the real outcome ("Your $X deposit has been refunded" / non-refundable after cutoff / free-reservation copy).

## Tests
- `orch_1148g_venue_reservation_cancel` — 8 deno contract pins (cancel-as-user, eligible-only refund, connected-account direct charge, idempotency, refund-failure-stays-cancelled, verify_jwt).
- Consumer source-assert grows +3 (video cover, edge-fn call, refund copy).

## Deploy
New edge fn `venue-reservation-cancel` (verify_jwt=false; enforces auth itself) — deployed from merged main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)