### PR TITLE
G3 Sentry live: edge capture + mingla-business plugin config (#426)

### DIFF
--- a/docs/evidence/g3-sentry/README.md
+++ b/docs/evidence/g3-sentry/README.md
@@ -1,0 +1,77 @@
+# G3 — Sentry live (#426 Tier 2)
+
+**Gate:** G3 — Sentry live  
+**Owner:** Platform  
+**Status:** In progress (code + runbooks landed; operator secrets + proof pending)
+
+## Evidence required (LAUNCH_GATES.md)
+
+| Check | How to prove |
+|-------|----------------|
+| Org/project configured | Sentry project `mingla-business` in org `mingla-llc` |
+| `EXPO_PUBLIC_SENTRY_DSN` in EAS | `eas env:list` shows DSN for preview + production |
+| Edge fn errors visible | Trigger `logError` path → event in Sentry Issues |
+
+## Operator setup
+
+### 1. mingla-business native (EAS)
+
+```bash
+cd mingla-business
+
+# DSN from Sentry → Settings → mingla-business → Client Keys
+eas env:create --scope project --name EXPO_PUBLIC_SENTRY_DSN \
+  --value "https://<key>@o4511136062701568.ingest.us.sentry.io/4511334517243904" \
+  --environment preview
+
+eas env:create --scope project --name EXPO_PUBLIC_SENTRY_DSN \
+  --value "https://<key>@o4511136062701568.ingest.us.sentry.io/4511334517243904" \
+  --environment production
+
+# Source map upload (production builds only — eas.json already sets SENTRY_DISABLE_AUTO_UPLOAD=false)
+eas env:create --scope project --name SENTRY_AUTH_TOKEN \
+  --value "<sentry-auth-token>" --environment production --visibility secret
+```
+
+Local dev: copy DSN into `mingla-business/.env` from `.env.example`.
+
+### 2. Supabase edge functions
+
+```bash
+export SUPABASE_ACCESS_TOKEN=...
+export SENTRY_DSN="https://<key>@o4511136062701568.ingest.us.sentry.io/<edge-or-shared-project>"
+./scripts/ops/deploy-g3-sentry.sh gqnoajqerqhnvulmnyvv
+```
+
+Edge functions using `logError` or `wrapEdgeHandler` automatically forward `Error` instances to Sentry when `SENTRY_DSN` is set.
+
+### 3. Validation
+
+**Native app**
+
+1. Build with DSN configured (preview or production profile).
+2. Temporarily add a dev-only throw or use ErrorBoundary test screen.
+3. Confirm event in [Sentry mingla-business project](https://sentry.io).
+
+**Edge**
+
+1. Invoke a wrapped function with invalid input that hits `logError` (e.g. `ticket-checkout-status` with bad token).
+2. Confirm issue tagged `runtime:supabase-edge` and `fn:<function-name>`.
+
+## CI contract
+
+```bash
+node scripts/audit/g3-sentry-contract.mjs
+```
+
+## G1 deferral note
+
+G1 (100k load test) deferred — discover scale blocked by Supabase edge saturation. Harness + partial evidence in `docs/evidence/g1-load/`.
+
+## Close checklist for #426
+
+- [ ] Sentry project URL pasted in #426 comment
+- [ ] Screenshot: native test exception captured
+- [ ] Screenshot: edge test exception captured
+- [ ] `eas env:list` redacted screenshot or CLI output
+- [ ] Mark G3 complete in LAUNCH_GATES.md (separate PR)

--- a/mingla-business/.env.example
+++ b/mingla-business/.env.example
@@ -26,3 +26,10 @@ GOOGLE_ANDROID_CLIENT_ID=your_google_android_client_id_here
 EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 EXPO_PUBLIC_MINGLA_BUSINESS_WEB_URL=https://business.usemingla.com
+
+# Sentry (#426 G3) — separate project `mingla-business` in mingla-llc org.
+# Required for crash capture on native iOS/Android. Also set in EAS Secrets:
+#   eas env:create --scope project --name EXPO_PUBLIC_SENTRY_DSN --value "<dsn>" --environment production
+#   eas env:create --scope project --name EXPO_PUBLIC_SENTRY_DSN --value "<dsn>" --environment preview
+# For source map upload on production builds, also set SENTRY_AUTH_TOKEN in EAS.
+EXPO_PUBLIC_SENTRY_DSN=

--- a/mingla-business/app.config.ts
+++ b/mingla-business/app.config.ts
@@ -95,7 +95,13 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       // Checkout via expo-web-browser. Removing the plugin omits the native
       // framework on the next EAS rebuild — shrinking binary size and
       // retiring the iOS 26 + bridgeless TurboModule hang surface.
-      "@sentry/react-native/expo",
+      [
+        "@sentry/react-native/expo",
+        {
+          organization: "mingla-llc",
+          project: "mingla-business",
+        },
+      ],
       // [TRANSITIONAL] react-native-nfc-manager auto-linked via npm install
       // (D-NFC-OUTCOME = Option 3). No plugin entry required for auto-link.
       // If iOS NFC entitlement is needed for Cycle 13 door-mode, re-evaluate

--- a/mingla-business/app/_layout.tsx
+++ b/mingla-business/app/_layout.tsx
@@ -97,6 +97,9 @@ if (sentryDsn) {
     dsn: sentryDsn,
     enableAutoSessionTracking: true,
     debug: __DEV__,
+    environment: __DEV__
+      ? "development"
+      : (process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ?? "production"),
     // 100% trace sample in dev for visibility; 20% in production to balance
     // cost vs visibility. Adjust via DEC if production volume changes.
     tracesSampleRate: __DEV__ ? 1.0 : 0.2,

--- a/mingla-business/package.json
+++ b/mingla-business/package.json
@@ -61,7 +61,8 @@
     "test:orch-430": "node ../scripts/audit/checkout-grade-a-contract.mjs",
     "test:orch-431": "node ../scripts/audit/hub-grade-a-contract.mjs",
     "test:orch-432": "node ../scripts/audit/marketing-grade-a-contract.mjs",
-    "test:orch-433": "node ../scripts/audit/trip-checkout-grade-a-contract.mjs"
+    "test:orch-433": "node ../scripts/audit/trip-checkout-grade-a-contract.mjs",
+    "test:g3-sentry": "node ../scripts/audit/g3-sentry-contract.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",

--- a/scripts/audit/g3-sentry-contract.mjs
+++ b/scripts/audit/g3-sentry-contract.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * #426 G3 — CI contract: Sentry live gate scaffolding present.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const paths = {
+  layout: join(root, "mingla-business/app/_layout.tsx"),
+  appConfig: join(root, "mingla-business/app.config.ts"),
+  envExample: join(root, "mingla-business/.env.example"),
+  eas: join(root, "mingla-business/eas.json"),
+  sentryEdge: join(root, "supabase/functions/_shared/sentryEdge.ts"),
+  structuredLog: join(root, "supabase/functions/_shared/structuredLog.ts"),
+  evidence: join(root, "docs/evidence/g3-sentry/README.md"),
+  deploy: join(root, "scripts/ops/deploy-g3-sentry.sh"),
+};
+
+const layout = readFileSync(paths.layout, "utf8");
+const appConfig = readFileSync(paths.appConfig, "utf8");
+const envExample = readFileSync(paths.envExample, "utf8");
+const eas = readFileSync(paths.eas, "utf8");
+const sentryEdge = readFileSync(paths.sentryEdge, "utf8");
+const structuredLog = readFileSync(paths.structuredLog, "utf8");
+
+const checks = [
+  [layout.includes("EXPO_PUBLIC_SENTRY_DSN"), "mingla-business DSN env guard"],
+  [layout.includes("Sentry.init"), "mingla-business Sentry.init"],
+  [layout.includes("environment:"), "mingla-business Sentry environment tag"],
+  [appConfig.includes('organization: "mingla-llc"'), "Sentry org in expo plugin"],
+  [appConfig.includes('project: "mingla-business"'), "Sentry project in expo plugin"],
+  [envExample.includes("EXPO_PUBLIC_SENTRY_DSN"), "DSN documented in .env.example"],
+  [eas.includes('"SENTRY_DISABLE_AUTO_UPLOAD": "false"'), "production source map upload enabled"],
+  [sentryEdge.includes("captureEdgeException"), "edge Sentry capture helper"],
+  [sentryEdge.includes("SENTRY_DSN"), "edge SENTRY_DSN secret hook"],
+  [structuredLog.includes("captureEdgeException"), "structuredLog forwards errors to Sentry"],
+  [readFileSync(paths.evidence, "utf8").includes("G3"), "G3 evidence README"],
+  [readFileSync(paths.deploy, "utf8").includes("SENTRY_DSN"), "G3 deploy runbook"],
+];
+
+let failed = 0;
+for (const [ok, label] of checks) {
+  if (!ok) {
+    console.error(`FAIL g3-sentry-contract: missing ${label}`);
+    failed += 1;
+  }
+}
+
+if (failed > 0) process.exit(1);
+console.log("OK g3-sentry-contract");

--- a/scripts/ops/deploy-g3-sentry.sh
+++ b/scripts/ops/deploy-g3-sentry.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# #426 G3 — deploy Sentry secrets to staging + production Supabase projects.
+#
+# Usage:
+#   export SUPABASE_ACCESS_TOKEN=...
+#   export SENTRY_DSN="https://<key>@o4511136062701568.ingest.us.sentry.io/<project>"
+#   ./scripts/ops/deploy-g3-sentry.sh [project-ref]
+#
+# Default project-ref: gqnoajqerqhnvulmnyvv (Mingla-dev / G2 staging)
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+PROJECT_REF="${1:-gqnoajqerqhnvulmnyvv}"
+
+: "${SUPABASE_ACCESS_TOKEN:?Set SUPABASE_ACCESS_TOKEN}"
+: "${SENTRY_DSN:?Set SENTRY_DSN (mingla-business edge project DSN)}"
+
+supabase link --project-ref "$PROJECT_REF" --yes
+supabase secrets set "SENTRY_DSN=$SENTRY_DSN" "SENTRY_ENVIRONMENT=staging"
+
+echo ":: G3 Sentry edge secrets set on $PROJECT_REF"
+echo ":: Next: set EXPO_PUBLIC_SENTRY_DSN in EAS for mingla-business (preview + production)"
+echo ":: See docs/evidence/g3-sentry/README.md"

--- a/supabase/functions/_shared/sentryEdge.test.ts
+++ b/supabase/functions/_shared/sentryEdge.test.ts
@@ -1,0 +1,15 @@
+import { __parseDsnForTest } from "./sentryEdge.ts";
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+
+Deno.test("parseDsn extracts host, key, and project id", () => {
+  const parsed = __parseDsnForTest(
+    "https://abc123@o4511136062701568.ingest.us.sentry.io/4511334517243904",
+  );
+  assertEquals(parsed?.publicKey, "abc123");
+  assertEquals(parsed?.host, "o4511136062701568.ingest.us.sentry.io");
+  assertEquals(parsed?.projectId, "4511334517243904");
+});
+
+Deno.test("parseDsn returns null for invalid dsn", () => {
+  assertEquals(__parseDsnForTest("not-a-dsn"), null);
+});

--- a/supabase/functions/_shared/sentryEdge.ts
+++ b/supabase/functions/_shared/sentryEdge.ts
@@ -1,0 +1,109 @@
+/**
+ * #426 G3 — lightweight Sentry capture for Supabase edge functions.
+ *
+ * Set `SENTRY_DSN` (or `SUPABASE_SENTRY_DSN`) as a project secret. Fire-and-forget
+ * so error reporting never blocks the response path.
+ */
+
+export interface EdgeSentryContext {
+  fn?: string;
+  requestId?: string;
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+}
+
+interface ParsedDsn {
+  publicKey: string;
+  host: string;
+  projectId: string;
+}
+
+function parseDsn(dsn: string): ParsedDsn | null {
+  try {
+    const url = new URL(dsn);
+    const projectId = url.pathname.replace(/^\//, "");
+    const publicKey = url.username;
+    if (!publicKey || !projectId) return null;
+    return { publicKey, host: url.host, projectId };
+  } catch {
+    return null;
+  }
+}
+
+function resolveDsn(): string | null {
+  const dsn = Deno.env.get("SENTRY_DSN") ?? Deno.env.get("SUPABASE_SENTRY_DSN");
+  return dsn && dsn.length > 0 ? dsn : null;
+}
+
+function stackFrames(stack: string): Array<{ filename?: string; function?: string }> {
+  return stack
+    .split("\n")
+    .slice(1, 6)
+    .map((line) => {
+      const trimmed = line.trim();
+      const match = trimmed.match(/at (.+?) \((.+)\)/) ??
+        trimmed.match(/at (.+)/);
+      if (!match) return { function: trimmed };
+      if (match.length >= 3) {
+        return { function: match[1], filename: match[2] };
+      }
+      return { function: match[1] };
+    });
+}
+
+export function captureEdgeException(
+  error: unknown,
+  context: EdgeSentryContext = {},
+): void {
+  const dsn = resolveDsn();
+  if (!dsn) return;
+
+  const parsed = parseDsn(dsn);
+  if (!parsed) return;
+
+  const err = error instanceof Error ? error : new Error(String(error));
+  const eventId = crypto.randomUUID().replace(/-/g, "");
+
+  const event = {
+    event_id: eventId,
+    timestamp: new Date().toISOString(),
+    platform: "javascript",
+    level: "error",
+    environment: Deno.env.get("SENTRY_ENVIRONMENT") ?? "edge",
+    tags: {
+      runtime: "supabase-edge",
+      ...(context.fn ? { fn: context.fn } : {}),
+      ...(context.tags ?? {}),
+    },
+    extra: {
+      requestId: context.requestId,
+      ...(context.extra ?? {}),
+    },
+    exception: {
+      values: [{
+        type: err.name || "Error",
+        value: err.message,
+        stacktrace: err.stack ? { frames: stackFrames(err.stack) } : undefined,
+      }],
+    },
+  };
+
+  const sentryAuth =
+    `Sentry sentry_version=7, sentry_client=mingla-edge/1.0, sentry_key=${parsed.publicKey}`;
+
+  void fetch(`https://${parsed.host}/api/${parsed.projectId}/store/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Sentry-Auth": sentryAuth,
+    },
+    body: JSON.stringify(event),
+  }).catch(() => {
+    // Never throw from telemetry
+  });
+}
+
+/** @internal Test hook */
+export function __parseDsnForTest(dsn: string): ParsedDsn | null {
+  return parseDsn(dsn);
+}

--- a/supabase/functions/_shared/structuredLog.ts
+++ b/supabase/functions/_shared/structuredLog.ts
@@ -1,9 +1,11 @@
 /**
  * #426 — Structured JSON logging for edge functions.
  *
- * Emits one JSON line per event for Supabase log drains / future Sentry wiring.
- * Use instead of bare console.log for errors and latency spans.
+ * Emits one JSON line per event for Supabase log drains. Errors also forward to
+ * Sentry when SENTRY_DSN is configured (#426 G3).
  */
+
+import { captureEdgeException } from "./sentryEdge.ts";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -53,6 +55,13 @@ export function logError(
         ? error
         : JSON.stringify(error);
   structuredLog("error", message, { ...fields, err });
+  if (error instanceof Error) {
+    captureEdgeException(error, {
+      fn: fields.fn,
+      requestId: fields.requestId,
+      extra: { message, ...fields },
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wire G3 (Sentry live) for epic #426: edge functions forward `logError` / `wrapEdgeHandler` throws to Sentry when `SENTRY_DSN` is set.
- Configure mingla-business `@sentry/react-native/expo` plugin (`mingla-llc` / `mingla-business`) and add environment tag on native init.
- Add operator runbook (`docs/evidence/g3-sentry/README.md`), Supabase deploy script, and `g3-sentry-contract.mjs` CI check.

## Context
G1 load testing deferred (edge saturation). Pivoting to G3 — native Sentry init was already wired but dormant without EAS DSN; edge had no Sentry path.

## Operator follow-up (post-merge)
- [ ] `eas env:create` — `EXPO_PUBLIC_SENTRY_DSN` for preview + production
- [ ] `./scripts/ops/deploy-g3-sentry.sh` — `SENTRY_DSN` on Supabase staging/prod
- [ ] Proof: native crash + edge error visible in Sentry → attach to #426

## Test plan
- [x] `node scripts/audit/g3-sentry-contract.mjs`
- [ ] `npm run test:g3-sentry` (from mingla-business)
- [ ] Operator: set secrets + confirm events in Sentry dashboard