### PR TITLE
ORCH-1164: restore anon web TRIP page (#507 theme-column grant gap) [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1164_507_REGRESSION_RECOVERY.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1164_507_REGRESSION_RECOVERY.md
@@ -1,0 +1,141 @@
+# IMPLEMENTATION — ORCH-1164 [#507 regression recovery — restore the anon web TRIP page]
+
+- **Phase:** IMPLEMENT (single pass). Worktree `~/Desktop/mingla-orchs/ORCH-1164-[507-regression-recovery]/` on branch `ORCH-1164-507-regression-recovery`, rebased onto current `origin/main`.
+- **Spec:** `Mingla_Artifacts/specs/SPEC_ORCH-1164_507_REGRESSION_RECOVERY.md` (read from anchor; only artifact inputs read there — no anchor product code touched).
+- **Investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1164_507_BLAST_RADIUS.md`.
+- **Comms:** Acked COMMS-0042 (WARN, CORRECTED) — narrow scope confirmed: ONLY the anon web trip page broke; NO 1147 re-apply, NO pricing bug. No ORCH-1147 or ORCH-1138-owned file touched.
+- **Status:** implemented and verified (static/CI-grade + live DB probes). On-device anon trip-page render + WYSIWYP re-prove are the tester's runtime steps.
+
+---
+
+## 1. Summary
+
+#507 (ORCH-1138 Leg 3) added `theme_color/theme_font/theme_animation` to the DIRECT anon `supabase.from("brands").select(...)` in the trip read hook. The `anon` Postgres role has only column-level SELECT on `public.brands` and was never granted those three columns → Postgres aborts the whole statement with `42501 permission denied for table brands` → the anon `/t/{brandSlug}/{tripSlug}` page blanked for every logged-out buyer (all anon web trip sales blocked). Event + experience pages were fine (they read theme via the anon-safe `business_public_events_view`).
+
+This change restores anon trip-page rendering by (A1) granting anon column-SELECT on the 3 theme columns (forward-only migration, self-verifying), (A2) moving the trip hook's brand-theme read onto `business_public_events_view` (COMMS-0009 pattern, mirroring the experience leg) and dropping the 3 theme columns from the direct brands select, (B1) extending the ORCH-1138 anon-column guard to scan the trip hook (the gap that let #507 through), and (C) adding an anon-load regression test.
+
+**OQ-2 RESOLVED — HELD:** live read-only probe confirmed `business_public_events_view` exposes `brand_theme_color/brand_theme_font/brand_theme_animation` AND contains 3 `event_type='trip'` rows resolvable by `(brand_slug, slug)`. A2 (view-sourced theme) is therefore viable; both A1 and A2 ship (OQ-1 = both).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence / commit |
+|----|-----------|--------|-------------------|
+| SC-1-Web | Anon loads published `/t/.../...` (no `permission denied`) | ✓ implemented; runtime UNVERIFIED (tester) | A1 grant + A2 view-sourced theme; brands select now anon-clean (`5d9acc15d`) |
+| SC-2-DB | `has_column_privilege('anon','brands','theme_*')` = true after migration | ✓ migration authored + self-verifying probe | `20261014000000_orch_1164_anon_brand_theme_grant.sql` (orchestrator applies) |
+| SC-3 | trip hook has NO `theme_*` in any `.from("brands").select(...)`; theme via view | ✓ verified | `usePublicTripBySlug.ts` (`5d9acc15d`); test `orch_1164_anon_trip_page_loads.test.ts` |
+| SC-4 | B1 guard FAILS on revert, PASSES on fix | ✓ proven | fails-on-revert below (`5d9acc15d`) |
+| SC-5-Auth | authenticated still loads trip page | ✓ no-regression (auth has table SELECT; hook unchanged for authed) | unchanged read path |
+| SC-6 | WYSIWYP re-prove (1147 intact) | n/a here — re-prove only, NO code change | tester runs `orch-1153-pass-fee` fixture |
+
+---
+
+## 3. Files changed (4, all in scope)
+
+| File | Δ | Kind |
+|------|---|------|
+| `supabase/migrations/20261014000000_orch_1164_anon_brand_theme_grant.sql` | +72 (new) | A1 migration |
+| `mingla-business/src/hooks/usePublicTripBySlug.ts` | ~ +35 / -12 | A2 hook fix |
+| `mingla-business/src/services/__tests__/orch_1138_tester_anon_brand_theme_columns.test.ts` | +47 (append-only) | B1 guard |
+| `mingla-business/src/hooks/__tests__/orch_1164_anon_trip_page_loads.test.ts` | +110 (new) | C regression test |
+
+Closing diff (`git diff origin/main...HEAD --name-only`) = exactly these 4. Working tree clean.
+
+---
+
+## 4. Data-model changes
+
+- **Forward-only, additive GRANT** (no DDL beyond the grant): `GRANT SELECT (theme_color, theme_font, theme_animation) ON public.brands TO anon;`
+- Self-verifying `DO $$ ... RAISE EXCEPTION` probe asserting 3 anon column grants (mirrors ORCH-0879).
+- NO RLS change, NO REVOKE, NO other column grant, NO view change.
+- **Live pre-apply probe (read-only):** `has_table_privilege('anon','brands','SELECT')=false`; `theme_color/font/animation` anon SELECT = false/false/false; `cover_hue`=true (kept as a direct read). Confirms the root cause and that the grant is the correct minimal restore.
+
+---
+
+## 5. Edge functions touched
+
+None. No `verify_jwt` impact.
+
+---
+
+## 6. Regression tests added
+
+- **Happy-path (implementor, C):** `mingla-business/src/hooks/__tests__/orch_1164_anon_trip_page_loads.test.ts` — asserts every column the trip hook selects off `brands` is in the anon-readable set, and that brand theme is sourced from `business_public_events_view` (`event_type='trip'`). 3 tests, PASS.
+- **Guard generalization (B1):** extended `orch_1138_tester_anon_brand_theme_columns.test.ts` with an ORCH-1164 describe block scanning the trip hook for forbidden `theme_*` in any brands select. Append-only (zero deletions to existing assertions, verified via diff). PASS.
+
+**fails-on-revert verified at `5d9acc15d`:** re-adding `theme_color, theme_font, theme_animation` to the trip hook's `.from("brands").select(...)` (the exact #507 break) → **2 suites / 4 tests FAIL** (the new `orch_1164` anon-readable-column subset check + the B1 guard's 3 forbidden-column assertions). Restoring the fix → 11/11 PASS. Reverted via true edit of the select string (not a comment-out).
+
+Test run (fixed tree): `Test Suites: 2 passed, 2 total / Tests: 11 passed, 11 total`.
+
+---
+
+## 7. Old → New receipts
+
+### usePublicTripBySlug.ts
+- **Before:** the direct anon `brands` select listed `... cover_hue, theme_color, theme_font, theme_animation`; `brandTheme` was built from `brand.theme_color/font/animation`. A false comment claimed the theme columns "are anon-readable (verified)".
+- **Now:** the brands select lists only anon-granted columns (`id, slug, name, description, cover_media_url, cover_media_type, cover_hue`). A new `fetchBrandThemeFromView(brandSlug, tripSlug)` reads `brand_theme_*` from `business_public_events_view` filtered to `event_type='trip'` (mirrors `publicExperienceService.fetchBrandThemeFromView`), and `brandTheme = await fetchBrandThemeFromView(...)`. Per-trip overrides still come off the `events` row (anon-readable). A non-null narrowing guard at the top of `queryFn` (mirrors `enabled`) narrows the slugs to `string` for the view lookup with no unsafe `!`/`as`.
+- **Why:** SC-1/SC-3 — the column-privilege failure mode is removed and the page is robust to grant drift (COMMS-0009).
+- **Lines:** ~+35 / -12.
+
+### Migration (new)
+- **Before:** anon had no SELECT on the 3 theme columns.
+- **Now:** anon has column-SELECT on them (the belt; A2 is the suspenders).
+- **Why:** SC-2; minimal immediate restore matching the ORCH-0879 template.
+
+### Guard test (B1, append) + regression test (C, new)
+- Close the CI coverage gap (1138 guard scanned only the experience service) + prove anon-load. Why: SC-4.
+
+---
+
+## 8. Cross-surface impact
+
+| # | Surface | Affected | Note |
+|---|---------|----------|------|
+| 1 | Consumer iOS | No | reads off deck RPC, no client `.from(brands)` |
+| 2 | Consumer Android | No | same |
+| 3 | Buyer/anon Web | **YES** | the fix — published trip page renders for logged-out buyers |
+| 4 | Business iOS | No | authed has table SELECT; unchanged |
+| 5 | Business Android | No | same |
+| 6 | Admin Web | No | does not use this hook |
+| 7 | Business Web preview | Incidental | shares the hook → benefits automatically |
+
+Parity: the backend grant is shared (all anon `brands.theme_*` readers benefit at once); the hook fix is the shared business/web RN codebase → automatic across surfaces 3 + 7.
+
+---
+
+## 9. Smoke / verification result
+
+- Live read-only DB probes (MCP, project `gqnoajqerqhnvulmnyvv`): root-cause grant gap reconfirmed; OQ-2 view-trip-rows confirmed (3 trip rows with theme columns). No mutations.
+- `npx tsc --noEmit` on the hook: no type errors in `usePublicTripBySlug.ts`.
+- Jest: ORCH-1164 + extended 1138 suites = 11/11 PASS; fails-on-revert proven.
+- Strict-grep gates run (all PASS): `orch-0792-no-published-event-theme-reads`, `orch-0964-checkout-no-brand-theme`, `orch-0964-theme-resolver-canonical`, `orch-0964-theme-typed-columns`, `orch-0963-public-trip-rpc-and-route-segregation`, `i-proposed-trip-canonical-columns`, `orch-1138-trip-reserve-straight-to-cart`.
+- **Pre-existing failures (NOT caused by ORCH-1164):** a broad `src/services/__tests__` run shows ~25 suites failing on a `publicEventsService.ts:18` import-resolution issue; **confirmed identical on a pristine `origin/main` worktree** (verified `tripsService.test.ts` + `publicEventsService.tripFetch.test.ts` fail the same way without any ORCH-1164 change). Out of scope — flagged below.
+
+---
+
+## 10. Known issues / deferred
+
+- No `[TRANSITIONAL]` code introduced.
+- A1 + A2 both shipped (OQ-1 = both, per spec recommendation). A2 makes the page robust even if the grant is later dropped; A1 is the immediate restore.
+
+---
+
+## 11. Operator action required
+
+- **Apply the migration (NOT applied by implementor — orchestrator/Management API per the migration-apply hazard runbook, gated behind Seth's QA):**
+  ```bash
+  cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1164-[507-regression-recovery]" && /Users/sethogieva/bin/supabase db push --linked
+  ```
+  (or apply `20261014000000_orch_1164_anon_brand_theme_grant.sql` via the Management API). Migration is monotonic — highest on origin/main + this branch is `20261013000002`; no sibling worktree uses `20261014*`. After apply, the self-verifying `DO $$` block raises if any grant didn't take; confirm `has_column_privilege('anon','brands','theme_color'/'theme_font'/'theme_animation','SELECT')` = true (SC-2).
+- **Edge functions:** none to deploy.
+- **Tester:** SC-1-Web anon trip-page render on buyer-web (against a real published trip, e.g. `travelbrand/the-dc-adventure`); SC-5 authed no-regression; SC-6/T7 WYSIWYP re-prove on the `orch-1153-pass-fee` fixture; SC-8 event/experience anon-page parity (no regression from the migration).
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **D-1 (pre-existing, broad):** ~25 `mingla-business/src/services/__tests__` suites fail on a `publicEventsService.ts:18` import resolution — confirmed present on pristine `origin/main`, unrelated to ORCH-1164. Likely a jest-config/module-resolution drift on this machine; worth a dedicated investigation so the business-app jest suite is green again (it currently masks real regressions for any nearby ORCH).
+- **D-2 (process, from spec OQ-4):** COMMS-0042 is already CORRECTED on origin; at CLOSE the orchestrator should mark Part B (1147 revert) as a false alarm and flip `I-PROPOSED-1164-ANON-BRAND-THEME-VIA-VIEW` ACTIVE.
+- **D-3 (process, OQ-3):** the shared anchor `~/Desktop/mingla-main` working tree is polluted (~40 uncommitted reverts) — needs Seth's confirmation before any `git reset --hard origin/main`. Not in ORCH-1164 code scope; not touched.
+- **D-4 (generalization, from investigation D-2):** the anon-brand-theme guard now covers the experience service + the trip hook. Consider globbing ALL public read paths (`src/services/public*Service.ts` + `src/hooks/usePublic*.ts`) under the proposed `I-PROPOSED-1164-ANON-BRAND-THEME-VIA-VIEW` so any future direct `brands.theme_*` read fails CI everywhere.

--- a/mingla-business/src/hooks/__tests__/orch_1164_anon_trip_page_loads.test.ts
+++ b/mingla-business/src/hooks/__tests__/orch_1164_anon_trip_page_loads.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ORCH-1164 (#507 regression recovery) — IMPLEMENTOR happy-path regression test.
+ *
+ * PROVES the anon web TRIP page (/t/{brandSlug}/{tripSlug}) can load for a
+ * logged-out buyer, i.e. the trip hook's direct `brands` select lists ONLY
+ * columns the `anon` Postgres role can read.
+ *
+ * #507 (ORCH-1138 Leg 3) added theme_color/theme_font/theme_animation to the
+ * DIRECT `supabase.from("brands").select(...)` in usePublicTripBySlug.ts. The
+ * `anon` role has only COLUMN-level SELECT on `public.brands` (table-level
+ * SELECT is false), and those three theme columns were never granted to anon →
+ * Postgres aborts the whole statement with `42501 permission denied for table
+ * brands` (HTTP 401) → the entire anon trip page fails to render → all anon web
+ * trip sales blocked. (Proven live: has_column_privilege('anon','brands',
+ * 'theme_color') = false.)
+ *
+ * The fix sources brand theme from the anon-safe `business_public_events_view`
+ * (COMMS-0009) and selects ONLY anon-granted columns directly off `brands`.
+ *
+ * FAILS-ON-REVERT: re-adding any of theme_color/theme_font/theme_animation to
+ * the trip hook's brands select makes ANON_READABLE_BRAND_COLUMNS no longer a
+ * superset of the requested columns → this test FAILS (exactly the #507 break).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const TRIP_HOOK = resolve(__dirname, "..", "usePublicTripBySlug.ts");
+const src = readFileSync(TRIP_HOOK, "utf8");
+
+// The columns the `anon` Postgres role can SELECT off `public.brands`.
+// SOURCE OF TRUTH = the live grant set (baseline column grants + ORCH-0879
+// cover grant). theme_color/theme_font/theme_animation are DELIBERATELY ABSENT:
+// anon has no column-SELECT on them; reading them directly off brands 401s the
+// whole anon query (the #507 regression). After ORCH-1164's migration anon will
+// ALSO have the three theme columns, but the trip hook must NOT depend on that —
+// it sources theme from business_public_events_view (COMMS-0009). So this guard
+// holds the trip hook to the columns that are safe on EVERY deploy, grant or no.
+const ANON_READABLE_BRAND_COLUMNS = new Set([
+  "id",
+  "account_id",
+  "name",
+  "slug",
+  "description",
+  "profile_photo_url",
+  "contact_email",
+  "contact_phone",
+  "social_links",
+  "custom_links",
+  "display_attendee_count",
+  "default_currency",
+  "cover_media_url",
+  "cover_media_type",
+  "cover_hue",
+  "created_at",
+  "updated_at",
+  "deleted_at",
+]);
+
+// Extract every `.from("brands") ... .select(<literal>)` column list in the hook
+// (the chain may span lines; the select string itself may be multi-line).
+// Note: the select-string capture allows an OPTIONAL trailing comma + whitespace
+// before the closing paren (the trip hook formats the column list with a
+// trailing comma), so the lazy match terminates at the real string boundary.
+const brandSelectColumnLists = Array.from(
+  src.matchAll(
+    /\.from\(\s*["']brands["']\s*\)[\s\S]*?\.select\(\s*([`"'])([\s\S]*?)\1\s*,?\s*\)/g,
+  ),
+).map((m) =>
+  m[2]
+    .split(",")
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0),
+);
+
+describe("ORCH-1164 — anon can load the public trip page", () => {
+  test("the trip hook DOES read brands directly (sanity — guard targets the right call)", () => {
+    expect(brandSelectColumnLists.length).toBeGreaterThan(0);
+  });
+
+  test("every column the trip hook selects off brands is anon-readable (no 42501 for logged-out buyers)", () => {
+    const notAnonReadable = brandSelectColumnLists
+      .flat()
+      .filter((col) => !ANON_READABLE_BRAND_COLUMNS.has(col));
+    expect(notAnonReadable).toEqual([]);
+  });
+
+  test("brand theme is sourced from the anon-safe business_public_events_view, not brands (COMMS-0009)", () => {
+    // The hook must resolve brand theme via the view helper, filtered to the
+    // trip row by event_type='trip'.
+    expect(src).toContain("business_public_events_view");
+    expect(src).toContain('"event_type", "trip"');
+    expect(src).toMatch(/fetchBrandThemeFromView\s*\(/);
+  });
+});

--- a/mingla-business/src/hooks/usePublicTripBySlug.ts
+++ b/mingla-business/src/hooks/usePublicTripBySlug.ts
@@ -47,6 +47,38 @@ const asThemeInput = (
   return Object.keys(out).length > 0 ? out : null;
 };
 
+// ORCH-1164 (#507 regression recovery) — COMMS-0009 anon-safe-theme contract.
+// The brand THEME (theme_color/theme_font/theme_animation) is NOT read off the
+// `brands` table: the `anon` Postgres role has NO column-level SELECT on those
+// three columns (live: HTTP 401 `42501 permission denied for table brands`),
+// which #507 introduced on the trip read path and which blanked the entire anon
+// /t/{brandSlug}/{tripSlug} page. The theme is sourced from the anon-safe
+// security-definer `business_public_events_view` (brand_theme_color/
+// brand_theme_font/brand_theme_animation — anon-readable), filtered to THIS
+// trip's row by (brand_slug, slug, event_type='trip'), exactly as the
+// experience leg does (publicExperienceService.fetchBrandThemeFromView). The
+// view has trip rows (verified live: event_type='trip' rows present). Non-fatal:
+// any view error / miss → null (the page resolves the default palette, never
+// 401s). The trip hook's direct brands select keeps only anon-granted columns.
+const fetchBrandThemeFromView = async (
+  brandSlug: string,
+  tripSlug: string,
+): Promise<ThemeInput | null> => {
+  const { data, error } = await supabase
+    .from("business_public_events_view")
+    .select("brand_theme_color, brand_theme_font, brand_theme_animation")
+    .eq("brand_slug", brandSlug)
+    .eq("slug", tripSlug)
+    .eq("event_type", "trip")
+    .maybeSingle();
+  if (error !== null || data === null) return null;
+  return asThemeInput(
+    data.brand_theme_color,
+    data.brand_theme_font,
+    data.brand_theme_animation,
+  );
+};
+
 // ORCH-1138 B2 — anon-callable remaining-capacity RPC, mirroring
 // publicEventsService.fetchTicketTypesRemaining / getPublicTripById. Fail OPEN
 // on RPC error (empty map ⇒ ticketsRemaining stays null ⇒ no fabricated
@@ -159,7 +191,16 @@ export const usePublicTripBySlug = (
     enabled,
     staleTime: PUBLIC_TRIP_STALE_MS,
     queryFn: async () => {
-      if (!enabled) return null;
+      if (
+        typeof brandSlug !== "string" ||
+        brandSlug.length === 0 ||
+        typeof tripSlug !== "string" ||
+        tripSlug.length === 0
+      ) {
+        // mirrors `enabled` — narrows brandSlug/tripSlug to non-empty string for
+        // the view-theme lookup (ORCH-1164) without an unsafe non-null assert.
+        return null;
+      }
 
       // 1. Resolve brand by slug — anon-readable via brands public policy
       // (a brand is anon-readable when it has any published event;
@@ -168,16 +209,19 @@ export const usePublicTripBySlug = (
       // policy).
       const brandResp = await supabase
         .from("brands")
-        // ORCH-1138 B1 — theme_color/theme_font/theme_animation added so the
-        // public trip page is brand-themed (Direction A). No schema change —
-        // these columns exist (20260729000002_orch_0964_brand_event_theme).
-        // ORCH-1138 FIX-3 — cover_media_type + cover_hue added so the
-        // "Presented by" brand chip can render an animated (gif/video) brand
-        // cover via the media-aware EventCoverMedia (a plain <Image> on a video
-        // URL was showing a broken "COVE…" alt placeholder). All three columns
-        // exist on `brands` and are anon-readable (verified). No schema change.
+        // ORCH-1164 (#507 regression recovery) — theme_color/theme_font/
+        // theme_animation are NOT selected here. The `anon` role has no
+        // column-level SELECT on those three columns, so including them aborted
+        // the whole anon query with `42501 permission denied for table brands`
+        // and blanked the public trip page (the #507 regression). The brand
+        // theme is sourced from the anon-safe `business_public_events_view`
+        // (COMMS-0009) via fetchBrandThemeFromView below.
+        // ORCH-1138 FIX-3 — cover_media_type + cover_hue stay here: both ARE
+        // anon-granted (verified live) and the view exposes no brand_cover_hue.
+        // They let the "Presented by" brand chip render an animated (gif/video)
+        // brand cover via the media-aware EventCoverMedia.
         .select(
-          "id, slug, name, description, cover_media_url, cover_media_type, cover_hue, theme_color, theme_font, theme_animation",
+          "id, slug, name, description, cover_media_url, cover_media_type, cover_hue",
         )
         .eq("slug", brandSlug)
         .is("deleted_at", null)
@@ -421,11 +465,11 @@ export const usePublicTripBySlug = (
       // ORCH-1138 B1 — guard the brand theme + the per-trip overrides into
       // ThemeInputs (the page resolves + builds the palette). Trips are events
       // rows, so `event` (select("*")) already carries theme_*_override.
-      const brandTheme = asThemeInput(
-        brand.theme_color,
-        brand.theme_font,
-        brand.theme_animation,
-      );
+      // ORCH-1164 (#507 regression recovery) — the BRAND theme is now sourced
+      // from the anon-safe `business_public_events_view` (COMMS-0009), NOT from
+      // brands.theme_* (which anon cannot read). The per-trip overrides still
+      // come off the `events` row (anon-readable; not on the brands table).
+      const brandTheme = await fetchBrandThemeFromView(brandSlug, tripSlug);
       const themeOverrides = asThemeInput(
         event.theme_color_override,
         event.theme_font_override,

--- a/mingla-business/src/services/__tests__/orch_1138_tester_anon_brand_theme_columns.test.ts
+++ b/mingla-business/src/services/__tests__/orch_1138_tester_anon_brand_theme_columns.test.ts
@@ -56,3 +56,51 @@ describe("ORCH-1138 tester adversarial — anon cannot read brands.theme_* (P0)"
     },
   );
 });
+
+// ============================================================
+// ORCH-1164 (#507 regression recovery) — GENERALIZE the same guard to the TRIP
+// read path. The original guard (above) scanned ONLY publicExperienceService.ts
+// — so when #507 (ORCH-1138 Leg 3) added the IDENTICAL non-anon-readable
+// theme_color/theme_font/theme_animation columns to the DIRECT
+// `supabase.from("brands").select(...)` in usePublicTripBySlug.ts, CI never
+// caught it and the anon /t/{brandSlug}/{tripSlug} page shipped blanked
+// ("permission denied for table brands", 42501). This block closes that
+// coverage gap: it asserts the trip hook's brands select carries NO theme_*
+// column. FAILS-ON-REVERT: re-adding any theme_* to the trip hook's
+// `.from("brands").select(...)` flips this red.
+// ============================================================
+const TRIP_HOOK = resolve(
+  __dirname,
+  "..",
+  "..",
+  "hooks",
+  "usePublicTripBySlug.ts",
+);
+
+describe("ORCH-1164 — anon cannot read brands.theme_* on the TRIP read path (P0)", () => {
+  const src = readFileSync(TRIP_HOOK, "utf8");
+
+  // The select-string capture allows an OPTIONAL trailing comma before the
+  // closing paren (the trip hook formats its column list with a trailing comma),
+  // so the lazy match terminates at the real string boundary rather than
+  // over-running to a later `")` further down the chain.
+  const brandSelects = Array.from(
+    src.matchAll(
+      /\.from\(\s*["']brands["']\s*\)[\s\S]*?\.select\(\s*([`"'])([\s\S]*?)\1\s*,?\s*\)/g,
+    ),
+  ).map((m) => m[2]);
+
+  test("usePublicTripBySlug DOES read brands (sanity — guard targets the right call)", () => {
+    expect(brandSelects.length).toBeGreaterThan(0);
+  });
+
+  const FORBIDDEN = ["theme_color", "theme_font", "theme_animation"];
+
+  test.each(FORBIDDEN)(
+    "no trip-hook brands.select(...) requests the non-anon-readable column %s",
+    (col) => {
+      const offenders = brandSelects.filter((s) => s.includes(col));
+      expect(offenders).toEqual([]);
+    },
+  );
+});

--- a/mingla-business/src/services/__tests__/orch_1164_tester_anon_brand_theme_all_public_readers.test.ts
+++ b/mingla-business/src/services/__tests__/orch_1164_tester_anon_brand_theme_all_public_readers.test.ts
@@ -1,0 +1,84 @@
+/**
+ * ORCH-1164 (#507 regression recovery) — TESTER adversarial regression test.
+ *
+ * DIFFERENT ANGLE than the implementor's two tests:
+ *   - implementor `orch_1164_anon_trip_page_loads.test.ts` scans ONLY the trip
+ *     hook (`usePublicTripBySlug.ts`) for a column-subset.
+ *   - the (extended) `orch_1138_tester_anon_brand_theme_columns.test.ts` scans
+ *     ONLY `publicExperienceService.ts` + `usePublicTripBySlug.ts`.
+ *
+ * #507 proved the failure mode is NOT trip-specific: any anon-reachable read
+ * path that adds `theme_color/theme_font/theme_animation` to a DIRECT
+ * `supabase.from("brands").select(...)` 401s the whole anon query
+ * (`42501 permission denied for table brands`) and blanks the public page.
+ * The implementor's guards leave a HOLE: a future regression in
+ * `publicEventsService.ts`, `usePublicTripById.ts`, `usePublicEvents.ts`, or
+ * `usePublicExperience.ts` would ship green. This test closes that hole by
+ * GLOBBING EVERY public read path (the spec's preferred B1 coverage, OQ/D-4)
+ * and asserting NO brands.select anywhere requests a theme_* column.
+ *
+ * Brand theme on public pages MUST be sourced from the anon-safe
+ * security-definer `business_public_events_view` (COMMS-0009 /
+ * I-PROPOSED-1164-ANON-BRAND-THEME-VIA-VIEW), never read directly off `brands`.
+ *
+ * FAILS-ON-REVERT: re-adding theme_color/theme_font/theme_animation to ANY
+ * `.from("brands").select(...)` in ANY scanned public reader flips this red
+ * (verified by the tester against the exact #507 break in usePublicTripBySlug).
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SRC = resolve(__dirname, "..", "..");
+const HOOKS_DIR = resolve(SRC, "hooks");
+const SERVICES_DIR = resolve(SRC, "services");
+
+// EVERY anon-reachable public read path: usePublic*.ts hooks + public*Service.ts.
+// Globbed (not hardcoded) so a NEW public reader is automatically covered.
+const collect = (dir: string, re: RegExp): string[] =>
+  readdirSync(dir)
+    .filter((f) => re.test(f))
+    .map((f) => resolve(dir, f));
+
+const PUBLIC_READERS = [
+  ...collect(HOOKS_DIR, /^usePublic.*\.ts$/),
+  ...collect(SERVICES_DIR, /^public.*Service\.ts$/),
+];
+
+const FORBIDDEN = ["theme_color", "theme_font", "theme_animation"];
+
+// Matches `.from("brands") ... .select(<literal>)` allowing an optional trailing
+// comma before the close paren (the column lists are multi-line with a trailing
+// comma). The lazy capture terminates at the first real string boundary.
+const BRANDS_SELECT =
+  /\.from\(\s*["']brands["']\s*\)[\s\S]*?\.select\(\s*([`"'])([\s\S]*?)\1\s*,?\s*\)/g;
+
+describe("ORCH-1164 tester adversarial — NO public read path selects brands.theme_* (P0, all-readers glob)", () => {
+  test("sanity: the glob actually found public read paths (guard is not vacuous)", () => {
+    expect(PUBLIC_READERS.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("sanity: at least one public reader DOES select from brands directly (guard targets real calls)", () => {
+    const readersHittingBrands = PUBLIC_READERS.filter((f) =>
+      Array.from(readFileSync(f, "utf8").matchAll(BRANDS_SELECT)).length > 0,
+    );
+    expect(readersHittingBrands.length).toBeGreaterThan(0);
+  });
+
+  test("no public reader's brands.select(...) requests a non-anon-readable theme_* column", () => {
+    const offenders: string[] = [];
+    for (const file of PUBLIC_READERS) {
+      const src = readFileSync(file, "utf8");
+      for (const m of src.matchAll(BRANDS_SELECT)) {
+        const cols = m[2];
+        for (const col of FORBIDDEN) {
+          // word-boundary so brand_theme_color / theme_color_override do NOT
+          // false-positive — only a bare brands-table theme_* column counts.
+          if (new RegExp(`(^|[,\\s])${col}([,\\s]|$)`).test(cols)) {
+            offenders.push(`${file.split("/src/")[1]} :: ${col}`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/supabase/migrations/20261014000000_orch_1164_anon_brand_theme_grant.sql
+++ b/supabase/migrations/20261014000000_orch_1164_anon_brand_theme_grant.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- ORCH-1164 [#507 regression recovery — anon web TRIP page blank]
+--
+-- Root cause (proven live, 2026-06-18): #507 (ORCH-1138 Leg 3, 13c3ec4c5)
+-- added theme_color/theme_font/theme_animation to the DIRECT anon
+-- `supabase.from("brands").select(...)` on the public trip read path
+-- (mingla-business/src/hooks/usePublicTripBySlug.ts). The `anon` PostgreSQL
+-- role has only COLUMN-level SELECT on `public.brands` (table-level SELECT is
+-- false) and those three theme columns were NEVER granted to anon. PostgreSQL
+-- evaluates column privileges BEFORE RLS, so any SELECT listing one of those
+-- columns aborts the WHOLE statement with `42501 permission denied for table
+-- brands` (HTTP 401). The /t/{brandSlug}/{tripSlug} page therefore fails to
+-- render for every logged-out buyer → ALL anon web trip sales blocked.
+--
+-- The anon EVENT + EXPERIENCE web pages are FINE: they read brand theme via
+-- the anon-safe security-definer `business_public_events_view`
+-- (brand_theme_color/brand_theme_font/brand_theme_animation) per the COMMS-0009
+-- contract. Only the trip hook read theme columns directly off `brands`.
+--
+-- Fix (this migration = the belt): extend the per-column anon GRANT to the
+-- three theme columns, matching the ORCH-0879 column-grant template
+-- (20260617000000_orch_0879_anon_brand_cover_grant.sql) that added
+-- cover_media_url/cover_media_type. ORCH-1164 ALSO moves the trip hook's theme
+-- read onto business_public_events_view (the suspenders), so the page no longer
+-- depends on this grant — but the grant is the minimal, immediate restore and
+-- aligns the brands-table column grants with the already-public view fields.
+--
+-- Constitutional / safety check:
+--   - Does NOT widen RLS. The existing "Public can read brands with public
+--     events" + "Public can read non-deleted brands" SELECT policies still
+--     gate WHICH brand rows anon can read. This migration only grants
+--     COLUMN-level SELECT on rows the policy already admits.
+--   - Introduces NO new data exposure: theme_color/theme_font/theme_animation
+--     are ALREADY exposed to anon via business_public_events_view.brand_theme_*
+--     (security-definer view, anon-readable). This only aligns the brands-table
+--     column grant with the already-public view fields.
+--   - Forward-only, additive. No DROP, no REVOKE, no policy change, no other
+--     column grants touched.
+-- ============================================================
+
+BEGIN;
+
+GRANT SELECT (theme_color, theme_font, theme_animation) ON public.brands TO anon;
+
+-- Self-verification probe: assert the three grants are present (fails the
+-- migration if any grant did not take). Mirrors ORCH-0879's probe.
+DO $$
+DECLARE
+  grant_count int;
+BEGIN
+  SELECT count(*) INTO grant_count
+  FROM information_schema.column_privileges
+  WHERE table_schema = 'public'
+    AND table_name = 'brands'
+    AND grantee = 'anon'
+    AND privilege_type = 'SELECT'
+    AND column_name IN ('theme_color', 'theme_font', 'theme_animation');
+  IF grant_count != 3 THEN
+    RAISE EXCEPTION 'ORCH-1164 migration: expected 3 anon SELECT column grants on brands (theme_color, theme_font, theme_animation), got %', grant_count;
+  END IF;
+  RAISE NOTICE 'ORCH-1164 migration complete: anon now has SELECT on brands.theme_color + theme_font + theme_animation';
+END $$;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## ORCH-1164 — #507 regression recovery: anon web trip page blank

**S0 fixed.** #507 (ORCH-1138 Leg 3) added `brands.theme_color/theme_font/theme_animation` to a direct anon `brands` SELECT on the public trip read path without granting anon column-SELECT → Postgres rejects the whole query (`42501 permission denied for table brands`) → all logged-out web trip pages blank → all web trip sales blocked. Event/experience pages were unaffected (they read theme via `business_public_events_view`).

### Fix
- **A2 (the real fix):** `usePublicTripBySlug.ts` now sources brand theme from `business_public_events_view` (the anon-safe view the other pages use) and drops the theme columns from the direct `brands` select.
- **A1 (belt-and-suspenders):** migration `20261014000000` grants anon column-SELECT on the 3 theme columns (additive, no RLS change, no new exposure — already public via the view; mirrors ORCH-0879 template). **Already applied to prod** as the immediate hotfix; recorded in `schema_migrations`.
- **B1/C:** extended `orch_1138_tester_anon_brand_theme_columns.test.ts` to scan the trip hook (fails-on-revert guard) + new anon-load test + tester adversarial glob test across all public read paths.

### Proof
- Tester verdict PASS (P0:0 P1:0 P2:0). A2 proven to fix the page WITHOUT the grant (rolled-back grant-revoke probe vs prod). ORCH-1147 all-in pricing re-proven intact ($50→$55 fixture; zero pricing code touched). Event/experience uncollateral. Fails-on-revert verified.
- No edge functions. NOT a pricing regression — the earlier '1147 reverted' alarm was a dirty-anchor misread (see corrected COMMS-0042).

Closes ORCH-1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)