### PR TITLE
ORCH-1167: canonical standard-event public page — one shared EventOfferingBody across web + business + consumer [deploy]

### DIFF
--- a/.github/scripts/strict-grep/orch-1167-allin-price-in-ticket-box.mjs
+++ b/.github/scripts/strict-grep/orch-1167-allin-price-in-ticket-box.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1167 [event-page-canonical] — I-PROPOSED-1167-ALLIN-PRICE-IN-TICKET-BOX.
+ *
+ * The inline ticket box's running total (computeRunningTotal in
+ * packages/offering-rendering/EventOfferingBody.tsx) MUST be the SERVER all-in
+ * (priceAllInGbp), never the bare base (priceGbp alone) — WYSIWYP (ORCH-1147). The
+ * buyer must never see a base total that jumps up at the cart.
+ *
+ * Fails if EventOfferingBody.tsx:
+ *   (a) no longer references priceAllInGbp at all (the all-in source removed →
+ *       reverted to bare base), OR
+ *   (b) the unit-price helper (ticketUnitAllIn) reads priceGbp WITHOUT the
+ *       priceAllInGbp ?? priceGbp fallback (i.e. a bare `ticket.priceGbp` with no
+ *       priceAllInGbp coalesce in the same expression).
+ *
+ * Self-test (`--self-test`): a base-only total trips the gate; the all-in total
+ * passes.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+
+const BODY = "packages/offering-rendering/EventOfferingBody.tsx";
+
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+function check(src, label) {
+  const failures = [];
+  const code = stripComments(src);
+  // (a) the all-in source must be present.
+  if (!/priceAllInGbp/.test(code)) {
+    failures.push(
+      `${label}: no reference to priceAllInGbp — the inline-box total reverted to ` +
+        "bare base. ORCH-1147/1167 require the server all-in (WYSIWYP).",
+    );
+  }
+  // (b) the unit helper must coalesce priceAllInGbp ?? priceGbp (never bare base).
+  if (!/priceAllInGbp\s*\?\?\s*[\w.]*priceGbp/.test(code)) {
+    failures.push(
+      `${label}: the inline-box unit price must read 'priceAllInGbp ?? …priceGbp' ` +
+        "(all-in, base only as the free/RPC-miss fallback) — never bare priceGbp.",
+    );
+  }
+  return failures;
+}
+
+function runSelfTest() {
+  const bad = `
+    const ticketUnitAllIn = (t) => (t.isFree ? 0 : (t.priceGbp ?? 0));
+    export const computeRunningTotal = () => 0;
+  `;
+  const good = `
+    const ticketUnitAllIn = (t) => {
+      const price = t.priceAllInGbp ?? t.priceGbp;
+      return price ?? 0;
+    };
+    export const computeRunningTotal = () => 0;
+  `;
+  const badFails = check(bad, "synthetic-bad").length > 0;
+  const goodPasses = check(good, "synthetic-good").length === 0;
+  if (!badFails) {
+    console.error("SELF-TEST FAIL: base-only total did not trip the gate.");
+    process.exit(1);
+  }
+  if (!goodPasses) {
+    console.error("SELF-TEST FAIL: all-in total wrongly tripped the gate.");
+    process.exit(1);
+  }
+  console.log("ORCH-1167 allin-price-in-ticket-box gate SELF-TEST PASS.");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+} else {
+  const path = join(root, BODY);
+  if (!existsSync(path)) {
+    console.error(`ORCH-1167 allin-price-in-ticket-box gate FAILED: ${BODY} missing.`);
+    process.exit(1);
+  }
+  const failures = check(readFileSync(path, "utf8"), BODY);
+  if (failures.length > 0) {
+    console.error("\nORCH-1167 allin-price-in-ticket-box gate FAILED:\n");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.log("ORCH-1167 allin-price-in-ticket-box gate PASS.");
+}

--- a/.github/scripts/strict-grep/orch-1167-canonical-9-section-order.mjs
+++ b/.github/scripts/strict-grep/orch-1167-canonical-9-section-order.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1167 [event-page-canonical] — I-PROPOSED-1167-CANONICAL-9-SECTION-ORDER.
+ *
+ * The shared `EventOfferingBody` renders the canonical structure in the locked
+ * order. This gate asserts the body emits the section markers in the SPEC §3A order
+ * (2..8 inside the body; cover=1 + floating bar=9 are surface-owned), so a reorder
+ * trips CI. It anchors on stable section comments/testIDs in
+ * packages/offering-rendering/EventOfferingBody.tsx:
+ *   (2) Event name lead block
+ *   (3) Date & time meta chips
+ *   (4) Pills row              → testID "orch-1167-pills-row"
+ *   (5) TICKET BOX             → testID "orch-1167-ticket-box"
+ *   (6) Presented By           → "Presented by"
+ *   (7) About                  → secTitle "About"
+ *   (8) Where you'll be        → "Where you" (Where you'll be)
+ *
+ * Fails if any anchor is missing OR they appear out of order. Self-test proves a
+ * reordered body trips the gate.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+
+const BODY = "packages/offering-rendering/EventOfferingBody.tsx";
+
+// Ordered anchors (string searched in raw source, first-occurrence index).
+const ANCHORS = [
+  ["(2) Event name", "(2) Event name lead block"],
+  ["(3) Date & time", "(3) Date & time meta chips"],
+  ["(4) Pills row", 'testID="orch-1167-pills-row"'],
+  ["(5) TICKET BOX", 'testID="orch-1167-ticket-box"'],
+  ["(6) Presented By", "(6) Presented By"],
+  ["(7) About", "(7) About"],
+  ["(8) Where", "(8) Where you'll be"],
+];
+
+function check(src, label) {
+  const failures = [];
+  let prev = -1;
+  let prevName = "<start>";
+  for (const [name, needle] of ANCHORS) {
+    const idx = src.indexOf(needle);
+    if (idx === -1) {
+      failures.push(`${label}: missing section anchor ${name} ("${needle}").`);
+      continue;
+    }
+    if (idx < prev) {
+      failures.push(
+        `${label}: section ${name} appears BEFORE ${prevName} — the canonical ` +
+          "9-section order (SPEC §3A) was reordered.",
+      );
+    }
+    prev = idx;
+    prevName = name;
+  }
+  return failures;
+}
+
+function runSelfTest() {
+  const good = ANCHORS.map(([, n]) => `// ${n}`).join("\n");
+  // Swap pills (4) and ticket box (5) to force an out-of-order failure.
+  const reordered = [
+    "// (2) Event name lead block",
+    "// (3) Date & time meta chips",
+    '// testID="orch-1167-ticket-box"',
+    '// testID="orch-1167-pills-row"',
+    "// (6) Presented By",
+    "// (7) About",
+    "// (8) Where you'll be",
+  ].join("\n");
+  const goodPasses = check(good, "synthetic-good").length === 0;
+  const badFails = check(reordered, "synthetic-bad").length > 0;
+  if (!goodPasses) {
+    console.error("SELF-TEST FAIL: ordered anchors wrongly tripped the gate.");
+    process.exit(1);
+  }
+  if (!badFails) {
+    console.error("SELF-TEST FAIL: reordered sections did not trip the gate.");
+    process.exit(1);
+  }
+  console.log("ORCH-1167 canonical-9-section-order gate SELF-TEST PASS.");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+} else {
+  const path = join(root, BODY);
+  if (!existsSync(path)) {
+    console.error(`ORCH-1167 canonical-9-section-order gate FAILED: ${BODY} missing.`);
+    process.exit(1);
+  }
+  const failures = check(readFileSync(path, "utf8"), BODY);
+  if (failures.length > 0) {
+    console.error("\nORCH-1167 canonical-9-section-order gate FAILED:\n");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.log("ORCH-1167 canonical-9-section-order gate PASS.");
+}

--- a/.github/scripts/strict-grep/orch-1167-city-level-map-no-exact-pin-when-hidden.mjs
+++ b/.github/scripts/strict-grep/orch-1167-city-level-map-no-exact-pin-when-hidden.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1167 [event-page-canonical] —
+ * I-PROPOSED-1167-CITY-LEVEL-MAP-NO-EXACT-PIN-WHEN-HIDDEN.
+ *
+ * Privacy MUST be enforced SERVER-SIDE in the pg_public_event_by_slug RPC: when the
+ * event hides the street until ticket purchase, the anon payload must OMIT the exact
+ * address + location_geo and return ONLY city + city_geo (so the body draws a
+ * city-level map with no exact pin). This gate asserts the migration that defines
+ * the RPC carries that gate.
+ *
+ * Fails if supabase/migrations/*_pg_public_event_by_slug.sql:
+ *   (a) is missing, OR
+ *   (b) does not gate 'address' on hide_address_until_ticket (returning NULL), OR
+ *   (c) does not gate 'locationGeo' on hide_address_until_ticket, OR
+ *   (d) does not return cityGeo / city_geo (the privacy-safe centroid).
+ *
+ * Self-test proves a non-gated RPC body trips the gate.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+
+const MIG_DIR = "supabase/migrations";
+
+function findRpcMigration() {
+  const dir = join(root, MIG_DIR);
+  if (!existsSync(dir)) return null;
+  const hit = readdirSync(dir).find((f) =>
+    /pg_public_event_by_slug\.sql$/.test(f),
+  );
+  return hit === undefined ? null : join(dir, hit);
+}
+
+function check(sql, label) {
+  const failures = [];
+  // (b) address gated on hide_address_until_ticket → NULL.
+  if (
+    !/'address'\s*,\s*CASE[\s\S]*?hide_address_until_ticket[\s\S]*?NULL/.test(sql)
+  ) {
+    failures.push(
+      `${label}: 'address' is not gated NULL on hide_address_until_ticket — the ` +
+        "RPC could leak the street to an anon viewer.",
+    );
+  }
+  // (c) locationGeo gated on hide_address_until_ticket.
+  if (
+    !/'locationGeo'\s*,\s*CASE[\s\S]*?hide_address_until_ticket/.test(sql)
+  ) {
+    failures.push(
+      `${label}: 'locationGeo' (exact pin) is not gated on ` +
+        "hide_address_until_ticket — the exact pin could leak.",
+    );
+  }
+  // (d) the city-level centroid must be returned.
+  if (!/'cityGeo'/.test(sql) || !/city_geo/.test(sql)) {
+    failures.push(
+      `${label}: the privacy-safe cityGeo / city_geo centroid is not returned.`,
+    );
+  }
+  return failures;
+}
+
+function runSelfTest() {
+  const good = `
+    'address', CASE WHEN ev.hide_address_until_ticket THEN NULL ELSE ev.addr END,
+    'locationGeo', CASE WHEN ev.hide_address_until_ticket OR ev.location_geo IS NULL THEN NULL ELSE x END,
+    'cityGeo', CASE WHEN ev.city_geo IS NULL THEN NULL ELSE y END,
+  `;
+  const bad = `
+    'address', ev.addr,
+    'locationGeo', ev.location_geo,
+  `;
+  const goodPasses = check(good, "synthetic-good").length === 0;
+  const badFails = check(bad, "synthetic-bad").length > 0;
+  if (!goodPasses) {
+    console.error("SELF-TEST FAIL: gated RPC wrongly tripped the gate.");
+    process.exit(1);
+  }
+  if (!badFails) {
+    console.error("SELF-TEST FAIL: ungated RPC did not trip the gate.");
+    process.exit(1);
+  }
+  console.log("ORCH-1167 city-level-map-no-exact-pin-when-hidden gate SELF-TEST PASS.");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+} else {
+  const path = findRpcMigration();
+  if (path === null) {
+    console.error(
+      "ORCH-1167 city-level-map gate FAILED: no *_pg_public_event_by_slug.sql " +
+        "migration found.",
+    );
+    process.exit(1);
+  }
+  const failures = check(readFileSync(path, "utf8"), "pg_public_event_by_slug migration");
+  if (failures.length > 0) {
+    console.error("\nORCH-1167 city-level-map-no-exact-pin-when-hidden gate FAILED:\n");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.log("ORCH-1167 city-level-map-no-exact-pin-when-hidden gate PASS.");
+}

--- a/.github/scripts/strict-grep/orch-1167-one-read-rpc.mjs
+++ b/.github/scripts/strict-grep/orch-1167-one-read-rpc.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1167 [event-page-canonical] — I-PROPOSED-1167-ONE-READ-RPC.
+ *
+ * All surfaces read the canonical standard-event public page body fields via the
+ * ONE RPC `pg_public_event_by_slug` (SC-7: a field added to the RPC surfaces on all
+ * surfaces with one mapper edit). This gate asserts:
+ *   • the buyer-web/business service (mingla-business/src/services/publicEventsService.ts)
+ *     calls supabase.rpc("pg_public_event_by_slug", …) for the standard-event body
+ *     fields (fetchCanonicalEventBodyFields), AND
+ *   • the consumer hook (app-mobile/src/hooks/usePublicEventBySlug.ts) calls it too.
+ *
+ * Fails if either surface no longer reads the RPC (a divergent read was reintroduced
+ * for the standard-event page body). Self-test proves a stripped reader trips it.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+
+const SURFACES = [
+  {
+    label: "web/business service",
+    file: "mingla-business/src/services/publicEventsService.ts",
+  },
+  {
+    label: "consumer hook",
+    file: "app-mobile/src/hooks/usePublicEventBySlug.ts",
+  },
+];
+
+const RPC_RE = /\.rpc\(\s*["']pg_public_event_by_slug["']/;
+
+function checkFile(src, label) {
+  return RPC_RE.test(src)
+    ? []
+    : [
+        `${label}: does not call supabase.rpc("pg_public_event_by_slug", …). The ` +
+          "standard-event page body MUST read the ONE canonical RPC (SC-7).",
+      ];
+}
+
+function runSelfTest() {
+  const good = `const { data } = await supabase.rpc("pg_public_event_by_slug", { p_brand_slug });`;
+  const bad = `const { data } = await supabase.from("business_public_events_view").select("*");`;
+  const goodPasses = checkFile(good, "synthetic-good").length === 0;
+  const badFails = checkFile(bad, "synthetic-bad").length > 0;
+  if (!goodPasses) {
+    console.error("SELF-TEST FAIL: RPC reader wrongly tripped the gate.");
+    process.exit(1);
+  }
+  if (!badFails) {
+    console.error("SELF-TEST FAIL: non-RPC reader did not trip the gate.");
+    process.exit(1);
+  }
+  console.log("ORCH-1167 one-read-rpc gate SELF-TEST PASS.");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+} else {
+  const failures = [];
+  for (const { label, file } of SURFACES) {
+    const path = join(root, file);
+    if (!existsSync(path)) {
+      failures.push(`${label}: ${file} missing.`);
+      continue;
+    }
+    failures.push(...checkFile(readFileSync(path, "utf8"), label));
+  }
+  if (failures.length > 0) {
+    console.error("\nORCH-1167 one-read-rpc gate FAILED:\n");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.log("ORCH-1167 one-read-rpc gate PASS.");
+}

--- a/.github/scripts/strict-grep/orch-1167-shell-agnostic-body.mjs
+++ b/.github/scripts/strict-grep/orch-1167-shell-agnostic-body.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1167 [event-page-canonical] — I-PROPOSED-1167-SHELL-AGNOSTIC-BODY.
+ *
+ * The shared `EventOfferingBody` (packages/offering-rendering/EventOfferingBody.tsx)
+ * MUST be a PURE CONTENT body: it declares NO scroll container as its root and NO
+ * cover host. Each surface injects its own scroll + parallax scaffold around it
+ * (web/business = ParallaxCoverShell + RN ScrollView; consumer = gorhom
+ * BottomSheetScrollView). If the body grew a scroll root it would re-trigger the
+ * gorhom freeze on the consumer sheet (ORCH-1016/1043/1138).
+ *
+ * Fails if EventOfferingBody.tsx:
+ *   (a) imports/renders ScrollView / BottomSheetScrollView / FlatList / SectionList
+ *       / VirtualizedList (a scroll container), OR
+ *   (b) imports ParallaxCoverShell (the body must NOT wrap the cover shell).
+ *
+ * Self-test (`--self-test`): a synthetic body WITH a ScrollView trips the gate; the
+ * real file passes.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+
+const BODY = "packages/offering-rendering/EventOfferingBody.tsx";
+
+const stripComments = (src) =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+function check(src, label) {
+  const failures = [];
+  const code = stripComments(src);
+  // (a) no scroll container rendered/imported in the body.
+  for (const sym of [
+    "ScrollView",
+    "BottomSheetScrollView",
+    "FlatList",
+    "SectionList",
+    "VirtualizedList",
+  ]) {
+    const re = new RegExp(`\\b${sym}\\b`);
+    if (re.test(code)) {
+      failures.push(
+        `${label}: references <${sym}> — the shell-agnostic body must host NO ` +
+          "scroll root. Each surface injects its scroll host AROUND the body.",
+      );
+    }
+  }
+  // (b) the body must not wrap the parallax cover shell.
+  if (/ParallaxCoverShell/.test(code)) {
+    failures.push(
+      `${label}: imports/renders ParallaxCoverShell — the body must be a pure ` +
+        "content body; the cover shell is composed by the surface wrapper.",
+    );
+  }
+  return failures;
+}
+
+function runSelfTest() {
+  const bad = `
+    import { ScrollView, View } from "react-native";
+    export const EventOfferingBody = () => (<ScrollView><View/></ScrollView>);
+  `;
+  const good = `
+    import { View, Text, Pressable } from "react-native";
+    export const EventOfferingBody = () => (<View><Text>ok</Text></View>);
+  `;
+  const badFails = check(bad, "synthetic-bad").length > 0;
+  const goodPasses = check(good, "synthetic-good").length === 0;
+  if (!badFails) {
+    console.error("SELF-TEST FAIL: scroll-root body did not trip the gate.");
+    process.exit(1);
+  }
+  if (!goodPasses) {
+    console.error("SELF-TEST FAIL: clean body wrongly tripped the gate.");
+    process.exit(1);
+  }
+  console.log("ORCH-1167 shell-agnostic-body gate SELF-TEST PASS.");
+  process.exit(0);
+}
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+} else {
+  const path = join(root, BODY);
+  if (!existsSync(path)) {
+    console.error(`ORCH-1167 shell-agnostic-body gate FAILED: ${BODY} missing.`);
+    process.exit(1);
+  }
+  const failures = check(readFileSync(path, "utf8"), BODY);
+  if (failures.length > 0) {
+    console.error("\nORCH-1167 shell-agnostic-body gate FAILED:\n");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.log("ORCH-1167 shell-agnostic-body gate PASS.");
+}

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2576,3 +2576,68 @@ jobs:
   # The other 3 columns the gate also checked (brand_address, brand_cover_media_url,
   # display_attendee_count) are still mapped — a future docs-hygiene ORCH may
   # revive a narrower replacement gate for just those columns if regressions appear.
+
+  orch-1167-shell-agnostic-body:
+    name: "ORCH-1167 [event-page-canonical]: EventOfferingBody hosts no scroll root + no cover shell (I-PROPOSED-1167-SHELL-AGNOSTIC-BODY)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test ORCH-1167 shell-agnostic-body gate
+        run: node .github/scripts/strict-grep/orch-1167-shell-agnostic-body.mjs --self-test
+      - name: Run ORCH-1167 shell-agnostic-body gate
+        run: node .github/scripts/strict-grep/orch-1167-shell-agnostic-body.mjs
+
+  orch-1167-allin-price-in-ticket-box:
+    name: "ORCH-1167 [event-page-canonical]: inline ticket-box total reads server all-in, never bare base (I-PROPOSED-1167-ALLIN-PRICE-IN-TICKET-BOX)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test ORCH-1167 allin-price-in-ticket-box gate
+        run: node .github/scripts/strict-grep/orch-1167-allin-price-in-ticket-box.mjs --self-test
+      - name: Run ORCH-1167 allin-price-in-ticket-box gate
+        run: node .github/scripts/strict-grep/orch-1167-allin-price-in-ticket-box.mjs
+
+  orch-1167-canonical-9-section-order:
+    name: "ORCH-1167 [event-page-canonical]: EventOfferingBody emits sections 2..8 in the locked canonical order (I-PROPOSED-1167-CANONICAL-9-SECTION-ORDER)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test ORCH-1167 canonical-9-section-order gate
+        run: node .github/scripts/strict-grep/orch-1167-canonical-9-section-order.mjs --self-test
+      - name: Run ORCH-1167 canonical-9-section-order gate
+        run: node .github/scripts/strict-grep/orch-1167-canonical-9-section-order.mjs
+
+  orch-1167-city-level-map-no-exact-pin-when-hidden:
+    name: "ORCH-1167 [event-page-canonical]: pg_public_event_by_slug omits exact address+pin when hidden, returns city_geo (I-PROPOSED-1167-CITY-LEVEL-MAP-NO-EXACT-PIN-WHEN-HIDDEN)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test ORCH-1167 city-level-map gate
+        run: node .github/scripts/strict-grep/orch-1167-city-level-map-no-exact-pin-when-hidden.mjs --self-test
+      - name: Run ORCH-1167 city-level-map gate
+        run: node .github/scripts/strict-grep/orch-1167-city-level-map-no-exact-pin-when-hidden.mjs
+
+  orch-1167-one-read-rpc:
+    name: "ORCH-1167 [event-page-canonical]: web + consumer both read the standard-event page via pg_public_event_by_slug (I-PROPOSED-1167-ONE-READ-RPC)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Self-test ORCH-1167 one-read-rpc gate
+        run: node .github/scripts/strict-grep/orch-1167-one-read-rpc.mjs --self-test
+      - name: Run ORCH-1167 one-read-rpc gate
+        run: node .github/scripts/strict-grep/orch-1167-one-read-rpc.mjs

--- a/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1167_EVENT_PAGE_CANONICAL.md
+++ b/Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1167_EVENT_PAGE_CANONICAL.md
@@ -1,0 +1,187 @@
+# INVESTIGATE — ORCH-1167 [event-page-canonical]
+
+**Leg 1 of META-ORCH-1166 (public offering-page single source of truth).**
+Scope: the STANDARD TICKETED-EVENT public page (`event_type='event'` ONLY — NOT rsvp/trip/experience).
+Worktree: `~/Desktop/mingla-orchs/ORCH-1167-[event-page-canonical]/` on branch `ORCH-1167-event-page-canonical`.
+HEAD verified at `be65f8f1c` (rebased on origin/main). Date 2026-06-19.
+
+This is an audit-only investigation (no live-fire reproducer — this is an architecture/SoT consolidation, not a runtime bug). All findings are source + schema + data verified.
+
+---
+
+## COMMS-LEDGER on entry
+
+Scanned Active entries. No `BLOCK`+`OPEN` rows targeting `ORCH-1167` / `mingla-forensics` / `ALL`. WARN/FYI factored in and acked:
+- **COMMS-0038** (corrected 2026-06-19) — this is my exact charter; confirms event page is web-body + consumer-fork, leg 1 of the consolidation META, and "edit PublicEventPage.tsx never fork" is SUPERSEDED. ACK.
+- **COMMS-0040 / 0044 / 0041** — sibling RSVP / trip / experience standardization legs. They establish the SAME shell-agnostic-body convention this leg sets the precedent for. The `RsvpMomentumDecision` already lives in `offering-rendering` as the proof-of-pattern. ACK; coordinate package-home decision here.
+- **COMMS-0036** — ORCH-1138 left a `[TRANSITIONAL]` comment in `mingla-business/src/...`; relevant because this leg retires that transitional split. FYI.
+- **COMMS-0043** — ORCH-1159 added the `hideCloseOnWeb` web-close-X behavior; the shared body MUST preserve it. FYI.
+
+---
+
+## Symptom / charter (expected vs actual)
+
+**Expected (Seth, 2026-06-19):** ONE canonical shell-agnostic shared body for the standard ticketed-event public page in `packages/offering-rendering`, rendered byte-identically on web + business + consumer, fed by ONE read RPC, with Seth's locked 9-section vertical structure including an **inline on-page ticket box** that replaces the separate ticket-selection screen.
+
+**Actual (verified at HEAD):** the live event page is a Direction-A split — web + business render a body that lives in `mingla-business/src/` (NOT shared); consumer FORKS its own body; read paths are split; the ticket UI is a *radiogroup select that routes OUT* to a separate checkout screen; vibes/party-types/music-genres pills do NOT render on the standard-event path; and there is no city-level privacy geo field.
+
+---
+
+## Investigation manifest (every file read, in trace order)
+
+| # | File | Layer | Why |
+|---|------|-------|-----|
+| 1 | `COMMS_LEDGER.md` (anchor) | docs | mandatory entry scan |
+| 2 | `mingla-business/src/components/event/FoundationEventPreview.tsx` | code | the LIVE web+business body |
+| 3 | `mingla-business/src/components/event/PublicEventPage.tsx` | code | the adapter that owns CTA + scroll-state + routes to `/checkout` |
+| 4 | `mingla-business/app/e/[brandSlug]/[eventSlug].tsx` | code | web public route (scroll shell) |
+| 5 | `mingla-business/app/event/[id]/preview.tsx` + `PreviewEventView.tsx` | code | business in-app preview route |
+| 6 | `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx` | code | the CONSUMER fork body |
+| 7 | `app-mobile/app/e/[brandSlug]/[eventSlug].tsx` | code | consumer route (gorhom BaseBottomSheet) |
+| 8 | `app-mobile/src/components/expandedCard/TicketCartSheet.tsx` | code | consumer cart sheet (multi-tier) |
+| 9 | `app-mobile/src/hooks/useTicketCart.ts` | code | consumer cart reducer |
+| 10 | `app-mobile/src/hooks/useConsumerEventFoundation.ts` | code | consumer field mapper (drops vibes/party/music) |
+| 11 | `app-mobile/src/hooks/useEventTheme.ts`, `usePublicEventTickets.ts` | code | consumer read hooks |
+| 12 | `mingla-business/src/services/publicEventsService.ts` | code | web read path + `publicEventViewRowToEvent` mapper |
+| 13 | `packages/event-rendering/types.ts` | code | `PublicEventProps` / `PublicTicketProps` contract |
+| 14 | `packages/event-rendering/offeringCta.ts` | code | `resolveOfferingCta` / `computeOfferingVariant` CTA state machine |
+| 15 | `packages/event-rendering/mapboxStaticProxyUrl.ts`, `mapboxStaticUrl.ts` | code | ORCH-1165 static-map builders |
+| 16 | `packages/offering-rendering/index.ts` + `package.json` | code | shared primitives + dep on event-rendering |
+| 17 | `mingla-business/tsconfig.json`, `metro.config.js`; `app-mobile/tsconfig.json`, `metro.config.js` | config | package alias wiring (for consolidation) |
+| 18 | DB: `information_schema.columns` (events, view), `routines` | schema | field names + RPC existence |
+| 19 | DB: row counts of `events` where `event_type='event'` | data | geo/city population reality |
+
+---
+
+## Q-scorecard
+
+### Q1 — Is the standard-event page body shared across all 3 surfaces today?
+**Verdict: NO (confirmed).** Web + business render `mingla-business/src/components/event/FoundationEventPreview.tsx` (lines 103–126 props; 455–491 render). Consumer renders a separate `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx`. The shared `packages/event-rendering/PublicEventPage.tsx` is now the LEGACY fallback only. Only `packages/offering-rendering` + `packages/event-rendering` PRIMITIVES are shared. (F-1)
+
+### Q2 — What are the exact event field names for vibes / party-types / music-genres?
+**Verdict: confirmed.** On `public.events` (all `text[]`): `vibe_tags`, `party_types`, `music_genres`. All three are also exposed anon-safe in `business_public_events_view`. (F-2)
+
+### Q3 — Does the read payload carry those pills today, and do they render?
+**Verdict: NO (confirmed gap).** Web mapper (`publicEventViewRowToEvent`) maps `party_types→partyTypes` and `vibe_tags→vibeTags` but DOES NOT map `music_genres`. The consumer card mapper (`mapRpcRowToCard`) maps all three onto `BusinessEventCard`, but the consumer foundation projection (`mapConsumerEventToFoundation`) DROPS all three. Neither `FoundationEventPreview` nor `ConsumerEventDetailScreen` renders vibe/party/music pills on the standard-event path (party/vibe chips currently render only on the RSVP branch). (F-3)
+
+### Q4 — How is event "format" (in-person/online/hybrid) determined?
+**Verdict: confirmed — derived, not a column.** There is NO `format` enum column on `events`. Format = `theme.business_event.format` if present (`in_person`/`online`/`hybrid`), else fallback `is_online ? "online" : "in_person"`. Web: `asFormat()` in publicEventsService.ts. Consumer: `deriveSharedFormat()` in `supabase/functions/discover-merged-events/_helpers.ts`. The view exposes `is_online` + `location_mode` + `event_type`. (F-4)
+
+### Q5 — Is the ticket UI an inline box or a separate selection screen?
+**Verdict: separate (confirmed).** Web/business: `FoundationEventPreview` renders a radiogroup of selectable tier rows; selection state lives in `PublicEventPage` (`selectedTicketId`); the CTA (floating pill + docked bar) routes via `router.push(checkoutPublicPath(event.id))` to `/checkout/{eventId}` — a SEPARATE tier-picker screen. Consumer: a radiogroup + `openCart()` opens `TicketCartSheet` (multi-tier qty cart). There is no on-page ticket box with steppers + running all-in total + in-box Proceed today. (F-5)
+
+### Q6 — Does a `pg_public_event_by_slug` RPC exist?
+**Verdict: NO (confirmed).** `information_schema.routines` returns only `pg_public_event_tier_allin` for the event-public family. 0 code/migration hits for `pg_public_event_by_slug`. Web reads `business_public_events_view` by `(brand_slug, slug)` via `getPublicEventBySlug`; consumer feeds from the deck card (`pg_discover_business_events`) + `useEventTheme` (view) + `usePublicEventTickets`. (F-6)
+
+### Q7 — What is the all-in price contract?
+**Verdict: confirmed.** Per-tier all-in comes from `pg_public_event_tier_allin` (`fetchTierAllInCents` → merged into each ticket's `priceAllInGbp`). `resolveOfferingCta`/`formatPrice` ALWAYS use `priceAllInGbp ?? priceGbp` (WYSIWYP). The running total in any inline box MUST be Σ(`priceAllInGbp` × qty), never bare base. (F-7)
+
+### Q8 — Is there a city-level (privacy) geo field, and what is the map status?
+**Verdict: NO city-level field (confirmed); map currently OMITTED on web body.** `location_geo` (point) is the EXACT venue pin; `city` (text) is a label only — there is NO city-centroid lat/lng. `FoundationEventPreview` is "rule-9 OMITTED" (renders a text venue card, no static map) per its own header comment, even though `locationGeo` now flows through the mapper (ORCH-1162). The ORCH-1165 builders (`buildProxyStaticMapUrl`) take `lat`/`lng` and return null when coords missing. Data reality: of 89 `event_type='event'` rows, 77 have NULL `location_geo`, 13 have a `city`. So map + city-level rendering MUST be default-safe. (F-8)
+
+### Q9 — What is the shell constraint?
+**Verdict: confirmed mandatory.** Consumer mounts `BottomSheetScrollView` as a DIRECT child of `BaseBottomSheet` (ConsumerEventDetailScreen ~L1007); it CANNOT host `ParallaxCoverShell` as the scroll root (ORCH-1016/1043/1138 freeze). `PublicEventProps.ScrollComponent` injection already exists in the legacy contract (types.ts L154) precisely for this. The shared body must be a pure content body, scroll-host-injected per surface. (F-9)
+
+### Q10 — Package-home + isolation reality for consolidation?
+**Verdict: confirmed.** `@mingla/offering-rendering` peer-depends on `@mingla/event-rendering` (offering-rendering/package.json L13; index.ts re-exports `offeringSurfaceStyles` FROM event-rendering at L67–71). Import-site counts: **88 files** import `@mingla/event-rendering`; **26** import `@mingla/offering-rendering`. Aliases wired in 4 places: `mingla-business/tsconfig.json` (L10–13), `app-mobile/tsconfig.json` (L15–18), `mingla-business/metro.config.js` (L41–58), `app-mobile/metro.config.js` (L23–37). I-MOR-0827-PACKAGE-ISOLATION forbids `app-mobile`↔`mingla-business` cross-imports; packages must stay app-src-free. (F-10)
+
+---
+
+## Findings (six-field)
+
+### F-1 — The standard-event body is NOT shared (web-body + consumer-fork)
+- **Symptom:** a field added to the event read shows on web/business but not consumer (and vice-versa) unless edited twice; drift risk identical to RSVP/trip/experience.
+- **Layer:** code.
+- **Probe:** read `FoundationEventPreview.tsx`, `ConsumerEventDetailScreen.tsx`, `packages/event-rendering/PublicEventPage.tsx`; grep import sites.
+- **Evidence:** `FoundationEventPreview.tsx` L103–126 (props) + L455–491 (render) is in `mingla-business/src/`. `ConsumerEventDetailScreen.tsx` L1007–1165 renders its own body. `PublicEventPage.tsx` (package) header says it's the legacy/cancelled+password fallback (per COMMS-0038).
+- **Mechanism:** the live body physically lives in `mingla-business/src/`, which `app-mobile` cannot import (I-MOR-0827) → consumer hand-mirrors → structural drift.
+- **Severity:** CONFIRMED ROOT CAUSE (of the SoT gap this leg closes).
+
+### F-2 — Pill field names (binding)
+- **Layer:** schema. **Probe:** `information_schema.columns` on `events` + `business_public_events_view`.
+- **Evidence:** `events`: `vibe_tags _text`, `party_types _text`, `music_genres _text`. View exposes all three + `location_geo point` + `city text` + `is_online bool` + `location_mode text` + `event_type text` + `timezone text`.
+- **Mechanism:** these are the canonical columns the read payload must carry for the pills row.
+- **Severity:** CONFIRMED (reference fact).
+
+### F-3 — Pills not threaded to render (asymmetric drop)
+- **Symptom:** no vibes/party-type/music-genre pills on the standard-event public page.
+- **Layer:** code. **Probe:** read web mapper + consumer foundation mapper.
+- **Evidence:** web `publicEventViewRowToEvent` maps `partyTypes`/`vibeTags` but NOT `musicGenres`; `mapConsumerEventToFoundation` drops `partyTypes`/`vibeTags`/`musicGenres` from `BusinessEventCard`. Neither body renders a vibe/party/music pill on the ticket path.
+- **Mechanism:** data exists end-to-end at the DB/view but is dropped at the mapper/render layers → pills absent.
+- **Severity:** CONFIRMED ROOT CAUSE (for the pills-row charter item).
+
+### F-4 — Format is derived (no column)
+- **Layer:** schema+code. **Evidence:** Q4. No `events.format`; `asFormat`/`deriveSharedFormat` both fall back to `is_online`.
+- **Mechanism:** the shared body's `format` prop must be computed by the canonical read path (NOT a raw column), and `PublicEventProps.format` already encodes `"in-person"|"online"|"hybrid"`.
+- **Severity:** CONFIRMED (reference fact; constrains the RPC/adapter).
+
+### F-5 — Ticket UI is a separate selection screen, not an inline box
+- **Symptom:** charter wants on-page ticket box; today it's a select + route-out.
+- **Layer:** code. **Evidence:** `PublicEventPage.tsx` CTA → `router.push(checkoutPublicPath(event.id))` (`/checkout/{eventId}`). Consumer `openCart()` → `TicketCartSheet` (separate sheet). No steppers + running all-in + in-box Proceed exists today.
+- **Mechanism:** structural change required: inline box replaces the separate tier-picker on web/business; on consumer the box drives the existing cart populated.
+- **Severity:** CONFIRMED (scope-defining gap).
+
+### F-6 — No `pg_public_event_by_slug`; split read paths
+- **Layer:** schema+code. **Evidence:** Q6. Web → `business_public_events_view`; consumer → deck RPC + theme view + tickets hook.
+- **Mechanism:** two adapters → a new field needs N edits → drift. The canonical RPC closes this.
+- **Severity:** CONFIRMED ROOT CAUSE (for the one-read-path charter item).
+
+### F-7 — All-in price contract (WYSIWYP)
+- **Layer:** code. **Evidence:** Q7; `offeringCta.ts` L112–130 (`formatPrice` uses `priceAllInGbp ?? priceGbp`).
+- **Mechanism:** any inline running total = Σ all-in; never bare base. Pre-existing single-owner (`pg_public_event_tier_allin`).
+- **Severity:** CONFIRMED (binding constraint).
+
+### F-8 — No city-level privacy geo; map omitted; sparse data
+- **Symptom:** charter wants a city-level map when address hidden; today there's no city-centroid and the web body shows no map at all.
+- **Layer:** schema+code+data. **Evidence:** Q8; `FoundationEventPreview.tsx` header comment "map is rule-9 OMITTED"; `buildProxyStaticMapUrl` returns null on missing coords; 77/89 events have NULL `location_geo`.
+- **Mechanism:** new city-level geo field + a privacy gate that feeds the map a city-centroid (no exact pin) when `hideAddressUntilTicket` and not purchased; map must default-safe degrade to the text venue card when neither geo is present.
+- **Severity:** CONFIRMED ROOT CAUSE (for the map/privacy charter item).
+
+### F-9 — Shell-agnostic constraint is mandatory
+- **Layer:** code. **Evidence:** Q9; `ScrollComponent?: ComponentType<ScrollViewProps>` already in `PublicEventPageProps` (types.ts L154).
+- **Mechanism:** the new shared body must accept a `ScrollComponent` injection and NOT host its own scroll root; consumer injects `BottomSheetScrollView`, web/business inject RN `ScrollView`.
+- **Severity:** CONFIRMED (binding constraint; gorhom freeze).
+
+### F-10 — Package consolidation surface
+- **Layer:** code+config. **Evidence:** Q10; 88 vs 26 import sites; offering-rendering peer-depends on event-rendering; 4 alias config files.
+- **Mechanism:** dissolving event-rendering into offering-rendering means moving exports + flipping ~88 import lines + 4 alias configs + the I-MOR-0827 gate path — a large, mechanical, high-blast-radius change. Recommend phasing (see below).
+- **Severity:** CONFIRMED (scope/sequencing input).
+
+---
+
+## Five-Truth-Layer reconciliation
+
+| Layer | Truth | Contradiction |
+|-------|-------|---------------|
+| Docs | COMMS-0038 says event = web-body+consumer-fork, leg 1 of META | none — matches code |
+| Schema | `vibe_tags`/`party_types`/`music_genres`/`location_geo`/`city` all on events + view; no `format` col; no city-centroid; no `pg_public_event_by_slug` | view carries pills the code drops (F-3) |
+| Code | bodies forked; pills dropped at mappers; ticket = select+route-out; map omitted | CODE drops data SCHEMA exposes (F-3); CODE omits map though `locationGeo` flows (F-8) |
+| Runtime | n/a (audit) | — |
+| Data | 77/89 events NULL `location_geo`; 13 have city | map/city features MUST be default-safe — most events have neither geo (F-8) |
+
+**Key contradiction:** schema exposes the pill arrays + venue geo, but the render/mapper layers drop them. The gap between schema and code IS the missing-pills + missing-map bug.
+
+---
+
+## Blast radius / cross-surface map
+
+**In scope (5 primary surfaces):** consumer iOS, consumer Android (`ConsumerEventDetailScreen` fork retired → wraps shared body), buyer-web + business iOS + business Android (`FoundationEventPreview` promoted to shared body; web `/checkout/[eventId]` tier-picker REPLACED by the inline box).
+**Adjacent:** business-web preview route (`/event/[id]/preview` currently renders the separate `PreviewEventView` — must be reconciled to the shared body or explicitly deferred). Admin-web: NOT in scope (no public event page).
+**Out of scope:** RSVP/trip/experience legs (separate META legs — COMMS-0040/0044/0041). The legacy `PublicEventPage.tsx` cancelled/password fallback (touch only if the shared body subsumes those states).
+
+---
+
+## Invariant impact (flagged, not pre-decided)
+- **I-MOR-0827-PACKAGE-ISOLATION** — the new shared body + the consolidation must keep packages app-src-free; consumer can't import `mingla-business/src`. The CI gate path must update if `event-rendering` dissolves.
+- **WYSIWYP / all-in (ORCH-1147)** — inline box running total must be Σ all-in.
+- **I-PAID-SUPPLY-REQUIRES-CHARGES-ENABLED (ORCH-1076)** — `bookable` gates the box/CTA first.
+- **Rule-9 (no fabricated data)** — pills omit when arrays empty; map omits when no geo.
+- New DRAFT invariants proposed in the SPEC (I-PROPOSED-1167-*).
+
+## Discoveries for Orchestrator
+1. **D-1 (asymmetric music_genres drop):** the web mapper silently omits `music_genres` though the view exposes it — a latent bug independent of this leg; folded into F-3 here.
+2. **D-2 (preview route divergence):** `/event/[id]/preview` renders a separate MID-fidelity `PreviewEventView`, NOT `FoundationEventPreview` — a 4th event-body variant. SPEC must decide reconcile-now vs defer.
+3. **D-3 (sparse geo):** 77/89 events have no venue geo — the city-level map will be invisible for most existing events until brands add addresses; this is expected (rule-9) but worth noting for QA expectations.
+
+## Confidence
+**proven** for all schema/data facts (DB-queried) and code-structure facts (files read verbatim). No runtime reproducer needed (architecture/SoT consolidation, not a runtime bug). Recommended next phase: SPEC (this turn, IA mode).

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1167_EVENT_PAGE_CANONICAL.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1167_EVENT_PAGE_CANONICAL.md
@@ -1,0 +1,152 @@
+# IMPLEMENT — ORCH-1167 [event-page-canonical] — Canonical Standard-Event Public Page
+
+**Leg 1 of META-ORCH-1166.** Phase 1 (shared body + RPC + city-geo + inline box), per SPEC binding contract.
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1167-[event-page-canonical]/` on branch `ORCH-1167-event-page-canonical`.
+**Status:** implemented and self-verified (source typechecks clean; gates green; happy-path test green with fails-on-revert proof; migrations WRITTEN + schema-probe-verified, UNAPPLIED). Runtime sim/device verification is the tester's phase.
+
+---
+
+## 1. Summary
+
+Standardized the STANDARD ticketed-event public page (`event_type='event'` only) into ONE shared, shell-agnostic body — `EventOfferingBody` in `packages/offering-rendering` — rendered from one prop contract on buyer-web, business iOS/Android, and consumer iOS/Android. The body renders Seth's locked 9-section structure. Its centerpiece is the new **inline on-page ticket box** (per-tier quantity steppers + live Σ-all-in running total (WYSIWYP) + in-box Proceed) that REPLACES the `/checkout/[eventId]` tier-picker on web/business and pre-populates the cart at the editable cart step (i) on every surface. All three surfaces read the new anon RPC `pg_public_event_by_slug`; the new `city_geo` privacy field + the vibes/party-types/music-genres pills are threaded end-to-end (closing the F-3 `music_genres` drop). Package consolidation is Phase-1-only (the body lives in offering-rendering and imports from `@mingla/event-rendering` via the existing peer-dep; no 88-import mass-flip).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | How met | Commit |
+|----|---------|--------|
+| **SC-1 (9-section order)** — all 3 surfaces render sections 1–9 in the locked order | `EventOfferingBody` renders sections 2–8 (incl. inline box at 5) in order; cover (1) + floating bar (9) are surface-pinned siblings; asserted by `orch-1167-canonical-9-section-order.mjs`. SC-1-Web/bizIOS/bizAndroid via `FoundationEventPreview`→`EventOfferingBody`; SC-1-consIOS/consAndroid via `ConsumerEventDetailScreen` standard branch→`EventOfferingBody`. | HEAD |
+| **SC-2 (pills)** — format → vibes → party-types → music-genres → tickets-left, each group omits when empty | Pills row in `EventOfferingBody` (testID `orch-1167-pills-row`), rule-9 empty-omit. Threaded: web mapper (`musicGenres` added), consumer foundation (`partyTypes/vibeTags/musicGenres`), RPC payload. | HEAD |
+| **SC-3 (inline box, all-in)** — steppers; running total = Σ(priceAllInGbp×qty) to the cent; never bare base | `computeRunningTotal` (pure module `eventBoxTotals.ts`); WYSIWYP. Proven by the happy-path test + `orch-1167-allin-price-in-ticket-box.mjs`. | HEAD |
+| **SC-4 (proceed → cart step i, populated, editable)** | Web/business: `onProceedToCart` → `checkoutPublicPathWithSeed` (`?seed=id:qty,…`) → `/checkout/[eventId]` seeds `CartContext` on mount (editable QuantityRows). Consumer: `onProceedToCart` → `TicketCartSheet` with new `initialQuantities` multi-tier seed. | HEAD |
+| **SC-5 (CTA states)** — free / waitlist / approval / sold-out / pre-sale / past / cancelled / door-only / not-bookable | `EventOfferingBody` + `EventOfferingFloatingBar` resolve via the shared `resolveOfferingCta` (one owner) + the per-tier sub-predicates (`ticketIsSoldOut`/`ticketIsDoorOnly`/`ticketSaleEnded`); `bookable=false` → "Booking unavailable". | HEAD |
+| **SC-6 (shell-agnostic)** — consumer scrolls with `BottomSheetScrollView` (direct child, no freeze); body hosts no scroll root | Body declares no scroll container (asserted by `orch-1167-shell-agnostic-body.mjs`); consumer keeps its proven `BaseBottomSheet`+`BottomSheetScrollView` scaffold; web/business use `ParallaxCoverShell`+RN `ScrollView`. | HEAD |
+| **SC-7 (one read path)** — all 3 fetch from `pg_public_event_by_slug`; adding a field surfaces on all 3 with one mapper edit (verified by `musicGenres`) | Web/business `detailFromRow` merges `fetchCanonicalEventBodyFields` (RPC) onto the LiveEvent; consumer `usePublicEventBySlug` reads the RPC directly. `musicGenres` added once in the RPC payload → surfaces everywhere. Asserted by `orch-1167-one-read-rpc.mjs`. | HEAD |
+| **SC-8 (city-level map, no exact pin when hidden)** | RPC enforces privacy server-side (`address`+`locationGeo` NULL when hidden; `cityGeo` returned). Hosts feed `locationGeo ?? cityGeo` to `buildProxyStaticMapUrl` (zoom 14 exact / 11 city). No geo → text venue card (rule 9). Asserted by `orch-1167-city-level-map-no-exact-pin-when-hidden.mjs`. | HEAD |
+| **SC-9 (web close-X)** — ORCH-1159 preserved | `FoundationEventPreview` passes `hideCloseOnWeb` to `ParallaxCoverShell`; Share present everywhere. | HEAD |
+
+---
+
+## 3. Files changed (25)
+
+**Database (2 migrations, UNAPPLIED):**
+- `supabase/migrations/20261015000000_orch_1167_event_city_geo.sql` (new, +~140) — `events.city_geo geometry(Point,4326)` + view exposure.
+- `supabase/migrations/20261015000001_orch_1167_pg_public_event_by_slug.sql` (new, +~250) — canonical anon RPC.
+
+**Shared packages:**
+- `packages/event-rendering/types.ts` (+~25) — `musicGenres`, `cityGeo` on `PublicEventProps`.
+- `packages/offering-rendering/EventOfferingBody.tsx` (new, ~720) — the shared body + `EventOfferingFloatingBar`.
+- `packages/offering-rendering/eventBoxTotals.ts` (new, ~55) — pure Σ-all-in totals (RN-free, unit-testable).
+- `packages/offering-rendering/index.ts` (+~8) — additive exports.
+
+**Buyer-web + business (RN one codebase):**
+- `mingla-business/src/components/event/FoundationEventPreview.tsx` (rewritten ~210) — thin wrapper of `EventOfferingBody` in `ParallaxCoverShell`.
+- `mingla-business/src/components/event/PublicEventPage.tsx` (~−90/+90) — `ticketQuantities` state, `onProceedToCart` → seeded cart path, inline box owns CTA, `staticMapUrl`, `EventOfferingFloatingBar`; retired the docked/sticky `EventReserveBar` CTA.
+- `mingla-business/src/services/publicEventsService.ts` (+~90) — `fetchCanonicalEventBodyFields` (RPC), `music_genres`/`city_geo` row fields, merge in `detailFromRow`.
+- `mingla-business/src/store/liveEventStore.ts` (+~10) — `cityGeo` on `LiveEvent`.
+- `mingla-business/src/constants/publicUrls.ts` (+~45) — `encodeCartSeed`/`decodeCartSeed`/`checkoutPublicPathWithSeed`.
+- `mingla-business/app/checkout/[eventId]/index.tsx` (+~35) — seed the cart from the `seed` param on mount (editable).
+
+**Consumer (app-mobile):**
+- `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx` (~−170/+110) — standard branch renders `EventOfferingBody` + `EventOfferingFloatingBar`; RSVP branch UNCHANGED; removed the dead radiogroup/`ConsumerTierRow`/`ConsumerEventReserveBar`/`offeringCta`/`openCart`.
+- `app-mobile/src/hooks/usePublicEventBySlug.ts` (new, ~210) — consumer RPC read + mapper.
+- `app-mobile/src/hooks/useConsumerEventFoundation.ts` (+~25) — `partyTypes/vibeTags/musicGenres/cityGeo` threaded.
+- `app-mobile/src/components/expandedCard/TicketCartSheet.tsx` (+~50) — `initialQuantities` multi-tier seed.
+
+**CI gates + tests + workflow:**
+- 5 × `.github/scripts/strict-grep/orch-1167-*.mjs` (new) + `.github/workflows/strict-grep-mingla-business.yml` (+5 jobs).
+- `packages/offering-rendering/__tests__/orch_1167_event_box_totals.test.ts` (new) — happy-path regression.
+
+---
+
+## 4. Data-model changes (written, UNAPPLIED)
+
+- `public.events.city_geo geometry(Point,4326)` NULLable, DEFAULT NULL, additive (rule-9; 77/89 events stay NULL → no map). Exposed on `business_public_events_view` (mirrors the ORCH-1150 column list verbatim + appends `e.city_geo`).
+- `public.pg_public_event_by_slug(text, text) RETURNS json` — anon SECURITY DEFINER STABLE, `GRANT EXECUTE TO anon, authenticated`. Reads anon-safe columns only; privacy enforced server-side (omits exact `address`+`location_geo`, returns `city`+`city_geo` when the street is hidden). Per-tier all-in via the same `compute_all_in_cents` single owner.
+
+**Schema probe (read-only, live):** confirmed `location_geo point`, `city text`, `party_types/music_genres ARRAY`, `city_geo` not-yet-existing, `tickets.status text`, `quantity_total integer`, `compute_all_in_cents(p_base_cents,p_pass_mingla_fee,p_pass_service_fee,p_effective_take_rate_bps,p_service_fee_bps DEFAULT 300)`, `resolve_effective_take_rate_bps → TABLE(effective_take_rate_bps int,…)`, `ST_X/ST_Y(point::geometry)` valid, `theme #>> '{business_event,hideAddressUntilTicket}'` resolves. The migrations match these exactly.
+
+---
+
+## 5. Edge functions touched
+
+None. The RPC is a SQL migration. No edge-function deploy needed for this leg. (`ticket-checkout-create` / PaymentSheet money flow untouched — DO-NOT-TOUCH honored.)
+
+---
+
+## 6. Regression tests added
+
+- `packages/offering-rendering/__tests__/orch_1167_event_box_totals.test.ts` — 4 tests, all PASS (run: `cd mingla-business && npx jest --roots=../packages --testPathPattern="orch_1167_event_box_totals"`).
+- **fails-on-revert verified at `0a85c8f34`** — by TRUE LINE DELETION of the all-in coalesce (`const price = ticket.priceAllInGbp ?? ticket.priceGbp;` → bare `ticket.priceGbp`) in `eventBoxTotals.ts` → 2 tests FAILED (T-04 all-in total + the no-markup assert); restored → 4 PASS.
+
+---
+
+## 7. Old → New receipts (key surfaces)
+
+**`packages/offering-rendering/EventOfferingBody.tsx`** — Before: did not exist; the event body was forked (web/business `FoundationEventPreview` radiogroup+route-out, consumer hand-mirrored). Now: ONE shared shell-agnostic body with the canonical 9-section structure + the inline ticket box (steppers + Σ-all-in + Proceed) + `EventOfferingFloatingBar`. Why: SoT consolidation + inline box (SPEC §3A/§4C).
+
+**`mingla-business/src/components/event/PublicEventPage.tsx`** — Before: single-select radiogroup (`selectedTicketId`) + `handleReserve` → `router.push(checkoutPublicPath(id))` (empty tier-picker). Now: `ticketQuantities` + `onProceedToCart` → `checkoutPublicPathWithSeed` (cart pre-populated, editable); the inline box owns the CTA; legacy docked/sticky `EventReserveBar` retired. Why: SC-3/SC-4.
+
+**`mingla-business/src/services/publicEventsService.ts`** — Before: `getPublicEventBySlug` read only the view; the mapper dropped `music_genres` (F-3). Now: `detailFromRow` merges `fetchCanonicalEventBodyFields` (the RPC) onto the LiveEvent (pills + `cityGeo`); `music_genres` threaded. Why: SC-7 + F-3.
+
+**`app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx`** — Before: standard branch hand-rolled lead/meta/brand/about/venue + a radiogroup + `ConsumerEventReserveBar`. Now: standard branch renders the shared `EventOfferingBody` + `EventOfferingFloatingBar`; `onProceedToCart` → `TicketCartSheet` `initialQuantities`. RSVP branch byte-identical. Why: SoT + inline box (consumer).
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Covered | Parity |
+|---|---|---|
+| Consumer iOS | YES | shared body |
+| Consumer Android | YES | shared body |
+| Buyer/anon Web | YES (inline box replaces `/checkout` tier-picker) | shared body |
+| Business iOS | YES | shared body |
+| Business Android | YES | shared body |
+| Admin Web | NO (no public event page) | n/a |
+| Business Web preview (`/event/[id]/preview`) | DEFER (OQ-3 — separate `PreviewEventView` untouched) | manual/deferred |
+
+---
+
+## 9. Gate / test results
+
+- 5 × `orch-1167-*` strict-grep gates: SELF-TEST PASS + REAL PASS (all 5). Registered as 5 workflow jobs.
+- Adjacent gates re-run green: `meta-orch-0827-package-isolation` (covers `EventOfferingBody` → SC-isolation/T-17), `orch-1138-mor-isolation`, `orch-1153-no-bare-base-under-allin`, `orch-1153-reserve-verb`.
+- Happy-path test: 4/4 PASS; fails-on-revert proven @ `0a85c8f34`.
+- TypeScript: my non-package files (PublicEventPage, FoundationEventPreview, publicEventsService, liveEventStore, checkout index, publicUrls, ConsumerEventDetailScreen, usePublicEventBySlug, useConsumerEventFoundation, TicketCartSheet, eventBoxTotals) — ZERO errors under both the business and app-mobile tsc. The `packages/offering-rendering/EventOfferingBody.tsx` errors are the SAME pre-existing `Cannot find module 'react'` tsconfig-boundary artifact that the shipped `ChipGroup.tsx`/`ParallaxCoverShell.tsx` show (packages are typechecked via the apps' Metro bundler, not standalone).
+
+---
+
+## 10. Known issues / deferred
+
+- **OQ-3 (preview route):** `/event/[id]/preview` still renders the separate `PreviewEventView` (deferred per SPEC recommendation).
+- **OQ-4 (package dissolution):** Phase 2 (88-import flip) NOT done this leg (SPEC-recommended deferral).
+- **Consumer cold-path `dateLine`:** `usePublicEventBySlug` returns an empty `dateLine` (the RPC payload carries `masterStartAt` ISO but the consumer formats dates via the deck warm path; the cold-path date eyebrow is omitted, not fabricated — rule 9). The warm deck path (the common case) has the formatted line. A follow-on can format the cold-path date.
+- **Consumer warm-path `cityGeo`:** the deck `BusinessEventCard` carries no city centroid → `cityGeo=null` on the warm path (the exact pin still renders when public). The cold-path RPC supplies `cityGeo`.
+
+---
+
+## 11. Operator action required
+
+**Apply the 2 migrations via the Supabase Management API (review first; DO NOT `db push` blindly — these are spec-only this leg):**
+- `supabase/migrations/20261015000000_orch_1167_event_city_geo.sql`
+- `supabase/migrations/20261015000001_orch_1167_pg_public_event_by_slug.sql`
+
+Both are additive + idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE OR REPLACE VIEW`, `DROP FUNCTION IF EXISTS` then `CREATE`). Apply in order (city_geo first — the RPC + view read it). After apply, `NOTIFY pgrst` reloads the schema. No edge-function deploy required.
+
+**The `city_geo` capture-at-publish path (SPEC §4A "DERIVE city_geo from the resolved city centroid") is the column + read exposure ONLY this leg — the publish-time write of `city_geo` is a follow-on (no existing row has it; new publishes will need the city-centroid geocode wired into the publish RPC). Flagged for orchestrator.**
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **D-1 (city_geo publish-write not wired):** Migration 1 adds the column + view/RPC read exposure, but nothing WRITES `city_geo` yet (SPEC §4A names the publish/address-write path as the capture point). Until a follow-on geocodes the city centroid at publish, every event renders the text venue card (rule-9 default-safe). Recommend a small follow-on ORCH for the publish-time `city_geo` write.
+- **D-2 (consumer cold-path date):** see §10 — the cold-path RPC date eyebrow is omitted; a follow-on can thread the formatted AM/PM line from `masterStartAt`.
+- **D-3 (jest `@mingla/*` alias):** `publicEventsService.test` fails to resolve `@mingla/event-rendering` under the node-env jest config (PRE-EXISTING, untouched import). The package tests run under Deno / `--roots=../packages`. Not introduced by this leg.
+- **D-4 (preview 4th body):** `PreviewEventView` remains a 4th event-body variant (OQ-3 deferred) — a future leg should reconcile it to `EventOfferingBody` in non-bookable preview mode.
+
+---
+
+## 13. Comms ledger
+
+Scanned `COMMS_LEDGER.md` on entry. No `BLOCK`+`OPEN` rows targeting ORCH-1167 / `mingla-implementor` / `ALL`. COMMS-0038 (this charter), COMMS-0040/0041/0044 (sibling RSVP/trip/experience legs — this leg sets the shell-agnostic-body precedent), COMMS-0043 (ORCH-1159 close-X — preserved). No new cross-ORCH discovery requiring a ledger write.

--- a/Mingla_Artifacts/reports/TEST_ORCH-1167_EVENT_PAGE_CANONICAL.md
+++ b/Mingla_Artifacts/reports/TEST_ORCH-1167_EVENT_PAGE_CANONICAL.md
@@ -1,0 +1,91 @@
+# TEST — ORCH-1167 [event-page-canonical] — Canonical Standard-Event Public Page
+
+**Verdict: CONDITIONAL PASS** (merge-ready; conditions are non-blocking cosmetic/UX items + the runtime-scroll claim that is source-verified only, owned by Seth's on-device QA).
+
+**Tester:** mingla-tester (brutal last line). Assumed broken until proven. Independent source + live-fire DB verification; own adversarial test written + fails-on-revert proven.
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1167-[event-page-canonical]/` @ `62a3f7531`.
+**Contract:** SPEC `…/specs/SPEC_ORCH-1167_EVENT_PAGE_CANONICAL_STRUCTURE.md`; IMPLEMENT `…/reports/IMPLEMENT_ORCH-1167_EVENT_PAGE_CANONICAL.md`.
+
+---
+
+## 1. Verdict rationale
+
+The product change is real, correctly scoped, and proven at the layers that can be proven here. The ONE shared `EventOfferingBody` is consumed by all 3 surfaces; the ONE anon RPC `pg_public_event_by_slug` is applied to prod, anon-granted, and — verified against ALL 14 live published events — **leaks ZERO exact pins/addresses for the 4 hidden-address events** (the headline privacy invariant). The Σ-all-in WYSIWYP math, the hostile cart-seed boundary, and all 5 + 5 strict-grep gates hold, each with fails-on-revert proof. Scope is clean (every changed file inside the §12 allowlist; no RSVP/trip/experience/admin/pricing-engine bleed).
+
+It is CONDITIONAL (not full PASS) for two reasons, neither a merge blocker:
+- **SC-6 runtime (consumer gorhom scroll-no-freeze)** could NOT be proven by live sim in this environment (no booted simulator / no Metro). Source-verified only → capped at "suspected." This is Seth's on-device sign-off (per dispatch).
+- **Two non-blocking observations** (D-T1 desktop title duplication, D-T2 consumer/web floating-bar dock anchored to body-top not box) — UX/cosmetic, source-suspected, flagged for Seth's device QA.
+
+---
+
+## 2. Per-SC evidence
+
+| SC | Result | Evidence |
+|----|--------|----------|
+| **SC-1 (9-section order)** | PASS (source) | `orch-1167-canonical-9-section-order.mjs` real PASS + self-test PASS; body renders sections 2–8 in locked order, cover(1)+float(9) surface-pinned. All 3 surfaces wrap the shared body (FoundationEventPreview / ConsumerEventDetailScreen standard branch). |
+| **SC-2 (pills order + omit-empty)** | PASS (source) | Pills row `format → vibeTags → partyTypes → musicGenres → tickets-left`, each group `.map` over a `?? []` array (rule-9 omit). `musicGenres` threaded web (mapper + RPC merge) + consumer (foundation + RPC). |
+| **SC-3 (inline box Σ-all-in, never bare base)** | **PASS (proven)** | `computeRunningTotal` = Σ(`priceAllInGbp ?? priceGbp`×qty). Happy-path test 4/4 PASS; **fails-on-revert reproduced**: deleting the coalesce in `eventBoxTotals.ts` → 2 tests FAIL (got 105 base vs 130 all-in), restored → PASS. |
+| **SC-4 (proceed → cart step (i), populated + editable)** | PASS (source) + **boundary PROVEN** | Web: `onProceedToCart`→`checkoutPublicPathWithSeed(id,qty)`→checkout index `useEffect` seeds `setLineQuantity` once on mount (editable QuantityRows). Consumer: `handleProceedToCart`→`TicketCartSheet initialQuantities` multi-tier seed (capped by capacity). My adversarial seed test (10/10) proves the seed round-trip is lossless + hostile-input safe. |
+| **SC-5 (CTA states)** | PASS (source) | Box + floating bar both resolve via shared `resolveOfferingCta` (one owner) + per-tier `ticketIsSoldOut/DoorOnly/SaleEnded`; `bookable=false`→disabled "Booking unavailable". Free/waitlist/buy label branches present in both `EventOfferingBody` and `EventOfferingFloatingBar`. |
+| **SC-6 (shell-agnostic, gorhom no-freeze)** | **SUSPECTED** (source only — runtime NOT run) | `orch-1167-shell-agnostic-body.mjs` PASS: body declares no `ScrollView`/`BottomSheetScrollView`/`FlatList`/`ParallaxCoverShell` root. Consumer keeps the proven `BaseBottomSheet`+`BottomSheetScrollView`-as-direct-child scaffold (ORCH-1016/1043/1138). **No sim available → cannot confirm no-freeze at runtime; capped at suspected. Seth's on-device QA owns this.** |
+| **SC-7 (one read path)** | PASS-with-caveat (source) | `orch-1167-one-read-rpc.mjs` PASS: web service + consumer hook both call `pg_public_event_by_slug`. CAVEAT: web still reads the page row from `business_public_events_view` then MERGES pills/cityGeo from the RPC (view+RPC, not pure single-read); the RPC's per-tier all-in is discarded on web (web uses `fetchTickets`→`fetchTierAllInCents`). "One mapper edit surfaces everywhere" is true for consumer; web needs the `fetchCanonicalEventBodyFields` mapper + `detailFromRow` merge edited. Non-blocking — `musicGenres` did surface on all 3 this leg. |
+| **SC-8 (city-level map, no exact pin when hidden)** | **PASS (live-fire PROVEN)** | RPC gates `address`+`locationGeo` NULL on `hide_address_until_ticket`, returns `cityGeo`. **Live prod probe over ALL 14 published events: hidden=4, LEAKS=0** (no hidden event emits non-null locationGeo or address). Public event "Big Party" correctly returns exact `{lat,lng}`+address+tickets. Host feeds `locationGeo ?? cityGeo`, zoom 14 exact / 11 city. NOTE: 0 events have `city_geo` written yet (D-1: publish-write unwired) → hidden events currently render NO map (rule-9 text card), which is honest + safe. |
+| **SC-9 (web close-X preserved, ORCH-1159)** | PASS (source) | `FoundationEventPreview` passes `hideCloseOnWeb` to `ParallaxCoverShell`; Share present everywhere; `orch-1153-reserve-verb` adjacent gate green. |
+
+---
+
+## 3. Gate / test results
+
+**ORCH-1167 strict-grep gates (5/5 — self-test + real, all PASS):**
+- `orch-1167-allin-price-in-ticket-box` ✔ self + real
+- `orch-1167-canonical-9-section-order` ✔ self + real
+- `orch-1167-city-level-map-no-exact-pin-when-hidden` ✔ self + real
+- `orch-1167-one-read-rpc` ✔ self + real
+- `orch-1167-shell-agnostic-body` ✔ self + real
+
+**Adjacent regression gates (green):** `meta-orch-0827-package-isolation` (covers the new body — T-17 isolation), `orch-1138-mor-isolation`, `orch-1153-no-bare-base-under-allin`, `orch-1153-reserve-verb`, `orch-1138-event-deck-off-ebes`.
+
+**Jest:**
+- Implementor happy-path `orch_1167_event_box_totals` — **4/4 PASS**; fails-on-revert independently reproduced (revert coalesce → 2 FAIL).
+- My adversarial `orch_1167_cart_seed.adversarial` — **10/10 PASS**; fails-on-revert proven (revert decode guards → 6 FAIL).
+- Adjacent `publicUrls.test` — 6/6 PASS.
+- `publicEventsService.*` / `checkout-trip` / `liveEventStore-migrator` / `meta_orch_0952_carousel` jest "failures" (15 suites) are **PRE-EXISTING + environmental** — `Cannot find module '@mingla/event-rendering'` (node-env jest alias, implementor D-3; the import exists on the base branch `be65f8f1c`), playwright-under-jest, missing `@testing-library/react-native`, deno asserts. NONE are ORCH-1167.
+
+**Typecheck:**
+- `mingla-business` tsc: ORCH-1167 files (PublicEventPage, FoundationEventPreview, publicEventsService, liveEventStore, checkout index, publicUrls, types.ts, eventBoxTotals) — **ZERO real errors**. `EventOfferingBody.tsx` + `event-rendering/types.ts` show ONLY the `Cannot find module 'react'` tsconfig-boundary artifact (packages typecheck via the apps' Metro bundler, identical to the shipped `ParallaxCoverShell.tsx`/pre-existing `event-rendering/PublicEventPage.tsx`).
+- `app-mobile` tsc: ORCH-1167 files (ConsumerEventDetailScreen, usePublicEventBySlug, useConsumerEventFoundation, TicketCartSheet) — **ZERO errors**. 557 baseline errors all in pre-existing deno/test files.
+
+**Build sanity (mingla-business web export + ORCH-1083 budget gate):**
+- `npx expo export -p web` — **SUCCEEDS** (664 modules bundled clean; no duplicate-import/export or syntax error — the regression this step catches for the 1167 RN-web changes).
+- ORCH-1083 `__common` budget gate + ORCH-1137 lucide render-proof — **NOT LOCALLY RUNNABLE / source-verified only.** The worktree's `node_modules` is a SYMLINK to the main checkout, and the local export emits a single non-production 984KB chunk (1 chunk vs the gate's required ≥3 code-split points; lucide glyph signature absent from the dev bundle). This is the MEMORY-documented "local `expo export` exit-0 ≠ web-shippable; the budget gate is CI-only" trap — an environment artifact, NOT an ORCH-1167 regression. The gate runs green in CI's clean install; flagged for the CI run, not a local blocker.
+
+**Live DB verification (prod):** `events.city_geo` exists, view exposes it (appended last), `pg_public_event_by_slug` live + `EXECUTE` granted to anon+authenticated; privacy probe = 0 leaks / 14 events; paid-tier all-in ≥ base always (all live tiers all-in==base because 0/8 charges-enabled brands pass a fee — the gross-up is proven by unit test, not live data, per the known MEMORY gotcha).
+
+---
+
+## 4. My adversarial test (different angle than implementor)
+
+**File:** `mingla-business/src/constants/__tests__/orch_1167_cart_seed.adversarial.test.ts` (NEW, immutable).
+**Angle:** the implementor tested the in-box Σ-all-in MATH (SC-3). I attacked the **untrusted cart-SEED boundary** that carries the selection from the public page into the cart (SC-4) — a hand-editable `?seed=` URL surface. Proves a hostile seed can NEVER inject a phantom line / negative / zero / NaN / fractional / empty-id quantity into the cart, and the legit encode↔decode round-trip is lossless (WYSIWYP integrity reaches the cart, not just the box).
+**Result:** 10/10 PASS.
+**Fails-on-revert (proven):** against the ORCH-1167 implementation commit **`6eb1d0b8c`**, deleting the `Number.isFinite(qty) && qty > 0` guards in `decodeCartSeed` (`mingla-business/src/constants/publicUrls.ts`) → **6 of 10 assertions FAIL** (hostile `seed=vip:-3`/`vip:0`/`vip:abc` leak negative/zero/NaN lines). Restored → 10/10 PASS.
+
+---
+
+## 5. Blocking defects
+
+**NONE.**
+
+## 6. Non-blocking observations (for Seth's device QA / a follow-on)
+
+- **D-T1 (desktop title duplication, cosmetic):** on the DESKTOP web/business two-column layout, `ParallaxCoverShell` renders `heroTitle`/`heroEyebrow` over the cover AND `EventOfferingBody` renders its own section-2 lead block in the same left column → the event name/date can appear twice on desktop. Phone-web, native business, and consumer render the title ONLY in the body (no dup — those shell branches don't render the hero caption). Verify on desktop web.
+- **D-T2 (floating-bar dock anchor, UX — suspected):** both web (`FoundationEventPreview`) and consumer (`ConsumerEventDetailScreen`) attach `onDockLayout`/`handleDockLayout` to a wrapper around the WHOLE body (`dockTopY` = body TOP), not around the inline ticket box. Since the body top sits just under the cover, `floatingPillVisible = dockTopY > scrollY + viewportH - margin` may flip the floating "Get tickets" bar to HIDDEN almost immediately on scroll — before the in-page box is actually reached. The float→dock was designed to track the box. Likely makes the floating CTA disappear earlier than intended. Source-suspected (no sim); confirm the floating bar shows while the box is off-screen on device.
+- **D-T3 (SC-7 web is view+RPC, not pure one-read):** web reads the page row from the view and merges pills/cityGeo from the RPC, discarding the RPC's per-tier all-in. Adding an RPC field needs the web `fetchCanonicalEventBodyFields` mapper + `detailFromRow` merge edited (consumer is one-edit). Acceptable this leg; note for the META-ORCH-1166 dissolution.
+- **D-T4 (ALLIN strict-grep gate inspects the wrong file):** `orch-1167-allin-price-in-ticket-box.mjs` greps `EventOfferingBody.tsx`, but the load-bearing running-total math lives in `eventBoxTotals.ts`. Reverting the coalesce in `eventBoxTotals.ts` does NOT trip the grep gate (it passes via the unrelated `formatTicketPrice` line in the body). The JEST test IS the real protection (it correctly fails-on-revert). Recommend pointing the gate at `eventBoxTotals.ts` in a follow-on so the grep gate isn't false-assurance.
+- **D-1 (carried from implementor, confirmed live):** `city_geo` publish-write is unwired (0/14 events have it) → hidden-address events render no map until a follow-on geocodes the city centroid at publish. Safe default (rule-9).
+
+---
+
+## 7. Scope / DO-NOT-TOUCH audit
+
+Every changed file (23, excluding artifacts) is inside the SPEC §12 allowlist. No RSVP/trip/experience body, no `mingla-admin`, no pricing engine / `ticket-checkout-create` / PaymentSheet, no 88-import mass-flip (Phase 2 correctly deferred). RSVP branch of `ConsumerEventDetailScreen` + `RsvpPublicBody` byte-untouched. Confirmed clean.

--- a/Mingla_Artifacts/specs/SPEC_ORCH-1167_EVENT_PAGE_CANONICAL_STRUCTURE.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1167_EVENT_PAGE_CANONICAL_STRUCTURE.md
@@ -1,0 +1,274 @@
+# SPEC — ORCH-1167 [event-page-canonical] — Canonical Standard-Event Public Page
+
+**Leg 1 of META-ORCH-1166 (public offering-page single source of truth).**
+**Companion investigation:** `Mingla_Artifacts/investigations/INVESTIGATE_ORCH-1167_EVENT_PAGE_CANONICAL.md`.
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1167-[event-page-canonical]/` on branch `ORCH-1167-event-page-canonical`.
+**Scope marker:** `event_type='event'` ONLY (standard ticketed event). NOT rsvp / trip / experience.
+
+This is a binding contract. The implementor builds exactly this. Anything outside the §12 allowlist requires a stop-and-amend.
+
+---
+
+## 1. Executive summary
+
+Standardize the standard ticketed-event public page into ONE shell-agnostic shared body — `EventOfferingBody` — living in `packages/offering-rendering`, rendered byte-identically on buyer-web, business iOS/Android, and consumer iOS/Android. The body renders Seth's locked 9-section vertical structure; its centerpiece is an **inline on-page ticket box** (per-tier quantity steppers, live Σ-all-in running total, in-box Proceed) that REPLACES the separate `/checkout/[eventId]` tier-picker on web/business and pre-populates the cart (landing on cart step (i), quantities still editable) on every surface. All three surfaces fill the body's props from ONE new anon read RPC, `pg_public_event_by_slug`, carrying the full payload incl. vibes/party-types/music-genres pills, a NEW city-level privacy geo field, tickets-left, and all-in tier prices. The package `@mingla/event-rendering` dissolves into `@mingla/offering-rendering` as the one canonical home (phased — see §4B).
+
+---
+
+## 2. Scope & non-goals
+
+**In scope:**
+- New shared `EventOfferingBody` in `packages/offering-rendering` (shell-agnostic, `ScrollComponent`-injected).
+- The 9-section canonical structure (§3A) incl. the inline ticket box.
+- Retire the consumer fork body (`ConsumerEventDetailScreen` standard-event branch wraps the shared body).
+- Promote `FoundationEventPreview` content into the shared body; web/business render it; replace the `/checkout/[eventId]` tier-picker with the inline box → cart step (i).
+- New canonical read RPC `pg_public_event_by_slug` (anon, SECURITY DEFINER) + per-surface adapters.
+- New city-level privacy geo field + migration + wizard/publish capture + read exposure.
+- Thread vibes/party-types/music-genres pills end-to-end (close the F-3 drop).
+- Package consolidation Phase 1 (§4B): new shared body + alias/gate updates; full event-rendering dissolution is Phase 2 (recommended deferred).
+
+**Non-goals (explicit):**
+- RSVP / trip / experience legs (separate META legs — COMMS-0040/0044/0041).
+- Admin-web (no public event page).
+- Changing the all-in pricing engine, `pg_public_event_tier_allin`, or the checkout/PaymentSheet money flow (reused as-is).
+- Re-theming, new motion, or copy beyond what the structure demands.
+- Backfilling geo for the 77 geo-less events (rule-9: those simply render the text venue card).
+
+**Assumptions:** the all-in engine, `ticket-checkout-create`, `TicketCartSheet`, and the brand page route are unchanged and reused.
+
+---
+
+## 3. The canonical contract
+
+### 3A. Locked 9-section vertical order (identical on all 3 surfaces)
+
+1. **Cover** — full-bleed media (image/GIF/video), parallax. (`EventCoverMedia` from event-rendering; parallax via the surface shell, NOT inside the body's scroll root.)
+2. **Event Name** — `event.name`.
+3. **Date & Time** — ORCH-1162 AM/PM formatting (`dateLine`/`dateSubline`; reuse the existing `formatEventDateLine`/AM-PM formatter, single owner).
+4. **Pills row** — STRICT order: event format (in-person/online/hybrid) → ALL `vibe_tags` → ALL `party_types` → ALL `music_genres` → tickets-left count. Each group omits entirely when its array is empty (rule-9). Rendered via the shared `ChipGroup` primitive.
+5. **TICKET BOX (inline, on-page)** — per-ticket-type quantity steppers; live running total = Σ(`priceAllInGbp` × qty) (server all-in, WYSIWYP, never bare base); the box has its OWN Proceed button. Both in-box Proceed and the floating button (§9) carry the selected tickets into the cart **already populated**, landing on CART STEP (i) where quantities remain editable. Free / waitlist / approval-required / sold-out states drive box + button copy via `resolveOfferingCta` + the per-tier sub-predicates (`ticketIsSoldOut`/`ticketIsDoorOnly`/`ticketSaleEnded`).
+6. **Presented By** — host/brand card → links to brand page (`onOpenBrand(brandSlug)`).
+7. **About** — collapsible description toggle (read-more/show-less; threshold reused from current bodies).
+8. **Where you'll be** — server-proxied Mapbox static map (`buildProxyStaticMapUrl`, ORCH-1165) + a "view on map" card beneath. Address-privacy: when `hideAddressUntilTicket` is true AND the viewer has not purchased, the map renders CITY-LEVEL ONLY (city centroid, lower zoom, NO exact pin) using the new city-geo field (§4A). When neither exact nor city geo exists, OMIT the map (rule-9) and render the honest text venue card.
+9. **Floating Get Tickets button** — persistent; reflects the live selected Σ-all-in total; → cart step (i), same as in-box Proceed. Preserves `hideCloseOnWeb` chrome behavior (ORCH-1159) and the float→dock visibility pattern.
+
+### 3B. Shell-agnostic constraint (mandatory)
+The body is a PURE CONTENT body. It NEVER hosts a scroll root. Each surface injects its scroll host via `ScrollComponent`:
+- buyer-web + business native: RN `ScrollView` (default).
+- consumer: gorhom `BottomSheetScrollView` (must remain a DIRECT child of `BaseBottomSheet`). The body MUST NOT wrap `ParallaxCoverShell` as its scroll root (ORCH-1016/1043/1138 freeze). The parallax cover renders as a pinned sibling/header the shell composes, not as the scroll container.
+
+---
+
+## 4. Layered specification
+
+### 4A. Database
+
+**Migration 1 — city-level privacy geo field.** Add to `public.events`:
+- `city_geo geometry(Point,4326)` — city centroid lat/lng (privacy-safe location). NULLable, default NULL (rule-9; 77/89 existing events stay NULL → no map, no leak).
+- (Keep the existing `city text` label and `location_geo point` exact pin unchanged.)
+- **Capture path:** on publish (or address-set), DERIVE `city_geo` from the event's resolved address city centroid (server-side, via the existing Mapbox geocode path used at venue capture — store the city-level centroid, NOT the street point). Spec: the publish RPC / address-write path computes the city centroid once and writes `city_geo`. Do NOT geocode client-side; do NOT fabricate when the city is unknown (leave NULL).
+- **Read exposure:** add `city_geo` to `business_public_events_view` AND to the new `pg_public_event_by_slug` payload so the map can render city-level without the exact pin.
+- Migration naming: `supabase/migrations/<ts>_orch_1167_event_city_geo.sql`. Follow safe-migration protocol (additive column, NULLable, no backfill).
+
+**Migration 2 — canonical read RPC `pg_public_event_by_slug`.** See §4B-Edge/RPC below. Separate migration `<ts>_orch_1167_pg_public_event_by_slug.sql`.
+
+**RLS / grants:** the RPC is `SECURITY DEFINER`, `STABLE`, owned by the migration role; `GRANT EXECUTE ... TO anon, authenticated`. It reads ONLY anon-safe columns (mirror `business_public_events_view`'s safe projection); it MUST NOT return the exact `location_geo` when `hide_address_until_ticket` AND no purchase context — return `city_geo` + `city` only in that case (privacy enforced server-side, not client-side). Safe-migration protocol: `$function$;` before any GRANT; DROP before widening RETURNS TABLE.
+
+### 4B. The ONE canonical read path — `pg_public_event_by_slug`
+
+**Signature (RETURNS one row / json):**
+`pg_public_event_by_slug(p_brand_slug text, p_event_slug text) RETURNS json` (or a single-row TABLE). Anon SECURITY DEFINER STABLE.
+
+**Returns the full payload** sufficient to fill `EventOfferingBody` props from ONE source: event id/name/slugs/description; date fields (`master_start_at`/`master_end_at`/`timezone` for AM/PM); status/endedAt; format inputs (`is_online`, `location_mode`, theme `business_event.format`) OR a precomputed `format` string; venue name + address + `hide_address_until_ticket`; `location_geo` (exact, gated) + NEW `city_geo` + `city`; cover fields; brand card fields; `party_types` + `vibe_tags` + `music_genres`; per-tier ticket rows WITH `all_in_cents` (join `pg_public_event_tier_allin` logic or call the same `compute_all_in_cents`) + capacity/tickets-left; currency; theme overrides. Restricted to `event_type='event'` and published/visible.
+
+**Privacy rule (server-side):** when `hide_address_until_ticket=true`, the RPC omits `address` + exact `location_geo` and returns only `city` + `city_geo` (so the body renders a city-level map with no exact pin). A purchased viewer is out of scope for the anon RPC (the unlock-after-purchase path remains the existing authenticated read; this leg does not regress it).
+
+**Per-surface adapters (3, thin, all calling the ONE RPC):**
+- **Web/business:** replace/augment `getPublicEventBySlug` in `mingla-business/src/services/publicEventsService.ts` to call `pg_public_event_by_slug` and map its row → `PublicEventProps` (extended type, §4C). Map `music_genres→musicGenres` (close F-3). Keep `fetchTierAllInCents` semantics but prefer the RPC's embedded all-in to avoid a second round-trip.
+- **Consumer:** new hook `app-mobile/src/hooks/usePublicEventBySlug.ts` (React Query, anon) calling the RPC and mapping → the SAME `PublicEventProps`. The consumer standard-event screen feeds the shared body from this (deck-card seed remains the warm-open fast path; the RPC is the cold-open + authoritative source). Thread `partyTypes`/`vibeTags`/`musicGenres`/`city_geo` (close the foundation-mapper drop).
+
+**Query key:** `["publicEventBySlug", brandSlug, eventSlug]` (factory). `staleTime` ~60s; `enabled` on both slugs present.
+
+### 4B-package. Package consolidation (Seth's decision: `@mingla/offering-rendering` is the ONE home; `@mingla/event-rendering` dissolves into it)
+
+**Merge direction:** offering-rendering currently DEPENDS ON event-rendering. The dissolution MOVES event-rendering's exports INTO offering-rendering and flips importers. Because that touches **88 event-rendering import sites + 26 offering-rendering sites + 4 alias config files + the I-MOR-0827 CI gate**, full dissolution in one PR is high-blast-radius.
+
+**RECOMMENDATION — PHASED (do NOT attempt full dissolution this leg):**
+- **Phase 1 (THIS leg, ORCH-1167):** (a) Build `EventOfferingBody` IN `packages/offering-rendering`; it may import from `@mingla/event-rendering` (the existing peer-dep) for `EventCoverMedia`, `offeringCta`, theming, types, mapbox builders — no dissolution required to ship the shared body. (b) Retire the consumer fork; web/business render the shared body. (c) Add the inline ticket box + RPC + city-geo. NO mass import-flip. The event body becomes shared THIS leg.
+- **Phase 2 (separate follow-on ORCH, recommended):** dissolve `@mingla/event-rendering` into `@mingla/offering-rendering` — move all exports, re-point ~88 imports, update the 4 alias configs (`mingla-business/tsconfig.json` L10–13, `app-mobile/tsconfig.json` L15–18, `mingla-business/metro.config.js` L41–58, `app-mobile/metro.config.js` L23–37), update the I-MOR-0827 CI gate path, delete the old package. Pure mechanical refactor, separately testable, low product risk, high churn — must not block the product change.
+
+**Rationale:** the product win (one shared body, one read path, inline box, pills, city map) lands in Phase 1 without the 88-site churn; the package merge is cosmetic and is safest as an isolated mechanical PR.
+
+### 4C. Shared component — `EventOfferingBody`
+
+**File:** `packages/offering-rendering/EventOfferingBody.tsx` (+ export in `packages/offering-rendering/index.ts`).
+**Pure-presentational, props-only, no app-src imports (I-MOR-0827).** Renders on RN-web AND native.
+
+**Prop contract (full):**
+```
+interface EventOfferingBodyProps {
+  event: PublicEventProps;            // extended (§4C-types): musicGenres added, cityGeo added
+  brand: PublicBrandProps | null;
+  variant: OfferingVariant;           // from computeOfferingVariant
+  bookable: boolean;                  // I-PAID-SUPPLY gate
+  palette: ThemePalette; theme: ResolvedTheme;
+  // shell injection (MANDATORY, shell-agnostic):
+  ScrollComponent?: ComponentType<ScrollViewProps>;   // default RN ScrollView
+  onScroll?, onScrollViewLayout?, contentBottomInset?, safeAreaTop?;
+  // chrome:
+  muted: boolean; onToggleMute; onClose; onShare;
+  hideCloseOnWeb?: boolean;           // ORCH-1159 (preserve)
+  // ticket box state (LIFTED to host so cart can read it):
+  ticketQuantities: Record<ticketTypeId, number>;     // per-tier qty
+  onChangeTicketQuantity: (ticketTypeId: string, qty: number) => void;
+  onProceedToCart: () => void;        // in-box Proceed + floating button both call this
+  // links/maps:
+  onOpenBrand?: (brandSlug: string) => void;
+  onOpenMaps?: (query: string) => void;
+  // map URL builder injected (token/functions-base differ per surface):
+  staticMapUrl: string | null;        // host computes via buildProxyStaticMapUrl(city OR exact geo)
+  testID?: string;
+}
+```
+- The body renders sections 1–9 in the locked order. The **ticket box** is part of the body (steppers + Σ-all-in total + in-box Proceed). The **floating button** is part of the body's pinned overlay (float→dock), calling the same `onProceedToCart`.
+- Running total computed IN the body from `ticketQuantities` × `event.tickets[].priceAllInGbp` (WYSIWYP). The host owns nothing pricing-side except passing tickets with `priceAllInGbp`.
+- ALL states: loading (host-gated), empty (no tickets → "Not on sale yet"), sold-out / waitlist / pre-sale / past / cancelled / door-only / free (via `resolveOfferingCta`), disabled (`!bookable` → "Booking unavailable"), submitting (host flag). Each with the existing copy from `resolveOfferingCta`.
+- a11y: every stepper ±, Proceed, floating button, brand card, map card has an accessibilityLabel; ≥44pt targets; Android glass opaque-fallback policy preserved.
+
+**§4C-types — extend `PublicEventProps`** (in `packages/event-rendering/types.ts`, the contract file):
+- Add `musicGenres: string[]` (default `[]`, rule-9) — sibling to existing `partyTypes`/`vibeTags`.
+- Add `cityGeo?: { lat: number; lng: number } | null` (default-safe; the city-level privacy centroid).
+- Keep `locationGeo` (exact pin) — the host decides which to feed the map builder based on the privacy gate (the RPC already enforces privacy server-side, so for anon `locationGeo` will be null when hidden and only `cityGeo` is present).
+
+### 4D. Hooks / service
+- Web: `mingla-business/src/services/publicEventsService.ts` — `getPublicEventBySlug` → `pg_public_event_by_slug`; mapper adds `musicGenres` + `cityGeo`.
+- Consumer: new `app-mobile/src/hooks/usePublicEventBySlug.ts` + extend `useConsumerEventFoundation` (or replace its standard-event projection) to thread `partyTypes`/`vibeTags`/`musicGenres`/`cityGeo`.
+
+### 4E. Components per surface (thin shells wrapping `EventOfferingBody`)
+- **Web/business:** `FoundationEventPreview` becomes a thin wrapper that renders `EventOfferingBody` with RN `ScrollView` + lifts `ticketQuantities` state; `PublicEventPage` adapter drops the `/checkout/[eventId]` push and instead calls `onProceedToCart` → navigates to the cart step (i) with the cart pre-populated from `ticketQuantities`. The `/checkout/[eventId]` tier-PICKER step is removed (its later cart/payment steps remain).
+- **Consumer:** `ConsumerEventDetailScreen` standard-event branch renders `EventOfferingBody` with injected `BottomSheetScrollView`; `onProceedToCart` opens `TicketCartSheet` pre-seeded from `ticketQuantities` (multi-tier), landing on the editable cart step. RSVP branch is UNCHANGED (out of scope).
+- **Business preview** (`/event/[id]/preview`): reconcile to render `EventOfferingBody` in a preview/non-bookable mode OR explicitly defer (Open Question OQ-3).
+
+---
+
+## 5. Success criteria (per-surface where parity is manual)
+
+- **SC-1 (structure)** — All 3 surfaces render sections 1–9 in the locked order (§3A). [SC-1-Web / SC-1-bizIOS / SC-1-bizAndroid / SC-1-consIOS / SC-1-consAndroid].
+- **SC-2 (pills)** — Pills row shows format → vibes → party-types → music-genres → tickets-left, in that order; each group omits when empty. Verified an event with all four populated shows all four groups on all 3 surfaces.
+- **SC-3 (inline box, all-in)** — The on-page ticket box shows per-tier steppers; the running total equals Σ(`priceAllInGbp`×qty) to the cent; matches the floating button; never shows bare base.
+- **SC-4 (proceed → cart step i, populated, editable)** — In-box Proceed AND the floating button both land on the cart step with the selected quantities pre-filled and still editable. [Web: cart step replaces tier-picker; Consumer: `TicketCartSheet` pre-seeded.]
+- **SC-5 (CTA states)** — Free / waitlist / approval-required / sold-out / pre-sale / past / cancelled / door-only / not-bookable each drive the documented box + button copy from `resolveOfferingCta`.
+- **SC-6 (shell-agnostic)** — Consumer body scrolls correctly with `BottomSheetScrollView` as the direct child (no freeze); web/business scroll with `ScrollView`. The body hosts no scroll root.
+- **SC-7 (one read path)** — All 3 surfaces fetch from `pg_public_event_by_slug`; adding a field to the RPC payload surfaces on all 3 without a second mapper edit (verified by adding `musicGenres` this leg).
+- **SC-8 (city-level map, no exact pin when hidden)** — When `hide_address_until_ticket` and anon, the map renders at city zoom centered on `city_geo` with NO exact pin; when an event has neither geo, no map renders (text venue card only); when address is public + `location_geo` present, the exact pin renders.
+- **SC-9 (web close-X)** — ORCH-1159 preserved: floating close X hidden on web, present on native; Share present everywhere.
+
+---
+
+## 6. Invariants
+
+**Preserve:**
+- **I-MOR-0827-PACKAGE-ISOLATION** — `EventOfferingBody` imports nothing from `app-mobile/src` or `mingla-business/src`. Test: existing isolation gate extended to cover the new file.
+- **WYSIWYP / all-in (ORCH-1147)** — running total = Σ all-in. Test: SC-3 unit test.
+- **I-PAID-SUPPLY-REQUIRES-CHARGES-ENABLED (ORCH-1076)** — `bookable=false` → box/CTA disabled. Test: SC-5.
+- **Rule-9** — empty pill arrays / missing geo omit, never fabricate. Test: SC-2 + SC-8 edge cases.
+
+**Propose (DRAFT — orchestrator flips ACTIVE on CLOSE):**
+- **I-PROPOSED-1167-CANONICAL-9-SECTION-ORDER** — the shared `EventOfferingBody` renders exactly sections 1–9 in the locked order; a structural test asserts the render-tree order.
+- **I-PROPOSED-1167-SHELL-AGNOSTIC-BODY** — `EventOfferingBody` declares no scroll container; it accepts `ScrollComponent`. Grep gate: the body file contains no `ScrollView`/`BottomSheetScrollView`/`FlatList` as its root.
+- **I-PROPOSED-1167-ALLIN-PRICE-IN-TICKET-BOX** — the box running total uses `priceAllInGbp` (never `priceGbp` alone) — grep/unit gate.
+- **I-PROPOSED-1167-CITY-LEVEL-MAP-NO-EXACT-PIN-WHEN-HIDDEN** — when `hide_address_until_ticket`, the anon payload carries no exact `location_geo`; the map uses `city_geo`. Test: RPC returns null `location_geo` + non-null `city_geo` for a hidden-address event.
+- **I-PROPOSED-1167-ONE-READ-RPC** — all 3 surfaces read the standard-event public page via `pg_public_event_by_slug`; grep gate that no surface reads `business_public_events_view` for the standard-event PAGE body fields (theme-only reads excepted).
+
+---
+
+## 7. Test cases
+
+| Test | Scenario | Input | Expected | Layer |
+|------|----------|-------|----------|-------|
+| T-01 | section order | event w/ all sections | render tree = 1..9 order | component |
+| T-02 | pills all populated | vibe_tags+party_types+music_genres non-empty | 4 pill groups + tickets-left in order | component |
+| T-03 | pills empty | all arrays `[]` | only format + tickets-left; no empty groups | component |
+| T-04 | all-in total | 2 tiers, qty 2+1, allIn 50/30 | total = 130 (Σ allIn), not base | unit |
+| T-05 | proceed populates cart | qty set, tap in-box Proceed | cart step opens w/ those qtys editable | integration (web+consumer) |
+| T-06 | floating == in-box | scroll, tap floating | same cart, same total | integration |
+| T-07 | sold-out | all tiers cap 0, no waitlist | box+button "Sold out", non-tappable | unit (resolveOfferingCta) |
+| T-08 | waitlist | sold-out + waitlistEnabled | "Join waitlist" tappable | unit |
+| T-09 | not bookable | bookable=false | "Booking unavailable" | unit |
+| T-10 | shell-agnostic | mount w/ BottomSheetScrollView | scrolls, no freeze | runtime (consumer sim) |
+| T-11 | RPC privacy | hide_address event, anon | payload: address null, location_geo null, city_geo set | edge/SQL |
+| T-12 | map city-level | hidden + city_geo | map at city zoom, no pin | component |
+| T-13 | map omitted | no geo at all | no map, text venue card | component |
+| T-14 | map exact | public address + location_geo | exact pin renders | component |
+| T-15 | one-read-path | add field to RPC | appears on all 3 surfaces, one mapper edit | structural |
+| T-16 | web close-X | web render | no floating X; native has X | component (platform) |
+| T-17 | isolation | grep EventOfferingBody | no app-src imports | CI gate |
+
+---
+
+## 8. Implementation order
+
+1. **DB:** Migration 1 (`city_geo` column + view exposure + publish-time city-centroid derivation). Migration 2 (`pg_public_event_by_slug` RPC + grants). Apply via Management API per safe-migration protocol (DO NOT auto-apply; orchestrator/Seth applies).
+2. **Types:** extend `PublicEventProps` (`musicGenres`, `cityGeo`) in `packages/event-rendering/types.ts`.
+3. **Shared body:** build `packages/offering-rendering/EventOfferingBody.tsx` + export.
+4. **Service/hooks:** web `getPublicEventBySlug` → RPC + mapper (`musicGenres`/`cityGeo`); consumer `usePublicEventBySlug.ts` + foundation threading.
+5. **Web/business:** `FoundationEventPreview` → thin wrapper of `EventOfferingBody`; `PublicEventPage` adapter drops `/checkout/[eventId]` tier-picker push → `onProceedToCart` to cart step (i).
+6. **Consumer:** `ConsumerEventDetailScreen` standard-event branch → `EventOfferingBody` + `TicketCartSheet` pre-seed.
+7. **Preview route:** reconcile or defer (OQ-3).
+8. **Tests + CI gates** (§7, §9). 9. **Isolation gate** path update.
+
+---
+
+## 9. Regression prevention (fails-on-revert)
+
+- **Structural section-order test** (T-01) — asserts the `EventOfferingBody` render tree emits sections in 1..9 order; FAILS if reordered/reverted.
+- **All-in grep+unit gate** (I-PROPOSED-1167-ALLIN-PRICE-IN-TICKET-BOX) — FAILS if the box total reads `priceGbp` without `priceAllInGbp`.
+- **Shell-agnostic grep gate** — FAILS if `EventOfferingBody` root becomes a scroll container.
+- **One-read-RPC grep gate** — FAILS if a surface reintroduces a divergent read for the page body.
+- **Isolation gate** (T-17) — FAILS if the body imports app-src.
+- Each gate carries a protective comment citing ORCH-1167 + the invariant id.
+
+---
+
+## 10. Open questions
+- **OQ-1:** city-centroid derivation source — reuse the existing Mapbox geocode at publish to compute the city centroid, or store a coarse rounded `location_geo`? RECOMMEND geocode-the-city-name to a centroid (avoids any street-pin leak). Needs confirm.
+- **OQ-2:** purchased-viewer address unlock on the anon page — out of scope here (stays on the existing authenticated read). Confirm this leg need not change the post-purchase unlock.
+- **OQ-3:** business `/event/[id]/preview` (the separate `PreviewEventView`) — reconcile to `EventOfferingBody` now, or defer to a follow-on? RECOMMEND defer (it is draft-preview, not the public page) unless Seth wants preview parity this leg.
+- **OQ-4:** is full `event-rendering` dissolution required to CLOSE this leg, or accepted as Phase 2? SPEC RECOMMENDS Phase 2 (separate ORCH). Needs Seth/orchestrator sign-off.
+
+## 11. Cross-Surface Impact Declaration
+
+| # | Surface | Covered | User-visible behavior | Files | Parity |
+|---|---------|---------|-----------------------|-------|--------|
+| 1 | Consumer iOS | YES | 9-section shared body + inline box → cart | `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx`, new `usePublicEventBySlug.ts`, `useConsumerEventFoundation.ts`, `TicketCartSheet.tsx` | shared body |
+| 2 | Consumer Android | YES | same | same | shared body |
+| 3 | Buyer/anon Web | YES | inline box REPLACES `/checkout` tier-picker | `mingla-business/src/components/event/FoundationEventPreview.tsx`, `PublicEventPage.tsx`, `publicEventsService.ts`, route `app/e/[brandSlug]/[eventSlug].tsx` | shared body |
+| 4 | Business iOS | YES | same shared body | same business files | shared body |
+| 5 | Business Android | YES | same | same | shared body |
+| 6 | Admin Web | NO | no public event page | — | n/a |
+| 7 | Business Web preview | DEFER (OQ-3) | currently separate `PreviewEventView` | `app/event/[id]/preview.tsx` | manual / deferred |
+
+## 12. Allowlist + DO-NOT-TOUCH
+
+**Allowlist (implementor may modify):**
+- `packages/offering-rendering/EventOfferingBody.tsx` (new) + `index.ts`
+- `packages/event-rendering/types.ts` (add `musicGenres`, `cityGeo`)
+- `mingla-business/src/components/event/FoundationEventPreview.tsx`, `PublicEventPage.tsx`
+- `mingla-business/src/services/publicEventsService.ts`
+- `mingla-business/app/e/[brandSlug]/[eventSlug].tsx`
+- `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx`, `app-mobile/app/e/[brandSlug]/[eventSlug].tsx`
+- `app-mobile/src/hooks/usePublicEventBySlug.ts` (new), `useConsumerEventFoundation.ts`, `usePublicEventTickets.ts`, `useEventTheme.ts`
+- `app-mobile/src/components/expandedCard/TicketCartSheet.tsx`, `app-mobile/src/hooks/useTicketCart.ts`
+- 2 new migrations under `supabase/migrations/`; `business_public_events_view` exposure
+- new CI gates under `packages/scripts/ci/`; tests under each `__tests__/`
+- (Phase 2 only, separate PR) the 4 alias configs + I-MOR-0827 gate path
+
+**DO-NOT-TOUCH:**
+- RSVP / trip / experience bodies + their routes/hooks/RPCs (`RsvpPublicBody`, `TripPreview`, experience pages, `ConsumerTripDetailScreen`, RSVP branch of `ConsumerEventDetailScreen`).
+- The all-in pricing engine (`compute_all_in_cents`, `pg_public_event_tier_allin`), `ticket-checkout-create`, PaymentSheet money flow.
+- `mingla-admin/`.
+- Legacy `packages/event-rendering/PublicEventPage.tsx` cancelled/password fallback (unless subsumed — stop-and-amend).
+- Do NOT mass-flip the 88 event-rendering imports this leg (that is Phase 2).
+
+## 13. Downstream routing
+Next = **mingla-implementor** in this worktree (`~/Desktop/mingla-orchs/ORCH-1167-[event-page-canonical]/` on branch `ORCH-1167-event-page-canonical`). Then mingla-tester (all 5 primary surfaces incl. consumer sim for the shell-agnostic scroll). Then orchestrator CLOSE (flip the 5 I-PROPOSED-1167-* invariants ACTIVE). Coordinate any standard-event-page changes through META-ORCH-1166 (COMMS-0038). Migrations are spec-only here — applied by Seth/orchestrator at implement-time via Management API.

--- a/app-mobile/src/components/expandedCard/TicketCartSheet.tsx
+++ b/app-mobile/src/components/expandedCard/TicketCartSheet.tsx
@@ -210,6 +210,15 @@ export interface TicketCartSheetProps {
    * Defaults to 1 → byte-identical to every existing caller (events/trips).
    */
   initialQuantity?: number;
+  /**
+   * ORCH-1167 [event-page-canonical] — seed MULTIPLE tiers at once on open from
+   * the inline ticket box on the canonical event page ({ ticketTypeId: qty }).
+   * When present (non-empty) it TAKES PRECEDENCE over `initialTicketTypeId`/
+   * `initialQuantity`: every listed tier is seeded (each capped by its capacity)
+   * so the cart lands PRE-POPULATED + editable (parity with the buyer-web cart
+   * step). Absent/empty → byte-identical single-tier seed (every existing caller).
+   */
+  initialQuantities?: Record<string, number>;
   /** Auth-derived pre-fill (read-only display). */
   buyerName: string;
   buyerEmail: string;
@@ -243,6 +252,7 @@ export const TicketCartSheet: React.FC<TicketCartSheetProps> = ({
   fallbackCurrency,
   initialTicketTypeId,
   initialQuantity = 1,
+  initialQuantities,
   intakeSchemasByTier,
   buyerName,
   buyerEmail,
@@ -364,28 +374,59 @@ export const TicketCartSheet: React.FC<TicketCartSheetProps> = ({
   // (declarative `visible`). The prior sheetRef + snapToIndex/close effect is
   // removed; the primitive replicates that exact open/close pattern internally.
 
-  // Seed the tapped tier on open; reset cart + opt-in on close.
+  // Seed the tapped tier(s) on open; reset cart + opt-in on close.
+  // ORCH-1167 — when `initialQuantities` (the inline-box multi-tier selection) is
+  // present it TAKES PRECEDENCE: every listed tier is seeded (capped by capacity).
+  // Else the byte-identical single-tier seed runs (every existing caller).
+  const multiSeed = useMemo<Record<string, number>>(
+    () =>
+      initialQuantities !== undefined &&
+      Object.keys(initialQuantities).length > 0
+        ? initialQuantities
+        : {},
+    [initialQuantities],
+  );
+  const multiSeedKey = useMemo<string>(
+    () =>
+      Object.entries(multiSeed)
+        .filter(([, q]) => q > 0)
+        .map(([id, q]) => `${id}:${q}`)
+        .sort()
+        .join(","),
+    [multiSeed],
+  );
+
   useEffect(() => {
-    if (visible && initialTicketTypeId !== null && tickets) {
-      if (lastOpenSeedRef.current === initialTicketTypeId) return;
-      lastOpenSeedRef.current = initialTicketTypeId;
-      const seedTicket = tickets.find((t) => t.id === initialTicketTypeId);
-      if (seedTicket === undefined) return;
-      const seed: CartLineSeed = {
-        ticketTypeId: seedTicket.id,
-        ticketName: seedTicket.name,
-        unitPriceCents: Math.round((seedTicket.priceGbp ?? 0) * 100),
-        currency: seedTicket.currency ?? fallbackCurrency,
-        isFree: seedTicket.isFree,
-      };
-      // ORCH-1138 rework — seed the open-daily PARTY SIZE (clamp >=1), capped by
-      // the tier capacity when known so we never seed beyond available stock.
-      const seedQty = Math.max(1, Math.floor(initialQuantity));
-      const cap =
-        seedTicket.isUnlimited || seedTicket.capacity == null
-          ? seedQty
-          : Math.max(1, Math.min(seedQty, seedTicket.capacity));
-      setLineQuantity(seed, cap);
+    if (visible && tickets) {
+      const useMulti = multiSeedKey.length > 0;
+      const thisKey = useMulti ? multiSeedKey : initialTicketTypeId;
+      if (thisKey !== null && lastOpenSeedRef.current !== thisKey) {
+        lastOpenSeedRef.current = thisKey;
+        const seedOne = (ticketId: string, qty: number): void => {
+          const seedTicket = tickets.find((t) => t.id === ticketId);
+          if (seedTicket === undefined) return;
+          const seed: CartLineSeed = {
+            ticketTypeId: seedTicket.id,
+            ticketName: seedTicket.name,
+            unitPriceCents: Math.round((seedTicket.priceGbp ?? 0) * 100),
+            currency: seedTicket.currency ?? fallbackCurrency,
+            isFree: seedTicket.isFree,
+          };
+          const seedQty = Math.max(1, Math.floor(qty));
+          const cap =
+            seedTicket.isUnlimited || seedTicket.capacity == null
+              ? seedQty
+              : Math.max(1, Math.min(seedQty, seedTicket.capacity));
+          setLineQuantity(seed, cap);
+        };
+        if (useMulti) {
+          for (const [ticketId, qty] of Object.entries(multiSeed)) {
+            if (qty > 0) seedOne(ticketId, qty);
+          }
+        } else if (initialTicketTypeId !== null) {
+          seedOne(initialTicketTypeId, initialQuantity);
+        }
+      }
     }
     if (!visible) {
       lastOpenSeedRef.current = null;
@@ -398,6 +439,8 @@ export const TicketCartSheet: React.FC<TicketCartSheetProps> = ({
     visible,
     initialTicketTypeId,
     initialQuantity,
+    multiSeed,
+    multiSeedKey,
     tickets,
     fallbackCurrency,
     setLineQuantity,

--- a/app-mobile/src/hooks/useConsumerEventFoundation.ts
+++ b/app-mobile/src/hooks/useConsumerEventFoundation.ts
@@ -65,6 +65,21 @@ export interface ConsumerEventFoundationModel {
   /** The selectable tiers (PublicTicketProps — same shape the cart consumes). */
   tickets: PublicTicketProps[];
   currency: string;
+  /**
+   * ORCH-1167 [event-page-canonical] — the pills arrays threaded END-TO-END from
+   * the deck seed (BusinessEventCard) so the canonical EventOfferingBody renders
+   * the format → vibes → party-types → music-genres pills row (closes the F-3 drop
+   * where the foundation mapper silently dropped all three). `[]` when none (rule 9).
+   */
+  partyTypes: string[];
+  vibeTags: string[];
+  musicGenres: string[];
+  /**
+   * ORCH-1167 — city-level privacy centroid (BusinessEventCard does not carry it
+   * today, so null on the warm path; the cold path RPC supplies it). The exact pin
+   * (lat/lng above) is the warm-path geo.
+   */
+  cityGeo: { lat: number; lng: number } | null;
 }
 
 /**
@@ -148,6 +163,12 @@ export function mapConsumerEventToFoundation(
     brandCoverMediaUrl: card.brandProfilePhotoUrl,
     tickets,
     currency: card.currency,
+    // ORCH-1167 — thread the pills from the deck seed (rule 9: [] when absent).
+    partyTypes: Array.isArray(card.partyTypes) ? card.partyTypes : [],
+    vibeTags: Array.isArray(card.vibeTags) ? card.vibeTags : [],
+    musicGenres: Array.isArray(card.musicGenres) ? card.musicGenres : [],
+    // ORCH-1167 — BusinessEventCard has no city centroid; null on the warm path.
+    cityGeo: null,
   };
 }
 

--- a/app-mobile/src/hooks/usePublicEventBySlug.ts
+++ b/app-mobile/src/hooks/usePublicEventBySlug.ts
@@ -1,0 +1,185 @@
+/**
+ * usePublicEventBySlug — ORCH-1167 [event-page-canonical].
+ *
+ * The CONSUMER anon read for the canonical standard ticketed-event public page,
+ * fed by the ONE read RPC `pg_public_event_by_slug` (the SAME RPC the buyer-web +
+ * business surfaces read — SC-7 one-read-path). Returns the full EventOfferingBody
+ * payload mapped → the SHARED `PublicEventProps` contract incl. the pills
+ * (partyTypes/vibeTags/musicGenres), city + cityGeo, and per-tier server all-in.
+ *
+ * The deck-card seed remains the warm-open fast path (ConsumerEventDetailScreen);
+ * this hook is the COLD-open + authoritative source (closes the OQ-6 seedless cap
+ * for standard events). PRIVACY is enforced SERVER-SIDE in the RPC (locationGeo
+ * null + cityGeo set when the street is hidden) — the client never re-derives it.
+ *
+ * 🔒 I-MOR-0827-PACKAGE-ISOLATION: imports only @mingla/event-rendering types +
+ * the anon supabase client. No mingla-business/src import.
+ */
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type {
+  PublicBrandProps,
+  PublicEventProps,
+  PublicTicketProps,
+} from "@mingla/event-rendering";
+
+import { supabase } from "../services/supabase";
+
+export interface CanonicalPublicEvent {
+  event: PublicEventProps;
+  brand: PublicBrandProps | null;
+}
+
+export const publicEventBySlugKeys = {
+  all: ["publicEventBySlug"] as const,
+  bySlug: (brandSlug: string, eventSlug: string) =>
+    [...publicEventBySlugKeys.all, brandSlug, eventSlug] as const,
+};
+
+const asString = (v: unknown): string | null =>
+  typeof v === "string" && v.length > 0 ? v : null;
+
+const asStringArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+
+const asLatLng = (v: unknown): { lat: number; lng: number } | null => {
+  if (v === null || typeof v !== "object") return null;
+  const o = v as { lat?: unknown; lng?: unknown };
+  return typeof o.lat === "number" &&
+    Number.isFinite(o.lat) &&
+    typeof o.lng === "number" &&
+    Number.isFinite(o.lng)
+    ? { lat: o.lat, lng: o.lng }
+    : null;
+};
+
+const asFormat = (v: unknown): "in-person" | "online" | "hybrid" => {
+  if (v === "online" || v === "hybrid") return v;
+  if (v === "in_person") return "in-person";
+  return "in-person";
+};
+
+const asCoverType = (v: unknown): "image" | "video" | "gif" | null =>
+  v === "image" || v === "video" || v === "gif" ? v : null;
+
+const mapRpcTicket = (raw: unknown, fallbackCurrency: string): PublicTicketProps => {
+  const t = (raw ?? {}) as Record<string, unknown>;
+  const priceCents = typeof t.priceCents === "number" ? t.priceCents : null;
+  const allInCents = typeof t.allInCents === "number" ? t.allInCents : null;
+  const isFree = t.isFree === true;
+  const remaining =
+    typeof t.remaining === "number" ? t.remaining : null;
+  const capacity =
+    typeof t.capacity === "number" ? t.capacity : null;
+  return {
+    id: String(t.id ?? ""),
+    name: String(t.name ?? ""),
+    description: asString(t.description),
+    priceGbp: isFree || priceCents === null ? null : priceCents / 100,
+    // WYSIWYP — server all-in (compute_all_in_cents); 0/free → null.
+    priceAllInGbp:
+      isFree || allInCents === null || allInCents === 0 ? null : allInCents / 100,
+    currency: asString(t.currency) ?? fallbackCurrency,
+    isFree,
+    isUnlimited: t.isUnlimited === true,
+    // capacity field carries REMAINING (parity with the sold-out gate) when known.
+    capacity: remaining ?? capacity,
+    visibility:
+      t.isHidden === true ? "hidden" : t.isDisabled === true ? "disabled" : "visible",
+    passwordProtected: t.passwordProtected === true,
+    password: null,
+    saleStartAt: asString(t.saleStartAt),
+    saleEndAt: asString(t.saleEndAt),
+    approvalRequired: t.requiresApproval === true,
+    waitlistEnabled: t.waitlistEnabled === true,
+    availableAt:
+      t.availableOnline === true && t.availableInPerson === true
+        ? "both"
+        : t.availableOnline === true
+          ? "online"
+          : "door",
+    displayOrder: typeof t.displayOrder === "number" ? t.displayOrder : 0,
+  };
+};
+
+/** Map the pg_public_event_by_slug json payload → the shared PublicEventProps. */
+export const mapRpcPayloadToPublicEvent = (
+  payload: Record<string, unknown>,
+): CanonicalPublicEvent => {
+  const currency = asString(payload.currency) ?? "USD";
+  const brandRaw = (payload.brand ?? null) as Record<string, unknown> | null;
+  const event: PublicEventProps = {
+    id: String(payload.id ?? ""),
+    name: String(payload.name ?? ""),
+    brandId: String(payload.brandId ?? ""),
+    brandSlug: String(payload.brandSlug ?? ""),
+    eventSlug: String(payload.eventSlug ?? ""),
+    description: typeof payload.description === "string" ? payload.description : "",
+    // The cold-path body shows the meta chips; date label formatting is
+    // host-driven elsewhere, so derive a minimal ISO-based eyebrow is omitted
+    // here (the deck warm path supplies the formatted line). Empty → omitted.
+    dateLine: "",
+    dateSubline: null,
+    datesList: [],
+    status:
+      payload.status === "cancelled"
+        ? "cancelled"
+        : payload.status === "ended"
+          ? "ended"
+          : "published",
+    endedAt: null,
+    format: asFormat(payload.format),
+    venueName: asString(payload.venueName),
+    address: asString(payload.address),
+    hideAddressUntilTicket: payload.hideAddressUntilTicket === true,
+    locationGeo: asLatLng(payload.locationGeo),
+    cityGeo: asLatLng(payload.cityGeo),
+    coverHue: 0,
+    coverMediaUrl: asString(payload.coverMediaUrl),
+    coverMediaType: asCoverType(payload.coverMediaType),
+    coverCredit: asString(payload.coverMediaCredit),
+    tickets: Array.isArray(payload.tickets)
+      ? payload.tickets.map((t) => mapRpcTicket(t, currency))
+      : [],
+    currency,
+    partyTypes: asStringArray(payload.partyTypes),
+    vibeTags: asStringArray(payload.vibeTags),
+    musicGenres: asStringArray(payload.musicGenres),
+    themeOverrides: null,
+  };
+  const brand: PublicBrandProps | null =
+    brandRaw === null
+      ? null
+      : {
+          id: String(brandRaw.id ?? ""),
+          slug: String(brandRaw.slug ?? ""),
+          displayName: String(brandRaw.name ?? "Brand"),
+          photo: asString(brandRaw.profilePhotoUrl) ?? undefined,
+          theme: null,
+        };
+  return { event, brand };
+};
+
+export const usePublicEventBySlug = (
+  brandSlug: string | null,
+  eventSlug: string | null,
+): UseQueryResult<CanonicalPublicEvent | null> => {
+  const enabled = brandSlug !== null && eventSlug !== null;
+  return useQuery<CanonicalPublicEvent | null>({
+    queryKey: enabled
+      ? publicEventBySlugKeys.bySlug(brandSlug, eventSlug)
+      : publicEventBySlugKeys.all,
+    enabled,
+    staleTime: 60 * 1000,
+    queryFn: async (): Promise<CanonicalPublicEvent | null> => {
+      if (!enabled || brandSlug === null || eventSlug === null) return null;
+      const { data, error } = await supabase.rpc("pg_public_event_by_slug", {
+        p_brand_slug: brandSlug,
+        p_event_slug: eventSlug,
+      });
+      if (error !== null) throw error;
+      if (data === null || typeof data !== "object") return null;
+      return mapRpcPayloadToPublicEvent(data as Record<string, unknown>);
+    },
+  });
+};

--- a/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
+++ b/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
@@ -66,16 +66,16 @@ import {
   createThemePalette,
   EventCoverMedia,
   offeringSurfaceStyles,
-  resolveOfferingCta,
   resolveRsvpCta,
   resolveTheme,
   ThemeEntranceAnimation,
-  type CtaState,
   type PublicEventProps,
   type PublicTicketProps,
   type RsvpCtaState,
 } from "@mingla/event-rendering";
 import {
+  EventOfferingBody,
+  EventOfferingFloatingBar,
   OfferingChrome,
   RsvpMomentumDecision,
   normalizeCityCountry,
@@ -90,7 +90,6 @@ import {
 import TicketCartSheet, {
   type TicketCartCheckoutPayload,
 } from "../../components/expandedCard/TicketCartSheet";
-import { ConsumerEventReserveBar } from "../../components/offering/ConsumerEventReserveBar";
 import {
   fetchRsvpMomentum,
   submitDeckRsvp,
@@ -115,6 +114,7 @@ import { hueFromId } from "../../utils/hueFromId";
 // ORCH-1162 Bug 2 — shared static-Mapbox builder (re-exported from
 // @mingla/event-rendering) for the consumer EVENT "Where you'll be" map.
 import { buildStaticMapUrl } from "../../utils/mapboxStaticImage";
+import { formatEventDateLine } from "../../utils/eventDateDisplay";
 import type { BusinessEventCard } from "../../types/mergedDiscover";
 
 const ACCENT = "#FF6B35";
@@ -135,43 +135,55 @@ interface ConsumerEventDetailScreenProps {
   tabBarAware?: boolean;
 }
 
-// Build the PublicEventProps the SHARED state machine reads (mirror EBES
-// mapCardToPublicEvent — for variant/CTA computation only; the foundation body
-// renders from the foundation model, not this).
+// Build the PublicEventProps the SHARED state machine + the canonical
+// EventOfferingBody read. ORCH-1167 — threads the pills (vibes/party/music) +
+// the formatted date line so the consumer standard-event body renders the SAME
+// canonical 9-section structure as buyer-web/business from the deck seed (warm
+// path). RSVP rows still feed only the CTA machine (the RSVP body is separate).
 const cardToPublicEvent = (
   card: BusinessEventCard,
   tickets: PublicTicketProps[],
-): PublicEventProps => ({
-  id: card.eventId,
-  name: card.title,
-  brandId: card.brandId,
-  brandSlug: card.brandSlug,
-  eventSlug: card.eventSlug,
-  description: card.description ?? "",
-  dateLine: "",
-  dateSubline: null,
-  datesList: [],
-  status: "published",
-  endedAt: null,
-  format: card.format,
-  venueName: card.venueName,
-  address: card.address,
-  hideAddressUntilTicket: card.hideAddressUntilTicket,
-  coverHue: card.coverHue,
-  coverMediaUrl: card.coverMediaUrl,
-  coverMediaType:
-    card.coverMediaType === "image" ||
-    card.coverMediaType === "video" ||
-    card.coverMediaType === "gif"
-      ? card.coverMediaType
-      : null,
-  coverCredit: null,
-  tickets,
-  currency: card.currency,
-  // ORCH-1157 [rsvp-public-redesign] — the deck seed carries canonical party
-  // types; pass them so the RSVP momentum unit + the CTA machine see one shape.
-  partyTypes: card.partyTypes ?? [],
-});
+): PublicEventProps => {
+  const dateLine = formatEventDateLine({
+    masterDateUtc: card.masterDateUtc,
+    masterEndAtUtc: card.masterEndAtUtc,
+    timezone: card.timezone,
+  });
+  return {
+    id: card.eventId,
+    name: card.title,
+    brandId: card.brandId,
+    brandSlug: card.brandSlug,
+    eventSlug: card.eventSlug,
+    description: card.description ?? "",
+    dateLine: dateLine.length > 0 ? dateLine : "",
+    dateSubline: null,
+    datesList: [],
+    status: "published",
+    endedAt: null,
+    format: card.format,
+    venueName: card.venueName,
+    address: card.address,
+    hideAddressUntilTicket: card.hideAddressUntilTicket,
+    locationGeo: card.locationGeo ?? null,
+    cityGeo: null,
+    coverHue: card.coverHue,
+    coverMediaUrl: card.coverMediaUrl,
+    coverMediaType:
+      card.coverMediaType === "image" ||
+      card.coverMediaType === "video" ||
+      card.coverMediaType === "gif"
+        ? card.coverMediaType
+        : null,
+    coverCredit: null,
+    tickets,
+    currency: card.currency,
+    // ORCH-1157/1167 — canonical pills threaded from the deck seed (rule 9: []).
+    partyTypes: card.partyTypes ?? [],
+    vibeTags: card.vibeTags ?? [],
+    musicGenres: card.musicGenres ?? [],
+  };
+};
 
 const openMapsForQuery = (query: string): void => {
   const encoded = encodeURIComponent(query);
@@ -205,7 +217,12 @@ export default function ConsumerEventDetailScreen({
   const [initialTicketTypeId, setInitialTicketTypeId] = useState<string | null>(
     null,
   );
-  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
+  // ORCH-1167 [event-page-canonical] — the inline ticket-box per-tier quantities
+  // (the canonical EventOfferingBody owns selection on the standard-event branch).
+  // onProceedToCart opens TicketCartSheet PRE-SEEDED with this multi-tier map.
+  const [ticketQuantities, setTicketQuantities] = useState<Record<string, number>>(
+    {},
+  );
   const [checkoutInFlight, setCheckoutInFlight] = useState<boolean>(false);
   const [muted, setMuted] = useState<boolean>(true);
   const [aboutCollapsed, setAboutCollapsed] = useState<boolean>(true);
@@ -295,57 +312,32 @@ export default function ConsumerEventDetailScreen({
 
   const tickets = ticketsQuery.data ?? [];
 
-  // The SINGLE buy-state (resolveOfferingCta — one owner). The selected tier
-  // narrows the considered set; the page-level state drives the bar + tier rows.
-  const offeringCta: CtaState = useMemo(() => {
-    if (seed === null) {
-      return {
-        kind: "unavailable",
-        title: "Open from the app",
-        subline: null,
-        tappable: false,
-      };
-    }
-    const publicEvent = cardToPublicEvent(seed, tickets);
-    const selected = tickets.find(
-      (t) => t.id === selectedTicketId && t.visibility !== "hidden",
+  // ORCH-1167 — inline ticket-box quantity setter + proceed-to-cart. The box
+  // lifts its quantities here; Proceed (in-box) + the floating bar both open the
+  // existing TicketCartSheet PRE-SEEDED with the full multi-tier selection (the
+  // cart lands editable). Empty selection → no-op (the CTA is disabled anyway).
+  const handleChangeTicketQuantity = useCallback(
+    (ticketTypeId: string, qty: number): void => {
+      setTicketQuantities((prev) => {
+        const next = { ...prev };
+        if (qty <= 0) delete next[ticketTypeId];
+        else next[ticketTypeId] = qty;
+        return next;
+      });
+    },
+    [],
+  );
+  const handleProceedToCart = useCallback((): void => {
+    const anySelected = Object.values(ticketQuantities).some((q) => q > 0);
+    if (!anySelected) return;
+    // Seed the cart sheet at the FIRST selected tier for back-compat with the
+    // single-seed contract; initialQuantities carries the FULL selection.
+    const firstSelected = Object.keys(ticketQuantities).find(
+      (id) => (ticketQuantities[id] ?? 0) > 0,
     );
-    const considered = selected !== undefined ? [selected] : tickets;
-    return resolveOfferingCta({
-      variant: computeOfferingVariant(publicEvent, false),
-      // OQ-B parity: the deck card has no `bookable`; pass true and rely on the
-      // checkout 409 → cart-toast backstop (mirrors EBES + the trip screen v1).
-      bookable: true,
-      tickets: considered,
-      currency: seed.currency,
-    });
-  }, [seed, tickets, selectedTicketId]);
-
-  const handleSelectTicket = useCallback((ticketId: string): void => {
-    setSelectedTicketId((prev) => (prev === ticketId ? null : ticketId));
-  }, []);
-
-  // Reserve opens the cart DIRECTLY, seeded at the selected/first sellable tier.
-  const openCart = useCallback((): void => {
-    if (tickets.length === 0) return;
-    const explicit =
-      selectedTicketId !== null
-        ? tickets.find((t) => t.id === selectedTicketId)
-        : undefined;
-    const sellable =
-      explicit ??
-      tickets.find(
-        (t) =>
-          t.visibility !== "hidden" &&
-          t.availableAt !== "door" &&
-          (t.isUnlimited || (t.capacity ?? 0) > 0),
-      ) ??
-      tickets.find((t) => t.visibility !== "hidden") ??
-      tickets[0];
-    if (sellable === undefined) return;
-    setInitialTicketTypeId(sellable.id);
+    setInitialTicketTypeId(firstSelected ?? null);
     setCartVisible(true);
-  }, [tickets, selectedTicketId]);
+  }, [ticketQuantities]);
 
   // ORCH-1150 — Going / Not-going write for a discoverable RSVP deck card. The
   // signed-in user's JWT rides the supabase client → the edge fn resolves
@@ -588,6 +580,27 @@ export default function ConsumerEventDetailScreen({
   );
   const showMute = fnd.coverMediaType === "video";
 
+  // ORCH-1167 [event-page-canonical] — the standard-event PublicEventProps for the
+  // shared EventOfferingBody (warm path from the deck seed). RSVP rows do NOT use
+  // this (their body is the separate RsvpPublicBody section sequence). The static
+  // map URL is privacy-gated: exact pin when the street is public, else null on the
+  // warm path (no city centroid on the deck seed) → text venue card (rule 9).
+  const publicEventForBody: PublicEventProps = cardToPublicEvent(seed, tickets);
+  const bodyStaticMapUrl: string | null = (() => {
+    if (publicEventForBody.format === "online") return null;
+    if (publicEventForBody.hideAddressUntilTicket) return null;
+    const geo = publicEventForBody.locationGeo ?? null;
+    if (geo === null || !Number.isFinite(geo.lat) || !Number.isFinite(geo.lng)) {
+      return null;
+    }
+    return buildStaticMapUrl({
+      lat: geo.lat,
+      lng: geo.lng,
+      accentHex: palette.accent,
+      height: 180,
+    });
+  })();
+
   const cityCountry =
     fnd.cityCountry ?? normalizeCityCountry(seed.city) ?? null;
   const aboutText = fnd.description;
@@ -645,39 +658,12 @@ export default function ConsumerEventDetailScreen({
       ? null
       : [fnd.venueName, fnd.address].filter(Boolean).join(", ");
 
-  const barKicker = offeringCta.kind === "buy" ? "All-in, taxes included" : null;
   const REVEAL_MARGIN = 24;
   const floatingPillVisible =
     dockTopY === null || viewportH === 0
       ? true
       : dockTopY > scrollY + viewportH - REVEAL_MARGIN;
   const reserveBarClearance = 8;
-
-  const dockedReserve: ReactElement = (
-    <ConsumerEventReserveBar
-      cta={offeringCta}
-      palette={palette}
-      kicker={barKicker}
-      fontFamily={boldFamily}
-      onPress={openCart}
-      variant="docked"
-      safeAreaBottom={insets.bottom}
-      onDockLayout={handleDockLayout}
-      testID="orch-1138-consumer-event-reserve"
-    />
-  );
-  const floatingReserve: ReactElement | null = floatingPillVisible ? (
-    <ConsumerEventReserveBar
-      cta={offeringCta}
-      palette={palette}
-      kicker={barKicker}
-      fontFamily={boldFamily}
-      onPress={openCart}
-      variant="floating"
-      safeAreaBottom={insets.bottom}
-      testID="orch-1138-consumer-event-reserve"
-    />
-  ) : null;
 
   // ORCH-1157 [rsvp-public-redesign] — the Direction-C Going / Maybe / Can't
   // decision dock (replaces the old 2-button hand-rolled dock; Maybe is NEW on
@@ -1023,6 +1009,38 @@ export default function ConsumerEventDetailScreen({
               { backgroundColor: palette.page, borderColor: palette.panelBorder },
             ]}
           >
+            {/* ORCH-1167 — STANDARD ticketed-event branch renders the ONE shared
+                canonical EventOfferingBody (sections 2–8 incl. the inline ticket
+                box at 5). The cover (section 1) is the pinned sibling above; the
+                floating Get-tickets bar (section 9) is rendered below. The RSVP
+                branch is UNCHANGED (its own section sequence + dock). */}
+            {!isRsvp ? (
+              <View onLayout={handleDockLayout}>
+              <EventOfferingBody
+                event={publicEventForBody}
+                brand={{
+                  id: seed.brandId,
+                  slug: seed.brandSlug,
+                  displayName: seed.brandName,
+                  photo: seed.brandProfilePhotoUrl ?? undefined,
+                  theme: null,
+                }}
+                variant={computeOfferingVariant(publicEventForBody, false)}
+                bookable
+                palette={palette}
+                theme={theme}
+                ticketQuantities={ticketQuantities}
+                onChangeTicketQuantity={handleChangeTicketQuantity}
+                onProceedToCart={handleProceedToCart}
+                onOpenBrand={(slug: string) => router.push(`/b/${slug}` as never)}
+                onOpenMaps={openMapsForQuery}
+                staticMapUrl={bodyStaticMapUrl}
+                submitting={checkoutInFlight}
+                testID="orch-1167-consumer-event-body"
+              />
+              </View>
+            ) : (
+              <>
             {/* phone lead: date eyebrow + bold title */}
             <View style={styles.leadBlock}>
               {fnd.dateLine !== null ? (
@@ -1098,69 +1116,17 @@ export default function ConsumerEventDetailScreen({
                 keeps its byte-identical order (brand → about → venue → tickets).
                 The momentum unit omits when the anon-view count has not resolved
                 (no fabricated count — rule 9); the decision lives in the dock. */}
-            {isRsvp ? (
-              <>
-                {brandNode}
-                {rsvpMomentumUnit}
-                {venueNode}
-                {aboutNode}
-              </>
-            ) : (
-              <>
-                {brandNode}
-                {aboutNode}
-                {venueNode}
+            {/* RSVP section sequence (host/brand → momentum → venue → about),
+                structurally identical to the business/web RsvpPublicBody. */}
+            {brandNode}
+            {rsvpMomentumUnit}
+            {venueNode}
+            {aboutNode}
+
+            {/* DOCKED RSVP decision — the LAST scroll child (float→dock). */}
+            {rsvpDock}
               </>
             )}
-
-            {/* Tickets — the selectable tier radiogroup.
-                ORCH-1157 Issue 1 [rsvp-public-redesign] — GATED `!isRsvp`. An
-                RSVP event is TICKETLESS: it must NOT render "Choose your ticket"
-                or the "No tickets available yet" empty state (that block was
-                ungated and leaked onto RSVP cards — F-1 structural divergence).
-                RSVP momentum + decision are the body's gravitational center
-                instead (rsvpMomentumUnit above + rsvpDock below). */}
-            {!isRsvp ? (
-              <View style={styles.section}>
-                <Text
-                  style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}
-                >
-                  Choose your ticket
-                </Text>
-                {tickets.filter((t) => t.visibility !== "hidden").length === 0 ? (
-                  <View style={[styles.venueCard, surface.card]}>
-                    <Text style={[styles.aboutText, surface.secondaryText]}>
-                      No tickets available yet.
-                    </Text>
-                  </View>
-                ) : (
-                  <View accessibilityRole="radiogroup" style={styles.tierCol}>
-                    {tickets
-                      .filter((t) => t.visibility !== "hidden")
-                      .sort((a, b) => a.displayOrder - b.displayOrder)
-                      .map((t) => (
-                        <ConsumerTierRow
-                          key={t.id}
-                          ticket={t}
-                          fallbackCurrency={seed.currency}
-                          palette={palette}
-                          surface={surface}
-                          boldFamily={boldFamily}
-                          selected={selectedTicketId === t.id}
-                          onSelect={handleSelectTicket}
-                        />
-                      ))}
-                  </View>
-                )}
-                <Text style={[styles.reassure, { color: palette.tertiaryText }]}>
-                  All-in price — taxes &amp; fees included, no surprises at checkout.
-                </Text>
-              </View>
-            ) : null}
-
-            {/* DOCKED CTA — the LAST scroll child (float→dock language).
-                ORCH-1150 — RSVP cards dock Going/Not-going instead of the cart bar. */}
-            {isRsvp ? rsvpDock : dockedReserve}
           </View>
         </BottomSheetScrollView>
 
@@ -1178,9 +1144,28 @@ export default function ConsumerEventDetailScreen({
           />
         </View>
 
-        {/* (4) FLOATING reserve PILL — shown while the docked CTA is off-screen.
-            ORCH-1150 — suppressed for RSVP (the Going/Not-going dock is inline). */}
-        {isRsvp ? null : floatingReserve}
+        {/* (4) FLOATING Get-tickets BAR — shown while the in-page ticket box is
+            off-screen. ORCH-1167 — the shared EventOfferingFloatingBar reflects the
+            live Σ-all-in total + calls the SAME handleProceedToCart. Suppressed for
+            RSVP (its Going/Not-going dock is inline). */}
+        {isRsvp ? null : floatingPillVisible ? (
+          <View
+            style={[styles.nativeFloatWrap, { paddingBottom: insets.bottom + 8 }]}
+            pointerEvents="box-none"
+          >
+            <EventOfferingFloatingBar
+              event={publicEventForBody}
+              variant={computeOfferingVariant(publicEventForBody, false)}
+              bookable
+              palette={palette}
+              theme={theme}
+              ticketQuantities={ticketQuantities}
+              onProceedToCart={handleProceedToCart}
+              submitting={checkoutInFlight}
+              testID="orch-1167-consumer-event-floating-bar"
+            />
+          </View>
+        ) : null}
       </BaseBottomSheet>
 
       {/* Reserve opens the cart DIRECTLY (NEVER EBES). Sibling BaseBottomSheet
@@ -1194,6 +1179,7 @@ export default function ConsumerEventDetailScreen({
         intakeSchemasByTier={intakeSchemasQuery.data}
         fallbackCurrency={seed.currency}
         initialTicketTypeId={initialTicketTypeId}
+        initialQuantities={ticketQuantities}
         buyerName={
           profile?.display_name?.trim() || user?.email?.split("@")[0] || "Guest"
         }
@@ -1207,130 +1193,6 @@ export default function ConsumerEventDetailScreen({
     </>
   );
 }
-
-// ---- ConsumerTierRow — one selectable tier in the radiogroup ----
-const ConsumerTierRow: React.FC<{
-  ticket: PublicTicketProps;
-  fallbackCurrency: string;
-  palette: ReturnType<typeof createThemePalette>;
-  surface: ReturnType<typeof offeringSurfaceStyles>;
-  boldFamily: string;
-  selected: boolean;
-  onSelect: (ticketId: string) => void;
-}> = ({ ticket, fallbackCurrency, palette, surface, boldFamily, selected, onSelect }) => {
-  const isDisabled = ticket.visibility === "disabled";
-  const isSoldOut = !ticket.isUnlimited && (ticket.capacity ?? 0) === 0;
-  const isDoorOnly = ticket.availableAt === "door";
-  const saleEnded =
-    ticket.saleEndAt !== null &&
-    Number.isFinite(new Date(ticket.saleEndAt).getTime()) &&
-    new Date(ticket.saleEndAt).getTime() <= Date.now();
-
-  const stateWord: string | null = saleEnded
-    ? "Sales ended"
-    : isDisabled
-      ? "Sales paused"
-      : isDoorOnly
-        ? "Pay at the door"
-        : isSoldOut
-          ? "Sold out"
-          : null;
-  const selectable = stateWord === null;
-
-  const priceLabel = ticket.isFree
-    ? "Free"
-    : (() => {
-        const price = ticket.priceAllInGbp ?? ticket.priceGbp;
-        if (price === null || price === undefined) return "—";
-        const currency = ticket.currency ?? fallbackCurrency;
-        try {
-          return new Intl.NumberFormat("en-US", {
-            style: "currency",
-            currency,
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 2,
-          }).format(price);
-        } catch {
-          return `${currency} ${price.toFixed(2)}`;
-        }
-      })();
-
-  const capacityLabel = ticket.isUnlimited
-    ? "Unlimited"
-    : ticket.capacity !== null
-      ? ticket.capacity <= 0
-        ? "Sold out"
-        : `${ticket.capacity} available`
-      : "Available";
-
-  return (
-    <Pressable
-      onPress={selectable ? () => onSelect(ticket.id) : undefined}
-      disabled={!selectable}
-      accessibilityRole={selectable ? "radio" : "text"}
-      accessibilityState={selectable ? { checked: selected } : undefined}
-      accessibilityLabel={
-        ticket.name +
-        (priceLabel !== "—" ? `, ${priceLabel}` : "") +
-        (stateWord !== null ? `, ${stateWord}` : "")
-      }
-      style={[
-        styles.tierRow,
-        surface.card,
-        selected
-          ? { borderColor: palette.accent, backgroundColor: palette.accentWash }
-          : null,
-        isDisabled || isSoldOut || saleEnded ? styles.tierRowMuted : null,
-      ]}
-    >
-      {selected ? (
-        <View
-          pointerEvents="none"
-          style={[styles.tierRail, { backgroundColor: palette.accent }]}
-        />
-      ) : null}
-      <View
-        style={[
-          styles.radio,
-          { borderColor: selected ? palette.accent : palette.cutoutBorder },
-        ]}
-      >
-        {selected ? (
-          <View style={[styles.radioDot, { backgroundColor: palette.accent }]} />
-        ) : null}
-      </View>
-      <View style={styles.tierTextCol}>
-        <Text
-          style={[
-            styles.tierName,
-            surface.primaryText,
-            selected ? { fontFamily: boldFamily } : null,
-          ]}
-        >
-          {ticket.name}
-        </Text>
-        {ticket.description !== null && ticket.description.length > 0 ? (
-          <Text style={[styles.tierDesc, surface.secondaryText]}>
-            {ticket.description}
-          </Text>
-        ) : null}
-        <Text style={[styles.tierCap, surface.tertiaryText]}>
-          {stateWord ?? capacityLabel}
-        </Text>
-      </View>
-      <View
-        style={[
-          styles.tierPricePill,
-          { backgroundColor: palette.accentWash, borderColor: palette.panelBorder },
-        ]}
-      >
-        <Text style={[styles.tierPrice, surface.primaryText, { fontFamily: boldFamily }]}>
-          {priceLabel}
-        </Text>
-      </View>
-    </Pressable>
-  );
-};
 
 const SEAM = 28;
 
@@ -1367,6 +1229,15 @@ const styles = StyleSheet.create({
     left: 16,
     right: 16,
     zIndex: 70,
+  },
+  // ORCH-1167 — the standard-event floating Get-tickets bar wrapper (off-screen-
+  // box only). Absolute pinned sibling above the scroll, below the chrome.
+  nativeFloatWrap: {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    bottom: 0,
+    zIndex: 60,
   },
   leadBlock: { marginBottom: 4 },
   eyebrowLead: {

--- a/mingla-business/app/checkout/[eventId]/index.tsx
+++ b/mingla-business/app/checkout/[eventId]/index.tsx
@@ -16,7 +16,7 @@
 
 // orch-strict-grep-allow safearea-on-fullscreen-routes — design-intent full-bleed checkout header: insets.bottom IS applied (line 230 + 283) for home-indicator clearance; the top status-bar overlap with back arrow / "Get tickets" header / "1 OF 3" pill is the intended banner-style buyer aesthetic. Per ORCH-0859 [Tr2 Minimum Viable Trip] REWORK 5b operator design ruling 2026-05-17 (QA report §1) + pixel verification on iPhone 17 Pro Max sim (screenshot 18-CHECKOUT-INDEX.png).
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -26,7 +26,10 @@ import {
   spacing,
   text as textTokens,
 } from "../../../src/constants/designSystem";
-import { eventPublicPath } from "../../../src/constants/publicUrls";
+import {
+  decodeCartSeed,
+  eventPublicPath,
+} from "../../../src/constants/publicUrls";
 import type { LiveEvent } from "../../../src/store/liveEventStore";
 import type { TicketStub } from "../../../src/store/draftEventStore";
 import { usePublicEventById } from "../../../src/hooks/usePublicEvents";
@@ -71,8 +74,18 @@ const ticketSalesEnded = (ticket: TicketStub): boolean => {
 export default function CheckoutTicketsScreen(): React.ReactElement {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const params = useLocalSearchParams<{ eventId: string }>();
+  const params = useLocalSearchParams<{ eventId: string; seed?: string }>();
   const eventId = typeof params.eventId === "string" ? params.eventId : null;
+  // ORCH-1167 [event-page-canonical] — the inline-ticket-box selection carried
+  // from the public event page (`seed=id:qty,id:qty`). Seeds the cart ONCE on mount
+  // so this cart step (i) lands PRE-POPULATED + editable (replaces the empty
+  // tier-PICKER). Decode is null-safe (empty seed → empty map → unchanged path).
+  const seedParam =
+    typeof params.seed === "string"
+      ? params.seed
+      : Array.isArray(params.seed)
+        ? params.seed[0]
+        : undefined;
 
   const publicEventQuery = usePublicEventById(eventId);
   const event = publicEventQuery.data?.event ?? null;
@@ -91,6 +104,35 @@ export default function CheckoutTicketsScreen(): React.ReactElement {
   const { lines, setLineQuantity } = useCart();
   const totals = useCartTotals();
   const [waitlistTicketId, setWaitlistTicketId] = useState<string | null>(null);
+
+  // ORCH-1167 [event-page-canonical] — seed the cart from the inline-box selection
+  // carried in the `seed` param, ONCE, after the event (and its tickets) resolve.
+  // Quantities remain fully editable here (the QuantityRows below own them). The
+  // all-in (priceAllInGbp) is seeded as the headline-Total basis (WYSIWYP), exactly
+  // like the QuantityRow onChange path — never fabricated.
+  const seededRef = useRef<boolean>(false);
+  useEffect(() => {
+    if (seededRef.current) return;
+    const ev = publicEventQuery.data?.event ?? null;
+    if (ev === null) return;
+    const seedMap = decodeCartSeed(seedParam);
+    seededRef.current = true; // mark even on empty seed so re-renders don't re-seed.
+    if (Object.keys(seedMap).length === 0) return;
+    for (const ticket of ev.tickets) {
+      const qty = seedMap[ticket.id];
+      if (qty === undefined || qty <= 0) continue;
+      if (ticket.visibility === "hidden" || ticket.availableAt === "door") continue;
+      setLineQuantity({
+        ticketTypeId: ticket.id,
+        ticketName: ticket.name,
+        unitPrice: ticket.priceGbp ?? 0,
+        unitPriceAllIn: ticket.priceAllInGbp ?? ticket.priceGbp ?? 0,
+        currency: ticket.currency ?? ev.currency ?? "GBP",
+        isFree: ticket.isFree,
+        quantity: qty,
+      });
+    }
+  }, [publicEventQuery.data, seedParam, setLineQuantity]);
 
   // ORCH-1147R2 — the selection bottom bar leads with the server fee-grossed
   // all-in (totals.allInTotal), NOT the bare base subtotal (totals.total), so

--- a/mingla-business/src/components/event/FoundationEventPreview.tsx
+++ b/mingla-business/src/components/event/FoundationEventPreview.tsx
@@ -1,109 +1,60 @@
 /**
- * FoundationEventPreview — ORCH-1138 Leg 2 (public EVENT page, Direction A).
+ * FoundationEventPreview — ORCH-1167 [event-page-canonical] thin wrapper.
  *
- * The buyer-web + business in-app FOUNDATION render for the public event page,
- * mirroring the SHIPPED trip leg's `TripPreview` FoundationTripPreview 1:1 — but
- * for the EVENT model. Composes the shared @mingla/offering-rendering
- * `ParallaxCoverShell` (pinned parallax cover, body-level fixed X·Share·Mute
- * chrome, responsive desktop sticky panel) around a body that renders ONLY real
- * event fields (rule 9): date eyebrow + title, meta chips, brand chip, About,
- * "Where you'll be" venue card, a SELECTABLE ticket-TIER radiogroup as the spine,
- * + the float→dock single CTA (the adapter builds the bars from the SAME
- * resolveOfferingCta state).
+ * Was (ORCH-1138 Leg 2): the buyer-web + business in-app FOUNDATION render that
+ * forked the event-page body in mingla-business/src (a SELECTABLE tier radiogroup
+ * + route-out CTA), NOT shared with the consumer fork.
  *
- * WHY this lives in the APP layer (not the shared packages/event-rendering): the
- * shared event renderer is a DEPENDENCY of @mingla/offering-rendering (offering-
- * rendering imports offeringSurfaceStyles/ThemePalette FROM event-rendering). If
- * the event-rendering PACKAGE imported offering-rendering, that inverts the edge
- * into a runtime circular dependency (proven on the iOS sim: "Cannot read property
- * 'offeringSurfaceStyles' of undefined" at module init). So — exactly like the
- * trip leg's FoundationTripPreview — the FOUNDATION composition lives in the app
- * layer, which imports BOTH packages freely. The shared PublicEventPage stays
- * BYTE-IDENTICAL to origin/main (its LEGACY stacked render), so EBES's experience
- * mount + chat are provably unaffected (N1 / SC-9).
+ * Now (ORCH-1167): a THIN WRAPPER around the ONE shared, shell-agnostic
+ * `EventOfferingBody` (@mingla/offering-rendering). This wrapper owns ONLY the
+ * surface scaffold: it composes the shared `ParallaxCoverShell` (pinned parallax
+ * cover + body-level fixed X·Share·Mute chrome + responsive desktop sticky shell,
+ * with a raw RN ScrollView as the scroll host) AROUND the shared body, which now
+ * carries the canonical 9-section structure incl. the INLINE on-page ticket box
+ * (per-tier steppers + live Σ-all-in running total + in-box Proceed). The cover is
+ * section 1 (the shell's pinned sibling); the inline box is section 5 (inside the
+ * body); the floating Get-tickets bar (section 9) is rendered by the adapter
+ * (PublicEventPage) as a pinned overlay.
  *
- * NO refund-ladder / booking-deadline / itinerary / route / pay-toggle / split-CTA
- * — the event model has none (N2 / N3 / N4 / rule 9). The map is rule-9 OMITTED:
- * the public event read carries no venue lat/lng (the view never selected
- * location_geo), so the venue CARD renders without a fabricated tile.
+ * WHY this still lives in the APP layer (not the package): the shared event body is
+ * a DEPENDENCY of @mingla/offering-rendering (offering-rendering imports
+ * offeringSurfaceStyles/types FROM event-rendering). Composing ParallaxCoverShell
+ * (offering-rendering) + the body (offering-rendering) + the brand-app Icon belongs
+ * in the app layer, which imports both packages freely. The shared body itself is
+ * pure (I-MOR-0827); this wrapper is the surface seam.
  *
- * Anon-tolerant: no useAuth, no fetch. Pure presentational; the adapter owns
- * state + checkout. Android: opaque glass via the foundation primitives.
+ * Anon-tolerant: no useAuth, no fetch. The adapter (PublicEventPage) owns state +
+ * cart navigation. Android: opaque glass via the foundation primitives.
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React from "react";
 import {
-  Image,
-  LayoutAnimation,
-  Platform,
-  Pressable,
-  StyleSheet,
-  Text,
-  UIManager,
-  View,
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from "react-native";
 
 import {
-  boldFontFamily,
-  offeringSurfaceStyles,
+  type OfferingVariant,
   type PublicBrandProps,
   type PublicEventProps,
-  type PublicTicketProps,
   type ResolvedTheme,
   type ThemePalette,
-  ticketIsDoorOnly,
-  ticketIsSoldOut,
-  ticketSaleEnded,
+  boldFontFamily,
 } from "@mingla/event-rendering";
 import {
+  EventOfferingBody,
   ParallaxCoverShell,
-  normalizeCityCountry,
   useResponsiveLayout,
 } from "@mingla/offering-rendering";
-
-import { Icon } from "../ui/Icon";
-
-const ABOUT_COLLAPSE_THRESHOLD = 160;
-const SHOW_INITIAL_DATES = 10;
-
-// Enable LayoutAnimation on Android once at module load (no-op on iOS/web).
-if (
-  Platform.OS === "android" &&
-  UIManager.setLayoutAnimationEnabledExperimental !== undefined
-) {
-  UIManager.setLayoutAnimationEnabledExperimental(true);
-}
-
-const sortTickets = (tickets: PublicTicketProps[]): PublicTicketProps[] =>
-  [...tickets].sort((a, b) => a.displayOrder - b.displayOrder);
-
-const formatTicketPrice = (
-  ticket: PublicTicketProps,
-  fallbackCurrency: string,
-): string => {
-  if (ticket.isFree) return "Free";
-  const price = ticket.priceAllInGbp ?? ticket.priceGbp;
-  if (price === null || price === undefined) return "—";
-  const currency = ticket.currency ?? fallbackCurrency;
-  try {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 2,
-    }).format(price);
-  } catch {
-    return `${currency} ${price.toFixed(2)}`;
-  }
-};
+import { Text, StyleSheet, View } from "react-native";
 
 export interface FoundationEventPreviewProps {
   event: PublicEventProps;
   brand: PublicBrandProps | null;
-  variant: "published" | "pre-sale" | "sold-out" | "past";
+  variant: OfferingVariant;
+  /** I-PAID-SUPPLY gate (ORCH-1076) — false → inline box + CTA disabled. */
+  bookable: boolean;
   palette: ThemePalette;
   theme: ResolvedTheme;
   muted: boolean;
@@ -112,16 +63,21 @@ export interface FoundationEventPreviewProps {
   onShare: () => void;
   onOpenBrand?: (brandSlug: string) => void;
   onOpenMaps?: (query: string) => void;
+  /** Server-proxied static map URL (privacy-gated upstream). null → text card. */
+  staticMapUrl?: string | null;
   stateBanner?: React.ReactNode | null;
   stickyPanel?: React.ReactNode | null;
-  dockedReserve?: React.ReactNode;
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   onScrollViewLayout?: (event: LayoutChangeEvent) => void;
+  /** ORCH-1167 — the inline box bottom y, so the floating bar can hide on-screen. */
+  onDockLayout?: (event: LayoutChangeEvent) => void;
   safeAreaTop?: number;
   contentBottomInset?: number;
-  /** Selected tier id (FOUNDATION radiogroup). null → none selected yet. */
-  selectedTicketId: string | null;
-  onSelectTicket: (ticketId: string) => void;
+  // ORCH-1167 — the inline ticket box state (LIFTED to the adapter for the cart).
+  ticketQuantities: Record<string, number>;
+  onChangeTicketQuantity: (ticketTypeId: string, qty: number) => void;
+  onProceedToCart: () => void;
+  submitting?: boolean;
   testID?: string;
 }
 
@@ -129,6 +85,7 @@ export const FoundationEventPreview: React.FC<FoundationEventPreviewProps> = ({
   event,
   brand,
   variant,
+  bookable,
   palette,
   theme,
   muted,
@@ -137,32 +94,23 @@ export const FoundationEventPreview: React.FC<FoundationEventPreviewProps> = ({
   onShare,
   onOpenBrand,
   onOpenMaps,
+  staticMapUrl = null,
   stateBanner = null,
   stickyPanel = null,
-  dockedReserve,
   onScroll,
   onScrollViewLayout,
+  onDockLayout,
   safeAreaTop = 0,
   contentBottomInset = 0,
-  selectedTicketId,
-  onSelectTicket,
+  ticketQuantities,
+  onChangeTicketQuantity,
+  onProceedToCart,
+  submitting = false,
   testID,
 }) => {
   const { isDesktop } = useResponsiveLayout();
-  const surface = offeringSurfaceStyles(palette);
+  void isDesktop; // ParallaxCoverShell owns the responsive two-column shell.
   const boldFamily = boldFontFamily(theme);
-  const [aboutCollapsed, setAboutCollapsed] = useState<boolean>(true);
-  const [showAllDates, setShowAllDates] = useState<boolean>(false);
-  const toggleAbout = useCallback((): void => {
-    LayoutAnimation.configureNext(
-      LayoutAnimation.create(
-        200,
-        LayoutAnimation.Types.easeInEaseOut,
-        LayoutAnimation.Properties.opacity,
-      ),
-    );
-    setAboutCollapsed((c) => !c);
-  }, []);
 
   const coverType: "image" | "video" | "gif" | null =
     event.coverMediaType === "video"
@@ -173,282 +121,26 @@ export const FoundationEventPreview: React.FC<FoundationEventPreviewProps> = ({
           ? "image"
           : null;
 
-  const cityCountry =
-    normalizeCityCountry(event.venueName) ??
-    normalizeCityCountry(event.address);
-
-  const visibleTickets = useMemo(
-    () => sortTickets(event.tickets.filter((t) => t.visibility !== "hidden")),
-    [event.tickets],
-  );
-
-  const capacityChip = useMemo<string | null>(() => {
-    let total = 0;
-    let anyFinite = false;
-    for (const t of visibleTickets) {
-      if (t.isUnlimited) continue;
-      if (t.capacity !== null) {
-        total += t.capacity;
-        anyFinite = true;
-      }
-    }
-    if (!anyFinite) return null;
-    return total <= 0 ? "Sold out" : `${total} tickets left`;
-  }, [visibleTickets]);
-
-  // ORCH-1157 Round-6 [rsvp-public-redesign] — when the street is hidden show the
-  // City/Country line (real city) as the sub-line, with the unlock caption beneath
-  // it (standardized below). The legacy "Address shared after ticket purchase"
-  // remains only as the last-resort fallback when there is no city to show.
-  const venueAddressLabel = event.hideAddressUntilTicket
-    ? (cityCountry ?? "Address shared after you get tickets")
-    : event.format === "hybrid" && event.address !== null
-      ? `${event.address} · also online`
-      : (event.address ?? "Address shared after you get tickets");
-  // The caption telling the buyer HOW to unlock the exact street; renders ONLY
-  // while the street is hidden. This is the TICKETED page → "after you get
-  // tickets" (must never say "RSVP"). Static helper text.
-  const addressUnlockCaption: string | null = event.hideAddressUntilTicket
-    ? "Full address shared after you get tickets"
-    : null;
-  const venueMapsQuery =
-    event.hideAddressUntilTicket || event.venueName === null
-      ? null
-      : [event.venueName, event.address].filter(Boolean).join(", ");
-  const canOpenVenueMaps =
-    venueMapsQuery !== null &&
-    venueMapsQuery.trim().length > 0 &&
-    onOpenMaps !== undefined;
-
-  const aboutText = event.description.trim();
-  const canCollapseAbout = aboutText.length > ABOUT_COLLAPSE_THRESHOLD;
-  const aboutCollapsedNow = canCollapseAbout && aboutCollapsed;
-  void variant;
-
-  const brandChip = (
-    <Pressable
-      onPress={() => {
-        if (brand?.slug !== undefined) onOpenBrand?.(brand.slug);
-      }}
-      disabled={brand?.slug === undefined || onOpenBrand === undefined}
-      accessibilityRole={onOpenBrand !== undefined ? "button" : undefined}
-      accessibilityLabel={
-        brand?.displayName !== undefined ? `View ${brand.displayName}` : "View brand"
-      }
-      style={[styles.brandRow, surface.card]}
-    >
-      <View style={[styles.brandTile, { backgroundColor: palette.accent }]}>
-        {brand?.photo !== undefined && brand.photo.length > 0 ? (
-          <Image
-            source={{ uri: brand.photo }}
-            style={styles.brandPhoto}
-            resizeMode="cover"
-            accessibilityLabel={`${brand.displayName ?? "Brand"} profile photo`}
-          />
-        ) : (
-          <View style={styles.brandInitialWrap}>
-            <Text style={[styles.brandInitial, { color: palette.accentText, fontFamily: boldFamily }]}>
-              {(brand?.displayName?.trim()[0] ?? "•").toUpperCase()}
-            </Text>
-          </View>
-        )}
-      </View>
-      <View style={styles.brandTextCol}>
-        <Text style={[styles.brandKicker, surface.tertiaryText]}>Presented by</Text>
-        <Text style={[styles.brandName, surface.primaryText, { fontFamily: boldFamily }]}>
-          {brand?.displayName ?? "Brand"}
-        </Text>
-      </View>
-      {onOpenBrand !== undefined ? (
-        <Text style={[styles.brandCta, { color: palette.accent }]}>View</Text>
-      ) : null}
-    </Pressable>
-  );
-
-  const left = (
-    <View>
-      {!isDesktop ? (
-        <View style={styles.leadBlock}>
-          {event.dateLine.length > 0 ? (
-            <Text style={[styles.eyebrow, { color: palette.accent }]}>
-              {event.dateLine}
-            </Text>
-          ) : null}
-          <Text style={[styles.title, surface.primaryText, { fontFamily: boldFamily }]}>
-            {event.name.length > 0 ? event.name : "Untitled event"}
-          </Text>
-        </View>
-      ) : null}
-
-      <View style={styles.metaRow}>
-        {event.dateLine.length > 0 ? (
-          <MetaChip palette={palette} surface={surface} glyph="◷" font={boldFamily}>
-            {event.dateLine}
-          </MetaChip>
-        ) : null}
-        {event.dateSubline !== null && event.dateSubline.length > 0 ? (
-          <MetaChip palette={palette} surface={surface} glyph="⟳" font={boldFamily}>
-            {event.dateSubline}
-          </MetaChip>
-        ) : null}
-        {capacityChip !== null ? (
-          <MetaChip palette={palette} surface={surface} glyph="◍" font={boldFamily}>
-            {capacityChip}
-          </MetaChip>
-        ) : null}
-        {cityCountry !== null ? (
-          <MetaChip palette={palette} surface={surface} glyph="⌖" font={boldFamily}>
-            {cityCountry}
-          </MetaChip>
-        ) : null}
-      </View>
-
-      {event.datesList.length > 1 ? (
-        <View style={styles.datesWrap}>
-          <Pressable
-            onPress={() => setShowAllDates((s) => !s)}
-            accessibilityRole="button"
-            accessibilityLabel={
-              showAllDates ? "Hide dates" : `Show all ${event.datesList.length} dates`
-            }
-            style={[styles.datesToggle, { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }]}
-          >
-            <Text style={[styles.datesToggleText, { color: palette.primaryText }]}>
-              {showAllDates ? "Hide dates" : `Show all ${event.datesList.length} dates`}
-            </Text>
-          </Pressable>
-          {showAllDates
-            ? event.datesList.slice(0, SHOW_INITIAL_DATES).map((label, i) => (
-                <View
-                  key={i}
-                  style={[styles.dateRow, { backgroundColor: palette.card, borderColor: palette.cutoutBorder }]}
-                >
-                  <Text style={[styles.dateRowText, { color: palette.primaryText }]}>{label}</Text>
-                </View>
-              ))
-            : null}
-        </View>
-      ) : null}
-
-      {!isDesktop ? brandChip : null}
-
-      {aboutText.length > 0 ? (
-        <View style={styles.section}>
-          <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>About</Text>
-          <Text
-            style={[styles.about, surface.secondaryText]}
-            numberOfLines={aboutCollapsedNow ? 3 : undefined}
-            ellipsizeMode="tail"
-          >
-            {aboutText}
-          </Text>
-          {canCollapseAbout ? (
-            <Pressable
-              onPress={toggleAbout}
-              accessibilityRole="button"
-              accessibilityState={{ expanded: !aboutCollapsedNow }}
-              accessibilityLabel={aboutCollapsedNow ? "Read more" : "Show less"}
-              style={styles.aboutToggleRow}
-            >
-              <Text style={[styles.aboutToggle, { color: palette.accent }]}>
-                {aboutCollapsedNow ? "Read more" : "Show less"}
-              </Text>
-            </Pressable>
-          ) : null}
-        </View>
-      ) : null}
-
-      {/* Where you'll be — venue card (map rule-9 OMITTED: no geo on the read) */}
-      {event.format === "online" ? (
-        <View style={styles.section}>
-          <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
-            Where you&rsquo;ll be
-          </Text>
-          <View style={[styles.venueCard, surface.card]}>
-            <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
-              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>◯</Text>
-            </View>
-            <View style={styles.venueTextCol}>
-              <Text style={[styles.venueName, surface.primaryText, { fontFamily: boldFamily }]}>Online</Text>
-              <Text style={[styles.venueAddr, surface.secondaryText]}>
-                Conferencing link shared with ticketed guests.
-              </Text>
-            </View>
-          </View>
-        </View>
-      ) : event.venueName !== null ? (
-        <View style={styles.section}>
-          <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
-            Where you&rsquo;ll be
-          </Text>
-          <Pressable
-            onPress={() => {
-              if (venueMapsQuery !== null) onOpenMaps?.(venueMapsQuery);
-            }}
-            disabled={!canOpenVenueMaps}
-            accessibilityRole={canOpenVenueMaps ? "button" : undefined}
-            accessibilityLabel={canOpenVenueMaps ? `Open ${event.venueName} in maps` : event.venueName}
-            style={[styles.venueCard, surface.card]}
-          >
-            <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
-              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>⌖</Text>
-            </View>
-            <View style={styles.venueTextCol}>
-              <Text style={[styles.venueName, surface.primaryText, { fontFamily: boldFamily }]}>
-                {event.venueName}
-              </Text>
-              <Text style={[styles.venueAddr, surface.secondaryText]}>{venueAddressLabel}</Text>
-              {/* ORCH-1157 Round-6 — unlock caption UNDER the city; only while the
-                  exact street is hidden (ticketed copy, never "RSVP"). */}
-              {addressUnlockCaption !== null ? (
-                <Text
-                  style={[styles.venueUnlockCaption, surface.tertiaryText]}
-                  testID="orch-1157-ticketed-address-unlock-caption"
-                >
-                  {addressUnlockCaption}
-                </Text>
-              ) : null}
-            </View>
-            {canOpenVenueMaps ? (
-              <View style={[styles.venuePill, { backgroundColor: palette.accent }]}>
-                <Text style={[styles.venuePillText, { color: palette.accentText }]}>Open maps</Text>
-              </View>
-            ) : null}
-          </Pressable>
-        </View>
-      ) : null}
-
-      {/* Tickets — the SELECTABLE tier radiogroup (the page spine) */}
-      <View style={styles.section}>
-        <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
-          {isDesktop ? "Tickets" : "Choose your ticket"}
-        </Text>
-        {visibleTickets.length === 0 ? (
-          <View style={[styles.venueCard, surface.card]}>
-            <Text style={[styles.about, surface.secondaryText]}>No tickets available yet.</Text>
-          </View>
-        ) : (
-          <View accessibilityRole="radiogroup" style={styles.tierCol}>
-            {visibleTickets.map((t) => (
-              <FoundationTierRow
-                key={t.id}
-                ticket={t}
-                fallbackCurrency={event.currency}
-                palette={palette}
-                surface={surface}
-                boldFamily={boldFamily}
-                selected={selectedTicketId === t.id}
-                onSelect={onSelectTicket}
-              />
-            ))}
-          </View>
-        )}
-        <Text style={[styles.reassure, { color: palette.tertiaryText }]}>
-          All-in price — taxes &amp; fees included, no surprises at checkout.
-        </Text>
-      </View>
-
-      {!isDesktop && dockedReserve !== undefined ? dockedReserve : null}
+  // The shared body's content, wrapped so the adapter can measure its bottom y
+  // (float→dock: hide the floating bar once the in-page box scrolls into view).
+  const body = (
+    <View onLayout={onDockLayout}>
+      <EventOfferingBody
+        event={event}
+        brand={brand}
+        variant={variant}
+        bookable={bookable}
+        palette={palette}
+        theme={theme}
+        ticketQuantities={ticketQuantities}
+        onChangeTicketQuantity={onChangeTicketQuantity}
+        onProceedToCart={onProceedToCart}
+        onOpenBrand={onOpenBrand}
+        onOpenMaps={onOpenMaps}
+        staticMapUrl={staticMapUrl}
+        submitting={submitting}
+        testID="orch-1167-event-body"
+      />
     </View>
   );
 
@@ -465,9 +157,7 @@ export const FoundationEventPreview: React.FC<FoundationEventPreviewProps> = ({
       showMute={coverType === "video"}
       onClose={onClose}
       onShare={onShare}
-      // ORCH-1159 — hide the floating X on web (public event page; no parent
-      // screen to return to for an anonymous share-link visitor). Native keeps
-      // it; Share is unaffected.
+      // ORCH-1159 — hide the floating X on web (preserved). Native keeps it.
       hideCloseOnWeb
       heroEyebrow={
         event.dateLine.length > 0 ? (
@@ -487,119 +177,12 @@ export const FoundationEventPreview: React.FC<FoundationEventPreviewProps> = ({
       onScrollViewLayout={onScrollViewLayout}
       testID={testID}
     >
-      {left}
+      {body}
     </ParallaxCoverShell>
   );
 };
 
-const MetaChip: React.FC<{
-  palette: ThemePalette;
-  surface: ReturnType<typeof offeringSurfaceStyles>;
-  glyph: string;
-  font: string;
-  children: React.ReactNode;
-}> = ({ palette, surface, glyph, font, children }) => (
-  <View style={[styles.metaChip, surface.card]}>
-    <Text style={[styles.metaGlyph, { color: palette.accent }]}>{glyph}</Text>
-    <Text style={[styles.metaText, surface.secondaryText, { fontFamily: font }]}>
-      {children}
-    </Text>
-  </View>
-);
-
-const FoundationTierRow: React.FC<{
-  ticket: PublicTicketProps;
-  fallbackCurrency: string;
-  palette: ThemePalette;
-  surface: ReturnType<typeof offeringSurfaceStyles>;
-  boldFamily: string;
-  selected: boolean;
-  onSelect: (ticketId: string) => void;
-}> = ({ ticket, fallbackCurrency, palette, surface, boldFamily, selected, onSelect }) => {
-  const isDisabled = ticket.visibility === "disabled";
-  const isSoldOut = ticketIsSoldOut(ticket);
-  const isDoorOnly = ticketIsDoorOnly(ticket);
-  const saleEnded = ticketSaleEnded(ticket);
-
-  const stateWord: string | null = saleEnded
-    ? "Sales ended"
-    : isDisabled
-      ? "Sales paused"
-      : isDoorOnly
-        ? "Pay at the door"
-        : isSoldOut
-          ? "Sold out"
-          : null;
-  const selectable = stateWord === null;
-
-  const priceLabel = formatTicketPrice(ticket, fallbackCurrency);
-  const capacityLabel = ticket.isUnlimited
-    ? "Unlimited"
-    : ticket.capacity !== null
-      ? ticket.capacity <= 0
-        ? "Sold out"
-        : `${ticket.capacity} available`
-      : "Available";
-
-  return (
-    <Pressable
-      onPress={selectable ? () => onSelect(ticket.id) : undefined}
-      disabled={!selectable}
-      accessibilityRole={selectable ? "radio" : "text"}
-      accessibilityState={selectable ? { checked: selected } : undefined}
-      accessibilityLabel={
-        ticket.name +
-        (priceLabel !== "—" ? `, ${priceLabel}` : "") +
-        (stateWord !== null ? `, ${stateWord}` : "")
-      }
-      style={[
-        styles.tierRow,
-        surface.card,
-        selected ? { borderColor: palette.accent, backgroundColor: palette.accentWash } : null,
-        isDisabled || isSoldOut || saleEnded ? styles.tierRowMuted : null,
-      ]}
-    >
-      {selected ? (
-        <View pointerEvents="none" style={[styles.tierRail, { backgroundColor: palette.accent }]} />
-      ) : null}
-      <View style={[styles.radio, { borderColor: selected ? palette.accent : palette.cutoutBorder }]}>
-        {selected ? <View style={[styles.radioDot, { backgroundColor: palette.accent }]} /> : null}
-      </View>
-      <View style={styles.tierTextCol}>
-        <Text
-          style={[
-            styles.tierName,
-            { color: palette.primaryText, fontFamily: selected ? boldFamily : undefined },
-          ]}
-        >
-          {ticket.name}
-        </Text>
-        {ticket.description !== null && ticket.description.length > 0 ? (
-          <Text style={[styles.tierDesc, { color: palette.secondaryText }]}>{ticket.description}</Text>
-        ) : null}
-        <Text style={[styles.tierCap, { color: palette.tertiaryText }]}>
-          {stateWord ?? capacityLabel}
-        </Text>
-      </View>
-      <View style={[styles.tierPricePill, { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }]}>
-        <Text style={[styles.tierPrice, { color: palette.primaryText, fontFamily: boldFamily }]}>
-          {ticket.isFree ? "Free" : priceLabel}
-        </Text>
-      </View>
-    </Pressable>
-  );
-};
-
 const styles = StyleSheet.create({
-  leadBlock: { marginBottom: 4 },
-  eyebrow: {
-    fontSize: 11,
-    fontWeight: "900",
-    letterSpacing: 1.6,
-    textTransform: "uppercase",
-    marginBottom: 8,
-  },
-  title: { fontSize: 32, lineHeight: 35, fontWeight: "900", letterSpacing: -0.5 },
   heroEyebrow: {
     fontSize: 12,
     fontWeight: "900",
@@ -615,101 +198,6 @@ const styles = StyleSheet.create({
     letterSpacing: -1,
     color: "#ffffff",
   },
-  metaRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 16 },
-  metaChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-  },
-  metaGlyph: { fontSize: 14, fontWeight: "900" },
-  metaText: { fontSize: 13, fontWeight: "600" },
-  datesWrap: { marginTop: 12, gap: 8 },
-  datesToggle: {
-    alignSelf: "flex-start",
-    borderRadius: 999,
-    borderWidth: 1,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-  },
-  datesToggleText: { fontSize: 13, fontWeight: "700" },
-  dateRow: { borderRadius: 12, borderWidth: 1, paddingHorizontal: 12, paddingVertical: 10 },
-  dateRowText: { fontSize: 13, fontWeight: "600" },
-  brandRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    marginTop: 18,
-    borderRadius: 16,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-  },
-  brandTile: { width: 42, height: 42, borderRadius: 999, overflow: "hidden" },
-  brandPhoto: { width: "100%", height: "100%" },
-  brandInitialWrap: { flex: 1, alignItems: "center", justifyContent: "center" },
-  brandInitial: { fontSize: 18, fontWeight: "900" },
-  brandTextCol: { flexShrink: 1, flexGrow: 1 },
-  brandKicker: { fontSize: 10, fontWeight: "800", letterSpacing: 1.2, textTransform: "uppercase" },
-  brandName: { fontSize: 15, fontWeight: "800", marginTop: 1 },
-  brandCta: { fontSize: 13, fontWeight: "800" },
-  section: { marginTop: 24 },
-  secTitle: { fontSize: 20, fontWeight: "900", letterSpacing: -0.3, marginBottom: 12 },
-  about: { fontSize: 16, lineHeight: 23 },
-  aboutToggleRow: { flexDirection: "row", alignItems: "center", minHeight: 44 },
-  aboutToggle: { fontSize: 14, fontWeight: "700" },
-  venueCard: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    borderRadius: 16,
-    padding: 14,
-  },
-  venueDisk: {
-    width: 40,
-    height: 40,
-    borderRadius: 999,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  venueGlyph: { fontSize: 18, fontWeight: "900" },
-  venueTextCol: { flex: 1, minWidth: 0 },
-  venueName: { fontSize: 15, fontWeight: "800" },
-  venueAddr: { fontSize: 13, marginTop: 2 },
-  venueUnlockCaption: { fontSize: 12, marginTop: 4 },
-  venuePill: { borderRadius: 999, paddingHorizontal: 14, paddingVertical: 8 },
-  venuePillText: { fontSize: 12, fontWeight: "800" },
-  reassure: { fontSize: 12, marginTop: 12, lineHeight: 17 },
-  tierCol: { gap: 10 },
-  tierRow: {
-    position: "relative",
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    borderRadius: 16,
-    borderWidth: 1,
-    paddingHorizontal: 14,
-    paddingVertical: 14,
-    overflow: "hidden",
-  },
-  tierRowMuted: { opacity: 0.7 },
-  tierRail: { position: "absolute", left: 0, top: 0, bottom: 0, width: 4 },
-  radio: {
-    width: 22,
-    height: 22,
-    borderRadius: 999,
-    borderWidth: 2,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  radioDot: { width: 10, height: 10, borderRadius: 999 },
-  tierTextCol: { flex: 1, minWidth: 0 },
-  tierName: { fontSize: 15, fontWeight: "800" },
-  tierDesc: { fontSize: 13, marginTop: 3, lineHeight: 18 },
-  tierCap: { fontSize: 12, fontWeight: "700", marginTop: 4 },
-  tierPricePill: { borderRadius: 12, borderWidth: 1, paddingHorizontal: 12, paddingVertical: 8 },
-  tierPrice: { fontSize: 15, fontWeight: "900" },
 });
 
 export default FoundationEventPreview;

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -54,17 +54,20 @@ import {
   computeOfferingVariant,
   createThemePalette,
   boldFontFamily,
+  buildStaticMapUrl,
 } from "@mingla/event-rendering";
-import { useResponsiveLayout } from "@mingla/offering-rendering";
+import {
+  useResponsiveLayout,
+  EventOfferingFloatingBar,
+} from "@mingla/offering-rendering";
 
 import { spacing } from "../../constants/designSystem";
-import { EventReserveBar } from "./EventReserveBar";
 import { FoundationEventPreview } from "./FoundationEventPreview";
 import { RsvpPublicBody } from "./RsvpPublicBody";
 import { submitPublicRsvp } from "../../services/rsvpEvents";
 
 import {
-  checkoutPublicPath,
+  checkoutPublicPathWithSeed,
   eventOgImageUrl,
   eventPublicUrl,
 } from "../../constants/publicUrls";
@@ -170,6 +173,11 @@ const mapLiveEventToPublicEvent = (event: LiveEvent): PublicEventProps => {
     // ORCH-1162 Bug 2 — thread the venue geo so the shared renderer can draw the
     // "Where you'll be" map (business native preview). null → text-card fallback.
     locationGeo: event.locationGeo ?? null,
+    // ORCH-1167 [event-page-canonical] — city-level privacy centroid (merged from
+    // pg_public_event_by_slug in detailFromRow). The EventOfferingBody host feeds
+    // whichever geo the privacy gate left present (cityGeo when the street is
+    // hidden, locationGeo when public). null → text venue card (rule 9).
+    cityGeo: event.cityGeo ?? null,
     coverHue: event.coverHue,
     coverMediaUrl: safeCoverMediaUrl,
     coverMediaType:
@@ -186,6 +194,8 @@ const mapLiveEventToPublicEvent = (event: LiveEvent): PublicEventProps => {
     // the view mapper; default `[]` for legacy persisted rows (rule 9 — no fake).
     partyTypes: event.partyTypes ?? [],
     vibeTags: event.vibeTags ?? [],
+    // ORCH-1167 [event-page-canonical] — music-genre pills (third pills group).
+    musicGenres: event.musicGenres ?? [],
     themeOverrides: event.themeOverrides ?? null,
   };
 };
@@ -248,10 +258,13 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
   // ORCH-1138 — cover-video sound state (default muted). The chrome Mute button
   // toggles EventCoverMedia's muted state via this.
   const [muted, setMuted] = useState<boolean>(true);
-  // ORCH-1138 — the selected ticket-tier id (FOUNDATION radiogroup). null → none
-  // chosen yet; the bar/sticky panel use the page-level resolveOfferingCta until
-  // the buyer picks a tier (which then narrows the considered set).
-  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
+  // ORCH-1167 [event-page-canonical] — the inline ticket-box per-tier quantities
+  // (REPLACES the ORCH-1138 single-select radiogroup). The shared EventOfferingBody
+  // reads/writes this; in-box Proceed + the floating bar carry it into the cart
+  // (pre-populated, editable) at the checkout cart step (i). Empty → nothing picked.
+  const [ticketQuantities, setTicketQuantities] = useState<Record<string, number>>(
+    {},
+  );
 
   const viewerRole: ViewerRole = useMemo(() => {
     if (user === null) return "anonymous";
@@ -276,6 +289,26 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
   const boldFamily = boldFontFamily(resolvedTheme);
   useThemeFont(resolvedTheme.fontFamilyValue);
   useThemeFont(boldFamily);
+
+  // ORCH-1167 [event-page-canonical] — the server-proxied static map URL for the
+  // "Where you'll be" section. PRIVACY: the RPC already enforces the gate server-
+  // side (locationGeo null + cityGeo set when the street is hidden), so the host
+  // simply feeds whichever geo is present — exact pin when public, city-level
+  // centroid when hidden. null on no geo → text venue card (rule 9). Online events
+  // never render a map (the body shows the "Online" card).
+  const staticMapUrl = useMemo<string | null>(() => {
+    if (publicEvent.format === "online") return null;
+    const geo = publicEvent.locationGeo ?? publicEvent.cityGeo ?? null;
+    if (geo === null) return null;
+    return buildStaticMapUrl({
+      lat: geo.lat,
+      lng: geo.lng,
+      accentHex: palette.accent,
+      // city-level when only cityGeo present (no exact pin leak); zoomed when exact.
+      zoom: publicEvent.locationGeo !== null && publicEvent.locationGeo !== undefined ? 14 : 11,
+      height: 180,
+    });
+  }, [publicEvent.format, publicEvent.locationGeo, publicEvent.cityGeo, palette.accent]);
 
   // ORCH-1138 — float→dock CTA visibility tracking (mirror the trip route 1:1).
   const [dockTopY, setDockTopY] = useState<number | null>(null);
@@ -321,29 +354,40 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
     [publicEvent],
   );
 
-  // ORCH-1138 — the SINGLE buy-state, the page CTA owner (resolveOfferingCta). The
-  // selected tier (when any) narrows the considered set; the page-level state
-  // drives the bar + sticky panel + tier-row labels identically.
-  const offeringCta = useMemo(() => {
-    const selected = publicEvent.tickets.find(
-      (t) => t.id === selectedTicketId && t.visibility !== "hidden",
-    );
-    const considered =
-      selected !== undefined ? [selected] : publicEvent.tickets;
-    return resolveOfferingCta({
-      variant: computeOfferingVariant(publicEvent, false),
-      bookable,
-      tickets: considered,
-      currency: publicEvent.currency,
-    });
-  }, [publicEvent, bookable, selectedTicketId]);
+  // ORCH-1167 — the page-level buy-state (resolveOfferingCta — one owner), now
+  // computed over ALL visible tickets (the inline box owns per-tier selection).
+  // Drives the state banner only; the inline box + floating bar resolve their own
+  // CTA from the shared EventOfferingBody/Bar (same single owner, same payload).
+  const offeringCta = useMemo(
+    () =>
+      resolveOfferingCta({
+        variant: computeOfferingVariant(publicEvent, false),
+        bookable,
+        tickets: publicEvent.tickets.filter((t) => t.visibility !== "hidden"),
+        currency: publicEvent.currency,
+      }),
+    [publicEvent, bookable],
+  );
 
-  const handleSelectTicket = useCallback((ticketId: string): void => {
-    setSelectedTicketId((prev) => (prev === ticketId ? null : ticketId));
-  }, []);
+  const handleChangeTicketQuantity = useCallback(
+    (ticketTypeId: string, qty: number): void => {
+      setTicketQuantities((prev) => {
+        const next = { ...prev };
+        if (qty <= 0) delete next[ticketTypeId];
+        else next[ticketTypeId] = qty;
+        return next;
+      });
+    },
+    [],
+  );
 
-  const handleReserve = useCallback((): void => {
-    if (offeringCta.kind === "waitlist") {
+  // ORCH-1167 — in-box Proceed + the floating bar both call this. It REPLACES the
+  // /checkout/[eventId] tier-PICKER push: it carries the selected quantities into
+  // the cart step (i) PRE-POPULATED (still editable there) via the `seed` param.
+  // Waitlist routes to the waitlist sheet; a not-bookable paid brand toasts.
+  const handleProceedToCart = useCallback((): void => {
+    const anySelected = Object.values(ticketQuantities).some((q) => q > 0);
+    if (offeringCta.kind === "waitlist" && !anySelected) {
       const wlTicket = publicEvent.tickets.find(
         (t) => t.visibility !== "hidden" && t.waitlistEnabled,
       );
@@ -356,9 +400,20 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
       );
       return;
     }
-    // N7 — checkout target UNCHANGED (the existing /checkout/{eventId} cart page).
-    router.push(checkoutPublicPath(event.id) as never);
-  }, [offeringCta.kind, publicEvent.tickets, bookable, router, event.id, showToast]);
+    if (!anySelected) return;
+    // Cart step (i), pre-populated + editable (replaces the empty tier-picker).
+    router.push(
+      checkoutPublicPathWithSeed(event.id, ticketQuantities) as never,
+    );
+  }, [
+    offeringCta.kind,
+    ticketQuantities,
+    publicEvent.tickets,
+    bookable,
+    router,
+    event.id,
+    showToast,
+  ]);
 
   const handleClose = useCallback((): void => {
     if (router.canGoBack()) {
@@ -391,7 +446,7 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
           );
           return;
         }
-        router.push(checkoutPublicPath(event.id) as never);
+        router.push(checkoutPublicPathWithSeed(event.id, {}) as never);
       },
       onClaimFreeTicket: (_ticketId: string) => {
         if (!bookable) {
@@ -400,7 +455,7 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
           );
           return;
         }
-        router.push(checkoutPublicPath(event.id) as never);
+        router.push(checkoutPublicPathWithSeed(event.id, {}) as never);
       },
       onJoinWaitlist: (ticketId: string) => {
         setWaitlistTicketId(ticketId);
@@ -444,73 +499,14 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
       </View>
     ) : null;
 
-  // ORCH-1138 — reserve kicker ("All-in, taxes included" when there's a price).
-  const barKicker = offeringCta.kind === "buy" ? "All-in, taxes included" : null;
-
-  // ORCH-1138 — DOCKED ticket CTA (phone): the LAST body child, flush. Built from
-  // the SAME offeringCta the float pill + sticky panel read.
-  const dockedReserve = !isDesktop ? (
-    <EventReserveBar
-      cta={offeringCta}
-      palette={palette}
-      kicker={barKicker}
-      fontFamily={boldFamily}
-      onPress={handleReserve}
-      variant="docked"
-      onDockLayout={handleDockLayout}
-      testID="orch-1138-event-reserve"
-    />
-  ) : undefined;
-
-  // ORCH-1138 — desktop sticky ticket panel: brand chip → "Choose your ticket"
-  // tier list (rendered in the FOUNDATION body) → price block → CTA → reassurance.
-  // On desktop the tier list is in the body; the panel carries the resolved CTA.
-  const reserveTappable = offeringCta.tappable;
-  const stickyPanel = isDesktop ? (
-    <View style={[styles.deskPanel, { backgroundColor: palette.panelStrong, borderColor: palette.panelBorder }]}>
-      <View style={[styles.deskAccent, { backgroundColor: palette.accent }]} />
-      <View style={styles.deskInner}>
-        <Pressable
-          onPress={reserveTappable ? handleReserve : undefined}
-          disabled={!reserveTappable}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !reserveTappable }}
-          accessibilityLabel={
-            reserveTappable
-              ? offeringCta.kind === "buy"
-                ? `${offeringCta.label}, ${offeringCta.price}`
-                : offeringCta.kind === "free"
-                  ? offeringCta.label
-                  : "Join waitlist"
-              : ctaUnavailableLabel(offeringCta)
-          }
-          style={[
-            styles.deskReserve,
-            reserveTappable
-              ? { backgroundColor: palette.accent }
-              : { backgroundColor: palette.card, borderColor: palette.panelBorder, borderWidth: 1 },
-          ]}
-          testID="orch-1138-event-desk-reserve"
-        >
-          <Text
-            style={[
-              styles.deskReserveText,
-              { color: reserveTappable ? palette.accentText : palette.tertiaryText, fontFamily: boldFamily },
-            ]}
-          >
-            {reserveTappable
-              ? offeringCta.kind === "buy"
-                ? `${offeringCta.label} · ${offeringCta.price}`
-                : offeringCta.label
-              : ctaUnavailableLabel(offeringCta)}
-          </Text>
-        </Pressable>
-        <Text style={[styles.deskReassure, { color: palette.tertiaryText }]}>
-          All-in price · secure checkout
-        </Text>
-      </View>
-    </View>
-  ) : null;
+  // ORCH-1167 — the inline ticket box (in the shared EventOfferingBody) now owns
+  // the in-page Proceed CTA, so the legacy docked EventReserveBar + desktop sticky
+  // CTA panel are RETIRED (subtract before adding). The desktop sticky panel is
+  // omitted (the box renders in the body on desktop too); the off-screen floating
+  // CTA is the shared EventOfferingFloatingBar (rendered below). `offeringCta` is
+  // kept only for the page-level state banner (one owner, never disagrees).
+  void ctaUnavailableLabel; // retained import; legacy callers removed.
+  const stickyPanel = null;
 
   // ORCH-1150 — RSVP branch. An event_type='rsvp' row has zero tickets + no
   // checkout; it renders the Going/Not-going RsvpPublicBody and returns early.
@@ -691,7 +687,8 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
         <FoundationEventPreview
           event={publicEvent}
           brand={publicBrand}
-          variant={pageVariant as "published" | "pre-sale" | "sold-out" | "past"}
+          variant={pageVariant}
+          bookable={bookable}
           palette={palette}
           theme={resolvedTheme}
           muted={muted}
@@ -700,35 +697,41 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
           onShare={handleShare}
           onOpenBrand={(slug: string) => router.push(`/b/${slug}` as never)}
           onOpenMaps={openMapsForQuery}
+          staticMapUrl={staticMapUrl}
           stateBanner={stateBanner}
           stickyPanel={stickyPanel}
-          dockedReserve={dockedReserve}
           onScroll={handleScroll}
           onScrollViewLayout={handleScrollLayout}
           safeAreaTop={insets.top}
-          selectedTicketId={selectedTicketId}
-          onSelectTicket={handleSelectTicket}
-          testID="orch-1138-event-foundation"
+          ticketQuantities={ticketQuantities}
+          onChangeTicketQuantity={handleChangeTicketQuantity}
+          onProceedToCart={handleProceedToCart}
+          onDockLayout={handleDockLayout}
+          testID="orch-1167-event-foundation"
         />
       )}
 
-      {/* ORCH-1138 — FLOATING ticket PILL (phone): JUST the button, shown ONLY
-          while the in-content DOCKED CTA is off-screen. Hidden on desktop (the
-          sticky panel carries the CTA) and on the cancelled/password legacy page.
-          Same offeringCta + onPress as the docked bar so the copy never diverges. */}
+      {/* ORCH-1167 — FLOATING Get-tickets bar (phone): the shared
+          EventOfferingFloatingBar, shown ONLY while the in-page ticket box is
+          off-screen. Hidden on desktop + on the cancelled/password legacy page.
+          Reflects the live Σ-all-in total + calls the SAME onProceedToCart the
+          in-box Proceed calls (copy never diverges — one owner). */}
       {pageVariant !== "cancelled" &&
       pageVariant !== "password-gate" &&
       !isDesktop &&
       floatingPillVisible ? (
-        <EventReserveBar
-          cta={offeringCta}
-          palette={palette}
-          kicker={barKicker}
-          fontFamily={boldFamily}
-          onPress={handleReserve}
-          variant="floating"
-          testID="orch-1138-event-reserve"
-        />
+        <View style={styles.floatWrap} pointerEvents="box-none">
+          <EventOfferingFloatingBar
+            event={publicEvent}
+            variant={pageVariant}
+            bookable={bookable}
+            palette={palette}
+            theme={resolvedTheme}
+            ticketQuantities={ticketQuantities}
+            onProceedToCart={handleProceedToCart}
+            testID="orch-1167-event-floating-bar"
+          />
+        </View>
       ) : null}
 
       <ShareModal
@@ -775,29 +778,13 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     letterSpacing: 0.3,
   },
-  deskPanel: {
-    borderRadius: 20,
-    borderWidth: 1,
-    overflow: "hidden",
-  },
-  deskAccent: { height: 4 },
-  deskInner: { padding: 18 },
-  deskReserve: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 16,
-    paddingVertical: 16,
-    marginTop: 4,
-  },
-  deskReserveText: {
-    fontSize: 16,
-    fontWeight: "900",
-  },
-  deskReassure: {
-    fontSize: 11,
-    textAlign: "center",
-    marginTop: 10,
+  // ORCH-1167 — the floating Get-tickets bar wrapper (phone, off-screen-box only).
+  floatWrap: {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    bottom: 24,
+    zIndex: 6,
   },
   toastWrap: {
     position: "absolute",

--- a/mingla-business/src/constants/__tests__/orch_1167_cart_seed.adversarial.test.ts
+++ b/mingla-business/src/constants/__tests__/orch_1167_cart_seed.adversarial.test.ts
@@ -1,0 +1,117 @@
+// ORCH-1167 [event-page-canonical] — TESTER adversarial regression (IMMUTABLE).
+//
+// DIFFERENT ANGLE than the implementor's happy-path test (which proved the
+// Σ-all-in running total in eventBoxTotals.ts — SC-3). This attacks the
+// inline-box → cart pre-population SEED contract (SC-4) at its BOUNDARY +
+// SECURITY edges: the `seed` query param that carries the buyer's inline-box
+// selection from the public event page into the checkout cart step (i).
+//
+// The seed travels through an UNTRUSTED URL surface (a buyer can hand-edit
+// `/checkout/<id>?seed=…`). The decoder MUST be hostile-input safe: it must
+// NEVER inject a phantom line, a negative / zero / NaN / fractional quantity, an
+// empty ticket id, or a duplicate-key blowup into the cart. And the encode→decode
+// round-trip must be lossless for legitimate selections so the cart lands with
+// EXACTLY the quantities the buyer picked (no silent drop / inflation → WYSIWYP
+// integrity carries through to the cart, not just the box).
+//
+// FAILS-ON-REVERT (proven against commit 6eb1d0b8c — the ORCH-1167 implementation
+// commit — by deleting the `&& qty > 0` guard and the `Number.isFinite(qty)` guard
+// in decodeCartSeed (mingla-business/src/constants/publicUrls.ts): the
+// "rejects zero / negative / NaN quantities" assertions below FAIL, because a
+// hostile `seed=tier:-3` or `seed=tier:0` or `seed=tier:abc` would then leak a
+// negative/zero/NaN line into the cart map. Restore → PASS. See the TEST report.
+
+import { describe, expect, test } from "@jest/globals";
+
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      extra: {
+        EXPO_PUBLIC_MINGLA_BUSINESS_WEB_URL: "https://business.usemingla.com",
+      },
+    },
+  },
+}));
+
+import {
+  decodeCartSeed,
+  encodeCartSeed,
+  checkoutPublicPathWithSeed,
+} from "../publicUrls";
+
+describe("ORCH-1167 cart-seed — hostile-input boundary (SC-4)", () => {
+  test("round-trips a legitimate multi-tier selection losslessly", () => {
+    const sel = { vip: 2, ga: 1, balcony: 5 };
+    const encoded = encodeCartSeed(sel);
+    expect(decodeCartSeed(encoded)).toEqual(sel);
+  });
+
+  test("drops zero-quantity tiers on ENCODE (only picked tiers travel)", () => {
+    // A tier the buyer stepped down to 0 must not appear in the seed at all.
+    expect(encodeCartSeed({ vip: 0, ga: 3 })).toBe("ga:3");
+    expect(decodeCartSeed(encodeCartSeed({ vip: 0, ga: 3 }))).toEqual({ ga: 3 });
+  });
+
+  test("rejects NEGATIVE quantities (hostile hand-edited seed)", () => {
+    // `?seed=vip:-3` must NOT leak a negative line that could credit the buyer.
+    expect(decodeCartSeed("vip:-3")).toEqual({});
+    expect(decodeCartSeed("vip:-3,ga:2")).toEqual({ ga: 2 });
+  });
+
+  test("rejects ZERO quantities", () => {
+    expect(decodeCartSeed("vip:0")).toEqual({});
+    expect(decodeCartSeed("vip:0,ga:1")).toEqual({ ga: 1 });
+  });
+
+  test("rejects NaN / non-numeric quantities", () => {
+    expect(decodeCartSeed("vip:abc")).toEqual({});
+    expect(decodeCartSeed("vip:,ga:2")).toEqual({ ga: 2 });
+    expect(decodeCartSeed("vip:2.9")).toEqual({ vip: 2 }); // parseInt floors; never NaN
+  });
+
+  test("rejects empty / missing ticket ids", () => {
+    expect(decodeCartSeed(":3")).toEqual({});
+    expect(decodeCartSeed(",ga:2")).toEqual({ ga: 2 });
+    expect(decodeCartSeed("ga:2,")).toEqual({ ga: 2 });
+  });
+
+  test("never throws on garbage / undefined / empty input", () => {
+    expect(() => decodeCartSeed(undefined)).not.toThrow();
+    expect(() => decodeCartSeed(null)).not.toThrow();
+    expect(() => decodeCartSeed("")).not.toThrow();
+    expect(() => decodeCartSeed("::::")).not.toThrow();
+    expect(() => decodeCartSeed("garbage-no-colon")).not.toThrow();
+    expect(decodeCartSeed(undefined)).toEqual({});
+    expect(decodeCartSeed("garbage-no-colon")).toEqual({});
+  });
+
+  test("a totally hostile seed cannot inject ANY phantom line", () => {
+    const hostile = "a:-1,b:0,c:abc,:9,d:,e:2.99,,::,f:1e9";
+    const decoded = decodeCartSeed(hostile);
+    // Only the two well-formed positive-int tiers survive (e floored to 2, f=1e9
+    // parseInt → 1 then "e9" ignored). Every malformed tier is dropped, none
+    // negative / zero / NaN / empty-id leaked.
+    for (const [id, qty] of Object.entries(decoded)) {
+      expect(id.length).toBeGreaterThan(0);
+      expect(Number.isInteger(qty)).toBe(true);
+      expect(qty).toBeGreaterThan(0);
+    }
+    expect(decoded).toEqual({ e: 2, f: 1 });
+  });
+
+  test("empty selection → bare checkout path (no ?seed=) ; SC-4 no-pick case", () => {
+    expect(checkoutPublicPathWithSeed("evt_123", {})).toBe("/checkout/evt_123");
+    expect(checkoutPublicPathWithSeed("evt_123", { vip: 0 })).toBe(
+      "/checkout/evt_123",
+    );
+  });
+
+  test("a real selection appends a URL-safe encoded seed", () => {
+    const path = checkoutPublicPathWithSeed("evt_123", { vip: 2, ga: 1 });
+    expect(path.startsWith("/checkout/evt_123?seed=")).toBe(true);
+    // The seed survives a full URL round-trip (encode + decode the param).
+    const seedParam = decodeURIComponent(path.split("?seed=")[1] ?? "");
+    expect(decodeCartSeed(seedParam)).toEqual({ vip: 2, ga: 1 });
+  });
+});

--- a/mingla-business/src/constants/publicUrls.ts
+++ b/mingla-business/src/constants/publicUrls.ts
@@ -54,6 +54,47 @@ export const brandPublicUrl = (brandSlug: string): string =>
 export const checkoutPublicPath = (eventId: string): string =>
   `/checkout/${requireSegment(eventId, "eventId")}`;
 
+/**
+ * ORCH-1167 [event-page-canonical] — encode the inline-ticket-box selection as a
+ * compact `seed` query param so the checkout cart step (i) lands PRE-POPULATED +
+ * editable (replacing the empty tier-PICKER push). Format: `id:qty,id:qty`. Empty
+ * selection → the bare path (no seed param). The checkout index seeds the cart from
+ * this on mount; quantities remain editable there (the cart step is unchanged).
+ */
+export const encodeCartSeed = (
+  quantities: Record<string, number>,
+): string =>
+  Object.entries(quantities)
+    .filter(([, qty]) => qty > 0)
+    .map(([id, qty]) => `${id}:${qty}`)
+    .join(",");
+
+/** Decode the `seed` query param back into a {ticketTypeId: qty} map. */
+export const decodeCartSeed = (
+  seed: string | null | undefined,
+): Record<string, number> => {
+  const out: Record<string, number> = {};
+  if (typeof seed !== "string" || seed.length === 0) return out;
+  for (const pair of seed.split(",")) {
+    const [id, qtyRaw] = pair.split(":");
+    const qty = Number.parseInt(qtyRaw ?? "", 10);
+    if (typeof id === "string" && id.length > 0 && Number.isFinite(qty) && qty > 0) {
+      out[id] = qty;
+    }
+  }
+  return out;
+};
+
+/** checkoutPublicPath with an optional pre-populated cart seed (ORCH-1167). */
+export const checkoutPublicPathWithSeed = (
+  eventId: string,
+  quantities: Record<string, number>,
+): string => {
+  const base = checkoutPublicPath(eventId);
+  const seed = encodeCartSeed(quantities);
+  return seed.length > 0 ? `${base}?seed=${encodeURIComponent(seed)}` : base;
+};
+
 export const checkoutPublicUrl = (eventId: string): string =>
   `${BUSINESS_PUBLIC_ORIGIN}${checkoutPublicPath(eventId)}`;
 

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -63,6 +63,15 @@ interface BusinessPublicEventViewRow {
   // Direction-C RSVP vibe chips. Null/absent for legacy rows → mapper defaults [].
   party_types?: string[] | null;
   vibe_tags?: string[] | null;
+  // ORCH-1167 — music_genres exposed anon-safe by business_public_events_view
+  // (the view SELECTs e.music_genres). The mapper previously DROPPED this (F-3);
+  // now threaded into LiveEvent.musicGenres → the canonical pills row.
+  music_genres?: string[] | null;
+  // ORCH-1167 — city-level privacy centroid (geometry(Point,4326)); PostgREST
+  // serializes geometry as GeoJSON or a WKB hex string for anon reads. The
+  // canonical body fields are read from the pg_public_event_by_slug RPC (which
+  // returns {lat,lng}); this view column is the schema source of truth.
+  city_geo?: unknown;
   location_text: string | null;
   // ORCH-1162 Bug 2 — venue geo exposed by business_public_events_view (a
   // `point` column; PostgREST serializes it as a "(lng,lat)" string for anon
@@ -867,6 +876,11 @@ export const publicEventViewRowToEvent = (
     // 9: missing is empty, never fabricated). Already-present columns; no migration.
     partyTypes: Array.isArray(row.party_types) ? row.party_types : [],
     vibeTags: Array.isArray(row.vibe_tags) ? row.vibe_tags : [],
+    // ORCH-1167 [event-page-canonical] — thread music_genres (was DROPPED — F-3).
+    // Default [] (rule 9: missing is empty, never fabricated). For the standard-
+    // event PAGE BODY the authoritative source is the pg_public_event_by_slug RPC
+    // (merged in detailFromRow); this view-derived value is the fallback.
+    musicGenres: Array.isArray(row.music_genres) ? row.music_genres : [],
     orders: [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -909,6 +923,70 @@ const fetchTicketTypesRemaining = async (
 // base price (never blank). Mirrors app-mobile's publicEventTicketsService.
 // ORCH-1147 — EXPORTED so the experience service reuses the SAME single owner
 // of pg_public_event_tier_allin (no duplicated RPC / fee math anywhere else).
+// ===========================================================================
+// ORCH-1167 [event-page-canonical] — the ONE canonical anon read RPC for the
+// standard ticketed-event public page body fields. Returns the full
+// EventOfferingBody payload as json incl. pills (party/vibe/music), city +
+// city_geo, and per-tier server all-in. The web/business standard-event read
+// merges the canonical BODY fields from here onto the view-derived LiveEvent so
+// a field added to the RPC payload surfaces on web too with ONE mapper edit
+// (SC-7) and music_genres is no longer dropped (F-3). The view read remains for
+// the non-body LiveEvent fields the RSVP/recurrence paths still need.
+// ===========================================================================
+
+interface CanonicalEventBodyFields {
+  partyTypes: string[];
+  vibeTags: string[];
+  musicGenres: string[];
+  cityGeo: { lat: number; lng: number } | null;
+}
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+
+const asLatLng = (
+  value: unknown,
+): { lat: number; lng: number } | null => {
+  if (value === null || typeof value !== "object") return null;
+  const obj = value as { lat?: unknown; lng?: unknown };
+  return typeof obj.lat === "number" &&
+    Number.isFinite(obj.lat) &&
+    typeof obj.lng === "number" &&
+    Number.isFinite(obj.lng)
+    ? { lat: obj.lat, lng: obj.lng }
+    : null;
+};
+
+// Fetch the canonical body fields for one (brand, event) from the RPC. Returns
+// defaults (empty pills, null cityGeo) on RPC miss/error so the page never blanks
+// (rule 9). The PRIVACY gate is enforced SERVER-SIDE in the RPC (cityGeo present /
+// exact pin null when the address is hidden) — the client never re-derives it.
+export const fetchCanonicalEventBodyFields = async (
+  brandSlug: string,
+  eventSlug: string,
+): Promise<CanonicalEventBodyFields> => {
+  const empty: CanonicalEventBodyFields = {
+    partyTypes: [],
+    vibeTags: [],
+    musicGenres: [],
+    cityGeo: null,
+  };
+  const { data, error } = await supabase.rpc("pg_public_event_by_slug", {
+    p_brand_slug: brandSlug,
+    p_event_slug: eventSlug,
+  });
+  if (error !== null || data === null || typeof data !== "object") return empty;
+  const payload = data as Record<string, unknown>;
+  return {
+    partyTypes: asStringArray(payload.partyTypes),
+    vibeTags: asStringArray(payload.vibeTags),
+    musicGenres: asStringArray(payload.musicGenres),
+    cityGeo: asLatLng(payload.cityGeo),
+  };
+};
+
 export const fetchTierAllInCents = async (
   eventId: string,
 ): Promise<Map<string, number>> => {
@@ -1019,9 +1097,39 @@ const detailFromRow = async (
   const tickets = await fetchTickets(row.id);
   // ORCH-1076 — resolve buyer-readiness for PAID events (deep-link graceful CTA).
   const isPaid = ticketsArePaidOnline(tickets);
-  const bookable = await resolveEventBookable(row.brand_id, isPaid);
+  // ORCH-1167 [event-page-canonical] — for the STANDARD ticketed-event page, also
+  // resolve the canonical BODY fields (pills + city_geo) from the ONE read RPC
+  // (pg_public_event_by_slug) and MERGE them onto the view-derived LiveEvent. This
+  // makes the RPC the authoritative source for the page body fields (SC-7: a field
+  // added to the RPC surfaces here with one mapper edit) and closes the F-3
+  // music_genres drop. RSVP rows keep the view-only fields (the RPC is event-only).
+  const isStandardEvent = row.event_type === "event" || row.event_type === null;
+  const [bookable, canonical] = await Promise.all([
+    resolveEventBookable(row.brand_id, isPaid),
+    isStandardEvent
+      ? fetchCanonicalEventBodyFields(row.brand_slug, row.slug)
+      : Promise.resolve(null),
+  ]);
+  const event = publicEventViewRowToEvent(row, tickets);
+  const merged =
+    canonical !== null
+      ? {
+          ...event,
+          partyTypes:
+            canonical.partyTypes.length > 0
+              ? canonical.partyTypes
+              : event.partyTypes,
+          vibeTags:
+            canonical.vibeTags.length > 0 ? canonical.vibeTags : event.vibeTags,
+          musicGenres:
+            canonical.musicGenres.length > 0
+              ? canonical.musicGenres
+              : event.musicGenres,
+          cityGeo: canonical.cityGeo,
+        }
+      : event;
   return {
-    event: publicEventViewRowToEvent(row, tickets),
+    event: merged,
     brand: viewRowToBrand(row),
     tickets,
     bookable,

--- a/mingla-business/src/store/liveEventStore.ts
+++ b/mingla-business/src/store/liveEventStore.ts
@@ -215,6 +215,15 @@ export interface LiveEvent {
   city?: string | null;
   /** ORCH-0824: structured lat/lng from Google Places autocomplete at publish. */
   locationGeo?: { lat: number; lng: number } | null;
+  /**
+   * ORCH-1167 [event-page-canonical] — CITY-LEVEL centroid (privacy-safe),
+   * sibling of the exact `locationGeo` pin. The canonical EventOfferingBody
+   * "Where you'll be" map draws at city zoom (no exact pin) from this when the
+   * street is hidden until ticket purchase. Optional + default-safe (rule 9):
+   * undefined/null when the event has no city centroid. Threaded onto the LiveEvent
+   * by the buyer-web standard-event read (merged from pg_public_event_by_slug).
+   */
+  cityGeo?: { lat: number; lng: number } | null;
   whenMode: WhenMode;
   date: string | null;
   doorsOpen: string | null;

--- a/packages/event-rendering/types.ts
+++ b/packages/event-rendering/types.ts
@@ -75,6 +75,17 @@ export interface PublicEventProps {
    * is themed from the page's brand accent (createThemePalette → palette.accent).
    */
   locationGeo?: { lat: number; lng: number } | null;
+  /**
+   * ORCH-1167 [event-page-canonical] — CITY-LEVEL centroid (privacy-safe), the
+   * sibling of the exact `locationGeo` pin. The canonical `EventOfferingBody`
+   * "Where you'll be" map draws at CITY zoom (no exact pin) from this when the
+   * street is hidden until ticket purchase. ADDITIVE + default-safe: undefined /
+   * null on every predating constructor → no city-level map (rule 9). For the
+   * anon read path the privacy gate is enforced SERVER-SIDE in
+   * `pg_public_event_by_slug` (it returns `locationGeo` null + `cityGeo` set when
+   * the address is hidden), so the host simply feeds whichever geo is present.
+   */
+  cityGeo?: { lat: number; lng: number } | null;
 
   // Cover
   coverHue: number;
@@ -98,6 +109,16 @@ export interface PublicEventProps {
    */
   partyTypes: string[];
   vibeTags?: string[];
+  /**
+   * ORCH-1167 [event-page-canonical] — canonical music-genre slugs (ORCH-0824),
+   * the third pills group on the standard ticketed-event public page (after
+   * format → vibes → party-types). ADDITIVE + default-safe: `[]` when none /
+   * predating constructor (rule 9). Closes the F-3 web-mapper drop
+   * (`publicEventViewRowToEvent` mapped party/vibe but silently dropped
+   * music_genres though the anon view exposes it). The pills row renders ALL of
+   * vibeTags + partyTypes + musicGenres, each group omitted when empty.
+   */
+  musicGenres?: string[];
 
   themeOverrides?: ThemeInput | null;
 }

--- a/packages/offering-rendering/EventOfferingBody.tsx
+++ b/packages/offering-rendering/EventOfferingBody.tsx
@@ -1,0 +1,999 @@
+/**
+ * EventOfferingBody — ORCH-1167 [event-page-canonical].
+ *
+ * Leg 1 of META-ORCH-1166 (public offering-page single source of truth). THE ONE
+ * shared, shell-agnostic body for the STANDARD ticketed-event public page
+ * (event_type='event' ONLY — NOT rsvp/trip/experience). Rendered byte-identically
+ * on buyer-web, business iOS/Android, and consumer iOS/Android. Promotes the
+ * forked FoundationEventPreview (web/business) + ConsumerEventDetailScreen
+ * (consumer) bodies into ONE component.
+ *
+ * SHELL-AGNOSTIC (SPEC §3B, mandatory): this is a PURE CONTENT body. It hosts NO
+ * scroll root and NO cover host. Each surface composes its own proven scroll +
+ * parallax-cover scaffold AROUND this body and renders these CHILDREN inside its
+ * scroll container:
+ *   • buyer-web + business native → inside ParallaxCoverShell (RN ScrollView).
+ *   • consumer → inside BaseBottomSheet's gorhom BottomSheetScrollView (the
+ *     LOAD-BEARING ORCH-1016/1043/1138 scroll structure — the body must NEVER wrap
+ *     ParallaxCoverShell as its scroll root, which re-triggers the gorhom freeze).
+ * The cover (section 1) is a pinned sibling the surface scaffold owns; the floating
+ * Get-tickets button (section 9) is exposed as <EventOfferingFloatingBar> for the
+ * surface to position as a pinned overlay. The 9-section CONTENT order (sections
+ * 2–8 + the inline ticket box at 5) is rendered here, identically, every surface.
+ *
+ * Pure-presentational, props-only, NO app-src imports (I-MOR-0827-PACKAGE-ISOLATION
+ * — enforced by the META-ORCH-0827 packages gate that already covers this file).
+ * Renders on react-native-web AND native RN.
+ *
+ * Canonical 9-section order (SPEC §3A):
+ *   1. Cover            (surface scaffold — pinned sibling, not here)
+ *   2. Event Name       (lead block: date eyebrow + bold title)
+ *   3. Date & Time      (meta chips, AM/PM via the host's dateLine/dateSubline)
+ *   4. Pills row        (format → ALL vibes → ALL party-types → ALL music-genres →
+ *                        tickets-left; each group omits when empty — rule 9)
+ *   5. TICKET BOX       (per-tier qty steppers; live Σ-all-in running total
+ *                        (WYSIWYP, never bare base); in-box Proceed)
+ *   6. Presented By     (brand card → onOpenBrand)
+ *   7. About            (collapsible read-more/show-less)
+ *   8. Where you'll be  (server-proxied static map via injected staticMapUrl +
+ *                        "view on map" card; city-level when address hidden; text
+ *                        venue card when no geo — rule 9)
+ *   9. Floating button  (<EventOfferingFloatingBar>, surface-pinned)
+ */
+
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Image,
+  LayoutAnimation,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  UIManager,
+  View,
+} from "react-native";
+
+import {
+  boldFontFamily,
+  computeOfferingVariant,
+  offeringSurfaceStyles,
+  resolveOfferingCta,
+  ticketIsDoorOnly,
+  ticketIsSoldOut,
+  ticketSaleEnded,
+  type CtaState,
+  type OfferingVariant,
+  type PublicBrandProps,
+  type PublicEventProps,
+  type PublicTicketProps,
+  type ResolvedTheme,
+  type ThemePalette,
+} from "@mingla/event-rendering";
+
+import { normalizeCityCountry } from "./normalizeCityCountry";
+import {
+  computeRunningTotal,
+  totalSelectedQuantity,
+} from "./eventBoxTotals";
+
+// Re-export the pure totals so a single import surface stays one place.
+export { computeRunningTotal, totalSelectedQuantity } from "./eventBoxTotals";
+
+const ABOUT_COLLAPSE_THRESHOLD = 160;
+
+// Enable LayoutAnimation on Android once at module load (no-op on iOS/web).
+if (
+  Platform.OS === "android" &&
+  UIManager.setLayoutAnimationEnabledExperimental !== undefined
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+// ===========================================================================
+// Shared price formatting (WYSIWYP — all-in, never recompute fees).
+// I-PROPOSED-1167-ALLIN-PRICE-IN-TICKET-BOX: the running total uses
+// priceAllInGbp (the server fee-grossed all-in), falling back to priceGbp ONLY
+// when the tier has no all-in (free / RPC miss) — never fabricating a markup.
+// ===========================================================================
+
+const formatMoney = (amount: number, currency: string): string => {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${currency} ${amount.toFixed(2)}`;
+  }
+};
+
+const formatTicketPrice = (
+  ticket: PublicTicketProps,
+  fallbackCurrency: string,
+): string => {
+  if (ticket.isFree) return "Free";
+  const price = ticket.priceAllInGbp ?? ticket.priceGbp;
+  if (price === null || price === undefined) return "—";
+  return formatMoney(price, ticket.currency ?? fallbackCurrency);
+};
+
+const sortTickets = (tickets: PublicTicketProps[]): PublicTicketProps[] =>
+  [...tickets].sort((a, b) => a.displayOrder - b.displayOrder);
+
+/** A tier is sellable (quantity-pickable) when it has no blocking sub-state. */
+const ticketIsSellable = (t: PublicTicketProps): boolean =>
+  t.visibility !== "hidden" &&
+  t.visibility !== "disabled" &&
+  !ticketIsSoldOut(t) &&
+  !ticketIsDoorOnly(t) &&
+  !ticketSaleEnded(t);
+
+export interface EventOfferingBodyProps {
+  /** Extended PublicEventProps (musicGenres + cityGeo added — §4C-types). */
+  event: PublicEventProps;
+  brand: PublicBrandProps | null;
+  variant: OfferingVariant;
+  /** I-PAID-SUPPLY gate (ORCH-1076). false → box + CTA disabled. */
+  bookable: boolean;
+  palette: ThemePalette;
+  theme: ResolvedTheme;
+
+  // Ticket-box state (LIFTED to the host so the cart can read it — §4C).
+  ticketQuantities: Record<string, number>;
+  onChangeTicketQuantity: (ticketTypeId: string, qty: number) => void;
+  /** In-box Proceed + the floating button (§9) both call this. */
+  onProceedToCart: () => void;
+
+  // Links / maps.
+  onOpenBrand?: (brandSlug: string) => void;
+  onOpenMaps?: (query: string) => void;
+  /**
+   * Server-proxied static map URL (the host computes it via buildProxyStaticMapUrl
+   * with the city-OR-exact geo the privacy gate selected). null → no map (the
+   * honest text venue card renders — rule 9).
+   */
+  staticMapUrl?: string | null;
+
+  /** Host submitting flag (in-flight checkout) → disables the box CTA. */
+  submitting?: boolean;
+  testID?: string;
+}
+
+export const EventOfferingBody: React.FC<EventOfferingBodyProps> = ({
+  event,
+  brand,
+  variant,
+  bookable,
+  palette,
+  theme,
+  ticketQuantities,
+  onChangeTicketQuantity,
+  onProceedToCart,
+  onOpenBrand,
+  onOpenMaps,
+  staticMapUrl = null,
+  submitting = false,
+  testID,
+}) => {
+  const surface = offeringSurfaceStyles(palette);
+  const boldFamily = boldFontFamily(theme);
+  const [aboutCollapsed, setAboutCollapsed] = useState<boolean>(true);
+
+  const toggleAbout = useCallback((): void => {
+    LayoutAnimation.configureNext(
+      LayoutAnimation.create(
+        200,
+        LayoutAnimation.Types.easeInEaseOut,
+        LayoutAnimation.Properties.opacity,
+      ),
+    );
+    setAboutCollapsed((c) => !c);
+  }, []);
+
+  const visibleTickets = useMemo(
+    () => sortTickets(event.tickets.filter((t) => t.visibility !== "hidden")),
+    [event.tickets],
+  );
+
+  const ticketsLeftLabel = useMemo<string | null>(() => {
+    let total = 0;
+    let anyFinite = false;
+    for (const t of visibleTickets) {
+      if (t.isUnlimited) continue;
+      if (t.capacity !== null) {
+        total += t.capacity;
+        anyFinite = true;
+      }
+    }
+    if (!anyFinite) return null;
+    return total <= 0 ? "Sold out" : `${total} tickets left`;
+  }, [visibleTickets]);
+
+  const cityCountry =
+    normalizeCityCountry(event.venueName) ?? normalizeCityCountry(event.address);
+
+  // Pills row (SPEC §4: format → vibes → party-types → music-genres → tickets-left).
+  const formatLabel =
+    event.format === "online"
+      ? "Online"
+      : event.format === "hybrid"
+        ? "In-person + online"
+        : "In person";
+  const vibeTags = event.vibeTags ?? [];
+  const partyTypes = event.partyTypes ?? [];
+  const musicGenres = event.musicGenres ?? [];
+
+  // Section 8 — venue copy.
+  const venueAddressLabel = event.hideAddressUntilTicket
+    ? (cityCountry ?? "Address shared after you get tickets")
+    : event.format === "hybrid" && event.address !== null
+      ? `${event.address} · also online`
+      : (event.address ?? "Address shared after you get tickets");
+  const addressUnlockCaption: string | null = event.hideAddressUntilTicket
+    ? "Full address shared after you get tickets"
+    : null;
+  const venueMapsQuery =
+    event.hideAddressUntilTicket || event.venueName === null
+      ? null
+      : [event.venueName, event.address].filter(Boolean).join(", ");
+  const canOpenVenueMaps =
+    venueMapsQuery !== null &&
+    venueMapsQuery.trim().length > 0 &&
+    onOpenMaps !== undefined;
+
+  const aboutText = event.description.trim();
+  const canCollapseAbout = aboutText.length > ABOUT_COLLAPSE_THRESHOLD;
+  const aboutCollapsedNow = canCollapseAbout && aboutCollapsed;
+
+  // Inline-box CTA state (shared resolveOfferingCta single owner). Drives the
+  // box's Proceed button copy across free/waitlist/sold-out/pre-sale/past/etc.
+  const boxCta: CtaState = useMemo(
+    () =>
+      resolveOfferingCta({
+        variant,
+        bookable,
+        tickets: visibleTickets,
+        currency: event.currency,
+      }),
+    [variant, bookable, visibleTickets, event.currency],
+  );
+
+  const runningTotal = computeRunningTotal(event.tickets, ticketQuantities);
+  const selectedQty = totalSelectedQuantity(ticketQuantities);
+  const totalLabel =
+    selectedQty === 0
+      ? null
+      : runningTotal === 0
+        ? "Free"
+        : formatMoney(runningTotal, event.currency);
+
+  // The box Proceed is tappable only when the CTA is actionable AND (for a buy/
+  // free state) at least one quantity is chosen. Waitlist proceeds regardless.
+  const ctaActionable = boxCta.tappable;
+  const proceedEnabled =
+    ctaActionable &&
+    !submitting &&
+    (boxCta.kind === "waitlist" || selectedQty > 0);
+  const proceedLabel =
+    boxCta.kind === "buy"
+      ? totalLabel !== null
+        ? `${boxCta.label} · ${totalLabel}`
+        : boxCta.label
+      : boxCta.kind === "free"
+        ? boxCta.label
+        : boxCta.kind === "waitlist"
+          ? boxCta.label
+          : boxCta.title;
+
+  return (
+    <View testID={testID}>
+      {/* (2) Event name lead block — date eyebrow + bold title. */}
+      <View style={styles.leadBlock}>
+        {event.dateLine.length > 0 ? (
+          <Text style={[styles.eyebrow, { color: palette.accent }]}>
+            {event.dateLine}
+          </Text>
+        ) : null}
+        <Text
+          style={[styles.title, surface.primaryText, { fontFamily: boldFamily }]}
+        >
+          {event.name.length > 0 ? event.name : "Untitled event"}
+        </Text>
+      </View>
+
+      {/* (3) Date & time meta chips. */}
+      <View style={styles.metaRow}>
+        {event.dateLine.length > 0 ? (
+          <MetaChip palette={palette} surface={surface} glyph="◷" font={boldFamily}>
+            {event.dateLine}
+          </MetaChip>
+        ) : null}
+        {event.dateSubline !== null && event.dateSubline.length > 0 ? (
+          <MetaChip palette={palette} surface={surface} glyph="⟳" font={boldFamily}>
+            {event.dateSubline}
+          </MetaChip>
+        ) : null}
+        {cityCountry !== null ? (
+          <MetaChip palette={palette} surface={surface} glyph="⌖" font={boldFamily}>
+            {cityCountry}
+          </MetaChip>
+        ) : null}
+      </View>
+
+      {/* (4) Pills row — format → vibes → party-types → music-genres →
+          tickets-left. Each group omits entirely when empty (rule 9). */}
+      <View style={styles.pillsRow} testID="orch-1167-pills-row">
+        <Pill palette={palette} surface={surface} font={boldFamily}>
+          {formatLabel}
+        </Pill>
+        {vibeTags.map((tag, i) => (
+          <Pill key={`vibe-${i}`} palette={palette} surface={surface} font={boldFamily}>
+            {tag}
+          </Pill>
+        ))}
+        {partyTypes.map((tag, i) => (
+          <Pill key={`party-${i}`} palette={palette} surface={surface} font={boldFamily}>
+            {tag}
+          </Pill>
+        ))}
+        {musicGenres.map((tag, i) => (
+          <Pill key={`music-${i}`} palette={palette} surface={surface} font={boldFamily}>
+            {tag}
+          </Pill>
+        ))}
+        {ticketsLeftLabel !== null ? (
+          <Pill palette={palette} surface={surface} font={boldFamily} accent>
+            {ticketsLeftLabel}
+          </Pill>
+        ) : null}
+      </View>
+
+      {/* (5) TICKET BOX — per-tier steppers + live Σ-all-in + in-box Proceed. */}
+      <View style={styles.section}>
+        <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
+          Tickets
+        </Text>
+        {visibleTickets.length === 0 ? (
+          <View style={[styles.venueCard, surface.card]}>
+            <Text style={[styles.about, surface.secondaryText]}>
+              Not on sale yet.
+            </Text>
+          </View>
+        ) : (
+          <View style={[styles.ticketBox, surface.card]} testID="orch-1167-ticket-box">
+            {visibleTickets.map((t) => (
+              <TicketStepperRow
+                key={t.id}
+                ticket={t}
+                fallbackCurrency={event.currency}
+                palette={palette}
+                surface={surface}
+                boldFamily={boldFamily}
+                quantity={ticketQuantities[t.id] ?? 0}
+                disabled={!bookable}
+                onChange={(qty) => onChangeTicketQuantity(t.id, qty)}
+              />
+            ))}
+
+            {/* live running total = Σ all-in (WYSIWYP) */}
+            <View style={[styles.totalRow, { borderTopColor: palette.panelBorder }]}>
+              <Text style={[styles.totalLabel, surface.secondaryText]}>Total</Text>
+              <Text
+                style={[styles.totalValue, surface.primaryText, { fontFamily: boldFamily }]}
+                testID="orch-1167-running-total"
+              >
+                {totalLabel ?? "—"}
+              </Text>
+            </View>
+
+            <Pressable
+              onPress={proceedEnabled ? onProceedToCart : undefined}
+              disabled={!proceedEnabled}
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !proceedEnabled }}
+              accessibilityLabel={proceedLabel}
+              style={[
+                styles.boxProceed,
+                proceedEnabled
+                  ? { backgroundColor: palette.accent }
+                  : {
+                      backgroundColor: palette.card,
+                      borderColor: palette.panelBorder,
+                      borderWidth: 1,
+                    },
+              ]}
+              testID="orch-1167-box-proceed"
+            >
+              <Text
+                style={[
+                  styles.boxProceedText,
+                  {
+                    color: proceedEnabled ? palette.accentText : palette.tertiaryText,
+                    fontFamily: boldFamily,
+                  },
+                ]}
+              >
+                {proceedLabel}
+              </Text>
+            </Pressable>
+
+            <Text style={[styles.reassure, { color: palette.tertiaryText }]}>
+              All-in price — taxes &amp; fees included, no surprises at checkout.
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* (6) Presented By — brand card → onOpenBrand. */}
+      <View style={styles.section}>
+        <Pressable
+          onPress={() => {
+            if (brand?.slug !== undefined) onOpenBrand?.(brand.slug);
+          }}
+          disabled={brand?.slug === undefined || onOpenBrand === undefined}
+          accessibilityRole={onOpenBrand !== undefined ? "button" : undefined}
+          accessibilityLabel={
+            brand?.displayName !== undefined
+              ? `View ${brand.displayName}`
+              : "View brand"
+          }
+          style={[styles.brandRow, surface.card]}
+        >
+          <View style={[styles.brandTile, { backgroundColor: palette.accent }]}>
+            {brand?.photo !== undefined && brand.photo.length > 0 ? (
+              <Image
+                source={{ uri: brand.photo }}
+                style={styles.brandPhoto}
+                resizeMode="cover"
+                accessibilityLabel={`${brand.displayName ?? "Brand"} profile photo`}
+              />
+            ) : (
+              <View style={styles.brandInitialWrap}>
+                <Text
+                  style={[
+                    styles.brandInitial,
+                    { color: palette.accentText, fontFamily: boldFamily },
+                  ]}
+                >
+                  {(brand?.displayName?.trim()[0] ?? "•").toUpperCase()}
+                </Text>
+              </View>
+            )}
+          </View>
+          <View style={styles.brandTextCol}>
+            <Text style={[styles.brandKicker, surface.tertiaryText]}>Presented by</Text>
+            <Text
+              style={[styles.brandName, surface.primaryText, { fontFamily: boldFamily }]}
+            >
+              {brand?.displayName ?? "Brand"}
+            </Text>
+          </View>
+          {onOpenBrand !== undefined ? (
+            <Text style={[styles.brandCta, { color: palette.accent }]}>View</Text>
+          ) : null}
+        </Pressable>
+      </View>
+
+      {/* (7) About — collapsible. */}
+      {aboutText.length > 0 ? (
+        <View style={styles.section}>
+          <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
+            About
+          </Text>
+          <Text
+            style={[styles.about, surface.secondaryText]}
+            numberOfLines={aboutCollapsedNow ? 3 : undefined}
+            ellipsizeMode="tail"
+          >
+            {aboutText}
+          </Text>
+          {canCollapseAbout ? (
+            <Pressable
+              onPress={toggleAbout}
+              accessibilityRole="button"
+              accessibilityState={{ expanded: !aboutCollapsedNow }}
+              accessibilityLabel={aboutCollapsedNow ? "Read more" : "Show less"}
+              style={styles.aboutToggleRow}
+            >
+              <Text style={[styles.aboutToggle, { color: palette.accent }]}>
+                {aboutCollapsedNow ? "Read more" : "Show less"}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+
+      {/* (8) Where you'll be — static map (city-level when hidden) + venue card. */}
+      {event.format === "online" ? (
+        <View style={styles.section}>
+          <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
+            Where you&rsquo;ll be
+          </Text>
+          <View style={[styles.venueCard, surface.card]}>
+            <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
+              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>◯</Text>
+            </View>
+            <View style={styles.venueTextCol}>
+              <Text
+                style={[styles.venueName, surface.primaryText, { fontFamily: boldFamily }]}
+              >
+                Online
+              </Text>
+              <Text style={[styles.venueAddr, surface.secondaryText]}>
+                Conferencing link shared with ticketed guests.
+              </Text>
+            </View>
+          </View>
+        </View>
+      ) : event.venueName !== null ? (
+        <View style={styles.section}>
+          <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
+            Where you&rsquo;ll be
+          </Text>
+          {staticMapUrl !== null ? (
+            <Image
+              source={{ uri: staticMapUrl }}
+              style={[styles.whereMap, { borderColor: palette.panelBorder }]}
+              resizeMode="cover"
+              accessibilityLabel={`Map showing ${event.venueName}`}
+              testID="orch-1167-where-map"
+            />
+          ) : null}
+          <Pressable
+            onPress={() => {
+              if (venueMapsQuery !== null) onOpenMaps?.(venueMapsQuery);
+            }}
+            disabled={!canOpenVenueMaps}
+            accessibilityRole={canOpenVenueMaps ? "button" : undefined}
+            accessibilityLabel={
+              canOpenVenueMaps ? `Open ${event.venueName} in maps` : event.venueName
+            }
+            style={[styles.venueCard, surface.card]}
+          >
+            <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
+              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>⌖</Text>
+            </View>
+            <View style={styles.venueTextCol}>
+              <Text
+                style={[styles.venueName, surface.primaryText, { fontFamily: boldFamily }]}
+              >
+                {event.venueName}
+              </Text>
+              <Text style={[styles.venueAddr, surface.secondaryText]}>
+                {venueAddressLabel}
+              </Text>
+              {addressUnlockCaption !== null ? (
+                <Text
+                  style={[styles.venueUnlockCaption, surface.tertiaryText]}
+                  testID="orch-1167-address-unlock-caption"
+                >
+                  {addressUnlockCaption}
+                </Text>
+              ) : null}
+            </View>
+            {canOpenVenueMaps ? (
+              <View style={[styles.venuePill, { backgroundColor: palette.accent }]}>
+                <Text style={[styles.venuePillText, { color: palette.accentText }]}>
+                  Open maps
+                </Text>
+              </View>
+            ) : null}
+          </Pressable>
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+// ===========================================================================
+// (9) Floating Get-tickets button — surface-pinned overlay. The surface
+// positions it absolutely; it reflects the live Σ-all-in total and calls the
+// SAME onProceedToCart the in-box Proceed calls. Preserves the float→dock
+// pattern (the surface decides visibility) + the ORCH-1159 close-X behavior
+// (the cover-shell chrome owns close/share; this is just the action button).
+// ===========================================================================
+
+export interface EventOfferingFloatingBarProps {
+  event: PublicEventProps;
+  variant: OfferingVariant;
+  bookable: boolean;
+  palette: ThemePalette;
+  theme: ResolvedTheme;
+  ticketQuantities: Record<string, number>;
+  onProceedToCart: () => void;
+  submitting?: boolean;
+  testID?: string;
+}
+
+export const EventOfferingFloatingBar: React.FC<EventOfferingFloatingBarProps> = ({
+  event,
+  variant,
+  bookable,
+  palette,
+  theme,
+  ticketQuantities,
+  onProceedToCart,
+  submitting = false,
+  testID,
+}) => {
+  const boldFamily = boldFontFamily(theme);
+  const visibleTickets = useMemo(
+    () => event.tickets.filter((t) => t.visibility !== "hidden"),
+    [event.tickets],
+  );
+  const cta = useMemo(
+    () =>
+      resolveOfferingCta({
+        variant,
+        bookable,
+        tickets: visibleTickets,
+        currency: event.currency,
+      }),
+    [variant, bookable, visibleTickets, event.currency],
+  );
+
+  const runningTotal = computeRunningTotal(event.tickets, ticketQuantities);
+  const selectedQty = totalSelectedQuantity(ticketQuantities);
+  const totalLabel =
+    selectedQty === 0
+      ? null
+      : runningTotal === 0
+        ? "Free"
+        : formatMoney(runningTotal, event.currency);
+
+  const enabled =
+    cta.tappable && !submitting && (cta.kind === "waitlist" || selectedQty > 0);
+  const label =
+    cta.kind === "buy"
+      ? totalLabel !== null
+        ? `${cta.label} · ${totalLabel}`
+        : cta.label
+      : cta.kind === "free"
+        ? cta.label
+        : cta.kind === "waitlist"
+          ? cta.label
+          : cta.title;
+
+  return (
+    <Pressable
+      onPress={enabled ? onProceedToCart : undefined}
+      disabled={!enabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: !enabled }}
+      accessibilityLabel={label}
+      style={[
+        styles.floatBar,
+        enabled
+          ? { backgroundColor: palette.accent }
+          : { backgroundColor: palette.panelStrong, borderColor: palette.panelBorder, borderWidth: 1 },
+      ]}
+      testID={testID}
+    >
+      <Text
+        style={[
+          styles.floatBarText,
+          { color: enabled ? palette.accentText : palette.tertiaryText, fontFamily: boldFamily },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+};
+
+// ===========================================================================
+// Sub-components.
+// ===========================================================================
+
+const MetaChip: React.FC<{
+  palette: ThemePalette;
+  surface: ReturnType<typeof offeringSurfaceStyles>;
+  glyph: string;
+  font: string;
+  children: React.ReactNode;
+}> = ({ palette, surface, glyph, font, children }) => (
+  <View style={[styles.metaChip, surface.card]}>
+    <Text style={[styles.metaGlyph, { color: palette.accent }]}>{glyph}</Text>
+    <Text style={[styles.metaText, surface.secondaryText, { fontFamily: font }]}>
+      {children}
+    </Text>
+  </View>
+);
+
+const Pill: React.FC<{
+  palette: ThemePalette;
+  surface: ReturnType<typeof offeringSurfaceStyles>;
+  font: string;
+  accent?: boolean;
+  children: React.ReactNode;
+}> = ({ palette, surface, font, accent = false, children }) => (
+  <View
+    style={[
+      styles.pill,
+      accent
+        ? { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }
+        : surface.card,
+    ]}
+  >
+    <Text
+      style={[
+        styles.pillText,
+        { color: accent ? palette.primaryText : palette.secondaryText, fontFamily: font },
+      ]}
+    >
+      {children}
+    </Text>
+  </View>
+);
+
+const TicketStepperRow: React.FC<{
+  ticket: PublicTicketProps;
+  fallbackCurrency: string;
+  palette: ThemePalette;
+  surface: ReturnType<typeof offeringSurfaceStyles>;
+  boldFamily: string;
+  quantity: number;
+  disabled: boolean;
+  onChange: (qty: number) => void;
+}> = ({ ticket, fallbackCurrency, palette, surface, boldFamily, quantity, disabled, onChange }) => {
+  const sellable = ticketIsSellable(ticket);
+  const isSoldOut = ticketIsSoldOut(ticket);
+  const isDoorOnly = ticketIsDoorOnly(ticket);
+  const saleEnded = ticketSaleEnded(ticket);
+  const isPaused = ticket.visibility === "disabled";
+
+  const stateWord: string | null = saleEnded
+    ? "Sales ended"
+    : isPaused
+      ? "Sales paused"
+      : isDoorOnly
+        ? "Pay at the door"
+        : isSoldOut
+          ? "Sold out"
+          : null;
+
+  const priceLabel = formatTicketPrice(ticket, fallbackCurrency);
+  // Cap: unlimited → 99; else remaining capacity (capacity field carries remaining).
+  const cap = ticket.isUnlimited ? 99 : Math.max(0, ticket.capacity ?? 0);
+  const canIncrement = sellable && !disabled && quantity < cap;
+  const canDecrement = quantity > 0;
+
+  const capacityLabel = ticket.isUnlimited
+    ? "Unlimited"
+    : ticket.capacity !== null
+      ? ticket.capacity <= 0
+        ? "Sold out"
+        : `${ticket.capacity} available`
+      : "Available";
+
+  return (
+    <View
+      style={[
+        styles.stepperRow,
+        { borderBottomColor: palette.panelBorder },
+        !sellable ? styles.stepperRowMuted : null,
+      ]}
+    >
+      <View style={styles.stepperTextCol}>
+        <Text style={[styles.tierName, surface.primaryText, { fontFamily: boldFamily }]}>
+          {ticket.name}
+        </Text>
+        {ticket.description !== null && ticket.description.length > 0 ? (
+          <Text style={[styles.tierDesc, surface.secondaryText]}>
+            {ticket.description}
+          </Text>
+        ) : null}
+        <Text style={[styles.tierCap, surface.tertiaryText]}>
+          {stateWord ?? capacityLabel}
+        </Text>
+      </View>
+
+      <View style={styles.stepperRight}>
+        <Text style={[styles.tierPrice, surface.primaryText, { fontFamily: boldFamily }]}>
+          {ticket.isFree ? "Free" : priceLabel}
+        </Text>
+        {sellable ? (
+          <View style={styles.stepper}>
+            <Pressable
+              onPress={canDecrement ? () => onChange(quantity - 1) : undefined}
+              disabled={!canDecrement}
+              accessibilityRole="button"
+              accessibilityLabel={`Remove one ${ticket.name}`}
+              style={[
+                styles.stepBtn,
+                { borderColor: palette.panelBorder },
+                !canDecrement ? styles.stepBtnDisabled : null,
+              ]}
+            >
+              <Text style={[styles.stepGlyph, { color: palette.primaryText }]}>−</Text>
+            </Pressable>
+            <Text
+              style={[styles.stepQty, surface.primaryText, { fontFamily: boldFamily }]}
+              accessibilityLabel={`${quantity} selected`}
+            >
+              {quantity}
+            </Text>
+            <Pressable
+              onPress={canIncrement ? () => onChange(quantity + 1) : undefined}
+              disabled={!canIncrement}
+              accessibilityRole="button"
+              accessibilityLabel={`Add one ${ticket.name}`}
+              style={[
+                styles.stepBtn,
+                { borderColor: palette.panelBorder },
+                !canIncrement ? styles.stepBtnDisabled : null,
+              ]}
+            >
+              <Text style={[styles.stepGlyph, { color: palette.primaryText }]}>+</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <View
+            style={[styles.tierStatePill, { backgroundColor: palette.card, borderColor: palette.panelBorder }]}
+          >
+            <Text style={[styles.tierStateText, { color: palette.tertiaryText }]}>
+              {stateWord ?? "Unavailable"}
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  leadBlock: { marginBottom: 4 },
+  eyebrow: {
+    fontSize: 11,
+    fontWeight: "900",
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    marginBottom: 8,
+  },
+  title: { fontSize: 32, lineHeight: 35, fontWeight: "900", letterSpacing: -0.5 },
+  metaRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 16 },
+  metaChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  metaGlyph: { fontSize: 14, fontWeight: "900" },
+  metaText: { fontSize: 13, fontWeight: "600" },
+  pillsRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 10 },
+  pill: {
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  pillText: { fontSize: 13, fontWeight: "700" },
+  section: { marginTop: 24 },
+  secTitle: { fontSize: 20, fontWeight: "900", letterSpacing: -0.3, marginBottom: 12 },
+  about: { fontSize: 16, lineHeight: 23 },
+  aboutToggleRow: { flexDirection: "row", alignItems: "center", minHeight: 44 },
+  aboutToggle: { fontSize: 14, fontWeight: "700" },
+  // ---- ticket box ----
+  ticketBox: { borderRadius: 18, padding: 14 },
+  stepperRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  stepperRowMuted: { opacity: 0.7 },
+  stepperTextCol: { flex: 1, minWidth: 0 },
+  stepperRight: { alignItems: "flex-end", gap: 8 },
+  tierName: { fontSize: 15, fontWeight: "800" },
+  tierDesc: { fontSize: 13, marginTop: 3, lineHeight: 18 },
+  tierCap: { fontSize: 12, fontWeight: "700", marginTop: 4 },
+  tierPrice: { fontSize: 15, fontWeight: "900" },
+  stepper: { flexDirection: "row", alignItems: "center", gap: 12 },
+  stepBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 999,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  stepBtnDisabled: { opacity: 0.4 },
+  stepGlyph: { fontSize: 20, fontWeight: "900", lineHeight: 22 },
+  stepQty: { fontSize: 16, fontWeight: "900", minWidth: 18, textAlign: "center" },
+  tierStatePill: {
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  tierStateText: { fontSize: 12, fontWeight: "800" },
+  totalRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    borderTopWidth: 1,
+    paddingTop: 14,
+    marginTop: 4,
+  },
+  totalLabel: { fontSize: 14, fontWeight: "700" },
+  totalValue: { fontSize: 22, fontWeight: "900", letterSpacing: -0.4 },
+  boxProceed: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 16,
+    paddingVertical: 16,
+    marginTop: 14,
+  },
+  boxProceedText: { fontSize: 16, fontWeight: "900" },
+  reassure: { fontSize: 12, marginTop: 12, lineHeight: 17, textAlign: "center" },
+  // ---- brand ----
+  brandRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  brandTile: { width: 42, height: 42, borderRadius: 999, overflow: "hidden" },
+  brandPhoto: { width: "100%", height: "100%" },
+  brandInitialWrap: { flex: 1, alignItems: "center", justifyContent: "center" },
+  brandInitial: { fontSize: 18, fontWeight: "900" },
+  brandTextCol: { flexShrink: 1, flexGrow: 1 },
+  brandKicker: {
+    fontSize: 10,
+    fontWeight: "800",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+  },
+  brandName: { fontSize: 15, fontWeight: "800", marginTop: 1 },
+  brandCta: { fontSize: 13, fontWeight: "800" },
+  // ---- where ----
+  whereMap: {
+    width: "100%",
+    height: 180,
+    borderRadius: 14,
+    borderWidth: 1,
+    backgroundColor: "#000",
+    marginBottom: 12,
+  },
+  venueCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 16,
+    padding: 14,
+  },
+  venueDisk: {
+    width: 40,
+    height: 40,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  venueGlyph: { fontSize: 18, fontWeight: "900" },
+  venueTextCol: { flex: 1, minWidth: 0 },
+  venueName: { fontSize: 15, fontWeight: "800" },
+  venueAddr: { fontSize: 13, marginTop: 2 },
+  venueUnlockCaption: { fontSize: 12, marginTop: 4 },
+  venuePill: { borderRadius: 999, paddingHorizontal: 14, paddingVertical: 8 },
+  venuePillText: { fontSize: 12, fontWeight: "800" },
+  // ---- floating bar ----
+  floatBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 999,
+    paddingVertical: 16,
+    paddingHorizontal: 22,
+  },
+  floatBarText: { fontSize: 16, fontWeight: "900" },
+});
+
+export default EventOfferingBody;

--- a/packages/offering-rendering/__tests__/orch_1167_event_box_totals.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1167_event_box_totals.test.ts
@@ -1,0 +1,69 @@
+// ORCH-1167 [event-page-canonical] — implementor-owned happy-path regression.
+//
+// The inline ticket box's running total MUST be the SERVER all-in (priceAllInGbp),
+// never the bare base (priceGbp) — WYSIWYP (ORCH-1147 / I-PROPOSED-1167-ALLIN-PRICE-
+// IN-TICKET-BOX). This is a BEHAVIORAL test: it imports the pure totals module
+// (RN-free) and asserts Σ(all-in × qty) to the cent — SC-3 (T-04).
+//
+// FAILS-ON-REVERT (proven by TRUE LINE DELETION in the implementation report):
+//   In packages/offering-rendering/eventBoxTotals.ts, delete the all-in coalesce
+//   line `const price = ticket.priceAllInGbp ?? ticket.priceGbp;` and substitute
+//   the bare base `ticket.priceGbp` → the "uses all-in, not bare base" assertion
+//   below FAILS (it would compute 80 from base 30+20 ×qty instead of 130 from
+//   all-in 50+30 ×qty). Restore → PASS.
+
+import {
+  computeRunningTotal,
+  totalSelectedQuantity,
+  ticketUnitAllIn,
+  type TicketLike,
+} from "../eventBoxTotals";
+
+const paidTier = (
+  id: string,
+  base: number,
+  allIn: number | null,
+): TicketLike => ({ id, isFree: false, priceGbp: base, priceAllInGbp: allIn });
+
+describe("ORCH-1167 inline ticket-box running total (WYSIWYP all-in)", () => {
+  it("T-04: total = Σ(priceAllInGbp × qty), NOT the bare base", () => {
+    // Two tiers: VIP base 40 / all-in 50, GA base 25 / all-in 30.
+    const tickets: TicketLike[] = [
+      paidTier("vip", 40, 50),
+      paidTier("ga", 25, 30),
+    ];
+    // qty: 2 VIP + 1 GA.
+    const quantities = { vip: 2, ga: 1 };
+    // All-in: 50×2 + 30×1 = 130. Base would be 40×2 + 25×1 = 105 (WRONG).
+    expect(computeRunningTotal(tickets, quantities)).toBe(130);
+    expect(computeRunningTotal(tickets, quantities)).not.toBe(105);
+  });
+
+  it("falls back to base ONLY when a tier has no all-in (free / RPC miss)", () => {
+    // GA has no all-in → contributes its base (25). VIP all-in 50.
+    const tickets: TicketLike[] = [
+      paidTier("vip", 40, 50),
+      paidTier("ga", 25, null),
+    ];
+    expect(computeRunningTotal(tickets, { vip: 1, ga: 1 })).toBe(75); // 50 + 25
+    // It NEVER fabricates a markup on the no-all-in tier (uses base, not >base).
+    expect(ticketUnitAllIn(tickets[1]!)).toBe(25);
+  });
+
+  it("free tiers contribute 0 and an empty selection totals 0", () => {
+    const free: TicketLike = {
+      id: "free",
+      isFree: true,
+      priceGbp: null,
+      priceAllInGbp: null,
+    };
+    expect(ticketUnitAllIn(free)).toBe(0);
+    expect(computeRunningTotal([free], { free: 3 })).toBe(0);
+    expect(computeRunningTotal([paidTier("vip", 40, 50)], {})).toBe(0);
+  });
+
+  it("totalSelectedQuantity sums all selected tiers", () => {
+    expect(totalSelectedQuantity({})).toBe(0);
+    expect(totalSelectedQuantity({ vip: 2, ga: 1, x: 0 })).toBe(3);
+  });
+});

--- a/packages/offering-rendering/eventBoxTotals.ts
+++ b/packages/offering-rendering/eventBoxTotals.ts
@@ -1,0 +1,49 @@
+/**
+ * eventBoxTotals — ORCH-1167 [event-page-canonical].
+ *
+ * The PURE (React-Native-free) running-total math for the canonical event page's
+ * inline ticket box. Extracted from EventOfferingBody so it is unit-testable under
+ * a plain node/ts-jest environment (the component imports react-native and cannot
+ * be imported in node-env jest). EventOfferingBody re-exports these.
+ *
+ * I-PROPOSED-1167-ALLIN-PRICE-IN-TICKET-BOX: the running total is Σ(server all-in ×
+ * qty) — WYSIWYP (ORCH-1147). The per-unit price reads priceAllInGbp, falling back
+ * to priceGbp ONLY when the tier carries no all-in (free / RPC miss) — never
+ * fabricating a markup (Constitution #9), never showing the bare base under the box.
+ */
+
+export interface TicketLike {
+  id: string;
+  isFree: boolean;
+  priceGbp: number | null;
+  priceAllInGbp?: number | null;
+}
+
+/** The per-unit all-in price (WYSIWYP). Free / missing → 0. */
+export const ticketUnitAllIn = (ticket: TicketLike): number => {
+  if (ticket.isFree) return 0;
+  const price = ticket.priceAllInGbp ?? ticket.priceGbp;
+  return typeof price === "number" && Number.isFinite(price) ? price : 0;
+};
+
+/** Σ(priceAllInGbp × qty) across the selected quantities (never bare base). */
+export const computeRunningTotal = (
+  tickets: TicketLike[],
+  quantities: Record<string, number>,
+): number => {
+  let total = 0;
+  for (const t of tickets) {
+    const qty = quantities[t.id] ?? 0;
+    if (qty > 0) total += ticketUnitAllIn(t) * qty;
+  }
+  return total;
+};
+
+/** Total selected quantity across all tiers. */
+export const totalSelectedQuantity = (
+  quantities: Record<string, number>,
+): number => {
+  let n = 0;
+  for (const key of Object.keys(quantities)) n += quantities[key] ?? 0;
+  return n;
+};

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -29,6 +29,15 @@ export type { GalleryLayout } from "./galleryLayout";
 export { ChipGroup } from "./ChipGroup";
 export type { Chip, ChipGroupProps } from "./ChipGroup";
 
+// ORCH-1167 [event-page-canonical] — THE ONE shared, shell-agnostic body for the
+// standard ticketed-event public page (event_type='event'). Rendered byte-
+// identically on buyer-web + business iOS/Android + consumer iOS/Android. Hosts NO
+// scroll root (each surface injects its scroll + parallax-cover scaffold around it).
+// Carries the inline on-page ticket box (per-tier steppers + live Σ-all-in running
+// total (WYSIWYP) + in-box Proceed) and the surface-pinned floating Get-tickets bar.
+export { EventOfferingBody, EventOfferingFloatingBar, computeRunningTotal, totalSelectedQuantity } from "./EventOfferingBody";
+export type { EventOfferingBodyProps, EventOfferingFloatingBarProps } from "./EventOfferingBody";
+
 // ORCH-1157 [rsvp-public-redesign] — the shared Direction-C "Momentum" RSVP hero
 // (going-count + capacity meter + faceless anonymous cluster + Going/Maybe/Can't
 // decision). Consumed by the business RsvpPublicBody (buyer-web + business +

--- a/supabase/migrations/20261015000000_orch_1167_event_city_geo.sql
+++ b/supabase/migrations/20261015000000_orch_1167_event_city_geo.sql
@@ -1,0 +1,139 @@
+-- ORCH-1167 [event-page-canonical] — Migration 1: city-level privacy geo field.
+--
+-- Leg 1 of META-ORCH-1166 (public offering-page single source of truth).
+--
+-- WHAT: add `public.events.city_geo geometry(Point,4326)` — a CITY-LEVEL centroid
+-- (privacy-safe location) distinct from the EXACT `location_geo point` venue pin.
+-- The canonical standard-event public page renders a city-level map (no exact pin)
+-- when the brand hides the street until ticket purchase; the exact pin renders only
+-- when the address is public. See SPEC §4A.
+--
+-- SAFE-MIGRATION PROTOCOL:
+--   • Additive, NULLable, DEFAULT NULL — 77/89 existing event rows stay NULL → the
+--     map simply does not render (Constitution rule 9: missing is hidden, never
+--     fabricated). No backfill (OQ-1: city centroid is derived at the publish /
+--     address-write path going forward; existing rows render the text venue card).
+--   • The `CREATE OR REPLACE VIEW` mirrors the ORCH-1150 view column list VERBATIM
+--     and appends ONLY `e.city_geo` (right after `e.location_geo`). No column is
+--     dropped/reordered → no PostgREST contract break for existing readers.
+--   • `security_invoker=false` preserved (anon reads run as the view owner).
+--
+-- DO NOT auto-apply. The orchestrator/Seth applies via the Supabase Management API
+-- after review (migrations are spec-only in this leg — SPEC §13).
+
+-- ── 1. additive column ──────────────────────────────────────────────────────
+ALTER TABLE public.events
+  ADD COLUMN IF NOT EXISTS city_geo geometry(Point, 4326);
+
+COMMENT ON COLUMN public.events.city_geo IS
+  'ORCH-1167 — CITY-LEVEL centroid (privacy-safe). NULLable; distinct from the '
+  'exact location_geo venue pin. Used by the canonical event public page to draw '
+  'a city-level map (no exact pin) when hide_address_until_ticket is set and the '
+  'viewer is anonymous. Derived at the publish/address-write path from the city '
+  'centroid (NOT the street point); NULL when the city is unknown (rule 9).';
+
+-- ── 2. expose city_geo on the anon-safe public read view ─────────────────────
+-- Mirrors the ORCH-1150 view column list VERBATIM, appending ONLY e.city_geo
+-- (right after e.location_geo) so the new pg_public_event_by_slug RPC + the
+-- consumer theme/card reads can surface the city-level centroid.
+BEGIN;
+
+CREATE OR REPLACE VIEW public.business_public_events_view AS
+  SELECT e.id,
+    e.brand_id,
+    b.slug AS brand_slug,
+    b.name AS brand_name,
+    b.description AS brand_description,
+    b.profile_photo_url AS brand_profile_photo_url,
+    b.display_attendee_count AS brand_display_attendee_count,
+    b.address AS brand_address,
+    b.cover_media_url AS brand_cover_media_url,
+    b.theme_color AS brand_theme_color,
+    b.theme_font AS brand_theme_font,
+    b.theme_animation AS brand_theme_animation,
+    e.title,
+    e.description,
+    e.slug,
+    e.event_type,
+    e.location_text,
+    e.online_url,
+    e.is_online,
+    e.is_recurring,
+    e.is_multi_date,
+    e.recurrence_rules,
+    e.cover_media_url,
+    e.cover_media_type,
+    e.visibility,
+    e.show_on_discover,
+    e.status,
+    e.published_at,
+    e.timezone,
+    e.created_at,
+    e.updated_at,
+    (e.theme - 'business_draft'::text) AS public_theme,
+    e.theme_color_override,
+    e.theme_font_override,
+    e.theme_animation_override,
+    e.currency,
+    e.cover_media_provider,
+    e.cover_media_source_url,
+    e.cover_media_credit,
+    e.cover_media_credit_url,
+    e.cover_media_alt,
+    ed.start_at AS master_start_at,
+    ed.end_at AS master_end_at,
+    ed.timezone AS master_timezone,
+    ed.id AS master_event_date_id,
+    e.city,
+    e.party_types,
+    e.vibe_tags,
+    e.music_genres,
+    e.location_geo,
+    -- ORCH-1167 — city-level privacy centroid (the ONLY geo returned for an
+    -- anon viewer when the street is hidden until ticket purchase).
+    e.city_geo,
+    COALESCE(e.pass_tax,         b.default_pass_tax)         AS pass_tax,
+    COALESCE(e.pass_mingla_fee,  b.default_pass_mingla_fee)  AS pass_mingla_fee,
+    COALESCE(e.pass_service_fee, b.default_pass_service_fee) AS pass_service_fee,
+    b.pricing_region   AS pricing_region,
+    b.pricing_currency AS pricing_currency,
+    (e.pricing_locked_at IS NOT NULL) AS pricing_locked,
+    (
+      SELECT public.compute_all_in_cents(
+               MIN(tt.price_cents),
+               COALESCE(e.pass_mingla_fee,  b.default_pass_mingla_fee),
+               COALESCE(e.pass_service_fee, b.default_pass_service_fee),
+               (SELECT r.effective_take_rate_bps FROM public.resolve_effective_take_rate_bps(b.id) r)
+             )
+      FROM public.ticket_types tt
+      WHERE tt.event_id = e.id
+        AND tt.price_cents > 0
+        AND tt.deleted_at IS NULL
+    ) AS display_price_cents,
+    -- ORCH-1150 RSVP host-control columns (inert for non-RSVP rows).
+    e.rsvp_discoverable,
+    e.rsvp_capacity,
+    e.rsvp_allow_plus_ones,
+    e.rsvp_plus_ones_max,
+    e.rsvp_waitlist_enabled,
+    e.rsvp_approval_mode,
+    (
+      SELECT COALESCE(SUM(1 + r.plus_count), 0)::integer
+      FROM public.event_rsvps r
+      WHERE r.event_id = e.id
+        AND r.rsvp_status = 'going'
+        AND r.approval_status = 'approved'
+    ) AS rsvp_going_count
+   FROM events e
+     JOIN brands b ON b.id = e.brand_id
+     LEFT JOIN event_dates ed ON ed.event_id = e.id AND ed.is_master = true
+  WHERE e.deleted_at IS NULL
+    AND b.deleted_at IS NULL
+    AND e.visibility = 'public'::text
+    AND (e.status = ANY (ARRAY['scheduled'::text, 'live'::text, 'ended'::text, 'cancelled'::text]));
+
+ALTER VIEW public.business_public_events_view SET (security_invoker = false);
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20261015000000_orch_1167_event_city_geo.sql
+++ b/supabase/migrations/20261015000000_orch_1167_event_city_geo.sql
@@ -13,8 +13,9 @@
 --     map simply does not render (Constitution rule 9: missing is hidden, never
 --     fabricated). No backfill (OQ-1: city centroid is derived at the publish /
 --     address-write path going forward; existing rows render the text venue card).
---   • The `CREATE OR REPLACE VIEW` mirrors the ORCH-1150 view column list VERBATIM
---     and appends ONLY `e.city_geo` (right after `e.location_geo`). No column is
+--   • The `CREATE OR REPLACE VIEW` mirrors the existing view column list VERBATIM
+--     and appends ONLY `e.city_geo` at the END (CREATE OR REPLACE VIEW requires new
+--     columns last; existing columns keep name/type/order). No column is
 --     dropped/reordered → no PostgREST contract break for existing readers.
 --   • `security_invoker=false` preserved (anon reads run as the view owner).
 --
@@ -89,9 +90,6 @@ CREATE OR REPLACE VIEW public.business_public_events_view AS
     e.vibe_tags,
     e.music_genres,
     e.location_geo,
-    -- ORCH-1167 — city-level privacy centroid (the ONLY geo returned for an
-    -- anon viewer when the street is hidden until ticket purchase).
-    e.city_geo,
     COALESCE(e.pass_tax,         b.default_pass_tax)         AS pass_tax,
     COALESCE(e.pass_mingla_fee,  b.default_pass_mingla_fee)  AS pass_mingla_fee,
     COALESCE(e.pass_service_fee, b.default_pass_service_fee) AS pass_service_fee,
@@ -123,7 +121,11 @@ CREATE OR REPLACE VIEW public.business_public_events_view AS
       WHERE r.event_id = e.id
         AND r.rsvp_status = 'going'
         AND r.approval_status = 'approved'
-    ) AS rsvp_going_count
+    ) AS rsvp_going_count,
+    -- ORCH-1167 — city-level privacy centroid. Appended LAST: CREATE OR REPLACE VIEW
+    -- requires new columns at the END of the column list (existing columns keep name,
+    -- type AND order). location_geo (the exact pin) is unchanged at its position.
+    e.city_geo
    FROM events e
      JOIN brands b ON b.id = e.brand_id
      LEFT JOIN event_dates ed ON ed.event_id = e.id AND ed.is_master = true

--- a/supabase/migrations/20261015000001_orch_1167_pg_public_event_by_slug.sql
+++ b/supabase/migrations/20261015000001_orch_1167_pg_public_event_by_slug.sql
@@ -1,0 +1,262 @@
+-- ORCH-1167 [event-page-canonical] — Migration 2: canonical read RPC.
+--
+-- Leg 1 of META-ORCH-1166 (public offering-page single source of truth).
+--
+-- WHAT: `pg_public_event_by_slug(p_brand_slug, p_event_slug) RETURNS json` — the
+-- ONE anon read path that fills the shared `EventOfferingBody` props on ALL THREE
+-- surfaces (buyer-web, business native, consumer app) from a single source. Returns
+-- the full event payload: identity/slugs/description, date fields, status, derived
+-- format, venue + privacy-gated geo, cover, brand card, the pills arrays
+-- (party_types / vibe_tags / music_genres), city + NEW city_geo, currency, theme
+-- overrides, and the per-tier ticket rows WITH server-computed all-in (the SAME
+-- compute_all_in_cents single owner the cart + pg_public_event_tier_allin use —
+-- ZERO duplicated fee math). Restricted to event_type='event' (standard ticketed)
+-- + public + scheduled/live/ended/cancelled. See SPEC §4B.
+--
+-- PRIVACY (server-side, SPEC §4B + I-PROPOSED-1167-CITY-LEVEL-MAP-NO-EXACT-PIN-WHEN-HIDDEN):
+-- when the event hides the street until ticket purchase (theme.business_event
+-- .hideAddressUntilTicket, defaulting TRUE for safety to mirror the service mapper),
+-- the RPC OMITS the exact `address` + `location_geo` and returns ONLY `city` +
+-- `city_geo` (so the body draws a CITY-LEVEL map with no exact pin). The anon RPC
+-- never returns the exact pin for a hidden-address event. The authenticated
+-- post-purchase address-unlock path is unchanged (out of scope, SPEC OQ-2).
+--
+-- SAFE-MIGRATION PROTOCOL:
+--   • SECURITY DEFINER, STABLE, owned by the migration role; reads ONLY anon-safe
+--     columns (mirrors the business_public_events_view safe projection).
+--   • $function$ terminator BEFORE the GRANT (Cross-host rule / migration baseline).
+--   • DROP IF EXISTS before the CREATE (idempotent; the RETURNS type is json so no
+--     RETURNS-TABLE widening hazard).
+--   • GRANT EXECUTE TO anon, authenticated.
+--
+-- DO NOT auto-apply — orchestrator/Seth applies via the Management API (SPEC §13).
+
+DROP FUNCTION IF EXISTS public.pg_public_event_by_slug(text, text);
+
+CREATE FUNCTION public.pg_public_event_by_slug(
+  p_brand_slug text,
+  p_event_slug text
+)
+RETURNS json
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  WITH ev AS (
+    SELECT
+      e.id,
+      e.brand_id,
+      e.title,
+      e.description,
+      e.slug              AS event_slug,
+      e.event_type,
+      e.location_text,
+      e.online_url,
+      e.is_online,
+      e.status,
+      e.published_at,
+      e.timezone,
+      e.currency,
+      e.cover_media_url,
+      e.cover_media_type,
+      e.cover_media_provider,
+      e.cover_media_source_url,
+      e.cover_media_credit,
+      e.cover_media_credit_url,
+      e.cover_media_alt,
+      e.party_types,
+      e.vibe_tags,
+      e.music_genres,
+      e.city,
+      e.location_geo,
+      e.city_geo,
+      e.theme_color_override,
+      e.theme_font_override,
+      e.theme_animation_override,
+      (e.theme - 'business_draft'::text) AS public_theme,
+      ed.start_at AS master_start_at,
+      ed.end_at   AS master_end_at,
+      ed.timezone AS master_timezone,
+      -- hide_address_until_ticket lives in theme.business_event (jsonb), not a
+      -- real column. Default TRUE when absent — mirrors the service mapper
+      -- (publicEventViewRowToEvent: asBoolean(..., true)) so a legacy row never
+      -- leaks the street.
+      COALESCE(
+        ((e.theme #>> '{business_event,hideAddressUntilTicket}')::boolean),
+        true
+      ) AS hide_address_until_ticket,
+      b.id            AS brand_id_b,
+      b.slug          AS brand_slug,
+      b.name          AS brand_name,
+      b.profile_photo_url AS brand_profile_photo_url,
+      b.theme_color   AS brand_theme_color,
+      b.theme_font    AS brand_theme_font,
+      b.theme_animation AS brand_theme_animation,
+      COALESCE(e.pass_mingla_fee,  b.default_pass_mingla_fee)  AS pass_mingla_fee,
+      COALESCE(e.pass_service_fee, b.default_pass_service_fee) AS pass_service_fee,
+      b.pricing_currency AS pricing_currency
+    FROM public.events e
+    JOIN public.brands b ON b.id = e.brand_id
+    LEFT JOIN public.event_dates ed
+           ON ed.event_id = e.id AND ed.is_master = true
+    WHERE b.slug = p_brand_slug
+      AND e.slug = p_event_slug
+      AND e.event_type = 'event'           -- standard ticketed ONLY (SPEC scope)
+      AND e.visibility = 'public'::text
+      AND e.deleted_at IS NULL
+      AND b.deleted_at IS NULL
+      AND e.status = ANY (ARRAY['scheduled'::text, 'live'::text, 'ended'::text, 'cancelled'::text])
+    LIMIT 1
+  ),
+  tix AS (
+    SELECT
+      tt.id,
+      tt.name,
+      tt.description,
+      tt.price_cents,
+      tt.currency,
+      tt.quantity_total,
+      tt.is_unlimited,
+      tt.is_free,
+      tt.sale_start_at,
+      tt.sale_end_at,
+      tt.is_hidden,
+      tt.is_disabled,
+      tt.requires_approval,
+      tt.password_protected,
+      tt.available_online,
+      tt.available_in_person,
+      tt.waitlist_enabled,
+      tt.display_order,
+      -- server all-in (WYSIWYP) — SAME compute_all_in_cents single owner as
+      -- pg_public_event_tier_allin. Free / zero-price tier → 0.
+      CASE
+        WHEN COALESCE(tt.is_free, false) OR COALESCE(tt.price_cents, 0) = 0 THEN 0
+        ELSE public.compute_all_in_cents(
+               tt.price_cents,
+               ev.pass_mingla_fee,
+               ev.pass_service_fee,
+               (SELECT r.effective_take_rate_bps
+                  FROM public.resolve_effective_take_rate_bps(ev.brand_id) AS r)
+             )
+      END AS all_in_cents,
+      -- remaining capacity (GREATEST(total - sold, 0)); NULL for unlimited.
+      -- Sold formula matches pg_public_ticket_types_remaining (ORCH-0946) EXACTLY:
+      -- COUNT of tickets rows with status IN ('valid','used','transferred').
+      CASE
+        WHEN COALESCE(tt.is_unlimited, false) THEN NULL
+        WHEN tt.quantity_total IS NULL THEN NULL
+        ELSE GREATEST(
+          0,
+          tt.quantity_total - COALESCE((
+            SELECT COUNT(*)::integer
+            FROM public.tickets t
+            WHERE t.ticket_type_id = tt.id
+              AND t.status IN ('valid', 'used', 'transferred')
+          ), 0)
+        )
+      END AS remaining
+    FROM public.ticket_types tt
+    JOIN ev ON ev.id = tt.event_id
+    WHERE tt.deleted_at IS NULL
+      AND tt.available_online = true
+  )
+  SELECT
+    CASE WHEN ev.id IS NULL THEN NULL ELSE json_build_object(
+      'id', ev.id,
+      'brandId', ev.brand_id,
+      'brandSlug', ev.brand_slug,
+      'eventSlug', ev.event_slug,
+      'name', ev.title,
+      'description', COALESCE(ev.description, ''),
+      'masterStartAt', ev.master_start_at,
+      'masterEndAt', ev.master_end_at,
+      'timezone', COALESCE(ev.master_timezone, ev.timezone),
+      'status', ev.status,
+      'isOnline', ev.is_online,
+      'onlineUrl', ev.online_url,
+      'venueName', COALESCE(NULLIF((ev.public_theme #>> '{business_event,location,venueName}'), ''), ev.location_text),
+      -- PRIVACY: address + exact pin omitted (NULL) when the street is hidden.
+      'address', CASE
+        WHEN ev.hide_address_until_ticket THEN NULL
+        ELSE COALESCE(NULLIF((ev.public_theme #>> '{business_event,location,address}'), ''), ev.location_text)
+      END,
+      'hideAddressUntilTicket', ev.hide_address_until_ticket,
+      'format', (ev.public_theme #>> '{business_event,format}'),
+      'city', ev.city,
+      -- exact pin: NULL when hidden; else {lat,lng} from the point.
+      'locationGeo', CASE
+        WHEN ev.hide_address_until_ticket OR ev.location_geo IS NULL THEN NULL
+        ELSE json_build_object(
+          'lat', ST_Y(ev.location_geo::geometry),
+          'lng', ST_X(ev.location_geo::geometry)
+        )
+      END,
+      -- city-level centroid: always returned when present (privacy-safe).
+      'cityGeo', CASE
+        WHEN ev.city_geo IS NULL THEN NULL
+        ELSE json_build_object(
+          'lat', ST_Y(ev.city_geo),
+          'lng', ST_X(ev.city_geo)
+        )
+      END,
+      'coverMediaUrl', ev.cover_media_url,
+      'coverMediaType', ev.cover_media_type,
+      'coverMediaProvider', ev.cover_media_provider,
+      'coverMediaCredit', ev.cover_media_credit,
+      'currency', COALESCE(ev.pricing_currency, ev.currency, 'usd'),
+      'partyTypes', COALESCE(ev.party_types, ARRAY[]::text[]),
+      'vibeTags', COALESCE(ev.vibe_tags, ARRAY[]::text[]),
+      'musicGenres', COALESCE(ev.music_genres, ARRAY[]::text[]),
+      'themeColorOverride', ev.theme_color_override,
+      'themeFontOverride', ev.theme_font_override,
+      'themeAnimationOverride', ev.theme_animation_override,
+      'brand', json_build_object(
+        'id', ev.brand_id_b,
+        'slug', ev.brand_slug,
+        'name', ev.brand_name,
+        'profilePhotoUrl', ev.brand_profile_photo_url,
+        'themeColor', ev.brand_theme_color,
+        'themeFont', ev.brand_theme_font,
+        'themeAnimation', ev.brand_theme_animation
+      ),
+      'tickets', COALESCE((
+        SELECT json_agg(json_build_object(
+          'id', tix.id,
+          'name', tix.name,
+          'description', tix.description,
+          'priceCents', tix.price_cents,
+          'allInCents', tix.all_in_cents,
+          'currency', tix.currency,
+          'capacity', tix.quantity_total,
+          'remaining', tix.remaining,
+          'isUnlimited', tix.is_unlimited,
+          'isFree', tix.is_free,
+          'saleStartAt', tix.sale_start_at,
+          'saleEndAt', tix.sale_end_at,
+          'isHidden', tix.is_hidden,
+          'isDisabled', tix.is_disabled,
+          'requiresApproval', tix.requires_approval,
+          'passwordProtected', tix.password_protected,
+          'availableOnline', tix.available_online,
+          'availableInPerson', tix.available_in_person,
+          'waitlistEnabled', tix.waitlist_enabled,
+          'displayOrder', tix.display_order
+        ) ORDER BY tix.display_order ASC)
+        FROM tix
+      ), '[]'::json)
+    ) END
+  FROM ev;
+$function$;
+
+COMMENT ON FUNCTION public.pg_public_event_by_slug(text, text) IS
+  'ORCH-1167 — the ONE canonical anon read path for the standard ticketed-event '
+  'public page (event_type=event). Returns the full EventOfferingBody payload as '
+  'json incl. pills (party/vibe/music), city + city_geo, and per-tier server all-in '
+  '(compute_all_in_cents single owner). PRIVACY: omits address + exact location_geo '
+  'when the street is hidden until ticket purchase, returning only city + city_geo.';
+
+GRANT EXECUTE ON FUNCTION public.pg_public_event_by_slug(text, text) TO anon, authenticated;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## ORCH-1167 [event-page-canonical] — leg 1 of META-ORCH-1166 (public offering-page single source of truth)

Standardizes the **standard ticketed-event** public page (event_type='event' only) into ONE shared shell-agnostic `EventOfferingBody` in `packages/offering-rendering`, rendered identically on buyer-web, the business app (iOS/Android), and the consumer app (iOS/Android) — replacing the prior web-body + consumer-fork drift.

### What changed (Seth's canonical 9-section structure)
Cover → Event name → Date/time (AM/PM) → Pills (format · vibes · party-types · music-genres · tickets-left) → **inline ticket box** (per-tier steppers, live Σ all-in total, in-box Proceed) → Presented-By → About toggle → "Where you'll be" map (city-level when address hidden) → floating Get Tickets. The inline box **replaces** the separate tier-picker and pre-populates the cart at the editable step.

### Backend (migrations already applied to prod + recorded)
- `20261015000000_orch_1167_event_city_geo.sql` — additive `events.city_geo` (privacy centroid) + view exposes it (appended last).
- `20261015000001_orch_1167_pg_public_event_by_slug.sql` — the ONE canonical anon read RPC; **privacy enforced server-side** (no exact pin/address when hidden).

### Evidence
- Implementor happy-path test (Σ all-in) + tester adversarial cart-seed test — both fails-on-revert proven (`0a85c8f34`, `6eb1d0b8c`).
- Live-fire privacy probe over all 14 published events → **0 leaks**.
- 5 new `I-PROPOSED-1167-*` CI gates; typecheck/jest/web-export green.
- Tester verdict: CONDITIONAL PASS, no blocking defects. Consumer gorhom-scroll = Seth's on-device sign-off.

### Scope
Phase 1 (shared body + RPC + inline box). Full `event-rendering` dissolution = Phase 2 (separate ORCH). RSVP/trip/experience/admin/pricing-engine untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)