### PR TITLE
G4 DR restore: runbook, drill tooling, CI contract (#426)

### DIFF
--- a/docs/evidence/g4-dr-restore/DRILL_REPORT.template.md
+++ b/docs/evidence/g4-dr-restore/DRILL_REPORT.template.md
@@ -1,0 +1,43 @@
+# G4 drill report template
+
+Reports are written automatically by `./scripts/ops/g4-dr-restore-drill.sh` to `reports/<utc>-drill.json`.
+
+## Example (fill after drill)
+
+```json
+{
+  "gate": "G4",
+  "projectRef": "gqnoajqerqhnvulmnyvv",
+  "restoredProjectRef": "xxxxxxxxxxxxxxxxxxxx",
+  "recoveryType": "pitr-clone",
+  "recoveryPointUtc": "2026-06-09T12:00:00Z",
+  "timestamps": {
+    "t0_decisionUtc": "2026-06-09T14:00:00Z",
+    "t1_restoreSubmittedUtc": "2026-06-09T14:05:00Z",
+    "t2_restoreCompleteUtc": "2026-06-09T14:47:00Z",
+    "t3_verificationCompleteUtc": "2026-06-09T15:02:00Z"
+  },
+  "durationsMinutes": {
+    "restoreJob": 42,
+    "verification": 15,
+    "total": 62
+  },
+  "verification": {
+    "sqlOk": true,
+    "k6SmokeExitCode": 0,
+    "stripeSmokeSkipped": true
+  },
+  "operator": "name",
+  "notes": "Restored to clone ref; staging ref unchanged."
+}
+```
+
+## Field definitions
+
+| Field | Meaning |
+|-------|---------|
+| `t0_decisionUtc` | Decision to restore (incident commander) |
+| `t1_restoreSubmittedUtc` | Restore job submitted in Supabase |
+| `t2_restoreCompleteUtc` | Dashboard shows restore complete |
+| `t3_verificationCompleteUtc` | All verification steps passed |
+| `recoveryType` | `pitr-clone`, `pitr-in-place`, `daily-backup-clone`, etc. |

--- a/docs/evidence/g4-dr-restore/README.md
+++ b/docs/evidence/g4-dr-restore/README.md
@@ -1,0 +1,75 @@
+# G4 — DR restore performed (#426 Tier 2)
+
+**Gate:** G4 — DR restore performed  
+**Owner:** Platform  
+**Status:** In progress (runbook + drill tooling landed; timed drill + evidence pending)
+
+## Evidence required (LAUNCH_GATES.md)
+
+| Check | How to prove |
+|-------|----------------|
+| Restore executed | Supabase dashboard screenshot: backup/PITR restore job **Complete** |
+| Timed duration | JSON report in `reports/` with T0–T3 UTC timestamps |
+| Runbook updated | `docs/runbooks/DR_RESTORE.md` RTO row matches measured `T3 - T0` |
+| Verification passed | SQL smoke + `k6 run scripts/load/smoke.js` exit 0 (or logged skip reason) |
+
+## Recommended drill scope
+
+Use **staging** project `gqnoajqerqhnvulmnyvv` (G2). Prefer **restore to a new project** so daily staging work is unaffected.
+
+Do not run destructive drills on production for gate evidence.
+
+## Operator steps
+
+### 1. Preflight
+
+```bash
+# Confirm backups/PITR visible in dashboard → Database → Backups
+./scripts/ops/g4-dr-restore-drill.sh start
+```
+
+### 2. Execute restore
+
+Follow [DR_RESTORE.md](../../runbooks/DR_RESTORE.md) sections 2–3 in the Supabase dashboard.
+
+After each milestone:
+
+```bash
+./scripts/ops/g4-dr-restore-drill.sh mark restore-submitted
+./scripts/ops/g4-dr-restore-drill.sh mark restore-complete
+```
+
+### 3. Verify restored project
+
+Point env at restored project ref (if clone):
+
+```bash
+export SUPABASE_URL="https://<restored-ref>.supabase.co"
+export SUPABASE_ANON_KEY="<anon-key>"
+./scripts/ops/g4-dr-restore-drill.sh verify
+./scripts/ops/g4-dr-restore-drill.sh finish
+```
+
+Copy the finished report path from script output into #426.
+
+### 4. Update RTO
+
+If total duration `T3 - T0` differs from the 4 h placeholder in the runbook, edit the RTO table in `DR_RESTORE.md` in a follow-up commit (or same PR as evidence).
+
+## CI contract
+
+```bash
+node scripts/audit/g4-dr-restore-contract.mjs
+```
+
+## Close checklist for #426
+
+- [ ] Drill report JSON committed or pasted in #426 (`reports/*-drill.json`)
+- [ ] Screenshot: Supabase restore job complete
+- [ ] Screenshot or log: verification smoke passed
+- [ ] RTO minutes recorded in runbook
+- [ ] Mark G4 complete in LAUNCH_GATES.md (separate PR after evidence review)
+
+## Report template
+
+See [DRILL_REPORT.template.md](./DRILL_REPORT.template.md) for the JSON field reference.

--- a/docs/runbooks/DR_RESTORE.md
+++ b/docs/runbooks/DR_RESTORE.md
@@ -1,0 +1,142 @@
+# DR restore — database point-in-time recovery
+
+**Gate:** G4 — DR restore performed (#426 Tier 2)  
+**Owner:** Platform  
+**Severity context:** P0 when production DB is lost or corrupted
+
+## Objectives
+
+| Metric | Target (initial) | Notes |
+|--------|------------------|-------|
+| **RPO** | ≤ 24 h (daily backup) or ≤ minutes (PITR on Pro) | Confirm plan tier in Supabase dashboard |
+| **RTO** | ≤ 4 h wall-clock | Fill with measured drill duration |
+| **Verification** | SQL + app smoke within 30 min of restore complete | See verification section |
+
+## When to use
+
+- Accidental destructive migration or bad data deploy
+- Regional Supabase outage with unrecoverable project state
+- Ransomware / credential compromise requiring clean restore
+- **G4 drill:** scheduled exercise on **staging only** (`gqnoajqerqhnvulmnyvv`)
+
+Do **not** run a restore drill on production unless executing a real incident.
+
+## Prerequisites
+
+- Supabase org **Owner** or **Admin** access
+- PITR or daily backups enabled on target project (Settings → Database → Backups)
+- Incident channel ready (Slack/email template from [INCIDENT_DATABASE_DOWN.md](./INCIDENT_DATABASE_DOWN.md))
+- Staging credentials for post-restore smoke (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, optional `SUPABASE_SERVICE_ROLE_KEY`)
+
+## Roles
+
+| Role | Responsibility |
+|------|----------------|
+| **Incident commander** | Declares start/end, owns comms |
+| **DB operator** | Executes Supabase restore in dashboard |
+| **Verifier** | Runs SQL + smoke checks, records timestamps |
+
+## Procedure (real incident or staging drill)
+
+### 1. Declare and freeze (T0)
+
+1. Post: *"Mingla Business DB restore started — writes paused."*
+2. Stop deploys and cron (marketing send, Ari batch jobs).
+3. Record **T0** = wall-clock UTC when decision to restore is made.
+
+### 2. Choose recovery point
+
+1. Open [Supabase Dashboard](https://supabase.com/dashboard) → project → **Database** → **Backups**.
+2. For PITR: pick timestamp **just before** the bad change (note timezone).
+3. For daily backup: pick latest clean snapshot before incident.
+4. Record target recovery timestamp in incident/drill log.
+
+### 3. Restore (T1 → T2)
+
+**Staging drill (recommended for G4 evidence):**
+
+1. Prefer **Restore to a new project** (clone) so staging ref stays stable for day-to-day work.
+2. If org policy requires in-place restore, schedule a maintenance window and accept staging downtime.
+
+**Production incident:**
+
+1. Follow Supabase guided restore (PITR or backup → new project or in-place per runbook decision).
+2. Update DNS / secrets only after verification on restored instance.
+
+Record:
+
+- **T1** = restore job submitted (UTC)
+- **T2** = Supabase reports restore **Complete** (UTC)
+
+### 4. Reconnect clients (if new project ref)
+
+If restore created a **new** project ref:
+
+1. Update staging secrets: EAS env, GitHub Actions, local `.env` for operators.
+2. Redeploy edge functions: `supabase link --project-ref <new-ref>` then deploy affected functions.
+3. Do **not** copy production Stripe live keys to a drill clone.
+
+### 5. Verification (T2 → T3)
+
+Run in order; all must pass before declaring recovery.
+
+**SQL (Supabase SQL editor on restored project)**
+
+```sql
+SELECT 1 AS ok;
+SELECT COUNT(*) AS profiles FROM profiles;
+SELECT COUNT(*) AS business_events FROM business_events;
+```
+
+Expect non-error counts consistent with pre-drill snapshot (exact counts optional for drill; zero rows = fail).
+
+**Edge / load smoke**
+
+```bash
+export SUPABASE_URL="https://<project-ref>.supabase.co"
+export SUPABASE_ANON_KEY="<anon-key>"
+
+# Quick HTTP smoke (adjust VUs for staging capacity)
+k6 run scripts/load/smoke.js
+```
+
+**Optional:** Stripe test smoke if Connect config unchanged:
+
+```bash
+export STRIPE_SECRET_KEY="sk_test_..."
+node scripts/e2e/stripe-connect-smoke.mjs
+```
+
+Record **T3** = last verification step passed (UTC).
+
+### 6. Close out
+
+1. Post all-clear with duration: `T3 - T0` (total), `T2 - T1` (restore job), `T3 - T2` (verify).
+2. File drill/incident report: `docs/evidence/g4-dr-restore/reports/<timestamp>-drill.json` (use `./scripts/ops/g4-dr-restore-drill.sh`).
+3. Update RTO line in this runbook if measured duration differs from target.
+4. For G4 gate: attach report + dashboard screenshot to GitHub #426.
+
+## Timed drill helper
+
+```bash
+./scripts/ops/g4-dr-restore-drill.sh start          # prints checklist, creates report stub
+# ... perform Supabase restore manually ...
+./scripts/ops/g4-dr-restore-drill.sh mark restore-submitted
+./scripts/ops/g4-dr-restore-drill.sh mark restore-complete
+./scripts/ops/g4-dr-restore-drill.sh verify         # optional smoke if env set
+./scripts/ops/g4-dr-restore-drill.sh finish
+```
+
+## Rollback of a bad restore
+
+If verification fails on restored instance:
+
+1. Do not repoint production traffic.
+2. Retry restore to an earlier PITR timestamp or alternate backup.
+3. Escalate to Supabase support with project ref + incident timeline.
+
+## Related
+
+- [INCIDENT_DATABASE_DOWN.md](./INCIDENT_DATABASE_DOWN.md) — live outage response
+- [LAUNCH_GATES.md](../LAUNCH_GATES.md) — G4 evidence requirements
+- [G4 evidence folder](../evidence/g4-dr-restore/README.md)

--- a/docs/runbooks/INCIDENT_DATABASE_DOWN.md
+++ b/docs/runbooks/INCIDENT_DATABASE_DOWN.md
@@ -13,7 +13,7 @@
 
 - If regional outage: wait for provider recovery; enable status page message.
 - If connection pool exhaustion: reduce edge concurrency; pause marketing send cron.
-- If bad migration: stop deploys; assess PITR restore (see G4 in [LAUNCH_GATES.md](../LAUNCH_GATES.md)).
+- If bad migration: stop deploys; assess PITR restore ([DR_RESTORE.md](./DR_RESTORE.md), gate G4 in [LAUNCH_GATES.md](../LAUNCH_GATES.md)).
 
 ## Recovery verification
 

--- a/scripts/audit/g4-dr-restore-contract.mjs
+++ b/scripts/audit/g4-dr-restore-contract.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * #426 G4 — CI contract: DR restore gate scaffolding present.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const paths = {
+  runbook: join(root, "docs/runbooks/DR_RESTORE.md"),
+  incident: join(root, "docs/runbooks/INCIDENT_DATABASE_DOWN.md"),
+  evidence: join(root, "docs/evidence/g4-dr-restore/README.md"),
+  template: join(root, "docs/evidence/g4-dr-restore/DRILL_REPORT.template.md"),
+  drill: join(root, "scripts/ops/g4-dr-restore-drill.sh"),
+};
+
+const runbook = readFileSync(paths.runbook, "utf8");
+const incident = readFileSync(paths.incident, "utf8");
+const evidence = readFileSync(paths.evidence, "utf8");
+const template = readFileSync(paths.template, "utf8");
+const drill = readFileSync(paths.drill, "utf8");
+
+const drillExecutable =
+  (() => {
+    try {
+      const mode = statSync(paths.drill).mode & 0o111;
+      return mode !== 0;
+    } catch {
+      return false;
+    }
+  })();
+
+const checks = [
+  [runbook.includes("G4"), "DR runbook references G4"],
+  [runbook.includes("T0"), "DR runbook timed phases (T0)"],
+  [runbook.includes("PITR"), "DR runbook PITR procedure"],
+  [runbook.includes("g4-dr-restore-drill.sh"), "DR runbook drill script link"],
+  [runbook.includes("gqnoajqerqhnvulmnyvv"), "DR runbook staging project ref"],
+  [incident.includes("DR_RESTORE.md"), "incident runbook links DR_RESTORE"],
+  [evidence.includes("G4"), "G4 evidence README"],
+  [evidence.includes("g4-dr-restore-contract.mjs"), "G4 evidence CI contract doc"],
+  [template.includes("t0_decisionUtc"), "drill report template timestamps"],
+  [drill.includes("cmd_start"), "drill script start command"],
+  [drill.includes("cmd_verify"), "drill script verify command"],
+  [drill.includes("write_report"), "drill script JSON report writer"],
+  [drillExecutable, "g4-dr-restore-drill.sh is executable"],
+];
+
+let failed = 0;
+for (const [ok, label] of checks) {
+  if (!ok) {
+    console.error(`FAIL g4-dr-restore-contract: missing ${label}`);
+    failed += 1;
+  }
+}
+
+if (failed > 0) process.exit(1);
+console.log("OK g4-dr-restore-contract");

--- a/scripts/ops/g4-dr-restore-drill.sh
+++ b/scripts/ops/g4-dr-restore-drill.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# #426 G4 — timed DR restore drill helper (staging).
+#
+# Does NOT perform Supabase restore — operator runs dashboard steps per
+# docs/runbooks/DR_RESTORE.md and records timestamps here.
+#
+# Usage:
+#   ./scripts/ops/g4-dr-restore-drill.sh start
+#   ./scripts/ops/g4-dr-restore-drill.sh mark restore-submitted
+#   ./scripts/ops/g4-dr-restore-drill.sh mark restore-complete
+#   ./scripts/ops/g4-dr-restore-drill.sh verify
+#   ./scripts/ops/g4-dr-restore-drill.sh finish
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR="$ROOT/docs/evidence/g4-dr-restore/reports"
+STATE_FILE="${G4_DRILL_STATE:-/tmp/mingla-g4-drill-state.txt}"
+DEFAULT_PROJECT_REF="${G4_DRILL_PROJECT_REF:-gqnoajqerqhnvulmnyvv}"
+
+utc_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+minutes_between() {
+  local start="$1"
+  local end="$2"
+  if [[ -z "$start" || -z "$end" ]]; then
+    echo ""
+    return
+  fi
+  python3 - "$start" "$end" <<'PY'
+import sys
+from datetime import datetime, timezone
+a = datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+b = datetime.fromisoformat(sys.argv[2].replace("Z", "+00:00"))
+print(int((b - a).total_seconds() // 60))
+PY
+}
+
+load_state() {
+  T0="" T1="" T2="" T3=""
+  REPORT_PATH=""
+  if [[ -f "$STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+  fi
+}
+
+save_state() {
+  mkdir -p "$(dirname "$STATE_FILE")"
+  cat >"$STATE_FILE" <<EOF
+T0="${T0:-}"
+T1="${T1:-}"
+T2="${T2:-}"
+T3="${T3:-}"
+REPORT_PATH="${REPORT_PATH:-}"
+EOF
+}
+
+cmd_start() {
+  load_state
+  local stamp
+  stamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+  REPORT_PATH="$REPORT_DIR/${stamp}-drill.json"
+  T0="$(utc_now)"
+  T1=""
+  T2=""
+  T3=""
+  save_state
+  mkdir -p "$REPORT_DIR"
+
+  cat <<EOF
+G4 DR drill started
+  T0 (decision):     $T0
+  Staging project:   $DEFAULT_PROJECT_REF
+  Report path:       $REPORT_PATH
+
+Next:
+  1. Supabase Dashboard → Database → Backups → restore (prefer clone)
+  2. ./scripts/ops/g4-dr-restore-drill.sh mark restore-submitted
+  3. When complete: ./scripts/ops/g4-dr-restore-drill.sh mark restore-complete
+  4. ./scripts/ops/g4-dr-restore-drill.sh verify
+  5. ./scripts/ops/g4-dr-restore-drill.sh finish
+
+Runbook: docs/runbooks/DR_RESTORE.md
+EOF
+}
+
+cmd_mark() {
+  local which="${1:-}"
+  load_state
+  if [[ -z "${REPORT_PATH:-}" ]]; then
+    echo "No active drill — run: ./scripts/ops/g4-dr-restore-drill.sh start" >&2
+    exit 1
+  fi
+  case "$which" in
+    restore-submitted) T1="$(utc_now)" ;;
+    restore-complete)  T2="$(utc_now)" ;;
+    verification-complete) T3="$(utc_now)" ;;
+    *)
+      echo "Unknown mark: $which (use restore-submitted | restore-complete | verification-complete)" >&2
+      exit 1
+      ;;
+  esac
+  save_state
+  echo "Marked $which at $(utc_now)"
+}
+
+cmd_verify() {
+  load_state
+  if [[ -z "${REPORT_PATH:-}" ]]; then
+    echo "No active drill — run start first" >&2
+    exit 1
+  fi
+
+  local k6_exit=0
+  local stripe_skip=true
+  local sql_ok=false
+
+  if [[ -n "${SUPABASE_URL:-}" && -n "${SUPABASE_ANON_KEY:-}" ]]; then
+    echo ":: Running k6 smoke against $SUPABASE_URL"
+    if k6 run "$ROOT/scripts/load/smoke.js"; then
+      k6_exit=0
+    else
+      k6_exit=$?
+    fi
+  else
+    echo ":: SKIP k6 smoke — set SUPABASE_URL and SUPABASE_ANON_KEY"
+    k6_exit=-1
+  fi
+
+  if [[ -n "${STRIPE_SECRET_KEY:-}" ]]; then
+    stripe_skip=false
+    echo ":: Running Stripe connect smoke (test key)"
+    node "$ROOT/scripts/e2e/stripe-connect-smoke.mjs" || true
+  else
+    echo ":: SKIP Stripe smoke — STRIPE_SECRET_KEY not set"
+  fi
+
+  echo ":: SQL check: run SELECT 1 + row counts in Supabase SQL editor"
+  echo ":: Re-run with G4_DRILL_SQL_OK=1 when SQL checks pass"
+  if [[ "${G4_DRILL_SQL_OK:-}" == "1" ]]; then
+    sql_ok="true"
+  fi
+
+  export G4_K6_EXIT="$k6_exit"
+
+  if [[ "$k6_exit" -eq 0 && "$sql_ok" == "true" ]]; then
+    T3="$(utc_now)"
+    save_state
+    echo "Verification passed — T3=$T3"
+  else
+    echo "Verification incomplete (k6_exit=$k6_exit sql_ok=$sql_ok). Fix and re-run verify." >&2
+    exit 1
+  fi
+}
+
+write_report() {
+  load_state
+  local restore_min verify_min total_min
+  restore_min="$(minutes_between "$T1" "$T2")"
+  verify_min="$(minutes_between "$T2" "$T3")"
+  total_min="$(minutes_between "$T0" "$T3")"
+
+  python3 - "$REPORT_PATH" "$DEFAULT_PROJECT_REF" "$T0" "$T1" "$T2" "$T3" \
+    "${restore_min:-}" "${verify_min:-}" "${total_min:-}" <<'PY'
+import json, os, sys
+path, project_ref, t0, t1, t2, t3, restore_min, verify_min, total_min = sys.argv[1:]
+
+def num(v):
+    return int(v) if v else None
+
+data = {
+    "gate": "G4",
+    "projectRef": project_ref,
+    "restoredProjectRef": os.environ.get("G4_DRILL_RESTORED_REF", ""),
+    "recoveryType": os.environ.get("G4_DRILL_RECOVERY_TYPE", "pitr-clone"),
+    "recoveryPointUtc": os.environ.get("G4_DRILL_RECOVERY_POINT", ""),
+    "timestamps": {
+        "t0_decisionUtc": t0,
+        "t1_restoreSubmittedUtc": t1,
+        "t2_restoreCompleteUtc": t2,
+        "t3_verificationCompleteUtc": t3,
+    },
+    "durationsMinutes": {
+        "restoreJob": num(restore_min),
+        "verification": num(verify_min),
+        "total": num(total_min),
+    },
+    "verification": {
+        "sqlOk": os.environ.get("G4_DRILL_SQL_OK") == "1",
+        "k6SmokeExitCode": num(os.environ.get("G4_K6_EXIT", "")),
+        "stripeSmokeSkipped": not os.environ.get("STRIPE_SECRET_KEY"),
+    },
+    "operator": os.environ.get("G4_DRILL_OPERATOR", ""),
+    "notes": os.environ.get("G4_DRILL_NOTES", ""),
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+print(path)
+PY
+}
+
+cmd_finish() {
+  load_state
+  if [[ -z "$T0" || -z "$T1" || -z "$T2" || -z "$T3" ]]; then
+    echo "Missing timestamps — need T0–T3 (start, restore-submitted, restore-complete, verify)" >&2
+    exit 1
+  fi
+  local out
+  out="$(write_report)"
+  rm -f "$STATE_FILE"
+  echo "G4 drill report written: $out"
+  echo "Attach to GitHub #426 and update RTO in docs/runbooks/DR_RESTORE.md"
+}
+
+CMD="${1:-}"
+case "$CMD" in
+  start) cmd_start ;;
+  mark) cmd_mark "${2:-}" ;;
+  verify) cmd_verify ;;
+  finish) cmd_finish ;;
+  *)
+    echo "Usage: $0 {start|mark restore-submitted|mark restore-complete|verify|finish}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "validate:categories": "node validate-category-consistency.mjs"
+    "validate:categories": "node validate-category-consistency.mjs",
+    "test:g4-dr-restore": "node audit/g4-dr-restore-contract.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2",


### PR DESCRIPTION
## Summary
- Add `docs/runbooks/DR_RESTORE.md` with PITR/backup restore procedure and T0–T3 timing for gate evidence.
- Add timed drill helper (`scripts/ops/g4-dr-restore-drill.sh`) and evidence scaffold under `docs/evidence/g4-dr-restore/`.
- Add CI contract `scripts/audit/g4-dr-restore-contract.mjs` (`npm run test:g4-dr-restore --prefix scripts`).
- Link incident runbook to DR restore doc.

## Test plan
- [ ] `npm run test:g4-dr-restore --prefix scripts` passes
- [ ] `./scripts/ops/g4-dr-restore-drill.sh start` prints checklist and report path
- [ ] Operator drill on staging (`gqnoajqerqhnvulmnyvv`) + evidence attached to #426 (post-merge)