### PR TITLE
ORCH-1159: hide public event/trip/experience/brand close-X on web [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1159_HIDE_WEB_CLOSE_X.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1159_HIDE_WEB_CLOSE_X.md
@@ -30,7 +30,7 @@ The dispatch carried the contract inline (no separate SPEC file). Mapped to its 
 | SC-4 | Share button stays on ALL surfaces incl. web | ✓ | Share/Mute never gated; only the close slot is conditional |
 | SC-5 | Close handler logic UNCHANGED | ✓ | no `onClose`/handler edits |
 | SC-6 | No new web-detection helper invented | ✓ | uses the package's existing `Platform.OS === "web"` idiom |
-| SC-7 | Non-public-page consumer (brand page) not regressed | ✓ | brand page does not opt in; test asserts it |
+| SC-7 | Non-public-page consumer (brand page) not regressed | ✓ (SUPERSEDED 2026-06-18) | base impl left brand page un-opted; the §13 scope extension now opts the brand page IN — it is a public page too. The "opt-in mechanism not a blanket gate" guarantee moves to a synthetic NOT-opted predicate case. |
 
 ---
 
@@ -152,3 +152,70 @@ Parity is **automatic** (shared `OfferingChrome` + the predicate). The only manu
 3. **Stale isolation gate:** `mingla-business/src/components/trip/__tests__/offeringRenderingIsolation.orch1138.test.ts` (test 71, "depends only on @mingla/event-rendering + RN + svg") walks `packages/offering-rendering/__tests__/` and FAILS on clean HEAD because the existing ORCH-1157 Deno tests import `https://deno.land/std...` (not in its allow-list). My new Deno test follows the same established convention. The gate should exclude `__tests__/` (test files legitimately import Deno std). Pre-existing; not modified (append-only). Recommend a follow-up to exclude `__tests__/` from that walk.
 
 4. **Acked COMMS-0025 (WARN, OPEN):** ORCH-1117 ask #6 folds the Sound/Mute pill move into the SAME shared chrome region (`PublicEventPage.tsx` close+share row). No file collision — ORCH-1117 edits the `EventCoverMedia` audio-control position and the legacy `packages/event-rendering/PublicEventPage.tsx`; ORCH-1159 edits the shared `OfferingChrome` close button + the FOUNDATION page opt-ins. Disjoint files. Factored in; appended ack.
+
+---
+
+## 13. SCOPE EXTENSION — public BRAND page (Seth 2026-06-18)
+
+**Ask:** the public BRAND page (`packages/brand-rendering/PublicBrandPage.tsx`) is the FIFTH consumer of the same shared chrome (`ParallaxCoverShell` → `OfferingChrome`) and still showed its close "X" on web. Seth wants it hidden on web too, identical to the four offering pages. This REVERSES the base implementation's deliberate "brand page out of scope, keeps its X" decision (original SC-7).
+
+### 13.1 Brand-page change
+
+**File:** `packages/brand-rendering/PublicBrandPage.tsx` — **line 619** (inside the single `<ParallaxCoverShell …>` call that renders the whole brand page).
+
+**Before:**
+```tsx
+      onClose={callbacks.onClose}
+      onShare={callbacks.onShare}
+      heroEyebrow={heroEyebrow}
+```
+**After:**
+```tsx
+      onClose={callbacks.onClose}
+      onShare={callbacks.onShare}
+      hideCloseOnWeb
+      heroEyebrow={heroEyebrow}
+```
+
+Matches the exact idiom the offering pages use (bare-boolean `hideCloseOnWeb` shorthand sitting alongside the preserved Share wiring). `Platform` was already imported in this file (line 31) and `hideCloseOnWeb?: boolean` is already a declared, type-safe prop on `ParallaxCoverShell` (line 128) forwarded to `OfferingChrome` (line 182). Native (iOS/Android) is unchanged — the predicate `shouldRenderCloseButton(true, "ios"|"android")` still returns `true`. Share + Mute on the brand page stay on web (never gated). No edit to `closeButtonVisibility.ts`, `OfferingChrome.tsx`, or `ParallaxCoverShell.tsx` was needed — the opt-in mechanism already existed.
+
+### 13.2 Test cases that flipped
+
+`packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts`:
+
+- **FLIPPED** — the case formerly titled *"the public BRAND page is OUT of scope — it does NOT opt in (keeps its X on web)"* (asserted `!/hideCloseOnWeb/`) is now *"(scope extension): the public BRAND page opts in — HIDES its X on web"* and asserts the brand page DOES pass `hideCloseOnWeb` and preserves `onShare={callbacks.onShare}`.
+- **BROADENED** — the case formerly *"the 3 public-offering pages … opt in"* is now *"ALL 5 public pages (event ticketed+RSVP, trip, experience, BRAND) opt in"*; the `PublicBrandPage` row (with its `onShare={callbacks.onShare}` share-call check) was added to the table.
+- **ADDED/RETITLED** — the NOT-opted-in mechanism case was retitled to *"a NOT-opted-in caller (hideCloseOnWeb=false) KEEPS the X on every surface"* and now documents that it covers the opt-in mechanism itself (synthetic caller, distinct from the brand page which now opts in). This is the explicit "hypothetical NON-opted caller still keeps its X" coverage the dispatch required.
+- **KEPT INTACT** — the three predicate-level behavioral cases (web hides, iOS keeps, Android keeps) and the two source-contract cases (OfferingChrome gates ONLY close / Share never gated; ParallaxCoverShell forwards the prop).
+
+### 13.3 Pass count
+
+`deno test --allow-read packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts` → **8 passed | 0 failed** (was 8/8 before; same count — one case flipped, one broadened, none net-added).
+
+### 13.4 Fails-on-revert (brand-page addition specifically)
+
+Committed the fix + test together at **`67fa1a0e4`**. Then TRUE LINE-DELETED the `hideCloseOnWeb` line from `PublicBrandPage.tsx` only (test untouched) and re-ran:
+
+```
+ORCH-1159: ALL 5 public pages (… BRAND) opt in ... FAILED
+  AssertionError: PublicBrandPage (brand) must pass hideCloseOnWeb to ParallaxCoverShell
+ORCH-1159 (scope extension): the public BRAND page opts in — HIDES its X on web ... FAILED
+  AssertionError: PublicBrandPage must pass hideCloseOnWeb (brand page now opts in — Seth 2026-06-18)
+FAILED | 6 passed | 2 failed
+```
+
+Restored the line → **8 passed | 0 failed** again. **fails-on-revert verified at `67fa1a0e4`** (the two brand-page cases fail on deletion of the single brand-page opt-in line; the four offering-page assertions stay green, proving the brand-page coverage is independent).
+
+### 13.5 Gates
+
+- `deno check packages/offering-rendering/closeButtonVisibility.ts packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts` → clean.
+- `tsc --noEmit -p packages/brand-rendering/tsconfig.json` → no errors referencing `PublicBrandPage` / `hideCloseOnWeb` / `ParallaxCoverShell` (prop is typed `hideCloseOnWeb?: boolean` on the shell).
+- No new strict-grep gate exists for ORCH-1159; the Deno regression is the gate. The pre-existing broad jest baseline / stale isolation gate noted in §12 are unchanged by this extension.
+
+### 13.6 Comms
+
+Acked **COMMS-0037 (WARN, OPEN, to ALL):** the program-level "public experience page → single source of truth" coordination hold. This extension touches public-page CHROME (a single boolean prop on an existing shared `ParallaxCoverShell` call), not the experience read-path or page IA, so it does not conflict with that standardization scope; factored in, no collision.
+
+### 13.7 Cross-surface impact (extension)
+
+The brand page (`PublicBrandPage.tsx`) is the ONE shared renderer for the brand route `/b/{slug}` across buyer-web + business iOS/Android + consumer iOS/Android. Parity is AUTOMATIC (single shared component). Buyer-WEB: X now hidden. Native (business + consumer iOS/Android): UNCHANGED (X still shows). Admin web: not affected (no brand public page). Web ships via Vercel from merged main; native change is pure-JS conditional, OTA-optional (native behavior identical).

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1159_HIDE_WEB_CLOSE_X.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1159_HIDE_WEB_CLOSE_X.md
@@ -1,0 +1,154 @@
+# IMPLEMENT — ORCH-1159 [hide public-page "X" close button on web]
+
+**Status:** implemented and verified (behavioral predicate + source-contract; native unaffected by construction).
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1159-[hide-web-close-x]/` · branch `ORCH-1159-hide-web-close-x` · rebased on origin/main HEAD `a58f46ffa`.
+
+---
+
+## 1. Summary
+
+On the public event, trip, and experience pages, the floating "X" (close) button is now HIDDEN on web and KEPT on native (iOS/Android). The Share button and all other chrome render on every surface, web included. Native behavior is byte-identical to before.
+
+**Key finding — the dispatch's render-site map was STALE.** The dispatch named three independent render sites (an `IconChrome icon="close" testID="orch-0961-public-event-close"` in `mingla-business/src/components/event/PublicEventPage.tsx` ~464-482, a close `ChromeButton` in `OfferingChrome.tsx`, and an `IconChrome` in `app/exp/.../[experienceSlug].tsx` ~247-257). Two of those no longer exist: the event page and experience route were refactored (ORCH-1138 + ORCH-1117 era) to delegate `onClose`/`onShare` down to shared FOUNDATION renderers. The close button on **all** public event (ticketed + RSVP), trip, and experience pages is now rendered by exactly **one** owner — `packages/offering-rendering/OfferingChrome.tsx` (lines ~154-162), reached via `packages/offering-rendering/ParallaxCoverShell.tsx`.
+
+**Approach (scoped opt-in, per the dispatch's "scope the gate so only the public-offering use is affected" guard).** A NOT-named fourth consumer — the public BRAND page (`packages/brand-rendering/PublicBrandPage.tsx`) — also renders its X through the same `OfferingChrome`. An unconditional gate in `OfferingChrome` would have hidden the brand-page X on web too (out of ORCH-1159 scope). So instead of an unconditional gate, I added an opt-in prop `hideCloseOnWeb` threaded `OfferingChrome ← ParallaxCoverShell ← {the 4 public-offering FOUNDATION render components}`. The brand page does NOT opt in → keeps its X on web (current behavior). The decision is a single-owner pure predicate `shouldRenderCloseButton(hideCloseOnWeb, Platform.OS)`.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+The dispatch carried the contract inline (no separate SPEC file). Mapped to its stated requirements:
+
+| SC | Requirement | Status | Commit |
+|----|-------------|--------|--------|
+| SC-1-Web | Public EVENT page X hidden on web | ✓ | (see §commit) — `hideCloseOnWeb` on `FoundationEventPreview` + `RsvpPublicBody` → `OfferingChrome` predicate |
+| SC-1-Native | Public EVENT page X kept on iOS/Android | ✓ | predicate returns `true` for non-web |
+| SC-2-Web | Public TRIP page X hidden on web | ✓ | `hideCloseOnWeb` on `TripPreview` (FoundationTripPreview) |
+| SC-2-Native | Public TRIP page X kept on native | ✓ | predicate |
+| SC-3-Web | Public EXPERIENCE page X hidden on web | ✓ | `hideCloseOnWeb` on `ExperiencePreview` (FoundationExperiencePreview) |
+| SC-3-Native | Public EXPERIENCE page X kept on native | ✓ | predicate |
+| SC-4 | Share button stays on ALL surfaces incl. web | ✓ | Share/Mute never gated; only the close slot is conditional |
+| SC-5 | Close handler logic UNCHANGED | ✓ | no `onClose`/handler edits |
+| SC-6 | No new web-detection helper invented | ✓ | uses the package's existing `Platform.OS === "web"` idiom |
+| SC-7 | Non-public-page consumer (brand page) not regressed | ✓ | brand page does not opt in; test asserts it |
+
+---
+
+## 3. Files changed
+
+| File | Δ |
+|------|---|
+| `packages/offering-rendering/closeButtonVisibility.ts` | **NEW** (+~30 lines) — RN-free single-owner predicate |
+| `packages/offering-rendering/OfferingChrome.tsx` | +~20 / -1 — `hideCloseOnWeb` prop, `showClose` guard around the close button + right-pin placeholder, import predicate |
+| `packages/offering-rendering/ParallaxCoverShell.tsx` | +~10 — `hideCloseOnWeb` prop + forward to OfferingChrome |
+| `packages/offering-rendering/index.ts` | +3 — export `shouldRenderCloseButton` + `PlatformOSValue` |
+| `mingla-business/src/components/event/FoundationEventPreview.tsx` | +4 — `hideCloseOnWeb` on ParallaxCoverShell |
+| `mingla-business/src/components/event/RsvpPublicBody.tsx` | +3 — `hideCloseOnWeb` |
+| `mingla-business/src/components/trip/TripPreview.tsx` | +3 — `hideCloseOnWeb` (FoundationTripPreview) |
+| `mingla-business/src/components/experience/ExperiencePreview.tsx` | +3 — `hideCloseOnWeb` (FoundationExperiencePreview) |
+| `packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts` | **NEW** — regression test (8 cases) |
+
+**Web-detection idiom used:** `Platform.OS === "web"` (from `react-native`) — the exact idiom already used inside `OfferingChrome.tsx` (`Platform.select` for the Android glass fallback) and `ParallaxCoverShell.tsx`, and surfaced via `useResponsiveLayout().isWeb` (`Platform.OS === "web"`). No new helper invented; the predicate just wraps the existing idiom for single-owner testability.
+
+---
+
+## 4. Data-model changes applied
+
+None. Pure client-side render gating. No migrations, no RLS, no schema.
+
+## 5. Edge functions touched
+
+None.
+
+---
+
+## 6. Regression tests added
+
+**Path:** `packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts` (Deno test — the established convention for this package; siblings `orch_1157_*.test.ts` use the same `https://deno.land/std` import + readTextFile source-contract style).
+
+- **(1) BEHAVIORAL** — executes the real `shouldRenderCloseButton` predicate: web+opt-in → hidden; iOS/Android+opt-in → shown; not-opted-in (brand page) → shown on all surfaces.
+- **(2) SOURCE-CONTRACT** — OfferingChrome gates ONLY the close button (Share/Mute never platform-gated); ParallaxCoverShell forwards the prop; the 4 public pages opt in (and keep `onShare`); the brand page does NOT opt in.
+
+**Run output (8/8 pass):**
+```
+ok | 8 passed | 0 failed (18ms)
+```
+
+**fails-on-revert verified at commit `a58f46ffa` (worktree base)** via TRUE LINE DELETION (not comment-out): I replaced the predicate body `!(hideCloseOnWeb && platformOS === "web")` with `true` in `closeButtonVisibility.ts`, re-ran → `FAILED | 7 passed | 1 failed` (the "HIDES the close button on web" behavioral assert failed at test:39). Restored → `8 passed | 0 failed`. (The fix lines are part of this ORCH's commit; the deletion proof was performed in the working tree against base `a58f46ffa`.)
+
+Append-only: this is a NEW test file; no existing test modified or deleted.
+
+---
+
+## 7. Old → New receipts
+
+### packages/offering-rendering/OfferingChrome.tsx
+- **Before:** always rendered the close `ChromeButton` (CloseGlyph) as the first row child on every platform.
+- **Now:** renders the close button only when `shouldRenderCloseButton(hideCloseOnWeb, Platform.OS)` is true; otherwise an empty placeholder keeps the space-between row pinning Share/Mute to the right. Share + Mute unchanged.
+- **Why:** SC-1..SC-4 — hide the X on web for opted-in public pages without touching Share or native.
+
+### packages/offering-rendering/ParallaxCoverShell.tsx
+- **Before:** built `chrome = <OfferingChrome ... />` with no web-close control.
+- **Now:** accepts `hideCloseOnWeb` (default false) and forwards it verbatim to OfferingChrome.
+- **Why:** the shell is the single mount point for chrome; the opt-in must pass through it.
+
+### closeButtonVisibility.ts (NEW)
+- **Now:** RN-free pure predicate `shouldRenderCloseButton(hideCloseOnWeb, platformOS)`. Single owner of the decision; enables a true behavioral Deno test without mounting RN.
+
+### FoundationEventPreview.tsx / RsvpPublicBody.tsx / TripPreview.tsx / ExperiencePreview.tsx
+- **Before:** mounted ParallaxCoverShell with the default (X shown on web).
+- **Now:** pass `hideCloseOnWeb` → X hidden on web for these public pages only.
+- **Why:** SC-1/2/3 per page; scopes the gate to event/trip/experience and leaves the brand page (SC-7) untouched.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected? | What changes / why not |
+|---------|-----------|------------------------|
+| Consumer iOS | No | Consumer app renders its own detail screens, not these business-app public pages. |
+| Consumer Android | No | Same. |
+| Buyer/anonymous Web | **YES** | The floating X disappears on public event/trip/experience pages; Share stays. |
+| Business iOS | No (byte-identical) | Native predicate returns true → X still renders. |
+| Business Android | No (byte-identical) | Same. |
+| Admin Web (adjacent) | No | Does not render these pages. |
+| Business Web preview (adjacent) | **YES** | Same web build as buyer web — X hidden there too (intended). |
+
+Parity is **automatic** (shared `OfferingChrome` + the predicate). The only manual element is the per-page opt-in (4 call sites), all in this commit.
+
+---
+
+## 9. Smoke result
+
+- Behavioral predicate executed across web/iOS/android × opt-in/opt-out (8/8 Deno tests pass).
+- `deno check closeButtonVisibility.ts` → exit 0.
+- `tsc --noEmit` on the predicate module → exit 0.
+- Full `mingla-business` jest suite run BEFORE and AFTER my changes is byte-identical (98 failed / 409 passed suites, 172 failed / 3928 passed tests) — my change introduces **zero new jest failures** (the pre-existing failures are worktree-state drift, see §12).
+- No device/simulator render performed (pure conditional render of an existing button; native path provably unchanged because the predicate returns true for non-web). Recommend the tester eyeball web (X gone, Share present) + native (X present) on all three page types.
+
+---
+
+## 10. Known issues / deferred
+
+- No `[TRANSITIONAL]` markers introduced.
+- The legacy event variant (`packages/event-rendering/PublicEventPage.tsx`, used only for cancelled / password-gate events) renders its OWN inline close button (role-gated to the organizer), NOT via OfferingChrome. It was NOT in the dispatch's three sites and is out of scope; its X is not affected. Flagged for awareness only.
+
+---
+
+## 11. Operator action required
+
+- No migration, no edge-function deploy.
+- Web ships via Vercel from MERGED main (buyer web cannot be OTA'd — deploys only from main). Business-app native change is a pure-JS conditional → OTA-able once merged, but native behavior is unchanged so an OTA is optional.
+- Route to orchestrator REVIEW → tester.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **The ORCH-1159 dispatch's render-site map was STALE** (two of three named sites no longer exist; all three collapse to the shared `OfferingChrome`). Implemented against the real render tree. No scope change — same three public pages, plus the explicit decision to LEAVE the brand-page X on web (out of scope).
+
+2. **Pre-existing broad jest failure baseline in this worktree:** the full `mingla-business` jest suite reports **172 failed / 3928 passed (98 suites failed)** on CLEAN origin/main HEAD `a58f46ffa` — identical before and after my change. These appear to be worktree-state drift (e.g. `PublicBrandPage.ve4.test.ts` asserting `isVerifiedVenue ? <VerifiedBadge />` source that isn't present in this checkout's package state). Unrelated to ORCH-1159; flagging for a worktree-freshness / source-reconciliation check.
+
+3. **Stale isolation gate:** `mingla-business/src/components/trip/__tests__/offeringRenderingIsolation.orch1138.test.ts` (test 71, "depends only on @mingla/event-rendering + RN + svg") walks `packages/offering-rendering/__tests__/` and FAILS on clean HEAD because the existing ORCH-1157 Deno tests import `https://deno.land/std...` (not in its allow-list). My new Deno test follows the same established convention. The gate should exclude `__tests__/` (test files legitimately import Deno std). Pre-existing; not modified (append-only). Recommend a follow-up to exclude `__tests__/` from that walk.
+
+4. **Acked COMMS-0025 (WARN, OPEN):** ORCH-1117 ask #6 folds the Sound/Mute pill move into the SAME shared chrome region (`PublicEventPage.tsx` close+share row). No file collision — ORCH-1117 edits the `EventCoverMedia` audio-control position and the legacy `packages/event-rendering/PublicEventPage.tsx`; ORCH-1159 edits the shared `OfferingChrome` close button + the FOUNDATION page opt-ins. Disjoint files. Factored in; appended ack.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1159_HIDE_WEB_CLOSE_X.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1159_HIDE_WEB_CLOSE_X.md
@@ -1,0 +1,177 @@
+# TEST — ORCH-1159 [hide public-page "X" close button on web]
+
+**Verdict: PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 0 · P4: 2 (praise) · Discoveries: 3 (all pre-existing, none introduced by ORCH-1159).
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1159-[hide-web-close-x]/` · branch `ORCH-1159-hide-web-close-x` · HEAD after tester commit `25ec42258` (was `8d9128730` at dispatch).
+
+**Evidence level reached: RUNTIME / BUILD-ARTIFACT (above "suspected").** A clean `mingla-business` web export was produced and the SHIPPED web bundle was inspected — the gated render compiled in with `Platform.OS` statically resolved to `"web"`. Combined with the executed single-owner predicate. This is the correct evidence ceiling for an S3 presentational gate and it is honest (no on-screen pixel eyeball was performed — see §Runtime).
+
+---
+
+## 1. Per-consumer verification (independent source read)
+
+All five public-page consumers were read directly and each was confirmed to (a) pass `hideCloseOnWeb` on the **full-page** `<ParallaxCoverShell>` element, (b) sit adjacent to a PRESERVED `onClose`/`onShare`, and (c) leave Share/Mute ungated.
+
+| # | Consumer | File | Shell element | `hideCloseOnWeb` | Share preserved | Native keeps X |
+|---|----------|------|---------------|------------------|-----------------|----------------|
+| 1 | Event (ticketed) | `mingla-business/src/components/event/FoundationEventPreview.tsx` | L456–491 | ✓ L471 | ✓ `onShare={onShare}` L467 | ✓ predicate→true |
+| 2 | Event (RSVP) | `mingla-business/src/components/event/RsvpPublicBody.tsx` | L498–610 | ✓ L520 | ✓ `onShare={onShare}` L517 | ✓ |
+| 3 | Trip | `mingla-business/src/components/trip/TripPreview.tsx` | L698–737 | ✓ L711 | ✓ `onShare={onShare}` L708 | ✓ |
+| 4 | Experience | `mingla-business/src/components/experience/ExperiencePreview.tsx` | L586–627 | ✓ L599 | ✓ `onShare={onShare}` L596 | ✓ |
+| 5 | Brand | `packages/brand-rendering/PublicBrandPage.tsx` | L607–628 | ✓ L619 | ✓ `onShare={callbacks.onShare}` L618 | ✓ |
+
+**Card-grade siblings correctly NOT opted in:** `TripPreview`'s `TripCardPreview` block (~L234–247) and `ExperiencePreview`'s card block (~L233–234) are internal card renderers, not public pages — they have no `hideCloseOnWeb`, which is correct.
+
+**Predicate applied to the close button ONLY.** `OfferingChrome.tsx` L170 computes `showClose = shouldRenderCloseButton(hideCloseOnWeb, Platform.OS)`. L173–185 wrap **only** the close `ChromeButton` (`<CloseGlyph/>`) in `{showClose ? ( ... ) : ( <View pointerEvents="none" /> )}`. Share + optional Mute live in a SEPARATE `<View style={styles.rightGroup}>` (L186–209) that is a sibling AFTER the close ternary — never gated by `showClose`, `Platform.OS`, or `hideCloseOnWeb`.
+
+**Native immunity by construction.** Predicate `!(hideCloseOnWeb && platformOS === "web")` returns `true` for ios/android (and windows/macos) regardless of `hideCloseOnWeb` → X always renders on native for every consumer.
+
+**Desktop web also covered (not missed).** `ParallaxCoverShell`'s desktop branch (L207–266) mounts the same `chrome` (with `hideCloseOnWeb` forwarded) at L233; on desktop `Platform.OS === "web"` → X hidden there too. Good.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Requirement | Result | Evidence |
+|----|-------------|--------|----------|
+| SC-1-Web | Public EVENT (ticketed+RSVP) X hidden on web | **PASS** | Consumers #1/#2 opt in; compiled bundle `shouldRenderCloseButton)(y,"web")` → showClose=false |
+| SC-1-Native | Public EVENT X kept on native | **PASS** | predicate returns true for ios/android (ADV/D exhaustive) |
+| SC-2-Web | Public TRIP X hidden on web | **PASS** | Consumer #3 opt-in + compiled gate |
+| SC-2-Native | Public TRIP X kept on native | **PASS** | predicate |
+| SC-3-Web | Public EXPERIENCE X hidden on web | **PASS** | Consumer #4 opt-in + compiled gate |
+| SC-3-Native | Public EXPERIENCE X kept on native | **PASS** | predicate |
+| SC-4 | Share stays on ALL surfaces incl. web | **PASS** | rightGroup ungated in source AND compiled bundle (`accessibilityLabel:"Share"` rendered unconditionally after the close ternary) |
+| SC-5 | Close handler logic UNCHANGED | **PASS** | `git diff` shows no `onClose` handler edits; only render gating |
+| SC-6 | No new web-detection helper | **PASS** | reuses `Platform.OS === "web"` (the package's existing idiom); predicate just wraps it for testability |
+| SC-7 (revised by §13) | Public BRAND page opts in (X hidden on web) | **PASS** | Consumer #5 L619; the opt-in MECHANISM still covered by a synthetic non-opted predicate case (ADV-equivalent) |
+
+All criteria PASS with build-artifact + executable-predicate evidence.
+
+---
+
+## 3. Findings
+
+No P0/P1/P2/P3. Two P4 (praise):
+
+- **P4-1 (praise):** Single-owner RN-free predicate `closeButtonVisibility.ts` is the right factoring — it makes the decision executable in a Deno test without mounting RN, and keeps exactly ONE owner of the close decision (verified compiled: exactly one `shouldRenderCloseButton(...)` call). Constitution Rule 2 (one owner per truth) satisfied cleanly.
+- **P4-2 (praise):** The hidden-X case uses an empty `pointerEvents="none"` placeholder rather than removing the child — preserving the `space-between` right-edge pinning of Share/Mute without letting the empty slot intercept taps. This is the correct structural choice and it compiled through verbatim.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Ran the implementor's happy-path test `packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts` myself with Deno 2.7.14:
+
+- **As-shipped:** `ok | 8 passed | 0 failed`.
+- **Revert (true line-edit of the predicate to `=> true;`** in `closeButtonVisibility.ts`): `FAILED | 7 passed | 1 failed` — the failing test was *"ORCH-1159: opted-in public page HIDES the close button on web"* at `orch_1159_hide_web_close_x.test.ts:43` (asserted `shouldRenderCloseButton(true,"web") === false`, got `true`).
+- **Restore:** `ok | 8 passed | 0 failed`.
+
+The implementor's fails-on-revert claim (cited at base `a58f46ffa` / extension `67fa1a0e4`) is **independently confirmed** at the current branch HEAD `8d9128730`.
+
+---
+
+## 5. Adversarial test added (tester-owned, different angle)
+
+**Path:** `packages/offering-rendering/__tests__/orch_1159_hide_web_close_x_adversarial.test.ts`
+**Committed:** `25ec42258` (on branch `ORCH-1159-hide-web-close-x`).
+**In closing diff:** yes — `git diff origin/main...HEAD --name-only` lists BOTH `orch_1159_hide_web_close_x.test.ts` (implementor) AND `orch_1159_hide_web_close_x_adversarial.test.ts` (tester). Append-only: NEW file, no existing test touched.
+
+**Distinct angle (NOT a renamed copy — shares zero assertions with the implementor test):**
+- **A. Boundary:** `windows`/`macos` KEEP the X even when opted in; exhaustive over the `PlatformOSValue` union proving web is the *only* hideable platform. (This catches the tempting "mobile-only" refactor the implementor's web=false test would pass.)
+- **B. Invariant (structural):** Share + Mute render strictly OUTSIDE/AFTER the `showClose` ternary; `hideCloseOnWeb` is consumed EXACTLY ONCE (one predicate call) and never appears on the Share path.
+- **C. Structural:** the hidden-X placeholder is `<View pointerEvents="none" />` (no pointer theft) and the row stays `space-between` with the close slot FIRST and rightGroup SECOND (right-edge pin preserved).
+- **D. Defensive:** NO caller can hide the X on native — exhaustive over `{true,false} × {ios,android}`.
+
+**Run:** `ok | 8 passed | 0 failed`.
+
+**fails-on-revert verified at `25ec42258`** across THREE distinct reverts:
+1. Predicate → `=> true;` → ADV/A *"web is the ONLY platform…"* fails (`FAILED | 7 passed | 1 failed`).
+2. Predicate → naive mobile-only `=> platformOS === "ios" || platformOS === "android";` → ADV/A *macos* AND *web-only* fail (`FAILED | 5 passed | 3 failed`) — the boundary trap fires.
+3. Remove `pointerEvents="none"` from the placeholder in `OfferingChrome.tsx` → ADV/C *pointer-safety* fails (`FAILED | 7 passed | 1 failed`).
+
+Restore after each → `ok | 8 passed | 0 failed`. `deno check` on the test → clean. Imports only `deno.land/std` (matching 7 pre-existing sibling tests) + relative `../closeButtonVisibility.ts` → introduces no new forbidden import.
+
+---
+
+## 6. Constitution 14-rule matrix (independent re-check vs the diff)
+
+| # | Rule | Result | Evidence |
+|---|------|--------|----------|
+| 1 | No dead taps | PASS | hidden X is removed, not a dead button; placeholder `pointerEvents="none"`; Share/Mute taps intact |
+| 2 | One owner per truth | PASS | single predicate `shouldRenderCloseButton`; compiled bundle shows exactly one call |
+| 3 | No silent failures | PASS | pure render gate; no error paths added |
+| 4 | One query key per entity | N/A | no data layer touched |
+| 5 | Server state server-side | N/A | client render only |
+| 6 | Logout clears everything | N/A | no auth/state |
+| 7 | `[TRANSITIONAL]` labels | PASS | none introduced (none needed) |
+| 8 | Subtract before adding | PASS | opt-in prop threaded through existing chrome; no parallel mechanism |
+| 9 | No fabricated data | N/A | no data |
+| 10 | Currency-aware | N/A | no money |
+| 11 | One auth instance | N/A | anon public pages; no `useAuth` added |
+| 12 | Validate at the right time | N/A | no datetime |
+| 13 | Exclusion consistency | N/A | no filtering |
+| 14 | Persisted-state startup | N/A | no persisted state |
+
+No violations.
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Result | Evidence |
+|---------|--------|----------|
+| Consumer iOS | N/A (skip) | These business-app public pages are not rendered by app-mobile; consumer detail screens unaffected. Brand page `/b/{slug}` is shared but native predicate→true (X kept), no change. |
+| Consumer Android | N/A (skip) | Same. |
+| Buyer/anonymous Web | **PASS (build-artifact)** | Web export produced; compiled `[eventSlug]`/`[experienceSlug]`/brand chunks + `__common` contain `shouldRenderCloseButton)(y,"web")` → `showClose=false` for opted-in pages; Share renders unconditionally in the same compiled chunk. |
+| Business iOS | **PASS (by construction)** | predicate returns true for `ios`; ADV/D exhaustive; no diff to native render path |
+| Business Android | **PASS (by construction)** | predicate returns true for `android`; ADV/D exhaustive |
+| Admin Web (adjacent) | N/A (skip) | does not render these pages |
+| Business Web preview (adjacent) | **PASS (build-artifact)** | same web bundle as buyer web |
+
+**Physical iPhone HITL:** not required — the native render path is provably unchanged (the only diff is a `Platform.OS === "web"`-gated branch that is dead on iOS; predicate returns true). No native behavior delta to eyeball.
+
+---
+
+## Runtime / live-fire honesty cap
+
+- **What I DID:** produced a clean `mingla-business` web export (`npx expo export -p web`, exit 0, `Exported: /tmp/orch1159-webbuild` with real route chunks). Inspected the SHIPPED web JS: the predicate compiled verbatim as `(t,n)=>!(t&&"web"===n)`, the OfferingChrome call compiled as `v=(0,F.shouldRenderCloseButton)(y,"web")` with `Platform.OS` statically resolved to the literal `"web"`, the close button rendered `{v ? <close testID=…-close> : <View pointerEvents:"none">}`, and Share rendered unconditionally after it. This is build-artifact runtime evidence — the gate fires in the actual web build.
+- **What I did NOT do:** I did not serve the build in a browser and visually confirm the pixel (no on-screen screenshot of a real public page with the X absent + Share present). The compiled-bundle proof is strictly stronger than a source read but stops short of a rendered-pixel eyeball.
+- **Cap:** evidence level = **RUNTIME / BUILD-ARTIFACT**, which is the appropriate and sufficient ceiling for this S3 presentational gate per the dispatch ("Source + executable-predicate evidence is acceptable… a web render proof raises the verdict above suspected"). I reached above source-only. No runtime evidence was fabricated.
+
+---
+
+## Gate-regression result
+
+| Gate | Result | Note |
+|------|--------|------|
+| `meta-orch-0827-package-isolation.mjs` | **PASS** (exit 0) | "META-ORCH-0827 package isolation gate PASS." |
+| `orch-1138-mor-isolation.mjs` | **PASS** (exit 0) | consumer experience surface imports nothing from mingla-business/src |
+| `orch-0964-brand-rendering-self-contained.mjs` | **PASS** (exit 0) | brand-rendering self-contained (touched `PublicBrandPage.tsx`) |
+| `orch-1138-experience-checkout-byte-identical.mjs` | **PASS** (exit 0) | money path unchanged |
+| `i38-icon-chrome-touch-target.mjs` | **BLOCKED-on-env (pre-existing)** | `ERR_MODULE_NOT_FOUND: @babel/parser` — absent at repo-root `node_modules` in this worktree (worktree dep gap, not ORCH-1159). The diff proves ORCH-1159 did NOT touch `HIT_SLOP` or the 40×40 glass touch targets, so the gate's subject is unaffected. Runs in CI with deps installed. |
+
+---
+
+## Pre-existing-vs-introduced determination (jest reds)
+
+The implementor reported a broad `mingla-business` jest baseline failure and an isolation-gate red. I verified by checkout-compare against `origin/main`:
+
+1. **`offeringRenderingIsolation.orch1138.test.ts` (test 71) FAILS on the branch** — failing spec `../../../app-mobile/src/utils/eventDateDisplay.ts`. **PRE-EXISTING, NOT introduced by ORCH-1159.** Proof: that forbidden import lives in `__tests__/orch_1157_round2_rsvp_fixes.test.ts` and `__tests__/orch_1157_round7_doors_locale_pill.test.ts`, BOTH of which exist UNCHANGED on `origin/main` (`git grep -l … origin/main` confirms) and are NOT in the ORCH-1159 diff (the diff touches only the 5 ORCH-1159 files). The gate also walks `__tests__/` and trips on the 7 pre-existing ORCH-1157 `deno.land/std` imports — a gate design flaw, not a code defect.
+2. **My adversarial test does not worsen this gate** — it adds only a `deno.land/std` import (matching the 7 pre-existing files) + a relative import; no new forbidden app-src spec.
+3. **Broad jest baseline (172 failed / 3928 passed, 98 suites):** consistent with the implementor's before/after byte-identical claim; the specific failure I reproduced (the app-mobile import in the orch1138 gate) is pre-existing. I did not exhaustively re-run all 507 suites, but the touched-file gates I ran are green and the one red I reproduced is provably pre-existing.
+
+**Conclusion: zero jest reds are attributable to ORCH-1159.**
+
+---
+
+## 8. Discoveries for Orchestrator (NOT fixed here)
+
+1. **orch1138 isolation gate walks `__tests__/`** and fails on legitimate Deno test-file imports (`https://deno.land/std…`) and a test fixture's app-mobile import. PRE-EXISTING on origin/main (ORCH-1157 era). Recommend a follow-up to exclude `__tests__/` from `offeringRenderingIsolation.orch1138.test.ts`'s `walk()` (production files only). Carried forward from implementor Discovery #3.
+2. **`@babel/parser` absent at repo-root `node_modules`** in the per-ORCH worktree → `i38-icon-chrome-touch-target.mjs` cannot run locally (ERR_MODULE_NOT_FOUND). Worktree dependency-state gap; runs in CI. Recommend a worktree-freshness/`npm ci`-at-root step.
+3. **Broad pre-existing mingla-business jest baseline** (172 failed tests) on clean origin/main — worktree-state drift per implementor Discovery #2. Orthogonal to ORCH-1159; flag for a source-reconciliation pass.
+
+---
+
+## Routing
+
+**PASS → CLOSE (orchestrator).** Zero P0, zero unaccepted P1; regression gate satisfied (implementor happy-path fails-on-revert independently re-run @ `8d9128730`; tester adversarial test on-branch + in-diff @ `25ec42258` with fails-on-revert across 3 distinct reverts); all SC met with build-artifact + executable-predicate evidence; cross-domain checked (native by construction, web by compiled bundle); Constitution clean; the two required gates + two relevant gates PASS; the one un-runnable gate and all jest reds proven PRE-EXISTING.

--- a/mingla-business/src/components/event/FoundationEventPreview.tsx
+++ b/mingla-business/src/components/event/FoundationEventPreview.tsx
@@ -465,6 +465,10 @@ export const FoundationEventPreview: React.FC<FoundationEventPreviewProps> = ({
       showMute={coverType === "video"}
       onClose={onClose}
       onShare={onShare}
+      // ORCH-1159 — hide the floating X on web (public event page; no parent
+      // screen to return to for an anonymous share-link visitor). Native keeps
+      // it; Share is unaffected.
+      hideCloseOnWeb
       heroEyebrow={
         event.dateLine.length > 0 ? (
           <Text style={styles.heroEyebrow}>{event.dateLine}</Text>

--- a/mingla-business/src/components/event/RsvpPublicBody.tsx
+++ b/mingla-business/src/components/event/RsvpPublicBody.tsx
@@ -515,6 +515,9 @@ export const RsvpPublicBody: React.FC<RsvpPublicBodyProps> = ({
         showMute={event.coverMediaType === "video"}
         onClose={onClose}
         onShare={onShare}
+        // ORCH-1159 — hide the floating X on web (public RSVP event page; no
+        // parent screen for an anonymous share-link visitor). Native keeps it.
+        hideCloseOnWeb
         heroEyebrow={
           event.dateLine.length > 0 ? (
             <Text style={styles.heroEyebrow}>{event.dateLine}</Text>

--- a/mingla-business/src/components/experience/ExperiencePreview.tsx
+++ b/mingla-business/src/components/experience/ExperiencePreview.tsx
@@ -594,6 +594,9 @@ const FoundationExperiencePreview: React.FC<{
       showMute={coverType === "video"}
       onClose={onClose}
       onShare={onShare}
+      // ORCH-1159 — hide the floating X on web (public experience page; no
+      // parent screen for an anonymous share-link visitor). Native keeps it.
+      hideCloseOnWeb
       heroEyebrow={
         /* ORCH-1138 rework (§4.D F-1.1) — N-stop eyebrow (was cityCountry; city
            is the meta chip). */

--- a/mingla-business/src/components/trip/TripPreview.tsx
+++ b/mingla-business/src/components/trip/TripPreview.tsx
@@ -706,6 +706,9 @@ const FoundationTripPreview: React.FC<{
       showMute={coverType === "video"}
       onClose={onClose}
       onShare={onShare}
+      // ORCH-1159 — hide the floating X on web (public trip page; no parent
+      // screen for an anonymous share-link visitor). Native keeps it.
+      hideCloseOnWeb
       heroEyebrow={
         duration !== null ? (
           <Text style={styles.heroEyebrow}>

--- a/packages/brand-rendering/PublicBrandPage.tsx
+++ b/packages/brand-rendering/PublicBrandPage.tsx
@@ -616,6 +616,7 @@ export const PublicBrandPage: React.FC<PublicBrandPageProps> = ({
       showMute={coverType === "video"}
       onClose={callbacks.onClose}
       onShare={callbacks.onShare}
+      hideCloseOnWeb
       heroEyebrow={heroEyebrow}
       heroTitle={heroTitle}
       stickyPanel={stickyPanel}

--- a/packages/offering-rendering/OfferingChrome.tsx
+++ b/packages/offering-rendering/OfferingChrome.tsx
@@ -23,6 +23,8 @@ import Svg, { Circle, Line, Path } from "react-native-svg";
 
 import { type ThemePalette } from "@mingla/event-rendering";
 
+import { shouldRenderCloseButton } from "./closeButtonVisibility";
+
 const HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };
 
 const CloseGlyph: React.FC = () => (
@@ -114,6 +116,16 @@ export interface OfferingChromeProps {
   onShare: () => void;
   onToggleMute: () => void;
   closeAccessibilityLabel?: string;
+  /**
+   * ORCH-1159 — when true, the floating "X" (close) button is HIDDEN on web
+   * (`Platform.OS === "web"`) and KEPT on native. On the public event / trip /
+   * experience pages there is no parent screen to return to on web — the close
+   * handler just bounces an anonymous share-link visitor to the brand page or
+   * home, which is confusing. Share + Mute are NEVER affected. Native is
+   * byte-identical to before. Absent / false ⇒ the close button renders on all
+   * surfaces (current behavior — the public brand page keeps its X on web).
+   */
+  hideCloseOnWeb?: boolean;
   testID?: string;
 }
 
@@ -143,23 +155,34 @@ export const OfferingChrome: React.FC<OfferingChromeProps> = ({
   onShare,
   onToggleMute,
   closeAccessibilityLabel = "Close",
+  hideCloseOnWeb = false,
   testID,
 }) => {
   // accentWash tints the glass slightly toward the brand color over the dark
   // scrim, keeping the buttons readable on any cover.
   const tint: ViewStyle = { backgroundColor: "rgba(0,0,0,0.48)" };
   void palette; // palette reserved for future accent-tinted chrome; scrim stays neutral for contrast.
+  // ORCH-1159 — hide ONLY the close button on web when the caller opts in
+  // (public event / trip / experience pages). Share + Mute always render; native
+  // is unaffected. When the close button is hidden, an empty placeholder keeps
+  // the left slot so the space-between row still pins the Share/Mute group to the
+  // right edge (a single child under space-between would otherwise flush LEFT).
+  const showClose = shouldRenderCloseButton(hideCloseOnWeb, Platform.OS);
   return (
     <View style={styles.row} pointerEvents="box-none" testID={testID}>
-      <ChromeButton
-        onPress={onClose}
-        accessibilityLabel={closeAccessibilityLabel}
-        testID={testID !== undefined ? `${testID}-close` : undefined}
-      >
-        <View style={[styles.glass, tint]}>
-          <CloseGlyph />
-        </View>
-      </ChromeButton>
+      {showClose ? (
+        <ChromeButton
+          onPress={onClose}
+          accessibilityLabel={closeAccessibilityLabel}
+          testID={testID !== undefined ? `${testID}-close` : undefined}
+        >
+          <View style={[styles.glass, tint]}>
+            <CloseGlyph />
+          </View>
+        </ChromeButton>
+      ) : (
+        <View pointerEvents="none" />
+      )}
       <View style={styles.rightGroup}>
         <ChromeButton
           onPress={onShare}

--- a/packages/offering-rendering/ParallaxCoverShell.tsx
+++ b/packages/offering-rendering/ParallaxCoverShell.tsx
@@ -120,6 +120,13 @@ export interface ParallaxCoverShellProps {
   onScrollViewLayout?: (event: LayoutChangeEvent) => void;
   closeAccessibilityLabel?: string;
   /**
+   * ORCH-1159 — forwarded verbatim to OfferingChrome. When true, the floating
+   * "X" (close) button is HIDDEN on web and KEPT on native (Share + Mute
+   * unaffected). The public event / trip / experience pages pass `true`; the
+   * public brand page omits it (keeps its X on web). Absent ⇒ unchanged.
+   */
+  hideCloseOnWeb?: boolean;
+  /**
    * ORCH-1153 BUG-2 — OPTIONAL phone/native cover aspect ratio (width / height).
    * The pinned cover + its flow spacer both use this. Default `4 / 5` (the
    * proven event/trip/RSVP full-bleed cover; native-stacking test asserts 4/5).
@@ -156,6 +163,7 @@ export const ParallaxCoverShell: React.FC<ParallaxCoverShellProps> = ({
   onScroll,
   onScrollViewLayout,
   closeAccessibilityLabel,
+  hideCloseOnWeb = false,
   coverAspectRatio = 4 / 5,
   testID,
 }) => {
@@ -171,6 +179,7 @@ export const ParallaxCoverShell: React.FC<ParallaxCoverShellProps> = ({
       onShare={onShare}
       onToggleMute={onToggleMute}
       closeAccessibilityLabel={closeAccessibilityLabel}
+      hideCloseOnWeb={hideCloseOnWeb}
       testID={testID !== undefined ? `${testID}-chrome` : undefined}
     />
   );

--- a/packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts
@@ -1,0 +1,125 @@
+// ORCH-1159 [hide-web-close-x] — implementor-owned happy-path regression.
+//
+// CONTRACT: on the PUBLIC event / trip / experience pages the floating "X"
+// (close) button is HIDDEN on web (`Platform.OS === "web"`) and KEPT on native.
+// The Share button (and Mute) render on EVERY surface, web included. Native is
+// byte-identical to before. The public BRAND page is out of ORCH-1159 scope and
+// keeps its X on web (it does NOT opt in).
+//
+// All three "render sites" named in the dispatch collapse to ONE shared owner:
+// the close button is rendered exclusively by `OfferingChrome` (reached via
+// `ParallaxCoverShell`) on all of event/trip/experience. So the gate is the
+// `hideCloseOnWeb` opt-in threaded OfferingChrome ← ParallaxCoverShell ← the 4
+// public-offering FOUNDATION render components, applied through the single-owner
+// `shouldRenderCloseButton` predicate.
+//
+// (1) BEHAVIORAL — the real RN-free predicate is EXECUTED across web/native ×
+//     opt-in/opt-out.
+// (2) SOURCE-CONTRACT — the wiring (gate scoped to CLOSE only, Share never
+//     gated, prop forwarded, 4 pages opt in, brand page does NOT).
+//
+// FAILS-ON-REVERT (proven by true line-deletion — see the implementation report):
+//   - delete the `hideCloseOnWeb && platformOS === "web"` term in
+//     closeButtonVisibility.ts → the web-hidden behavioral assert fails.
+//   - delete `shouldRenderCloseButton(...)` / the `showClose ?` guard in
+//     OfferingChrome.tsx → the "close is gated" source assert fails.
+//   - delete `hideCloseOnWeb` from any of the 4 page call sites → that page's
+//     opt-in source assert fails.
+
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import { shouldRenderCloseButton } from "../closeButtonVisibility.ts";
+
+// ── (1) BEHAVIORAL: execute the single-owner predicate ──────────────────────
+
+Deno.test("ORCH-1159: opted-in public page HIDES the close button on web", () => {
+  assertEquals(shouldRenderCloseButton(true, "web"), false);
+});
+
+Deno.test("ORCH-1159: opted-in public page KEEPS the close button on iOS", () => {
+  assertEquals(shouldRenderCloseButton(true, "ios"), true);
+});
+
+Deno.test("ORCH-1159: opted-in public page KEEPS the close button on Android", () => {
+  assertEquals(shouldRenderCloseButton(true, "android"), true);
+});
+
+Deno.test("ORCH-1159: NOT-opted-in caller (e.g. brand page) KEEPS the X on web", () => {
+  // The public brand page does not pass hideCloseOnWeb → unchanged on web.
+  assertEquals(shouldRenderCloseButton(false, "web"), true);
+  assertEquals(shouldRenderCloseButton(false, "ios"), true);
+  assertEquals(shouldRenderCloseButton(false, "android"), true);
+});
+
+// ── (2) SOURCE-CONTRACT: the wiring is correctly scoped ─────────────────────
+
+const read = (rel: string): string =>
+  Deno.readTextFileSync(new URL(rel, import.meta.url));
+
+Deno.test("ORCH-1159: OfferingChrome gates ONLY the close button (Share/Mute never gated)", () => {
+  const src = read("../OfferingChrome.tsx");
+  // The close render is wrapped in the showClose guard derived from the predicate.
+  assertStringIncludes(src, "shouldRenderCloseButton(hideCloseOnWeb, Platform.OS)");
+  assertStringIncludes(src, "{showClose ? (");
+  // The guard wraps the CLOSE button (CloseGlyph), not Share/Mute.
+  const guardIdx = src.indexOf("{showClose ? (");
+  const closeIdx = src.indexOf("<CloseGlyph />");
+  const shareIdx = src.indexOf("<ShareGlyph />");
+  assert(guardIdx >= 0 && closeIdx > guardIdx, "showClose guard must precede CloseGlyph");
+  // Share renders unconditionally and AFTER the close guard block, never inside it.
+  assert(shareIdx > closeIdx, "Share must render after the close button");
+  // Share/Mute are NOT behind any web/Platform gate.
+  assert(
+    !/Platform\.OS[^\n]*ShareGlyph/.test(src),
+    "Share must never be platform-gated",
+  );
+});
+
+Deno.test("ORCH-1159: ParallaxCoverShell forwards hideCloseOnWeb to OfferingChrome", () => {
+  const src = read("../ParallaxCoverShell.tsx");
+  assertStringIncludes(src, "hideCloseOnWeb?: boolean");
+  assertStringIncludes(src, "hideCloseOnWeb = false");
+  assertStringIncludes(src, "hideCloseOnWeb={hideCloseOnWeb}");
+});
+
+Deno.test("ORCH-1159: the 3 public-offering pages (event ticketed+RSVP, trip, experience) opt in", () => {
+  const pages: Array<[string, string]> = [
+    [
+      "FoundationEventPreview (event ticketed)",
+      "../../../mingla-business/src/components/event/FoundationEventPreview.tsx",
+    ],
+    [
+      "RsvpPublicBody (event RSVP)",
+      "../../../mingla-business/src/components/event/RsvpPublicBody.tsx",
+    ],
+    [
+      "TripPreview (trip)",
+      "../../../mingla-business/src/components/trip/TripPreview.tsx",
+    ],
+    [
+      "ExperiencePreview (experience)",
+      "../../../mingla-business/src/components/experience/ExperiencePreview.tsx",
+    ],
+  ];
+  for (const [label, rel] of pages) {
+    const src = read(rel);
+    assert(
+      /hideCloseOnWeb\b/.test(src),
+      `${label} must pass hideCloseOnWeb to ParallaxCoverShell`,
+    );
+    // The prop must sit on the ParallaxCoverShell call alongside onShare (Share kept).
+    assertStringIncludes(src, "onShare={onShare}");
+  }
+});
+
+Deno.test("ORCH-1159: the public BRAND page is OUT of scope — it does NOT opt in (keeps its X on web)", () => {
+  const src = read("../../../packages/brand-rendering/PublicBrandPage.tsx");
+  assert(
+    !/hideCloseOnWeb/.test(src),
+    "PublicBrandPage must NOT pass hideCloseOnWeb (brand page is out of ORCH-1159 scope)",
+  );
+});

--- a/packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts
@@ -1,10 +1,14 @@
 // ORCH-1159 [hide-web-close-x] — implementor-owned happy-path regression.
 //
-// CONTRACT: on the PUBLIC event / trip / experience pages the floating "X"
-// (close) button is HIDDEN on web (`Platform.OS === "web"`) and KEPT on native.
-// The Share button (and Mute) render on EVERY surface, web included. Native is
-// byte-identical to before. The public BRAND page is out of ORCH-1159 scope and
-// keeps its X on web (it does NOT opt in).
+// CONTRACT: on the PUBLIC event / trip / experience pages AND the public BRAND
+// page the floating "X" (close) button is HIDDEN on web (`Platform.OS === "web"`)
+// and KEPT on native. The Share button (and Mute) render on EVERY surface, web
+// included. Native is byte-identical to before.
+//
+// SCOPE EXTENSION (Seth 2026-06-18): the public BRAND page (PublicBrandPage.tsx)
+// is the FIFTH consumer of the shared chrome and now ALSO opts in — its X is
+// hidden on web, same as the offering pages. The opt-in MECHANISM itself stays
+// covered by a synthetic NOT-opted caller (predicate returns true on web).
 //
 // All three "render sites" named in the dispatch collapse to ONE shared owner:
 // the close button is rendered exclusively by `OfferingChrome` (reached via
@@ -23,8 +27,8 @@
 //     closeButtonVisibility.ts → the web-hidden behavioral assert fails.
 //   - delete `shouldRenderCloseButton(...)` / the `showClose ?` guard in
 //     OfferingChrome.tsx → the "close is gated" source assert fails.
-//   - delete `hideCloseOnWeb` from any of the 4 page call sites → that page's
-//     opt-in source assert fails.
+//   - delete `hideCloseOnWeb` from any of the 5 page call sites (4 offering
+//     pages + the brand page) → that page's opt-in source assert fails.
 
 import {
   assert,
@@ -48,8 +52,11 @@ Deno.test("ORCH-1159: opted-in public page KEEPS the close button on Android", (
   assertEquals(shouldRenderCloseButton(true, "android"), true);
 });
 
-Deno.test("ORCH-1159: NOT-opted-in caller (e.g. brand page) KEEPS the X on web", () => {
-  // The public brand page does not pass hideCloseOnWeb → unchanged on web.
+Deno.test("ORCH-1159: a NOT-opted-in caller (hideCloseOnWeb=false) KEEPS the X on every surface", () => {
+  // The opt-in MECHANISM itself: any chrome consumer that does NOT pass
+  // hideCloseOnWeb is unchanged on web (and native). This proves the gate is
+  // opt-in, not a blanket web-hide — distinct from the brand page, which now
+  // DOES opt in (asserted below).
   assertEquals(shouldRenderCloseButton(false, "web"), true);
   assertEquals(shouldRenderCloseButton(false, "ios"), true);
   assertEquals(shouldRenderCloseButton(false, "android"), true);
@@ -86,40 +93,52 @@ Deno.test("ORCH-1159: ParallaxCoverShell forwards hideCloseOnWeb to OfferingChro
   assertStringIncludes(src, "hideCloseOnWeb={hideCloseOnWeb}");
 });
 
-Deno.test("ORCH-1159: the 3 public-offering pages (event ticketed+RSVP, trip, experience) opt in", () => {
-  const pages: Array<[string, string]> = [
+Deno.test("ORCH-1159: ALL 5 public pages (event ticketed+RSVP, trip, experience, BRAND) opt in", () => {
+  const pages: Array<[string, string, string]> = [
     [
       "FoundationEventPreview (event ticketed)",
       "../../../mingla-business/src/components/event/FoundationEventPreview.tsx",
+      "onShare={onShare}",
     ],
     [
       "RsvpPublicBody (event RSVP)",
       "../../../mingla-business/src/components/event/RsvpPublicBody.tsx",
+      "onShare={onShare}",
     ],
     [
       "TripPreview (trip)",
       "../../../mingla-business/src/components/trip/TripPreview.tsx",
+      "onShare={onShare}",
     ],
     [
       "ExperiencePreview (experience)",
       "../../../mingla-business/src/components/experience/ExperiencePreview.tsx",
+      "onShare={onShare}",
+    ],
+    // SCOPE EXTENSION (Seth 2026-06-18) — the 5th chrome consumer.
+    [
+      "PublicBrandPage (brand)",
+      "../../../packages/brand-rendering/PublicBrandPage.tsx",
+      "onShare={callbacks.onShare}",
     ],
   ];
-  for (const [label, rel] of pages) {
+  for (const [label, rel, shareCall] of pages) {
     const src = read(rel);
     assert(
       /hideCloseOnWeb\b/.test(src),
       `${label} must pass hideCloseOnWeb to ParallaxCoverShell`,
     );
-    // The prop must sit on the ParallaxCoverShell call alongside onShare (Share kept).
-    assertStringIncludes(src, "onShare={onShare}");
+    // The opt-in sits on the same ParallaxCoverShell call that keeps Share.
+    assertStringIncludes(src, shareCall);
   }
 });
 
-Deno.test("ORCH-1159: the public BRAND page is OUT of scope — it does NOT opt in (keeps its X on web)", () => {
+Deno.test("ORCH-1159 (scope extension): the public BRAND page opts in — HIDES its X on web", () => {
   const src = read("../../../packages/brand-rendering/PublicBrandPage.tsx");
   assert(
-    !/hideCloseOnWeb/.test(src),
-    "PublicBrandPage must NOT pass hideCloseOnWeb (brand page is out of ORCH-1159 scope)",
+    /hideCloseOnWeb\b/.test(src),
+    "PublicBrandPage must pass hideCloseOnWeb (brand page now opts in — Seth 2026-06-18)",
   );
+  // Share is preserved on the brand page on web (never gated).
+  assertStringIncludes(src, "onShare={callbacks.onShare}");
 });

--- a/packages/offering-rendering/__tests__/orch_1159_hide_web_close_x_adversarial.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1159_hide_web_close_x_adversarial.test.ts
@@ -1,0 +1,173 @@
+// ORCH-1159 [hide-web-close-x] — TESTER-OWNED ADVERSARIAL regression.
+//
+// DIFFERENT ANGLE than the implementor's happy-path test
+// (orch_1159_hide_web_close_x.test.ts). The implementor proves the predicate
+// returns false on web+opt-in and that the 5 pages opt in. This file attacks the
+// SURVIVORS of that happy path:
+//
+//   A. BOUNDARY — the close button must survive on NON-web, NON-mobile platforms
+//      (windows / macos). The predicate's PlatformOSValue union includes them; a
+//      naive `platformOS !== "web"` rewrite would pass, but a `platformOS === "ios"
+//      || platformOS === "android"` rewrite (the tempting "only show on mobile"
+//      refactor) would WRONGLY hide the X on windows/macos. Pin every union member.
+//
+//   B. INVARIANT — Share + Mute render-presence is PLATFORM-INVARIANT and
+//      independent of hideCloseOnWeb. There is NO predicate, NO Platform.OS check,
+//      and NO hideCloseOnWeb reference anywhere on the Share or Mute render path in
+//      OfferingChrome. Proven structurally: the entire rightGroup (Share + Mute)
+//      lives OUTSIDE — strictly AFTER — the `{showClose ? ( ... ) : ( ... )}`
+//      ternary, so the close gate can never gate Share/Mute.
+//
+//   C. STRUCTURAL — when the X is hidden, the replacement placeholder must (1) NOT
+//      steal pointer events (`pointerEvents="none"`) and (2) NOT shift the
+//      Share/Mute group off the right edge: the row stays `space-between` with the
+//      close slot FIRST and rightGroup SECOND, so the right group always pins right
+//      whether the close slot is the real button or the empty placeholder.
+//
+//   D. DEFENSIVE — NO caller, under ANY hideCloseOnWeb value, can hide the X on
+//      native. shouldRenderCloseButton(*, "ios"|"android") is unconditionally true.
+//      Exhaustive over {true,false} × {ios,android}.
+//
+// This is NOT a renamed copy of the implementor test: it shares zero assertions
+// (the implementor asserts web=false + the 5 opt-in sites; this asserts the
+// windows/macos boundary, the Share/Mute structural invariant, the placeholder
+// pointer-safety + right-edge pinning, and native-immunity). Append-only: NEW file.
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  shouldRenderCloseButton,
+  type PlatformOSValue,
+} from "../closeButtonVisibility.ts";
+
+const read = (rel: string): string =>
+  Deno.readTextFileSync(new URL(rel, import.meta.url));
+
+// ── A. BOUNDARY: non-web non-mobile platforms KEEP the X ────────────────────
+
+Deno.test("ORCH-1159 ADV/A: windows KEEPS the close button even when opted in", () => {
+  assertEquals(shouldRenderCloseButton(true, "windows"), true);
+});
+
+Deno.test("ORCH-1159 ADV/A: macos KEEPS the close button even when opted in", () => {
+  assertEquals(shouldRenderCloseButton(true, "macos"), true);
+});
+
+Deno.test("ORCH-1159 ADV/A: web is the ONLY platform the opt-in can hide", () => {
+  // Exhaustive over the entire PlatformOSValue union: only "web" + opt-in hides.
+  const all: PlatformOSValue[] = ["ios", "android", "web", "windows", "macos"];
+  const hidden = all.filter((p) => shouldRenderCloseButton(true, p) === false);
+  assertEquals(
+    hidden,
+    ["web"],
+    "exactly one platform (web) may hide the close button under opt-in",
+  );
+});
+
+// ── B. INVARIANT: Share/Mute never touched by the close gate (structural) ───
+
+Deno.test("ORCH-1159 ADV/B: Share + Mute render OUTSIDE the showClose ternary (never gated)", () => {
+  const src = read("../OfferingChrome.tsx");
+
+  // The close ternary block: from `{showClose ? (` to the close of its else branch.
+  const ternaryStart = src.indexOf("{showClose ? (");
+  assert(ternaryStart >= 0, "showClose ternary must exist");
+
+  // The right-hand button group (Share + optional Mute) must begin AFTER the
+  // ternary opens. We require it to begin after the placeholder else-branch too —
+  // i.e. the rightGroup View is a SIBLING of the close slot, not nested inside it.
+  const rightGroupIdx = src.indexOf('<View style={styles.rightGroup}>');
+  assert(rightGroupIdx > ternaryStart, "rightGroup must come after the close slot");
+
+  // Slice the close ternary region (start → rightGroup) and prove NEITHER the
+  // Share nor the Mute glyph lives inside it.
+  const closeRegion = src.slice(ternaryStart, rightGroupIdx);
+  assert(
+    !closeRegion.includes("<ShareGlyph"),
+    "Share must NOT be inside the close (showClose) gate",
+  );
+  assert(
+    !closeRegion.includes("<VolumeGlyph"),
+    "Mute must NOT be inside the close (showClose) gate",
+  );
+
+  // And there is NO platform / opt-in token anywhere on the Share/Mute path:
+  // the only platform-conditional thing about Share/Mute is `showMute` (a
+  // caller-supplied data flag, NOT a Platform.OS / hideCloseOnWeb decision).
+  const shareIdx = src.indexOf("onPress={onShare}");
+  assert(shareIdx > rightGroupIdx, "Share Pressable lives in the right group");
+  // No `hideCloseOnWeb` reference downstream of the Share render (it is consumed
+  // exactly once, in the showClose computation above the row).
+  const downstreamOfShare = src.slice(shareIdx);
+  assert(
+    !downstreamOfShare.includes("hideCloseOnWeb"),
+    "hideCloseOnWeb must not appear on/after the Share render path",
+  );
+});
+
+Deno.test("ORCH-1159 ADV/B: hideCloseOnWeb is consumed EXACTLY ONCE in OfferingChrome (only the close decision)", () => {
+  const src = read("../OfferingChrome.tsx");
+  // Count substantive uses (the prop destructure default + the predicate call).
+  // It must NOT proliferate onto Share/Mute. Allow it in the prop signature,
+  // JSDoc, destructure, and the single shouldRenderCloseButton(...) call.
+  const predicateCallMatches = src.match(
+    /shouldRenderCloseButton\(hideCloseOnWeb, Platform\.OS\)/g,
+  );
+  assertEquals(
+    predicateCallMatches?.length,
+    1,
+    "the close decision must derive from exactly ONE predicate call",
+  );
+});
+
+// ── C. STRUCTURAL: hidden-X placeholder is pointer-safe + preserves right pin ─
+
+Deno.test("ORCH-1159 ADV/C: the hidden-X placeholder does NOT steal pointer events", () => {
+  const src = read("../OfferingChrome.tsx");
+  const elseIdx = src.indexOf(") : (");
+  assert(elseIdx >= 0, "showClose ternary must have an else branch (placeholder)");
+  const rightGroupIdx = src.indexOf('<View style={styles.rightGroup}>');
+  // The placeholder lives between the else `(` and the rightGroup. It must carry
+  // pointerEvents="none" so the empty left slot can never intercept taps meant
+  // for the body underneath.
+  const elseRegion = src.slice(elseIdx, rightGroupIdx);
+  assert(
+    /<View\s+pointerEvents="none"\s*\/>/.test(elseRegion),
+    'hidden-X placeholder must be `<View pointerEvents="none" />`',
+  );
+});
+
+Deno.test("ORCH-1159 ADV/C: the row pins Share/Mute right via space-between with close FIRST", () => {
+  const src = read("../OfferingChrome.tsx");
+  // The container row uses space-between so the FIRST child (close slot OR
+  // placeholder) flushes left and the SECOND child (rightGroup) flushes right.
+  assert(
+    /row:\s*\{[^}]*justifyContent:\s*"space-between"/s.test(src),
+    "the chrome row must use justifyContent: space-between",
+  );
+  // The close slot ternary must be the FIRST child of the row, and rightGroup the
+  // next sibling — so removing the close button (placeholder) never reorders the
+  // right group off the right edge.
+  const rowOpen = src.indexOf("<View style={styles.row}");
+  const ternaryIdx = src.indexOf("{showClose ? (");
+  const rightGroupIdx = src.indexOf('<View style={styles.rightGroup}>');
+  assert(rowOpen >= 0 && ternaryIdx > rowOpen, "close slot must be first child of row");
+  assert(rightGroupIdx > ternaryIdx, "rightGroup must be the sibling AFTER the close slot");
+});
+
+// ── D. DEFENSIVE: native immunity is unconditional ──────────────────────────
+
+Deno.test("ORCH-1159 ADV/D: NO caller can hide the X on native (exhaustive over opt-in × mobile)", () => {
+  for (const opt of [true, false]) {
+    for (const os of ["ios", "android"] as PlatformOSValue[]) {
+      assertEquals(
+        shouldRenderCloseButton(opt, os),
+        true,
+        `native ${os} must keep the X regardless of hideCloseOnWeb=${opt}`,
+      );
+    }
+  }
+});

--- a/packages/offering-rendering/closeButtonVisibility.ts
+++ b/packages/offering-rendering/closeButtonVisibility.ts
@@ -1,0 +1,25 @@
+// ORCH-1159 [hide-web-close-x] — single-owner decision for whether the floating
+// "X" (close) button renders on an offering cover.
+//
+// Extracted to its own RN-free module so the regression test can EXECUTE the
+// real decision on both web and native inputs without mounting the
+// react-native / react-native-svg tree (Deno can't import those). OfferingChrome
+// imports this and applies it to its close-button render.
+//
+// Contract: the close button is hidden ONLY when the caller opts in
+// (`hideCloseOnWeb`, set by the public event / trip / experience pages) AND the
+// platform is web. The Share + Mute buttons are NEVER governed by this — they
+// render on every surface. Native is byte-identical to before. The public brand
+// page does NOT opt in, so it keeps its X on web.
+
+export type PlatformOSValue =
+  | "ios"
+  | "android"
+  | "web"
+  | "windows"
+  | "macos";
+
+export const shouldRenderCloseButton = (
+  hideCloseOnWeb: boolean,
+  platformOS: PlatformOSValue,
+): boolean => !(hideCloseOnWeb && platformOS === "web");

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -14,6 +14,10 @@ export type { ParallaxCoverShellProps } from "./ParallaxCoverShell";
 export { OfferingChrome } from "./OfferingChrome";
 export type { OfferingChromeProps } from "./OfferingChrome";
 
+// ORCH-1159 — RN-free close-button visibility predicate (single owner).
+export { shouldRenderCloseButton } from "./closeButtonVisibility";
+export type { PlatformOSValue } from "./closeButtonVisibility";
+
 export { CountAwareGallery } from "./CountAwareGallery";
 export type {
   CountAwareGalleryProps,


### PR DESCRIPTION
## ORCH-1159 — hide the public-page floating "X" (close) button on web

**Plain English:** On the public event, RSVP-event, trip, experience, and brand pages, the floating close "X" now disappears on the **web** build and stays on **native** (iOS/Android). On web there's no parent screen to return to — an anonymous share-link visitor tapping the X just bounced to the brand page or home, which was confusing. The Share button (and Mute on video covers) stays on every surface, web included. Native behavior is byte-identical.

## How
- New RN-free single-owner predicate `shouldRenderCloseButton(hideCloseOnWeb, Platform.OS)` in `packages/offering-rendering/closeButtonVisibility.ts`.
- Opt-in `hideCloseOnWeb` prop on `OfferingChrome` + `ParallaxCoverShell` (default `false` → native + non-opted consumers byte-identical). Gates ONLY the close glyph; Share/Mute always render; an empty placeholder preserves the right-pinned `space-between` layout.
- Five opted-in consumers: `FoundationEventPreview`, `RsvpPublicBody`, `ExperiencePreview`, `TripPreview`, `PublicBrandPage`.

## Evidence
- Implementor happy-path test `packages/offering-rendering/__tests__/orch_1159_hide_web_close_x.test.ts` (8/8), fails-on-revert proven.
- Tester adversarial test `packages/offering-rendering/__tests__/orch_1159_hide_web_close_x_adversarial.test.ts` (different angle: boundary windows/macos keep X, Share/Mute platform-invariant, placeholder pointer-safety + right-edge pin, native immunity), fails-on-revert ×3.
- Runtime: compiled `mingla-business` web bundle inspected — close-button logic resolves to web → X not rendered; Share unconditional.
- Required isolation gates `meta-orch-0827-package-isolation` + `orch-1138-mor-isolation` PASS. Pre-existing mingla-business jest reds proven to exist on clean origin/main (untouched ORCH-1157 files).

Reports: `Mingla_Artifacts/reports/IMPLEMENT_ORCH-1159_HIDE_WEB_CLOSE_X.md`, `Mingla_Artifacts/reports/TEST_ORCH-1159_HIDE_WEB_CLOSE_X.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)