### PR TITLE
ORCH-1167 R8: web cover as imperative DOM <video> — fix desktop-Safari autoplay poison [deploy]

### DIFF
--- a/.github/scripts/strict-grep/orch-0978-video-autoplay-muted-contract.mjs
+++ b/.github/scripts/strict-grep/orch-0978-video-autoplay-muted-contract.mjs
@@ -16,7 +16,16 @@ const failures = [];
 if (!/muted = true/.test(eventCoverMedia)) {
   failures.push("EventCoverMedia must default muted to true.");
 }
-if (!eventCoverMedia.includes("playsInline") || !eventCoverMedia.includes("autoPlay: shouldPlay")) {
+// ORCH-1167-R8: the web cover <video> is now created imperatively via
+// document.createElement (React never owns the node — fixes the desktop-Safari
+// autoplay poison), so the muted-autoplay-inline primitives are set as element
+// properties (`video.autoplay = shouldPlay`) instead of the prior React-prop
+// literal (`autoPlay: shouldPlay`). Accept either form — the CONTRACT (inline
+// muted autoplay primitives present) is preserved.
+if (
+  !eventCoverMedia.includes("playsInline") ||
+  !/(?:autoPlay: shouldPlay|\.autoplay = shouldPlay)/.test(eventCoverMedia)
+) {
   failures.push("EventCoverMedia web branch must keep muted autoplay inline playback primitives.");
 }
 if (!eventCoverMedia.includes("setIsMuted((prev)") || !eventCoverMedia.includes("accessibilityRole=\"button\"")) {

--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1167_R8_IMPERATIVE_WEB_COVER.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1167_R8_IMPERATIVE_WEB_COVER.md
@@ -1,0 +1,90 @@
+# IMPLEMENT — ORCH-1167 R8 — Imperative-DOM web cover video (WebKit autoplay poison fix)
+
+**Ticket:** ORCH-1167 [event-page-canonical] · Round 8
+**Branch:** `ORCH-1167-r8-imperative-web-cover` (off latest origin/main, incl. R1–R7)
+**Scope:** WEB-ONLY, UI-ONLY. Cover video render mechanism in the shared cover component. No schema / RPC / migration / package-config / native changes.
+**Surface impact:** buyer-web + business-web event/trip/experience/rsvp public-page hero cover (shared component). Native (expo-video) path UNCHANGED. Image/GIF covers UNCHANGED.
+
+> ⚠️ **Autoplay verification is the ORCHESTRATOR's job, not this report's.** Three prior rounds (R5/R6/R7) FALSE-PASSED because local/isolated test beds do NOT reproduce the desktop-Safari/WebKit autoplay denial. This report makes **no claim** that autoplay is fixed. The authoritative check is the orchestrator's headless-WebKit verification against a real **Vercel PREVIEW** deploy of this branch. This report only attests that the imperative-DOM cover is implemented cleanly, typechecks, and passes the gates/tests.
+
+---
+
+## Proven root cause (orchestrator, exhaustive Playwright forensics on the LIVE page vs desktop Safari/WebKit)
+
+- The event-cover video PLAYS but does NOT AUTOPLAY on desktop Safari/WebKit (native play button shown; user must click). Autoplays fine on Chrome + all mobile (incl. mobile web).
+- NOT caused by: play() calls, attributes, ancestor CSS (transform/overflow/aspect-ratio), or the lazy-mount swap — all autoplay fine when tested with a hand-created element on the same live page.
+- **Decisive finding:** EVERY video created via `document.createElement('video')` (raw DOM) and appended on the exact live page AUTOPLAYS — but the component's REACT-RENDERED `<video>` (R5/R6/R7 used `React.createElement("video", {...})`) is PERMANENTLY DENIED autoplay by WebKit. **React's rendering/reconciliation of the `<video>` node is itself the poison.**
+
+## The fix (this round)
+
+In `EventCoverWebVideo` (web branch of `packages/event-rendering/EventCoverMedia.tsx`):
+
+- React now renders ONLY a plain container `React.createElement("div", { ref: containerRef, ... })`. **React never owns/reconciles the `<video>` node.**
+- A `useEffect` (keyed on `uri` + `contentFit`) creates the video with `document.createElement('video')`, mirrors the proven-working bare element, and appends it into the container ref:
+  - `muted = true` (property) + `setAttribute('muted','')` + `setAttribute('playsinline','')` + `setAttribute('webkit-playsinline','')` + `playsInline = true`
+  - `autoplay = shouldPlay` + `loop = <loop>` + `controls = false` + `preload = 'auto'`
+  - cover styles (objectFit `cover|contain`, absolute fill) via `Object.assign(video.style, …)`
+  - `src = uri` set LAST, then `appendChild` — matching the bare element's construction order.
+  - **No manual play() is required for autoplay** — the attributes drive it (the WebKit-granted path).
+- **Existing features wired through to the imperative element:**
+  - **Mute/Unmute toggle:** a follow-prop `useEffect` updates `videoEl.muted` (= `effectiveMuted`) when the parent `muted` prop changes (unmute = real user gesture → honored). R5 behavior preserved: FIRST autoplay is hard-muted (`hasUnmutedRef`); only follows the prop after the user has unmuted.
+  - **Aspect ratio:** `loadedmetadata` → `videoWidth/videoHeight` → `onAspectRatio` (read via ref so the create effect doesn't re-run on a callback swap).
+  - **Error → fallback:** `error` event → existing `onError` path (EventCover placeholder shows).
+  - **Reduce-motion freeze:** preserved via the existing parent path — when frozen, presentation becomes `video_still` and the parent passes `autoplay={false}`, so `shouldPlay` is false and `video.autoplay` is not set / the element is paused.
+  - **Guarded late recovery:** the `canplaythrough` listener (gated `readyState >= 3` AND `paused`) is retained — never at readyState 0.
+  - **Full teardown** on unmount / src change: listeners removed, `pause()`, `removeAttribute('src')`, `removeChild`, ref cleared.
+- Lazy-mount/`inView` gating, image/GIF covers, and the NATIVE (expo-video) path are UNCHANGED.
+
+`WEB_VIDEO_STYLE` (the old element style) was replaced by `WEB_VIDEO_CONTAINER_STYLE` (the React-owned div); the video's styles are applied imperatively.
+
+---
+
+## Changed files
+
+| File | Change |
+|------|--------|
+| `packages/event-rendering/EventCoverMedia.tsx` | `EventCoverWebVideo` rewritten to render a React `<div>` container + an imperatively-created DOM `<video>` (was `React.createElement("video")`). Style constant renamed `WEB_VIDEO_STYLE` → `WEB_VIDEO_CONTAINER_STYLE`. Native path untouched. |
+| `packages/event-rendering/__tests__/coverWebVideoImperativeMount.orch1167r8.test.ts` | **NEW** source-structural test for the imperative-mount contract + feature wiring + teardown + native-path-untouched. |
+| `packages/offering-rendering/__tests__/orch_1167_r7_webkit_cover_no_play_hammer.test.ts` | **`[TEST-MOD-APPROVED ORCH-1167]`** — migrated assertions from the React-rendered-`<video>` mechanism to the imperative-DOM mechanism (intent preserved). |
+| `packages/offering-rendering/__tests__/orch_1167_r5_web_cover_autoplay_muted.test.ts` | **`[TEST-MOD-APPROVED ORCH-1167]`** — first `describe` block's React-prop assertions migrated to the imperative-element form (intent preserved). Parent-state `describe` block unchanged. |
+
+The two test files were MODIFIED IN PLACE (not deleted) per the tests-append-only gate; the new test is ADDED.
+
+---
+
+## Results
+
+**Typecheck:** zero net-new type errors. Diff of `EventCoverMedia.tsx` errors between baseline (R7) and R8 under `mingla-business/tsc -p .` is EMPTY (the only errors are the pre-existing `react`-module-resolution artifact of compiling the path-mapped package, identical on both).
+
+**Jest — ORCH-1167 cover tests (run via `jest --roots ../packages`):**
+- `coverWebVideoImperativeMount.orch1167r8.test.ts` (NEW) — PASS (7 tests)
+- `orch_1167_r7_webkit_cover_no_play_hammer.test.ts` — PASS (6 tests)
+- `orch_1167_r5_web_cover_autoplay_muted.test.ts` — PASS (7 tests)
+- `coverWebVideoAutoplay.orch1167r6.test.ts` — PASS (placeholder)
+- `orch_1167_r2/r3/r4_*` + `orch_1167_event_box_totals` — PASS (unchanged)
+
+**Full offering-rendering + event-rendering jest run:** `Tests: 52 passed, 52 total`. The 13 "failed suites" are pre-existing **Deno-syntax** tests (`Deno.test(...)`) that error at collection under jest — identical to baseline (verified each FAIL file contains `Deno.test`). Zero jest-runnable tests fail. Net delta vs baseline: only the new R8 file added (now passing) and R5 flipped back to passing.
+
+**5 ORCH-1167 strict-grep gates:** ALL PASS
+- `orch-1167-allin-price-in-ticket-box` ✅
+- `orch-1167-canonical-9-section-order` ✅
+- `orch-1167-city-level-map-no-exact-pin-when-hidden` ✅
+- `orch-1167-one-read-rpc` ✅
+- `orch-1167-shell-agnostic-body` ✅
+
+**I-MOR-0827 package-isolation gate:** PASS (no new app-src imports; only react/react-native + the `document` web global).
+
+**FAILS-ON-REVERT proof:** the NEW `coverWebVideoImperativeMount.orch1167r8.test.ts` FAILS against the unmodified R7 source (proven by running it on `git stash`-reverted baseline — the React-rendered-`<video>` source has no `document.createElement('video')`/imperative mount, so the imperative-mount assertions fail). It passes only with the R8 imperative-DOM cover.
+
+---
+
+## Guards honored
+
+- WEB-only; native (expo-video) path byte-unchanged.
+- No schema/RPC/migration/package-config change.
+- R1–R7 contracts preserved (canonical body, one-read RPC, shell-agnostic body, all-in price, city-level map). The 5 I-PROPOSED-1167 gates + I-MOR-0827 all green.
+- Trip/experience/rsvp covers inherit the same shared cover component (expected — same cover, no per-page logic touched).
+
+## `[deploy]`-readiness
+
+Buyer-web ships from **main** only (it can't be OTA'd). This branch is PUSHED so Vercel builds a **PREVIEW** for the orchestrator's headless-WebKit autoplay verification. Do NOT merge/OTA from here. When the orchestrator confirms autoplay on the preview, the merge commit to main must carry `[deploy]` (and beware the Vercel `[deploy]`-gate cancel trap — a non-`[deploy]` commit landing after yours cancels the web build; push an empty `[deploy]` commit if so).

--- a/packages/event-rendering/EventCoverMedia.tsx
+++ b/packages/event-rendering/EventCoverMedia.tsx
@@ -65,11 +65,15 @@ export interface EventCoverMediaErrorEvent {
   nativeEvent?: unknown;
 }
 
-const WEB_VIDEO_STYLE: React.CSSProperties = {
+// ORCH-1167-R8 — the React-owned container <div> that hosts the IMPERATIVELY
+// created DOM <video> (see EventCoverWebVideo). React reconciles only this div;
+// the <video> is appended via document.createElement so WebKit grants it inline
+// muted autoplay (the React-reconciled <video> is permanently denied autoplay).
+const WEB_VIDEO_CONTAINER_STYLE: React.CSSProperties = {
   backgroundColor: "#000000",
   height: "100%",
   inset: 0,
-  objectFit: "cover",
+  overflow: "hidden",
   position: "absolute",
   width: "100%",
 };
@@ -139,8 +143,28 @@ const EventCoverWebVideo: React.FC<{
   onAspectRatio,
   onError,
 }) => {
+  // ORCH-1167-R8 — IMPERATIVE DOM `<video>` (NO React JSX / NO
+  // React.createElement). ROOT CAUSE (orchestrator, exhaustive Playwright
+  // forensics on the LIVE page, headless WebKit): R5/R6/R7's React-RENDERED
+  // `<video>` is PERMANENTLY DENIED inline-muted autoplay by WebKit — it shows
+  // the native play button and never autoplays on desktop Safari/WebKit. The
+  // decisive proof: EVERY video created via `document.createElement('video')`
+  // (raw DOM) and appended on the EXACT live page AUTOPLAYS, while the
+  // component's React-reconciled `<video>` stays poisoned. So React's
+  // rendering/reconciliation of the `<video>` node is itself the poison.
+  //
+  // THE FIX: render a plain `<div>` container that React owns, and in a
+  // useEffect create the `<video>` with `document.createElement('video')`,
+  // mirror the proven-working bare element (autoplay + muted + playsinline
+  // ATTRIBUTES, NO manual play() required), and append it into the container.
+  // React must NEVER own/reconcile the `<video>` node. The existing features —
+  // mute toggle, aspect-ratio report, error→fallback, reduce-motion freeze
+  // (via the autoplay prop), lazy-mount gating — are wired through to the
+  // imperative element below. The NATIVE (expo-video) path is UNCHANGED.
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const shouldPlay = autoplay && playbackActive;
+
   // ORCH-1167-R5 — web autoplay was still showing the browser's native PLAY
   // BUTTON because the FIRST autoplay attempt could fire while the `<video>` was
   // not yet guaranteed-muted at the element level. Browsers ONLY permit inline
@@ -150,104 +174,143 @@ const EventCoverWebVideo: React.FC<{
   // forced muted (so the browser always permits it and NO play button shows).
   // Once the chrome Mute toggle unmutes (a real user gesture, which the browser
   // honors), we follow the live `muted` prop. Re-muting works too. `hasUnmuted`
-  // is a ref so flipping it never re-triggers the autoplay effect mid-play.
+  // is a ref so flipping it never re-triggers the create effect mid-play.
   const hasUnmutedRef = useRef<boolean>(false);
   if (!muted) hasUnmutedRef.current = true;
   // The mute value actually applied to the element: hard-muted for the initial
   // ambient autoplay, then the prop once the user has taken over.
   const effectiveMuted = hasUnmutedRef.current ? muted : true;
 
-  // Synchronous ref callback: set the muted PROPERTY + ATTRIBUTE the instant the
-  // element mounts, BEFORE the browser evaluates autoplay eligibility. React 19
-  // emits `muted` as a property only (no HTML attribute), and even the property
-  // can land after the browser's first eligibility check — so we pin both here,
-  // guaranteeing the very first autoplay attempt is muted and permitted.
-  const attachVideo = React.useCallback(
-    (node: HTMLVideoElement | null): void => {
-      videoRef.current = node;
-      if (node === null) return;
-      node.muted = true;
-      node.setAttribute("muted", "");
-      node.setAttribute("playsinline", "");
-      node.setAttribute("webkit-playsinline", "");
-    },
-    [],
-  );
+  // Keep the latest callbacks/flags in refs so the create effect can read them
+  // WITHOUT re-running (which would tear down + recreate the element and lose
+  // its autoplay eligibility). The create effect re-runs ONLY on uri change.
+  const onAspectRatioRef = useRef(onAspectRatio);
+  onAspectRatioRef.current = onAspectRatio;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const loopRef = useRef(loop);
+  loopRef.current = loop;
+  const shouldPlayRef = useRef(shouldPlay);
+  shouldPlayRef.current = shouldPlay;
 
-  // ORCH-0992: report the video's intrinsic aspect ratio once metadata loads,
-  // so a hero can size its box to the video's shape. videoWidth/videoHeight are
-  // 0 until metadata is available; the loadedmetadata listener covers the case
-  // where metadata is already cached (the effect runs after the event fired).
+  // Create the imperative DOM <video> exactly like the proven-working bare
+  // element. Re-runs only when the source url changes; fully torn down on
+  // unmount / src change. NO manual play() is required for autoplay — the
+  // attributes drive it (that is the WebKit-granted path; the React-reconciled
+  // node is the poison, NOT a missing play()).
   useEffect(() => {
-    if (onAspectRatio === undefined) return;
-    const video = videoRef.current;
-    if (video === null) return;
-    const report = (): void => {
+    const container = containerRef.current;
+    if (container === null) return;
+    if (typeof document === "undefined") return;
+
+    const video = document.createElement("video");
+    videoRef.current = video;
+
+    // Mirror the bare element that autoplays on the live page. `muted` must be
+    // both the PROPERTY and the ATTRIBUTE before the browser evaluates autoplay
+    // eligibility (iOS/WebKit only grant inline muted autoplay when the
+    // muted + playsinline ATTRIBUTES are present at the element level).
+    video.muted = true;
+    video.setAttribute("muted", "");
+    video.setAttribute("playsinline", "");
+    video.setAttribute("webkit-playsinline", "");
+    video.playsInline = true;
+    video.autoplay = shouldPlayRef.current;
+    video.loop = loopRef.current;
+    video.controls = false;
+    video.preload = "auto";
+    // Cover styles (objectFit cover/contain, fill the container).
+    Object.assign(video.style, {
+      backgroundColor: "#000000",
+      height: "100%",
+      inset: "0",
+      objectFit: contentFit,
+      position: "absolute",
+      width: "100%",
+    } as Partial<CSSStyleDeclaration>);
+
+    // ORCH-0992: report intrinsic aspect ratio once metadata is known. The
+    // listener covers the cached-metadata case (event already fired). Reads the
+    // latest callback via ref so this effect never re-runs for a callback swap.
+    const reportAspectRatio = (): void => {
+      const cb = onAspectRatioRef.current;
+      if (cb === undefined) return;
       if (video.videoWidth > 0 && video.videoHeight > 0) {
-        onAspectRatio(video.videoWidth / video.videoHeight);
+        cb(video.videoWidth / video.videoHeight);
       }
     };
-    report();
-    video.addEventListener("loadedmetadata", report);
-    return () => video.removeEventListener("loadedmetadata", report);
-  }, [onAspectRatio, uri]);
+    // Error → fallback (EventCover placeholder shows).
+    const handleError = (): void => {
+      onErrorRef.current();
+    };
+    // Loop manually too (belt-and-suspenders with the loop attribute) so the
+    // ambient cover keeps cycling; never forces play when we should be paused.
+    const handleEnded = (): void => {
+      if (!loopRef.current || !shouldPlayRef.current) return;
+      video.currentTime = 0;
+      void video.play().catch(() => undefined);
+    };
 
+    video.addEventListener("loadedmetadata", reportAspectRatio);
+    video.addEventListener("error", handleError);
+    video.addEventListener("ended", handleEnded);
+
+    // Set src LAST, after attributes are pinned, then append — matching the
+    // proven bare element's construction order so the very first autoplay
+    // eligibility check sees a muted, playsinline, autoplay element.
+    video.src = uri;
+    container.appendChild(video);
+    reportAspectRatio();
+
+    return () => {
+      video.removeEventListener("loadedmetadata", reportAspectRatio);
+      video.removeEventListener("error", handleError);
+      video.removeEventListener("ended", handleEnded);
+      try {
+        video.pause();
+      } catch {
+        // ignore
+      }
+      video.removeAttribute("src");
+      if (video.parentNode !== null) video.parentNode.removeChild(video);
+      if (videoRef.current === video) videoRef.current = null;
+    };
+  }, [uri, contentFit]);
+
+  // Follow prop changes on the EXISTING element WITHOUT recreating it. Mute /
+  // unmute toggle: when the parent `muted` prop changes we update
+  // `video.muted` — unmute is a real user gesture the browser honors. The R5
+  // contract holds: the FIRST autoplay is hard-muted (effectiveMuted), and we
+  // only follow the live prop once the user has unmuted (hasUnmutedRef). Also
+  // keeps loop + the play/pause state in sync with playbackActive/autoplay.
   useEffect(() => {
     const video = videoRef.current;
     if (video === null) return;
-    // iOS Safari only treats a video as eligible for inline muted autoplay when
-    // the `muted` + `playsinline` ATTRIBUTES are present at the element level.
-    // React 19 sets `muted` as a DOM property only (no attribute), so iOS refuses
-    // to autoplay and shows its native play button. Set the attributes + property
-    // imperatively so the element is autoplay-eligible. (Desktop works on the
-    // property alone.)
-    //
-    // ORCH-1167-R5 — `effectiveMuted` (not the raw prop) is hard-true until the
-    // user unmutes, so the initial inline autoplay is always permitted and the
-    // native play button never paints. After a user-gesture unmute it follows
-    // the live prop, so the chrome Mute/Unmute toggle keeps working.
+    video.loop = loop;
     video.muted = effectiveMuted;
     if (effectiveMuted) video.setAttribute("muted", "");
     else video.removeAttribute("muted");
-    video.setAttribute("playsinline", "");
-    video.setAttribute("webkit-playsinline", "");
+    video.autoplay = shouldPlay;
 
     if (!shouldPlay) {
-      video.pause();
+      try {
+        video.pause();
+      } catch {
+        // ignore
+      }
       return;
     }
 
-    // ORCH-1167-R7 — ROOT CAUSE (proven via Playwright against the LIVE page,
-    // headless WebKit): the R5/R6 code drove the muted ambient autoplay by
-    // calling `video.play()` MANUALLY — R6 hammered it ~50× via a retry driver,
-    // with the FIRST attempt firing at `readyState 0` (before any media). On
-    // WebKit that gesture-less play()-at-readyState-0 POISONS the
-    // element's one-time inline-autoplay eligibility: WebKit rejects it with
-    // NotAllowedError and PERMANENTLY denies that specific element — every one of
-    // the 56 retries then rejected too, and Safari painted its native play-button
-    // overlay on the dead, paused cover. Decisive proof: on the SAME live page a
-    // fresh bare `<video autoplay muted playsinline src>` (which NEVER calls
-    // play()) autoplays, while the component's hammered element stays paused.
-    //
-    // THE FIX: render the cover EXACTLY like that proven-working bare element —
-    // rely SOLELY on the native `autoplay` + `muted` + `playsinline` ATTRIBUTES
-    // (pinned at mount by `attachVideo`, re-pinned above) to drive the muted
-    // ambient autoplay. Do NOT call play() while hard-muted, and NEVER at
-    // readyState 0. The attributes-only path is what WebKit grants without a
-    // gesture; manual play() is what poisons it.
-    //
-    // A single GUARDED late recovery (the `canplaythrough` listener below) covers
-    // the rare case where the autoplay attribute didn't kick the element off:
-    // it attempts play() ONCE, only when the media is genuinely ready
-    // (readyState >= 3) AND still paused — never at readyState 0 — and stops the
-    // moment it plays. That can't poison (the element is past the eligibility
-    // window and truly ready), and it is fully torn down on cleanup.
     if (effectiveMuted) {
+      // Hard-muted ambient autoplay is driven by the ATTRIBUTES alone (the
+      // proven-working path). We do NOT call play() here — a gesture-less
+      // play() is unnecessary for the imperative element and was the R7
+      // poison theory. A single GUARDED late recovery covers the rare case
+      // where the autoplay attribute didn't kick it off: play() ONCE, only
+      // when the media is genuinely ready (readyState >= 3) AND still paused.
       let recovered = false;
       const recover = (): void => {
         if (recovered) return;
-        // Only recover when truly ready (>=3 HAVE_FUTURE_DATA) AND still paused.
-        // Never at readyState 0 — that is the attempt that poisons WebKit.
         if (video.readyState < 3 || !video.paused) return;
         recovered = true;
         video.muted = true;
@@ -257,41 +320,16 @@ const EventCoverWebVideo: React.FC<{
       return () => video.removeEventListener("canplaythrough", recover);
     }
 
-    // User has unmuted (a real gesture the browser honors): follow the live prop
-    // with a single play() attempt; no hard-muted retry loop.
+    // User has unmuted (a real gesture the browser honors): follow the live
+    // prop with a single play() attempt; no hard-muted retry loop.
     void video.play().catch(() => undefined);
     return;
-  }, [shouldPlay, uri, effectiveMuted]);
+  }, [shouldPlay, effectiveMuted, loop]);
 
-  return React.createElement("video", {
-    ref: attachVideo,
-    autoPlay: shouldPlay,
-    controls: false,
-    loop,
-    muted: effectiveMuted,
-    onCanPlay: (event: React.SyntheticEvent<HTMLVideoElement>): void => {
-      if (!shouldPlay) return;
-      // ORCH-1167-R7 — NO play() at readyState 0 (that poisons WebKit). Re-assert
-      // muted so a browser that deferred its eligibility check still permits the
-      // attribute-driven inline autoplay (R5 contract), and ONLY attempt a recovery
-      // play() when the media is genuinely ready (readyState >= 3) AND still paused
-      // — never on an empty element. The native `autoplay` attribute is the
-      // primary driver.
-      event.currentTarget.muted = effectiveMuted;
-      if (event.currentTarget.readyState >= 3 && event.currentTarget.paused) {
-        void event.currentTarget.play().catch(() => undefined);
-      }
-    },
-    onEnded: (event: React.SyntheticEvent<HTMLVideoElement>): void => {
-      if (!loop || !shouldPlay) return;
-      event.currentTarget.currentTime = 0;
-      void event.currentTarget.play().catch(() => undefined);
-    },
-    onError,
-    playsInline: true,
-    preload: "auto",
-    src: uri,
-    style: { ...WEB_VIDEO_STYLE, objectFit: contentFit },
+  // React owns ONLY this container <div>; it never owns/reconciles the <video>.
+  return React.createElement("div", {
+    ref: containerRef,
+    style: WEB_VIDEO_CONTAINER_STYLE,
   });
 };
 

--- a/packages/event-rendering/__tests__/coverWebVideoImperativeMount.orch1167r8.test.ts
+++ b/packages/event-rendering/__tests__/coverWebVideoImperativeMount.orch1167r8.test.ts
@@ -1,0 +1,104 @@
+// ORCH-1167-R8 [imperative DOM web cover]. New implementor-owned source contract
+// for the R8 fix: on WEB the cover `<video>` is created IMPERATIVELY via
+// `document.createElement('video')` and appended into a React-owned container
+// `<div>`, so React NEVER reconciles the `<video>` node. PROVEN ROOT CAUSE
+// (orchestrator, exhaustive Playwright forensics on the LIVE page, headless
+// WebKit): every React-rendered/reconciled `<video>` is permanently DENIED
+// inline-muted autoplay on desktop Safari/WebKit (shows the play button), while
+// every `document.createElement('video')` appended on the same live page
+// AUTOPLAYS. So React's reconciliation of the `<video>` is itself the poison.
+//
+// This test pins the IMPERATIVE-MOUNT contract specifically:
+//   • the element is built imperatively and appended into the container ref;
+//   • the existing features are wired through to the imperative element —
+//     aspect-ratio (loadedmetadata), error → onError fallback, loop (ended),
+//     mute toggle (video.muted follows effectiveMuted), reduce-motion freeze
+//     (the autoplay attribute follows shouldPlay, which the parent zeroes when
+//     the cover is frozen / not playing);
+//   • the element is fully TORN DOWN on unmount / src change (listeners removed,
+//     src cleared, node removed from the DOM);
+//   • the NATIVE (expo-video) branch is untouched.
+//
+// Source-structural (readFileSync) — these mounts pull react-native + expo-video
+// and there is no jsdom here, so the web autoplay contract is a SOURCE contract;
+// the AUTHORITATIVE runtime proof is the orchestrator's Vercel-preview headless-
+// WebKit autoplay check (no local bed reproduces the WebKit poison).
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(__dirname, "..", "..", "..");
+const read = (rel: string): string => readFileSync(join(repoRoot, rel), "utf8");
+
+const COVER = "packages/event-rendering/EventCoverMedia.tsx";
+
+const stripComments = (src: string): string =>
+  src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+const sliceBetween = (src: string, startMarker: string, endMarker: string): string => {
+  const open = src.indexOf(startMarker);
+  expect(open).toBeGreaterThanOrEqual(0);
+  const next = src.indexOf(endMarker, open + startMarker.length);
+  expect(next).toBeGreaterThan(open);
+  return src.slice(open, next);
+};
+
+describe("ORCH-1167-R8 — imperative DOM <video> mount + feature wiring + teardown", () => {
+  const cover = stripComments(read(COVER));
+  const web = sliceBetween(cover, "const EventCoverWebVideo", "const EventCoverNativeVideo");
+  const native = sliceBetween(cover, "const EventCoverNativeVideo", "const EventCoverVideo");
+
+  it("builds the <video> imperatively and appends it into the container ref (React reconciles only the div)", () => {
+    expect(web).toMatch(/const video\s*=\s*document\.createElement\(\s*["']video["']\s*\)/);
+    expect(web).toMatch(/container(?:Ref\.current)?\??\.appendChild\(\s*video\s*\)/);
+    // The src is assigned to the imperative element (not a React `src=` prop).
+    expect(web).toMatch(/video\.src\s*=\s*uri/);
+    // React renders the container div, never a video element.
+    expect(web).toMatch(/React\.createElement\(\s*["']div["']/);
+    expect(web).not.toMatch(/React\.createElement\(\s*["']video["']/);
+  });
+
+  it("wires aspect-ratio reporting through loadedmetadata on the imperative element", () => {
+    expect(web).toMatch(/addEventListener\(\s*["']loadedmetadata["']/);
+    expect(web).toMatch(/video\.videoWidth\s*\/\s*video\.videoHeight/);
+  });
+
+  it("wires error → onError fallback and loop via the ended event", () => {
+    expect(web).toMatch(/addEventListener\(\s*["']error["']/);
+    expect(web).toMatch(/onError/);
+    expect(web).toMatch(/addEventListener\(\s*["']ended["']/);
+    // The loop recovery only fires when we should be playing.
+    expect(web).toMatch(/shouldPlay/);
+  });
+
+  it("the mute toggle follows the parent prop on the imperative element (effectiveMuted, R5 first-autoplay-muted)", () => {
+    expect(web).toMatch(/const effectiveMuted\s*=/);
+    expect(web).toMatch(/hasUnmutedRef/);
+    expect(web).toMatch(/video\.muted\s*=\s*effectiveMuted/);
+  });
+
+  it("the reduce-motion freeze flows through the autoplay attribute (shouldPlay drives video.autoplay)", () => {
+    expect(web).toMatch(/const shouldPlay\s*=\s*autoplay\s*&&\s*playbackActive/);
+    expect(web).toMatch(/video\.autoplay\s*=\s*shouldPlay/);
+  });
+
+  it("fully tears down the imperative element on unmount / src change (listeners removed, src cleared, node removed)", () => {
+    expect(web).toMatch(/removeEventListener\(\s*["']loadedmetadata["']/);
+    expect(web).toMatch(/removeEventListener\(\s*["']error["']/);
+    expect(web).toMatch(/removeEventListener\(\s*["']ended["']/);
+    expect(web).toMatch(/video\.removeAttribute\(\s*["']src["']\s*\)/);
+    expect(web).toMatch(/removeChild\(\s*video\s*\)/);
+    // The create effect re-runs on uri change (so a new src rebuilds + cleans up
+    // the old element). The dependency array includes uri.
+    expect(web).toMatch(/\}\s*,\s*\[uri[\s\S]*?\]\s*\)/);
+  });
+
+  it("leaves the NATIVE (expo-video) path untouched — still uses VideoView + useVideoPlayer, no document.createElement", () => {
+    expect(native).toMatch(/useVideoPlayer/);
+    expect(native).toMatch(/VideoView/);
+    expect(native).not.toMatch(/document\.createElement/);
+  });
+});

--- a/packages/offering-rendering/__tests__/orch_1167_r5_web_cover_autoplay_muted.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1167_r5_web_cover_autoplay_muted.test.ts
@@ -6,34 +6,48 @@
 // <video> is MUTED at play() time, so a single unmuted play() attempt paints the
 // native control overlay (the bug Seth saw live on buyer-web).
 //
+// [TEST-MOD-APPROVED ORCH-1167] — R8 MECHANISM MIGRATION (intent UNCHANGED).
+// R5/R6/R7 expressed the web cover as a React-RENDERED <video> (React.createElement
+// + JSX props: `muted: effectiveMuted`, `attachVideo` ref callback, `onCanPlay`,
+// `controls: false`). ORCH-1167-R8 proved (orchestrator Playwright forensics, live
+// page, headless WebKit) that ANY React-reconciled <video> is permanently DENIED
+// inline-muted autoplay by desktop Safari/WebKit, and replaced it with an
+// IMPERATIVELY created `document.createElement('video')` appended into a React-owned
+// container <div>. The R5 INTENT below is fully preserved on the imperative element
+// — the FIRST autoplay is hard-muted (`effectiveMuted` / `hasUnmutedRef`), the
+// muted + playsinline + webkit-playsinline ATTRIBUTES are pinned at create, controls
+// stay off, loop + inline playback are preserved — but the ASSERTION ANCHORS are
+// migrated from the React-prop form to the imperative-element form
+// (`video.muted = effectiveMuted`, `video.controls = false`, `video.loop = …`,
+// `video.playsInline = true`). The React-prop assertions are intentionally removed
+// (they would now pin the very mechanism R8 proved poisons WebKit autoplay).
+//
 // THE FIX, asserted here (all in the web branch of EventCoverMedia.tsx):
 //   (1) The web <video>'s FIRST autoplay attempt is HARD-MUTED regardless of the
 //       incoming `muted` prop (`effectiveMuted` is true until the user unmutes),
 //       so the browser always permits the inline autoplay and no play button
 //       shows. A `hasUnmutedRef` records the first user-gesture unmute; only then
 //       does the element follow the live `muted` prop.
-//   (2) The element is mounted via a SYNCHRONOUS ref callback that pins the
-//       `muted` + `playsinline` ATTRIBUTES the instant it mounts — before the
-//       browser evaluates autoplay eligibility (React 19 emits `muted` as a
-//       property only, which can land after the first eligibility check).
-//   (3) `onCanPlay` re-asserts `muted` before the (re)play attempt.
-//   (4) `controls` stays false (no native chrome), `playsInline`/`webkit-
-//       playsinline` stay set, `loop` is preserved.
-//   (5) The shared EventCoverMedia mute STATE follows the parent `muted` prop on
+//   (2) The imperatively created element pins the `muted` + `playsinline` +
+//       `webkit-playsinline` ATTRIBUTES at create — before the browser evaluates
+//       autoplay eligibility.
+//   (3) `controls` stays false (no native chrome), `playsInline` stays true,
+//       `loop` is preserved.
+//   (4) The shared EventCoverMedia mute STATE follows the parent `muted` prop on
 //       in-place changes (so the chrome Mute/Unmute toggle reaches the cover),
 //       and resets to the web autoplay-muted default only on a NEW media url.
 //
-// Source-structural (readFileSync) — the same proven pattern as the R2/R3/R4
+// Source-structural (readFileSync) — the same proven pattern as the R2/R3/R4/R7/R8
 // ORCH-1167 tests: these mounts import react-native + expo-video and cannot run
 // under node-env jest, and there is no jsdom in this repo, so the web autoplay
-// contract is pinned as a source contract.
+// contract is pinned as a source contract. The AUTHORITATIVE runtime proof is the
+// orchestrator's Vercel-preview headless-WebKit check (no local bed reproduces it).
 //
-// FAILS-ON-REVERT (proven by TRUE deletion in the implementation report):
-//   • Pass the raw `muted` prop to the web <video> instead of `effectiveMuted`
-//     (drop the hasUnmutedRef hard-mute) → "first autoplay is hard-muted" FAILS.
-//   • Drop the synchronous ref-callback muted-attribute pin → "ref callback pins
-//     muted attribute on mount" FAILS.
-//   • Drop the onCanPlay muted re-assert → "onCanPlay re-asserts muted" FAILS.
+// FAILS-ON-REVERT:
+//   • Pass the raw `muted` prop to the element instead of `effectiveMuted` (drop
+//     the hasUnmutedRef hard-mute) → "first autoplay is hard-muted" FAILS.
+//   • Drop the muted-attribute pin at create → "pins muted attribute" FAILS.
+//   • Re-enable controls → "controls disabled" FAILS.
 //   • Make EventCoverMedia's sync effect force muted on web again (re-mute on
 //     every prop change) → "mute state follows the parent prop on in-place
 //     change" FAILS.
@@ -66,48 +80,48 @@ describe("ORCH-1167-R5 — web video cover autoplays MUTED (no native play butto
   const src = stripComments(read(COVER));
   const web = webVideoBody(src);
 
-  it("the web <video> autoplay attempt is HARD-MUTED until the user unmutes (effectiveMuted, not the raw prop)", () => {
+  it("the imperative <video>'s autoplay attempt is HARD-MUTED until the user unmutes (effectiveMuted, not the raw prop)", () => {
     // The hard-mute gate exists.
     expect(web).toMatch(/hasUnmutedRef/);
     expect(web).toMatch(/const effectiveMuted\s*=/);
-    // The element's `muted` is driven by effectiveMuted, NOT the raw `muted` prop.
-    expect(web).toMatch(/muted:\s*effectiveMuted/);
-    // The imperative effect mutes the element with effectiveMuted before play().
+    // The imperative element's `muted` is driven by effectiveMuted, NOT the raw prop.
     expect(web).toMatch(/video\.muted\s*=\s*effectiveMuted/);
     // The user-gesture unmute is recorded so the toggle can later take over.
     expect(web).toMatch(/if\s*\(!muted\)\s*hasUnmutedRef\.current\s*=\s*true/);
   });
 
-  it("a synchronous ref callback pins the muted + playsinline ATTRIBUTES on mount (before autoplay eligibility check)", () => {
-    expect(web).toMatch(/attachVideo/);
-    expect(web).toMatch(/node\.muted\s*=\s*true/);
-    expect(web).toMatch(/node\.setAttribute\("muted",\s*""\)/);
-    expect(web).toMatch(/setAttribute\("playsinline",\s*""\)/);
-    expect(web).toMatch(/setAttribute\("webkit-playsinline",\s*""\)/);
-    // The element uses the ref callback (not a bare ref) so the pin runs on mount.
-    expect(web).toMatch(/ref:\s*attachVideo/);
+  it("pins the muted + playsinline + webkit-playsinline ATTRIBUTES at create (before autoplay eligibility check)", () => {
+    // The imperative element is muted at create...
+    expect(web).toMatch(/video\.muted\s*=\s*true/);
+    // ...and the autoplay-eligibility attributes are pinned on it.
+    expect(web).toMatch(/video\.setAttribute\(\s*["']muted["']\s*,\s*""\s*\)/);
+    expect(web).toMatch(/video\.setAttribute\(\s*["']playsinline["']\s*,\s*""\s*\)/);
+    expect(web).toMatch(
+      /video\.setAttribute\(\s*["']webkit-playsinline["']\s*,\s*""\s*\)/,
+    );
+    // It is built imperatively via document.createElement (never React-rendered).
+    expect(web).toMatch(/document\.createElement\(\s*["']video["']\s*\)/);
+    expect(web).not.toMatch(/React\.createElement\(\s*["']video["']/);
   });
 
-  it("onCanPlay re-asserts muted before the (re)play attempt", () => {
-    expect(web).toMatch(/onCanPlay/);
-    expect(web).toMatch(/event\.currentTarget\.muted\s*=\s*effectiveMuted/);
+  it("re-asserts muted (effectiveMuted) when prop changes on the existing element", () => {
+    // The follow-prop effect re-applies effectiveMuted to the existing element.
+    expect(web).toMatch(/video\.muted\s*=\s*effectiveMuted/);
   });
 
-  it("keeps controls disabled, loop, and inline-playback attributes (no native chrome regression)", () => {
-    expect(web).toMatch(/controls:\s*false/);
-    expect(web).toMatch(/loop,/);
-    expect(web).toMatch(/playsInline:\s*true/);
-    // It must NOT regress to showing native controls.
-    expect(web).not.toMatch(/controls:\s*true/);
+  it("keeps controls disabled, loop, and inline-playback on the imperative element (no native chrome regression)", () => {
+    expect(web).toMatch(/video\.controls\s*=\s*false/);
+    expect(web).toMatch(/video\.loop\s*=/);
+    expect(web).toMatch(/video\.playsInline\s*=\s*true/);
+    // It must NOT regress to enabling native controls.
+    expect(web).not.toMatch(/video\.controls\s*=\s*true/);
   });
 
-  it("does NOT pass the raw `muted` prop straight to the <video> element (would reintroduce the play button)", () => {
-    // The element-level muted is effectiveMuted; a bare `muted,` (shorthand) or
-    // `muted: muted` on the createElement props would defeat the hard-mute gate.
-    const createEl = web.slice(web.indexOf('React.createElement("video"'));
-    expect(createEl).toMatch(/muted:\s*effectiveMuted/);
-    expect(createEl).not.toMatch(/\bmuted,\b/);
-    expect(createEl).not.toMatch(/muted:\s*muted\b/);
+  it("does NOT pass the raw `muted` prop straight to the element (would reintroduce the play button)", () => {
+    // The element-level muted is effectiveMuted; a `video.muted = muted` would
+    // defeat the hard-mute gate.
+    expect(web).toMatch(/video\.muted\s*=\s*effectiveMuted/);
+    expect(web).not.toMatch(/video\.muted\s*=\s*muted\b/);
   });
 });
 

--- a/packages/offering-rendering/__tests__/orch_1167_r7_webkit_cover_no_play_hammer.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1167_r7_webkit_cover_no_play_hammer.test.ts
@@ -1,42 +1,49 @@
-// ORCH-1167-R7 [WebKit cover poison] — implementor-owned regression for the R7
-// fix. ROOT CAUSE (proven via Playwright against the LIVE deployed page on
-// headless WebKit): the R6 web cover drove its muted ambient autoplay by calling
-// `video.play()` MANUALLY and HAMMERING it (~50× via `driveMutedAutoplay`), with
-// the FIRST attempt firing at `readyState 0` (before any media). On WebKit that
-// gesture-less play()-at-readyState-0 POISONS the element's one-time inline-
-// autoplay eligibility: WebKit rejects with NotAllowedError and PERMANENTLY denies
-// THAT element (all 56 retries rejected), so the cover stayed paused under
-// Safari's native play-button overlay. Decisive proof: on the SAME live page a
-// fresh bare `<video autoplay muted playsinline src>` (which NEVER calls play())
-// autoplays, while the component's hammered element stays dead.
+// ORCH-1167-R7 → R8 [TEST-MOD-APPROVED ORCH-1167]. This file originally pinned
+// the R7 fix: a React-RENDERED `<video>` (React.createElement) driven by the
+// native `autoPlay` attribute with no play()-hammer. R8 SUPERSEDES the
+// MECHANISM (not the intent): exhaustive Playwright forensics on the LIVE page
+// (headless WebKit) proved that ANY React-RENDERED / React-reconciled `<video>`
+// is PERMANENTLY DENIED inline-muted autoplay by desktop Safari/WebKit — it
+// shows the native play button and never autoplays — while EVERY video created
+// via `document.createElement('video')` (raw DOM) and appended on the EXACT
+// same live page AUTOPLAYS. So React's rendering/reconciliation of the
+// `<video>` node is ITSELF the poison; the R7 attribute-only React video was
+// still poisoned.
 //
-// THE R7 FIX, asserted here (all in the EventCoverWebVideo web branch of
+// THE R8 FIX, asserted here (all in the EventCoverWebVideo web branch of
 // EventCoverMedia.tsx):
-//   (1) The cover relies on the native `autoPlay` ATTRIBUTE (+ the muted +
-//       playsinline attributes pinned at mount) to drive the muted ambient
-//       autoplay — the SAME mechanism as the proven-working bare element.
-//   (2) The R6 `driveMutedAutoplay` play()-hammer driver is GONE (no import, no
-//       call). The module + its export were deleted.
-//   (3) NO unconditional `video.play()` is issued while hard-muted. Any recovery
-//       play() (the canplaythrough listener + onCanPlay) is GUARDED by
-//       `readyState >= 3` AND `paused` — never at readyState 0, which is the
-//       attempt that poisons WebKit.
-//   (4) The R5 contracts survive: `effectiveMuted`, the `attachVideo` mount pin,
-//       `muted: effectiveMuted`, controls:false, loop, playsInline.
+//   (1) React owns ONLY a plain container `<div>` (React.createElement("div"));
+//       it NEVER owns/reconciles the `<video>`. The `<video>` is created
+//       IMPERATIVELY via `document.createElement('video')` and appended into
+//       the container ref. There is NO `React.createElement("video"` and NO
+//       `<video>` JSX in the web branch.
+//   (2) The muted ambient autoplay is driven by the native ATTRIBUTES on the
+//       imperative element (autoplay + muted + playsinline), mirroring the
+//       proven-working bare element — NOT by a manual play() kickoff.
+//   (3) The R6 `driveMutedAutoplay` play()-hammer driver stays GONE (no import,
+//       no call, no export), and there is no setTimeout/rAF retry-backoff in
+//       the web path. Any recovery play() is GUARDED by `readyState >= 3` AND
+//       `paused` — never at readyState 0 (the WebKit poison theory).
+//   (4) The R5 contracts survive on the imperative element: `effectiveMuted`,
+//       the muted/playsinline attribute pin at create, `controls = false`,
+//       loop, inline playback (`playsInline`).
 //
-// Source-structural (readFileSync) — the same proven pattern as the R2–R5
+// Source-structural (readFileSync) — the same proven pattern as the R2–R7
 // ORCH-1167 tests: these mounts import react-native + expo-video and cannot run
 // under node-env jest, and there is no jsdom in this repo, so the web autoplay
-// contract is pinned as a source contract. The RUNTIME proof (real R7 component
-// autoplaying on the live denying page, headless WebKit) is in the R7 report.
+// contract is pinned as a source contract. The AUTHORITATIVE runtime proof
+// (real R8 imperative-DOM cover autoplaying on the live denying page, headless
+// WebKit) is the ORCHESTRATOR's Vercel-preview WebKit check — NOT any local bed.
 //
-// FAILS-ON-REVERT (proven by TRUE deletion in the implementation report):
-//   • Re-introduce the `driveMutedAutoplay(video)` hammer call (the R6 bug) →
-//     "no play()-hammer driver" FAILS.
-//   • Drop the `autoPlay` attribute → "drives autoplay via the autoplay
-//     attribute" FAILS.
-//   • Issue an unconditional `video.play()` while muted (the R5 single-attempt /
-//     R6 hammer at readyState 0) → "no unguarded play() while muted" FAILS.
+// FAILS-ON-REVERT:
+//   • Reintroduce a React-rendered `<video>` (React.createElement("video") or
+//     `<video>` JSX) → "React owns ONLY the container div" FAILS.
+//   • Reintroduce the `driveMutedAutoplay(video)` hammer → "no play()-hammer
+//     driver" FAILS.
+//   • Drop `document.createElement('video')` → "creates the video imperatively"
+//     FAILS.
+//   • Issue an unguarded play() while muted (drop the readyState>=3 guard) →
+//     "no unguarded play() while muted" FAILS.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -62,64 +69,71 @@ const webVideoBody = (src: string): string => {
   return src.slice(open, next);
 };
 
-describe("ORCH-1167-R7 — web cover autoplays via the native autoplay ATTRIBUTE, no play()-hammer (WebKit poison fix)", () => {
+describe("ORCH-1167-R8 — web cover renders an IMPERATIVE DOM <video> (React never reconciles it); attribute-driven autoplay, no play()-hammer (WebKit poison fix)", () => {
   const rawCover = read(COVER);
   const cover = stripComments(rawCover);
   const web = webVideoBody(cover);
   const index = stripComments(read(INDEX));
 
+  it("React owns ONLY a container div — there is NO React-rendered <video> in the web branch (the R8 poison fix)", () => {
+    // No React.createElement("video", …) and no <video> JSX — React must never
+    // own/reconcile the cover video node (that is what WebKit poisons).
+    expect(web).not.toMatch(/React\.createElement\(\s*["']video["']/);
+    expect(web).not.toMatch(/<video[\s/>]/);
+    // React owns the plain container div instead.
+    expect(web).toMatch(/React\.createElement\(\s*["']div["']/);
+  });
+
+  it("creates the <video> IMPERATIVELY via document.createElement and appends it into the container ref", () => {
+    expect(web).toMatch(/document\.createElement\(\s*["']video["']\s*\)/);
+    expect(web).toMatch(/\.appendChild\(\s*video\s*\)/);
+    // The container ref is wired to the React div.
+    expect(web).toMatch(/const containerRef\s*=/);
+    expect(web).toMatch(/ref:\s*containerRef/);
+  });
+
+  it("drives the muted ambient autoplay via the native ATTRIBUTES on the imperative element (like the proven bare element)", () => {
+    // autoplay attribute set from shouldPlay; muted + playsinline attributes
+    // pinned at create.
+    expect(web).toMatch(/video\.autoplay\s*=\s*shouldPlay/);
+    expect(web).toMatch(/video\.setAttribute\(\s*["']muted["']\s*,\s*""\s*\)/);
+    expect(web).toMatch(
+      /video\.setAttribute\(\s*["']playsinline["']\s*,\s*""\s*\)/,
+    );
+    expect(web).toMatch(
+      /video\.setAttribute\(\s*["']webkit-playsinline["']\s*,\s*""\s*\)/,
+    );
+  });
+
   it("the R6 driveMutedAutoplay play()-hammer driver is REMOVED (no import, no call, no export)", () => {
-    // The bug was the hammer. It must be gone from the web branch...
     expect(web).not.toMatch(/driveMutedAutoplay/);
-    // ...from the whole cover module (no import)...
     expect(cover).not.toMatch(/driveMutedAutoplay/);
     expect(cover).not.toMatch(/coverWebVideoAutoplay/);
-    // ...and from the package barrel (no export).
     expect(index).not.toMatch(/driveMutedAutoplay/);
     expect(index).not.toMatch(/coverWebVideoAutoplay/);
   });
 
-  it("drives the muted ambient autoplay via the native autoPlay ATTRIBUTE (like the proven bare element)", () => {
-    const createEl = web.slice(web.indexOf('React.createElement("video"'));
-    expect(createEl).toMatch(/autoPlay:\s*shouldPlay/);
-    // muted + playsinline attributes are pinned at mount (R5 attachVideo).
-    expect(web).toMatch(/node\.setAttribute\("muted",\s*""\)/);
-    expect(web).toMatch(/node\.setAttribute\("playsinline",\s*""\)/);
-    expect(web).toMatch(/ref:\s*attachVideo/);
-  });
-
   it("issues NO unguarded play() while hard-muted — any recovery play() is gated by readyState >= 3 AND paused (never at readyState 0)", () => {
-    // There must be no bare `video.play()` kickoff in the muted ambient path.
-    // The ONLY play() calls allowed in the web branch are: (a) the unmuted
-    // user-gesture branch, and (b) recovery calls guarded by `readyState >= 3`.
-    // Count the play() invocations and ensure every one in a muted context is
-    // either the unmuted branch or readyState-guarded.
-    // 1) The effect's muted branch uses a `canplaythrough` recovery guarded by rs>=3.
-    expect(web).toMatch(/addEventListener\("canplaythrough"/);
+    // The guarded late recovery is the canplaythrough listener gated by rs>=3.
+    expect(web).toMatch(/addEventListener\(\s*["']canplaythrough["']/);
     expect(web).toMatch(/readyState\s*<\s*3/);
-    // 2) onCanPlay only plays when readyState >= 3 AND paused.
-    expect(web).toMatch(/readyState\s*>=\s*3\s*&&[\s\S]*?\.paused/);
-    // 3) No "play() every readyState event" retry loop pattern (the R6 hammer):
-    //    there is no array of ready events each calling play(), and no setTimeout
-    //    backoff re-driving play() while muted.
-    expect(web).not.toMatch(/COVER_AUTOPLAY_READY_EVENTS/);
-    // 4) The muted branch registers the guarded `recover` listener and returns
-    //    its cleanup; the recover closure's play() is gated by rs>=3 + paused, and
-    //    there is no setTimeout/rAF retry-backoff hammer anywhere in the web path.
     expect(web).toMatch(/const recover\s*=/);
-    expect(web).toMatch(/if\s*\(video\.readyState\s*<\s*3\s*\|\|\s*!video\.paused\)\s*return/);
-    expect(web).toMatch(/video\.removeEventListener\("canplaythrough"/);
-    // No retry-backoff hammer anywhere in the web cover branch (R6 used these).
+    expect(web).toMatch(
+      /if\s*\(\s*video\.readyState\s*<\s*3\s*\|\|\s*!video\.paused\s*\)\s*return/,
+    );
+    expect(web).toMatch(/removeEventListener\(\s*["']canplaythrough["']/);
+    // No retry-backoff hammer anywhere in the web cover branch.
+    expect(web).not.toMatch(/COVER_AUTOPLAY_READY_EVENTS/);
     expect(web).not.toMatch(/setTimeout/);
     expect(web).not.toMatch(/requestAnimationFrame/);
   });
 
-  it("preserves the R5 contracts (effectiveMuted, controls disabled, loop, inline playback)", () => {
+  it("preserves the R5 contracts on the imperative element (effectiveMuted, controls disabled, loop, inline playback)", () => {
     expect(web).toMatch(/const effectiveMuted\s*=/);
-    expect(web).toMatch(/muted:\s*effectiveMuted/);
-    expect(web).toMatch(/controls:\s*false/);
-    expect(web).toMatch(/loop,/);
-    expect(web).toMatch(/playsInline:\s*true/);
-    expect(web).not.toMatch(/controls:\s*true/);
+    expect(web).toMatch(/video\.muted\s*=\s*effectiveMuted/);
+    expect(web).toMatch(/video\.controls\s*=\s*false/);
+    expect(web).toMatch(/video\.loop\s*=/);
+    expect(web).toMatch(/video\.playsInline\s*=\s*true/);
+    expect(web).not.toMatch(/video\.controls\s*=\s*true/);
   });
 });


### PR DESCRIPTION
## ORCH-1167 R8 — imperative-DOM web cover (UI-only, web-only behavior)

PROVEN root cause (orchestrator Playwright forensics vs desktop Safari/WebKit): the React-rendered `<video>` is permanently denied autoplay by WebKit. Every hand-created `document.createElement('video')` autoplays on the same live page; only React's reconciled node is poisoned. R5/R6/R7 false-passed on isolated beds.

Fix: `EventCoverWebVideo` now renders only a container `<div>`; the `<video>` is created via `document.createElement` in a useEffect and appended to the ref — React never owns the node. Mirrors the proven bare element. Mute toggle / aspect-ratio / error-fallback / reduce-motion / teardown all wired. Native (expo-video) + image/GIF unchanged.

VERIFICATION: authoritative check is the orchestrator's headless-WebKit test against THIS PR's Vercel preview deploy (no local-bed claims — they false-passed 3×).

### Gates
- Jest 52/52; 5 ORCH-1167 strict-grep gates + I-MOR-0827 PASS; typecheck baseline; fails-on-revert proven. Tests migrated in place under [TEST-MOD-APPROVED ORCH-1167].

🤖 Generated with [Claude Code](https://claude.com/claude-code)