### PR TITLE
G5 synthetic incident drill: runbook, tooling, CI contract (#426)

### DIFF
--- a/docs/evidence/g5-synthetic-incident/DRILL_REPORT.template.md
+++ b/docs/evidence/g5-synthetic-incident/DRILL_REPORT.template.md
@@ -1,0 +1,42 @@
+# G5 drill report template
+
+Reports are written by `./scripts/ops/g5-synthetic-incident-drill.sh finish` to `reports/<utc>-drill.json`.
+
+## Example (fill after drill)
+
+```json
+{
+  "gate": "G5",
+  "severity": "P1",
+  "slaAckMinutes": 30,
+  "injectMethod": "inject-g5-synthetic-alert.mjs",
+  "sentryProject": "mingla-business",
+  "notificationChannel": "slack:#mingla-incidents",
+  "timestamps": {
+    "t0_drillStartUtc": "2026-06-19T10:00:00Z",
+    "t1_alertReceivedUtc": "2026-06-19T10:00:45Z",
+    "t2_acknowledgedUtc": "2026-06-19T10:03:12Z",
+    "t3_resolvedUtc": "2026-06-19T10:08:00Z"
+  },
+  "durationsMinutes": {
+    "alertDelivery": 0,
+    "ack": 3,
+    "totalToAck": 3,
+    "resolve": 5
+  },
+  "slaMet": true,
+  "operator": "name",
+  "onCall": "name",
+  "notes": "Drill inject via Sentry store API; ack in Slack."
+}
+```
+
+## Field definitions
+
+| Field | Meaning |
+|-------|---------|
+| `t0_drillStartUtc` | Drill started / inject sent |
+| `t1_alertReceivedUtc` | On-call notification received |
+| `t2_acknowledgedUtc` | Human ack in Slack/Sentry/PagerDuty |
+| `t3_resolvedUtc` | Issue marked resolved, drill closed |
+| `slaMet` | `totalToAck` ≤ `slaAckMinutes` |

--- a/docs/evidence/g5-synthetic-incident/README.md
+++ b/docs/evidence/g5-synthetic-incident/README.md
@@ -1,0 +1,76 @@
+# G5 — Synthetic incident drill (#426 Tier 2)
+
+**Gate:** G5 — Synthetic incident drill  
+**Owner:** Platform  
+**Status:** In progress (runbook + drill tooling landed; Sentry alert + timed drill pending)
+
+## Evidence required (LAUNCH_GATES.md)
+
+| Check | How to prove |
+|-------|----------------|
+| Alert fired | Screenshot: Slack/email notification with Sentry link |
+| Ack within SLA | Drill report JSON: `ackMinutes` ≤ SLA for severity |
+| End-to-end closed | Screenshot: Sentry issue resolved; `t3_resolvedUtc` in report |
+| Runbook exists | [`docs/runbooks/SYNTHETIC_INCIDENT_DRILL.md`](../../runbooks/SYNTHETIC_INCIDENT_DRILL.md) |
+
+## Prerequisites (G3)
+
+G5 closes only after alerting works:
+
+- [ ] `SENTRY_DSN` on Supabase staging (`./scripts/ops/deploy-g3-sentry.sh`)
+- [ ] Sentry alert rule → Slack or email (see runbook)
+- [ ] Optional: `EXPO_PUBLIC_SENTRY_DSN` in EAS for native path drills
+
+## Operator steps
+
+### 1. Configure alert rule (one-time)
+
+Sentry → Alerts → create issue alert for edge/staging errors (see runbook table).  
+Include filter `tags.drill equals g5` for drill-only rule, or use a dedicated `#mingla-drills` channel.
+
+### 2. Run timed drill
+
+```bash
+./scripts/ops/g5-synthetic-incident-drill.sh start --severity P1
+
+export SENTRY_DSN="https://<key>@o4511136062701568.ingest.us.sentry.io/<project>"
+node scripts/ops/inject-g5-synthetic-alert.mjs
+
+# When notification arrives:
+./scripts/ops/g5-synthetic-incident-drill.sh mark alert-received
+
+# When on-call acks:
+./scripts/ops/g5-synthetic-incident-drill.sh mark acknowledged
+
+./scripts/ops/g5-synthetic-incident-drill.sh finish
+```
+
+**Alternate inject (full edge path):** call any wrapped function that reaches `logError` after setting drill context — e.g. invalid auth on a staging-only test endpoint documented in your drill notes.
+
+### 3. SLA targets
+
+| Severity | Ack SLA | Incident runbook |
+|----------|---------|------------------|
+| P0 | 15 min | [INCIDENT_DATABASE_DOWN.md](../../runbooks/INCIDENT_DATABASE_DOWN.md) |
+| P1 | 30 min | [INCIDENT_EDGE_FUNCTION_STORM.md](../../runbooks/INCIDENT_EDGE_FUNCTION_STORM.md) |
+
+Update runbook SLA table if measured drill differs and team agrees new targets.
+
+## CI contract
+
+```bash
+npm run test:g5-synthetic-incident --prefix scripts
+# or: node scripts/audit/g5-synthetic-incident-contract.mjs
+```
+
+## Close checklist for #426
+
+- [ ] Drill report JSON in `reports/` or pasted in #426
+- [ ] Screenshot: alert notification (redact tokens)
+- [ ] Screenshot: ack + resolved issue in Sentry
+- [ ] Ack time within SLA for chosen severity
+- [ ] Mark G5 complete in LAUNCH_GATES.md (separate PR after evidence review)
+
+## Report template
+
+See [DRILL_REPORT.template.md](./DRILL_REPORT.template.md).

--- a/docs/runbooks/INCIDENT_DATABASE_DOWN.md
+++ b/docs/runbooks/INCIDENT_DATABASE_DOWN.md
@@ -25,3 +25,4 @@
 
 - Timeline + root cause in incident doc
 - Add missing index/RLS fix ORCH if query storm caused pool exhaustion
+- On-call drill reference: [SYNTHETIC_INCIDENT_DRILL.md](./SYNTHETIC_INCIDENT_DRILL.md) (G5)

--- a/docs/runbooks/INCIDENT_EDGE_FUNCTION_STORM.md
+++ b/docs/runbooks/INCIDENT_EDGE_FUNCTION_STORM.md
@@ -29,3 +29,7 @@
 
 - Error rate &lt; 0.1% for 15 minutes
 - p95 within SLO in [load-profile.md](../load-profile.md)
+
+## Drill
+
+Quarterly synthetic alert drill: [SYNTHETIC_INCIDENT_DRILL.md](./SYNTHETIC_INCIDENT_DRILL.md) (G5).

--- a/docs/runbooks/SYNTHETIC_INCIDENT_DRILL.md
+++ b/docs/runbooks/SYNTHETIC_INCIDENT_DRILL.md
@@ -1,0 +1,123 @@
+# Synthetic incident drill — alert → ack → resolve
+
+**Gate:** G5 — Synthetic incident drill (#426 Tier 2)  
+**Owner:** Platform  
+**Prerequisite:** G3 Sentry live (errors + alert rule routed to Slack/email)
+
+## Objectives
+
+| Metric | Target (initial) | Notes |
+|--------|------------------|-------|
+| **P0 ack SLA** | ≤ 15 min | Database unavailable — [INCIDENT_DATABASE_DOWN.md](./INCIDENT_DATABASE_DOWN.md) |
+| **P1 ack SLA** | ≤ 30 min | Edge storm — [INCIDENT_EDGE_FUNCTION_STORM.md](./INCIDENT_EDGE_FUNCTION_STORM.md) |
+| **End-to-end drill** | Alert fired → human ack → resolve | Timed evidence for #426 |
+
+## When to use
+
+- **G5 gate evidence:** scheduled drill on staging (non-customer impact)
+- **Quarterly:** re-run to validate on-call routing still works after Sentry/Slack changes
+- **Not for production incidents** — use the severity-specific runbooks above
+
+## Roles
+
+| Role | Responsibility |
+|------|----------------|
+| **Drill coordinator** | Starts drill, records timestamps, files report |
+| **On-call** | Acknowledges alert in notification channel within SLA |
+| **Observer** | Confirms alert content is actionable (project, env, link to Sentry) |
+
+## Prerequisites
+
+- [ ] G3: `SENTRY_DSN` on Supabase staging + native DSN in EAS (for real error path)
+- [ ] Sentry alert rule configured (see [G5 evidence README](../evidence/g5-synthetic-incident/README.md))
+- [ ] Notification destination live (Slack channel or email list)
+- [ ] On-call roster known for drill window
+
+## Procedure
+
+### 1. Start drill (T0)
+
+```bash
+./scripts/ops/g5-synthetic-incident-drill.sh start --severity P1
+```
+
+Record **T0** = UTC when inject is about to be sent.
+
+### 2. Inject synthetic alert
+
+**Option A — programmatic (recommended):**
+
+```bash
+export SENTRY_DSN="https://<key>@o4511136062701568.ingest.us.sentry.io/<project>"
+node scripts/ops/inject-g5-synthetic-alert.mjs
+```
+
+Event is tagged `drill:g5` and `severity:P1` (or `P0` if drill uses `--severity P0`).
+
+**Option B — edge path (validates full G3 pipeline):**
+
+Invoke a wrapped edge function that hits `logError` with the drill tag (see G5 evidence README).
+
+**Option C — Sentry UI:**
+
+Alert rule → **Send test notification** (only valid if rule already exists).
+
+Record **T0-inject** when inject completes (script prints timestamp).
+
+### 3. Alert received (T1)
+
+When Slack/email notification arrives:
+
+```bash
+./scripts/ops/g5-synthetic-incident-drill.sh mark alert-received
+```
+
+### 4. Acknowledge (T2)
+
+On-call acknowledges in the notification tool (Slack reaction, PagerDuty ack, or Sentry issue assign):
+
+```bash
+./scripts/ops/g5-synthetic-incident-drill.sh mark acknowledged
+```
+
+**SLA check:** `T2 - T0` must be ≤ 15 min (P0) or ≤ 30 min (P1). Drill fails gate evidence if exceeded.
+
+### 5. Resolve and close (T3)
+
+1. Mark Sentry issue resolved (filter: tag `drill:g5`).
+2. Post drill all-clear in internal channel.
+
+```bash
+./scripts/ops/g5-synthetic-incident-drill.sh finish
+```
+
+Attach report JSON + notification screenshot to GitHub #426.
+
+## Timed drill helper
+
+```bash
+./scripts/ops/g5-synthetic-incident-drill.sh start [--severity P0|P1]
+node scripts/ops/inject-g5-synthetic-alert.mjs   # or edge / Sentry test path
+./scripts/ops/g5-synthetic-incident-drill.sh mark alert-received
+./scripts/ops/g5-synthetic-incident-drill.sh mark acknowledged
+./scripts/ops/g5-synthetic-incident-drill.sh finish
+```
+
+## Recommended Sentry alert rule (operator)
+
+Create in Sentry → **Alerts** → **Issues**:
+
+| Field | Value |
+|-------|-------|
+| Name | `G5 drill — edge error (staging)` |
+| Environment | `staging` or `edge` |
+| Filter | `tags.drill is g5` OR error level from edge runtime |
+| Action | Slack `#mingla-incidents` (or email on-call list) |
+
+For production readiness, duplicate rule without `drill:g5` filter for real edge errors.
+
+## Related
+
+- G3 setup: [docs/evidence/g3-sentry/README.md](../evidence/g3-sentry/README.md)
+- G5 evidence: [docs/evidence/g5-synthetic-incident/README.md](../evidence/g5-synthetic-incident/README.md)
+- [LAUNCH_GATES.md](../LAUNCH_GATES.md)

--- a/scripts/audit/g5-synthetic-incident-contract.mjs
+++ b/scripts/audit/g5-synthetic-incident-contract.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * #426 G5 — CI contract: synthetic incident drill gate scaffolding present.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const paths = {
+  runbook: join(root, "docs/runbooks/SYNTHETIC_INCIDENT_DRILL.md"),
+  edgeIncident: join(root, "docs/runbooks/INCIDENT_EDGE_FUNCTION_STORM.md"),
+  dbIncident: join(root, "docs/runbooks/INCIDENT_DATABASE_DOWN.md"),
+  evidence: join(root, "docs/evidence/g5-synthetic-incident/README.md"),
+  template: join(root, "docs/evidence/g5-synthetic-incident/DRILL_REPORT.template.md"),
+  drill: join(root, "scripts/ops/g5-synthetic-incident-drill.sh"),
+  inject: join(root, "scripts/ops/inject-g5-synthetic-alert.mjs"),
+  g3Evidence: join(root, "docs/evidence/g3-sentry/README.md"),
+};
+
+const runbook = readFileSync(paths.runbook, "utf8");
+const edgeIncident = readFileSync(paths.edgeIncident, "utf8");
+const dbIncident = readFileSync(paths.dbIncident, "utf8");
+const evidence = readFileSync(paths.evidence, "utf8");
+const template = readFileSync(paths.template, "utf8");
+const drill = readFileSync(paths.drill, "utf8");
+const inject = readFileSync(paths.inject, "utf8");
+
+const drillExecutable =
+  (() => {
+    try {
+      return (statSync(paths.drill).mode & 0o111) !== 0;
+    } catch {
+      return false;
+    }
+  })();
+
+const checks = [
+  [runbook.includes("G5"), "runbook references G5"],
+  [runbook.includes("T0"), "runbook timed phases"],
+  [runbook.includes("15 min"), "runbook P0 ack SLA"],
+  [runbook.includes("30 min"), "runbook P1 ack SLA"],
+  [runbook.includes("inject-g5-synthetic-alert.mjs"), "runbook inject script"],
+  [runbook.includes("g5-synthetic-incident-drill.sh"), "runbook drill script"],
+  [edgeIncident.includes("SYNTHETIC_INCIDENT_DRILL.md"), "edge incident links G5 drill"],
+  [dbIncident.includes("SYNTHETIC_INCIDENT_DRILL.md"), "db incident links G5 drill"],
+  [evidence.includes("G5"), "G5 evidence README"],
+  [evidence.includes("g5-synthetic-incident-contract.mjs"), "G5 evidence CI contract doc"],
+  [evidence.includes("G3"), "G5 evidence documents G3 prerequisite"],
+  [template.includes("t0_drillStartUtc"), "drill report template timestamps"],
+  [template.includes("slaMet"), "drill report template SLA field"],
+  [drill.includes("cmd_start"), "drill script start command"],
+  [drill.includes("write_report"), "drill script JSON report writer"],
+  [inject.includes("drill:g5"), "inject script tags drill:g5"],
+  [inject.includes("G5SyntheticIncident"), "inject script synthetic error type"],
+  [readFileSync(paths.g3Evidence, "utf8").includes("Sentry"), "G3 sentry evidence exists"],
+  [drillExecutable, "g5-synthetic-incident-drill.sh is executable"],
+];
+
+let failed = 0;
+for (const [ok, label] of checks) {
+  if (!ok) {
+    console.error(`FAIL g5-synthetic-incident-contract: missing ${label}`);
+    failed += 1;
+  }
+}
+
+if (failed > 0) process.exit(1);
+console.log("OK g5-synthetic-incident-contract");

--- a/scripts/ops/g5-synthetic-incident-drill.sh
+++ b/scripts/ops/g5-synthetic-incident-drill.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# #426 G5 — timed synthetic incident drill helper.
+#
+# Records alert → ack → resolve timestamps for gate evidence.
+# Does NOT configure Sentry alerts — operator sets those up per runbook.
+#
+# Usage:
+#   ./scripts/ops/g5-synthetic-incident-drill.sh start [--severity P0|P1]
+#   ./scripts/ops/g5-synthetic-incident-drill.sh mark alert-received
+#   ./scripts/ops/g5-synthetic-incident-drill.sh mark acknowledged
+#   ./scripts/ops/g5-synthetic-incident-drill.sh finish
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+REPORT_DIR="$ROOT/docs/evidence/g5-synthetic-incident/reports"
+STATE_FILE="${G5_DRILL_STATE:-/tmp/mingla-g5-drill-state.txt}"
+
+utc_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+minutes_between() {
+  local start="$1"
+  local end="$2"
+  if [[ -z "$start" || -z "$end" ]]; then
+    echo ""
+    return
+  fi
+  python3 - "$start" "$end" <<'PY'
+import sys
+from datetime import datetime
+a = datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+b = datetime.fromisoformat(sys.argv[2].replace("Z", "+00:00"))
+print(int((b - a).total_seconds() // 60))
+PY
+}
+
+sla_for_severity() {
+  case "$1" in
+    P0) echo 15 ;;
+    P1) echo 30 ;;
+    *) echo 30 ;;
+  esac
+}
+
+load_state() {
+  T0="" T1="" T2="" T3=""
+  SEVERITY="P1"
+  REPORT_PATH=""
+  if [[ -f "$STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+  fi
+}
+
+save_state() {
+  mkdir -p "$(dirname "$STATE_FILE")"
+  cat >"$STATE_FILE" <<EOF
+T0="${T0:-}"
+T1="${T1:-}"
+T2="${T2:-}"
+T3="${T3:-}"
+SEVERITY="${SEVERITY:-P1}"
+REPORT_PATH="${REPORT_PATH:-}"
+EOF
+}
+
+cmd_start() {
+  load_state
+  local severity="${1:-P1}"
+  if [[ "$severity" != "P0" && "$severity" != "P1" ]]; then
+    echo "Severity must be P0 or P1" >&2
+    exit 1
+  fi
+  local stamp
+  stamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+  REPORT_PATH="$REPORT_DIR/${stamp}-drill.json"
+  SEVERITY="$severity"
+  T0="$(utc_now)"
+  T1=""
+  T2=""
+  T3=""
+  save_state
+  mkdir -p "$REPORT_DIR"
+
+  cat <<EOF
+G5 synthetic incident drill started
+  T0 (start):        $T0
+  Severity:          $SEVERITY (ack SLA: $(sla_for_severity "$SEVERITY") min)
+  Report path:       $REPORT_PATH
+
+Next:
+  1. Inject alert:
+       export SENTRY_DSN=...
+       node scripts/ops/inject-g5-synthetic-alert.mjs
+     (or Sentry alert test / edge logError path)
+  2. When notification arrives:
+       ./scripts/ops/g5-synthetic-incident-drill.sh mark alert-received
+  3. When on-call acks:
+       ./scripts/ops/g5-synthetic-incident-drill.sh mark acknowledged
+  4. Resolve issue in Sentry, then:
+       ./scripts/ops/g5-synthetic-incident-drill.sh finish
+
+Runbook: docs/runbooks/SYNTHETIC_INCIDENT_DRILL.md
+EOF
+}
+
+cmd_mark() {
+  local which="${1:-}"
+  load_state
+  if [[ -z "${REPORT_PATH:-}" ]]; then
+    echo "No active drill — run: ./scripts/ops/g5-synthetic-incident-drill.sh start" >&2
+    exit 1
+  fi
+  case "$which" in
+    alert-received) T1="$(utc_now)" ;;
+    acknowledged)   T2="$(utc_now)" ;;
+    resolved)       T3="$(utc_now)" ;;
+    *)
+      echo "Unknown mark: $which (use alert-received | acknowledged | resolved)" >&2
+      exit 1
+      ;;
+  esac
+  save_state
+  echo "Marked $which at $(utc_now)"
+}
+
+write_report() {
+  load_state
+  local alert_min ack_min total_ack_min resolve_min sla sla_met
+  alert_min="$(minutes_between "$T0" "$T1")"
+  ack_min="$(minutes_between "$T1" "$T2")"
+  total_ack_min="$(minutes_between "$T0" "$T2")"
+  resolve_min="$(minutes_between "$T2" "$T3")"
+  sla="$(sla_for_severity "$SEVERITY")"
+  sla_met="false"
+  if [[ -n "$total_ack_min" && "$total_ack_min" -le "$sla" ]]; then
+    sla_met="true"
+  fi
+
+  python3 - "$REPORT_PATH" "$SEVERITY" "$sla" "$sla_met" "$T0" "$T1" "$T2" "$T3" \
+    "${alert_min:-}" "${ack_min:-}" "${total_ack_min:-}" "${resolve_min:-}" <<'PY'
+import json, os, sys
+(path, severity, sla, sla_met, t0, t1, t2, t3,
+ alert_min, ack_min, total_ack_min, resolve_min) = sys.argv[1:]
+
+def num(v):
+    return int(v) if v else None
+
+data = {
+    "gate": "G5",
+    "severity": severity,
+    "slaAckMinutes": int(sla),
+    "injectMethod": os.environ.get("G5_INJECT_METHOD", "inject-g5-synthetic-alert.mjs"),
+    "sentryProject": os.environ.get("G5_SENTRY_PROJECT", "mingla-business"),
+    "notificationChannel": os.environ.get("G5_NOTIFICATION_CHANNEL", ""),
+    "timestamps": {
+        "t0_drillStartUtc": t0,
+        "t1_alertReceivedUtc": t1,
+        "t2_acknowledgedUtc": t2,
+        "t3_resolvedUtc": t3,
+    },
+    "durationsMinutes": {
+        "alertDelivery": num(alert_min),
+        "ack": num(ack_min),
+        "totalToAck": num(total_ack_min),
+        "resolve": num(resolve_min),
+    },
+    "slaMet": sla_met == "true",
+    "operator": os.environ.get("G5_DRILL_OPERATOR", ""),
+    "onCall": os.environ.get("G5_ON_CALL", ""),
+    "notes": os.environ.get("G5_DRILL_NOTES", ""),
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+print(path)
+if sla_met != "true":
+    sys.exit(1)
+PY
+}
+
+cmd_finish() {
+  load_state
+  if [[ -z "$T0" || -z "$T1" || -z "$T2" ]]; then
+    echo "Missing timestamps — need start, alert-received, acknowledged" >&2
+    exit 1
+  fi
+  if [[ -z "$T3" ]]; then
+    T3="$(utc_now)"
+    save_state
+  fi
+  local out exit_code=0
+  set +e
+  out="$(write_report)"
+  exit_code=$?
+  set -e
+  rm -f "$STATE_FILE"
+  echo "G5 drill report written: $out"
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "WARN: ack SLA not met for $SEVERITY (see report)" >&2
+    exit 1
+  fi
+  echo "SLA met — attach report + screenshots to GitHub #426"
+}
+
+CMD="${1:-}"
+shift || true
+case "$CMD" in
+  start)
+    severity="P1"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --severity) severity="${2:-P1}"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+      esac
+    done
+    cmd_start "$severity"
+    ;;
+  mark) cmd_mark "${1:-}" ;;
+  finish) cmd_finish ;;
+  *)
+    echo "Usage: $0 {start [--severity P0|P1]|mark alert-received|mark acknowledged|finish}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ops/inject-g5-synthetic-alert.mjs
+++ b/scripts/ops/inject-g5-synthetic-alert.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * #426 G5 — inject a tagged synthetic error into Sentry for incident drill.
+ *
+ * Usage:
+ *   export SENTRY_DSN="https://<key>@..."
+ *   node scripts/ops/inject-g5-synthetic-alert.mjs
+ *
+ * Optional:
+ *   G5_DRILL_SEVERITY=P0|P1  (default P1)
+ *   SENTRY_ENVIRONMENT=staging|edge|production
+ */
+
+const dsn = process.env.SENTRY_DSN ?? process.env.SUPABASE_SENTRY_DSN;
+if (!dsn) {
+  console.error("Set SENTRY_DSN (or SUPABASE_SENTRY_DSN)");
+  process.exit(2);
+}
+
+const severity = process.env.G5_DRILL_SEVERITY ?? "P1";
+const environment = process.env.SENTRY_ENVIRONMENT ?? "staging";
+
+function parseDsn(raw) {
+  try {
+    const url = new URL(raw);
+    const projectId = url.pathname.replace(/^\//, "");
+    const publicKey = url.username;
+    if (!publicKey || !projectId) return null;
+    return { publicKey, host: url.host, projectId };
+  } catch {
+    return null;
+  }
+}
+
+const parsed = parseDsn(dsn);
+if (!parsed) {
+  console.error("Invalid SENTRY_DSN");
+  process.exit(2);
+}
+
+const eventId = crypto.randomUUID().replace(/-/g, "");
+const message =
+  `[G5 drill] Synthetic ${severity} incident — safe to ignore (${new Date().toISOString()})`;
+
+const event = {
+  event_id: eventId,
+  timestamp: new Date().toISOString(),
+  platform: "javascript",
+  level: "error",
+  environment,
+  tags: {
+    runtime: "g5-drill",
+    drill: "g5",
+    "drill:g5": "true",
+    severity,
+  },
+  extra: {
+    gate: "G5",
+    purpose: "synthetic-incident-drill",
+  },
+  exception: {
+    values: [{
+      type: "G5SyntheticIncident",
+      value: message,
+      stacktrace: {
+        frames: [{ filename: "scripts/ops/inject-g5-synthetic-alert.mjs", function: "main" }],
+      },
+    }],
+  },
+};
+
+const sentryAuth =
+  `Sentry sentry_version=7, sentry_client=mingla-g5-drill/1.0, sentry_key=${parsed.publicKey}`;
+
+const res = await fetch(`https://${parsed.host}/api/${parsed.projectId}/store/`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-Sentry-Auth": sentryAuth,
+  },
+  body: JSON.stringify(event),
+});
+
+if (!res.ok) {
+  const body = await res.text();
+  console.error(`Sentry store failed: ${res.status} ${body}`);
+  process.exit(1);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  eventId,
+  severity,
+  environment,
+  injectedUtc: new Date().toISOString(),
+  message,
+}));

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "validate:categories": "node validate-category-consistency.mjs",
-    "test:g4-dr-restore": "node audit/g4-dr-restore-contract.mjs"
+    "test:g4-dr-restore": "node audit/g4-dr-restore-contract.mjs",
+    "test:g5-synthetic-incident": "node audit/g5-synthetic-incident-contract.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2",


### PR DESCRIPTION
## Summary
- Add `docs/runbooks/SYNTHETIC_INCIDENT_DRILL.md` with alert → ack → resolve procedure and P0/P1 SLA targets.
- Add timed drill helper (`g5-synthetic-incident-drill.sh`) and Sentry inject script (`inject-g5-synthetic-alert.mjs`).
- Add evidence scaffold under `docs/evidence/g5-synthetic-incident/` and CI contract.
- Link incident runbooks to G5 drill.

## Test plan
- [ ] `npm run test:g5-synthetic-incident --prefix scripts` passes
- [ ] `./scripts/ops/g5-synthetic-incident-drill.sh start --severity P1` prints checklist
- [ ] Operator drill after G3 alert rule configured + evidence attached to #426 (post-merge)