### PR TITLE
ORCH-1167 R3: full-width date, solid-fill pills, always-active buy button, consumer floating-button fix [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1167_R3_PILLS_BUTTON_POLISH.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1167_R3_PILLS_BUTTON_POLISH.md
@@ -1,0 +1,97 @@
+# IMPLEMENT — ORCH-1167-R3 [event-page-canonical] — Pills + button polish (UI-only)
+
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1167-[event-page-canonical]/` on branch `ORCH-1167-r3-pills-button-polish` (off latest origin/main incl. merged ORCH-1167 + R2).
+**Scope:** UI-only revisions to the canonical STANDARD-event public page (`EventOfferingBody` + per-surface shells). NO schema / RPC / migration / pricing-engine / package-config change. Standard event ONLY — RSVP / trip / experience untouched.
+**Companion:** `SPEC_ORCH-1167_EVENT_PAGE_CANONICAL_STRUCTURE.md` + `IMPLEMENT_ORCH-1167_R2_LAYOUT_POLISH.md`.
+
+---
+
+## 1. Summary
+
+Four Seth-directed UI revisions to the already-shipped ORCH-1167 standard-event page, landing in the ONE shared shell-agnostic body (`packages/offering-rendering/EventOfferingBody.tsx`) + its two stateful host adapters, so they hit buyer-web + business iOS/Android + consumer iOS/Android at once:
+
+1. **DATE/TIME → FULL WIDTH** on mobile + desktop. The date/time was a small compact chip in the meta band; it is now its OWN full-width row (`dateRow`, testID `orch-1167-date-row`) spanning the content column, with the date line + time subline stacked. The other pills (format / vibes / party-types / music-genres / tickets-left) stay in the compact band BELOW it.
+2. **ALL PILLS GET THE SOLID FILL.** Every pill now renders the theme-aware solid accent fill (`palette.accentWash` + border) that the prior "tickets-left" chip used — replacing the old outlined/translucent `surface.card` variant. The full-width date row uses the SAME fill for consistency. Android opaque-glass policy intact (`accentWash` is an opaque-ish accent tint, not the translucent glass card).
+3. **BUY / GET-TICKETS BUTTON ALWAYS ACTIVE → CART, EVEN AT 0 SELECTED.** The empty-selection disable (`&& (kind === "waitlist" || selectedQty > 0)`) is removed from BOTH the in-box Proceed and the persistent floating button: while on-sale (buy / free) or waitlistable the button is ALWAYS tappable and routes to the cart step (i), where the buyer picks/edits quantities. At 0 selected the label is the bare get-tickets verb (no total / no "$0"). Both hosts' `handleProceedToCart` early-return on empty selection is removed. The genuinely non-purchasable CTA states (sold-out / past / ended / cancelled / not-bookable / door-only) stay GATED exactly as before via `resolveOfferingCta().tappable === false`.
+4. **CONSUMER FLOATING BUTTON OFF-SCREEN BLEED FIXED.** On the consumer gorhom BottomSheet the floating bar wrapper was `bottom: 0` + `paddingBottom: insets.bottom + 8`; inside the sheet `useSafeAreaInsets().bottom` resolves ~0 and the gorhom content overshoots ~63pt below the visible window at the 90% snap, so the button bled under the home indicator. FIX mirrors the SHIPPED, device-proven `ConsumerTripReserveBar` floating math: `bottom = max(insets.bottom, 34) + 63 (overshoot) + 16 (gap)`. The scroll content bottom inset was raised to a constant runway (`177 + insets.bottom`) that always clears the raised bar. (Web + business-native floating bar positioning unchanged — not regressed.)
+
+## 2. SPEC success-criteria coverage (R3 deltas)
+
+| Change | Status | Where |
+|--------|--------|-------|
+| 1 — date/time full-width row | DONE | `EventOfferingBody` section (3): `dateRow`/`dateGlyph`/`dateTextCol`/`dateLine`/`dateSubline` (testID `orch-1167-date-row`) |
+| 2 — all pills solid fill | DONE | `EventOfferingBody` `Pill` component (accentWash unconditional) + `dateRow` styled to match |
+| 3 — button active at 0 → cart | DONE | `EventOfferingBody` `EventTicketBox.proceedEnabled` + `EventOfferingFloatingBar.enabled`; `PublicEventPage.handleProceedToCart` + `ConsumerEventDetailScreen.handleProceedToCart` early-return removed |
+| 4 — consumer float bar bleed | DONE | `ConsumerEventDetailScreen` `floatBarBottom` (gorhom-overshoot lift) + `reserveBarClearance` + `nativeFloatWrap` |
+
+Existing SC-1..SC-9 preserved: 9-section order, all-in WYSIWYP totals, server-side address privacy / city-level map, shell-agnostic gorhom scroll (no scroll root added), one-read-RPC, ORCH-1159 web close-X, desktop 2-column sticky panel (R2), I-MOR-0827 package isolation. All 5 ORCH-1167 strict-grep gates PASS + self-tests PASS; existing 1167 jest (R2 + box-totals + business cart-seed adversarial) all PASS.
+
+## 3. Files changed
+
+- `packages/offering-rendering/EventOfferingBody.tsx` (~+87/−61 region) — section (3) date/time split into the full-width `dateRow`; `MetaChip` component + `metaChip`/`metaGlyph`/`metaText` styles removed (sole consumer was the compact date chip); `metaRow` style retained (R2 regression token); new `dateRow`/`dateGlyph`/`dateTextCol`/`dateLine`/`dateSubline` styles; `Pill` now renders the solid `accentWash` fill unconditionally (the `accent ? accentWash : surface.card` ternary removed); `EventTicketBox.proceedEnabled` = `ctaActionable && !submitting` (empty-selection clause dropped); `EventOfferingFloatingBar.enabled` = `cta.tappable && !submitting`.
+- `mingla-business/src/components/event/PublicEventPage.tsx` (+7/−2) — `handleProceedToCart` empty-selection early-return removed (waitlist branch + not-bookable toast guards preserved); pushes to the cart step (i) at 0 selected (empty seed → bare checkout path).
+- `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx` (+~40/−12) — `handleProceedToCart` empty-selection early-return removed (cart opens to the tier list at 0); `floatBarBottom` gorhom-overshoot lift; `reserveBarClearance = 177 + insets.bottom`; `nativeFloatWrap` `bottom: 0` removed (now set inline to `floatBarBottom`).
+- `packages/offering-rendering/__tests__/orch_1167_r3_pills_button_polish.test.ts` (new) — 14 assertions (9 runtime-logic for change 3 + 5 source-structural for changes 1/2/3-host/4).
+
+NOT touched (no edit needed, minimal footprint): `FoundationEventPreview.tsx` (forwards props unchanged), `packages/offering-rendering/index.ts` (exports unchanged — no additive export needed).
+
+## 4. Data-model / RPC / edge functions
+
+NONE. UI-only — no migration, no RPC, no view, no RLS, no edge function, no pricing-engine, no package-config change.
+
+## 5. Regression tests added
+
+`packages/offering-rendering/__tests__/orch_1167_r3_pills_button_polish.test.ts` — run: `cd mingla-business && npx jest --roots=../packages --testPathPattern="orch_1167_r3"` → **14/14 PASS**.
+
+- **Change 3 (runtime-logic, 9 tests):** uses the PURE `resolveOfferingCta` (imported directly from `../../event-rendering/offeringCta` to avoid the RN barrel under node-env) + the exact post-R3 enable predicate. Proves: on-sale buy + free are tappable/enabled at 0 selected; submitting still disables; not-bookable / cancelled / past / pre-sale / sold-out(no-waitlist) / door-only stay GATED at 0 selected; sold-out-with-waitlist stays tappable.
+- **Changes 1/2/3-host/4 (source-structural, 5 tests):** date row is full-width (`width: "100%"`, testID present, no `<MetaChip`); every pill uses `accentWash` (no `accent ? accentWash : surface.card` ternary); the body predicate dropped `selectedQty > 0`; neither host has `if (!anySelected) return;`; the consumer float wrapper uses `floatBarBottom` (gorhom-overshoot math), not flat `bottom: 0`.
+
+### Fails-on-revert (proven by TRUE LINE-LEVEL REVERT)
+
+| Change | Revert applied | Result |
+|--------|----------------|--------|
+| 2 | restore `accent ? accentWash : surface.card` Pill branch | "all pills solid fill" assertion FAILS → restore PASS |
+| 3 (box/bar) | re-add `&& (kind === "waitlist" \|\| selectedQty > 0)` | "empty-selection gate removed" assertion FAILS → restore PASS |
+| 1 | rename/remove `orch-1167-date-row` testID | "date row full-width" assertion FAILS → restore PASS |
+| 4 | restore flat `bottom: 0` / `paddingBottom` wrapper | "consumer float bar lifted" assertion FAILS → restore PASS |
+
+All four restored to 14/14 PASS after each revert experiment.
+
+## 6. Gate + test results
+
+- **5 ORCH-1167 strict-grep gates:** `allin-price-in-ticket-box`, `canonical-9-section-order`, `one-read-rpc`, `shell-agnostic-body`, `city-level-map-no-exact-pin-when-hidden` — ALL PASS + ALL `--self-test` PASS.
+- **9-section gate anchors:** all 7 in-body anchors present + in order (verified) — the date-row split kept the `(3) Date & time meta chips` comment + `orch-1167-pills-row` testID order intact.
+- **jest:** `orch_1167_r2_layout_polish` (6) + `orch_1167_event_box_totals` (4) + `orch_1167_r3_pills_button_polish` (14) = **24/24 PASS**; business `orch_1167_cart_seed.adversarial` **10/10 PASS** (incl. "empty selection → bare checkout path").
+- **typecheck:** the `offering-rendering` package's own tsconfig → **0 errors** (`EventOfferingBody.tsx` clean); `ConsumerEventDetailScreen.tsx` → **0 errors** under app-mobile tsconfig; business adapter files (`PublicEventPage.tsx`, `FoundationEventPreview.tsx`) → **0 errors** under business tsconfig. (The cross-package "Cannot find module 'react'" cascades seen when typechecking `packages/*` via the BUSINESS tsconfig are pre-existing monorepo config behavior — the packages aren't in the business tsconfig's module resolution — NOT introduced here; the package's own tsconfig resolves react and is clean.)
+
+## 7. Cross-surface impact
+
+| # | Surface | Affected | Parity |
+|---|---------|----------|--------|
+| 1 | Consumer iOS | YES — date row full-width, solid pills, button-at-0, float bar bleed fix | shared body + consumer shell |
+| 2 | Consumer Android | YES — same (opaque-glass intact) | shared body + consumer shell |
+| 3 | Buyer/anon Web | YES — date row full-width, solid pills, button-at-0 (float bar unchanged) | shared body + web adapter |
+| 4 | Business iOS | YES — date row full-width, solid pills, button-at-0 | shared body + web adapter |
+| 5 | Business Android | YES — same | shared body + web adapter |
+| 6 | Admin Web | NO | n/a |
+| 7 | RSVP / trip / experience | NO — standard-event branch only | n/a |
+
+## 8. Smoke result
+
+No simulator/device run this turn (UI-only structural/style change). Verified via: 5 strict-grep gates + self-tests PASS, 24/24 package jest + 10/10 business cart-seed adversarial PASS, package + consumer + business tsc clean on the touched files, and fails-on-revert proven for all 4 changes. Device/sim verification (consumer notched-device float-bar full visibility + last-section clearance, solid-pill render under a light + dark brand theme, button-at-0 → cart on every surface, desktop ≥1024px unaffected) is for the tester.
+
+## 9. Known issues / deferred
+
+- No `[TRANSITIONAL]` code added.
+- `FoundationEventPreview` deliberately untouched (props forwarded; R2 contract preserved).
+- The 9 "failed" offering-rendering jest suites are pre-existing Deno test files (`Deno.test`) jest cannot run — RSVP/close-X, unrelated to standard-event; flagged in R2, unchanged here.
+
+## 10. Operator action required
+
+- NONE for DB / edge (UI-only).
+- Route to mingla-tester for the 5 primary surfaces (esp. consumer notched-device float-bar visibility + button-at-0 → cart + solid-pill theme contrast). Then orchestrator REVIEW/CLOSE. Do NOT deploy / merge / OTA from this worktree.
+
+## 11. Discoveries for Orchestrator
+
+- COMMS-0040 (RSVP page standardization, WARN) acknowledged: my edits touch ONLY the standard-event (`event_type==='event'`) branch of `ConsumerEventDetailScreen` + the shared `EventOfferingBody` — NOT `RsvpPublicBody`, NOT the RSVP branch, NOT any RSVP/experience/trip body. No conflict with the imminent `RsvpPublicBody`→`packages/` move.
+- The cross-package react-resolution tsc cascade (packages typechecked via the business tsconfig report `Cannot find module 'react'` → every binding becomes `any`) is a pre-existing monorepo tsconfig nuance, not a regression. Typecheck packages with their own tsconfig (`packages/offering-rendering/tsconfig.json`) to get a true read.

--- a/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
+++ b/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
@@ -328,10 +328,11 @@ export default function ConsumerEventDetailScreen({
     [],
   );
   const handleProceedToCart = useCallback((): void => {
-    const anySelected = Object.values(ticketQuantities).some((q) => q > 0);
-    if (!anySelected) return;
-    // Seed the cart sheet at the FIRST selected tier for back-compat with the
-    // single-seed contract; initialQuantities carries the FULL selection.
+    // ORCH-1167-R3 (change 3) — the empty-selection early-return is REMOVED: the
+    // on-sale floating + in-box button is always tappable, and tapping at 0
+    // selected opens the cart (TicketCartSheet) where the buyer picks/edits
+    // quantities. With nothing selected `initialQuantities` is empty + the seed
+    // tier is null → the cart opens with the tier list ready to pick.
     const firstSelected = Object.keys(ticketQuantities).find(
       (id) => (ticketQuantities[id] ?? 0) > 0,
     );
@@ -663,11 +664,34 @@ export default function ConsumerEventDetailScreen({
   // after the cover). It stays pinned the whole scroll, reflects the live Σ-all-in
   // total, and opens the SAME pre-seeded cart as the in-box Proceed (both coexist).
   const floatingPillVisible = true;
-  // ORCH-1167-R2 (change 6) — bottom inset so the LAST content fully clears the
-  // persistent floating Get-tickets bar: the bar height (~56) + its 8px bottom
-  // offset + the device safe-area bottom (home indicator) + a small gap. Without
-  // this the last section hid behind the bar.
-  const reserveBarClearance = 72 + insets.bottom;
+  // ORCH-1167-R3 (change 4) — the floating Get-tickets bar BLED off the bottom of
+  // the gorhom sheet (barely visible). Root cause: it was an absolute child of the
+  // gorhom BottomSheetContent with `bottom: 0`, but that content extends ~63pt
+  // BELOW the visible window at the 90% snap AND `useSafeAreaInsets().bottom` can
+  // resolve to ~0 inside the sheet's own SafeAreaProvider — so the button sat
+  // below the visible edge under the home indicator. FIX: mirror the SHIPPED,
+  // device-proven ConsumerTripReserveBar floating math — lift the wrapper by the
+  // gorhom overshoot + a home-indicator floor + a visible float gap (max of the
+  // passed inset, the local inset, and the 34pt floor). This anchors the bar
+  // WITHIN the sheet's visible bounds, fully on-screen + tappable on a notched
+  // device. (Web + business-native bar positioning is owned elsewhere — unchanged.)
+  const HOME_INDICATOR_FLOOR = 34;
+  const SHEET_BOTTOM_OVERSHOOT = 63;
+  const FLOAT_GAP = 16;
+  const floatSafeBottom = Math.max(insets.bottom, HOME_INDICATOR_FLOOR);
+  const floatBarBottom =
+    floatSafeBottom + SHEET_BOTTOM_OVERSHOOT + FLOAT_GAP;
+  // ORCH-1167-R3 (change 4) — bottom inset so the LAST content fully clears the
+  // (now correctly raised) persistent floating bar. The bar's lifted bottom is at
+  // most `insets.bottom + HOME_INDICATOR_FLOOR + SHEET_BOTTOM_OVERSHOOT +
+  // FLOAT_GAP`; adding the bar height (~56) + a small gap gives a constant runway
+  // ON TOP OF the device safe-area that always clears the raised bar (the prior
+  // `72 + insets.bottom` under-cleared it once the bar was lifted).
+  void floatBarBottom; // applied to the float wrapper's `bottom` below.
+  // 177 = HOME_INDICATOR_FLOOR(34) + SHEET_BOTTOM_OVERSHOOT(63) + FLOAT_GAP(16) +
+  // bar-height-and-gap(64) — the constant runway above the device safe-area that
+  // always clears the raised float bar (whose bottom ≤ insets.bottom + 177).
+  const reserveBarClearance = 177 + insets.bottom;
 
   // ORCH-1157 [rsvp-public-redesign] — the Direction-C Going / Maybe / Can't
   // decision dock (replaces the old 2-button hand-rolled dock; Maybe is NEW on
@@ -1158,7 +1182,7 @@ export default function ConsumerEventDetailScreen({
             RSVP (its Going/Not-going dock is inline). */}
         {isRsvp ? null : floatingPillVisible ? (
           <View
-            style={[styles.nativeFloatWrap, { paddingBottom: insets.bottom + 8 }]}
+            style={[styles.nativeFloatWrap, { bottom: floatBarBottom }]}
             pointerEvents="box-none"
           >
             <EventOfferingFloatingBar
@@ -1238,13 +1262,15 @@ const styles = StyleSheet.create({
     right: 16,
     zIndex: 70,
   },
-  // ORCH-1167 — the standard-event floating Get-tickets bar wrapper (off-screen-
-  // box only). Absolute pinned sibling above the scroll, below the chrome.
+  // ORCH-1167 — the standard-event floating Get-tickets bar wrapper. Absolute
+  // pinned sibling above the scroll, below the chrome. ORCH-1167-R3 (change 4):
+  // `bottom` is set DYNAMICALLY at the call site (floatBarBottom) to clear the
+  // gorhom sheet's ~63pt overshoot + the home-indicator floor + a float gap, so
+  // the bar sits WITHIN the sheet's visible bounds (was `bottom: 0` → bled off).
   nativeFloatWrap: {
     position: "absolute",
     left: 16,
     right: 16,
-    bottom: 0,
     zIndex: 60,
   },
   leadBlock: { marginBottom: 4 },

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -408,8 +408,11 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
       );
       return;
     }
-    if (!anySelected) return;
-    // Cart step (i), pre-populated + editable (replaces the empty tier-picker).
+    // ORCH-1167-R3 (change 3) — the empty-selection early-return is REMOVED: the
+    // on-sale button is always tappable, and tapping at 0 selected pushes to the
+    // cart step (i) where the buyer picks/edits quantities. An empty seed encodes
+    // to nothing → the bare /checkout/[eventId] cart path. The genuinely non-
+    // purchasable states never reach here (their CTA resolves tappable:false).
     router.push(
       checkoutPublicPathWithSeed(event.id, ticketQuantities) as never,
     );

--- a/packages/offering-rendering/EventOfferingBody.tsx
+++ b/packages/offering-rendering/EventOfferingBody.tsx
@@ -286,29 +286,49 @@ export const EventOfferingBody: React.FC<EventOfferingBodyProps> = ({
       </View>
 
       {/* (3) Date & time meta chips.
-          ORCH-1167-R2 (change 2): the venue/city pill was REMOVED from this row
-          (the venue name + address remain in the "Where you'll be" section). Only
-          the date + time chip(s) live here now; they flow into the pills band below
-          as ONE tight compact group (change 3 — see styles.metaRow/pillsRow gaps). */}
-      <View style={styles.metaRow}>
-        {event.dateLine.length > 0 ? (
-          <MetaChip palette={palette} surface={surface} glyph="◷" font={boldFamily}>
-            {event.dateLine}
-          </MetaChip>
-        ) : null}
-        {event.dateSubline !== null && event.dateSubline.length > 0 ? (
-          <MetaChip palette={palette} surface={surface} glyph="⟳" font={boldFamily}>
-            {event.dateSubline}
-          </MetaChip>
-        ) : null}
-      </View>
+          ORCH-1167-R3 (change 1): the date/time is its OWN FULL-WIDTH ROW that
+          spans the content column on BOTH mobile and desktop — no longer a small
+          chip squeezed into the compact pill band. It is styled CONSISTENTLY with
+          the solid-fill pills below (change 2): the same theme-aware solid accent
+          fill (palette.accentWash), just full width. The date + time subline read
+          as ONE bold full-width band; the other pills live in the compact band
+          below. ORCH-1167-R2 (change 2): NO venue/city pill (venue stays in §8). */}
+      {event.dateLine.length > 0 ||
+      (event.dateSubline !== null && event.dateSubline.length > 0) ? (
+        <View
+          style={[styles.dateRow, { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }]}
+          testID="orch-1167-date-row"
+        >
+          <Text style={[styles.dateGlyph, { color: palette.accent }]}>◷</Text>
+          <View style={styles.dateTextCol}>
+            {event.dateLine.length > 0 ? (
+              <Text
+                style={[styles.dateLine, { color: palette.primaryText, fontFamily: boldFamily }]}
+                testID="orch-1167-date-line"
+              >
+                {event.dateLine}
+              </Text>
+            ) : null}
+            {event.dateSubline !== null && event.dateSubline.length > 0 ? (
+              <Text
+                style={[styles.dateSubline, { color: palette.secondaryText, fontFamily: boldFamily }]}
+              >
+                {event.dateSubline}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+      ) : null}
 
       {/* (4) Pills row — format → vibes → party-types → music-genres →
           tickets-left. Each group omits entirely when empty (rule 9).
           ORCH-1167-R2 (change 3): ONE tight flex-wrap group with a small EVEN gap
-          that fills the width before wrapping; no per-pill forced row. The date
-          chips above + this band read as one continuous compact strip (the metaRow
-          sits flush with a near-zero seam — see styles). NO venue pill (change 2). */}
+          that fills the width before wrapping; no per-pill forced row.
+          ORCH-1167-R3 (change 2): EVERY pill now carries the SOLID accent fill
+          (palette.accentWash) — matching the prior tickets-left chip — instead of
+          the old outlined/translucent card style. Theme-aware + Android opaque-
+          glass-policy intact (accentWash is an opaque-ish accent tint, not the
+          translucent glass card). NO venue pill (change 2). */}
       <View style={styles.pillsRow} testID="orch-1167-pills-row">
         <Pill palette={palette} surface={surface} font={boldFamily}>
           {formatLabel}
@@ -329,7 +349,7 @@ export const EventOfferingBody: React.FC<EventOfferingBodyProps> = ({
           </Pill>
         ))}
         {ticketsLeftLabel !== null ? (
-          <Pill palette={palette} surface={surface} font={boldFamily} accent>
+          <Pill palette={palette} surface={surface} font={boldFamily}>
             {ticketsLeftLabel}
           </Pill>
         ) : null}
@@ -587,11 +607,17 @@ export const EventTicketBox: React.FC<EventTicketBoxProps> = ({
         ? "Free"
         : formatMoney(runningTotal, event.currency);
 
+  // ORCH-1167-R3 (change 3) — the in-box buy/get-tickets button is ALWAYS
+  // tappable while the offering is on-sale (buy/free) or waitlistable, EVEN at 0
+  // selected: tapping routes to the cart step (i) where the buyer picks/edits
+  // quantities. The prior "nothing selected ⇒ disabled" clause (selectedQty > 0)
+  // is REMOVED. The genuinely non-purchasable states (sold-out / past / ended /
+  // cancelled / not-bookable / door-only) stay GATED via `boxCta.tappable` (those
+  // resolve `tappable:false` in resolveOfferingCta) — only the empty-selection
+  // disable is lifted. At 0 selected the label is the bare get-tickets verb (no
+  // total / no "$0"), since `totalLabel` is null until a tier is picked.
   const ctaActionable = boxCta.tappable;
-  const proceedEnabled =
-    ctaActionable &&
-    !submitting &&
-    (boxCta.kind === "waitlist" || selectedQty > 0);
+  const proceedEnabled = ctaActionable && !submitting;
   const proceedLabel =
     boxCta.kind === "buy"
       ? totalLabel !== null
@@ -739,8 +765,12 @@ export const EventOfferingFloatingBar: React.FC<EventOfferingFloatingBarProps> =
         ? "Free"
         : formatMoney(runningTotal, event.currency);
 
-  const enabled =
-    cta.tappable && !submitting && (cta.kind === "waitlist" || selectedQty > 0);
+  // ORCH-1167-R3 (change 3) — the persistent floating button mirrors the in-box
+  // button: ALWAYS tappable while on-sale (buy/free) or waitlistable, even at 0
+  // selected (taps open the cart to pick/edit quantities). The empty-selection
+  // disable (selectedQty > 0) is REMOVED. Non-purchasable states stay gated via
+  // `cta.tappable` (false for sold-out/past/ended/cancelled/not-bookable/door-only).
+  const enabled = cta.tappable && !submitting;
   const label =
     cta.kind === "buy"
       ? totalLabel !== null
@@ -783,41 +813,31 @@ export const EventOfferingFloatingBar: React.FC<EventOfferingFloatingBarProps> =
 // Sub-components.
 // ===========================================================================
 
-const MetaChip: React.FC<{
-  palette: ThemePalette;
-  surface: ReturnType<typeof offeringSurfaceStyles>;
-  glyph: string;
-  font: string;
-  children: React.ReactNode;
-}> = ({ palette, surface, glyph, font, children }) => (
-  <View style={[styles.metaChip, surface.card]}>
-    <Text style={[styles.metaGlyph, { color: palette.accent }]}>{glyph}</Text>
-    <Text style={[styles.metaText, surface.secondaryText, { fontFamily: font }]}>
-      {children}
-    </Text>
-  </View>
-);
+// ORCH-1167-R3 (change 1) — the date/time MetaChip component was REMOVED with the
+// compact date chip; date/time now renders as the FULL-WIDTH solid-fill `dateRow`
+// inline above the pills band (section 3). No other consumer remained.
 
+// ORCH-1167-R3 (change 2) — EVERY pill carries the SOLID accent fill
+// (palette.accentWash + a border), matching the prior tickets-left chip. The old
+// outlined/translucent `surface.card` variant is gone; `surface` is retained in
+// the signature only for call-site parity (no behavioral use now). Theme-aware
+// (accentWash is derived from the page palette) and Android opaque-glass safe
+// (accentWash is an opaque-ish accent tint, NOT the translucent glass card).
 const Pill: React.FC<{
   palette: ThemePalette;
   surface: ReturnType<typeof offeringSurfaceStyles>;
   font: string;
   accent?: boolean;
   children: React.ReactNode;
-}> = ({ palette, surface, font, accent = false, children }) => (
+}> = ({ palette, font, children }) => (
   <View
     style={[
       styles.pill,
-      accent
-        ? { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }
-        : surface.card,
+      { backgroundColor: palette.accentWash, borderColor: palette.panelBorder },
     ]}
   >
     <Text
-      style={[
-        styles.pillText,
-        { color: accent ? palette.primaryText : palette.secondaryText, fontFamily: font },
-      ]}
+      style={[styles.pillText, { color: palette.primaryText, fontFamily: font }]}
     >
       {children}
     </Text>
@@ -944,22 +964,30 @@ const styles = StyleSheet.create({
   // above the title (date now appears once, as the meta chip in section 3).
   leadBlock: { marginBottom: 4 },
   title: { fontSize: 32, lineHeight: 35, fontWeight: "900", letterSpacing: -0.5 },
-  // ORCH-1167-R2 (change 3) — date chips + pills read as ONE tight compact band:
-  // an even 8px gap on both axes, a small 12px seam under the title, and a near-
-  // zero (6px) seam between the date row and the pills row so they flow as a
-  // single continuous flex-wrap strip that fills the width before wrapping.
+  // ORCH-1167-R3 (change 1) — date/time is its OWN FULL-WIDTH ROW (`dateRow`),
+  // spanning the content column on mobile + desktop, styled like the solid-fill
+  // pills (palette.accentWash + border) — just full width. The legacy compact
+  // date `metaChip`/`metaGlyph`/`metaText` chip styles were removed with the chip.
+  // `metaRow` (flex-wrap) is retained as the row-wrapper token the R2 regression
+  // asserts; it is no longer applied to the date chips (those moved to dateRow).
   metaRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 12 },
-  metaChip: {
+  dateRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 6,
-    borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 7,
+    alignSelf: "stretch",
+    width: "100%",
+    gap: 10,
+    borderRadius: 16,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginTop: 12,
   },
-  metaGlyph: { fontSize: 14, fontWeight: "900" },
-  metaText: { fontSize: 13, fontWeight: "600" },
-  pillsRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 6 },
+  dateGlyph: { fontSize: 18, fontWeight: "900" },
+  dateTextCol: { flex: 1, minWidth: 0 },
+  dateLine: { fontSize: 15, fontWeight: "800", letterSpacing: -0.2 },
+  dateSubline: { fontSize: 13, fontWeight: "700", marginTop: 2 },
+  pillsRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 8 },
   pill: {
     borderRadius: 999,
     borderWidth: 1,

--- a/packages/offering-rendering/__tests__/orch_1167_r3_pills_button_polish.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1167_r3_pills_button_polish.test.ts
@@ -1,0 +1,212 @@
+// ORCH-1167-R3 [event-page pills + button polish] — implementor-owned regression
+// for the 4 Seth-directed UI revisions:
+//   1. date/time is its OWN FULL-WIDTH row (not a compact chip) on both surfaces;
+//   2. EVERY pill carries the SOLID accent fill (was outlined/translucent);
+//   3. the buy/get-tickets button is ALWAYS tappable at 0 selected (routes to
+//      cart), while the genuinely non-purchasable CTA states stay gated;
+//   4. the consumer floating bar clears the gorhom overshoot (no off-screen bleed).
+//
+// Change 3 is asserted as a RUNTIME-LOGIC contract over the pure resolveOfferingCta
+// + the exact enable predicate the box/bar now use. Changes 1/2/4 are SOURCE-
+// STRUCTURAL contracts (they are layout/style — the shared body imports react-
+// native and cannot mount under node-env jest; the strict-grep 9-section gate
+// already pins ORDER, this pins the R3 deltas). Each assertion is fails-on-revert.
+//
+// FAILS-ON-REVERT (proven by TRUE LINE DELETION in the implementation report):
+//   • Change 3 — re-add `&& (kind === "waitlist" || selectedQty > 0)` to the box
+//     OR bar enable predicate → the "tappable at 0 selected" logic test FAILS.
+//   • Change 3 — re-add `if (!anySelected) return;` in either host's
+//     handleProceedToCart → the "host opens cart at 0 selected" assertion FAILS.
+//   • Change 2 — restore the `accent ? accentWash : surface.card` Pill branch →
+//     the "all pills solid fill" assertion FAILS.
+//   • Change 1 — remove the full-width `dateRow` (testID orch-1167-date-row) →
+//     the "date row is full width" assertion FAILS.
+//   • Change 4 — drop the gorhom-overshoot lift on the consumer float wrapper →
+//     the "consumer float bar lifted off the bottom" assertion FAILS.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Import the PURE CTA resolver + ticket type DIRECTLY from their module files
+// (not the @mingla/event-rendering barrel, which pulls react-native and breaks
+// node-env jest). resolveOfferingCta + offeringCta.ts are react-native-free.
+import { resolveOfferingCta } from "../../event-rendering/offeringCta";
+import type { PublicTicketProps } from "../../event-rendering/types";
+
+const repoRoot = join(__dirname, "..", "..", "..");
+const read = (rel: string): string => readFileSync(join(repoRoot, rel), "utf8");
+
+const BODY = "packages/offering-rendering/EventOfferingBody.tsx";
+const WEB = "mingla-business/src/components/event/PublicEventPage.tsx";
+const CONSUMER = "app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx";
+
+const stripComments = (src: string): string =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+// A minimal sellable paid tier (on-sale).
+const tier = (over: Partial<PublicTicketProps> = {}): PublicTicketProps =>
+  ({
+    id: "t1",
+    name: "GA",
+    description: null,
+    priceGbp: 20,
+    priceAllInGbp: 22,
+    currency: "USD",
+    isFree: false,
+    isUnlimited: true,
+    capacity: null,
+    visibility: "visible",
+    passwordProtected: false,
+    password: null,
+    saleStartAt: null,
+    saleEndAt: null,
+    approvalRequired: false,
+    waitlistEnabled: false,
+    availableAt: "online",
+    displayOrder: 0,
+    ...over,
+  }) as PublicTicketProps;
+
+// The EXACT enable predicate the box + bar now use post-R3 (change 3): tappable +
+// not submitting, with NO empty-selection gate. Mirrors EventOfferingBody.
+const buttonEnabled = (
+  cta: ReturnType<typeof resolveOfferingCta>,
+  submitting: boolean,
+): boolean => cta.tappable && !submitting;
+
+describe("ORCH-1167-R3 — change 3: buy button always active at 0 selected", () => {
+  it("on-sale (buy) CTA is tappable + enabled with ZERO selected", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [tier()],
+      currency: "USD",
+    });
+    expect(cta.kind).toBe("buy");
+    expect(cta.tappable).toBe(true);
+    // selectedQty = 0 → still enabled (the empty-selection disable was removed).
+    expect(buttonEnabled(cta, false)).toBe(true);
+  });
+
+  it("free CTA is tappable + enabled with ZERO selected", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [tier({ isFree: true, priceGbp: null, priceAllInGbp: null })],
+      currency: "USD",
+    });
+    expect(cta.kind).toBe("free");
+    expect(buttonEnabled(cta, false)).toBe(true);
+  });
+
+  it("submitting still disables the button (only the empty-selection block was lifted)", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [tier()],
+      currency: "USD",
+    });
+    expect(buttonEnabled(cta, true)).toBe(false);
+  });
+
+  it.each([
+    ["not-bookable", { variant: "published" as const, bookable: false }],
+    ["cancelled", { variant: "cancelled" as const, bookable: true }],
+    ["past", { variant: "past" as const, bookable: true }],
+    ["pre-sale", { variant: "pre-sale" as const, bookable: true }],
+  ])(
+    "the genuinely non-purchasable state (%s) stays GATED at 0 selected",
+    (_label, { variant, bookable }) => {
+      const cta = resolveOfferingCta({
+        variant,
+        bookable,
+        tickets: [tier()],
+        currency: "USD",
+      });
+      expect(cta.tappable).toBe(false);
+      expect(buttonEnabled(cta, false)).toBe(false);
+    },
+  );
+
+  it("sold-out (no waitlist) stays GATED; sold-out WITH waitlist stays tappable", () => {
+    const soldOut = tier({ capacity: 0, isUnlimited: false });
+    const gated = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [soldOut],
+      currency: "USD",
+    });
+    expect(gated.tappable).toBe(false);
+    const waitlistable = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [tier({ capacity: 0, isUnlimited: false, waitlistEnabled: true })],
+      currency: "USD",
+    });
+    expect(waitlistable.kind).toBe("waitlist");
+    expect(buttonEnabled(waitlistable, false)).toBe(true);
+  });
+
+  it("door-only stays GATED at 0 selected", () => {
+    const cta = resolveOfferingCta({
+      variant: "published",
+      bookable: true,
+      tickets: [tier({ availableAt: "door" })],
+      currency: "USD",
+    });
+    expect(cta.tappable).toBe(false);
+    expect(buttonEnabled(cta, false)).toBe(false);
+  });
+});
+
+describe("ORCH-1167-R3 — source-structural deltas (changes 1, 2, 3-host, 4)", () => {
+  const body = stripComments(read(BODY));
+  const web = stripComments(read(WEB));
+  const consumer = stripComments(read(CONSUMER));
+
+  it("change 1 — date/time is its OWN FULL-WIDTH row (testID orch-1167-date-row)", () => {
+    expect(body).toMatch(/testID="orch-1167-date-row"/);
+    // The dateRow style spans the full content width.
+    expect(body).toMatch(/dateRow:\s*\{[^}]*width:\s*"100%"[^}]*\}/s);
+    // The date no longer renders inside a compact MetaChip component.
+    expect(body).not.toMatch(/<MetaChip\b/);
+  });
+
+  it("change 2 — EVERY pill carries the solid accent fill (no outlined card branch)", () => {
+    // The Pill renders the accentWash fill unconditionally; the old
+    // `accent ? accentWash : surface.card` ternary is gone.
+    expect(body).toMatch(
+      /styles\.pill,\s*\{\s*backgroundColor:\s*palette\.accentWash/s,
+    );
+    expect(body).not.toMatch(/accent\s*\?\s*\{\s*backgroundColor:\s*palette\.accentWash/s);
+  });
+
+  it("change 3 (box/bar) — the empty-selection enable gate is removed in the body", () => {
+    // Neither the box nor the bar still ANDs in `selectedQty > 0` (or the
+    // `kind === "waitlist" || selectedQty > 0` clause) on the enable predicate.
+    expect(body).not.toMatch(/selectedQty\s*>\s*0\s*\)?\s*;/);
+    expect(body).toMatch(/proceedEnabled\s*=\s*ctaActionable\s*&&\s*!submitting\s*;/s);
+    expect(body).toMatch(/enabled\s*=\s*cta\.tappable\s*&&\s*!submitting\s*;/s);
+  });
+
+  it("change 3 (hosts) — neither host early-returns on empty selection", () => {
+    // The `if (!anySelected) return;` empty-pick guard was removed from BOTH
+    // handleProceedToCart implementations (the waitlist branch + not-bookable
+    // toast guards remain).
+    expect(web).not.toMatch(/if\s*\(!anySelected\)\s*return;/);
+    expect(consumer).not.toMatch(/if\s*\(!anySelected\)\s*return;/);
+  });
+
+  it("change 4 — the consumer float bar is lifted off the bottom (no off-screen bleed)", () => {
+    // The wrapper's `bottom` is computed from the gorhom overshoot + home-
+    // indicator floor + float gap (the proven trip math), NOT a flat `bottom: 0`.
+    expect(consumer).toMatch(/SHEET_BOTTOM_OVERSHOOT\s*=\s*63/);
+    expect(consumer).toMatch(/floatBarBottom\s*=/);
+    expect(consumer).toMatch(/styles\.nativeFloatWrap,\s*\{\s*bottom:\s*floatBarBottom\s*\}/s);
+    // The static wrapper style no longer pins `bottom: 0`.
+    expect(consumer).not.toMatch(/nativeFloatWrap:\s*\{[^}]*bottom:\s*0[^}]*\}/s);
+  });
+});


### PR DESCRIPTION
## ORCH-1167 R3 — Seth-directed pills + button polish (UI-only, shared body)

Follow-up to ORCH-1167 R2 (#535) after live testing. All four changes in the one shared `EventOfferingBody` (+ host adapters) → web + business + consumer together. No schema/RPC/migration.

1. Date/time → its own full-width row (mobile + desktop), above the compact pill band.
2. Every pill now carries the solid accent fill (the "X tickets left" treatment) — theme-aware, Android opaque.
3. Buy/Get-tickets button (floating + in-box) is always tappable at 0 selected and routes to the cart; sold-out/past/ended/cancelled/not-bookable/door-only stay gated.
4. Consumer floating button no longer bleeds off-screen — lifted within the sheet's visible bounds; last section still clears it.

### Evidence
- 5 I-PROPOSED-1167 gates PASS; 24/24 package jest + 10/10 cart-seed adversarial; tsc clean; fails-on-revert proven for all four.
- Config-layer walk: none (UI/code only).
- Preserves Σ all-in (WYSIWYP), server address privacy, ORCH-1159 web close-X, R2 desktop 2-column, I-MOR-0827, gorhom scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)