### PR TITLE
META-ORCH-1161 Sub-A (thin slice): buyer_reservation_changed notify end-to-end [deploy-skip]

### DIFF
--- a/.github/scripts/strict-grep/i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs
+++ b/.github/scripts/strict-grep/i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * META-ORCH-1161 Sub-A — SMS sender + kill-switch invariants (DRAFT).
+ *
+ * I-PROPOSED-1161-SMS-FROM-APPROVED-SENDER-ONLY: the smsAdapter MUST send only
+ * via a configured Messaging Service SID (TWILIO_MESSAGING_SERVICE_SID), never a
+ * raw `From:` number.
+ *
+ * I-PROPOSED-1161-SMS-MARKET-KILL-SWITCH: the smsAdapter MUST consult a
+ * per-market kill-switch env (SMS_LIVE_ENABLED_US) and return WITHOUT an HTTP
+ * call when off.
+ *
+ * This gate fails if:
+ *   (a) the smsAdapter is missing (the unified SMS owner must exist), OR
+ *   (b) the smsAdapter references MessagingServiceSid is removed, OR
+ *   (c) the kill-switch (SMS_LIVE_ENABLED_) check is removed, OR
+ *   (d) the adapter introduces a raw Twilio `From` form param.
+ *
+ * Mirrors the modular gate pattern (sibling: orch-1130-no-buyer-tax-form.mjs).
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd().endsWith("mingla-business")
+  ? join(process.cwd(), "..")
+  : process.cwd();
+const failures = [];
+
+const adapterPath = join(root, "supabase/functions/_shared/adapters/smsAdapter.ts");
+
+if (!existsSync(adapterPath)) {
+  failures.push(
+    `smsAdapter missing at supabase/functions/_shared/adapters/smsAdapter.ts — the unified SMS owner must exist (I-PROPOSED-1161-UNIFIED-DISPATCHER-SOLE-SEND-PATH).`,
+  );
+} else {
+  const src = readFileSync(adapterPath, "utf8");
+
+  if (!src.includes("MessagingServiceSid")) {
+    failures.push(
+      `smsAdapter must send via MessagingServiceSid (the approved toll-free), not a raw From number — I-PROPOSED-1161-SMS-FROM-APPROVED-SENDER-ONLY.`,
+    );
+  }
+
+  // A raw From: number param is forbidden (the adapter must use the Messaging
+  // Service). Allow the word in comments; forbid an actual URLSearchParams "From".
+  if (/params\.set\(\s*["']From["']/.test(src) || /["']From["']\s*:/.test(src)) {
+    failures.push(
+      `smsAdapter must NOT set a raw Twilio "From" param — use MessagingServiceSid (I-PROPOSED-1161-SMS-FROM-APPROVED-SENDER-ONLY).`,
+    );
+  }
+
+  if (!/SMS_LIVE_ENABLED_/.test(src)) {
+    failures.push(
+      `smsAdapter must consult the per-market kill-switch SMS_LIVE_ENABLED_<MKT> and skip without an HTTP call when off — I-PROPOSED-1161-SMS-MARKET-KILL-SWITCH.`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error("✗ I-PROPOSED-1161 SMS sender/kill-switch gate FAILED:\n");
+  for (const f of failures) console.error("  - " + f);
+  process.exit(1);
+}
+
+console.log("✓ I-PROPOSED-1161 SMS sender/kill-switch gate passed.");

--- a/.github/workflows/strict-grep-mingla-business.yml
+++ b/.github/workflows/strict-grep-mingla-business.yml
@@ -2641,3 +2641,14 @@ jobs:
         run: node .github/scripts/strict-grep/orch-1167-one-read-rpc.mjs --self-test
       - name: Run ORCH-1167 one-read-rpc gate
         run: node .github/scripts/strict-grep/orch-1167-one-read-rpc.mjs
+
+  i-proposed-1161-sms-sender-kill-switch:
+    name: "META-ORCH-1161 [notif-system]: SMS via approved Messaging Service + per-market kill-switch (I-PROPOSED-1161-SMS-FROM-APPROVED-SENDER-ONLY / -SMS-MARKET-KILL-SWITCH)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run I-PROPOSED-1161 SMS sender/kill-switch gate
+        run: node .github/scripts/strict-grep/i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs

--- a/.github/workflows/supabase-migrations-and-stripe-deno.yml
+++ b/.github/workflows/supabase-migrations-and-stripe-deno.yml
@@ -25,11 +25,13 @@ on:
       - "supabase/migrations/**"
       - "supabase/functions/_shared/**"
       - "supabase/functions/_shared/__tests__/**"
+      - "supabase/functions/__tests__/**"
       - ".github/workflows/supabase-migrations-and-stripe-deno.yml"
   pull_request:
     paths:
       - "supabase/migrations/**"
       - "supabase/functions/_shared/**"
+      - "supabase/functions/__tests__/**"
 
 jobs:
   migrations:
@@ -130,5 +132,44 @@ jobs:
               exit 1
             fi
             echo "Stripe Deno tests failed (attempt ${attempt}), retrying in 10s..."
+            sleep 10
+          done
+
+  notification-deno-tests:
+    name: "Deno unit tests for META-ORCH-1161 notification system"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: "1.46.x"
+      - name: Run META-ORCH-1161 notification Deno tests
+        env:
+          # Inert defaults — these tests use fake supabase clients + stubbed fetch
+          # and never reach a real Supabase/Twilio/Resend instance. The SMS
+          # kill-switch (SMS_LIVE_ENABLED_US) is intentionally UNSET so the
+          # kill-switch-off assertions hold by default; the ON tests set it inline.
+          SUPABASE_URL: "https://example-test.supabase.co"
+          SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key-not-real"
+        run: |
+          set -euo pipefail
+          # META-ORCH-1161 Sub-A Deno test files (registered ORCH-1161 REWORK 2026-06-20):
+          #   - implementor happy-path (8 tests)
+          #   - tester adversarial anon/guest path (3 tests)
+          #   - implementor REWORK guest-ledger + atomic-dedupe (2 tests)
+          DENO_TEST_FILES=(
+            supabase/functions/__tests__/orch_1161_notify_dispatch_v2.test.ts
+            supabase/functions/__tests__/orch_1161_anon_guest_path.test.ts
+            supabase/functions/__tests__/orch_1161_guest_ledger_and_dedupe.test.ts
+          )
+          for attempt in 1 2 3; do
+            if deno test --allow-env --allow-net --no-check "${DENO_TEST_FILES[@]}"; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Notification Deno tests failed after 3 attempts (esm.sh flake?)"
+              exit 1
+            fi
+            echo "Notification Deno tests failed (attempt ${attempt}), retrying in 10s..."
             sleep 10
           done

--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA_THIN_SLICE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA_THIN_SLICE.md
@@ -1,0 +1,198 @@
+# IMPLEMENTATION — META-ORCH-1161 Sub-A (THIN SLICE) — buyer_reservation_changed end-to-end
+
+**ORCH:** META-ORCH-1161 Sub-A (thin slice)
+**Phase:** IMPLEMENT (single pass; self-verified; NOT deployed/merged)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[notif-system]/` on branch `ORCH-1161-notif-system`
+**Commit:** `a511b7944`
+**Date:** 2026-06-19
+**Status:** implemented and verified (source + Deno unit tests). Migration apply + edge deploy are operator-owned (NOT run here).
+
+---
+
+## 1. Summary
+
+A reservation status/table/time change now reaches the buyer. An `AFTER UPDATE`
+trigger on `reservations` writes a durable `notification_outbox` row mapped to
+`buyer_reservation_changed`; a 1-minute pg_cron drains it into `notify-dispatch`
+v2, which writes the in-app inbox row and fans out to **push + in-app + email
+simultaneously** (per DEC-185 — there is NO push-first/SMS-fallback waterfall),
+and fires **SMS** only when `SMS_LIVE_ENABLED_US=true` AND transactional consent
+is present AND the recipient is not suppressed. A STOP inbound (`twilio-inbound-sms`,
+new) writes a `channel_suppressions` row so the next SMS is skipped, and
+`twilio-message-status` (extended) reconciles `notification_deliveries` status by
+`provider_message_id`. Every outbound SMS carries the brand name + a "Reply STOP
+to opt out" footer, is GSM-7-sanitized, and records its segment count.
+
+**Key deviation from the written SPEC (documented, not silent):** SPEC §5.4
+describes a push-first / SMS-fallback waterfall. The dispatch contract for this
+slice supersedes that with **DEC-185 (simultaneous policy send)** — every channel
+in `default_channels` that passes `can_send()` fires at once, no fallback ordering.
+The implementation follows the dispatch contract (DEC-185). `reach_mode` is kept
+on `notification_categories` for forward use but the thin-slice dispatcher does
+not consult it.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| Criterion (dispatch /goal) | How verified | Status | Commit |
+|---|---|---|---|
+| Reservation change → `notification_outbox` row | `AFTER UPDATE` trigger `orch_1161_reservation_notify_outbox` (migration 2) inserts on status/table/time change | ✓ source | `a511b7944` |
+| Outbox → notify-dispatch v2 | `notify-outbox-drain` edge fn + 1-min cron (migration 3) | ✓ source | `a511b7944` |
+| push + in-app + email fire simultaneously | `dispatchV2` writes inapp delivery always, then fans out per-channel via `can_send`; Deno test #3 asserts inapp=delivered + push + email all attempted | ✓ test | `a511b7944` |
+| SMS fires only when kill-switch ON + consent + not suppressed | Deno test #4 (ON → sent) + smsAdapter kill-switch | ✓ test | `a511b7944` |
+| SMS skipped without HTTP when kill-switch OFF | Deno test "kill-switch OFF returns skipped WITHOUT an HTTP call" + test #3 | ✓ test | `a511b7944` |
+| brand-name + STOP footer + GSM-7 + segment count | `composeSmsBody` + `sanitizeGsm7` + `computeSegments`; Deno tests #1/#2 | ✓ test | `a511b7944` |
+| STOP inbound suppresses next SMS | `twilio-inbound-sms` writes `channel_suppressions`; `can_send` denies; Deno test #5 | ✓ test (logic) | `a511b7944` |
+| `notification_deliveries` reconciles from webhook | `twilio-message-status` extended (by `provider_message_id`, channel='sms') | ✓ source | `a511b7944` |
+| consent recorded on the moment | `notify-dispatch` v2 writes `consent_records(scope='transactional', source='reservation')` if absent | ✓ source | `a511b7944` |
+| legacy dispatch path byte-identical | v2 is an early additive branch on `category_key`; legacy `type` path untouched; `deno check` passes | ✓ | `a511b7944` |
+| migrations monotonic + REVOKE on SECURITY DEFINER | versions `20261110000000-3` (> max `20261015000001`); `REVOKE PUBLIC+anon` on `can_send` + trigger fn | ✓ | `a511b7944` |
+
+---
+
+## 3. Files changed
+
+**Migrations (new):**
+- `supabase/migrations/20261110000000_orch_1161_notification_foundation_tables.sql` (+~210)
+- `supabase/migrations/20261110000001_orch_1161_seed_notification_categories.sql` (+~70)
+- `supabase/migrations/20261110000002_orch_1161_can_send_and_reservation_trigger.sql` (+~180)
+- `supabase/migrations/20261110000003_orch_1161_outbox_drain_cron.sql` (+~95)
+
+**Edge functions / shared (new):**
+- `supabase/functions/_shared/adapters/smsAdapter.ts` (+~210)
+- `supabase/functions/_shared/adapters/pushAdapter.ts` (+~55)
+- `supabase/functions/_shared/adapters/emailAdapter.ts` (+~90)
+- `supabase/functions/_shared/notifyV2.ts` (+~245)
+- `supabase/functions/_shared/notifyTemplates.ts` (+~110)
+- `supabase/functions/notify-outbox-drain/index.ts` (+~135)
+- `supabase/functions/twilio-inbound-sms/index.ts` (+~130)
+
+**Edge functions (modified):**
+- `supabase/functions/notify-dispatch/index.ts` (+~60; additive v2 branch + consent write; legacy path byte-identical)
+- `supabase/functions/twilio-message-status/index.ts` (+~30; additive deliveries reconcile + error codes)
+
+**Config / gates / tests (new + modified):**
+- `supabase/config.toml` (+10; entries for the 2 new fns)
+- `.github/scripts/strict-grep/i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs` (new gate)
+- `.github/workflows/strict-grep-mingla-business.yml` (+11; gate job)
+- `supabase/functions/__tests__/orch_1161_notify_dispatch_v2.test.ts` (new; 8 tests)
+
+---
+
+## 4. Data-model changes applied (by migration — NOT yet applied to remote)
+
+- `notification_categories` (PK key) — taxonomy read as data; RLS public-read.
+- `notification_channel_prefs` (PK user_id,category_key,channel) — RLS owner.
+- `channel_suppressions` (+ partial unique idx) — RLS read-own; service-role write.
+- `consent_records` (append-only audit) — RLS read-own; service-role write.
+- `notification_deliveries` (FK→notifications) — RLS read-own-via-notification.
+- `notification_outbox` (unique idempotency_key) — service-role only (no policy).
+- `can_send(uuid,text,text,text)` SECURITY DEFINER STABLE; REVOKE PUBLIC+anon, GRANT authenticated.
+- `orch_1161_reservation_notify_outbox()` SECURITY DEFINER trigger fn; REVOKE PUBLIC+anon.
+- `AFTER UPDATE ON reservations` trigger `orch_1161_reservation_notify_trg`.
+- pg_cron job `orch_1161_notify_outbox_drain` (`* * * * *`).
+- All 16 §5.2 category rows seeded (idempotent upsert).
+
+---
+
+## 5. Edge functions touched — verify_jwt to preserve
+
+| Function | verify_jwt | Note |
+|---|---|---|
+| `notify-dispatch` | (no config entry → Supabase default) | unchanged; service-role bearer caller |
+| `twilio-message-status` | `false` | unchanged (gated on `?secret=`) |
+| `notify-outbox-drain` (new) | `false` | cron service-role bearer |
+| `twilio-inbound-sms` (new) | `false` | Twilio webhook, gated on `?secret=` |
+
+---
+
+## 6. Regression tests added
+
+- Path: `supabase/functions/__tests__/orch_1161_notify_dispatch_v2.test.ts` — 8 Deno tests.
+- Run: `cd "~/Desktop/mingla-orchs/ORCH-1161-[notif-system]" && DENO_TESTING=1 /Users/sethogieva/.deno/bin/deno test --allow-env --allow-net --no-check supabase/functions/__tests__/orch_1161_notify_dispatch_v2.test.ts`
+- Result: **8 passed | 0 failed**.
+- **fails-on-revert verified at `a511b7944`** — true line-deletion of the kill-switch guard block (`if (!envTrue(killSwitch)) { ... }`) in `smsAdapter.ts` → 2 tests FAIL ("kill-switch OFF returns skipped WITHOUT an HTTP call" + "dispatchV2: kill-switch OFF … SMS skipped"); restoring the guard → 8 pass again.
+
+---
+
+## 7. Old → New receipts
+
+### supabase/functions/notify-dispatch/index.ts
+- **Before:** single legacy `{userId,type,title,body,...}` contract → in-app + push + optional email, with type→preference gating + quiet hours.
+- **Now:** an early additive branch — when `category_key` is present, routes to `dispatchV2` (simultaneous fan-out via `can_send`) + writes a transactional `consent_records` row. A caller sending `type` (no `category_key`) hits the byte-identical legacy path.
+- **Why:** DC-1 (unified dispatcher, sole send path) without breaking existing callers (§5.7 transitional).
+- **Lines:** ~+60.
+
+### supabase/functions/twilio-message-status/index.ts
+- **Before:** reconciled `ticket_order_notifications` status only.
+- **Now:** ALSO updates `notification_deliveries.status` by `provider_message_id` (channel='sms'); records 30034/30007/30032 into `failed_reason`. Original logic untouched.
+- **Why:** §5.6 cross-channel delivery reconciliation.
+- **Lines:** ~+30.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Note |
+|---|---|---|
+| Consumer iOS / Android | indirect | a consumer with `consumer_user_id` on a reservation gets a push + inbox row (no UI change shipped this slice). |
+| Buyer/anon Web | no | no buyer-web file touched in this slice (checkout consent UX is OUT). |
+| Business iOS / Android | no | brand push semantics untouched. |
+| Backend (`supabase/`) | YES (all of it) | the whole slice. |
+| Admin Web | no | OUT of META-ORCH-1161. |
+| Business Web preview | no | n/a. |
+
+Parity: backend-only; no manual cross-surface parity needed this slice.
+
+---
+
+## 9. Self-verify results
+
+- `deno check` on all touched/new edge functions + the test file: **clean**.
+- Deno tests: **8 passed**, fails-on-revert proven.
+- strict-grep gate `i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs`: **pass**.
+- No DO-NOT-TOUCH file modified (`send-otp`/`verify-otp`, `send-venue-sms` send path, `venue_sms_opt_out`/`venue_sms_log` write semantics, reservation lifecycle money RPCs, `stripeWebhookRouter` money seam — all untouched).
+- Migration apply: **NOT run** (no local Postgres/Docker; operator applies — §11).
+
+---
+
+## 10. Known issues / deferred
+
+- **[TRANSITIONAL]** `notify-dispatch` v2 branch + `notifyV2.ts` are labeled `META-ORCH-1161 transitional:` — exit condition: legacy `type` contract retired at CLOSE (§5.7).
+- **Anon/guest reservations** (no `consumer_user_id`): the delivery ledger requires a `notifications.notification_id` FK (table is `user_id NOT NULL`), so a user-less reservation gets email/SMS but no `notification_deliveries` rows (handled in `dispatchAnon`). Surfaced for Sub-C hardening.
+- **Consent disclosure_text** is NOT recorded in this slice's reservation-derived consent (the §1b verbatim string has unresolved `[[FILL]]` legal placeholders — see COPY §5). The consent row is written with `source='reservation'` and no `disclosure_text`; the checkout-grant path (with disclosure) is OUT of this slice.
+- **The other §5.2 categories are seeded but only `buyer_reservation_changed` is wired** end-to-end (per dispatch scope). `confirmed`/`cancelled` mappings exist in the trigger but are proven only for `changed`.
+- **Resend inbound webhook** (`resend-email-status`) is OUT of this slice (SPEC §5.6 / Sub-B).
+- Deno tests are NOT in the CI `deno-tests` explicit file list — operator/orchestrator should add the path to `.github/workflows/supabase-migrations-and-stripe-deno.yml` DENO_TEST_FILES at CLOSE if CI coverage is desired (the migration-apply job already runs the new migrations).
+
+---
+
+## 11. Operator action required
+
+**Apply migrations (after REVIEW, monotonic above `20261015000001`):**
+```bash
+cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1161-[notif-system]" && /Users/sethogieva/bin/supabase db push --linked
+```
+(Or via the Management API per the migration-apply hazard runbook if the CLI is drift-wedged. Migrations apply in order 000000→000003.)
+
+**Deploy edge functions FROM MERGED main (orchestrator/operator-owned, never the worktree):**
+- `notify-dispatch` (v2 branch added; preserve default verify_jwt)
+- `notify-outbox-drain` (NEW; verify_jwt=false)
+- `twilio-inbound-sms` (NEW; verify_jwt=false)
+- `twilio-message-status` (extended; verify_jwt=false)
+
+**Secrets (Supabase secrets — already set for SMS today, plus the new kill-switch):**
+- `SMS_LIVE_ENABLED_US` — **set to `true` only after the §8 US go/no-go gate passes.** Default false → SMS skips with no HTTP call. `SMS_LIVE_ENABLED_NG` reserved for the NG phase.
+- Existing: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_MESSAGING_SERVICE_SID`, `TWILIO_STATUS_CALLBACK_SECRET`, `RESEND_API_KEY`, `MINGLA_LOGO_URL`, `MINGLA_FOOTER_ADDRESS`, OneSignal keys.
+
+**Twilio console:** point the Messaging Service "A MESSAGE COMES IN" inbound webhook at `/functions/v1/twilio-inbound-sms?secret=<TWILIO_STATUS_CALLBACK_SECRET>` for app-side STOP sync.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **COMMS-0038 (I-PROPOSED-BV realtime-publication gate) is RED on origin/main** (META-ORCH-1148's `reservations`/`venue_waitlist` subscriptions unpaired). This slice adds NO realtime subscriptions and does NOT add tables to the publication, so it does not worsen that gate — but any PR for this branch will still inherit the red gate until META-ORCH-1148 fixes it. Factored, not owned by 1161.
+- **DEC-185 in the local `DECISION_LOG.md` is a DIFFERENT decision** (ORCH-1146 experience parser) than the "simultaneous policy send" DEC-185 the dispatch references. The notification DEC-185/186 are recorded in the COPY file header but not yet in `DECISION_LOG.md` — orchestrator should log the notification DEC-185 (simultaneous send) / DEC-186 (bundled consent) to avoid the ID-collision confusion.
+- The COPY file `COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md` lives in the **anchor** (`mingla-main`), not the worktree or origin/main — it was read from the anchor. Orchestrator may want it committed to main for durability.
+- The `[[FILL]]` legal placeholders in the consent disclosure string are a real blocker for the consent-capture leg (Sub-B/checkout) — counsel + real entity/URL values needed before any consent `disclosure_text` ships.

--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA_THIN_SLICE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA_THIN_SLICE.md
@@ -196,3 +196,63 @@ cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1161-[notif-system]" && /Users/s
 - **DEC-185 in the local `DECISION_LOG.md` is a DIFFERENT decision** (ORCH-1146 experience parser) than the "simultaneous policy send" DEC-185 the dispatch references. The notification DEC-185/186 are recorded in the COPY file header but not yet in `DECISION_LOG.md` — orchestrator should log the notification DEC-185 (simultaneous send) / DEC-186 (bundled consent) to avoid the ID-collision confusion.
 - The COPY file `COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md` lives in the **anchor** (`mingla-main`), not the worktree or origin/main — it was read from the anchor. Orchestrator may want it committed to main for durability.
 - The `[[FILL]]` legal placeholders in the consent disclosure string are a real blocker for the consent-capture leg (Sub-B/checkout) — counsel + real entity/URL values needed before any consent `disclosure_text` ships.
+
+---
+
+## REWORK 2026-06-20 — NEEDS-REWORK loop (fix tester P2-1 + P2-2 + CI registration)
+
+**Trigger:** `TEST_META-ORCH-1161_SUBA_THIN_SLICE.md` CONDITIONAL PASS → REWORK for the two P2 anon/guest defects + the CI housekeeping item. Built on top of code `a511b7944` / tester adversarial test `577de017b`. NOT deployed/merged.
+
+### Fixes
+
+**P2-1 — guest double-fire / non-atomic outbox claim → CLOSED.**
+- The drain claimed pending rows with a non-atomic `select status='pending'` then per-row `update status='processing'` — two overlapping cron runs could both claim the same row (the guest/no-`user_id` path has no `notifications` UNIQUE backstop → double SMS/email).
+- New migration `20261110000004_orch_1161_atomic_claim_and_guest_ledger.sql` adds `claim_notification_outbox(p_limit int)` — a SECURITY DEFINER function doing a single `UPDATE … WHERE id IN (SELECT id … WHERE status='pending' ORDER BY created_at FOR UPDATE SKIP LOCKED LIMIT N) RETURNING *`. The drain (`notify-outbox-drain/index.ts`) now calls this RPC instead of select-then-update, and the redundant per-row mark-processing UPDATE is removed.
+- **Second line of defense (dispatcher idempotency for guests):** the guest delivery ledger now carries `idempotency_key`, and a partial `UNIQUE(idempotency_key, channel) WHERE idempotency_key IS NOT NULL AND notification_id IS NULL` makes a second dispatch of the same key a 23505 → `dispatchAnon` skips the provider HTTP. This mirrors, for guests, the `notifications` UNIQUE backstop the `user_id` path already had.
+
+**P2-2 — guest sends not written to the delivery ledger → CLOSED.**
+- `notification_deliveries.notification_id` relaxed to NULLABLE; added `contact` + `idempotency_key` columns; added `CHECK (notification_id IS NOT NULL OR contact IS NOT NULL)` (no orphan rows).
+- `dispatchAnon` (`_shared/notifyV2.ts`) now writes a CONTACT-KEYED delivery row per guest send (email + SMS; push n/a for guest), claimed `queued` then reconciled to the provider result (`sent`/`failed` + `provider_message_id` + `segments`).
+- The Twilio status webhook (`twilio-message-status`) already reconciles by `provider_message_id` + `channel='sms'` with NO `notification_id` filter — so guest rows reconcile automatically; no webhook change needed.
+
+**CI registration → DONE.** Added `supabase/functions/__tests__/**` to the workflow trigger `paths` (push + pull_request) and a new `notification-deno-tests` job in `.github/workflows/supabase-migrations-and-stripe-deno.yml` that enumerates ALL THREE 1161 Deno test files (happy-path + tester adversarial + this rework's). Batch-run verified locally (CI parity): 13 passed | 0 failed.
+
+### Files changed (rework)
+| File | Change |
+|---|---|
+| `supabase/migrations/20261110000004_orch_1161_atomic_claim_and_guest_ledger.sql` | NEW (+~115) — atomic claim fn + guest ledger schema |
+| `supabase/functions/notify-outbox-drain/index.ts` | atomic `claim_notification_outbox` RPC; removed non-atomic select + per-row mark-processing (~−12/+12) |
+| `supabase/functions/_shared/notifyV2.ts` | `dispatchAnon` writes contact-keyed ledger + per-channel dedupe; `MinimalClient.update`; `insertGuestDelivery`/`updateGuestDelivery` helpers (~+70) |
+| `.github/workflows/supabase-migrations-and-stripe-deno.yml` | trigger paths + `notification-deno-tests` job (~+40) |
+| `supabase/functions/__tests__/orch_1161_guest_ledger_and_dedupe.test.ts` | NEW (2 tests) — proves the fixes; fails-on-revert |
+
+### How atomicity is guaranteed
+`claim_notification_outbox` flips `pending → processing` inside ONE statement whose inner `SELECT … FOR UPDATE SKIP LOCKED` row-locks the chosen rows; a concurrent drain invocation cannot lock the same rows and SKIPs them. Runtime-proven against real Postgres `supabase/postgres:17.4.1.075`: two concurrent claims (session A holding locks on c6–c10, session B claiming live) returned **disjoint** sets (A={c6..c10}, B={c1..c5}, overlap NONE). The dispatcher-level guest dedupe (partial UNIQUE) is the backstop if a single logical notification is ever re-enqueued.
+
+### Guest-ledger proof (runtime, real Postgres 17)
+- `notification_id` nullable: YES.
+- Guest insert (`notification_id NULL`, `contact` set) OK; duplicate `(idempotency_key, channel)` rejected with 23505; same `idempotency_key` + different `channel` allowed.
+- Orphan row (no `notification_id`, no `contact`) rejected by the CHECK.
+- `claim_notification_outbox(2)` over 3 pending rows claimed the 2 oldest and flipped exactly those to `processing` (third stayed `pending`).
+- `has_function_privilege` for `anon` and `authenticated` on `claim_notification_outbox(int)` = **false** (SECURITY DEFINER auto-grant gotcha closed).
+
+### Regression test (rework)
+- Path: `supabase/functions/__tests__/orch_1161_guest_ledger_and_dedupe.test.ts` (2 tests: G1 guest ledger write, G2 guest dedupe).
+- Run: 2 passed | 0 failed. Combined 1161 suite (3 files): **13 passed | 0 failed**.
+- **fails-on-revert verified at `577de017b`** (branch HEAD before the rework commit): deleting the `if (claim.duplicate) { … continue; }` dedupe guard in `dispatchAnon` → G2 FAILS (twilio===2 not 1); restored → pass. Neutering `insertGuestDelivery` (true line-deletion of the ledger write) → BOTH G1 and G2 FAIL; restored → pass.
+
+### CI registration confirmation
+All three files present and enumerated; CI-parity batch run (`deno test … orch_1161_notify_dispatch_v2.test.ts orch_1161_anon_guest_path.test.ts orch_1161_guest_ledger_and_dedupe.test.ts`) → 13 passed. `git diff origin/main --name-status` shows all three test files as `A` (added) — append-only satisfied; the tester's A3 (`twilio===2`) is UNCHANGED (its fake client never simulates the DB UNIQUE conflict, so it still passes — the dedupe is a real-DB constraint, proven separately in `orch_1161_guest_ledger_and_dedupe.test.ts` + the Postgres runtime probe).
+
+### Guards held (rework)
+- Legacy `notify-dispatch` `type` path: BYTE-IDENTICAL (untouched this rework).
+- `SMS_LIVE_ENABLED_US` default false: unchanged.
+- Migration monotonic: `20261110000004` > all local + sibling-worktree prefixes.
+- `claim_notification_outbox` REVOKE PUBLIC + anon + authenticated (service-role only).
+- DO-NOT-TOUCH (send-otp/verify-otp, venue send path, Stripe money seam, reservation lifecycle money RPCs): untouched.
+- strict-grep `i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs`: PASS. `deno check` on all 4 touched edge fns: clean.
+
+### Operator action required (rework — additive to §11)
+- **Apply the new migration** (in order, after REVIEW): `20261110000004_orch_1161_atomic_claim_and_guest_ledger.sql` is part of the same `db push` chain in §11 (applies after `…000003`).
+- **No new edge fn** to deploy beyond §11's list; `notify-outbox-drain` and `notify-dispatch` (v2 core) are re-deployed from MERGED main with the rework changes.
+- **Cron migration `…000003` (vault/net) unchanged** — the cron now POSTs the drain which calls the new claim RPC.

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA_THIN_SLICE.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA_THIN_SLICE.md
@@ -1,0 +1,176 @@
+# TEST — META-ORCH-1161 Sub-A (THIN SLICE) — buyer_reservation_changed end-to-end
+
+**ORCH:** META-ORCH-1161 Sub-A (thin slice)
+**Phase:** TEST (mingla-tester, adversarial)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[notif-system]/` on branch `ORCH-1161-notif-system`
+**Under test:** code commit `a511b7944`, report `6faa0dcbd`
+**Tester adversarial test commit:** `577de017b`
+**Date:** 2026-06-20
+**Mode:** TARGETED + SPEC-COMPLIANCE (backend-only — Phase 0.A live-fire-sim EXEMPT: no UI/runtime surface ships this slice; verified against real Postgres + Deno runtime instead)
+
+---
+
+## 1. VERDICT: **CONDITIONAL PASS**
+
+**P0: 0 | P1: 0 | P2: 2 | P3: 1 | P4: 3**
+
+Zero P0, zero unaccepted P1. The slice is correct and well-built; the two P2s are pre-disclosed limitations (anon-path idempotency gap + anon-path delivery-ledger gap) that do not block the thin-slice /goal and are the documented Sub-C hardening surface. **The CONDITIONAL is because the live SMS leg cannot be end-to-end-proven without a deployed Twilio + a flipped kill-switch (operator-owned go/no-go), and the two P2 anon-path gaps should be Seth-accepted (carried to Sub-C) rather than fixed in this slice.** If Seth accepts the two P2s as Sub-C carry-forward, this is a clean ship.
+
+Regression gate: SATISFIED — implementor happy-path test (fails-on-revert reproduced by me) + tester adversarial test (different angle, on-branch, in-diff, its own fails-on-revert) both present.
+
+---
+
+## 2. What I RUNTIME-PROVED vs SUSPECTED
+
+### RUNTIME-PROVEN (real Postgres `supabase/postgres:15.8.1.060` in Docker + Deno 2.7.14)
+- **Migrations apply IN ORDER against real Postgres** (the implementor's biggest unverified gap — they had no Docker). All 4 migrations `20261110000000→3` applied clean in sequence (the only failures were environment stubs — `auth.uid()`/`auth.users` absent in a bare container — resolved by stubbing the Supabase runtime objects, then clean).
+- **Monotonic versioning:** `20261110000000-3` > origin/main max `20261015000001`. ✓
+- **RLS enabled on all 6 new tables** (`relrowsecurity=t` for categories, channel_prefs, channel_suppressions, consent_records, deliveries, outbox). ✓
+- **REVOKE PUBLIC+anon on every SECURITY DEFINER fn** (the auto-grant gotcha): `can_send` → public=f, anon=f, authenticated=t; `orch_1161_reservation_notify_outbox` (trigger fn) → public=f, anon=f, auth=f. ✓
+- **`notification_outbox` is service-role-only** (0 RLS policies → all authenticated/anon access denied). ✓
+- **DC-3 closed SMS set:** exactly 7 categories have `urgency=high AND 'sms' in default_channels`; `buyer_purchase_confirmation` correctly NOT among them (DEC-185 removed purchase SMS). ✓
+- **Scope separation (I-PROPOSED-1161-TRANSACTIONAL-VS-MARKETING-CONSENT-SEPARATED):** a `scope='marketing'` STOP on a phone → `can_send(transactional, 'sms')` returns **TRUE** (not blocked); `marketing_blast` blocked. A `scope='all'` STOP → transactional **FALSE** (correct carve-out). ✓
+- **NULL user_id (anon/guest) does not crash `can_send`** (SPEC R-7): contact-keyed sms → TRUE; push with NULL contact → TRUE. ✓
+- **Reservation trigger fires correctly:** requested→confirmed enqueues `buyer_reservation_confirmed`; table change enqueues `buyer_reservation_changed`; a no-op UPDATE (party_size=party_size, guest_name change) enqueues NOTHING. ✓
+- **STOP round-trip:** inbound-webhook-style `scope='all'` suppression insert → next transactional SMS denied; repeat STOP idempotent via the partial unique index (INSERT 0 0, 1 row). ✓
+- **Legacy `notify-dispatch` `type` path is BYTE-IDENTICAL:** `git diff origin/main...HEAD` on `notify-dispatch/index.ts` shows ZERO deletions — purely an import + an early additive `if (category_key)` branch. `twilio-message-status` diff also 0 deletions (additive). ✓
+- **SMS kill-switch zero-HTTP:** smsAdapter returns `skipped` BEFORE `twilioSend` is reachable; my adversarial test stubs `fetch` and asserts `counters.twilio === 0` with the switch OFF. ✓
+- **Simultaneous send (DEC-185, supersedes SPEC §5.4 waterfall):** `dispatchV2` writes inapp always, then fans out push+email+sms in parallel via `Promise.all` — no fallback ordering. ✓ (Deviation is documented in the impl report §1; the dispatch contract / DEC-185 governs.)
+- **GSM-7 + segment count:** sanitizer normalizes smart quotes/em-dash/ellipsis/nbsp/bullet; templates authored ASCII-clean; `buyer_reservation_changed` SMS + STOP footer is single-segment. ✓
+- **8/8 implementor Deno tests pass; 3/3 tester adversarial pass; 11/11 combined.** ✓
+- **`deno check` clean** on all 5 touched edge functions; strict-grep gate `i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs` passes (exit 0). ✓
+
+### SUSPECTED (could not runtime-prove — no live deploy / no Twilio in test)
+- **End-to-end live SMS delivery + a real Twilio STOP round-trip** — requires `SMS_LIVE_ENABLED_US=true` + deployed `twilio-inbound-sms` webhook wired in the Twilio console. This is the §8 operator go/no-go gate, intentionally OFF. Source + stubbed-fetch + SQL prove the LOGIC; live delivery is operator-owned.
+- **The pg_cron drain actually firing every minute against live vault/pg_net** — `cron.schedule` registered correctly (proven); the `$cron$` body references `vault.decrypted_secrets`/`net.http_post` which exist only in deployed Supabase (the migration's own DO-block advisory NOTICE flags this). Suspected-correct (mirrors the proven `marketing-send` cron verbatim).
+- **OneSignal push actually delivering** — pushAdapter wraps the existing proven `sendPush`; not re-fired live here.
+
+---
+
+## 3. Migration-apply result (the headline gap, now CLOSED)
+
+| Migration | Apply result (real Postgres, in order) |
+|---|---|
+| `20261110000000_..._foundation_tables` | OK — 6 tables + 6 RLS enables + 5 policies (after stubbing `auth.uid()`/`auth.users`, which are Supabase-runtime objects absent from a bare container — NOT a migration defect) |
+| `20261110000001_..._seed_categories` | OK — INSERT 0 16, idempotent ON CONFLICT upsert |
+| `20261110000002_..._can_send_and_trigger` | OK — `can_send` + trigger fn + `AFTER UPDATE` trigger; REVOKE/GRANT correct |
+| `20261110000003_..._outbox_drain_cron` | OK — `cron.schedule` registered `* * * * *`; advisory NOTICE for vault (expected in non-Supabase PG) |
+
+**Conclusion:** the migration chain is valid SQL, monotonic, and structurally sound. The implementor's "NOT run — no local Docker" gap is now independently closed.
+
+---
+
+## 4. Findings
+
+### P2-1 — Anon/guest path has NO idempotency dedupe → duplicate SMS/email on a double-fire
+- **Evidence:** `_shared/notifyV2.ts:217-254` (`dispatchAnon`) sends email/SMS directly with no dedupe. The `notifications` UNIQUE(idempotency_key) backstop (lines 96-115) guards ONLY the `user_id` path. The drain (`notify-outbox-drain/index.ts:47-68`) claims rows with a NON-atomic `select status='pending'` then `update status='processing'` — two overlapping crons (a run >60s) can both claim the same pending row. For a user-bearing reservation the downstream 23505 dedupes; for an anon/guest reservation it does NOT. **Proven by my adversarial test** `ANON: double-dispatch of the SAME idempotency_key sends SMS TWICE` → `counters.twilio === 2`.
+- **Impact:** a guest (created_via='guest', no consumer_user_id) reservation change could send the buyer two identical SMS (Twilio cost + UX) if the drain double-claims. Low probability today (every-minute cron, fast dispatch), real at scale or on a slow dispatch.
+- **Required fix (Sub-C):** make the drain claim atomic (a single `UPDATE ... WHERE status='pending' ... RETURNING` or `FOR UPDATE SKIP LOCKED`), OR add an anon-side dedupe keyed on `idempotency_key` (e.g. a unique `sent_outbox_idempotency` ledger checked before the anon send).
+- **Retest:** re-run `orch_1161_anon_guest_path.test.ts`; flip the A3 assertion to `assertEquals(counters.twilio, 1)` once fixed.
+- **Status:** pre-disclosed in impl report §10 ("anon reservations get email/SMS but no deliveries rows") — but the report frames it as a ledger gap, NOT a double-send gap. This finding sharpens it. Recommend Seth-accept as Sub-C carry-forward.
+
+### P2-2 — Anon/guest deliveries are NOT recorded in `notification_deliveries`
+- **Evidence:** `dispatchAnon` returns inline deliveries but writes NO `notification_deliveries` rows (the FK requires a `notifications.id`, and `notifications.user_id` is NOT NULL → no inbox row for a user-less guest). `notifyV2.ts:214-216` comment acknowledges this.
+- **Impact:** for guest reservations there is no durable cross-channel delivery ledger; the Twilio status webhook (`provider_message_id` reconcile) has no row to update → guest SMS delivery/failure is unobservable in `notification_deliveries`.
+- **Required fix (Sub-C):** either relax `notifications.user_id` to nullable for guest rows, or add a guest-scoped delivery ledger not FK-bound to `notifications`.
+- **Status:** pre-disclosed (impl report §10). Recommend Seth-accept as Sub-C carry-forward.
+
+### P3-1 — Idempotency key uses millisecond wall-clock `now()` → dedupes only WITHIN a transaction
+- **Evidence:** `20261110000002...sql:148` builds `idempotency_key = category || ':' || id || ':' || to_char(now(),'YYYYMMDD"T"HH24MISSMS')`. `now()` is transaction-start time (stable per-txn), so two identical changes in ONE txn dedupe via `ON CONFLICT`; two identical changes in SEPARATE transactions get DIFFERENT keys → no dedupe. SPEC §7.2 specified `:{transitionAt}` which is itself per-transition, so this matches intent — but it means the outbox idempotency only protects against same-txn re-fires, not logical-duplicate transitions.
+- **Impact:** minor — a legitimate distinct transition SHOULD get a distinct notification, so this is arguably correct. Flagged because it interacts with P2-1 (the dedupe people might assume exists across the drain does not).
+- **Required fix:** none required for the thin slice; document the semantics. Consider a coarser bucket (e.g. truncate to the second, or use the reservation `updated_at`) if cross-txn dedupe is ever desired.
+
+### P4 (praise)
+- **P4-1:** `notify-dispatch` v2 is a textbook additive branch — ZERO deletions on the legacy path, proven by diff. Exactly the §5.7 transitional contract. Constitution Rule 7 ([TRANSITIONAL] labels) honored.
+- **P4-2:** the kill-switch returns `skipped` before any Twilio env is even read — the cost-law fails CLOSED. Clean.
+- **P4-3:** every SECURITY DEFINER fn carries the explicit REVOKE PUBLIC + REVOKE anon (the well-known Supabase auto-grant gotcha) — independently verified live.
+
+---
+
+## 5. Step 0.5 — Independent re-run of the implementor's fails-on-revert proof
+
+- **Checked-out commit:** `a511b7944` (current branch HEAD before my test commit).
+- **Ran:** `deno test ... orch_1161_notify_dispatch_v2.test.ts` → **8 passed | 0 failed**.
+- **Reverted the fix** by true line-deletion of the kill-switch guard block (`const killSwitch = ...; if (!envTrue(killSwitch)) { return skipped }`) in `smsAdapter.ts` → **6 passed | 2 failed**:
+  - FAIL: `smsAdapter: kill-switch OFF returns skipped WITHOUT an HTTP call` (asserts on the skipped status / no-call mechanism, asserts.ts:190).
+  - FAIL: `dispatchV2: kill-switch OFF — inapp+push+email fire, SMS skipped (no fallback)` — `AssertionError: SMS skipped when kill-switch off` (test file:239).
+- **Restored** the guard → **8 passed | 0 failed**.
+- **Conclusion:** the implementor's `fails-on-revert verified at a511b7944` claim is REPRODUCED. ✓
+
+---
+
+## 6. Adversarial test added (different angle, on-branch, in-diff)
+
+- **Path:** `supabase/functions/__tests__/orch_1161_anon_guest_path.test.ts`
+- **Commit:** `577de017b` (on branch `ORCH-1161-notif-system`)
+- **Angle:** the ANON/GUEST path (`dispatchV2 → dispatchAnon`, `user_id === null`) — which NONE of the implementor's 8 tests exercise (all use a user_id). Stubs `globalThis.fetch` to COUNT Twilio HTTP. Three tests:
+  1. anon kill-switch OFF → SMS `skipped`, ZERO Twilio HTTP, no push/inapp attempted;
+  2. anon kill-switch ON → exactly 1 Twilio HTTP per single dispatch;
+  3. anon double-dispatch of the SAME idempotency_key → SMS sent TWICE (pins the P2-1 gap).
+- **fails-on-revert verified at `a511b7944`** — deleting the smsAdapter kill-switch guard makes the anon SMS leg hit `fetch` → test 1's `counters.twilio === 0` assertion FAILS (asserts.ts:190, test file:116, `2 passed | 1 failed`); restore → `3 passed`.
+- **Both tests confirmed in the closing diff:** `git diff origin/main...HEAD --name-only -- supabase/functions/__tests__/` lists BOTH `orch_1161_notify_dispatch_v2.test.ts` and `orch_1161_anon_guest_path.test.ts`. ✓
+
+---
+
+## 7. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|---|---|---|
+| 1 | No dead taps | N/A | no UI in this slice |
+| 2 | One owner per truth | PASS | `notify-dispatch` v2 = sole dispatch entry; adapters = sole provider-HTTP owners; `notification_deliveries` = sole cross-channel ledger (transitional dual-write labeled) |
+| 3 | No silent failures | PASS | every can_send denial / no-contact writes a `suppressed`/`skipped` deliveries row; drain re-queues on failure (3 attempts → `failed`, not dropped); consent-write failure logged non-fatal. ONE soft spot: anon path has no ledger (P2-2) but returns inline deliveries (not silent) |
+| 4 | One query key per entity | N/A | edge/SQL only |
+| 5 | Server state server-side | N/A | no client state |
+| 6 | Logout clears everything | N/A | no client |
+| 7 | `[TRANSITIONAL]` + exit | PASS | `META-ORCH-1161 transitional:` labels on the v2 branch + notifyV2; exit = legacy `type` retired at CLOSE |
+| 8 | Subtract before adding | PASS | additive-only by design (legacy path 0 deletions); no parallel new sender |
+| 9 | No fabricated data | PASS | templates render from payload only; default branch never fabricates (renders payload.body or a plain notice) |
+| 10 | Currency-aware | N/A | no money |
+| 11 | One auth instance | N/A | service-role only |
+| 12 | Validate at right time | PASS | trigger only enqueues on a real status/table/time change; idempotency on transition instant |
+| 13 | Exclusion consistency | PASS | DC-3 closed SMS set holds (7 high-urgency sms rows; can_send denies channel-not-in-default) |
+| 14 | Persisted-state startup | N/A | no client hydration |
+
+No violations → no automatic P0.
+
+---
+
+## 8. Device / parity matrix
+
+| Surface | Result | Note |
+|---|---|---|
+| Consumer iOS | N/A (skip) | no UI shipped this slice (impl §8: indirect only). |
+| Consumer Android | N/A (skip) | same. |
+| Buyer/anon Web | N/A (skip) | no buyer-web file touched. |
+| Business iOS | N/A (skip) | brand push untouched. |
+| Business Android | N/A (skip) | same. |
+| Admin Web | N/A | OUT of META-ORCH-1161. |
+| Backend (`supabase/`) | **PASS (runtime-proven)** | the whole slice; real-Postgres migration apply + Deno runtime + stubbed-fetch + SQL live-fire. |
+
+Physical-iPhone HITL: not applicable (no user-touchable surface this slice). **Edge-fn live deploy state:** the 2 new + 2 extended edge fns are NOT yet deployed (operator-owned, from merged main per impl §11) — confirmed via the impl report; not independently checked against live Supabase because nothing is merged yet.
+
+---
+
+## 9. Discoveries for Orchestrator (not fixed here)
+
+- **DEC-185 / DEC-186 ID COLLISION (carry the impl's Discovery #2).** The local `DECISION_LOG.md` DEC-185/DEC-186 are ORCH-1146/1151 (experience-parser) decisions — NOT the "simultaneous policy send" / "bundled consent" decisions the dispatch + this slice reference. The notification DEC-185 (simultaneous send) governs the code (correctly), but it is NOT in `DECISION_LOG.md`. **Orchestrator must log the notification decisions under FRESH, non-colliding IDs at CLOSE** or the audit trail is ambiguous. The SPEC §5.4 (push-first/SMS-fallback waterfall) is SUPERSEDED by simultaneous-send — record that supersession explicitly.
+- **COMMS-0038 (I-PROPOSED-BV realtime-publication gate) RED on origin/main** is pre-existing (META-ORCH-1148) and does NOT block this slice (it adds no realtime subscriptions). Noted, not chased — per dispatch instruction. The closing PR will inherit the red gate until 1148 fixes it.
+- **CI coverage:** the 2 Deno test files are NOT in `.github/workflows/supabase-migrations-and-stripe-deno.yml` DENO_TEST_FILES (impl §10). Orchestrator should add both paths at CLOSE so they gate future PRs.
+- **The COPY file** (`COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md`) lives in the anchor, not on origin/main — commit it to main for durability (impl Discovery #3). The `[[FILL]]` legal placeholders block the Sub-B/checkout consent-disclosure path.
+- **`payout_paid` business SMS category** was seeded (a single business SMS per DEC-185/COPY §3.12) though the SPEC §2 non-goal said "brand SMS OUT." This is a documented DEC-185 deviation, not a defect — but the SPEC non-goal and the seed now disagree; orchestrator should reconcile the SPEC text.
+
+---
+
+## 10. Accepted conditions (CONDITIONAL PASS)
+
+This verdict is CONDITIONAL on Seth accepting, as deliberate Sub-C carry-forward (not this-slice rework):
+1. **P2-1** — anon/guest path has no idempotency dedupe (double-claim → duplicate guest SMS/email). Fix in Sub-C (atomic drain claim).
+2. **P2-2** — anon/guest deliveries are not recorded in `notification_deliveries` (no FK-bound ledger for user-less guests). Fix in Sub-C.
+
+If Seth accepts both → this routes to CLOSE. If either must be fixed in the thin slice → routes to REWORK (implementor), cited above by file:line.
+
+---
+
+## Downstream routing
+
+CONDITIONAL PASS with two P2 conditions requiring Seth's accept → **STOP and surface to Seth** (do not auto-route to CLOSE). On Seth's accept of P2-1 + P2-2 as Sub-C carry-forward → orchestrator CLOSE (flip I-PROPOSED-1161-* ACTIVE, log the notification DEC-185/186 under non-colliding IDs, add the 2 Deno test paths to CI). On reject → REWORK to implementor for the atomic drain claim + guest delivery ledger.

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA_THIN_SLICE.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA_THIN_SLICE.md
@@ -174,3 +174,63 @@ If Seth accepts both → this routes to CLOSE. If either must be fixed in the th
 ## Downstream routing
 
 CONDITIONAL PASS with two P2 conditions requiring Seth's accept → **STOP and surface to Seth** (do not auto-route to CLOSE). On Seth's accept of P2-1 + P2-2 as Sub-C carry-forward → orchestrator CLOSE (flip I-PROPOSED-1161-* ACTIVE, log the notification DEC-185/186 under non-colliding IDs, add the 2 Deno test paths to CI). On reject → REWORK to implementor for the atomic drain claim + guest delivery ledger.
+
+---
+
+# RE-VERIFY 2026-06-20 — RETEST after REWORK (P2-1 + P2-2 fixed in-slice)
+
+**Mode:** RETEST (mingla-tester, adversarial). Backend/SQL/edge-only → Phase 0.A live-fire-sim EXEMPT (no UI/runtime surface). Runtime proof = real Postgres `supabase/postgres:17.4.1.075` (CI-identical image) + Deno 2.7.x.
+**Under test:** REWORK commit `14cb98412` (7 files; the two P2s were sent back rather than Seth-accepted).
+**New migration:** `20261110000004_orch_1161_atomic_claim_and_guest_ledger.sql`.
+
+## RE-VERIFY VERDICT: **PASS**
+
+**P0: 0 | P1: 0 | P2: 0 | P3: 1 (carried, advisory) | P4: 3 (carried).**
+
+Both prior P2s are CLOSED with runtime proof against a real Postgres. The rework is tightly scoped (7 files; legacy path / `can_send` / `smsAdapter` / migration `…000002` all UNTOUCHED), the migration chain applies in order, CI now actually runs all three 1161 Deno files, and the regression gate is satisfied with an independently-reproduced fails-on-revert. **CLEAR TO CLOSE.**
+
+The earlier CONDITIONAL was gated on Seth accepting the two P2s as Sub-C carry-forward; the implementor instead fixed them in-slice, so that condition is moot and the verdict upgrades to a clean PASS.
+
+## What I RUNTIME-PROVED this cycle
+
+### P2-1 CLOSED — atomic outbox claim (real Postgres 17, true concurrency)
+- `claim_notification_outbox(int)` confirmed live: **SECURITY DEFINER = t**, body contains **`FOR UPDATE SKIP LOCKED`**, and **REVOKE'd** — `has_function_privilege` for anon / authenticated / public all = **false** (auto-grant gotcha closed). ✓
+- **Concurrency disjointness proof:** seeded 10 pending outbox rows. Session A opened a txn, called `claim_notification_outbox(5)`, and **held its row locks for 4s** while Session B concurrently called `claim_notification_outbox(10)`. Result: **A claimed 5, B claimed 5, OVERLAP = 0 double-claimed rows, 10 distinct rows total, all flipped to `processing`.** Two overlapping drains CANNOT claim the same row → exactly-once forwarding. ✓
+- **Guest dedupe backstop proven:** duplicate insert of `(idempotency_key, channel)` on a guest row (notification_id NULL) → **23505 `duplicate key … notification_deliveries_guest_idem_idx`** (a repeated guest send is a no-op skip); same key + different channel → allowed. This is the second line of defense for the no-user_id path that lacks the `notifications` UNIQUE backstop. ✓
+
+### P2-2 CLOSED — guest delivery ledger (real Postgres 17)
+- `notification_deliveries.notification_id` is now **NULLABLE**; `contact` + `idempotency_key` columns present. ✓
+- No-orphan integrity: `CHECK (notification_id IS NOT NULL OR contact IS NOT NULL)` confirmed; a row with **neither** set is **rejected by `check_violation`**; a guest row (notification_id NULL, contact set) is accepted. There is no way to write a delivery with neither key. ✓
+- Guest partial UNIQUE confirmed verbatim: `(idempotency_key, channel) WHERE idempotency_key IS NOT NULL AND notification_id IS NULL` (does not touch the authenticated path). ✓
+- `dispatchAnon` (`_shared/notifyV2.ts`) now writes a contact-keyed delivery row per guest send, claimed `queued` → reconciled to the provider result; the Twilio status webhook reconciles by `provider_message_id` with no `notification_id` filter → guest rows reconcile automatically. ✓ (source-confirmed; webhook untouched.)
+
+### Migration chain — applies IN ORDER after `…000003`, monotonic, RLS/REVOKE intact
+- `20261110000000 → 000004` applied in sequence against the CI-identical Postgres-17 image. `000000/000001/000002/000004` apply **clean**; `000003` errors ONLY on `cron.job` absent in a bare container — installing `pg_cron` (as the CI baseline does via `CREATE EXTENSION`) makes `000003` apply clean and register the cron job (`cron.schedule` jobid 1; only NOTICE is the expected vault advisory). NOT a migration defect. ✓
+- `20261110000004` > all existing 1161 prefixes and every sibling-worktree prefix → monotonic. The re-affirmed `notification_deliveries_read_own` RLS policy + the three REVOKEs on the new function are all present live. ✓
+
+### No regression to prior PASS items
+- **Rework scope:** commit `14cb98412` touched exactly 7 files — none of `notify-dispatch/index.ts` (legacy path), `…000002` (`can_send`), or `smsAdapter.ts`. Legacy `type` path is structurally **byte-identical**. ✓
+- **Marketing-scope STOP does NOT kill transactional (re-proven live):** a `scope='marketing'` STOP on a phone → `can_send(NULL,'buyer_reservation_changed','sms',phone)` = **t**; `can_send(…,'marketing_blast',…)` = **f**; a `scope='all'` STOP → transactional = **f**. ✓
+- **SMS kill-switch zero-HTTP:** re-proven via the Deno suite (`dispatchV2: kill-switch OFF` + anon `ZERO Twilio HTTP` both pass; smsAdapter returns `skipped` before any Twilio HTTP). ✓
+- strict-grep `i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs`: **PASS (exit 0)**; `deno check` on the 2 rework-touched edge fns: **clean**.
+
+### CI registration — both (all three) 1161 Deno files now enumerated and triggered
+- `.github/workflows/supabase-migrations-and-stripe-deno.yml` adds a new **`notification-deno-tests`** job enumerating all three files: `orch_1161_notify_dispatch_v2.test.ts`, `orch_1161_anon_guest_path.test.ts`, `orch_1161_guest_ledger_and_dedupe.test.ts`. The workflow `paths` trigger now includes `supabase/functions/__tests__/**` on **both** `push` and `pull_request` → they will actually run on CI. ✓
+- CI-parity batch run locally: **13 passed | 0 failed** (8 happy-path + 3 tester adversarial + 2 rework).
+
+### Tester's prior A3 (`twilio===2`) honored as append-only
+- The rework did **not** modify `orch_1161_anon_guest_path.test.ts` (append-only intact). That test's A3 still asserts `twilio===2` because its fake client never simulates the DB UNIQUE — correct: the dedupe is a real-DB constraint, and the FIXED behavior is proven in `orch_1161_guest_ledger_and_dedupe.test.ts` G2 (whose fake client DOES enforce the partial UNIQUE and asserts `twilio===1`) **and** independently in the live Postgres 23505 probe above. The dedupe is real, not a fake-client artifact. ✓
+
+## Independent fails-on-revert re-run (regression gate)
+- **Path:** `supabase/functions/__tests__/orch_1161_guest_ledger_and_dedupe.test.ts` (G1, G2). In-diff vs origin/main as `A` (added), alongside the other two 1161 files.
+- **Revert 1 (dedupe guard):** true line-deletion of the `if (claim.duplicate) { … continue; }` block in `dispatchAnon` → **G2 FAILS** (1 passed | 1 failed); restore → 2 pass. ✓
+- **Revert 2 (ledger write):** true neutering of the `insertGuestDelivery` INSERT body → **BOTH G1 and G2 FAIL** (0 passed | 2 failed); restore → 2 pass; working tree confirmed byte-clean (`git diff --quiet` = YES). ✓
+- `fails-on-revert reproduced at 14cb98412.`
+
+## Residual / carried (non-blocking)
+- **P3-1 (carried):** the idempotency key uses txn-start `now()` → dedupes within a txn, not across logical-duplicate transitions. Unchanged this cycle; arguably correct (a distinct transition should get a distinct notification). Advisory only — does NOT block.
+- **P4-1/2/3 (carried praise):** additive legacy branch (0 deletions), kill-switch fails-closed before any Twilio env read, REVOKE on every SECURITY DEFINER fn (now incl. `claim_notification_outbox`).
+- **Discoveries (unchanged, orchestrator-owned at CLOSE):** notification DEC-185/186 must be logged under non-colliding IDs (local DEC-185/186 are the ORCH-1146/1151 experience decisions); the COPY file lives in the anchor, not origin/main; `payout_paid` business-SMS seed vs SPEC §2 non-goal needs reconciliation; COMMS-0038 (META-ORCH-1148 realtime CI red) is pre-existing and inherited by the closing PR — does NOT block 1161 (this slice adds no realtime subscriptions).
+
+## RE-VERIFY routing
+PASS → **CLEAR TO CLOSE.** Routes to orchestrator CLOSE: open a PR (will inherit the pre-existing COMMS-0038 red gate; not a 1161 defect), apply the migration chain `…000000 → …000004` in order via `db push` / Management API, deploy `notify-dispatch` + `notify-outbox-drain` + `twilio-inbound-sms` + `twilio-message-status` from MERGED main, flip I-PROPOSED-1161-* ACTIVE, and log the notification DEC-185/186 under non-colliding IDs.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -264,3 +264,15 @@ verify_jwt = false
 # refund-order). verify_jwt=false: the fn validates the JWT + auth.uid() itself.
 [functions.venue-reservation-cancel]
 verify_jwt = false
+
+# META-ORCH-1161 Sub-A — notify-outbox-drain: pg_cron drains notification_outbox
+# and forwards each row to notify-dispatch v2. verify_jwt=false: invoked by cron
+# with the service-role bearer.
+[functions.notify-outbox-drain]
+verify_jwt = false
+
+# META-ORCH-1161 Sub-A — twilio-inbound-sms: the STOP/HELP inbound webhook.
+# verify_jwt=false: Twilio cannot present a Supabase JWT; gated on ?secret=
+# (same posture as twilio-message-status).
+[functions.twilio-inbound-sms]
+verify_jwt = false

--- a/supabase/functions/__tests__/orch_1161_anon_guest_path.test.ts
+++ b/supabase/functions/__tests__/orch_1161_anon_guest_path.test.ts
@@ -1,0 +1,167 @@
+// META-ORCH-1161 Sub-A (thin slice) — TESTER ADVERSARIAL regression test.
+//
+// DIFFERENT ANGLE than the implementor's 8 happy-path tests, ALL of which run the
+// dispatcher with a user_id (the dispatchV2 inbox path). This file attacks the
+// ANON / GUEST reservation path (dispatchV2 → dispatchAnon, user_id == null) —
+// the contact-keyed path a `created_via='guest'` reservation takes. The SPEC R-7
+// risk ("anon/guest reservations have no push token + may lack email; ensure
+// can_send handles user_id IS NULL contact-keyed paths") is exactly this branch.
+//
+// What this proves at the dispatcher core (no real network — fetch is stubbed and
+// COUNTED so we can assert ZERO Twilio HTTP under the kill-switch):
+//   A1. Anon path fires email + SMS but NEVER push or inapp (no inbox row exists
+//       for a user-less reservation → no FK; the anon guard must skip them).
+//   A2. Kill-switch OFF on the anon path → SMS returns 'skipped' with ZERO Twilio
+//       HTTP. (fails-on-revert anchor: deleting the smsAdapter kill-switch guard
+//       makes the anon SMS leg hit fetch → the zero-HTTP assertion fails.)
+//   A3. IDEMPOTENCY GAP (adversarial discovery): a double-dispatch of the SAME
+//       idempotency_key on the anon path sends the SMS TWICE — dispatchAnon has
+//       NO dedupe (the notifications UNIQUE(idempotency_key) backstop only guards
+//       the user_id path). This test PINS the current behavior so a future dedupe
+//       fix is a deliberate, visible change. (Severity P2 — see TEST report.)
+//
+// Append-only: this is a NEW file; no existing test is modified.
+
+import { assert, assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import { dispatchV2, type MinimalClient } from "../_shared/notifyV2.ts";
+
+const ANON_CATEGORY = {
+  key: "buyer_reservation_changed",
+  is_transactional: true,
+  urgency: "high",
+  default_channels: ["inapp", "push", "email", "sms"],
+  active: true,
+};
+
+// A fake client that ALWAYS allows can_send (so the gate is not what skips SMS —
+// the kill-switch / anon-guard is). No notifications/deliveries tables are hit on
+// the anon path, so those return inert.
+function makeAnonClient(): MinimalClient {
+  return {
+    // deno-lint-ignore no-explicit-any
+    from(table: string): any {
+      if (table === "notification_categories") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: ANON_CATEGORY, error: null }),
+            }),
+          }),
+        };
+      }
+      // notifications/deliveries are never expected on the anon path; return inert.
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+        insert: () => Promise.resolve({ data: null, error: null }),
+      };
+    },
+    rpc(fn: string): Promise<{ data: unknown; error: unknown }> {
+      if (fn === "can_send") return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: null, error: null });
+    },
+  } as unknown as MinimalClient;
+}
+
+// Stub Deno's global fetch, counting Twilio + Resend hits.
+interface NetCounters { twilio: number; resend: number }
+function withStubbedFetch<T>(fn: (c: NetCounters) => Promise<T>): Promise<T> {
+  const counters: NetCounters = { twilio: 0, resend: 0 };
+  const orig = globalThis.fetch;
+  globalThis.fetch = ((url: string | URL | Request, _init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("api.twilio.com")) counters.twilio++;
+    if (u.includes("api.resend.com")) counters.resend++;
+    // Mimic a Twilio/Resend success envelope so the adapter returns 'sent'.
+    return Promise.resolve(
+      new Response(JSON.stringify({ sid: `stub-${counters.twilio + counters.resend}`, id: "stub" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    // deno-lint-ignore no-explicit-any
+  }) as any;
+  return fn(counters).finally(() => {
+    globalThis.fetch = orig;
+  });
+}
+
+function setTwilioEnv() {
+  Deno.env.set("TWILIO_ACCOUNT_SID", "ACtest");
+  Deno.env.set("TWILIO_AUTH_TOKEN", "tokentest");
+  Deno.env.set("TWILIO_MESSAGING_SERVICE_SID", "MGtest");
+  Deno.env.set("RESEND_API_KEY", "re_test");
+}
+
+// ── A1 + A2: anon path, kill-switch OFF → email attempted, SMS skipped, ZERO Twilio HTTP ──
+Deno.test("ANON: kill-switch OFF → SMS skipped with ZERO Twilio HTTP; no push/inapp; email attempted", async () => {
+  setTwilioEnv();
+  Deno.env.delete("SMS_LIVE_ENABLED_US"); // kill-switch OFF
+  const result = await withStubbedFetch(async (counters) => {
+    const r = await dispatchV2(makeAnonClient(), {
+      user_id: null, // ANON / GUEST
+      contact: "+15551234567", // phone-only guest
+      category_key: "buyer_reservation_changed",
+      payload: { reservation_id: "res-anon-1", status: "confirmed", brand_name: "Lantern & Vine", date: "Jun 20", time: "7:30 PM", party_size: 2 },
+      idempotency_key: "buyer_reservation_changed:res-anon-1:T1",
+      country_code: "US",
+    });
+    return { r, counters };
+  });
+
+  // notificationId is null on the anon path (no inbox row).
+  assertEquals(result.r.notificationId, null, "anon path must not mint an inbox row");
+  const sms = result.r.deliveries?.find((d) => d.channel === "sms");
+  assert(sms, "anon path with a phone contact must attempt the sms channel");
+  assertEquals(sms!.status, "skipped", "kill-switch OFF → SMS skipped");
+  // THE fails-on-revert anchor: ZERO Twilio HTTP while the kill-switch is off.
+  assertEquals(result.counters.twilio, 0, "kill-switch OFF must make ZERO Twilio HTTP calls on the anon path");
+  // anon path must NEVER attempt push or inapp (no user → no inbox FK).
+  assert(!result.r.deliveries?.some((d) => d.channel === "push"), "anon path must not attempt push");
+  assert(!result.r.deliveries?.some((d) => d.channel === "inapp"), "anon path must not write inapp");
+});
+
+// ── A2b: anon path, kill-switch ON → exactly ONE Twilio HTTP for one dispatch ──
+Deno.test("ANON: kill-switch ON → exactly one Twilio HTTP per single dispatch", async () => {
+  setTwilioEnv();
+  Deno.env.set("SMS_LIVE_ENABLED_US", "true");
+  const { counters } = await withStubbedFetch(async (counters) => {
+    await dispatchV2(makeAnonClient(), {
+      user_id: null,
+      contact: "+15551234567",
+      category_key: "buyer_reservation_changed",
+      payload: { reservation_id: "res-anon-2", brand_name: "Lantern & Vine", date: "Jun 20", time: "7:30 PM", party_size: 2 },
+      idempotency_key: "buyer_reservation_changed:res-anon-2:T1",
+      country_code: "US",
+    });
+    return { counters };
+  });
+  Deno.env.delete("SMS_LIVE_ENABLED_US");
+  assertEquals(counters.twilio, 1, "one anon dispatch with kill-switch ON → exactly one Twilio send");
+});
+
+// ── A3: idempotency GAP — a DOUBLE dispatch of the SAME idempotency_key on the
+//        anon path sends the SMS TWICE (no dedupe). Pins current behavior. ──
+Deno.test("ANON: double-dispatch of the SAME idempotency_key sends SMS TWICE (idempotency gap, P2)", async () => {
+  setTwilioEnv();
+  Deno.env.set("SMS_LIVE_ENABLED_US", "true");
+  const idem = "buyer_reservation_changed:res-anon-3:T1"; // identical key both times
+  const { counters } = await withStubbedFetch(async (counters) => {
+    const input = {
+      user_id: null,
+      contact: "+15551234567",
+      category_key: "buyer_reservation_changed",
+      payload: { reservation_id: "res-anon-3", brand_name: "Lantern & Vine", date: "Jun 20", time: "7:30 PM", party_size: 2 },
+      idempotency_key: idem,
+      country_code: "US" as const,
+    };
+    await dispatchV2(makeAnonClient(), input);
+    await dispatchV2(makeAnonClient(), input); // same key again (drain double-claim)
+    return { counters };
+  });
+  Deno.env.delete("SMS_LIVE_ENABLED_US");
+  // DOCUMENTED DEFECT: the anon path has no dedupe → 2 sends for the same key.
+  // If a future fix adds anon idempotency, flip this to assertEquals(...,1) and
+  // close the P2. Until then this PROVES the gap exists.
+  assertEquals(counters.twilio, 2, "anon path currently double-sends on an identical idempotency_key (no dedupe — P2 gap)");
+});

--- a/supabase/functions/__tests__/orch_1161_guest_ledger_and_dedupe.test.ts
+++ b/supabase/functions/__tests__/orch_1161_guest_ledger_and_dedupe.test.ts
@@ -1,0 +1,201 @@
+// META-ORCH-1161 Sub-A (REWORK 2026-06-20) — implementor regression test for the
+// two tester-found P2 defects (TEST_META-ORCH-1161_SUBA_THIN_SLICE.md P2-1, P2-2).
+//
+// DIFFERENT ANGLE from the tester's orch_1161_anon_guest_path.test.ts: that file
+// uses a fake client that NEVER simulates the DB UNIQUE conflict (so it pins the
+// pre-fix gap with twilio===2). THIS file uses a fake client that DOES enforce the
+// real partial UNIQUE(idempotency_key, channel) on guest delivery rows (added in
+// migration 20261110000004) AND captures the contact-keyed ledger inserts — so it
+// proves the FIXED behavior:
+//
+//   G1 (P2-2): a guest (user_id=null) SMS send now WRITES a contact-keyed
+//       notification_deliveries row (notification_id=null, contact + idempotency_key
+//       populated, provider_message_id set) — the observability gap is closed.
+//   G2 (P2-1): a DOUBLE dispatch of the SAME idempotency_key on the guest path now
+//       sends the SMS exactly ONCE — the second dispatch hits a 23505 on the dedupe
+//       slot and SKIPS the provider HTTP. (Twilio HTTP count === 1, not 2.)
+//
+// fails-on-revert: deleting the dedupe-claim block in dispatchAnon (the
+// `if (claim.duplicate) { … continue; }` guard) makes the second dispatch send
+// again → G2's twilio===1 assertion fails. Deleting the insertGuestDelivery call
+// makes G1's "ledger row written" assertion fail.
+//
+// Append-only: NEW file; no existing test modified.
+
+import { assert, assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import { dispatchV2, type MinimalClient } from "../_shared/notifyV2.ts";
+
+const GUEST_CATEGORY = {
+  key: "buyer_reservation_changed",
+  is_transactional: true,
+  urgency: "high",
+  default_channels: ["inapp", "push", "email", "sms"],
+  active: true,
+};
+
+interface LedgerRow {
+  notification_id: string | null;
+  contact: string | null;
+  idempotency_key: string | null;
+  channel: string;
+  status: string;
+  provider: string | null;
+  provider_message_id: string | null;
+  segments: number | null;
+}
+
+// A fake client that ENFORCES the real partial UNIQUE(idempotency_key, channel) on
+// guest rows (notification_id IS NULL) — i.e. it returns a {code:'23505'} on a
+// duplicate insert, exactly like Postgres. It captures every ledger row so the
+// test can assert the contact-keyed write.
+function makeGuestClient(ledger: LedgerRow[]): MinimalClient {
+  return {
+    // deno-lint-ignore no-explicit-any
+    from(table: string): any {
+      if (table === "notification_categories") {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: () => Promise.resolve({ data: GUEST_CATEGORY, error: null }) }),
+          }),
+        };
+      }
+      if (table === "notification_deliveries") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            const idem = (row.idempotency_key as string | null) ?? null;
+            const ch = row.channel as string;
+            const nid = (row.notification_id as string | null) ?? null;
+            // Enforce the partial UNIQUE(idempotency_key, channel) WHERE
+            // idempotency_key IS NOT NULL AND notification_id IS NULL.
+            if (idem !== null && nid === null) {
+              const dup = ledger.some(
+                (r) => r.idempotency_key === idem && r.channel === ch && r.notification_id === null,
+              );
+              if (dup) return Promise.resolve({ data: null, error: { code: "23505" } });
+            }
+            ledger.push({
+              notification_id: nid,
+              contact: (row.contact as string | null) ?? null,
+              idempotency_key: idem,
+              channel: ch,
+              status: row.status as string,
+              provider: (row.provider as string | null) ?? null,
+              provider_message_id: (row.provider_message_id as string | null) ?? null,
+              segments: (row.segments as number | null) ?? null,
+            });
+            return Promise.resolve({ data: null, error: null });
+          },
+          update: (patch: Record<string, unknown>) => ({
+            eq: (_c1: string, idemVal: unknown) => ({
+              eq: (_c2: string, chVal: unknown) => {
+                for (const r of ledger) {
+                  if (r.idempotency_key === idemVal && r.channel === chVal && r.notification_id === null) {
+                    if (patch.status !== undefined) r.status = patch.status as string;
+                    if (patch.provider_message_id !== undefined) {
+                      r.provider_message_id = patch.provider_message_id as string | null;
+                    }
+                    if (patch.segments !== undefined) r.segments = patch.segments as number | null;
+                  }
+                }
+                return Promise.resolve({ data: null, error: null });
+              },
+            }),
+          }),
+        };
+      }
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+        insert: () => Promise.resolve({ data: null, error: null }),
+      };
+    },
+    rpc(fn: string): Promise<{ data: unknown; error: unknown }> {
+      if (fn === "can_send") return Promise.resolve({ data: true, error: null });
+      return Promise.resolve({ data: null, error: null });
+    },
+  } as unknown as MinimalClient;
+}
+
+interface NetCounters { twilio: number; resend: number }
+function withStubbedFetch<T>(fn: (c: NetCounters) => Promise<T>): Promise<T> {
+  const counters: NetCounters = { twilio: 0, resend: 0 };
+  const orig = globalThis.fetch;
+  globalThis.fetch = ((url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("api.twilio.com")) counters.twilio++;
+    if (u.includes("api.resend.com")) counters.resend++;
+    return Promise.resolve(
+      new Response(JSON.stringify({ sid: `SM-stub-${counters.twilio}`, id: "stub" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    // deno-lint-ignore no-explicit-any
+  }) as any;
+  return fn(counters).finally(() => {
+    globalThis.fetch = orig;
+  });
+}
+
+function setEnv() {
+  Deno.env.set("TWILIO_ACCOUNT_SID", "ACtest");
+  Deno.env.set("TWILIO_AUTH_TOKEN", "tokentest");
+  Deno.env.set("TWILIO_MESSAGING_SERVICE_SID", "MGtest");
+  Deno.env.set("RESEND_API_KEY", "re_test");
+}
+
+// ── G1 (P2-2): a guest SMS send writes a contact-keyed deliveries row ──────────
+Deno.test("REWORK G1: guest SMS send writes a contact-keyed notification_deliveries row (P2-2)", async () => {
+  setEnv();
+  Deno.env.set("SMS_LIVE_ENABLED_US", "true");
+  const ledger: LedgerRow[] = [];
+  await withStubbedFetch(async () => {
+    await dispatchV2(makeGuestClient(ledger), {
+      user_id: null, // GUEST
+      contact: "+15551230000",
+      category_key: "buyer_reservation_changed",
+      payload: { reservation_id: "res-g1", brand_name: "Lantern & Vine", date: "Jun 20", time: "7:30 PM", party_size: 2 },
+      idempotency_key: "buyer_reservation_changed:res-g1:T1",
+      country_code: "US",
+    });
+  });
+  Deno.env.delete("SMS_LIVE_ENABLED_US");
+
+  const smsRow = ledger.find((r) => r.channel === "sms");
+  assert(smsRow, "guest SMS send MUST write a notification_deliveries row (P2-2 ledger gap closed)");
+  assertEquals(smsRow!.notification_id, null, "guest row is not tied to an inbox notification");
+  assertEquals(smsRow!.contact, "+15551230000".toLowerCase(), "guest row is contact-keyed");
+  assertEquals(smsRow!.idempotency_key, "buyer_reservation_changed:res-g1:T1", "guest row carries the idempotency_key");
+  assertEquals(smsRow!.status, "sent", "ledger reconciled to the provider result");
+  assert(smsRow!.provider_message_id !== null, "provider_message_id recorded for webhook reconcile");
+});
+
+// ── G2 (P2-1): a double dispatch of the SAME key sends SMS exactly ONCE ────────
+Deno.test("REWORK G2: guest double-dispatch of the SAME idempotency_key sends SMS ONCE (P2-1 dedupe)", async () => {
+  setEnv();
+  Deno.env.set("SMS_LIVE_ENABLED_US", "true");
+  const ledger: LedgerRow[] = [];
+  const idem = "buyer_reservation_changed:res-g2:T1";
+  const { counters } = await withStubbedFetch(async (counters) => {
+    const input = {
+      user_id: null,
+      contact: "+15551230001",
+      category_key: "buyer_reservation_changed",
+      payload: { reservation_id: "res-g2", brand_name: "Lantern & Vine", date: "Jun 20", time: "7:30 PM", party_size: 2 },
+      idempotency_key: idem,
+      country_code: "US" as const,
+    };
+    // Two ticks with the SAME key (a double-claimed outbox row).
+    await dispatchV2(makeGuestClient(ledger), input);
+    await dispatchV2(makeGuestClient(ledger), input);
+    return { counters };
+  });
+  Deno.env.delete("SMS_LIVE_ENABLED_US");
+
+  // THE fix: the second dispatch hits a 23505 on the (idempotency_key, channel)
+  // dedupe slot → skips the provider HTTP. Exactly ONE Twilio send.
+  assertEquals(counters.twilio, 1, "guest dedupe → a duplicated drain tick sends SMS exactly once (P2-1)");
+  // Exactly one sms ledger row exists for the key.
+  const smsRows = ledger.filter((r) => r.channel === "sms" && r.idempotency_key === idem);
+  assertEquals(smsRows.length, 1, "exactly one guest SMS ledger row for the idempotency_key");
+});

--- a/supabase/functions/__tests__/orch_1161_notify_dispatch_v2.test.ts
+++ b/supabase/functions/__tests__/orch_1161_notify_dispatch_v2.test.ts
@@ -1,0 +1,330 @@
+// META-ORCH-1161 Sub-A (thin slice) — Step 0.5 happy-path regression test.
+//
+// Proves the buyer_reservation_changed moment end-to-end at the dispatcher core:
+//   - reservation-change category fans out IN-APP + PUSH + EMAIL simultaneously
+//     (DEC-185: no waterfall — every allowed channel fires);
+//   - SMS fires ONLY when SMS_LIVE_ENABLED_US=true AND consent present AND not
+//     suppressed; with the kill-switch OFF the smsAdapter returns 'skipped'
+//     WITHOUT any Twilio HTTP call;
+//   - a STOP suppression (can_send → false for sms) skips the next SMS;
+//   - the GSM-7 sanitizer + segment count run on the SMS body.
+//
+// fails-on-revert: deleting the kill-switch guard in smsAdapter (the
+// `if (!envTrue(killSwitch))` block) makes the OFF case attempt a Twilio HTTP
+// call → the "no HTTP when off" assertion fails. See the report's Regression
+// Test section for the verified commit hash.
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import {
+  composeSmsBody,
+  computeSegments,
+  resolveMarketKillSwitch,
+  sanitizeGsm7,
+  smsAdapter,
+} from "../_shared/adapters/smsAdapter.ts";
+import { renderCategoryMessage } from "../_shared/notifyTemplates.ts";
+import { dispatchV2, type MinimalClient } from "../_shared/notifyV2.ts";
+
+// ── A fake supabase client modeling can_send + capturing deliveries ──────────
+interface FakeState {
+  category: Record<string, unknown> | null;
+  // suppressions: set of `${channel}` that are suppressed for sms scope
+  smsSuppressed: boolean;
+  // explicit per-channel opt-out (enabled=false)
+  optOutChannels: Set<string>;
+  isTransactional: boolean;
+  deliveries: Array<Record<string, unknown>>;
+  insertedNotification: boolean;
+}
+
+function makeClient(state: FakeState): MinimalClient {
+  return {
+    // deno-lint-ignore no-explicit-any
+    from(table: string): any {
+      if (table === "notification_categories") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: state.category, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "notifications") {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: () => {
+                state.insertedNotification = true;
+                return Promise.resolve({ data: { id: "notif-1" }, error: null });
+              },
+            }),
+          }),
+        };
+      }
+      if (table === "notification_deliveries") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            state.deliveries.push(row);
+            return Promise.resolve({ data: null, error: null });
+          },
+        };
+      }
+      // default no-op
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }) }),
+        insert: () => Promise.resolve({ data: null, error: null }),
+      };
+    },
+    rpc(fn: string, args: Record<string, unknown>): Promise<{ data: unknown; error: unknown }> {
+      if (fn === "can_send") {
+        const channel = args.p_channel as string;
+        // Mirror can_send() logic for the test fake.
+        const cat = state.category as { default_channels: string[] } | null;
+        if (!cat) return Promise.resolve({ data: false, error: null });
+        if (!cat.default_channels.includes(channel)) {
+          return Promise.resolve({ data: false, error: null });
+        }
+        if (state.optOutChannels.has(channel)) {
+          return Promise.resolve({ data: false, error: null });
+        }
+        if (channel === "sms" && state.smsSuppressed) {
+          return Promise.resolve({ data: false, error: null });
+        }
+        if (!state.isTransactional) {
+          // marketing requires explicit enable — fake denies by default
+          return Promise.resolve({ data: false, error: null });
+        }
+        return Promise.resolve({ data: true, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+  } as unknown as MinimalClient;
+}
+
+const RESERVATION_CHANGED_CATEGORY = {
+  key: "buyer_reservation_changed",
+  is_transactional: true,
+  urgency: "high",
+  default_channels: ["inapp", "push", "email", "sms"],
+  active: true,
+};
+
+const PAYLOAD = {
+  reservation_id: "res-1",
+  status: "confirmed",
+  date: "Jun 20",
+  time: "7:30 PM",
+  party_size: 4,
+  brand_name: "Lantern & Vine",
+};
+
+function baseState(overrides: Partial<FakeState> = {}): FakeState {
+  return {
+    category: RESERVATION_CHANGED_CATEGORY,
+    smsSuppressed: false,
+    optOutChannels: new Set(),
+    isTransactional: true,
+    deliveries: [],
+    insertedNotification: false,
+    ...overrides,
+  };
+}
+
+// ── 1. GSM-7 + segment + kill-switch unit assertions ─────────────────────────
+Deno.test("smsAdapter: GSM-7 sanitizer normalizes smart punctuation", () => {
+  const dirty = "Café ‘Bar’ — now … done";
+  const clean = sanitizeGsm7(dirty);
+  assert(!clean.includes("‘"), "left smart quote should be normalized");
+  assert(!clean.includes("’"), "right smart quote should be normalized");
+  assert(!clean.includes("—"), "em dash should be normalized");
+  assert(!clean.includes("…"), "ellipsis should be normalized");
+  assert(clean.includes("'Bar'"), "should produce straight quotes");
+  assert(clean.includes("..."), "ellipsis should become three dots");
+});
+
+Deno.test("smsAdapter: composeSmsBody appends STOP footer + computes >=1 segment", () => {
+  const body = composeSmsBody("Lantern & Vine: Your reservation changed - now Jun 20 7:30 PM, party of 4.");
+  assert(/reply stop to opt out\.?$/i.test(body), "STOP footer appended");
+  assertEquals(computeSegments(body) >= 1, true);
+});
+
+Deno.test("smsAdapter: kill-switch OFF returns skipped WITHOUT an HTTP call", async () => {
+  Deno.env.delete("SMS_LIVE_ENABLED_US");
+  // Force a fetch failure if the adapter ever tries to call out — proves no HTTP.
+  const origFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = (() => {
+    fetchCalled = true;
+    throw new Error("HTTP should not be called when kill-switch is OFF");
+  }) as typeof fetch;
+  try {
+    Deno.env.set("TWILIO_ACCOUNT_SID", "AC_test");
+    Deno.env.set("TWILIO_AUTH_TOKEN", "tok");
+    Deno.env.set("TWILIO_MESSAGING_SERVICE_SID", "MG_test");
+    const r = await smsAdapter.send({
+      to: "+14155550123",
+      brandName: "Lantern & Vine",
+      message: "test",
+      countryCode: "US",
+    });
+    assertEquals(r.status, "skipped");
+    assertEquals(r.ok, false);
+    assertEquals(fetchCalled, false, "no Twilio HTTP call when kill-switch off");
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+Deno.test("smsAdapter: resolveMarketKillSwitch routes NG vs US", () => {
+  assertEquals(resolveMarketKillSwitch("US"), "SMS_LIVE_ENABLED_US");
+  assertEquals(resolveMarketKillSwitch("NG"), "SMS_LIVE_ENABLED_NG");
+  assertEquals(resolveMarketKillSwitch(null), "SMS_LIVE_ENABLED_US");
+});
+
+// ── 2. Templates carry the verbatim COPY §3.1 ────────────────────────────────
+Deno.test("templates: buyer_reservation_changed SMS matches COPY §3.1", () => {
+  const r = renderCategoryMessage("buyer_reservation_changed", PAYLOAD);
+  assertEquals(
+    r.sms,
+    "Lantern & Vine: Your reservation changed - now Jun 20 7:30 PM, party of 4.",
+  );
+  assertEquals(r.push.title, "Reservation updated");
+  assertEquals(r.push.body, "Lantern & Vine: now Jun 20 7:30 PM, party of 4.");
+});
+
+// ── 3. Dispatcher fan-out: kill-switch OFF → push+inapp+email, SMS skipped ───
+Deno.test("dispatchV2: kill-switch OFF — inapp+push+email fire, SMS skipped (no fallback)", async () => {
+  Deno.env.delete("SMS_LIVE_ENABLED_US");
+  const origFetch = globalThis.fetch;
+  // push (OneSignal) + email (Resend) have no creds → adapters return failed,
+  // but the IMPORTANT assertion is that they were ATTEMPTED (a delivery row each)
+  // and that NO Twilio HTTP happens. Stub fetch to fail loudly on Twilio.
+  globalThis.fetch = ((url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("api.twilio.com")) {
+      throw new Error("Twilio must not be called when kill-switch off");
+    }
+    // Simulate provider success for push/email so deliveries are 'sent'.
+    return Promise.resolve(new Response(JSON.stringify({ id: "pm-1" }), { status: 200 }));
+  }) as typeof fetch;
+  try {
+    Deno.env.set("ONESIGNAL_APP_ID", "os-app");
+    Deno.env.set("ONESIGNAL_REST_API_KEY", "os-key");
+    Deno.env.set("RESEND_API_KEY", "re_test");
+    Deno.env.set("MINGLA_LOGO_URL", "https://usemingla.com/logo.png");
+    Deno.env.set("MINGLA_FOOTER_ADDRESS", "Mingla, hello@usemingla.com");
+
+    const state = baseState();
+    const client = makeClient(state);
+    const res = await dispatchV2(client, {
+      user_id: "user-1",
+      contact: "+14155550123",
+      category_key: "buyer_reservation_changed",
+      payload: PAYLOAD,
+      idempotency_key: "buyer_reservation_changed:res-1:t1",
+    });
+
+    assertEquals(res.success, true);
+    const byChannel = Object.fromEntries(
+      (res.deliveries ?? []).map((d) => [d.channel, d.status]),
+    );
+    assertEquals(byChannel["inapp"], "delivered");
+    assert("push" in byChannel, "push attempted");
+    assert("email" in byChannel, "email attempted");
+    assertEquals(byChannel["sms"], "skipped", "SMS skipped when kill-switch off");
+    // No SMS HTTP happened (the throw above would have failed the test).
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+// ── 4. Dispatcher: kill-switch ON + consent + no suppression → SMS sent ──────
+Deno.test("dispatchV2: kill-switch ON + not suppressed → SMS sent with segments", async () => {
+  Deno.env.set("SMS_LIVE_ENABLED_US", "true");
+  const origFetch = globalThis.fetch;
+  let twilioCalled = false;
+  globalThis.fetch = ((url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("api.twilio.com")) {
+      twilioCalled = true;
+      return Promise.resolve(new Response(JSON.stringify({ sid: "SM_test" }), { status: 201 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ id: "pm-1" }), { status: 200 }));
+  }) as typeof fetch;
+  try {
+    Deno.env.set("ONESIGNAL_APP_ID", "os-app");
+    Deno.env.set("ONESIGNAL_REST_API_KEY", "os-key");
+    Deno.env.set("RESEND_API_KEY", "re_test");
+    Deno.env.set("MINGLA_LOGO_URL", "https://usemingla.com/logo.png");
+    Deno.env.set("MINGLA_FOOTER_ADDRESS", "Mingla, hello@usemingla.com");
+    Deno.env.set("TWILIO_ACCOUNT_SID", "AC_test");
+    Deno.env.set("TWILIO_AUTH_TOKEN", "tok");
+    Deno.env.set("TWILIO_MESSAGING_SERVICE_SID", "MG_test");
+
+    const state = baseState();
+    const client = makeClient(state);
+    const res = await dispatchV2(client, {
+      user_id: "user-1",
+      contact: "+14155550123",
+      category_key: "buyer_reservation_changed",
+      payload: PAYLOAD,
+      idempotency_key: "buyer_reservation_changed:res-1:t2",
+      country_code: "US",
+    });
+
+    const sms = (res.deliveries ?? []).find((d) => d.channel === "sms");
+    assert(sms, "sms delivery row present");
+    assertEquals(sms!.status, "sent");
+    assertEquals(twilioCalled, true, "Twilio HTTP called when kill-switch on");
+    assert((sms!.segments ?? 0) >= 1, "segment count recorded");
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+// ── 5. STOP suppression → next SMS skipped even with kill-switch ON ──────────
+Deno.test("dispatchV2: STOP suppression → SMS suppressed (can_send denies)", async () => {
+  Deno.env.set("SMS_LIVE_ENABLED_US", "true");
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("api.twilio.com")) {
+      throw new Error("Twilio must NOT be called for a suppressed recipient");
+    }
+    return Promise.resolve(new Response(JSON.stringify({ id: "pm-1" }), { status: 200 }));
+  }) as typeof fetch;
+  try {
+    Deno.env.set("ONESIGNAL_APP_ID", "os-app");
+    Deno.env.set("ONESIGNAL_REST_API_KEY", "os-key");
+    Deno.env.set("RESEND_API_KEY", "re_test");
+    Deno.env.set("MINGLA_LOGO_URL", "https://usemingla.com/logo.png");
+    Deno.env.set("MINGLA_FOOTER_ADDRESS", "Mingla, hello@usemingla.com");
+    Deno.env.set("TWILIO_ACCOUNT_SID", "AC_test");
+    Deno.env.set("TWILIO_AUTH_TOKEN", "tok");
+    Deno.env.set("TWILIO_MESSAGING_SERVICE_SID", "MG_test");
+
+    const state = baseState({ smsSuppressed: true }); // simulate a STOP row
+    const client = makeClient(state);
+    const res = await dispatchV2(client, {
+      user_id: "user-1",
+      contact: "+14155550123",
+      category_key: "buyer_reservation_changed",
+      payload: PAYLOAD,
+      idempotency_key: "buyer_reservation_changed:res-1:t3",
+      country_code: "US",
+    });
+
+    const byChannel = Object.fromEntries(
+      (res.deliveries ?? []).map((d) => [d.channel, d.status]),
+    );
+    assertEquals(byChannel["sms"], "suppressed", "STOP → SMS suppressed");
+    // The Twilio throw above proves no HTTP was attempted for the suppressed sms.
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});

--- a/supabase/functions/_shared/adapters/emailAdapter.ts
+++ b/supabase/functions/_shared/adapters/emailAdapter.ts
@@ -1,0 +1,91 @@
+// META-ORCH-1161 Sub-A — email adapter.
+//
+// Thin wrapper over the existing Resend transactional render (_shared/email
+// renderTransactionalEmail, generic_notification variant) → Resend HTTP. The
+// dispatcher never touches Resend HTTP directly. The marketing render path stays
+// in marketing-send (Sub-B); this adapter is the TRANSACTIONAL leg only.
+
+import {
+  formatSenderHeader,
+  renderTransactionalEmail,
+} from "../email/index.ts";
+import type { AdapterResult } from "./smsAdapter.ts";
+
+export interface EmailSendInput {
+  to: string;
+  title: string;
+  body: string; // plain paragraphs separated by \n\n
+  cta?: { label: string; url: string };
+}
+
+export const emailAdapter = {
+  async send(input: EmailSendInput): Promise<AdapterResult> {
+    const to = input.to?.trim() ?? "";
+    if (!to) {
+      return { ok: false, status: "skipped", providerMessageId: null, error: "no_recipient" };
+    }
+    const key = Deno.env.get("RESEND_API_KEY");
+    if (!key) {
+      return { ok: false, status: "failed", providerMessageId: null, error: "RESEND_API_KEY missing" };
+    }
+
+    let rendered;
+    try {
+      rendered = renderTransactionalEmail({
+        variant: "generic_notification",
+        recipient: { name: null, email: to },
+        body: {
+          variant: "generic_notification",
+          title: input.title,
+          paragraphs: input.body.split("\n\n"),
+          cta: input.cta ?? null,
+        },
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        status: "failed",
+        providerMessageId: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    try {
+      const res = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${key}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: formatSenderHeader(rendered.from),
+          to: [to],
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+        }),
+      });
+      if (!res.ok) {
+        return {
+          ok: false,
+          status: "failed",
+          providerMessageId: null,
+          error: `Resend ${res.status}: ${await res.text()}`,
+        };
+      }
+      const data = (await res.json().catch(() => ({}))) as { id?: string };
+      return {
+        ok: true,
+        status: "sent",
+        providerMessageId: data.id ?? null,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        status: "failed",
+        providerMessageId: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};

--- a/supabase/functions/_shared/adapters/emailAdapter.ts
+++ b/supabase/functions/_shared/adapters/emailAdapter.ts
@@ -51,6 +51,9 @@ export const emailAdapter = {
     }
 
     try {
+      // no-attachment: META-ORCH-1161 transactional notification emails (reservation
+      // changed/cancelled, reminders, refunds, order-cancelled) carry no PDF/file —
+      // the ticket-PDF/.ics path stays in ticket-confirmation-dispatch (ORCH-0785-A).
       const res = await fetch("https://api.resend.com/emails", {
         method: "POST",
         headers: {

--- a/supabase/functions/_shared/adapters/pushAdapter.ts
+++ b/supabase/functions/_shared/adapters/pushAdapter.ts
@@ -1,0 +1,51 @@
+// META-ORCH-1161 Sub-A — push adapter.
+//
+// Thin wrapper over the existing _shared/push-utils.ts sendPush(). The dispatcher
+// never touches OneSignal HTTP directly. Resolves consumer-vs-business app via
+// resolveOneSignalApp(type) (a category maps to a `type` for routing).
+
+import { resolveOneSignalApp, sendPush } from "../push-utils.ts";
+import type { AdapterResult } from "./smsAdapter.ts";
+
+export interface PushSendInput {
+  userId: string;
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+  // Routing key — `business.*`/`stripe.*` → business app, else consumer.
+  routingType?: string;
+}
+
+export const pushAdapter = {
+  async send(input: PushSendInput): Promise<AdapterResult> {
+    if (!input.userId) {
+      return { ok: false, status: "skipped", providerMessageId: null, error: "no_user_id" };
+    }
+    try {
+      const ok = await sendPush({
+        targetUserId: input.userId,
+        title: input.title,
+        body: input.body,
+        data: input.data ?? {},
+        app: resolveOneSignalApp(input.routingType ?? null),
+        iosBadgeType: "Increase",
+        iosBadgeCount: 1,
+      });
+      // sendPush returns a boolean (no provider message id surfaced); record
+      // sent/failed accordingly. No silent failure — failed is a real status.
+      return {
+        ok,
+        status: ok ? "sent" : "failed",
+        providerMessageId: null,
+        error: ok ? undefined : "push_not_delivered",
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        status: "failed",
+        providerMessageId: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};

--- a/supabase/functions/_shared/adapters/smsAdapter.ts
+++ b/supabase/functions/_shared/adapters/smsAdapter.ts
@@ -1,0 +1,188 @@
+// META-ORCH-1161 Sub-A — SMS adapter.
+//
+// GENERALIZED from send-venue-sms's sendTwilioSms (DO NOT introduce a new
+// provider — hard guard). The dispatcher never touches Twilio HTTP directly; it
+// calls smsAdapter.send(). Responsibilities (SPEC §5.5):
+//   - Send via TWILIO_MESSAGING_SERVICE_SID (the approved toll-free) — NEVER a
+//     raw From number (I-PROPOSED-1161-SMS-FROM-APPROVED-SENDER-ONLY).
+//   - StatusCallback wired to twilio-message-status?secret=… (reuse existing).
+//   - GSM-7 sanitizer (smart quotes/em-dash/ellipsis → ASCII) before send; flag
+//     UCS-2 fall-through; compute + record segment count.
+//   - Brand-name sender identity + "Reply STOP to opt out" footer (CTIA).
+//   - Region-routing seam (country_code → US route today; NG route is a phase).
+//   - Per-market kill-switch SMS_LIVE_ENABLED_US (default false) → return
+//     { ok:false, status:'skipped' } WITHOUT any HTTP call when off
+//     (I-PROPOSED-1161-SMS-MARKET-KILL-SWITCH).
+
+export interface AdapterResult {
+  ok: boolean;
+  status: "sent" | "skipped" | "failed";
+  providerMessageId: string | null;
+  segments?: number;
+  blacklisted?: boolean;
+  error?: string;
+}
+
+export interface SmsSendInput {
+  to: string; // E.164
+  brandName: string; // sender identity in the body (CTIA brand-name-in-body)
+  message: string; // the body WITHOUT the STOP footer (footer is appended here)
+  countryCode?: string | null; // ISO-2 for region routing (default US)
+}
+
+const E164_RE = /^\+[1-9][0-9]{1,14}$/;
+
+export const isValidE164 = (v: string): boolean => E164_RE.test(v.trim());
+
+// GSM-7 sanitizer — normalize the common UTF-8 punctuation that forces UCS-2
+// (and inflates segments) down to GSM-7-safe ASCII. Mirrors COPY §4 discipline.
+// I-PROPOSED-1161-GSM7-SANITIZED-TEMPLATES.
+export function sanitizeGsm7(input: string): string {
+  return input
+    .replace(/[‘’‚‛′]/g, "'") // curly/prime single quotes → '
+    .replace(/[“”„‟″]/g, '"') // curly/prime double quotes → "
+    .replace(/[–—―]/g, "-") // en/em dash, horiz bar → -
+    .replace(/…/g, "...") // ellipsis → ...
+    .replace(/[   ]/g, " ") // non-breaking spaces → space
+    .replace(/[•]/g, "-"); // bullet → -
+}
+
+// The GSM-7 default + basic extended alphabet (chars outside it force UCS-2).
+// https://en.wikipedia.org/wiki/GSM_03.38
+const GSM7_BASIC =
+  "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ ÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà";
+const GSM7_EXT = "^{}\\[~]|€";
+
+function isGsm7(text: string): boolean {
+  for (const ch of text) {
+    if (GSM7_BASIC.indexOf(ch) === -1 && GSM7_EXT.indexOf(ch) === -1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Segment count: GSM-7 = 160 single / 153 concatenated; UCS-2 = 70 / 67.
+// Extended GSM-7 chars count as 2; we approximate by length (the dispatcher only
+// needs cost observability, not billing precision).
+export function computeSegments(text: string): number {
+  const gsm7 = isGsm7(text);
+  const len = text.length;
+  if (gsm7) {
+    return len <= 160 ? 1 : Math.ceil(len / 153);
+  }
+  return len <= 70 ? 1 : Math.ceil(len / 67);
+}
+
+const STOP_FOOTER = "Reply STOP to opt out.";
+
+// Compose the final body: brand-name identity is the caller's responsibility in
+// `message` (the COPY templates already lead with "{Brand}:"). We append the
+// STOP footer only if not already present, then GSM-7-sanitize the whole thing.
+export function composeSmsBody(message: string): string {
+  let body = message.trim();
+  if (!/reply stop/i.test(body)) {
+    body = `${body} ${STOP_FOOTER}`;
+  }
+  return sanitizeGsm7(body);
+}
+
+// Region routing seam (SPEC §8.4). Today only the US route is live; NG is phased.
+// Returns the env var name of the per-market kill-switch for the resolved route.
+export function resolveMarketKillSwitch(countryCode?: string | null): string {
+  const cc = (countryCode ?? "US").toUpperCase();
+  if (cc === "NG") return "SMS_LIVE_ENABLED_NG";
+  return "SMS_LIVE_ENABLED_US";
+}
+
+function envTrue(name: string): boolean {
+  const raw = Deno.env.get(name);
+  return raw === "true" || raw === "1";
+}
+
+async function twilioSend(
+  to: string,
+  body: string,
+): Promise<{ ok: boolean; sid?: string; error?: string; blacklisted?: boolean }> {
+  const accountSid = Deno.env.get("TWILIO_ACCOUNT_SID");
+  const authToken = Deno.env.get("TWILIO_AUTH_TOKEN");
+  const messagingServiceSid = Deno.env.get("TWILIO_MESSAGING_SERVICE_SID");
+  if (!accountSid || !authToken || !messagingServiceSid) {
+    return { ok: false, error: "twilio_env_missing" };
+  }
+  const statusSecret = Deno.env.get("TWILIO_STATUS_CALLBACK_SECRET");
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const statusCallback =
+    statusSecret && supabaseUrl
+      ? `${supabaseUrl}/functions/v1/twilio-message-status?secret=${encodeURIComponent(statusSecret)}`
+      : undefined;
+  const params = new URLSearchParams({
+    To: to,
+    MessagingServiceSid: messagingServiceSid, // NEVER a raw From number.
+    Body: body,
+  });
+  if (statusCallback) params.set("StatusCallback", statusCallback);
+  try {
+    const res = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Basic ${btoa(`${accountSid}:${authToken}`)}`,
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: params,
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      const blacklisted = text.includes("21610"); // recipient opted out
+      return { ok: false, error: `Twilio ${res.status}: ${text}`, blacklisted };
+    }
+    const data = (await res.json()) as { sid?: string };
+    return { ok: true, sid: data.sid };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export const smsAdapter = {
+  async send(input: SmsSendInput): Promise<AdapterResult> {
+    const to = input.to?.trim() ?? "";
+    if (!isValidE164(to)) {
+      return { ok: false, status: "failed", providerMessageId: null, error: "invalid_e164" };
+    }
+
+    // Per-market kill-switch — return skipped WITHOUT any HTTP call when off.
+    const killSwitch = resolveMarketKillSwitch(input.countryCode);
+    if (!envTrue(killSwitch)) {
+      return {
+        ok: false,
+        status: "skipped",
+        providerMessageId: null,
+        error: `kill_switch_off:${killSwitch}`,
+      };
+    }
+
+    const body = composeSmsBody(input.message);
+    const segments = computeSegments(body);
+
+    const result = await twilioSend(to, body);
+    if (!result.ok) {
+      return {
+        ok: false,
+        status: "failed",
+        providerMessageId: null,
+        segments,
+        blacklisted: result.blacklisted ?? false,
+        error: result.error ?? "twilio_error",
+      };
+    }
+    return {
+      ok: true,
+      status: "sent",
+      providerMessageId: result.sid ?? null,
+      segments,
+    };
+  },
+};

--- a/supabase/functions/_shared/notifyTemplates.ts
+++ b/supabase/functions/_shared/notifyTemplates.ts
@@ -1,0 +1,92 @@
+// META-ORCH-1161 Sub-A — per-category message templates (single source of truth).
+//
+// Copy is VERBATIM from
+// Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md.
+// GSM-7 discipline: SMS bodies use only ASCII punctuation (straight quotes,
+// hyphens). The dispatcher's smsAdapter still runs the sanitizer, but these are
+// authored clean. The thin slice wires buyer_reservation_changed; the other
+// rendered moments are present so the v2 core can fan out the seeded categories.
+
+export interface RenderedMessage {
+  push: { title: string; body: string };
+  email: { subject: string; body: string };
+  sms: string; // WITHOUT the STOP footer — smsAdapter appends it.
+}
+
+function str(v: unknown, fallback = ""): string {
+  return v === null || v === undefined ? fallback : String(v);
+}
+
+// Format an ISO timestamp into a short date + time for copy interpolation.
+// Locale-aware-friendly but deterministic for tests (en-US, UTC-stable display
+// would require the venue tz — the thin slice passes pre-formatted date/time in
+// payload when available, else derives a simple split).
+function fmtDate(payload: Record<string, unknown>): { date: string; time: string } {
+  if (payload.date && payload.time) {
+    return { date: str(payload.date), time: str(payload.time) };
+  }
+  const iso = str(payload.reserved_for);
+  if (!iso) return { date: "", time: "" };
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return { date: "", time: "" };
+  const date = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  const time = d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  return { date, time };
+}
+
+export function renderCategoryMessage(
+  categoryKey: string,
+  payload: Record<string, unknown>,
+): RenderedMessage {
+  const brand = str(payload.brand_name ?? payload.brand, "Mingla");
+  const party = str(payload.party_size ?? payload.party, "");
+  const { date, time } = fmtDate(payload);
+
+  switch (categoryKey) {
+    case "buyer_reservation_changed":
+      // COPY §3.1
+      return {
+        push: {
+          title: "Reservation updated",
+          body: `${brand}: now ${date} ${time}, party of ${party}.`,
+        },
+        email: {
+          subject: `Your ${brand} reservation changed`,
+          body:
+            `Your reservation at ${brand} has been updated.\n\n` +
+            `It's now ${date} at ${time}, party of ${party}.\n\n` +
+            `See the details in the Mingla app.`,
+        },
+        sms: `${brand}: Your reservation changed - now ${date} ${time}, party of ${party}.`,
+      };
+
+    case "buyer_reservation_confirmed":
+      return {
+        push: { title: "Reservation confirmed", body: `${brand}: ${date} ${time}, party of ${party}.` },
+        email: {
+          subject: `Your ${brand} reservation is confirmed`,
+          body: `Your table for ${party} is confirmed at ${brand} on ${date} at ${time}.\n\nSee you there!`,
+        },
+        sms: `${brand}: Table for ${party} confirmed ${date} ${time}.`,
+      };
+
+    case "buyer_reservation_cancelled":
+      // COPY §3.2
+      return {
+        push: { title: "Reservation cancelled", body: `${brand}: your ${date} reservation was cancelled.` },
+        email: {
+          subject: `Your ${brand} reservation was cancelled`,
+          body: `Your reservation at ${brand} for ${date} was cancelled.\n\nQuestions? Contact the venue.`,
+        },
+        sms: `${brand}: Your reservation for ${date} was cancelled. Questions? Contact the venue.`,
+      };
+
+    default:
+      // Generic fallback — never fabricate; render a plain notice from payload.
+      return {
+        push: { title: str(payload.title, "Mingla update"), body: str(payload.body, "") },
+        email: { subject: str(payload.title, "Mingla update"), body: str(payload.body, "") },
+        sms: `${brand}: ${str(payload.body, "You have a new update.")}`,
+      };
+  }
+}

--- a/supabase/functions/_shared/notifyV2.ts
+++ b/supabase/functions/_shared/notifyV2.ts
@@ -1,0 +1,276 @@
+// META-ORCH-1161 Sub-A — notify-dispatch v2 core (the {category_key,...} contract).
+//
+// Simultaneous-send model (DEC-185): write the in-app delivery ALWAYS, then for
+// EACH channel in category.default_channels, if can_send() passes, fire the
+// adapter — ALL channels fire simultaneously (NO push-first/SMS-fallback
+// waterfall). Each attempt writes a notification_deliveries row.
+//
+// This module is imported by notify-dispatch/index.ts (the v2 branch). The legacy
+// dispatchNotification/type path in index.ts is left BYTE-IDENTICAL.
+
+import { pushAdapter } from "./adapters/pushAdapter.ts";
+import { emailAdapter } from "./adapters/emailAdapter.ts";
+import { smsAdapter } from "./adapters/smsAdapter.ts";
+import { renderCategoryMessage } from "./notifyTemplates.ts";
+
+// Minimal subset of the supabase-js client surface the v2 core uses, so the core
+// is unit-testable with a fake client.
+export interface MinimalClient {
+  from(table: string): {
+    select: (cols: string, opts?: unknown) => {
+      eq: (col: string, val: unknown) => {
+        maybeSingle: () => Promise<{ data: unknown; error: unknown }>;
+        single?: () => Promise<{ data: unknown; error: unknown }>;
+      };
+    };
+    insert: (row: Record<string, unknown>) => {
+      select?: (cols: string) => { single: () => Promise<{ data: unknown; error: unknown }> };
+    } & Promise<{ data: unknown; error: unknown }>;
+  };
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: unknown }>;
+}
+
+export interface DispatchV2Input {
+  user_id?: string | null;
+  contact?: string | null; // E.164 or email (anon/guest path)
+  category_key: string;
+  payload: Record<string, unknown>;
+  idempotency_key: string;
+  country_code?: string | null;
+}
+
+export interface CategoryRow {
+  key: string;
+  is_transactional: boolean;
+  urgency: string;
+  default_channels: string[];
+  active: boolean;
+}
+
+export interface DispatchV2Result {
+  success: boolean;
+  duplicate?: boolean;
+  notificationId?: string | null;
+  deliveries?: Array<{ channel: string; status: string; providerMessageId: string | null; segments?: number }>;
+  reason?: string;
+}
+
+const CHANNEL_PROVIDER: Record<string, string> = {
+  push: "onesignal",
+  email: "resend",
+  sms: "twilio",
+  inapp: "inapp",
+};
+
+const isEmail = (c: string | null | undefined): boolean =>
+  !!c && c.includes("@");
+const isPhone = (c: string | null | undefined): boolean =>
+  !!c && c.startsWith("+");
+
+export async function dispatchV2(
+  client: MinimalClient,
+  input: DispatchV2Input,
+): Promise<DispatchV2Result> {
+  // 1. Load + assert category active.
+  const { data: catData } = await client
+    .from("notification_categories")
+    .select("*")
+    .eq("key", input.category_key)
+    .maybeSingle();
+  const cat = catData as CategoryRow | null;
+  if (!cat || cat.active !== true) {
+    return { success: false, reason: "category_inactive_or_missing" };
+  }
+
+  // 2. Render the per-category copy (push title/body, email, sms).
+  const rendered = renderCategoryMessage(input.category_key, input.payload);
+
+  // 3. Idempotent insert into notifications (the inbox). Reuse the existing
+  //    23505 UNIQUE(idempotency_key) path. Only when we have a user_id (the
+  //    inbox is keyed on user_id NOT NULL).
+  let notificationId: string | null = null;
+  if (input.user_id) {
+    const insertRes = await client
+      .from("notifications")
+      .insert({
+        user_id: input.user_id,
+        type: input.category_key,
+        title: rendered.push.title,
+        body: rendered.push.body,
+        data: { ...input.payload, category_key: input.category_key },
+        idempotency_key: input.idempotency_key,
+      })
+      // deno-lint-ignore no-explicit-any
+      .select?.("id")
+      .single() as unknown as { data: { id: string } | null; error: { code?: string } | null };
+    if (insertRes.error) {
+      if (insertRes.error.code === "23505") {
+        return { success: true, duplicate: true, notificationId: null };
+      }
+      return { success: false, reason: "notification_insert_failed" };
+    }
+    notificationId = insertRes.data?.id ?? null;
+  } else {
+    // Anon/guest: no inbox row (notifications.user_id is NOT NULL). Use the
+    // idempotency_key against the outbox-side dedupe (already enforced upstream).
+    // We still need a notification_id FK for deliveries, so create a synthetic
+    // inbox row is NOT possible without a user — record deliveries against a
+    // freshly-minted notifications row is impossible; for the thin slice the
+    // guest reservation path that lacks a user_id still gets email/SMS but the
+    // delivery ledger requires a notification_id. Skip the ledger FK in that
+    // edge by returning early after channel sends without deliveries rows.
+    return await dispatchAnon(client, input, cat, rendered);
+  }
+
+  // A successful insert with no id is a contract violation — surface it, never
+  // proceed with a null FK (no silent failure).
+  if (!notificationId) {
+    return { success: false, reason: "notification_insert_no_id" };
+  }
+  const nid: string = notificationId;
+
+  // 4. ALWAYS write the in-app delivery (free, durable).
+  await writeDelivery(client, nid, "inapp", "delivered", null, null);
+
+  const deliveries: DispatchV2Result["deliveries"] = [
+    { channel: "inapp", status: "delivered", providerMessageId: null },
+  ];
+
+  // 5. Simultaneous fan-out: for EACH channel in default_channels (besides
+  //    inapp), if can_send passes, fire the adapter. ALL fire — no waterfall.
+  const contactEmail = isEmail(input.contact) ? input.contact! : null;
+  const contactPhone = isPhone(input.contact) ? input.contact! : null;
+  const brandName = String(input.payload.brand_name ?? input.payload.brand ?? "Mingla");
+
+  const tasks: Array<Promise<void>> = [];
+
+  for (const channel of cat.default_channels) {
+    if (channel === "inapp") continue;
+    const contactForChannel =
+      channel === "email" ? contactEmail : channel === "sms" ? contactPhone : null;
+
+    // can_send gate (the single chokepoint). push/inapp pass with contact=null.
+    const { data: allowedData } = await client.rpc("can_send", {
+      p_user_id: input.user_id ?? null,
+      p_category_key: input.category_key,
+      p_channel: channel,
+      p_contact: contactForChannel,
+    });
+    const allowed = allowedData === true;
+    if (!allowed) {
+      await writeDelivery(client, nid, channel, "suppressed", CHANNEL_PROVIDER[channel], "can_send_denied");
+      deliveries.push({ channel, status: "suppressed", providerMessageId: null });
+      continue;
+    }
+
+    if (channel === "push") {
+      tasks.push((async () => {
+        const r = await pushAdapter.send({
+          userId: input.user_id!,
+          title: rendered.push.title,
+          body: rendered.push.body,
+          data: { ...input.payload, category_key: input.category_key },
+          routingType: input.category_key,
+        });
+        await writeDelivery(client, nid, "push", r.status, CHANNEL_PROVIDER.push, r.error ?? null);
+        deliveries.push({ channel: "push", status: r.status, providerMessageId: r.providerMessageId });
+      })());
+    } else if (channel === "email" && contactEmail) {
+      tasks.push((async () => {
+        const r = await emailAdapter.send({
+          to: contactEmail,
+          title: rendered.email.subject,
+          body: rendered.email.body,
+        });
+        await writeDelivery(client, nid, "email", r.status, CHANNEL_PROVIDER.email, r.error ?? null, r.providerMessageId);
+        deliveries.push({ channel: "email", status: r.status, providerMessageId: r.providerMessageId });
+      })());
+    } else if (channel === "sms" && contactPhone) {
+      tasks.push((async () => {
+        const r = await smsAdapter.send({
+          to: contactPhone,
+          brandName,
+          message: rendered.sms,
+          countryCode: input.country_code,
+        });
+        await writeDelivery(client, nid, "sms", r.status, CHANNEL_PROVIDER.sms, r.error ?? null, r.providerMessageId, r.segments);
+        deliveries.push({ channel: "sms", status: r.status, providerMessageId: r.providerMessageId, segments: r.segments });
+      })());
+    } else {
+      // Channel allowed but no contact for it — record skipped (no silent drop).
+      await writeDelivery(client, nid, channel, "skipped", CHANNEL_PROVIDER[channel], "no_contact");
+      deliveries.push({ channel, status: "skipped", providerMessageId: null });
+    }
+  }
+
+  await Promise.all(tasks);
+
+  return { success: true, notificationId, deliveries };
+}
+
+// Anon/guest path: no inbox row (notifications.user_id NOT NULL), so no
+// notification_deliveries FK. Fire email/SMS directly through the gate; record
+// nothing in the FK-bound ledger. Returns the channel results inline.
+async function dispatchAnon(
+  client: MinimalClient,
+  input: DispatchV2Input,
+  cat: CategoryRow,
+  rendered: ReturnType<typeof renderCategoryMessage>,
+): Promise<DispatchV2Result> {
+  const deliveries: DispatchV2Result["deliveries"] = [];
+  const contactEmail = isEmail(input.contact) ? input.contact! : null;
+  const contactPhone = isPhone(input.contact) ? input.contact! : null;
+  const brandName = String(input.payload.brand_name ?? input.payload.brand ?? "Mingla");
+
+  for (const channel of cat.default_channels) {
+    if (channel === "inapp" || channel === "push") continue; // no user → no inbox/push
+    const contactForChannel = channel === "email" ? contactEmail : channel === "sms" ? contactPhone : null;
+    if (!contactForChannel) continue;
+
+    const { data: allowedData } = await client.rpc("can_send", {
+      p_user_id: null,
+      p_category_key: input.category_key,
+      p_channel: channel,
+      p_contact: contactForChannel,
+    });
+    if (allowedData !== true) {
+      deliveries.push({ channel, status: "suppressed", providerMessageId: null });
+      continue;
+    }
+
+    if (channel === "email") {
+      const r = await emailAdapter.send({ to: contactEmail!, title: rendered.email.subject, body: rendered.email.body });
+      deliveries.push({ channel: "email", status: r.status, providerMessageId: r.providerMessageId });
+    } else if (channel === "sms") {
+      const r = await smsAdapter.send({ to: contactPhone!, brandName, message: rendered.sms, countryCode: input.country_code });
+      deliveries.push({ channel: "sms", status: r.status, providerMessageId: r.providerMessageId, segments: r.segments });
+    }
+  }
+
+  return { success: true, notificationId: null, deliveries };
+}
+
+async function writeDelivery(
+  client: MinimalClient,
+  notificationId: string,
+  channel: string,
+  status: string,
+  provider: string | null,
+  failedReason: string | null,
+  providerMessageId?: string | null,
+  segments?: number,
+): Promise<void> {
+  await client.from("notification_deliveries").insert({
+    notification_id: notificationId,
+    channel,
+    status,
+    provider,
+    provider_message_id: providerMessageId ?? null,
+    failed_reason: failedReason,
+    delivered_at: status === "delivered" ? new Date().toISOString() : null,
+    segments: segments ?? null,
+  });
+}

--- a/supabase/functions/_shared/notifyV2.ts
+++ b/supabase/functions/_shared/notifyV2.ts
@@ -26,6 +26,11 @@ export interface MinimalClient {
     insert: (row: Record<string, unknown>) => {
       select?: (cols: string) => { single: () => Promise<{ data: unknown; error: unknown }> };
     } & Promise<{ data: unknown; error: unknown }>;
+    update?: (row: Record<string, unknown>) => {
+      eq: (col: string, val: unknown) => {
+        eq: (col: string, val: unknown) => Promise<{ data: unknown; error: unknown }>;
+      };
+    };
   };
   rpc(
     fn: string,
@@ -211,9 +216,14 @@ export async function dispatchV2(
   return { success: true, notificationId, deliveries };
 }
 
-// Anon/guest path: no inbox row (notifications.user_id NOT NULL), so no
-// notification_deliveries FK. Fire email/SMS directly through the gate; record
-// nothing in the FK-bound ledger. Returns the channel results inline.
+// Anon/guest path: no inbox row (notifications.user_id NOT NULL). REWORK (P2-2):
+// each send now writes a CONTACT-KEYED notification_deliveries row (notification_id
+// NULL, contact + idempotency_key populated) so the guest path has the same durable,
+// webhook-reconcilable ledger as the authenticated path. REWORK (P2-1, second line
+// of defense): before each send we INSERT the ledger row FIRST; the partial
+// UNIQUE(idempotency_key, channel) on guest rows means a duplicated drain tick that
+// re-dispatches the same key gets a 23505 → we skip the provider send entirely (the
+// notifications UNIQUE backstop the user_id path enjoys, now mirrored for guests).
 async function dispatchAnon(
   client: MinimalClient,
   input: DispatchV2Input,
@@ -237,20 +247,103 @@ async function dispatchAnon(
       p_contact: contactForChannel,
     });
     if (allowedData !== true) {
+      // Record the suppression in the ledger too (no silent gap). A dedupe
+      // collision here is harmless — the row already exists.
+      await insertGuestDelivery(
+        client, input.idempotency_key, channel, contactForChannel,
+        "suppressed", CHANNEL_PROVIDER[channel], "can_send_denied", null, null,
+      );
       deliveries.push({ channel, status: "suppressed", providerMessageId: null });
+      continue;
+    }
+
+    // Claim the (idempotency_key, channel) dedupe slot BEFORE sending. A 23505
+    // means a prior/concurrent drain tick already sent this channel → skip.
+    const claim = await insertGuestDelivery(
+      client, input.idempotency_key, channel, contactForChannel,
+      "queued", CHANNEL_PROVIDER[channel], null, null, null,
+    );
+    if (claim.duplicate) {
+      deliveries.push({ channel, status: "duplicate", providerMessageId: null });
       continue;
     }
 
     if (channel === "email") {
       const r = await emailAdapter.send({ to: contactEmail!, title: rendered.email.subject, body: rendered.email.body });
+      await updateGuestDelivery(
+        client, input.idempotency_key, channel,
+        r.status, r.providerMessageId ?? null, r.error ?? null, undefined,
+      );
       deliveries.push({ channel: "email", status: r.status, providerMessageId: r.providerMessageId });
     } else if (channel === "sms") {
       const r = await smsAdapter.send({ to: contactPhone!, brandName, message: rendered.sms, countryCode: input.country_code });
+      await updateGuestDelivery(
+        client, input.idempotency_key, channel,
+        r.status, r.providerMessageId ?? null, r.error ?? null, r.segments,
+      );
       deliveries.push({ channel: "sms", status: r.status, providerMessageId: r.providerMessageId, segments: r.segments });
     }
   }
 
   return { success: true, notificationId: null, deliveries };
+}
+
+// Insert a CONTACT-KEYED guest delivery row (notification_id NULL). Returns
+// duplicate=true on a 23505 (the dedupe slot is already taken → caller skips the
+// send). Any other insert error is non-fatal (logged), never throws — the ledger
+// is observability, not the send gate (the can_send chokepoint already ran).
+async function insertGuestDelivery(
+  client: MinimalClient,
+  idempotencyKey: string,
+  channel: string,
+  contact: string,
+  status: string,
+  provider: string | null,
+  failedReason: string | null,
+  providerMessageId: string | null,
+  segments: number | null,
+): Promise<{ duplicate: boolean }> {
+  const res = (await client.from("notification_deliveries").insert({
+    notification_id: null,
+    contact: contact.toLowerCase(),
+    idempotency_key: idempotencyKey,
+    channel,
+    status,
+    provider,
+    provider_message_id: providerMessageId,
+    failed_reason: failedReason,
+    delivered_at: status === "delivered" ? new Date().toISOString() : null,
+    segments,
+  })) as unknown as { error: { code?: string } | null };
+  if (res?.error) {
+    if (res.error.code === "23505") return { duplicate: true };
+    console.error("[notifyV2] guest delivery insert failed:", res.error);
+  }
+  return { duplicate: false };
+}
+
+// Reconcile the guest delivery row (claimed 'queued') with the provider result.
+async function updateGuestDelivery(
+  client: MinimalClient,
+  idempotencyKey: string,
+  channel: string,
+  status: string,
+  providerMessageId: string | null,
+  failedReason: string | null,
+  segments?: number,
+): Promise<void> {
+  const table = client.from("notification_deliveries");
+  if (!table.update) return; // fake clients without update — non-fatal
+  await table.update({
+    status,
+    provider_message_id: providerMessageId,
+    failed_reason: failedReason,
+    delivered_at: status === "delivered" ? new Date().toISOString() : null,
+    segments: segments ?? null,
+    attempt_at: new Date().toISOString(),
+  })
+    .eq("idempotency_key", idempotencyKey)
+    .eq("channel", channel);
 }
 
 async function writeDelivery(

--- a/supabase/functions/notify-dispatch/index.ts
+++ b/supabase/functions/notify-dispatch/index.ts
@@ -2,6 +2,11 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { resolveOneSignalApp, sendPush } from "../_shared/push-utils.ts";
 import { getTranslatedNotification } from "../_shared/push-translations.ts";
+// META-ORCH-1161 transitional: v2 dispatch core ({category_key,...} contract).
+// The legacy type-based path below is left BYTE-IDENTICAL — the v2 branch is an
+// early, additive return. Exit condition: when all senders migrate onto v2 and
+// the legacy contract is retired (CLOSE-time cleanup, §5.7).
+import { dispatchV2, type DispatchV2Input } from "../_shared/notifyV2.ts";
 import {
   assertNotResendSandbox,
   EMAIL_SENDERS,
@@ -238,6 +243,64 @@ serve(async (req) => {
 
     // ── Parse & validate input ──────────────────────────────────────────────
     const payload = await req.json();
+
+    // ── META-ORCH-1161 transitional: v2 ({category_key,...}) branch ──────────
+    // ADDITIVE — a caller that sends `category_key` opts into the unified
+    // simultaneous-send path (DEC-185). A caller that sends `type` (legacy) falls
+    // through to the byte-identical legacy path below. Exit condition: legacy
+    // contract retired at CLOSE (§5.7).
+    if (payload && typeof payload.category_key === "string" && payload.category_key.length > 0) {
+      const v2Input: DispatchV2Input = {
+        user_id: payload.user_id ?? payload.userId ?? null,
+        contact: payload.contact ?? null,
+        category_key: payload.category_key,
+        payload: (payload.payload ?? {}) as Record<string, unknown>,
+        idempotency_key: String(payload.idempotency_key ?? payload.idempotencyKey ?? ""),
+        country_code: payload.country_code ?? null,
+      };
+      if (!v2Input.idempotency_key) {
+        return jsonResponse({ success: false, reason: "idempotency_key required for v2" }, 400);
+      }
+
+      // Record the transactional consent for this moment if not already present
+      // (SPEC §7.2: source='reservation'). Append-only; failure is non-fatal.
+      const consentContact =
+        typeof v2Input.contact === "string" && v2Input.contact.length > 0
+          ? v2Input.contact
+          : null;
+      if (consentContact) {
+        const channel = consentContact.includes("@") ? "email" : "sms";
+        try {
+          const { data: existingConsent } = await adminClient
+            .from("consent_records")
+            .select("id")
+            .eq("contact", consentContact)
+            .eq("channel", channel)
+            .eq("scope", "transactional")
+            .eq("action", "granted")
+            .maybeSingle();
+          if (!existingConsent) {
+            await adminClient.from("consent_records").insert({
+              user_id: v2Input.user_id,
+              contact: consentContact,
+              channel,
+              scope: "transactional",
+              action: "granted",
+              source: "reservation",
+              country_code: v2Input.country_code,
+            });
+          }
+        } catch (consentErr) {
+          console.warn("[notify-dispatch v2] consent record write failed (non-fatal):", consentErr);
+        }
+      }
+
+      const v2Result = await dispatchV2(
+        adminClient as unknown as Parameters<typeof dispatchV2>[0],
+        v2Input,
+      );
+      return jsonResponse(v2Result, v2Result.success ? 200 : 400);
+    }
     const {
       userId,
       type,

--- a/supabase/functions/notify-outbox-drain/index.ts
+++ b/supabase/functions/notify-outbox-drain/index.ts
@@ -1,0 +1,128 @@
+// META-ORCH-1161 Sub-A — notify-outbox-drain.
+//
+// The 1-min cron (20261110000003_orch_1161_outbox_drain_cron.sql) POSTs here.
+// Claims pending notification_outbox rows and forwards each to notify-dispatch v2
+// with the {category_key,...} contract. Service-role only.
+//
+// verify_jwt=false (config.toml): invoked by pg_cron with the service-role bearer.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function json(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+const BATCH_LIMIT = 25;
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json({ error: "missing_authorization" }, 401);
+  }
+
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    return json({ error: "server_misconfigured" }, 500);
+  }
+
+  const admin = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+
+  // Claim a batch of pending rows (best-effort; the unique idempotency_key on the
+  // outbox + the notifications UNIQUE(idempotency_key) make a double-process a
+  // no-op duplicate downstream).
+  const { data: rows, error: claimErr } = await admin
+    .from("notification_outbox")
+    .select("id, category_key, user_id, contact, brand_id, payload, idempotency_key, country_code, attempts")
+    .eq("status", "pending")
+    .order("created_at", { ascending: true })
+    .limit(BATCH_LIMIT);
+
+  if (claimErr) {
+    console.error("[notify-outbox-drain] claim failed:", claimErr.message);
+    return json({ error: "claim_failed" }, 500);
+  }
+  if (!rows || rows.length === 0) {
+    return json({ ok: true, processed: 0 });
+  }
+
+  let processed = 0;
+  let failed = 0;
+
+  for (const row of rows as Array<Record<string, unknown>>) {
+    const id = row.id as string;
+    // Mark processing to avoid an overlapping cron re-claiming the same row.
+    await admin.from("notification_outbox").update({ status: "processing" }).eq("id", id);
+
+    // Resolve the brand display name for the copy (sender identity).
+    let brandName = "Mingla";
+    if (row.brand_id) {
+      const { data: brand } = await admin
+        .from("brands")
+        .select("name")
+        .eq("id", row.brand_id)
+        .maybeSingle();
+      if (brand?.name && typeof brand.name === "string") brandName = brand.name;
+    }
+
+    const payload = {
+      ...((row.payload as Record<string, unknown>) ?? {}),
+      brand_name: brandName,
+    };
+
+    try {
+      const res = await fetch(`${SUPABASE_URL}/functions/v1/notify-dispatch`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${SERVICE_KEY}`,
+        },
+        body: JSON.stringify({
+          category_key: row.category_key,
+          user_id: row.user_id ?? null,
+          contact: row.contact ?? null,
+          payload,
+          idempotency_key: row.idempotency_key,
+          country_code: row.country_code ?? null,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`notify-dispatch ${res.status}: ${text}`);
+      }
+      await admin
+        .from("notification_outbox")
+        .update({ status: "done", processed_at: new Date().toISOString() })
+        .eq("id", id);
+      processed++;
+    } catch (err) {
+      failed++;
+      const attempts = ((row.attempts as number) ?? 0) + 1;
+      // Re-queue (pending) unless we've exhausted attempts → failed (no silent drop).
+      await admin
+        .from("notification_outbox")
+        .update({
+          status: attempts >= 3 ? "failed" : "pending",
+          attempts,
+          last_error: err instanceof Error ? err.message : String(err),
+        })
+        .eq("id", id);
+      console.error("[notify-outbox-drain] dispatch failed for", id, err);
+    }
+  }
+
+  return json({ ok: true, processed, failed });
+});

--- a/supabase/functions/notify-outbox-drain/index.ts
+++ b/supabase/functions/notify-outbox-drain/index.ts
@@ -41,15 +41,16 @@ serve(async (req) => {
     auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
   });
 
-  // Claim a batch of pending rows (best-effort; the unique idempotency_key on the
-  // outbox + the notifications UNIQUE(idempotency_key) make a double-process a
-  // no-op duplicate downstream).
-  const { data: rows, error: claimErr } = await admin
-    .from("notification_outbox")
-    .select("id, category_key, user_id, contact, brand_id, payload, idempotency_key, country_code, attempts")
-    .eq("status", "pending")
-    .order("created_at", { ascending: true })
-    .limit(BATCH_LIMIT);
+  // ATOMICALLY claim a batch of pending rows (P2-1). claim_notification_outbox
+  // flips status='pending'→'processing' inside a single UPDATE … FOR UPDATE SKIP
+  // LOCKED statement, so two overlapping cron runs can NEVER both claim the same
+  // row — the second invocation skips the row the first has locked. This is the
+  // primary double-send guard (incl. the guest/no-user_id path, which lacks the
+  // notifications UNIQUE backstop); the per-channel guest dedupe in dispatchAnon
+  // is the second line of defense.
+  const { data: rows, error: claimErr } = await admin.rpc("claim_notification_outbox", {
+    p_limit: BATCH_LIMIT,
+  });
 
   if (claimErr) {
     console.error("[notify-outbox-drain] claim failed:", claimErr.message);
@@ -64,8 +65,8 @@ serve(async (req) => {
 
   for (const row of rows as Array<Record<string, unknown>>) {
     const id = row.id as string;
-    // Mark processing to avoid an overlapping cron re-claiming the same row.
-    await admin.from("notification_outbox").update({ status: "processing" }).eq("id", id);
+    // The atomic claim already flipped this row to 'processing' — no separate
+    // mark-processing UPDATE (that was the non-atomic step that P2-1 removed).
 
     // Resolve the brand display name for the copy (sender identity).
     let brandName = "Mingla";

--- a/supabase/functions/twilio-inbound-sms/index.ts
+++ b/supabase/functions/twilio-inbound-sms/index.ts
@@ -1,0 +1,111 @@
+// META-ORCH-1161 Sub-A — twilio-inbound-sms (the STOP/HELP webhook gap).
+//
+// Twilio "A MESSAGE COMES IN" webhook. Twilio auto-handles STOP at the carrier
+// level; this webhook is the APP-SIDE suppression sync (FCC requires honoring
+// opt-out from any channel). On a STOP keyword:
+//   - write channel_suppressions(channel='sms', scope='all', reason='stop_keyword')
+//   - write the back-compat venue ledger via biz_sms_record_global_opt_out
+// On HELP: reply with sender identity + support (TwiML).
+//
+// verify_jwt=false (config.toml): Twilio cannot present a Supabase JWT; we gate on
+// a shared ?secret= query param (same posture as twilio-message-status).
+// DO-NOT-TOUCH: this EXTENDS the venue opt-out semantics via the inbound webhook
+// only — it does not change send-venue-sms or venue_sms_opt_out write logic.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// The 7 FCC keywords + the standard Twilio Advanced Opt-Out set.
+const STOP_KEYWORDS = new Set([
+  "stop", "stopall", "unsubscribe", "cancel", "end", "quit", "revoke", "optout", "opt-out",
+]);
+const HELP_KEYWORDS = new Set(["help", "info"]);
+
+function twiml(message: string | null): Response {
+  const body = message
+    ? `<?xml version="1.0" encoding="UTF-8"?><Response><Message>${message}</Message></Response>`
+    : `<?xml version="1.0" encoding="UTF-8"?><Response></Response>`;
+  return new Response(body, { status: 200, headers: { "Content-Type": "text/xml" } });
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "method_not_allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const url = new URL(req.url);
+  const sharedSecret = Deno.env.get("TWILIO_STATUS_CALLBACK_SECRET");
+  if (sharedSecret && url.searchParams.get("secret") !== sharedSecret) {
+    return new Response(JSON.stringify({ error: "forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return twiml(null);
+  }
+
+  const from = String(form.get("From") ?? "").trim(); // the user's E.164
+  const bodyRaw = String(form.get("Body") ?? "").trim();
+  const keyword = bodyRaw.toLowerCase().replace(/[^a-z-]/g, "");
+
+  if (!from) return twiml(null);
+
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    console.error("[twilio-inbound-sms] missing supabase env");
+    return twiml(null);
+  }
+  const admin = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+
+  if (STOP_KEYWORDS.has(keyword)) {
+    // 1. App-side suppression (scope='all' — one opt-out kills all SMS scopes).
+    try {
+      await admin.from("channel_suppressions").insert({
+        user_id: null,
+        contact: from,
+        channel: "sms",
+        scope: "all",
+        reason: "stop_keyword",
+        brand_id: null,
+      });
+    } catch (err) {
+      // Unique-index conflict is fine (already suppressed); anything else logs.
+      console.warn("[twilio-inbound-sms] suppression insert note:", String(err));
+    }
+
+    // 2. Back-compat venue ledger (global opt-out via the existing RPC).
+    try {
+      const { error: optErr } = await admin.rpc("biz_sms_record_global_opt_out", {
+        p_phone_e164: from,
+        p_reason: "stop_keyword",
+      });
+      if (optErr) console.warn("[twilio-inbound-sms] venue opt-out note:", optErr.message);
+    } catch (err) {
+      console.warn("[twilio-inbound-sms] venue opt-out threw (non-fatal):", String(err));
+    }
+
+    // Twilio auto-sends the carrier STOP confirmation; return empty TwiML so we
+    // don't double-message.
+    return twiml(null);
+  }
+
+  if (HELP_KEYWORDS.has(keyword)) {
+    return twiml(
+      "Mingla: booking and event updates. Reply STOP to opt out. Help: support@usemingla.com",
+    );
+  }
+
+  // Any other inbound message — no action (no auto-reply on arbitrary inbound).
+  return twiml(null);
+});

--- a/supabase/functions/twilio-message-status/index.ts
+++ b/supabase/functions/twilio-message-status/index.ts
@@ -51,5 +51,34 @@ serve(async (req) => {
     }).eq("id", notification.id);
   }
 
+  // META-ORCH-1161 §5.6: ALSO reconcile the cross-channel delivery ledger keyed
+  // by provider_message_id. Record SMS error codes (30034 unregistered 10DLC,
+  // 30007 filtered/NG DND, 30032 toll-free not verified) into failed_reason for
+  // the cost/deliverability alarm. Additive — does not touch the logic above.
+  {
+    const delivered = status === "delivered";
+    const failed = ["failed", "undelivered"].includes(status);
+    const errorCode = String(payload.ErrorCode ?? "").trim();
+    const knownCodes = new Set(["30034", "30007", "30032"]);
+    const failedReason = failed
+      ? (knownCodes.has(errorCode)
+          ? `twilio_${errorCode}:${payload.ErrorMessage ?? status}`
+          : (payload.ErrorMessage ?? status))
+      : null;
+    const ledgerStatus = delivered ? "delivered" : failed ? "failed" : "sent";
+    const { error: deliveryErr } = await supabase
+      .from("notification_deliveries")
+      .update({
+        status: ledgerStatus,
+        delivered_at: delivered ? new Date().toISOString() : null,
+        failed_reason: failedReason,
+      })
+      .eq("provider_message_id", messageSid)
+      .eq("channel", "sms");
+    if (deliveryErr) {
+      console.warn("[twilio-message-status] notification_deliveries reconcile note:", deliveryErr.message);
+    }
+  }
+
   return jsonResponse({ ok: true });
 });

--- a/supabase/migrations/20261110000000_orch_1161_notification_foundation_tables.sql
+++ b/supabase/migrations/20261110000000_orch_1161_notification_foundation_tables.sql
@@ -1,0 +1,216 @@
+-- META-ORCH-1161 Sub-A (thin slice) — notification foundation data model.
+--
+-- The 5 foundation tables per SPEC §5.1 + the reservation→notify outbox.
+-- Additive only; nothing existing is altered. RLS on every table; service-role
+-- writes the ledgers, users read their own.
+--
+-- Simultaneous-send model (DEC-185): the dispatcher fans out to EVERY channel in
+-- a category's default_channels that passes can_send() — there is NO push-first/
+-- SMS-fallback waterfall. reach_mode is retained on the table for forward use but
+-- is NOT consulted by the thin-slice dispatcher.
+--
+-- Cross-refs:
+--   SPEC:  Mingla_Artifacts/specs/SPEC_META-ORCH-1161_NOTIFICATION_MESSAGING_SYSTEM.md §5.1
+--   Reuse: notifications (existing inbox, idempotency_key UNIQUE), venue_sms_opt_out
+--          (venue-scope ledger — EXTENDED via inbound webhook, not replaced).
+
+-- =============================================================
+-- §1. notification_categories — the taxonomy the dispatcher reads as DATA.
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.notification_categories (
+  key text PRIMARY KEY,
+  section text NOT NULL,
+  is_transactional boolean NOT NULL,
+  urgency text NOT NULL CHECK (urgency IN ('low','normal','high')),
+  default_channels text[] NOT NULL,
+  reach_mode text NOT NULL DEFAULT 'reach_once'
+    CHECK (reach_mode IN ('reach_once','escalate_on_no_engagement')),
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.notification_categories IS
+  'META-ORCH-1161 §5.1 — notification taxonomy read as data by notify-dispatch v2. '
+  'Only rows with urgency=high AND ''sms'' in default_channels can ever reach SMS (DC-3).';
+
+-- =============================================================
+-- §2. notification_channel_prefs — per-category × per-channel user toggle.
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.notification_channel_prefs (
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  category_key text NOT NULL REFERENCES public.notification_categories(key),
+  channel text NOT NULL CHECK (channel IN ('inapp','push','email','sms')),
+  enabled boolean NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, category_key, channel)
+);
+
+COMMENT ON TABLE public.notification_channel_prefs IS
+  'META-ORCH-1161 §5.1 — per-(category,channel) toggle. ABSENT ROW = '
+  'category.default_channels decides (transactional default-on; marketing default-off).';
+
+-- =============================================================
+-- §3. channel_suppressions — OVERRIDES prefs (a STOP beats any toggle).
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.channel_suppressions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NULL REFERENCES auth.users(id) ON DELETE CASCADE, -- NULL for anon-by-contact
+  contact text NULL,                 -- E.164 phone OR lowercased email
+  channel text NOT NULL CHECK (channel IN ('email','sms')),
+  scope text NOT NULL CHECK (scope IN ('transactional','marketing','all')),
+  reason text NOT NULL CHECK (reason IN
+    ('stop_keyword','manual','bounce','complaint','unsubscribe','twilio_blacklist')),
+  brand_id uuid NULL REFERENCES public.brands(id) ON DELETE CASCADE, -- NULL = global
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Partial unique idx so the same (target, channel, scope, brand) is recorded once.
+CREATE UNIQUE INDEX IF NOT EXISTS channel_suppressions_uniq_idx
+  ON public.channel_suppressions (
+    COALESCE(user_id::text, contact),
+    channel,
+    scope,
+    COALESCE(brand_id::text, 'global')
+  );
+
+COMMENT ON TABLE public.channel_suppressions IS
+  'META-ORCH-1161 §5.1 — suppression ledger. OVERRIDES preferences. A scope '
+  '(transactional|marketing|all) STOP/bounce/complaint denies can_send() for that scope.';
+
+-- =============================================================
+-- §4. consent_records — append-only legal audit of WHO consented to WHAT.
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.consent_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  contact text NOT NULL,             -- E.164 phone OR lowercased email
+  channel text NOT NULL CHECK (channel IN ('email','sms')),
+  scope text NOT NULL CHECK (scope IN ('transactional','marketing')),
+  action text NOT NULL CHECK (action IN ('granted','revoked')),
+  source text NOT NULL,              -- 'checkout'|'prefs_ui'|'stop_keyword'|'unsubscribe_link'|'reservation'
+  disclosure_text text NULL,         -- EXACT copy shown at grant (legal burden of proof)
+  ip_hash text NULL,
+  country_code text NULL,            -- ISO-2 buyer country at grant
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS consent_records_contact_idx
+  ON public.consent_records (contact, channel, scope);
+
+COMMENT ON TABLE public.consent_records IS
+  'META-ORCH-1161 §5.1 — append-only consent audit trail. The legal record of WHO '
+  'consented to WHAT, WHEN, with the EXACT disclosure shown.';
+
+-- =============================================================
+-- §5. notification_deliveries — the cross-channel delivery ledger.
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.notification_deliveries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  notification_id uuid NOT NULL REFERENCES public.notifications(id) ON DELETE CASCADE,
+  channel text NOT NULL CHECK (channel IN ('inapp','push','email','sms')),
+  status text NOT NULL CHECK (status IN
+    ('queued','sent','delivered','undelivered','failed','suppressed','skipped')),
+  provider text NULL,                -- 'onesignal'|'resend'|'twilio'
+  provider_message_id text NULL,
+  attempt_at timestamptz NOT NULL DEFAULT now(),
+  delivered_at timestamptz NULL,
+  failed_reason text NULL,
+  segments int NULL                  -- SMS segment count (cost observability)
+);
+
+CREATE INDEX IF NOT EXISTS notification_deliveries_notification_idx
+  ON public.notification_deliveries (notification_id);
+-- The webhook reconciles status by provider_message_id (twilio-message-status §5.6).
+CREATE INDEX IF NOT EXISTS notification_deliveries_provider_msg_idx
+  ON public.notification_deliveries (provider_message_id)
+  WHERE provider_message_id IS NOT NULL;
+
+COMMENT ON TABLE public.notification_deliveries IS
+  'META-ORCH-1161 §5.1 — THE cross-channel delivery ledger. One row per channel '
+  'attempt. Webhooks reconcile final status keyed by provider_message_id.';
+
+-- =============================================================
+-- §6. notification_outbox — reservation→notify durable queue (drained by cron).
+-- =============================================================
+CREATE TABLE IF NOT EXISTS public.notification_outbox (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  category_key text NOT NULL REFERENCES public.notification_categories(key),
+  user_id uuid NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  contact text NULL,                 -- E.164 phone OR lowercased email (anon/guest path)
+  brand_id uuid NULL REFERENCES public.brands(id) ON DELETE SET NULL,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key text NOT NULL,
+  country_code text NULL,
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','processing','done','failed')),
+  attempts int NOT NULL DEFAULT 0,
+  last_error text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  processed_at timestamptz NULL
+);
+
+-- One outbox row per idempotency_key (a repeated trigger fire is a no-op insert).
+CREATE UNIQUE INDEX IF NOT EXISTS notification_outbox_idempotency_idx
+  ON public.notification_outbox (idempotency_key);
+CREATE INDEX IF NOT EXISTS notification_outbox_pending_idx
+  ON public.notification_outbox (status, created_at)
+  WHERE status = 'pending';
+
+COMMENT ON TABLE public.notification_outbox IS
+  'META-ORCH-1161 §5.4/§7.2 — durable reservation→notify queue. An AFTER UPDATE '
+  'trigger on reservations writes a row; a 1-min cron drains it to notify-dispatch v2.';
+
+-- =============================================================
+-- §7. RLS — every table. Service-role bypasses RLS for writes; users read own.
+-- =============================================================
+ALTER TABLE public.notification_categories     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notification_channel_prefs  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.channel_suppressions        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.consent_records             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notification_deliveries     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notification_outbox         ENABLE ROW LEVEL SECURITY;
+
+-- Categories are public read (the taxonomy is not secret; the prefs UI reads it).
+DROP POLICY IF EXISTS notification_categories_read ON public.notification_categories;
+CREATE POLICY notification_categories_read
+  ON public.notification_categories FOR SELECT
+  TO authenticated, anon
+  USING (true);
+
+-- A user owns their own channel prefs (read + write).
+DROP POLICY IF EXISTS notification_channel_prefs_owner ON public.notification_channel_prefs;
+CREATE POLICY notification_channel_prefs_owner
+  ON public.notification_channel_prefs FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- A user reads their own suppressions (writes are service-role only — no policy
+-- for authenticated INSERT/UPDATE → RLS denies; service-role bypasses RLS).
+DROP POLICY IF EXISTS channel_suppressions_read_own ON public.channel_suppressions;
+CREATE POLICY channel_suppressions_read_own
+  ON public.channel_suppressions FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- A user reads their own consent records (append-only; service-role writes).
+DROP POLICY IF EXISTS consent_records_read_own ON public.consent_records;
+CREATE POLICY consent_records_read_own
+  ON public.consent_records FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- A user reads delivery rows for their own notifications (service-role writes).
+DROP POLICY IF EXISTS notification_deliveries_read_own ON public.notification_deliveries;
+CREATE POLICY notification_deliveries_read_own
+  ON public.notification_deliveries FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.notifications n
+     WHERE n.id = notification_deliveries.notification_id
+       AND n.user_id = auth.uid()
+  ));
+
+-- The outbox is service-role only — NO policy for authenticated/anon → RLS denies
+-- all non-service access. The trigger writes it as the table owner; the cron
+-- drains it via service-role. Intentionally no read/write policy.

--- a/supabase/migrations/20261110000001_orch_1161_seed_notification_categories.sql
+++ b/supabase/migrations/20261110000001_orch_1161_seed_notification_categories.sql
@@ -1,0 +1,61 @@
+-- META-ORCH-1161 Sub-A (thin slice) — seed notification_categories per SPEC §5.2.
+--
+-- ALL rows are seeded so the closed SMS set is correct from day one (DC-3): only
+-- rows with urgency='high' AND 'sms' in default_channels can EVER reach SMS.
+-- The thin slice only WIRES buyer_reservation_changed end-to-end; the other rows
+-- exist so can_send() and the strict-grep gate evaluate against the full matrix.
+--
+-- Idempotent: ON CONFLICT (key) DO UPDATE keeps the seed authoritative.
+
+INSERT INTO public.notification_categories
+  (key, section, is_transactional, urgency, default_channels, reach_mode)
+VALUES
+  -- Sub-C buyer reservation moments (the thin slice wires `changed`).
+  ('buyer_reservation_confirmed', 'Reservations', true, 'high',
+     ARRAY['inapp','push','email','sms'], 'reach_once'),
+  ('buyer_reservation_changed',   'Reservations', true, 'high',
+     ARRAY['inapp','push','email','sms'], 'reach_once'),
+  ('buyer_reservation_cancelled', 'Reservations', true, 'high',
+     ARRAY['inapp','push','email','sms'], 'reach_once'),
+  -- Sub-C reminders.
+  ('buyer_event_reminder',        'Reminders', true, 'high',
+     ARRAY['inapp','push','email','sms'], 'escalate_on_no_engagement'),
+  ('buyer_reservation_reminder',  'Reminders', true, 'high',
+     ARRAY['inapp','push','email','sms'], 'escalate_on_no_engagement'),
+  -- Purchase confirmation: per DEC-185 SMS is REMOVED for purchases (COPY §3.11);
+  -- push+email only. NOT SMS-eligible.
+  ('buyer_purchase_confirmation', 'Purchases', true, 'high',
+     ARRAY['inapp','push','email'], 'reach_once'),
+  -- Refund / order-cancelled (existing email-shaped moments; no SMS in the seed).
+  ('buyer_refund_issued',         'Purchases', true, 'normal',
+     ARRAY['inapp','push','email'], 'reach_once'),
+  ('buyer_order_cancelled',       'Purchases', true, 'normal',
+     ARRAY['inapp','push','email'], 'reach_once'),
+  -- Waitlist spot open (SMS-eligible high-urgency).
+  ('waitlist_spot_open',          'Purchases', true, 'high',
+     ARRAY['inapp','push','email','sms'], 'reach_once'),
+  -- Sub-B marketing blast (per-campaign channel; off-by-default, low urgency).
+  ('marketing_blast',             'Marketing', false, 'low',
+     ARRAY['email','sms'], 'reach_once'),
+  -- The single BUSINESS SMS per DEC-185 / COPY §3.12 (payout). high-urgency.
+  ('payout_paid',                 'Payouts', true, 'high',
+     ARRAY['inapp','push','sms'], 'reach_once'),
+  -- Existing consumer-social categories (mapped so the v2 gate is a no-op for
+  -- the legacy path; channels = what they use today, no SMS).
+  ('friend_requests',             'Social', true, 'low',
+     ARRAY['inapp','push'], 'reach_once'),
+  ('messages',                    'Social', true, 'normal',
+     ARRAY['inapp','push'], 'reach_once'),
+  ('collaboration_invites',       'Social', true, 'normal',
+     ARRAY['inapp','push'], 'reach_once'),
+  ('reminders',                   'Social', true, 'low',
+     ARRAY['inapp','push'], 'reach_once'),
+  ('marketing',                   'Marketing', false, 'low',
+     ARRAY['inapp','push','email'], 'reach_once')
+ON CONFLICT (key) DO UPDATE SET
+  section          = EXCLUDED.section,
+  is_transactional = EXCLUDED.is_transactional,
+  urgency          = EXCLUDED.urgency,
+  default_channels = EXCLUDED.default_channels,
+  reach_mode       = EXCLUDED.reach_mode,
+  active           = true;

--- a/supabase/migrations/20261110000002_orch_1161_can_send_and_reservation_trigger.sql
+++ b/supabase/migrations/20261110000002_orch_1161_can_send_and_reservation_trigger.sql
@@ -1,0 +1,186 @@
+-- META-ORCH-1161 Sub-A (thin slice) — can_send() gate + reservation→outbox trigger.
+--
+-- can_send() (SPEC §5.3) is the SINGLE consent chokepoint. Simultaneous model
+-- (DEC-185): the dispatcher calls can_send() once per channel and fires EVERY
+-- channel that passes — there is no fallback ordering. can_send() itself has no
+-- waterfall logic; it answers a pure per-channel question.
+--
+-- The AFTER UPDATE trigger on reservations (SPEC §7.2) writes a notification_outbox
+-- row on a status/table/time change → mapped to buyer_reservation_changed. It does
+-- NOT touch reservation money/lifecycle logic (DO-NOT-TOUCH) — it only enqueues.
+
+-- =============================================================
+-- §1. can_send(user, category, channel, contact) — SECURITY DEFINER.
+-- =============================================================
+-- Returns true iff:
+--   category active
+--   AND channel ∈ category.default_channels
+--   AND (is_transactional OR an explicit pref enabled=true)   -- marketing off-by-default
+--   AND no explicit per-(category,channel) opt-out row (enabled=false)
+--   AND no suppression for (user|contact, channel, scope ∈ {category_scope,'all'})
+-- Quiet-hours is a marketing-only concern (Sub-B) and is NOT applied to
+-- transactional categories here (thin slice is transactional-only).
+CREATE OR REPLACE FUNCTION public.can_send(
+  p_user_id uuid,
+  p_category_key text,
+  p_channel text,
+  p_contact text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_cat            public.notification_categories%ROWTYPE;
+  v_pref_enabled   boolean;
+  v_category_scope text;
+  v_suppressed     boolean;
+BEGIN
+  -- 1. Category must exist + be active.
+  SELECT * INTO v_cat
+    FROM public.notification_categories
+   WHERE key = p_category_key;
+  IF NOT FOUND OR v_cat.active IS NOT TRUE THEN
+    RETURN false;
+  END IF;
+
+  -- 2. Channel must be in the category's default_channels.
+  IF NOT (p_channel = ANY (v_cat.default_channels)) THEN
+    RETURN false;
+  END IF;
+
+  -- 3. Pref gate. Look up the explicit per-(category,channel) pref (if any).
+  v_pref_enabled := NULL;
+  IF p_user_id IS NOT NULL THEN
+    SELECT enabled INTO v_pref_enabled
+      FROM public.notification_channel_prefs
+     WHERE user_id = p_user_id
+       AND category_key = p_category_key
+       AND channel = p_channel;
+  END IF;
+
+  IF v_cat.is_transactional THEN
+    -- Transactional: on-by-default; an EXPLICIT enabled=false opts out of this channel.
+    IF v_pref_enabled IS NOT NULL AND v_pref_enabled = false THEN
+      RETURN false;
+    END IF;
+  ELSE
+    -- Marketing: off-by-default; requires an explicit enabled=true.
+    IF v_pref_enabled IS DISTINCT FROM true THEN
+      RETURN false;
+    END IF;
+  END IF;
+
+  -- 4. Suppression gate (only email/sms can be suppressed; inapp/push always pass step 4).
+  IF p_channel IN ('email','sms') THEN
+    v_category_scope := CASE WHEN v_cat.is_transactional
+                             THEN 'transactional' ELSE 'marketing' END;
+    SELECT EXISTS (
+      SELECT 1 FROM public.channel_suppressions s
+       WHERE s.channel = p_channel
+         AND s.scope IN (v_category_scope, 'all')
+         AND (
+           (p_user_id IS NOT NULL AND s.user_id = p_user_id)
+           OR (p_contact IS NOT NULL AND s.contact = lower(p_contact))
+           OR (p_contact IS NOT NULL AND s.contact = p_contact)
+         )
+    ) INTO v_suppressed;
+    IF v_suppressed THEN
+      RETURN false;
+    END IF;
+  END IF;
+
+  RETURN true;
+END;
+$function$;
+
+-- SECURITY DEFINER auto-grant gotcha — REVOKE PUBLIC + anon explicitly.
+REVOKE ALL ON FUNCTION public.can_send(uuid, text, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.can_send(uuid, text, text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.can_send(uuid, text, text, text) TO authenticated;
+
+COMMENT ON FUNCTION public.can_send(uuid, text, text, text) IS
+  'META-ORCH-1161 §5.3 — the single consent chokepoint. Pure per-channel answer; '
+  'the dispatcher fires every channel that returns true (DEC-185 simultaneous, no fallback).';
+
+-- =============================================================
+-- §2. reservations AFTER UPDATE → notification_outbox (buyer_reservation_changed).
+-- =============================================================
+-- Fires only on a meaningful change: status, table_id, or reserved_for (time).
+-- Maps to buyer_reservation_changed. confirmed/cancelled mappings are documented
+-- but the thin slice only PROVES `changed`. The trigger only ENQUEUES — it never
+-- touches money/lifecycle (DO-NOT-TOUCH).
+CREATE OR REPLACE FUNCTION public.orch_1161_reservation_notify_outbox()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_category text;
+  v_contact  text;
+  v_idem     text;
+BEGIN
+  -- Only enqueue on a real change to status / table / time.
+  IF NEW.status IS NOT DISTINCT FROM OLD.status
+     AND NEW.table_id IS NOT DISTINCT FROM OLD.table_id
+     AND NEW.reserved_for IS NOT DISTINCT FROM OLD.reserved_for THEN
+    RETURN NEW;
+  END IF;
+
+  -- Map the transition to a category. Thin slice proves `changed`.
+  IF NEW.status IN ('cancelled_by_guest','cancelled_by_venue')
+     AND NEW.status IS DISTINCT FROM OLD.status THEN
+    v_category := 'buyer_reservation_cancelled';
+  ELSIF NEW.status = 'confirmed' AND OLD.status = 'requested' THEN
+    v_category := 'buyer_reservation_confirmed';
+  ELSE
+    -- table reassignment, time change, seated, or any other status move.
+    v_category := 'buyer_reservation_changed';
+  END IF;
+
+  -- Contact for the SMS/email leg: the guest phone (preferred) or email.
+  v_contact := COALESCE(NEW.guest_phone_e164, NEW.guest_email);
+
+  -- Idempotency: one outbox row per (category, reservation, transition instant).
+  v_idem := v_category || ':' || NEW.id::text || ':'
+            || to_char(now(), 'YYYYMMDD"T"HH24MISSMS');
+
+  INSERT INTO public.notification_outbox
+    (category_key, user_id, contact, brand_id, payload, idempotency_key)
+  VALUES (
+    v_category,
+    NEW.consumer_user_id,
+    v_contact,
+    NEW.brand_id,
+    jsonb_build_object(
+      'reservation_id', NEW.id,
+      'status',         NEW.status,
+      'reserved_for',   NEW.reserved_for,
+      'party_size',     NEW.party_size,
+      'guest_name',     NEW.guest_name,
+      'guest_phone_e164', NEW.guest_phone_e164,
+      'guest_email',    NEW.guest_email
+    ),
+    v_idem
+  )
+  ON CONFLICT (idempotency_key) DO NOTHING;
+
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.orch_1161_reservation_notify_outbox() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.orch_1161_reservation_notify_outbox() FROM anon;
+
+DROP TRIGGER IF EXISTS orch_1161_reservation_notify_trg ON public.reservations;
+CREATE TRIGGER orch_1161_reservation_notify_trg
+  AFTER UPDATE ON public.reservations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.orch_1161_reservation_notify_outbox();
+
+COMMENT ON FUNCTION public.orch_1161_reservation_notify_outbox() IS
+  'META-ORCH-1161 §7.2 — enqueues a notification_outbox row on a reservation '
+  'status/table/time change. ENQUEUE ONLY; never touches money/lifecycle.';

--- a/supabase/migrations/20261110000003_orch_1161_outbox_drain_cron.sql
+++ b/supabase/migrations/20261110000003_orch_1161_outbox_drain_cron.sql
@@ -1,0 +1,95 @@
+-- META-ORCH-1161 Sub-A (thin slice) — pg_cron schedule to drain notification_outbox.
+--
+-- Mirrors supabase/migrations/20260603000000_orch_0815_b_marketing_send_cron.sql
+-- verbatim with: (1) jobname `orch_1161_notify_outbox_drain`, (2) endpoint
+-- `/functions/v1/notify-outbox-drain`, (3) `* * * * *` (every minute).
+--
+-- The notify-outbox-drain edge fn claims pending outbox rows and POSTs each to
+-- notify-dispatch v2 with the new {category_key,...} contract. The per-market
+-- SMS kill-switch (SMS_LIVE_ENABLED_US, default false) lives in smsAdapter, so
+-- the cron is harmless for SMS until the operator flips it.
+--
+-- Cross-references:
+--   - SPEC:      Mingla_Artifacts/specs/SPEC_META-ORCH-1161 §5.4 / §7.2 / §11
+--   - Precedent: supabase/migrations/20260603000000_orch_0815_b_marketing_send_cron.sql
+--   - Edge fn:   supabase/functions/notify-outbox-drain/index.ts
+
+-- =============================================================
+-- §1. Extension + vault pre-flight (advisory NOTICEs only — CI-safe).
+-- =============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'vault') THEN
+    RAISE NOTICE 'ORCH-1161 advisory: vault schema not present. Cron job will register but http_post calls will fail at runtime until Supabase vault is configured.';
+  ELSIF NOT EXISTS (SELECT 1 FROM vault.secrets WHERE name = 'supabase_url') THEN
+    RAISE NOTICE 'ORCH-1161 advisory: vault.secrets row "supabase_url" missing. Cron job will register but http_post calls will fail at runtime.';
+  ELSIF NOT EXISTS (SELECT 1 FROM vault.secrets WHERE name = 'service_role_key') THEN
+    RAISE NOTICE 'ORCH-1161 advisory: vault.secrets row "service_role_key" missing. Cron job will register but http_post calls will fail at runtime.';
+  END IF;
+END$$;
+
+-- =============================================================
+-- §2. Idempotent re-schedule (unschedule if present, then schedule).
+-- =============================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'orch_1161_notify_outbox_drain'
+  ) THEN
+    PERFORM cron.unschedule('orch_1161_notify_outbox_drain');
+  END IF;
+END$$;
+
+-- =============================================================
+-- §3. Schedule notify-outbox-drain every minute.
+-- =============================================================
+SELECT cron.schedule(
+  'orch_1161_notify_outbox_drain',
+  '* * * * *',
+  $cron$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret
+          FROM vault.decrypted_secrets
+         WHERE name = 'supabase_url'
+         LIMIT 1
+      ) || '/functions/v1/notify-outbox-drain',
+      headers := jsonb_build_object(
+        'Content-Type',  'application/json',
+        'Authorization', 'Bearer ' || (
+          SELECT decrypted_secret
+            FROM vault.decrypted_secrets
+           WHERE name = 'service_role_key'
+           LIMIT 1
+        )
+      ),
+      body := '{}'::jsonb,
+      timeout_milliseconds := 30000
+    );
+  $cron$
+);
+
+-- =============================================================
+-- §4. Verification probes.
+-- =============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'orch_1161_notify_outbox_drain'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-1161 probe failed: cron job not registered after schedule call';
+  END IF;
+END$$;
+
+DO $$
+DECLARE
+  v_schedule text;
+BEGIN
+  SELECT schedule INTO v_schedule
+    FROM cron.job
+   WHERE jobname = 'orch_1161_notify_outbox_drain'
+   LIMIT 1;
+  IF v_schedule IS DISTINCT FROM '* * * * *' THEN
+    RAISE EXCEPTION 'ORCH-1161 probe failed: cron job schedule is % but expected * * * * *', v_schedule;
+  END IF;
+END$$;

--- a/supabase/migrations/20261110000004_orch_1161_atomic_claim_and_guest_ledger.sql
+++ b/supabase/migrations/20261110000004_orch_1161_atomic_claim_and_guest_ledger.sql
@@ -1,0 +1,125 @@
+-- META-ORCH-1161 Sub-A (REWORK 2026-06-20) — atomic outbox claim + guest delivery ledger.
+--
+-- Closes two tester-found P2 defects (TEST_META-ORCH-1161_SUBA_THIN_SLICE.md):
+--   P2-1 — the drain claimed pending outbox rows with a NON-atomic
+--          SELECT status='pending' … then UPDATE status='processing'. Two
+--          overlapping cron runs (a run >60s) could BOTH claim the same row →
+--          the guest/no-user_id path (which has no notifications UNIQUE backstop)
+--          double-sends SMS/email. Fix: a single atomic claim function using
+--          FOR UPDATE SKIP LOCKED so each pending row is claimed by exactly one
+--          drain invocation.
+--   P2-2 — guest/anon (no user_id) sends were NOT written to
+--          notification_deliveries (the FK required a notifications.id, and
+--          notifications.user_id is NOT NULL → no inbox row for a user-less
+--          guest). Fix: make notification_deliveries.notification_id NULLABLE and
+--          add contact + idempotency_key columns so a guest send writes a
+--          contact-keyed delivery row reconcilable by the Twilio status webhook,
+--          PLUS a partial UNIQUE(idempotency_key, channel) on the guest rows so a
+--          duplicated drain tick sends each channel at most ONCE (the dispatcher
+--          idempotency that the user_id path already gets via notifications
+--          UNIQUE now also covers the guest path).
+--
+-- Additive + monotonic: prefix 20261110000004 > existing 1161 max …000003 and >
+-- every sibling-worktree prefix. Touches ONLY 1161-owned objects.
+--
+-- Cross-refs:
+--   SPEC:  Mingla_Artifacts/specs/SPEC_META-ORCH-1161 §5.1 / §5.4 / §7.2
+--   Tester:Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA_THIN_SLICE.md P2-1, P2-2
+
+-- =============================================================
+-- §1. notification_deliveries — allow guest (no-notification) rows.
+-- =============================================================
+-- The FK was NOT NULL, blocking a guest send (no inbox row) from being ledgered.
+-- Relax to NULL and add contact + idempotency_key so a guest row is contact-keyed
+-- and reconcilable by provider_message_id like the authenticated path.
+ALTER TABLE public.notification_deliveries
+  ALTER COLUMN notification_id DROP NOT NULL;
+
+ALTER TABLE public.notification_deliveries
+  ADD COLUMN IF NOT EXISTS contact text NULL;          -- E.164 / lowercased email for guest rows
+
+ALTER TABLE public.notification_deliveries
+  ADD COLUMN IF NOT EXISTS idempotency_key text NULL;  -- dispatch idempotency for guest dedupe
+
+-- Integrity: a delivery row is EITHER tied to a notification (authenticated) OR
+-- carries a contact (guest) — never neither (no orphan, no silent loss).
+ALTER TABLE public.notification_deliveries
+  DROP CONSTRAINT IF EXISTS notification_deliveries_owner_chk;
+ALTER TABLE public.notification_deliveries
+  ADD CONSTRAINT notification_deliveries_owner_chk
+  CHECK (notification_id IS NOT NULL OR contact IS NOT NULL);
+
+-- Guest dedupe: a duplicated drain tick that re-dispatches the SAME
+-- idempotency_key must write each (idempotency_key, channel) at most ONCE. The
+-- dispatcher inserts the guest row BEFORE sending; the 23505 on the second tick
+-- tells it the send already happened → skip the provider HTTP. Partial so the
+-- authenticated path (idempotency_key NULL on the deliveries row) is unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS notification_deliveries_guest_idem_idx
+  ON public.notification_deliveries (idempotency_key, channel)
+  WHERE idempotency_key IS NOT NULL AND notification_id IS NULL;
+
+COMMENT ON COLUMN public.notification_deliveries.contact IS
+  'META-ORCH-1161 §5.1 (rework) — guest/anon contact (E.164/email) for a delivery '
+  'row with no notification_id. Webhook reconciles by provider_message_id either way.';
+COMMENT ON COLUMN public.notification_deliveries.idempotency_key IS
+  'META-ORCH-1161 §5.4 (rework) — guest dispatch idempotency. UNIQUE(idempotency_key, '
+  'channel) on guest rows dedupes a double-claimed outbox tick to one send per channel.';
+
+-- The owner RLS policy referenced notification_id; guest rows (notification_id
+-- NULL, no auth.uid) are service-role-only reads — the existing policy already
+-- denies them to authenticated (EXISTS over a NULL FK is false), so no policy
+-- change is required. Re-affirm it explicitly so the intent is on record.
+DROP POLICY IF EXISTS notification_deliveries_read_own ON public.notification_deliveries;
+CREATE POLICY notification_deliveries_read_own
+  ON public.notification_deliveries FOR SELECT
+  TO authenticated
+  USING (
+    notification_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM public.notifications n
+       WHERE n.id = notification_deliveries.notification_id
+         AND n.user_id = auth.uid()
+    )
+  );
+
+-- =============================================================
+-- §2. claim_notification_outbox(p_limit) — ATOMIC claim (P2-1).
+-- =============================================================
+-- A single statement claims up to p_limit pending rows: the inner SELECT locks
+-- the chosen rows with FOR UPDATE SKIP LOCKED so a concurrent drain invocation
+-- can NEVER lock/claim the same row, then the outer UPDATE flips them to
+-- 'processing' and RETURNs them. Replaces the drain's non-atomic
+-- SELECT-then-UPDATE. SECURITY DEFINER so the service-role caller runs it under
+-- the table owner (the outbox is RLS service-role-only).
+CREATE OR REPLACE FUNCTION public.claim_notification_outbox(p_limit int DEFAULT 25)
+RETURNS SETOF public.notification_outbox
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+BEGIN
+  RETURN QUERY
+  UPDATE public.notification_outbox o
+     SET status = 'processing'
+   WHERE o.id IN (
+     SELECT c.id
+       FROM public.notification_outbox c
+      WHERE c.status = 'pending'
+      ORDER BY c.created_at
+      FOR UPDATE SKIP LOCKED
+      LIMIT GREATEST(p_limit, 0)
+   )
+  RETURNING o.*;
+END;
+$function$;
+
+-- SECURITY DEFINER auto-grant gotcha — REVOKE PUBLIC + anon + authenticated.
+-- Only the service-role (which bypasses GRANTs) may claim the outbox.
+REVOKE ALL ON FUNCTION public.claim_notification_outbox(int) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.claim_notification_outbox(int) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.claim_notification_outbox(int) FROM authenticated;
+
+COMMENT ON FUNCTION public.claim_notification_outbox(int) IS
+  'META-ORCH-1161 §5.4 (rework) — ATOMIC outbox claim. FOR UPDATE SKIP LOCKED so '
+  'two overlapping drain runs never claim the same row (P2-1 double-send fix). '
+  'Service-role only.';


### PR DESCRIPTION
## META-ORCH-1161 Sub-A — thin slice (buyer_reservation_changed)

First end-to-end slice of the multi-channel notification foundation. Reservation status/table/time change → AFTER UPDATE trigger → notification_outbox → 1-min cron drain → notify-dispatch v2 → push + in-app + email fire SIMULTANEOUSLY (DEC-185 policy model); SMS gated behind SMS_LIVE_ENABLED_US (default OFF) + transactional consent + channel_suppressions. STOP inbound suppresses; status webhook reconciles deliveries.

**Scope:** backend only. Foundation tables (categories/prefs/suppressions/consent/deliveries + outbox), can_send(), push/email/sms adapters (smsAdapter generalized from send-venue-sms), notify-dispatch v2 (legacy type path byte-identical), twilio-inbound-sms, twilio-message-status extension, notify-outbox-drain cron. Atomic claim (FOR UPDATE SKIP LOCKED) + guest delivery ledger.

**QA:** mingla-tester RE-VERIFY PASS — CLEAR TO CLOSE (P0:0 P1:0 P2:0), runtime-proven on real Postgres 17. Step 0.5: implementor happy-path (fails-on-revert @ a511b7944) + tester adversarial guest-path (@ 577de017b) + rework tests; 13/13 Deno green, registered in CI.

**SMS stays OFF** (per-market kill-switch default false). Migrations 20261110000000→04. Edge fns deploy from merged main.

Closes: META-ORCH-1161 Sub-A thin slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)