### PR TITLE
META-ORCH-1161 Sub-A.2: bundled-mandatory consent capture (onboarding + checkout) + seed correction [deploy]

### DIFF
--- a/Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md
+++ b/Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md
@@ -1,0 +1,257 @@
+# COPY — META-ORCH-1161 — Consent + T&C + Message Templates
+
+**ORCH:** META-ORCH-1161 (multi-channel notification & messaging system)
+**Phase:** mingla-product (COPY) — brand-voice + legally-grounded copy, NOT code
+**Date:** 2026-06-19
+**Owner:** mingla-product
+**Authority for this phase:** DEC-186 (bundled-mandatory consent; TCPA risk ACCEPTED + SIGNED OFF by Seth 2026-06-19) · SPEC_META-ORCH-1161 §7 (Sub-C moments), §8 (compliance gate), §8.6 (consent capture UX) · INVESTIGATE_META-ORCH-1161_SMS_COMPLIANCE_RESEARCH §2–§3 (required disclosure elements)
+
+---
+
+## ⚠️ LEGAL CALLOUT — READ BEFORE SHIPPING ANY OF THIS COPY
+
+1. **Counsel review is RECOMMENDED for the bundled-consent line (§1) and the full T&C/consent sheet (§2).** Seth has signed off on the **TCPA risk** of bundling SMS-marketing consent into a required-to-continue checkbox (DEC-186, 2026-06-19) — that unblocks the SMS-marketing legal gate item #8 on Seth's authority as the business owner accepting the risk. **Seth's risk sign-off is NOT a substitute for an attorney reviewing the actual wording** of the consent line and the T&C body for enforceability, completeness, and jurisdiction fit. The known TCPA exposure remains real ($500–$1,500/text + carrier filtering). Have counsel read §1 and §2 verbatim before SMS-marketing flips live, especially in the US.
+2. **Every `[[FILL: …]]` placeholder below MUST be replaced with Mingla's real legal/operational values before any of this copy ships.** A consent record that references a non-existent entity or a dead policy URL is worthless as a burden-of-proof artifact. The full list is in §5.
+3. **The §1 string is recorded VERBATIM into `consent_records.disclosure_text`** (both `scope='transactional'` and `scope='marketing'`) at every grant on both surfaces. It is the legal burden-of-proof artifact backing the risk-accepted bundling. Whatever ships is what gets recorded — do not let implementation paraphrase it.
+4. **GSM-7 discipline (I-PROPOSED-1161-GSM7-SANITIZED-TEMPLATES):** every SMS body below uses ONLY GSM-7-safe characters — straight apostrophes `'`, hyphens `-` (never em/en-dash), no curly quotes, no ellipsis character. The dispatcher still runs the sanitizer, but these are authored clean so nothing degrades. Segment counts assume GSM-7 (160 chars/segment, 153/segment when concatenated). Brand/event placeholders are variable-length; the per-template note states the worst-case assumption.
+
+---
+
+## 1. THE BUNDLED CONSENT LINE + CHECKBOX LABEL (the single mandatory gate)
+
+Used on BOTH:
+- the **consumer-app OTP / signup consent screen** (`app-mobile` onboarding consent step), and
+- the **anonymous buyer checkout page** (`mingla-business/app/checkout/[eventId]/buyer.tsx`).
+
+ONE mandatory checkbox. Pay/Continue is greyed out until checked. The visible label carries the underlined **terms and conditions** link that opens the §2 sheet.
+
+### 1a. Visible checkbox label (the short line shown next to the checkbox)
+
+> **I agree to Mingla's [terms and conditions]** and to receive booking confirmations, reminders, account updates, and marketing from Mingla and the businesses I book with — by email, push, and text. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out of texts, HELP for help.
+
+- `[terms and conditions]` renders as an underlined tappable link opening the §2 sheet.
+- This label is always fully visible (not collapsed) so the disclosure is presented at the point of consent.
+
+### 1b. EXACT disclosure string recorded into `consent_records.disclosure_text` (VERBATIM)
+
+> *Record this exact string (resolve the `[[FILL]]` placeholders to real values first). Both scopes get the same string. No paraphrase. Implementation must store the resolved, shipped wording.*
+
+```
+I agree to Mingla's Terms & Conditions and Privacy Policy, and I consent to receive from Mingla LLC and the businesses I book with: (1) transactional and account messages including booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, and payment notices; (2) event and reservation reminders for this booking and for future events; and (3) marketing and promotional messages, including offers and announcements from venues and experience brands. These messages may be sent by email, in-app notification, push notification, and recurring automated text message (SMS) to the phone number I provide. Message frequency varies. Msg & data rates may apply. Consent to texts is not a condition of any purchase. Reply STOP to any text to opt out, or HELP for help; you can also unsubscribe from email via the link in any message or change your preferences in the Mingla app at any time. Full terms: https://www.usemingla.com/terms-of-service | Privacy: https://www.usemingla.com/privacy-policy | SMS terms: https://www.usemingla.com/sms-terms.
+```
+
+**Required-disclosure-element checklist (proves §8.6 + INVESTIGATE §3 are satisfied):**
+
+| Required element (INVESTIGATE §3 [HARD]) | Where it appears in 1b |
+|---|---|
+| Brand / Mingla identity | "Mingla LLC and the businesses I book with" |
+| Agreement to receive marketing texts | "marketing and promotional messages … by … recurring automated text message (SMS)" |
+| Expected frequency | "Message frequency varies." |
+| "Msg & data rates may apply" | present verbatim |
+| STOP to opt out | "Reply STOP to any text to opt out" |
+| HELP for help | "or HELP for help" |
+| Terms & Conditions link | "[terms and conditions]" (1a) / "Full terms: https://www.usemingla.com/terms-of-service" (1b) |
+| Transactional scope covered | "transactional and account messages including booking and reservation confirmations…" |
+| Reminders (this + future events) | "reminders for this booking and for future events" |
+| Email marketing covered | "marketing … may be sent by email" |
+| "not a condition of purchase" (TCPA-mitigating language) | "Consent to texts is not a condition of any purchase." |
+| Withdraw/opt-out cross-channel | "unsubscribe from email via the link … or change your preferences in the Mingla app at any time" |
+
+> **Note on the "not a condition of purchase" sentence:** it is included deliberately. DEC-186 makes the checkbox required-to-continue (the accepted TCPA risk). Stating "consent to texts is not a condition of any purchase" is the standard TCPA-mitigating disclosure and is the single most useful sentence for counsel to keep. **Counsel may want to reconcile this sentence with the gated-checkbox behavior** — flag it explicitly in review. It is kept because it strengthens, not weakens, the record. (If counsel directs removal, that is a one-line edit + a re-record of `disclosure_text`.)
+
+---
+
+## 2. THE FULL TERMS & CONDITIONS / CONSENT SHEET BODY (opens from the §1 link)
+
+> This is the body the underlined "terms and conditions" link opens, on BOTH surfaces. It reads correctly for signup AND for checkout/marketing context (it says "when you create an account or complete a booking"). It (a) protects + absolves Mingla and (b) enrolls the user in reminders for this event + future events + marketing (email + SMS) with opt-out instructions.
+>
+> **This is plain-language product copy, NOT a finished legal contract.** It is written to be readable and to surface the legally-required consent disclosures in the user's flow. Mingla's full, counsel-drafted Terms of Service and Privacy Policy (linked at the bottom) remain the controlling documents. Have counsel review or replace this body before launch.
+
+---
+
+### Mingla — Terms, Notifications & Consent
+
+**Last updated: 2026-06-19**
+
+By creating a Mingla account or completing a booking, you agree to these terms and to Mingla's full https://www.usemingla.com/terms-of-service and https://www.usemingla.com/privacy-policy, which are incorporated here by reference. If you do not agree, do not create an account or complete a booking.
+
+**1. Who you're agreeing with.**
+Mingla is operated by Mingla LLC, 700 Corporate Center Dr, Raleigh, NC 27607, USA ("Mingla," "we," "us"). Questions: support@usemingla.com · +1 888-250-5351.
+
+**2. What Mingla is — and is not.**
+Mingla helps you discover places, events, experiences, and trips and connects you with venues and experience brands ("Businesses"). **Mingla is a platform; the Businesses are independent third parties.** Events, reservations, menus, prices, availability, and experiences are created and controlled by the Businesses, not by Mingla. Mingla does not own, operate, host, or supervise any venue, event, or experience, and is not a party to your agreement with a Business.
+
+**3. No guarantee; you assume the risks of real-world activity.**
+We work to keep listings accurate, but **Mingla does not guarantee** the accuracy, availability, quality, safety, legality, or outcome of any listing, event, reservation, experience, or Business, or that any event will occur as described. You attend events and experiences and visit venues **at your own risk.** You are responsible for your own conduct and safety and for evaluating any Business before you go.
+
+**4. Third-party responsibility.**
+Any dispute about an event, reservation, experience, refund, service, injury, or loss is between you and the relevant Business. **Mingla is not responsible or liable for the acts, omissions, products, services, or content of any Business or other user.** Where Mingla processes a payment, it does so as a technical facilitator; the Business remains the merchant of record for what it sells unless stated otherwise at checkout.
+
+**5. Limitation of liability; release.**
+To the fullest extent permitted by law, Mingla and its officers, employees, and partners are **not liable** for any indirect, incidental, special, consequential, or punitive damages, or for any loss arising from your use of the app, any listing, any Business, or any event or experience. To the fullest extent permitted by law, **you release Mingla from claims arising out of disputes with Businesses or other users or from your participation in any real-world activity discovered through Mingla.** Mingla's total liability for any claim is limited to the greater of the amount you paid Mingla (not the Business) for the transaction at issue or [[COUNSEL: liability cap, e.g. US $100]]. Some jurisdictions do not allow certain limitations; where that applies, the limitation applies to the maximum extent permitted.
+
+**6. Communications & consent — what you're signing up for.**
+When you create an account or complete a booking and check the consent box, you agree to receive the following from Mingla and from the Businesses you book with:
+
+- **Transactional & account messages** — booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, payment notices, and account/security messages. These are required to use Mingla and are tied to your activity.
+- **Reminders** — reminders for the event, experience, trip, or reservation you book, **and for future events** you may be interested in.
+- **Marketing & promotional messages** — offers, announcements, new events, and promotions from Mingla and from venues and experience brands, including via marketing blasts.
+
+These may be delivered by **email, in-app notification, push notification, and recurring automated text message (SMS)** to the contact details you provide. **Message frequency varies. Msg & data rates may apply.** Consent to receive marketing texts is not a condition of any purchase.
+
+**7. How to opt out.**
+- **Text (SMS):** reply **STOP** to any text to stop texts, or **HELP** for help. We also honor *quit, end, cancel, unsubscribe, revoke, and opt out*.
+- **Email:** use the unsubscribe link in any marketing email.
+- **In-app:** open the Mingla app and adjust your notification preferences at any time, per channel and per category.
+- **Outside the US:** opt-out may also run through your local registry (for example, in Nigeria, the NCC DND service by texting STOP to 2442) and the in-app preference center.
+
+We honor opt-out requests received by any reasonable means and process them promptly (within the timeframes required by law). **Opting out of marketing does not stop transactional or account messages**, which are required to deliver what you booked. You may still receive a single confirmation message after you opt out.
+
+**8. Data handling.**
+We collect and use the contact details and information you provide (including your name, email, phone number, and country) to operate Mingla, deliver the messages above, process bookings and payments, prevent fraud, and improve the service, as described in our https://www.usemingla.com/privacy-policy. We share necessary booking details with the Business you book with so it can fulfill your reservation or order. We do not sell your personal information except as described in the Privacy Policy. Where required, our lawful basis for marketing is your consent, which you may withdraw at any time as described in section 7. We record the date, time, exact text of this disclosure, and your country at the time you consent, as proof of your consent.
+
+**9. Payments, refunds & cancellations.**
+Prices, fees, taxes, refund eligibility, and cancellation terms are set by the Business and shown at checkout. Refunds, where offered, are handled under the Business's policy and applicable law. Mingla is not obligated to issue refunds for a Business's products or services.
+
+**10. Eligibility & acceptable use.**
+You must be the age of majority in your location (and at least 18) to enter into these terms and to receive marketing messages. You agree to provide accurate information, to use Mingla lawfully, and not to misuse the platform or other users.
+
+**11. Changes; governing law; contact.**
+We may update these terms; material changes will be notified in-app or by email, and continued use means acceptance. These terms are governed by the laws of the State of North Carolina, USA [[COUNSEL: confirm choice-of-law/venue]]. Disputes are resolved per the full https://www.usemingla.com/terms-of-service (including any arbitration or venue clause stated there). Contact us at support@usemingla.com or 700 Corporate Center Dr, Raleigh, NC 27607, USA.
+
+**Full Terms of Service: https://www.usemingla.com/terms-of-service · Privacy Policy: https://www.usemingla.com/privacy-policy · SMS Terms: https://www.usemingla.com/sms-terms**
+
+---
+
+## 3. TRANSACTIONAL SMS BODY TEMPLATES (GSM-7-safe, ≤1 segment target)
+
+**Conventions:**
+- `{Brand}` = the Business's display name. `{Mingla}` not used in body (the Business name is the sender identity per CTIA brand-name-in-body rule; Mingla is the platform-of-record disclosed at opt-in).
+- All transactional bodies are **PURE transactional** — zero promotional content (TCPA §2: mixing promo turns a transactional text into marketing). Do not add "see our other events" to any of these.
+- "Reply STOP to opt out" included on every SMS-eligible transactional body per CTIA + the closed SMS-eligible set. STOP is auto-handled by Twilio; the inline reminder satisfies the carrier expectation and reinforces opt-out.
+- Segment counts below = **fixed text only**; the brand name + interpolated values consume the rest of the segment. Worst-case guidance is given per template so implementation keeps each to 1 segment by truncating long brand names (recommend truncating `{Brand}` to ~20 chars in the SMS leg).
+
+> The matching push title/body (free, no STOP needed) is given for each so the simultaneous-send (DEC-185) copy is complete. Push has no STOP line and no segment limit but should stay short.
+
+### 3.1 `buyer_reservation_changed` (SMS)
+```
+{Brand}: Your reservation changed - now {date} {time}, party of {party}. Reply STOP to opt out.
+```
+- Fixed text ~75 chars. 1 segment with `{Brand}`≤20, short date/time. **Push:** title `Reservation updated` / body `{Brand}: now {date} {time}, party of {party}.`
+
+### 3.2 `buyer_reservation_cancelled` (SMS)
+```
+{Brand}: Your reservation for {date} was cancelled. Questions? Contact the venue. Reply STOP to opt out.
+```
+- Fixed text ~84 chars. 1 segment with `{Brand}`≤20. **Push:** title `Reservation cancelled` / body `{Brand}: your {date} reservation was cancelled.`
+
+### 3.3 `buyer_event_reminder_24h` (SMS)
+```
+{Brand}: {Event} is tomorrow at {time}. See you there! Reply STOP to opt out.
+```
+- Fixed text ~58 chars; `{Event}` variable. Keep `{Brand}`+`{Event}` combined ≤95 chars for 1 segment. **Push:** title `Tomorrow: {Event}` / body `{Brand}: starts {time}. See you there!`
+
+### 3.4 `buyer_event_reminder_2h` (SMS)
+```
+{Brand}: {Event} starts in 2 hours at {time}. See you soon! Reply STOP to opt out.
+```
+- Fixed text ~63 chars; keep combined ≤95 for 1 segment. **Push:** title `Starting soon: {Event}` / body `{Brand}: starts in 2h at {time}.`
+
+### 3.5 `buyer_reservation_reminder_24h` (SMS)
+```
+{Brand}: Reminder - your reservation is tomorrow at {time}, party of {party}. Reply STOP to opt out.
+```
+- Fixed text ~80 chars. 1 segment with `{Brand}`≤20. **Push:** title `Reservation tomorrow` / body `{Brand}: {time}, party of {party}.`
+
+### 3.6 `buyer_reservation_reminder_2h` (SMS)
+```
+{Brand}: Your reservation is in 2 hours at {time}, party of {party}. Reply STOP to opt out.
+```
+- Fixed text ~74 chars. 1 segment with `{Brand}`≤20. **Push:** title `Reservation soon` / body `{Brand}: in 2h at {time}, party of {party}.`
+
+### 3.7 `waitlist_table_ready` (SMS) — reservations
+```
+{Brand}: Your table is ready! Please check in within {minutes} min. Reply STOP to opt out.
+```
+- Fixed text ~73 chars. 1 segment with `{Brand}`≤20. **Push:** title `Your table is ready` / body `{Brand}: check in within {minutes} min.`
+
+### 3.8 `waitlist_spot_open` (SMS) — purchases (ticket/spot opens up)
+```
+{Brand}: A spot just opened for {Event}. Grab it in the Mingla app before it's gone. Reply STOP to opt out.
+```
+- Fixed text ~88 chars; `{Event}` variable. Keep combined ≤110 for 1 segment (this one is tight — truncate `{Event}` if long, or accept 2 segments). **Push:** title `Spot open: {Event}` / body `{Brand}: a spot opened. Tap to claim it.`
+- *Note: "grab it before it's gone" is urgency about the thing they waitlisted for - transactional, not a new promo. Counsel may prefer the more neutral push body; SMS kept action-oriented because the user explicitly asked to be told.*
+
+### 3.9 `buyer_refund_issued` (SMS)
+```
+{Brand}: Your refund of {amount} has been issued and should appear in 5-10 days. Reply STOP to opt out.
+```
+- Fixed text ~80 chars. 1 segment with `{Brand}`≤20. **Push:** title `Refund issued` / body `{Brand}: {amount} refunded, 5-10 days to appear.`
+
+### 3.10 `buyer_order_cancelled` (SMS)
+```
+{Brand}: Your order for {Event} was cancelled. Any payment will be refunded. Reply STOP to opt out.
+```
+- Fixed text ~79 chars; `{Event}` variable. Keep combined ≤100 for 1 segment. **Push:** title `Order cancelled` / body `{Brand}: your {Event} order was cancelled; payment refunded.`
+
+### 3.11 `buyer_purchase_confirmation` — NO SMS (DEC-185). Push + email copy only.
+- **Push:** title `You're in for {Event}` / body `{Brand}: {date} at {time} - your tickets are in the Mingla app.`
+- **Email subject:** `Your {Brand} tickets for {Event}`
+- **Email preheader:** `{date} at {time} - tickets, ticket details, and calendar file attached.`
+- **Email opening line:** `You're confirmed for {Event}. Your ticket and calendar invite are attached, and everything lives in the Mingla app.`
+- *(The email is the system-of-record and carries the PDF + .ics per §7.1. No STOP line on a pure transactional email, but the CAN-SPAM footer with physical address must still render — see §4.)*
+
+### 3.12 `payout_paid` — the single BUSINESS SMS (DEC-185)
+```
+Mingla: Your payout of {amount} is on its way to your bank, arriving in {N} business days. Reply STOP to opt out.
+```
+- Fixed text ~92 chars. 1 segment with short `{amount}`/`{N}`. Sender identity here is **Mingla** (this is a Mingla-to-brand platform message, not a Business-to-buyer message). **Push:** title `Payout sent` / body `Mingla: {amount} is on its way to your bank, {N} business days.`
+
+---
+
+## 4. EMAIL FOOTER REQUIREMENT (applies to every email leg, especially marketing)
+
+Every marketing email (and recommended on transactional too) MUST render the CAN-SPAM footer:
+
+```
+Mingla LLC, 700 Corporate Center Dr, Raleigh, NC 27607, USA.
+You're receiving this because you agreed to messages from Mingla when you signed up or booked.
+Unsubscribe: https://www.usemingla.com/unsubscribe | Manage preferences: https://www.usemingla.com/unsubscribe
+```
+- Physical postal address is **legally required** (CAN-SPAM [HARD]). Unsubscribe must work ≥30 days and be honored ≤10 business days.
+
+---
+
+## 5. PLACEHOLDERS — RESOLVED 2026-06-19 (Seth)
+
+All operational placeholders are now filled with real Mingla values (below). Two values are deferred to COUNSEL (liability cap, governing-law confirmation), and TWO marketing-site pages must be CREATED before the referenced URLs resolve (see §5.1).
+
+| Value | Resolved to | Status |
+|---|---|---|
+| Legal entity | **Mingla LLC** | ✅ filled |
+| Registered postal address | **700 Corporate Center Dr, Raleigh, NC 27607, USA** | ✅ filled (CAN-SPAM) |
+| Terms of Service URL | **https://www.usemingla.com/terms-of-service** | ✅ live page |
+| Privacy Policy URL | **https://www.usemingla.com/privacy-policy** | ✅ live page |
+| SMS Terms URL | **https://www.usemingla.com/sms-terms** | ⚠️ PAGE TO CREATE (§5.1) |
+| Unsubscribe / prefs URL | **https://www.usemingla.com/unsubscribe** | ⚠️ PAGE TO CREATE (§5.1) |
+| Support email | **support@usemingla.com** | ✅ live (/support page) |
+| Support / HELP phone | **+1 888-250-5351** (the approved toll-free) | ✅ filled |
+| Effective ("Last updated") date | **2026-06-19** (draft; counsel may restamp) | ✅ filled |
+| Liability cap | `[[COUNSEL: liability cap, e.g. US $100]]` | ⏳ counsel |
+| Governing law / jurisdiction | North Carolina, USA `[[COUNSEL: confirm]]` | ⏳ counsel |
+
+### 5.1 Marketing-site pages to CREATE (Seth directive 2026-06-19) — folded into the Sub-A consent slice
+
+The marketing site (`mingla-marketing`, Next.js app router, https://www.usemingla.com) has `/terms-of-service`, `/privacy-policy`, `/support` but **NO `/unsubscribe` and NO `/sms-terms`**. Both must be built so the consent copy's URLs resolve:
+- **`/unsubscribe`** — a self-serve opt-out page (enter email and/or phone → records an opt-out). Must write to the META-ORCH-1161 suppression model (`channel_suppressions`) once Sub-A lands it (and the existing `marketing_unsubscribes`/`marketing-unsubscribe` edge fn for tokenized one-click). NOT static — it must actually suppress. CAN-SPAM: must work ≥30 days, honored ≤10 business days.
+- **`/sms-terms`** — a static SMS program-terms page (program description, message types, frequency, "Msg & data rates may apply", STOP/HELP, support contact, links to Terms + Privacy). Often required for carrier/toll-free verification.
+- **Sequencing:** built in the Sub-A consent slice (the `/unsubscribe` opt-out write depends on `channel_suppressions` existing). Deferred behind the in-flight thin-slice implementor to avoid concurrent-agent conflict in the ORCH-1161 worktree.
+
+---
+
+## 6. PROVENANCE & HANDOFF NOTES
+
+- Brand voice: warm, plain-English, "show up for real life" (Canonical Voice) — but consent/legal copy is intentionally clear-and-flat where the law demands precision; warmth lives in the reminder/confirmation bodies ("See you there!", "You're in for {Event}"), not in the liability clauses.
+- The §1b string is the artifact recorded into `consent_records.disclosure_text` for BOTH `scope='transactional'` and `scope='marketing'` per §8.1 — single source of truth; do not let two surfaces drift to two different strings.
+- Reality-anchor: this is copy for an in-build system (META-ORCH-1161 is mid-flight, SMS kill-switches default false). Nothing here is marketed externally; it is in-product/legal copy. No grade-gated marketing claim is made.
+- COMMS context: COMMS-0040/0041 (RSVP public-page standardization) are FYI for this turn — the §1 consent line will appear on checkout-adjacent buyer-web surfaces; the copy is surface-agnostic text and does not constrain that refactor, but whoever standardizes the public RSVP page should reuse the SAME §1b string rather than authoring a variant.

--- a/Mingla_Artifacts/design/ORCH-1161/DESIGN_META-ORCH-1161_SUBA_CONSENT_AND_PREFS_UX.md
+++ b/Mingla_Artifacts/design/ORCH-1161/DESIGN_META-ORCH-1161_SUBA_CONSENT_AND_PREFS_UX.md
@@ -1,0 +1,415 @@
+# DESIGN — META-ORCH-1161 Sub-A — Consent Gates + Notification-Preferences UX
+
+**ORCH:** META-ORCH-1161 Sub-A (notification foundation)
+**Phase:** DESIGN (pixel-precise contract for mingla-implementor)
+**Author:** mingla-designer
+**Date:** 2026-06-19
+**Canonical spec:** `Mingla_Artifacts/specs/SPEC_META-ORCH-1161_NOTIFICATION_MESSAGING_SYSTEM.md` (v2; §5.1 data model, §5.2 seed, §8 compliance, §10 per-surface)
+**Decisions:** `Mingla_Artifacts/DECISION_LOG.md` DEC-185 (simultaneous policy send) + DEC-186 (bundled mandatory consent; TCPA risk accepted; legal sign-off RECORDED 2026-06-19)
+**Comms-ledger:** read on entry. No BLOCK directed at mingla-designer. COMMS-0040 / COMMS-0041 (WARN, ALL — RSVP/experience public-page standardization) factored: this design touches `buyer.tsx` (the CHECKOUT flow, not `PublicEventPage`/`RsvpPublicBody`), `AccountSettings.tsx`, and the OnboardingFlow `phone` substep — none of those are the public-page bodies being promoted into `packages/`, so there is no structural conflict. Noted for awareness only.
+
+> ### COPY DEPENDENCY (hard, blocks implement of the exact strings)
+> The **legal/consent COPY is owned by `mingla-product`** in a parallel task. This design specifies the LAYOUT, STATES, MOTION, TOKENS, and the EXACT BINDING POINTS where the disclosure string must be recorded into `consent_records.disclosure_text`. Every visible consent string below is a **`{COPY:product.<key>}` placeholder**. The implementor MUST NOT ship hand-written legal copy; it pulls the final strings from the mingla-product copy deliverable and wires the EXACT rendered string into the `consent_records` write (both scopes). See §6 "Consent-string binding contract."
+
+---
+
+## 0. The three surfaces (scope of this spec)
+
+| # | Surface | File | What changes |
+|---|---|---|---|
+| **S1** | Consumer notification-preferences matrix | `app-mobile/src/components/profile/AccountSettings.tsx` (extend the Notifications `AccordionCard`, L694-777) | Replace the flat 5-toggle list with a per-CATEGORY × per-CHANNEL matrix (§5.2 seed): sections Purchases / Reservations / Reminders / Marketing / Social. |
+| **S2** | Bundled mandatory consent gate — consumer OTP/consent onboarding | `app-mobile/src/components/OnboardingFlow.tsx` (the `phone` substep consent box, L2355-2397; CTA gate L2143) | Redesign the single consent checkbox to ONE mandatory bundled agreement (T&Cs + transactional + reminders + email marketing + SMS marketing); underlined "terms and conditions" opens a full-screen T&C view; cannot proceed until checked. |
+| **S3** | Bundled mandatory consent gate — anon buyer checkout | `mingla-business/app/checkout/[eventId]/buyer.tsx` (marketing checkbox L550-574; bottom-bar Button L594-602; validation L152-177) | Name/email/phone become REQUIRED with validation; replace the marketing checkbox with an underlined "I agree to all terms and conditions" that opens a T&C sheet; Pay/Continue greyed out until checked AND fields valid. Web + web-phone responsive. |
+
+Both S1 and S2 are **shared React Native** in `app-mobile` → **auto Android parity** (deltas in §7). S3 is `mingla-business` Expo Router rendered on **web + web-phone** (the public buyer checkout) → responsive deltas in §7.
+
+---
+
+## 1. Token foundations (the two design systems in play)
+
+This work spans two token files. Every value below is a real token in the named file — do NOT introduce raw hex in components.
+
+### 1A. Consumer app — `app-mobile/src/constants/designSystem.ts`
+- **spacing:** `xxs 2 · xs 4 · sm 8 · md 16 · lg 24 · xl 32 · xxl 48`
+- **radius:** `sm 8 · md 12 · lg 16 · xl 24 · full 999`
+- **typography (fontSize / lineHeight):** `xs 12/16 · sm 14/20 · md 16/24 · lg 18/28 · xl 20/32 · xxl 24/36 · xxxl 32/48`
+- **fontWeights:** `regular 400 · medium 500 · semibold 600 · bold 700`
+- **colors.primary:** `500 #f97316 · 600 #ea580c · 700 #c2410c` (note: AccountSettings hand-codes the brand orange as `#eb7825`; see §1C)
+- **colors.text:** `primary #111827 · secondary #4b5563 · tertiary #6b7280 · inverse #ffffff`
+- **colors.gray:** `200 #e5e7eb · 500 #6b7280 · 900 #111827`
+- **colors.success.500 #22c55e · colors.error.500 #ef4444**
+- **Checkbox** (`ui/Checkbox.tsx`): 20×20, radius 4, border 2 `#d1d5db`; checked fill+border `#eb7825`; inner check 10×10 radius 2 `#ffffff`. Sizes via `size` prop; `disabled` → reduced opacity.
+- **Toggle** (`profile/Toggle.tsx`): track 48×28 radius 14; thumb 22×22 radius 11 `#ffffff` (shadow y1 blur2 α0.15); ON track `#eb7825`, OFF track `#d1d5db`; thumb translateX 0→20 over **200ms `Easing.out(Easing.cubic)`**; `disabled` → opacity 0.5; hitSlop 8 all sides.
+
+### 1B. Business app / buyer web — `mingla-business/src/constants/designSystem.ts`
+- **spacing:** `xxs 2 · xs 4 · sm 8 · md 16 · lg 24 · xl 32 · xxl 48`
+- **radius:** `sm 8 · md 12 · lg 16 · xl 24 · xxl 28 · display 40 · full 999`
+- **accent.warm #eb7825** · accent.border `rgba(235,120,37,0.55)`
+- **text (dark surface):** `primary rgba(255,255,255,0.96) · secondary rgba(255,255,255,0.72) · tertiary rgba(255,255,255,0.52) · inverse #ffffff`
+- **semantic:** `success #22c55e · warning #f59e0b · error #ef4444` (+ tints at α0.18)
+- **glass.border.profileBase `rgba(255,255,255,0.08)`**
+- Checkout host canvas: `#0c0e12` (near-black). Bottom bar: `rgba(12,14,18,0.94)`, top border `rgba(255,255,255,0.06)`.
+- **Existing checkbox** (buyer.tsx local styles): box 22×22 radius `radiusTokens.sm` (8), border 1.5 `glass.border.profileBase`, transparent; checked fill+border `accent.warm`; inner check via `Icon name="check" size 14` color `textTokens.primary`.
+
+### 1C. Brand-orange reconciliation (do NOT regress)
+AccountSettings + Toggle + Checkbox all hard-code **`#eb7825`** as the brand action color (it predates this work and is the Mingla brand action color per `ariThread`/`userBubble` memory). The `colors.primary.500` token in the consumer system is `#f97316` (a sibling orange). **For S1 + S2, match the surrounding file: use the existing `#eb7825` literals already in AccountSettings/Toggle/Checkbox/`consentLink`'s `colors.primary[700]`.** Do not "fix" the orange to the token — that is out of scope and would visually drift this screen from the rest of settings. (The existing `consentLink` uses `colors.primary[700]` = `#c2410c`; keep that for S2 link styling — it's the established link treatment on that screen.)
+
+---
+
+# S1 — Consumer notification-preferences matrix
+
+## S1.1 IA & flow
+
+**The moment:** a user is in Settings → Notifications. Their intent is *control* — "stop texting me about X" or "I do want reminders." The cognitive task is **scanning + comparing** across categories and channels, so density is higher than a choosing screen but never a wall.
+
+**Information hierarchy (top → bottom):**
+1. **Master push toggle** (existing `push_enabled`) — the global push kill-switch, kept at the very top, unchanged in behavior (turning it off suppresses the PUSH column everywhere but never email/SMS — mirror §5.3 `can_send` semantics in the helper text).
+2. **Five category SECTIONS** in this fixed order (matches §5.2 + urgency-first intent): **Purchases · Reservations · Reminders · Marketing · Social**.
+3. Within each section, one **category ROW per seed category**, each showing only the **channels that category supports** (its `default_channels`) as small channel chips/toggles.
+
+**Decision the user makes:** per (category, channel) — on or off. Writes a `notification_channel_prefs(user_id, category_key, channel, enabled)` row (absent row = `default_channels` default; §5.1).
+
+**Flow:** single screen, no sub-navigation. Toggling is instant (optimistic, like the existing `updateNotifPref`). No save button.
+
+**Progressive disclosure:** Sections render as **labeled groups inside the one existing Notifications `AccordionCard`** (do NOT add five new top-level accordions — that buries control and breaks the ORCH-1040 "first card at scroll offset 0" contract). The card stays one accordion; inside it, each section is a sub-group with a small section header.
+
+## S1.2 Layout & spacing grid (4/8pt; reuse AccountSettings primitives)
+
+Reuse the EXACT existing row primitives so this looks native to the screen: `styles.row` + `styles.rowMultiline`, `styles.rowLabelWrap`, `styles.rowLabel`, `styles.rowHint`, `styles.rowDivider`, and the `Toggle` component. New styles are additive.
+
+**Card:** the existing Notifications `AccordionCard` (icon `notifications`, title from `t('settings:notifications.title')`). Card chrome unchanged: `styles.card` (white, radius 16, border `#e5e7eb`, `overflow:'hidden'`, shadow sm).
+
+**Master push row (row 1, unchanged):**
+- `styles.row + styles.rowMultiline`, `rowLabelWrap` → label `push_notifications` + hint `push_hint`, trailing `Toggle` bound to `push_enabled`.
+- Below it: `styles.rowDivider`.
+
+**Section group (repeat ×5):**
+```
+[section header row]            ← NEW: styles.prefSectionHeader
+  [category row]                ← styles.row + rowMultiline
+    label + hint  |  channel chips (right)
+  rowDivider (between categories within a section)
+  [category row] …
+[section gap]                   ← styles.prefSectionGap (height 8) before next header
+```
+
+**NEW styles (add to the AccountSettings `StyleSheet`):**
+```
+prefSectionHeader: {
+  paddingHorizontal: 16, paddingTop: 16, paddingBottom: 6,
+}
+prefSectionHeaderText: {
+  fontSize: 12, fontWeight: '700', color: '#9ca3af',
+  letterSpacing: 0.6, textTransform: 'uppercase',
+}            // matches the muted-caps section-label idiom used in buyer.tsx sectionLabel
+prefCategoryRow: {                 // extends styles.row; channels sit on the right
+  flexDirection: 'row', alignItems: 'flex-start',
+  paddingVertical: 12, paddingHorizontal: 16, minHeight: 56,
+}
+prefChannelCluster: {              // the right-side channel controls
+  flexDirection: 'row', alignItems: 'center', gap: 8,
+  flexShrink: 0, marginLeft: 12, paddingTop: 2,
+}
+prefSectionGap: { height: 8 }
+prefLockHint: {                    // tiny "Required" lock affordance
+  flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 4,
+}
+prefLockText: { fontSize: 11, color: '#9ca3af', fontWeight: '500' }
+```
+
+**Channel control choice — chip toggles, not full Toggles.** A full 48×28 `Toggle` per channel × up to 4 channels × ~13 categories is visual noise and blows the row width on small phones. Use a **compact channel chip**: a 44×44 tappable target (accessibility minimum) rendering a 28×28 rounded-square pill with the channel glyph, ON = filled `#eb7825` + white glyph, OFF = `#f3f4f6` fill + `#9ca3af` glyph, DISABLED/locked = `#f9fafb` fill + `#d1d5db` glyph + a 10px lock badge.
+```
+prefChip: {
+  width: 44, height: 44, alignItems: 'center', justifyContent: 'center',
+}                                  // 44pt hit target (a11y)
+prefChipInner: {
+  width: 28, height: 28, borderRadius: 8,
+  alignItems: 'center', justifyContent: 'center',
+}
+prefChipOn:   { backgroundColor: '#eb7825' }
+prefChipOff:  { backgroundColor: '#f3f4f6' }
+prefChipLocked: { backgroundColor: '#f9fafb' }
+```
+Channel glyphs (use the existing `Icon` set — SVG, never emoji): `inapp → 'notifications'`, `push → 'phone-portrait'` (or the bell-with-badge variant present in the set; fall back to `notifications-circle`), `email → 'mail'`, `sms → 'chatbubble'` (or `chatbox`). Icon size 16, color `#ffffff` (on) / `#9ca3af` (off) / `#d1d5db` (locked).
+
+**Row anatomy (one category):**
+```
+[ rowLabelWrap (flex 1) ]                         [ prefChannelCluster ]
+   rowLabel: "Purchase confirmations"               [chip inapp][chip push][chip email]
+   rowHint:  "When your ticket or order is confirmed."
+   (prefLockHint if any channel is locked): 🔒 "Always on"
+```
+Only the channels in that category's `default_channels` render as chips. A category with `{push,inapp,email}` shows 3 chips; one with `{push,inapp,email,sms}` shows 4.
+
+## S1.3 Category → row content (data-driven from the seed)
+
+The rows are driven by `notification_categories` filtered to the consumer (Explorer) sections, in seed order. Labels/hints are i18n keys under `settings:notifications.cat.*` (COPY owned by mingla-product for the user-facing category names; placeholders below).
+
+| Section header | Category row (`category_key`) | Channels shown (chips) | Lock rule |
+|---|---|---|---|
+| **PURCHASES** | `buyer_purchase_confirmation` | inapp, push, email | transactional — email locked-on (legal receipt); inapp/push user-toggleable |
+| | `waitlist_spot_open` | inapp, push, email, sms | transactional — all user-toggleable except inapp locked-on |
+| | `buyer_refund_issued` | inapp, push, email, sms | transactional |
+| | `buyer_order_cancelled` | inapp, push, email, sms | transactional |
+| | `buyer_payment_failed` | inapp, push, email | transactional — email locked-on |
+| **RESERVATIONS** | `buyer_reservation_confirmed` | inapp, push, email | transactional — email locked-on |
+| | `buyer_reservation_changed` | inapp, push, email, sms | transactional |
+| | `buyer_reservation_cancelled` | inapp, push, email, sms | transactional |
+| | `waitlist_table_ready` | inapp, push, email, sms | transactional |
+| **REMINDERS** | `buyer_event_reminder_24h` | inapp, push, email, sms | transactional |
+| | `buyer_event_reminder_2h` | inapp, push, email, sms | transactional |
+| | `buyer_reservation_reminder_24h` | inapp, push, email, sms | transactional |
+| | `buyer_reservation_reminder_2h` | inapp, push, email, sms | transactional |
+| **MARKETING** | `marketing_blast` | inapp, push, email, sms | marketing — ALL opt-OUT (default ON because DEC-186 auto-enrolls; user may turn any off here) |
+| **SOCIAL** | `social_friend_request` | inapp, push, email | non-transactional — user-toggleable |
+| | `social_collab_invite` | inapp, push, email | non-transactional |
+| | `social_message`+`social_rsvp`+`social_other` (one combined "Messages & activity" row) | inapp, push | non-transactional |
+
+> **Reminders density note:** 4 reminder categories with 4 chips each is the densest section. To avoid 4 near-identical rows, the implementor MAY collapse event + reservation reminders into **two rows** ("Event reminders", "Reservation reminders") each writing BOTH the `_24h` and `_2h` category prefs together (one chip toggles both buckets for that channel). **Design preference: collapse to 2 rows** — the 24h/2h split is a delivery detail, not a user mental model. Flagged as open question OQ-1 for Seth.
+
+**Locked channel rule (legal):** for `is_transactional` categories whose policy includes `email`, the **email chip is LOCKED ON** (the legal receipt/confirmation channel — CAN-SPAM transactional is permitted and the user cannot opt out of a purchase receipt). `inapp` is always locked-on for every category (it's the free durable inbox, zero-cost, the system-of-record surface). `push` and `sms` are user-toggleable on every category. Marketing: nothing locked (full opt-out). Show the lock affordance via `prefLockHint` ("Always on") only ONCE per row if any chip is locked, plus the locked chip's lock badge.
+
+## S1.4 States (every one designed)
+
+- **Loading:** while `notification_channel_prefs` fetch is in flight (extend the existing `isLoadingNotifPrefs`). Render the section headers immediately (they're static) and a **skeleton chip cluster** per row: 3-4 chip-sized `#f3f4f6` rounded rects at 0.6 opacity with a 1200ms ease-in-out opacity pulse 0.4↔0.7 (reduced-motion: static 0.6). No spinner — skeletons prevent layout jump (perf rule 3). Chips are non-interactive while loading.
+- **Empty (first-time, no rows yet):** there is no true empty state — absent rows mean "use category defaults," so every chip renders at its default ON/OFF immediately. The matrix is never blank.
+- **Default (loaded):** each chip reflects `coalesce(pref.enabled, default)`. Transactional defaults ON; marketing defaults ON (DEC-186 auto-enroll); locked chips render ON+lock.
+- **Press (chip):** scale to 0.92 over 90ms then back over 120ms (`Easing.out(quad)`); haptic `Haptics.impactAsync(Light)` on commit (mirror existing `updateNotifPref`). Optimistic flip immediately.
+- **Saving:** optimistic — chip flips instantly. No per-chip spinner. On the underlying upsert, no visible blocker.
+- **Error (save failed):** revert the chip to its prior value (mirror the existing `updateNotifPref` rollback) AND show a transient inline toast at the bottom of the card: `prefSaveErrorBar` — `#fef2f2` fill, `#fecaca` border, radius 12, `Icon "alert-circle" #dc2626 16`, text `#dc2626` 13/18 = `{COPY:settings.notifications.save_error}` ("Couldn't save that — tap to retry."). Tappable to retry the last write. Auto-dismiss after 4s. (Error-as-conversation principle.)
+- **Locked chip tapped:** no state change; haptic `notificationAsync(Warning)` + a one-time inline hint bubble under the row: `{COPY:settings.notifications.locked_email}` ("Purchase receipts are always emailed.") — fades in 200ms, auto-dismiss 3s.
+- **Master push OFF:** when `push_enabled` is false, every `push` chip across the matrix renders **dimmed + struck (opacity 0.4, non-interactive)** with a single explanatory hint under the master row: `{COPY:settings.notifications.push_master_off}` ("Push is off for the whole app. Turn it on to choose per-type push.") — mirrors `can_send` (a global push-off suppresses push only). Email/SMS chips stay live.
+
+## S1.5 Motion
+| Trigger | Property | Curve | Duration | Reduced-motion |
+|---|---|---|---|---|
+| Chip toggle ON→OFF | chip `backgroundColor` + glyph color crossfade | ease-in-out | 160ms | instant swap |
+| Chip press | `scale` 1→0.92→1 | `Easing.out(quad)` | 90+120ms | none (instant) |
+| Skeleton pulse | `opacity` 0.4↔0.7 | ease-in-out loop | 1200ms | static 0.6 |
+| Error bar enter | `translateY` 8→0 + `opacity` 0→1 | spring (damping 18, stiffness 180) | ~300ms | opacity-only fade 200ms |
+| Locked hint | `opacity` 0→1→0 | ease | 200ms in / 3s hold | same (no transform) |
+
+## S1.6 Accessibility (S1)
+- Each chip: `accessibilityRole="switch"` (NOT button), `accessibilityState={{ checked, disabled: locked }}`, `accessibilityLabel = "{channelName} for {categoryName}, {on|off}{, always on if locked}"`. Locked chips also set `accessibilityState.disabled=true`.
+- Hit target 44×44 even though the visual chip is 28×28 (the `prefChip` wrapper provides it).
+- Section headers: `accessibilityRole="header"`.
+- Reading order: master push → section header → category label+hint → its chips left-to-right (inapp, push, email, sms).
+- Contrast: `#ffffff` glyph on `#eb7825` = 3.0:1 (icon glyph, non-text, passes the 3:1 non-text minimum); off glyph `#9ca3af` on `#f3f4f6` = 2.3:1 — **bump the OFF glyph to `#6b7280` (4.0:1) so the channel is identifiable by more than fill state** (color-is-not-the-only-indicator rule: the glyph SHAPE already distinguishes channel; ON/OFF is fill + the a11y state). Locked chip glyph `#d1d5db` on `#f9fafb` is intentionally faint but the lock badge + "Always on" text carry the meaning non-visually.
+- Dynamic Type: labels/hints already use fixed sizes; allow them to grow — rows are `minHeight` not fixed height, and `rowMultiline` already wraps. The chip cluster stays fixed; at the largest Dynamic Type, the cluster wraps below the label (set `prefCategoryRow` to `flexWrap:'wrap'` fallback at very large text via `useWindowDimensions`/`PixelRatio.getFontScale() > 1.4`).
+
+---
+
+# S2 — Bundled mandatory consent gate (consumer OTP/consent onboarding)
+
+## S2.0 Ground truth (where the consent box actually lives)
+The consent box is on the **`phone` substep** of `OnboardingFlow.tsx` (NOT the `otp` substep, and NOT the passive `OnboardingConsentStep.tsx` informational screen which is a later step). Today (L2355-2397) it is a single `Pressable` row: a `Checkbox` bound to `smsConsentChecked` + `consentText` with two inline links (Terms of Service, Privacy Policy) opening a `LegalBrowser` modal. The "Send code" CTA is already gated: `disabled: !isPhoneValid() || !smsConsentChecked` (L2143). **This is the exact gate DEC-186 wants — we are upgrading its COPY + presentation to be the ONE bundled mandatory agreement, and making the T&C link a full-screen view.**
+
+## S2.1 IA & flow
+**The moment:** the user has typed their phone number and is about to receive an OTP. This is the legal consent capture point — DEC-186 bundles T&Cs + transactional + reminders + email marketing + SMS marketing into ONE mandatory checkbox here.
+
+**Hierarchy:** phone input (existing) → **bundled consent row** (redesigned) → "Send code" CTA (existing, stays gated).
+
+**Decision:** check the box (mandatory). Cannot proceed (CTA stays disabled) until both phone valid AND box checked — already the code's behavior; keep it.
+
+**Flow branch:** tapping the underlined "terms and conditions" opens a **full-screen T&C view** (the existing `LegalBrowser` modal, retitled and pointed at the bundled T&C URL). Reading is not required to check the box (checking is the affirmative act); the link is the disclosure access path for the legal record.
+
+## S2.2 Layout & states (reuse existing `consentRow` primitives)
+Keep the exact structure: `Pressable style={consentRow}` → `Checkbox` + `Text style={consentText}` with an inline underlined link. Only the COPY and the link target/treatment change.
+
+- **`consentRow`** unchanged: `flexDirection row, alignItems flex-start, marginTop spacing.md (16)`.
+- **`Checkbox`** unchanged (20×20, `#eb7825` checked).
+- **`consentText`** unchanged base: `typography.sm (14/20)`, `colors.text.tertiary #6b7280`, `flex 1`, `marginLeft spacing.sm (8)`.
+- **Underlined link treatment (NEW for the "terms and conditions" span):** keep `consentLink` color `colors.primary[700] #c2410c` + `fontWeight medium`, and ADD `textDecorationLine: 'underline'` (the task explicitly requires the link underlined; the current ToS/Privacy links are not underlined). Define:
+```
+consentLinkUnderlined: { color: colors.primary[700], fontWeight: '500', textDecorationLine: 'underline' }
+```
+
+**Copy structure (placeholder — mingla-product owns the verbatim string):**
+> `{COPY:onboarding.consent.bundled_prefix}` By continuing, you agree to Mingla's `[terms and conditions]`(underlined link) and consent to receive account & booking updates, event reminders, and marketing by email and text. Msg & data rates may apply. Reply STOP to opt out. `{COPY:onboarding.consent.bundled_suffix}`
+
+The "terms and conditions" span is the underlined link. (Per DEC-186/§8.6 the disclosure must surface: Mingla identity + agree to marketing texts + reminders + transactional + expected frequency + "Msg & data rates may apply" + STOP/HELP + link to full T&Cs. The visible row carries the short form; the full T&C view carries the long form. BOTH the rendered visible string AND the full T&C reference are what bind into `consent_records.disclosure_text` — see §6.)
+
+### States
+- **Unchecked (default):** box empty (`#d1d5db` border, transparent), CTA "Send code" **disabled** (Button disabled styling — the existing primary button at reduced opacity per its own disabled state; `disabled: !isPhoneValid() || !smsConsentChecked`).
+- **Checked:** box `#eb7825` filled + white check; if phone also valid, CTA enabled (full `#eb7825` / `colors.primary[500]`-family, full opacity, pressable). Haptic Light on check.
+- **Disabled-continue (phone invalid but box checked, or vice-versa):** CTA stays disabled; no error shouting (touched-flag pattern). If the user TAPS the disabled CTA region, surface the phone error (existing `phoneError`) — do not silently dead-tap.
+- **T&C view open:** full-screen `LegalBrowser` modal (existing). Title = `{COPY:onboarding.consent.tc_title}` ("Terms & Conditions"). A clear close affordance (existing modal chrome). Pointed at `LEGAL_URLS.termsOfService` (or a new bundled `LEGAL_URLS.bundledTerms` if mingla-product provides a combined doc).
+- **Pressed (row):** the `Pressable` toggles the box; standard `activeOpacity`-equivalent (the row has no explicit pressed style today — add `opacity 0.7` on press for affordance parity with the checkout checkbox).
+
+## S2.3 Motion (S2)
+- Checkbox check: the existing `Checkbox` has no entrance animation; ADD a 120ms scale-pop of the inner check (0.6→1, `Easing.out(back)` mild overshoot) + Light haptic. Reduced-motion: instant.
+- CTA enable transition: when it flips disabled→enabled, crossfade the button fill opacity over 180ms ease-out (no layout change). Reduced-motion: instant.
+
+## S2.4 Accessibility (S2)
+- Row `accessibilityRole="checkbox"`, `accessibilityState={{ checked: smsConsentChecked }}`, `accessibilityLabel = {COPY:onboarding.consent.a11y}` (must read the full agreement intent, not just "checkbox").
+- The underlined link span: `accessibilityRole="link"`, label `{COPY:onboarding.consent.tc_link_a11y}` ("Open terms and conditions").
+- CTA disabled state exposes `accessibilityState={{ disabled: true }}` so screen readers announce it's not yet actionable, and the label hints why when tapped.
+- Contrast: `consentText #6b7280` on the warm-white onboarding canvas (`#fff9f5`/white) = 4.6:1 (passes AA for 14px). Underlined link `#c2410c` on white = 5.9:1 (passes); underline guarantees color-is-not-the-only-indicator.
+
+---
+
+# S3 — Bundled mandatory consent gate (anonymous buyer checkout)
+
+## S3.1 IA & flow
+**The moment:** an anonymous buyer is about to pay for a ticket/RSVP. DEC-186: name/email/phone become REQUIRED, and ONE mandatory "I agree to all terms and conditions" gates the Pay button. The buyer's intent is to **complete a purchase fast**; friction must be minimal and the gate must feel like standard checkout consent, not a wall.
+
+**Hierarchy (existing order, kept):** order summary → Name* → Email* → Mobile number* → **bundled T&C agreement** (replaces the marketing checkbox) → sticky bottom bar (Total + Pay/Continue).
+
+**Decision:** fill 3 required fields + check the box. Pay/Continue is **greyed out until the box is checked AND all fields valid**.
+
+**Flow branch:** tapping the underlined "all terms and conditions" opens a **T&C sheet** (bottom sheet on web-phone, centered modal/sheet on wide web).
+
+## S3.2 Required fields (name/email/phone)
+Today name+email+phone already render with a red `*` (`styles.required`, `semantic.error #ef4444`) and `validate()` already requires all three for `isValid` (L162-176, `nameValid && emailValid && phoneValid`). **So the "make them required" work is largely present** — the visible asterisks and validation exist. Confirm:
+- Name: `fieldLabel "Name"` + `required *`; error `"Please enter your full name"` shown after blur (`visibleErrors.name`). Keep.
+- Email: same pattern; error `"Enter a valid email"`. Keep.
+- Mobile: `PhoneInput` with `error={visibleErrors.phone}`. Keep.
+- **Validation error visual:** `styles.errorText` — `marginTop 6, fontSize 12, color semantic.error #ef4444, fontWeight 500`. Keep. Touched-flag gating stays (don't scream on fresh mount).
+
+**No change needed to field requiredness/validation logic** beyond ensuring `validation.isValid` continues to require all three (it does). The NEW gate is the consent checkbox AND-ed into the Pay enable condition (§3.4).
+
+## S3.3 Replace marketing checkbox → bundled T&C agreement (L550-574)
+Replace the `Pressable` marketing-opt-in block with a structurally identical agreement row, new copy + underlined link + sheet trigger. Reuse the existing checkbox styles exactly (`checkboxRow`, `checkboxBox` 22×22 radius 8 border 1.5 `glass.border.profileBase`, `checkboxBoxChecked` fill `accent.warm`, inner `Icon "check" size 14 textTokens.primary`, `checkboxLabel` 14/20 `textTokens.secondary`).
+
+**New state:** rename `marketingOptIn` → `termsAccepted` (boolean) in cart/buyer state (the implementor wires the rename; the persisted field becomes the consent-grant signal, recorded into `consent_records` both scopes per §6). DEFAULT `false` (mandatory affirmative act).
+
+**Layout:**
+```
+<Pressable style={[checkboxRow, pressed && checkboxRowPressed]}
+           accessibilityRole="checkbox"
+           accessibilityState={{ checked: termsAccepted }}>
+  <View style={[checkboxBox, termsAccepted && checkboxBoxChecked]}>
+     {termsAccepted ? <Icon check 14 textTokens.primary/> : null}
+  </View>
+  <Text style={checkboxLabel}>
+     {COPY:checkout.consent.prefix} I agree to{' '}
+     <Text style={checkboxLinkUnderlined} onPress={openTermsSheet} accessibilityRole="link">
+        all terms and conditions
+     </Text>
+     . {COPY:checkout.consent.suffix}
+  </Text>
+</Pressable>
+```
+**NEW style:**
+```
+checkboxLinkUnderlined: {
+  color: accent.warm,            // #eb7825 — link affordance on the dark checkout canvas
+  fontWeight: '600',
+  textDecorationLine: 'underline',
+}
+```
+Rationale for accent.warm (not white): on the dark `#0c0e12` canvas the underlined link must be visually distinct from the `textTokens.secondary` label; warm-orange + underline gives two non-color affordances. Contrast `#eb7825` on `#0c0e12` = 5.4:1 (passes AA).
+
+**Copy (placeholder — mingla-product owns verbatim):**
+> `{COPY:checkout.consent.body}` I agree to `[all terms and conditions]`(underlined) and consent to receive booking confirmations, reminders, and marketing for this event and Mingla by email and text. Msg & data rates may apply. Reply STOP to opt out.
+
+## S3.4 Pay/Continue gating (L594-602)
+Today: `disabled={!validation.isValid || submitting}`. **Change to:** `disabled={!validation.isValid || !termsAccepted || submitting}`.
+- **Disabled (incomplete):** the existing `Button variant="primary" size="lg" fullWidth` renders its built-in disabled treatment (reduced opacity / muted fill per the Button component). The button label stays `continueLabel` (free → "Reserve"/"Continue"; paid → "Pay" / pay-amount label). Keep.
+- **Enabled (complete):** full `accent.warm` primary, full opacity, pressable.
+- **Loading:** `loading={submitting}` (existing) — spinner in button, disabled.
+- **Disabled tap → no dead tap:** if the buyer taps the disabled button, mark all fields touched (existing `handleContinue` already does `setAllTouched`-equivalent so errors render) AND if fields are valid but the box is unchecked, scroll the consent row into view + a 1-shot pulse on the checkbox border (`#ef4444` flash 400ms then back) + inline helper under the row: `{COPY:checkout.consent.must_agree}` ("Please agree to continue."). This is the ONLY way to communicate "you missed the box" — never a silent dead button.
+
+**NEW helper style:**
+```
+consentRequiredHint: { marginTop: 6, fontSize: 12, color: semantic.error, fontWeight: '500' }
+```
+
+## S3.5 T&C sheet (the underlined-link target)
+Open a sheet showing the full T&Cs. Reuse the existing `GlassCard`-based sheet idiom already imported in buyer.tsx, OR a standard bottom-sheet. Spec:
+- **Web-phone (< 600px):** bottom sheet, full-width, max-height 85vh, slides up. Radius top `radiusTokens.xl (24)`, fill near-opaque dark `rgba(18,20,26,0.98)` (NOT translucent — readable legal text), drag handle 36×4 `rgba(255,255,255,0.3)` at top, close X top-right (44×44 hit). Scrollable body, `textTokens.secondary` 14/22.
+- **Wide web (≥ 600px):** centered modal, width `min(560px, 92vw)`, max-height 80vh, radius `radiusTokens.lg (16)`, scrim `rgba(0,0,0,0.6)`. Same content.
+- **Title:** `{COPY:checkout.consent.tc_title}` ("Terms & Conditions"), 17/700 `textTokens.primary`, sticky top of sheet.
+- **Footer (optional but recommended):** a sticky "I agree" button at the bottom of the sheet that, when tapped, checks the box AND closes — a faster path than reading-then-hunting-the-checkbox. Secondary "Close" dismisses without checking. (Progressive-disclosure + thumb-zone primary action.)
+- Reading the sheet is NOT required to check the box; the sheet is the disclosure access path.
+
+## S3.6 Country capture (§10 requirement)
+§10 requires buyer **country** capture at checkout for `consent_records.country_code`. The `PhoneInput` already carries a `countryCode` (`phoneCountry`) — **derive `consent_records.country_code` from the phone country ISO** (no extra field; minimal friction). The design adds NO visible country field; the implementor maps `phoneCountry` → ISO-2 into the finalize RPC consent write. (If product later wants an explicit billing country, that's a separate field — out of scope here.)
+
+## S3.7 States summary (S3)
+| State | Pay button | Consent box | Fields |
+|---|---|---|---|
+| Fresh mount | disabled | unchecked | empty, no errors (touched=false) |
+| Typing, incomplete | disabled | unchecked | errors only after blur |
+| Fields valid, box unchecked | disabled | unchecked | valid |
+| Tap disabled Pay (box unchecked) | stays disabled | border flashes red 400ms + helper "Please agree to continue." | valid |
+| All valid + checked | ENABLED (full accent.warm) | checked (filled + check) | valid |
+| Submitting | disabled + spinner | checked | locked |
+| Submit error | enabled again | checked | `submitError` shown via existing `errorText` |
+
+## S3.8 Motion (S3)
+| Trigger | Property | Curve | Duration | Reduced-motion |
+|---|---|---|---|---|
+| Box check | inner check scale 0.6→1 | `Easing.out(back)` | 120ms | instant |
+| Pay enable | button fill opacity | ease-out | 180ms | instant |
+| Disabled-Pay tap (box unchecked) | checkbox border color `#ef4444`↔base + 1 shake (translateX ±4) | ease | 400ms | color flash only, no shake |
+| T&C sheet enter (web-phone) | `translateY` 100%→0 | spring (damping 22, stiffness 220) | ~320ms | opacity fade 200ms |
+| T&C modal enter (wide web) | `opacity` 0→1 + `scale` 0.96→1 | ease-out | 200ms | opacity only |
+
+## S3.9 Accessibility (S3)
+- Consent row: `accessibilityRole="checkbox"`, state checked, label = full agreement intent (`{COPY:checkout.consent.a11y}`).
+- Underlined link: `accessibilityRole="link"`, label "Open all terms and conditions".
+- Pay button: `accessibilityState={{ disabled }}`; when disabled, an `accessibilityHint` states what's missing ("Complete all fields and agree to terms to continue").
+- T&C sheet: focus moves into the sheet on open (web focus trap), Escape/back closes, focus returns to the link on close. Scrim tap closes (web).
+- Required fields: each input `accessibilityLabel` includes ", required" (already present for email/phone; add for name).
+- Web keyboard: the consent link + checkbox are tab-focusable with a visible focus ring (`outline: 2px solid #eb7825` on web; RN web respects `:focus-visible`). Pay button focusable.
+- Contrast: error `#ef4444` on `#0c0e12` = 5.0:1 (passes). `checkboxLabel #b3b3b3-equiv (rgba white .72)` on `#0c0e12` ≈ 9:1 (passes).
+
+---
+
+## 6. Consent-string binding contract (where the EXACT disclosure is recorded)
+
+This is the load-bearing legal requirement (DEC-186 / §8.1 / §8.6). At EVERY grant, the **exact rendered visible disclosure string** (the composed final copy the user actually saw, after i18n interpolation) MUST be written verbatim into `consent_records.disclosure_text`, for BOTH a `scope='transactional'` row AND a `scope='marketing'` row.
+
+| Surface | Grant trigger | What binds into `consent_records.disclosure_text` | `source` | Extra columns |
+|---|---|---|---|---|
+| **S2 consumer onboarding** | `smsConsentChecked === true` at the moment "Send code" succeeds / phone verified | The fully-rendered `consentText` string (prefix + "terms and conditions" link text + interpolated suffix) — the EXACT i18n-resolved string, not the key. PLUS a stored reference to the full T&C version/URL shown behind the link. | `'prefs_ui'`→ use `'checkout'`-style? → **`source='reservation'` is wrong here; use a new allowed value or `'prefs_ui'`.** NOTE: §5.1 `consent_records.source` enum lists `'checkout' \| 'prefs_ui' \| 'stop_keyword' \| 'unsubscribe_link' \| 'reservation'`. **Onboarding signup is none of these** — flag to forensics/implementor: add `'onboarding'` to the source CHECK, or reuse `'prefs_ui'`. (OQ-2.) | `user_id` (the just-created user), `contact` = E.164 phone + lowercased email, `country_code` from phone ISO, `ip_hash` (mobile: may be null or device-derived — null acceptable). |
+| **S3 buyer checkout** | `termsAccepted === true` at finalize (the finalize RPC consent write, §10) | The fully-rendered `checkboxLabel` string (prefix + "all terms and conditions" + suffix), EXACT resolved text. PLUS the T&C sheet version/URL reference. | `'checkout'` | `user_id` NULL (anon) → `contact` = E.164 phone + lowercased email; `country_code` from `phoneCountry` ISO; `ip_hash` = hashed request IP (web — available server-side at finalize). |
+
+**Implementation note for the implementor:** the visible copy lives in i18n; the binding requires capturing the RESOLVED string at grant time (not the key) and passing it through to the consent write. For S3, the finalize RPC receives `disclosure_text` as a parameter computed client-side from the exact rendered label (or, more robustly, the server composes it from a versioned `disclosure_versions` table keyed by a `disclosure_version` the client sends — RECOMMENDED so the legal record can't be spoofed/drifted by a stale client). **Design recommendation: a `disclosure_version` string is sent from each surface; the server stores both the version and the resolved text.** This is the legal burden-of-proof artifact backing the risk-accepted bundling (R-8).
+
+---
+
+## 7. Per-platform deltas
+
+### S1 + S2 (consumer RN — `app-mobile`)
+- **iOS:** as specified. Card shadow (sm) renders.
+- **Android (auto via shared RN):** the AccountSettings `card` already follows the ANDROID GLASS / opaque-fallback policy — opaque white `#ffffff` fill + `overflow:'hidden'` clip + the existing shadow is a real drop-shadow on an opaque card (acceptable; not a translucent glass surface, so the opaque-fallback policy is already satisfied — do NOT add Android `elevation` tweaks here). The chips are opaque fills (`#eb7825`/`#f3f4f6`) — no glass, no Android delta needed. Haptics: `expo-haptics` maps to Android vibration.
+- **No glass is introduced by this work** → the `ANDROID_GLASS_USES_OPAQUE_FALLBACK` invariant is not triggered (nothing translucent added). State this explicitly in the implementation report.
+
+### S3 (buyer web + web-phone — `mingla-business`)
+- **Web-phone (< 600px):** the sticky bottom bar (`bottomBar`, absolute, `rgba(12,14,18,0.94)`) stays; consent row sits in the scroll body above it. T&C = bottom sheet. The existing `bottomBarHidden` (translateY 200 when keyboard up) behavior is preserved.
+- **Wide web (≥ 600px):** the checkout is a centered column (max content width ~560px). T&C = centered modal. The sticky bottom bar may become a non-sticky footer at very wide widths if the existing layout does so — match whatever the current checkout does; do not regress.
+- **Web focus/keyboard:** visible focus rings on link, checkbox, Pay (RN-web `:focus-visible` → 2px `#eb7825` outline). The other two surfaces are native (no hover/focus-ring concern).
+- **No hover-induced layout shift:** the consent link hover (web) changes only color/underline emphasis, never layout (perf rule 3).
+
+---
+
+## 8. Cross-surface declaration
+
+- **Shared (single source of truth):** the `consent_records` write contract (§6) is identical in shape across S2 and S3 — both write a transactional + a marketing row with `disclosure_text`. The category seed (§5.2) is the single source for S1's rows; S1 must render exactly the seed's `default_channels` per category (no hardcoded channel lists in the component — read from `notification_categories`).
+- **Reused primitives:** S1 reuses AccountSettings `row`/`rowDivider`/`rowLabel`/`rowHint` + `Toggle` (master only) + `Icon` + `Checkbox` (consumer). S2 reuses `consentRow`/`consentText`/`Checkbox`/`LegalBrowser`. S3 reuses `checkboxRow`/`checkboxBox`/`Button`/`Input`/`PhoneInput`/`GlassCard`/`Icon`.
+- **NEW reusable token:** an underlined-link text style appears on all three surfaces. Recommend the implementor add `textDecorationLine:'underline'` variants co-located in each file (consumer: `consentLinkUnderlined`; business: `checkboxLinkUnderlined`) rather than a shared package (the two design systems differ). No new global token required.
+- **Brand orange consistency:** `#eb7825` is the action/link color on S1 (chips), S3 (link + checkbox); S2 link uses `colors.primary[700] #c2410c` (the established settings link color on that screen). This is intentional — match each screen's existing idiom (§1C).
+- **Parity:** S1+S2 are shared RN → Android parity is automatic. S3 is web/web-phone only (the consumer-app native checkout already removed the tax form per ORCH-1130/1147 and uses a different consent path — NOT in this Sub-A scope; the §10 "native checkout manual parity" note applies to a future leg, not this design).
+
+---
+
+## 9. Build-ready handoff summary
+
+**Files + anchors:**
+- S1: `app-mobile/src/components/profile/AccountSettings.tsx` — extend the Notifications `AccordionCard` (L694-777); add the listed `pref*` styles to the `styles` block (L1191+); add a `notification_channel_prefs` fetch + per-(category,channel) upsert helper mirroring `updateNotifPref`/`isLoadingNotifPrefs`; read categories from `notification_categories`.
+- S2: `app-mobile/src/components/OnboardingFlow.tsx` — update the `phone`-substep consent block (L2355-2397) copy + underlined-link treatment + full-screen T&C target; keep the CTA gate (L2143); on grant, write `consent_records` (both scopes, §6).
+- S3: `mingla-business/app/checkout/[eventId]/buyer.tsx` — replace the marketing checkbox (L550-574) with the bundled T&C agreement; rename `marketingOptIn`→`termsAccepted`; AND it into the Pay disable (L601); add T&C sheet; add disabled-tap helper + flash; map `phoneCountry`→`country_code`; finalize RPC writes `consent_records` (both scopes + `disclosure_text` + `ip_hash` + `country_code`).
+
+**Existing tokens used:** all listed in §1 (no new global tokens). New component-local styles enumerated in §S1.2, §S2.2, §S3.3-3.5.
+
+**Copy:** ALL user-facing strings are `{COPY:*}` placeholders owned by mingla-product. The implementor binds the RESOLVED strings into `consent_records.disclosure_text` per §6 (recommend a `disclosure_version` sent from each surface + server-side versioned storage).
+
+---
+
+## 10. Open design questions for Seth
+- **OQ-1 (Reminders density):** collapse the 4 reminder categories into 2 user-facing rows ("Event reminders", "Reservation reminders", each toggling its 24h+2h buckets together)? **Design recommendation: YES** (the 24h/2h split is a delivery detail, not a user mental model).
+- **OQ-2 (consent source enum):** `consent_records.source` (§5.1 CHECK) has no `'onboarding'` value, but S2 grants at signup. Add `'onboarding'` to the CHECK, or reuse `'prefs_ui'`? **Design/forensics handoff — recommend adding `'onboarding'`** for a clean audit trail. (Affects the migration, not the UI.)
+- **OQ-3 (T&C "I agree" footer in the sheet):** include a sticky "I agree" button inside the S3 T&C sheet that checks the box + closes (faster path)? **Recommendation: YES.**
+- **OQ-4 (disclosure versioning):** adopt a server-side `disclosure_version` + versioned-text store so the legal record can't drift with a stale client? **Recommendation: YES** (strengthens the R-8 burden-of-proof artifact).

--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
@@ -218,3 +218,48 @@ NOT run on sim/device this pass (logic + contract + DB-probe verification only).
 - **DISC-1161-A2-SEED-LAG:** the shipped thin-slice seed (`20261110000001`) did NOT match the DEC-185 matrix for three rows (refund_issued/order_cancelled missing `sms`; payout_paid missing `email`). This slice's migration corrects it, but it means the live `notification_categories` seed was briefly out of parity with the closed SMS-eligible set — worth a note when the `I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES` strict-grep gate is flipped ACTIVE at CLOSE (the gate must assert the CORRECTED seed).
 - **OQ-2 resolved:** `consent_records.source` has NO CHECK constraint (only a comment), so `source='onboarding'` is accepted with no migration needed (no enum widening required).
 - **Comms ledger:** COMMS-0040/0041 (RSVP/experience public-page standardization) are WARN/ALL — this slice touches the CHECKOUT flow + onboarding, NOT the public RSVP/experience page bodies, so no structural conflict (acked, no action).
+
+---
+
+## REWORK 2026-06-20 — NEEDS-REWORK loop (tester FAIL → fix P1-1 + commit drift test + P2-1 guard)
+
+Routed back from `TEST_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md` (verdict FAIL, P1: 1 / P2: 3). This loop fixes the one blocking P1 + two smaller items. No money seam touched; the verbatim §1b disclosure string left byte-identical (tester proved it); no new gorhom consumer; SMS kill-switch untouched.
+
+### R-1 — P1-1 (BLOCKING) — checkout Pay dead-tap FIXED
+
+**Before:** `mingla-business/app/checkout/[eventId]/buyer.tsx` set `consentHintVisible`/`checkboxBoxFlash` ONLY inside `handleContinue` behind `if (!termsAccepted)`. `handleContinue` fired only via the Pay `Button`'s `onPress`, which is `undefined` while the button is `disabled` (`isContinueDisabled`). Box unchecked → button disabled → tap swallowed → the specced red flash + "Please agree to continue." (DESIGN §S3.4 L311/335) was unreachable dead code = silent dead tap (Constitution Rule 1).
+
+**After (approach (a) — capture the tap, keep the button visually greyed):**
+- New `showConsentHint` callback marks all fields touched and, when the only blocker is the unchecked box, sets `consentHintVisible(true)` → renders the red checkbox flash (`checkboxBoxFlash`) + the "Please agree to continue." helper (`consentRequiredHint`).
+- The show/no-show decision is the new PURE predicate `shouldShowConsentHintOnDisabledTap({fieldsValid, termsAccepted})` in `checkoutConsentGate.ts` (`fieldsValid && !termsAccepted`) — testable in isolation (fails-on-revert), and avoids double-messaging when fields are still invalid (the field errors carry that message).
+- The Pay `Button` now sits inside a tap-capturing `<Pressable onPress={continueDisabled ? showConsentHint : undefined}>` wrapping a `<View pointerEvents={continueDisabled ? "none" : "auto"}>`. While disabled, `pointerEvents="none"` makes the inner Button transparent to touches so the outer Pressable reliably captures the tap and fires `showConsentHint` (robust on web + native). While enabled, `pointerEvents="auto"` lets the Button claim the responder and fire `handleContinue`; the outer `onPress` is `undefined` → no double-fire. The button stays VISUALLY disabled (`disabled={continueDisabled}`) per DESIGN §S3.4.
+- Single source of the gate value: `const continueDisabled = isContinueDisabled({...})` drives the visual disabled state, the pointer-events pass-through, and the tap-capture overlay so they cannot disagree.
+
+**Files:** `mingla-business/app/checkout/[eventId]/buyer.tsx` (+~45 lines), `mingla-business/src/components/checkout/checkoutConsentGate.ts` (+~18 lines).
+**Commit:** `c317d57ba` (filled below).
+
+### R-2 — tester adversarial drift test COMMITTED on-branch
+
+`mingla-business/src/services/__tests__/consentDisclosureDrift.tester.orch1161.test.ts` was UNTRACKED on the branch (would not appear in the closing `git diff main...HEAD`). Committed verbatim (append-only; NOT modified) so it lands in the closing diff. 3 tests PASS.
+
+### R-3 — P2-1 — record-consent open-write abuse guard ADDED
+
+`supabase/functions/record-consent/index.ts` is `verify_jwt=false` (anon checkout calls it), so anyone could POST fabricated consent rows; the 5-min dedupe only blocks an identical `(contact,channel,scope,source)` tuple, which an attacker rotating fake contacts bypasses. Added a lightweight per-IP sliding-window throttle (`RATE_LIMIT_WINDOW_MS=60s`, `RATE_LIMIT_MAX_PER_WINDOW=12`) checked BEFORE any JSON parse / DB work; over-cap → HTTP 429 with `Retry-After`. JWT stays disabled (legit buyer/onboarding callers are anon). Fail-OPEN on a missing/stripped IP header so a legitimate caller is never blocked. Reuses the existing `clientIp()` (the duplicate `clientIp` call for `ip_hash` was de-duped into the single `requestIp`).
+
+**Residual (documented):** this is a PER-INSTANCE in-memory guard — it does not coordinate across warm Deno instances and resets on cold start. It caps a single hot client's burst (the realistic cheap-spam shape) but a distributed/multi-instance flood is not fully blocked. A durable cross-instance limiter (e.g. a DB/Redis counter) is out of scope for this slice; registered as the residual. Note (from tester P2-1, re-confirmed): a poisoned consent row grants NO send capability — `can_send()` does not read `consent_records` — so there is no TCPA send-amplification harm; the guard targets audit-log pollution + cost-spam only.
+
+### Verification (this loop)
+
+- `npx jest` (mingla-business) on the 3 consent suites → **9/9 PASS** (`consentService.orch1161` 3, `consentDisclosureDrift.tester.orch1161` 3, `checkoutConsentGate.deadtap.orch1161` 3).
+- **fails-on-revert (new dead-tap test):** true LINE DELETION of `&& !params.termsAccepted` in `shouldShowConsentHintOnDisabledTap` (→ `params.fieldsValid`) → `checkoutConsentGate.deadtap.orch1161.test.ts` "box already checked → no consent helper" FAILED (expected false, received true); restored → 3/3 PASS. **fails-on-revert verified at `c317d57ba`**.
+- `deno check supabase/functions/record-consent/index.ts` → clean.
+- `tsc --noEmit` (mingla-business): the buyer.tsx/gate edits introduce ZERO new errors; the only buyer.tsx TS7006 lines are the pre-existing PhoneInput `iconRenderer`/`onChange` block (identical in the untouched sibling `checkout-trip/[tripEventId]/buyer.tsx`; baseline 461 repo-wide).
+- Strict-grep: `i-proposed-1161-sms-from-approved-sender-and-kill-switch` PASS; `i-proposed-orch-0945-dead-end-reason-coverage` PASS; `i-proposed-tr2-safearea-on-fullscreen-routes` is a pre-existing baseline FAIL (16 unrelated routes; `buyer.tsx` is allowlisted and NOT flagged) — not regressed by this loop.
+
+### New regression test (implementor-owned, this loop)
+
+`mingla-business/src/components/checkout/__tests__/checkoutConsentGate.deadtap.orch1161.test.ts` (3 tests) — pins that a disabled-Pay tap with valid fields + unchecked box surfaces the helper, and does NOT when the box is checked or fields are invalid. Append-only (new file).
+
+### Still operator-owned at CLOSE (unchanged from original report)
+
+Deploy `record-consent` from MERGED main (`verify_jwt=false`); apply migration `20261110000005`; flip the SMS-eligible strict-grep gate ACTIVE asserting the POST-000005 seed (P2-3 / DISC-1161-A2-SEED-LAG). P2-2 (live edge round-trip) confirmed at CLOSE post-deploy.

--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
@@ -1,0 +1,220 @@
+# IMPLEMENTATION — META-ORCH-1161 Sub-A.2 — Consent Capture
+
+**ORCH:** META-ORCH-1161 Sub-A.2 (consent-capture slice)
+**Phase:** mingla-implementor (single bounded pass)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[consent-surface]/` on `ORCH-1161-consent-surface`
+**Date:** 2026-06-20
+**Status:** implemented and verified (unit + gates + DB probe); device/runtime UNVERIFIED (no sim/device run — see §9)
+
+---
+
+## 1. Summary
+
+The bundled-mandatory consent gate (DEC-186) is now wired on both consent-capture
+surfaces. A consumer cannot finish phone-OTP signup, and an anonymous buyer cannot
+reach payment, without checking ONE mandatory "I agree to all terms and conditions"
+box. Checking it writes a verbatim `consent_records` audit trail (transactional +
+marketing, per channel) carrying the EXACT §1b disclosure string, the buyer country,
+a server-computed IP hash (web), and the pinned disclosure version. The thin-slice
+notification-category seed was corrected to match DEC-185 (the closed SMS-eligible
+set). S1 (the consumer notification-preferences matrix) is explicitly OUT of this
+slice and remains backlog.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion (dispatch /goal + SPEC §8.6 / DESIGN S2/S3) | Status | Evidence |
+|---|---|---|---|
+| SC-1 | Consumer OTP consent box uses §1a bundled label; underlined "terms and conditions" opens the §2 T&C view; cannot proceed until checked (gate kept) | ✓ | `OnboardingFlow.tsx` consent block + i18n keys; CTA gate `!isPhoneValid() \|\| !smsConsentChecked` unchanged (L2143) |
+| SC-2 | On consumer grant, write `consent_records` (transactional + marketing; source='onboarding'; disclosure=§1b verbatim; channels email+sms; country from phone; ip_hash null on native) | ✓ | `OnboardingFlow.handleVerifyOtp` → `recordConsent({source:'onboarding', disclosureText: CONSENT_DISCLOSURE_TEXT, ...})`; edge fn fans out both scopes × {sms,email} |
+| SC-3 | Checkout: name+email+phone REQUIRED with validation/error states | ✓ | Already present (`validate()` requires all three; `styles.required`/`errorText`); confirmed, kept |
+| SC-4 | Checkout marketing checkbox replaced with underlined "I agree to all terms and conditions" → §2 T&C sheet | ✓ | `buyer.tsx` consent block + `ConsentTermsSheet.tsx` |
+| SC-5 | Pay/Continue GREYED OUT until checked AND fields valid | ✓ | `isContinueDisabled({fieldsValid, termsAccepted, submitting})`; regression test + fails-on-revert |
+| SC-6 | On finalize, write `consent_records` (both scopes; source='checkout'; disclosure=§1b verbatim; country_code from buyer country; ip_hash of request IP) | ✓ | `buyer.handleContinue` → `recordConsent({source:'checkout', countryCode: phoneCountry, ...})`; edge fn computes ip_hash from `x-forwarded-for` |
+| SC-7 | Capture buyer country at checkout | ✓ | Derived from `phoneCountry` ISO (DESIGN §S3.6 — no extra field) → `country_code` |
+| SC-8 | Shared T&C sheet rendering §2 body verbatim, reused | ✓ | `ConsentTermsSheet.tsx` (checkout); consumer reuses full-screen `LegalBrowser` per DESIGN §S2.2; §2 body verbatim in `consentDisclosure.ts` (both apps) |
+| SC-9 | Seed-correction migration (monotonic 20261110000005): +sms to refund_issued & order_cancelled, +email to payout_paid; idempotent UPDATE WHERE key= | ✓ | `20261110000005_orch_1161_seed_corrections.sql`; DB probe confirmed target rows |
+| SC-10 | consent_records writer: shared service-role helper both surfaces call; dedupe on (contact,channel,scope,source) within a short window | ✓ | `record-consent` edge fn (verify_jwt=false); 5-min dedupe window |
+| SC-11 | §1b disclosure recorded VERBATIM (no paraphrase) | ✓ | `CONSENT_DISCLOSURE_TEXT` constant (both apps) = §1b string char-for-char; test asserts `toBe(CONSENT_DISCLOSURE_TEXT)` |
+| SC-12 | Bundled-mandatory per DEC-186 (no compliant split); SMS kill-switch unaffected | ✓ | ONE checkbox gates both surfaces; no marketing-split UI; no SMS send touched |
+
+---
+
+## 3. Files changed
+
+**New (8):**
+- `supabase/migrations/20261110000005_orch_1161_seed_corrections.sql` (+34)
+- `supabase/functions/record-consent/index.ts` (+232)
+- `mingla-business/src/constants/consentDisclosure.ts` (+112)
+- `app-mobile/src/constants/consentDisclosure.ts` (+112, byte-mirrored)
+- `mingla-business/src/services/consentService.ts` (+72)
+- `app-mobile/src/services/consentService.ts` (+62)
+- `mingla-business/src/components/checkout/ConsentTermsSheet.tsx` (+112)
+- `mingla-business/src/components/checkout/checkoutConsentGate.ts` (+20)
+- `mingla-business/src/services/__tests__/consentService.orch1161.test.ts` (+150, test)
+
+**Modified (6):**
+- `mingla-business/app/checkout/[eventId]/buyer.tsx` (~+95 / −25)
+- `mingla-business/src/components/checkout/CartContext.tsx` (+12)
+- `app-mobile/src/components/OnboardingFlow.tsx` (~+45 / −20)
+- `app-mobile/src/i18n/locales/en/onboarding.json` (+4 keys, ~2 changed)
+- `supabase/config.toml` (+6, `[functions.record-consent] verify_jwt=false`)
+- `Mingla_Artifacts/specs/...` + `Mingla_Artifacts/design/ORCH-1161/` (carried canonical docs)
+
+---
+
+## 4. Data-model changes applied
+
+No new tables/columns (the Sub-A thin slice already shipped `consent_records` etc.).
+ONE data correction migration (`20261110000005`): idempotent `UPDATE` of three
+`notification_categories.default_channels` arrays via guarded `array_append`. No
+DDL, no RLS change, no SECURITY DEFINER (so no GRANT/REVOKE needed).
+
+DB read-only probe (pre-handoff, Migration & Deploy Handoff requirement):
+```
+buyer_order_cancelled : {inapp,push,email}   → migration adds 'sms'  ✓
+buyer_refund_issued   : {inapp,push,email}   → migration adds 'sms'  ✓
+payout_paid           : {inapp,push,sms}     → migration adds 'email' ✓
+```
+The `WHERE NOT (... = ANY(default_channels))` guard means it cannot abort or
+double-append against existing remote rows — safe + idempotent.
+
+---
+
+## 5. Edge functions touched
+
+| Function | Change | verify_jwt to preserve |
+|---|---|---|
+| `record-consent` (NEW) | Shared consent writer; service-role insert of `consent_records` (both scopes × {sms,email}); server-side ip_hash; 5-min dedupe | **false** (anon-tolerant: checkout buyer is anon) |
+
+No other edge function was touched. The money seam (`ticket-checkout-create`,
+`stripeWebhookRouter`) was deliberately NOT entangled — consent writes via the
+dedicated `record-consent` call from the buyer surface at the Continue tap
+(before either the free or paid finalize path), keeping the money logic untouched.
+
+---
+
+## 6. Regression tests added
+
+- `mingla-business/src/services/__tests__/consentService.orch1161.test.ts` (3 tests, all PASS).
+- **fails-on-revert verified at `2f63604b6`** (worktree HEAD pre-commit), by TRUE LINE DELETION:
+  - Deleted `disclosureText: input.disclosureText` in `consentService.ts` → the
+    "VERBATIM" test FAILED; restored → PASS.
+  - Deleted the `!params.termsAccepted` term in `checkoutConsentGate.ts` → the
+    "DISABLED until checked" test FAILED; restored → PASS.
+- Passing run:
+  ```
+  PASS src/services/__tests__/consentService.orch1161.test.ts
+    ✓ records the EXACT §1b disclosure VERBATIM with source='checkout' + both contacts
+    ✓ returns ok=false (does NOT throw) when the edge fn errors — checkout must not deadlock
+    ✓ Pay/Continue is DISABLED until the bundled consent box is checked
+  Tests: 3 passed, 3 total
+  ```
+
+---
+
+## 7. Old → New receipts
+
+### mingla-business/app/checkout/[eventId]/buyer.tsx
+**Before:** an optional "Email me about this organiser's future events" marketing
+checkbox (`marketingOptIn`); Pay disabled only on `!validation.isValid || submitting`.
+**Now:** ONE mandatory "I agree to [terms and conditions]…" checkbox (`termsAccepted`,
+underlined link → `ConsentTermsSheet`); Pay disabled until `isContinueDisabled`
+(fields valid AND box checked); a disabled-tap-with-unchecked-box surfaces a red
+helper + box flash (no dead tap); on Continue with the box checked, `recordConsent`
+writes the audit (both scopes, country from phone ISO) before finalize; checking the
+box also sets `marketingOptIn=true` (DEC-186 bundling) so the downstream payment
+payload still carries the grant.
+**Why:** SC-4/5/6/7/12 + DEC-186.
+**Lines:** ~+95 / −25.
+
+### mingla-business/src/components/checkout/CartContext.tsx
+**Before:** `BuyerDetails` had `marketingOptIn` only.
+**Now:** added optional `termsAccepted` (the bundled-consent signal) + default false.
+Kept `marketingOptIn` (rides with `termsAccepted`) to avoid a cross-file rename
+beyond the allowlist (trip/experience checkout + payment finalize + persistence +
+native flow all read `marketingOptIn`).
+**Why:** SC-5; scope discipline (additive, not a risky rename).
+**Lines:** +12.
+
+### app-mobile/src/components/OnboardingFlow.tsx (+ en/onboarding.json)
+**Before:** phone-substep consent copy = SMS-only language with two links (ToS +
+Privacy); no consent record written.
+**Now:** §1a bundled label with ONE underlined "terms and conditions" link →
+full-screen `LegalBrowser`; on OTP verify success, `recordConsent({source:'onboarding'})`
+writes both scopes with the §1b verbatim disclosure (non-blocking).
+**Why:** SC-1/2/12.
+**Lines:** ~+45 / −20 (+4 i18n keys).
+
+### supabase/migrations/20261110000005_…
+**Before:** seed rows for refund_issued/order_cancelled lacked `sms`; payout_paid
+lacked `email`.
+**Now:** corrected to the DEC-185 matrix via idempotent guarded UPDATEs.
+**Why:** SC-9.
+**Lines:** +34.
+
+---
+
+## 8. Cross-surface impact table
+
+| Surface | Affected | What changes | Parity |
+|---|---|---|---|
+| Consumer iOS (`app-mobile`) | YES | OTP consent box copy + T&C link + consent record on verify | shared RN → auto |
+| Consumer Android (`app-mobile`) | YES | same | auto (shared) |
+| Buyer/anon Web (`mingla-business` checkout) | YES | required fields gate + bundled T&C sheet + Pay gating + consent record | web-specific (manual) |
+| Business iOS (`mingla-business`) | NO | no business-side consent surface in this slice | — |
+| Business Android | NO | same | — |
+| Admin Web | NO | no consent surface | — |
+| Business Web preview (adjacent) | INCIDENTAL | the buyer checkout renders on web-phone; `ConsentTermsSheet` built on the cross-platform `Modal` primitive | covered by the same code |
+
+No glass introduced → `ANDROID_GLASS_USES_OPAQUE_FALLBACK` not triggered (DESIGN §7).
+
+---
+
+## 9. Smoke result
+
+NOT run on sim/device this pass (logic + contract + DB-probe verification only).
+**UNVERIFIED, needs manual device testing:**
+- Consumer: phone substep shows the new bundled label + underlined T&C link opening
+  the legal view; box gates "Send code"; after OTP verify, a `consent_records` row
+  pair (transactional+marketing, source='onboarding') exists for the phone.
+- Checkout (web-phone + wide web): required-field errors; the underlined link opens
+  `ConsentTermsSheet`; "I agree" footer checks the box + closes; Pay greys out until
+  checked; disabled-Pay tap (box unchecked) shows the red helper + box flash; on
+  Continue, a `consent_records` pair (source='checkout', country_code set, ip_hash
+  non-null) is written.
+
+---
+
+## 10. Known issues / deferred (remaining backlog — OUT of this slice)
+
+- **S1 — consumer notification-preferences matrix** (`AccountSettings.tsx` per-category×channel) — later slice.
+- **Marketing-site pages `/unsubscribe` + `/sms-terms`** (COPY §5.1) — referenced by the §1b URLs; must be built so the links resolve (the `/unsubscribe` write depends on `channel_suppressions`). Deferred per the dispatch.
+- **Sub-B** marketing SMS leg; **Sub-C** moments (reminders cron, purchase push, refund/order/reservation notify wiring).
+- **`marketingOptIn`→`termsAccepted` full rename** intentionally NOT done (blast radius beyond the allowlist: trip/experience buyer+payment, persistence, native flow, order store). `termsAccepted` added additively; `marketingOptIn` rides with it. Flagged for a future consolidation ORCH.
+- **Disclosure versioning store** (DESIGN OQ-4) — `DISCLOSURE_VERSION` is sent + recorded, but no server-side versioned-text table yet (the verbatim text is recorded per-row, which satisfies the legal burden today).
+- **Strict-grep / type baseline:** repo-wide strict-grep gates have pre-existing failures (expo-export-stderr setup, GBP in rsvp preview, etc.) and `noImplicitAny` warnings on the PhoneInput callbacks exist on baseline; NONE flag the files this slice touched (verified by stash-compare).
+
+---
+
+## 11. Operator action required
+
+1. **Apply the migration** (after REVIEW, from MERGED main per the 1161 hazard note — apply via Supabase Management API; MCP read-only / CLI drift-wedged). If applying via CLI from the worktree:
+   ```bash
+   cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1161-[consent-surface]" && /Users/sethogieva/bin/supabase db push --linked
+   ```
+   Monotonic above remote head `20261110000004`; no drift; idempotent (safe to re-run).
+2. **Deploy the edge function** from MERGED `main` (NOT the worktree — clobber risk, COMMS-0015/0018):
+   - `record-consent` — `verify_jwt = false`.
+   No secrets required (uses `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`, already set).
+3. **OTA** (after merge): business buyer-web deploys from `main` with `[deploy]`; consumer/business per-platform `eas update`.
+4. **Device QA** the §9 UNVERIFIED items.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **DISC-1161-A2-SEED-LAG:** the shipped thin-slice seed (`20261110000001`) did NOT match the DEC-185 matrix for three rows (refund_issued/order_cancelled missing `sms`; payout_paid missing `email`). This slice's migration corrects it, but it means the live `notification_categories` seed was briefly out of parity with the closed SMS-eligible set — worth a note when the `I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES` strict-grep gate is flipped ACTIVE at CLOSE (the gate must assert the CORRECTED seed).
+- **OQ-2 resolved:** `consent_records.source` has NO CHECK constraint (only a comment), so `source='onboarding'` is accepted with no migration needed (no enum widening required).
+- **Comms ledger:** COMMS-0040/0041 (RSVP/experience public-page standardization) are WARN/ALL — this slice touches the CHECKOUT flow + onboarding, NOT the public RSVP/experience page bodies, so no structural conflict (acked, no action).

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
@@ -1,0 +1,141 @@
+# TEST — META-ORCH-1161 Sub-A.2 — Consent Capture
+
+**ORCH:** META-ORCH-1161 Sub-A.2 (consent-capture slice)
+**Phase:** mingla-tester (adversarial gate)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[consent-surface]/` on `ORCH-1161-consent-surface`
+**Commit under test:** `8b119de47`
+**Date:** 2026-06-20
+**Mode:** SPEC-COMPLIANCE + SECURITY + adversarial regression. Sim-gate EXEMPT for backend/SQL/edge-fn paths; the one UI/runtime finding (P1 below) is a source-provable wiring defect (a control that CANNOT fire), which caps the verdict regardless of sim.
+
+---
+
+## 1. Verdict
+
+**FAIL** — P0: 0 · **P1: 1** · P2: 3 · P3: 0 · P4: 2
+
+The legal core is excellent: the verbatim disclosure is byte-identical across both apps and the COPY authority, the dual-scope fan-out is correct, the seed-correction migration applies cleanly above remote head and yields the DEC-185 matrix, and the money seam is untouched. **But the checkout disabled-Pay "Please agree to continue" feedback is unreachable dead code** — the implementor's report and DESIGN §S3.4 both claim a tap on the greyed Pay surfaces a red flash + helper; the `Button` swallows the tap when disabled, so it is a silent dead tap (Constitution Rule 1 + behavioral-contract violation). That is an unaccepted P1 → FAIL → REWORK. Everything else is PASS-grade and re-tests fast once the dead-tap is fixed.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Status | Evidence |
+|---|---|---|---|
+| SC-1 | Consumer OTP consent box uses §1a bundled label; underlined "terms and conditions" → §2 view; CTA gated | **PASS** | `OnboardingFlow.tsx` L2173 CTA `disabled: !isPhoneValid() \|\| !smsConsentChecked` (matches DESIGN §S3.2); label parts = byte-mirror of business constant (verified) |
+| SC-2 | Consumer grant writes consent_records (txn+mktg; source='onboarding'; §1b verbatim; email+sms; country from phone; ip_hash null native) | **PASS (source + schema-on-real-PG)** | `handleVerifyOtp` L1412 → `recordConsent({source:'onboarding', disclosureText:CONSENT_DISCLOSURE_TEXT, phone:buildE164(), email:authUser.email, countryCode:data.phoneCountryCode, userId})`; edge fn fans out both scopes × provided channels; live `consent_records` schema accepts every column written |
+| SC-3 | Checkout name+email+phone REQUIRED with validation/error states | **PASS (source)** | `validate()` L166-191 — name≥min, email regex, phone `isValidE164`; all three feed `isValid`; per-field error strings render on touched |
+| SC-4 | Checkout marketing checkbox replaced with underlined "I agree…" → §2 sheet | **PASS** | `buyer.tsx` L631-664 Pressable + `ConsentTermsSheet`; `marketingOptIn` checkbox removed |
+| SC-5 | Pay/Continue GREYED until checked AND fields valid | **PASS (gate predicate)** | `isContinueDisabled` L18-19 `!fieldsValid \|\| !termsAccepted \|\| submitting`; bound at button L697; regression test + fails-on-revert |
+| SC-5b | Disabled-Pay tap → flash + "Please agree to continue" (no silent dead tap) — DESIGN §S3.4 L311/335 | **FAIL (P1)** | The flash/helper is set ONLY in `handleContinue` L381 (`if(!termsAccepted)…`), reachable ONLY when the button is ENABLED (requires termsAccepted=true) → contradiction; `Button` sets `onPress={interactive?…:undefined}` + `disabled` → disabled tap fires nothing. `consentHintVisible`/`checkboxBoxFlash`/the hint Text are unreachable dead code. |
+| SC-6 | Checkout finalize writes consent_records (both scopes; source='checkout'; §1b verbatim; country from buyer country; ip_hash of request IP) | **PASS (source + schema-on-real-PG)** | `handleContinue` L394 `recordConsent({source:'checkout', disclosureText:CONSENT_DISCLOSURE_TEXT, phone, email, countryCode:phoneCountry})`; edge fn L160-161 computes `ip_hash` from `x-forwarded-for`/`x-real-ip` via SHA-256 |
+| SC-7 | Capture buyer country at checkout | **PASS** | `phoneCountry` ISO → `country_code` (edge fn uppercases) |
+| SC-8 | Shared T&C sheet renders §2 body verbatim, reused | **PASS** | `ConsentTermsSheet.tsx` (checkout); consumer reuses full-screen `LegalBrowser`; §2 body byte-identical across both apps (6558 chars, verified) |
+| SC-9 | Seed-correction migration 20261110000005 (monotonic above 000004; +sms refund/cancel, +email payout; idempotent) | **PASS (applied vs real PG, rolled back)** | Order verified (remote head=20261110000004); transactional apply → `buyer_refund_issued`+`buyer_order_cancelled`={…,sms}, `payout_paid`={…,email}; re-run no-op (idempotent); guarded `NOT (… = ANY(default_channels))` |
+| SC-10 | consent_records writer: shared service-role helper both surfaces call; dedupe on (contact,channel,scope,source) window | **PASS (source)** | `record-consent` edge fn (verify_jwt=false); 5-min dedupe query-then-insert; both apps' `consentService.ts` call it |
+| SC-11 | §1b disclosure recorded VERBATIM | **PASS (byte-proven)** | `CONSENT_DISCLOSURE_TEXT` == COPY §1b == app-mobile mirror, all 1071 chars, char-for-char (python byte-compare) |
+| SC-12 | Bundled-mandatory per DEC-186; SMS kill-switch unaffected | **PASS** | ONE checkbox both surfaces; no marketing-split; no SMS send path touched |
+
+---
+
+## 3. Findings
+
+### P1-1 — Disabled-Pay "Please agree to continue" feedback is unreachable dead code (Constitution Rule 1 + DESIGN §S3.4 contract violation)
+- **Evidence:** `mingla-business/app/checkout/[eventId]/buyer.tsx` L381 is the ONLY site that sets `setConsentHintVisible(true)`; it lives in `handleContinue` behind `if (!termsAccepted)`. `handleContinue` is invoked ONLY via the Pay button `onPress` (L691). The Pay button uses the shared `Button` (`src/components/ui/Button.tsx` L296/299: `onPress={interactive ? handlePress : undefined}`, `disabled={disabled||loading}`), and is `disabled` whenever `!termsAccepted` (via `isContinueDisabled`). Therefore: box unchecked → button disabled → tap does nothing → hint never shows; box checked → button enabled → `!termsAccepted` is false → hint never shows. The `consentHintVisible` Text (L665-668), the `checkboxBoxFlash` style (L873), and the helper are all unreachable.
+- **Impact:** A buyer who fills all fields but misses the consent box taps the greyed Pay and gets ZERO feedback — a silent dead tap. DESIGN §S3.4 (L311) and the state table (L335) explicitly require "border flashes red 400ms + helper 'Please agree to continue.'" on that tap. The implementor report (§7, §9) claims this fires; it does not. This is the exact failure mode the dispatch flagged (verification point #3) and a Constitution Rule 1 auto-P0-class issue (graded P1 as it is a missing affordance on a still-visibly-disabled control, not a crash/data-loss).
+- **Required fix:** Make the disabled-Pay tap reachable. Either (a) keep the Button visually disabled but route taps to a handler that runs the field-touch + `setConsentHintVisible(true)` + scroll-into-view + flash (e.g. wrap the bottom bar in a `Pressable` overlay that, when `isContinueDisabled`, calls a `showConsentHint()` instead of `handleContinue`), or (b) keep the Button enabled and move the gate inside `handleContinue` (validate → show errors → if `!termsAccepted` show hint+flush, return), matching the DESIGN-specified anti-dead-tap pattern. Mirror the onboarding pattern only if onboarding also adopts tap-to-reveal (onboarding currently passes per §S3.2 which only requires surfacing the existing phone error).
+- **Retest:** Maestro/device: fill name/email/phone, leave box unchecked, tap Pay → assert the helper "Please agree to continue." renders + the checkbox border flashes. Add a render test that simulates a disabled-Pay tap and asserts `consentHintVisible` becomes true.
+
+### P2-1 — record-consent is an OPEN write endpoint (anon, no contact-ownership proof) → audit-log pollution / forged-consent rows / cost-spam
+- **Evidence:** `supabase/functions/record-consent/index.ts` runs `verify_jwt=false` and inserts `consent_records` for ANY `phone`/`email`/`countryCode`/`source` in the body with no proof the caller controls that contact (no OTP/session binding). The 5-min dedupe is per identical `(contact,channel,scope,source)` tuple, so an attacker rotating distinct fabricated contacts bypasses it entirely.
+- **Impact (BOUNDED — assessed):** It CANNOT amplify into sends to a victim — `can_send()` (`20261110000002…sql` L23-100, the single send chokepoint) reads `notification_categories` + `notification_channel_prefs` + `channel_suppressions` and **does NOT read `consent_records` at all**. So a poisoned consent row grants no SMS/email capability (no TCPA send harm). The realized harm is (1) legal-record integrity — an attacker can fabricate "contact X consented" rows polluting the burden-of-proof artifact, and (2) table/cost spam (unbounded row insertion). Fabricated `user_id` is rejected (FK to `auth.users`, proven on real PG); anon `user_id=null` rows are accepted (the legit path).
+- **Required fix (hardening, not a launch blocker by itself):** add a basic abuse control — per-IP rate limit on `record-consent`, and/or only accept a write when the same request also presents a fresh checkout/OTP token tying the caller to the contact. At minimum, log+alert on burst volume. Document the accepted residual if shipping as-is.
+- **Retest:** call the deployed fn 50× with rotating fake emails → confirm rate-limit/no unbounded insert.
+
+### P2-2 — Live edge round-trip NOT proven (record-consent not deployed; migration not applied)
+- **Evidence:** `mcp__supabase__list_edge_functions` → `record-consent` absent from deployed list; `supabase_migrations.schema_migrations` head = `20261110000004` (000005 not applied). Both are expected pre-merge, but it means the dual-scope write was verified at the SOURCE + against the real table schema/constraints (a representative anon insert succeeds, rolled back) — NOT as a deployed end-to-end round-trip.
+- **Impact:** SC-2 / SC-6 are PASS-by-mechanism, not PASS-by-live-round-trip. A deploy-time regression (env var, CORS, payload shape) would not be caught by this gate.
+- **Required fix:** none in code; operator must deploy `record-consent` from MERGED main + apply `20261110000005`, then a one-shot live POST should be confirmed at CLOSE (assert a txn+mktg row pair lands with the verbatim text + country + ip_hash).
+- **Retest:** after deploy, POST a grant and `select … from consent_records where contact=… order by created_at desc limit 4`.
+
+### P2-3 — SMS-eligible strict-grep gate not yet present on-branch (DISC-1161-A2-SEED-LAG)
+- **Evidence:** `.github/scripts/strict-grep/` has `i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs` but NO `i-proposed-1161-sms-only-for-policy-eligible-categories.mjs`. The SPEC marks it I-PROPOSED (flip ACTIVE at CLOSE).
+- **Impact:** The closed-SMS-eligible-set invariant is not yet enforced. Per the dispatch (DISC-1161-A2-SEED-LAG), when this gate is flipped ACTIVE at CLOSE it MUST assert the CORRECTED (post-000005) seed — i.e. `buyer_refund_issued`, `buyer_order_cancelled` include `sms` and `payout_paid` includes `email`. If the gate is authored against the pre-000005 seed it will be wrong.
+- **Required fix:** at CLOSE, author the gate to assert the post-correction matrix (these three rows + the rest of the §5.2 SMS rows) and run it against migrated state.
+- **Retest:** run the gate after 000005 is applied; it must pass.
+
+### P4-1 — Verbatim-disclosure discipline is exemplary (praise)
+The §1b string, §2 body, §1a label parts, and `DISCLOSURE_VERSION` are byte-identical between `mingla-business` and `app-mobile` AND byte-identical to the COPY authority. The text is recorded per-row (legal artifact survives even without a versioned-text table). This is exactly right for a burden-of-proof artifact.
+
+### P4-2 — Money seam cleanly NOT entangled (praise)
+Consent writes via a dedicated `record-consent` call at the Continue tap, BEFORE the free/paid finalize, non-blocking on failure (logged, never swallowed → Constitution #3). `ticket-checkout-create` / `stripeWebhookRouter` untouched. `marketingOptIn` ridden additively rather than a risky cross-file rename.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out HEAD `8b119de47`; ran `mingla-business` jest.
+- **Baseline:** `src/services/__tests__/consentService.orch1161.test.ts` → 3/3 PASS.
+- **Revert A (gate):** true line-deletion of `!params.termsAccepted` in `checkoutConsentGate.ts` (`!fieldsValid || !termsAccepted || submitting` → `!fieldsValid || submitting`) → test **"Pay/Continue is DISABLED until the bundled consent box is checked" FAILED** (`expected true, received false`); restored → PASS.
+- **Revert B (verbatim):** replaced `disclosureText: input.disclosureText` with a paraphrase in `consentService.ts` → test **"records the EXACT §1b disclosure VERBATIM…" FAILED**; restored → PASS.
+- Final: 3/3 PASS, worktree restored clean (`git status` empty). Implementor fails-on-revert **independently confirmed at `8b119de47`**.
+
+---
+
+## 5. Adversarial test added (different angle)
+
+- **Path:** `mingla-business/src/services/__tests__/consentDisclosureDrift.tester.orch1161.test.ts` (3 tests, PASS).
+- **Angle (NOT covered by implementor):** the implementor's test proves the service PASSES the constant through; it CANNOT detect drift in the constant ITSELF (a paraphrase/truncation of `CONSENT_DISCLOSURE_TEXT` would still pass their pass-through check). This test PINS the constant to a FROZEN char-for-char snapshot of the COPY §1b legal authority (length 1071) + asserts every hard-required disclosure element + the exact terminal SMS-terms URL (no tail truncation) + §2 body legal entity/address.
+- **fails-on-revert verified at `8b119de47`:** deleted the "Consent to texts is not a condition of any purchase. " sentence from `consentDisclosure.ts` → byte-identity + element-checklist assertions **FAILED**; restored → 3/3 PASS.
+- **In-diff status:** the file is currently UNTRACKED on the branch. It MUST be committed on `ORCH-1161-consent-surface` so it appears in `git diff main...HEAD` for the closing PR (append-only; new file, no existing test modified). The implementor's happy-path test IS already in the diff.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|---|---|---|
+| 1 | No dead taps | **FAIL** | P1-1: disabled-Pay tap gives no feedback; the specced flash/helper is unreachable |
+| 2 | One owner per truth | PASS | `record-consent` is the single consent writer; disclosure constants single-source per app (byte-mirrored) |
+| 3 | No silent failures | PASS | consent-write failure logged via `console.error`/`logger.onboarding`, surfaced in `RecordConsentResult.ok`, non-blocking by design |
+| 4 | One query key per entity | N/A | no React Query key added |
+| 5 | Server state server-side | PASS | consent state is server-written; no Zustand server cache |
+| 6 | Logout clears everything | N/A | no new persisted client auth state |
+| 7 | Label `[TRANSITIONAL]` | PASS | `marketingOptIn`-rides-with-`termsAccepted` documented as a deferred rename (report §10) |
+| 8 | Subtract before adding | PASS | removed the old marketing checkbox; added the bundled one |
+| 9 | No fabricated data | PASS | disclosure is the real authority text; country/ip derived, not faked |
+| 10 | Currency-aware | N/A | no pricing touched |
+| 11 | One auth instance | PASS | consumer reuses `supabase.auth.getUser()`; checkout anon |
+| 12 | Validate at right time | PASS | field validation on touched; consent recorded at the affirmative act |
+| 13 | Exclusion consistency | N/A | — |
+| 14 | Persisted-state startup | N/A | no `_hasHydrated` gate involved |
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Ships? | Verdict | Note |
+|---|---|---|---|
+| Consumer iOS (`app-mobile`) | YES | PASS (source) | onboarding gate + consent write; shared RN |
+| Consumer Android | YES | PASS (source, auto) | shared RN with iOS |
+| Buyer/anon Web (`mingla-business` checkout) | YES | **FAIL** | P1-1 dead-tap on the web/web-phone checkout (primary surface for this slice) |
+| Business iOS / Android | NO | N/A | no business-side consent surface this slice |
+| Admin Web | NO | N/A | no consent surface |
+| Business Web preview (adjacent) | INCIDENTAL | inherits P1-1 | same `buyer.tsx` |
+
+**Sim/device:** NOT driven this pass. Exempt for the backend/SQL/edge paths (migration verified vs real PG; schema/constraints verified live). The one UI finding (P1-1) is a source-provable wiring contradiction (a control that cannot fire) — sufficient to FAIL without a sim. A device retest is required to PASS SC-5b after the fix. **Operator physical-iPhone HITL: NOT requested this pass (verdict already FAIL on source).**
+**Edge deploy state:** `record-consent` NOT deployed (pre-merge, expected). Migration `20261110000005` NOT applied (remote head `20261110000004`, expected).
+
+---
+
+## 8. Discoveries for Orchestrator
+
+- **DISC-T-1161A2-1 (seed-key naming divergence, pre-existing, OUT of scope):** SPEC §5.2 line 242's "complete closed SMS-eligible set" enumerates keys like `buyer_event_reminder_24h`/`_2h`, `buyer_reservation_reminder_24h`/`_2h`, `waitlist_table_ready`, and omits `buyer_reservation_confirmed`. The LIVE seed uses single rows `buyer_event_reminder`, `buyer_reservation_reminder`, and includes `buyer_reservation_confirmed` (all sms-eligible). The three rows THIS migration touches (`buyer_refund_issued`/`buyer_order_cancelled`/`payout_paid`) match the SPEC §5.2 table rows exactly, so this slice is correct — but the broader seed-vs-SPEC key naming should be reconciled before the SMS-eligible strict-grep gate is finalized, or the gate's expected set will not match the live keys.
+- **OQ-2 confirmed:** `consent_records.source` has NO CHECK constraint (only `action`/`channel`/`scope` are constrained) — `source='onboarding'`/`'checkout'` accepted with no enum widening (matches implementor §12).
+- **No UNIQUE constraint** on `consent_records` → dedupe is purely the edge fn's query-then-insert (a concurrent double-tap race can still write duplicates; acceptable for an append-only audit log, noted).
+- **COMMS-0040/0041** (RSVP/experience public-page standardization) — FYI per dispatch; this slice touches checkout + onboarding, not the public RSVP/experience page bodies. No conflict.
+
+---
+
+## 9. Routing
+
+**FAIL → REWORK (mingla-implementor).** Single blocking item: **P1-1** — make the disabled-Pay tap surface the specced flash + "Please agree to continue." helper (DESIGN §S3.4 L311/335). Recommended to also commit the tester adversarial test on-branch (P2/process), address P2-1 hardening or document the accepted residual, and ensure the CLOSE-time SMS-eligible gate asserts the post-000005 seed (P2-3). NOT clear-to-close.

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md
@@ -139,3 +139,53 @@ Checked out HEAD `8b119de47`; ran `mingla-business` jest.
 ## 9. Routing
 
 **FAIL → REWORK (mingla-implementor).** Single blocking item: **P1-1** — make the disabled-Pay tap surface the specced flash + "Please agree to continue." helper (DESIGN §S3.4 L311/335). Recommended to also commit the tester adversarial test on-branch (P2/process), address P2-1 hardening or document the accepted residual, and ensure the CLOSE-time SMS-eligible gate asserts the post-000005 seed (P2-3). NOT clear-to-close.
+
+---
+
+# RETEST 2026-06-20 — rework re-verification (P1-1 fix + drift test commit + rate-limit)
+
+**Commit under test:** `3fa0bc072` (rework; the report's intermediate `c317d57ba` was squashed into it — `git cat-file -t c317d57ba` confirms it's an ancestor object). HEAD of `ORCH-1161-consent-surface`, tree clean.
+**Mode:** RETEST. Re-verify ONLY the four dispatch items: (1) P1-1 dead-tap CLOSED, (2) drift test tracked + in-diff + passing, (3) record-consent rate limit, (4) no regression to the already-PASS items.
+
+## RETEST Verdict
+
+**CONDITIONAL PASS** — P0: 0 · unaccepted P1: 0 · P2: 1 (P2-1 → now mitigated + residual documented) · P3: 0.
+**CLEAR-TO-CLOSE: YES** (operator-owned deploy/migration/gate steps remain, unchanged from the original report — they are CLOSE-time operator actions, not rework defects).
+
+The single rework conditional is the on-screen UI repro of P1-1, which is `probable` not `proven`: the decision logic is proven (pure predicate + independently re-run fails-on-revert + 9/9 jest), the capture mechanism is source-proven sound on web + native, and the dead code is now reachable — but the actual tap-renders-the-helper was NOT driven on a device this pass (the fix is a `mingla-business` checkout surface; the only connected device runs the consumer `app-mobile` on Metro 8081, and standing up the business checkout to the exact "valid fields + unchecked box + tap greyed Pay" state needs a live published event + fresh web export). A one-tap physical-iPhone HITL confirms it to `proven` (instructions below). Because the original FAIL was a source-provable wiring *contradiction* (the control could not fire under any state) and the fix is now a source-provable wiring *resolution* (the control fires under exactly the specced state), the source-level closure of P1-1 is strong; the device tap is the last 5%.
+
+## RETEST item-by-item
+
+### 1. P1-1 CLOSED — disabled-Pay dead tap is fixed (was the blocking FAIL)
+
+- **Pure predicate present:** `mingla-business/src/components/checkout/checkoutConsentGate.ts` L35-37 `shouldShowConsentHintOnDisabledTap = (params) => params.fieldsValid && !params.termsAccepted`. Decides show/no-show in isolation; avoids double-messaging when fields are still invalid (errors carry that message).
+- **Wiring in `buyer.tsx`:** import L81-82; `showConsentHint` callback L381-393 marks all fields touched and sets `consentHintVisible(true)` gated on the predicate; single-source `continueDisabled = isContinueDisabled({...})` L488; render: outer `<Pressable onPress={continueDisabled ? showConsentHint : undefined}>` L728-729 wraps `<View pointerEvents={continueDisabled ? "none" : "auto"}>` L732 wrapping the `Button` (`disabled={continueDisabled}` L741). Helper Text `consentHintVisible && !termsAccepted` → "Please agree to continue." L697-701; checkbox flash `consentHintVisible && !termsAccepted && styles.checkboxBoxFlash` L677.
+- **Mechanism is sound on BOTH platforms:** the inner `Button` (`src/components/ui/Button.tsx` L296/299) is itself a `Pressable` with `onPress=undefined` + `disabled` while not interactive — i.e. on its own it swallows the tap (the original dead tap). Wrapping it in `pointerEvents="none"` (while disabled) makes it transparent to the touch on web (CSS `pointer-events:none`) AND native (RN responder skips it), so the outer `Pressable` reliably captures the tap → `showConsentHint`. When enabled: inner `pointerEvents="auto"` claims the responder → `handleContinue`; outer `onPress` is `undefined` → no double-fire. No regression to the enabled (real Pay) path. `Pressable`/`View` both imported from `react-native` (L34/L38) — not a build break.
+- **Runtime evidence:** jest `checkoutConsentGate.deadtap.orch1161` 3/3 PASS; full consent suite 9/9 PASS. On-screen device tap = `probable` pending the HITL step.
+- **Verdict:** P1-1 **CLOSED** (source-proven + logic-proven; on-screen repro `probable`).
+
+### 2. Tester drift test — tracked, in-diff, passing, §1b byte-identical
+
+- `git ls-files` → `mingla-business/src/services/__tests__/consentDisclosureDrift.tester.orch1161.test.ts` is **tracked**; appears in `git diff main...HEAD --name-only` (closing diff). Working tree clean (not staged-on-a-side-branch). The implementor happy-path test + the new dead-tap test are also in the diff.
+- Runs **3/3 PASS** (verbatim §1b byte-identity to the COPY authority preserved; `consentDisclosure.ts` not touched by the rework — `git show 3fa0bc072` does not list it). **PASS.**
+
+### 3. record-consent rate limit — 12/min per IP, fail-open, cannot block legit checkout, no send-amplification
+
+- `supabase/functions/record-consent/index.ts`: `RATE_LIMIT_WINDOW_MS=60s`, `RATE_LIMIT_MAX_PER_WINDOW=12` (L58-59); per-IP sliding-window `isRateLimited()` L67-79 (prunes the window each call, bounded); checked **BEFORE** any JSON parse / DB work L137-151; over-cap → HTTP **429** + `Retry-After`. **Fail-OPEN** on null IP (`if (ipKey === null) return false` L68) → a legit caller behind a stripped header is never blocked. A real grant is 1 call → 12/min is generously above any legitimate checkout/onboarding cadence, so it **cannot block legit checkout**.
+- **Residual (documented + ACCEPTED):** per-instance in-memory map — does not coordinate across warm Deno instances, resets on cold start. Caps a single hot client's burst (the realistic cheap-spam shape); a distributed multi-instance flood is not fully blocked. **Acceptable** because the harm it guards is bounded to audit-log pollution + cost-spam only: **`can_send()` (the single send chokepoint, migration `20261110000002`) contains ZERO references to `consent_records`** (independently grepped: `grep -c consent_records … = 0`). A forged/poisoned consent row therefore grants NO sms/email send capability → no TCPA send-amplification. **PASS** (P2-1 mitigated; residual documented; no send blast).
+
+### 4. No regression to the already-PASS items
+
+- **Dual-scope consent_records write:** edge-fn fan-out `{transactional,marketing} × {sms,email}` L203-263 unchanged in shape; only the rate-limit guard + a `clientIp`/`requestIp` de-dup were added. Verbatim disclosure write intact. **No regression.**
+- **Seed-correction migration `20261110000005`:** present & untouched by the rework (`git show 3fa0bc072` lists no `supabase/migrations/*`). **No regression.**
+- **Money seam:** `ticket-checkout-create` / `stripeWebhookRouter` NOT in the rework diff; the enabled-Pay path still fires `handleContinue` exactly as before. **Untouched.**
+- **SMS kill-switch:** not touched by the rework. **Off / unchanged.**
+- **Independent fails-on-revert re-run (this pass):** true line-deletion of `&& !params.termsAccepted` in `shouldShowConsentHintOnDisabledTap` (→ `params.fieldsValid`) → `checkoutConsentGate.deadtap.orch1161` test "box already checked → no consent helper" **FAILED** (`expect false, received true`); restored → **3/3 PASS**; tree restored clean. **fails-on-revert independently confirmed at `3fa0bc072`.**
+
+## RETEST device / HITL
+
+The on-screen P1-1 repro is `probable`. To reach `proven`, the physical-iPhone HITL (one tap on the `mingla-business` buyer checkout): open any paid event's checkout, fill name + email + phone, leave the consent box UNCHECKED, tap the greyed Pay → expect the checkbox border to flash red ~400ms AND "Please agree to continue." to appear under it; then check the box → Pay un-greys and proceeds. NOT requested-and-blocking for CLOSE given the strong source + logic proof; flagged as the recommended final eyeball.
+
+## RETEST routing
+
+**CONDITIONAL PASS → CLEAR-TO-CLOSE: YES.** Route to **mingla-orchestrator for CLOSE**. The remaining items are operator-owned CLOSE-time actions (unchanged from the original report, NOT rework defects): deploy `record-consent` from MERGED main (`verify_jwt=false`); apply migration `20261110000005`; flip the SMS-eligible strict-grep gate ACTIVE asserting the POST-000005 seed (DISC-1161-A2-SEED-LAG); confirm the live edge round-trip post-deploy (P2-2). Single accepted condition: the on-screen P1-1 device tap is `probable` (logic + mechanism proven) — recommend the one HITL tap above at/after CLOSE.

--- a/Mingla_Artifacts/specs/SPEC_META-ORCH-1161_NOTIFICATION_MESSAGING_SYSTEM.md
+++ b/Mingla_Artifacts/specs/SPEC_META-ORCH-1161_NOTIFICATION_MESSAGING_SYSTEM.md
@@ -16,25 +16,41 @@
 
 ---
 
+## v2 changelog (2026-06-19)
+
+This is a v2 revision of the v1 canonical spec, encoding two locked decisions: **DEC-185** (channel model) and **DEC-186** (consent gate). Where they conflict with v1, the decisions WIN. What changed:
+
+1. **Channel model REWRITTEN (DEC-185).** Killed push-first/SMS-fallback (the old DC-2). The category's `default_channels` IS the policy: every listed channel sends **SIMULTANEOUSLY**, each independently gated by `can_send()` (consent + suppression + quiet-hours) and by the reach rule (push/in-app only for users with the consumer app / an account; email always; SMS only for policy-eligible categories). §5.4 is now a flat per-channel loop — no waterfall, no escalation timeout, no "SMS only if push undelivered." REMOVED: the `notify-escalate` worker, `reach_mode`/`escalate_on_no_engagement`, escalation timeout T, and §12 Q5/Q6 (marked MOOT).
+2. **Category matrix REPLACED (DEC-185).** §5.2 seed rewritten to the confirmed Explorer + Business matrix. SMS-eligible set is now a closed, enumerated list (the seed). New invariant `I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES` replaces the old fallback-gate invariant.
+3. **Business notifications gain email broadly + ONE SMS exception (DEC-185).** All business categories now `{push,inapp,email}` (was push-only); `payout_paid` is the SINGLE brand SMS (`{push,inapp,email,sms}`). New-reservation / reservation-change to the brand are NET-NEW.
+4. **Marketing now also delivers via push + in-app (DEC-185).** §6 (Sub-B) gains a push+inapp marketing delivery path for consumer-app users, not just email/SMS.
+5. **Consent BUNDLED into one mandatory gate; TCPA risk ACCEPTED (DEC-186).** §8 + §10 rewritten: the consumer-app OTP consent box and the anon checkout page gate continuation on ONE mandatory checkbox (T&Cs + transactional + reminders + email marketing + SMS marketing). New risk **R-8** + an §8 callout document the known TCPA violation (47 CFR 64.1200) that Seth accepted, with mitigations and an explicit **legal-sign-off go-live blocker** for SMS-marketing.
+6. **Thin slice changed to `buyer_reservation_changed`** so the first ship exercises the SMS leg + STOP round-trip (the v1 `buyer_reservation_confirmed` is now a NO-text category).
+7. **§12 mostly resolved** — answers recorded; only social-email scope and legal-sign-off owner/timing remain OPEN.
+
+Authoritative decision text: `Mingla_Artifacts/DECISION_LOG.md` DEC-185 + DEC-186 (2026-06-19).
+
+---
+
 ## 1. Executive summary
 
-We are building Mingla's **one** notification + messaging system: free push/in-app/email everywhere, paid SMS only on a few high-value moments, with a real consent/compliance spine so SMS is legal to send in the US and Nigeria.
+We are building Mingla's **one** notification + messaging system: free push/in-app/email everywhere, paid SMS only on a curated set of high-value categories, with a real consent/compliance spine so SMS is legal to send in the US and Nigeria.
 
-**Plain English:** A buyer who books a table, buys a ticket, or has an upcoming event gets told — first by free push (and a durable in-app inbox row), then cheap email, and only as a last resort by SMS (and only for the moments Seth picked). Brands can also send SMS marketing blasts (not just email). Every SMS is gated by a consent + suppression + quiet-hours check that lives in **one** place, so no flow can ever bypass it.
+**Plain English:** A buyer who books a table, buys a ticket, or has an upcoming event gets told across every channel the category's policy lists — a durable in-app inbox row, a free push (if they have the consumer app), an email (always), and an SMS (only for the categories Seth curated as text-worthy). **All listed channels fire at the same time** — SMS is NOT a last resort that waits for push to fail. Cost discipline comes from the *curated SMS-eligible set*, not from a waterfall. Brands can also send SMS marketing blasts (not just email). Every send is gated by a consent + suppression + quiet-hours check that lives in **one** place, so no flow can ever bypass it.
 
-**The single biggest insight:** the SMS *plumbing already exists and is production-proven*. We hold a **Twilio-approved toll-free number (+1 888-250-5351)** behind `TWILIO_MESSAGING_SERVICE_SID`, a working send pattern (`send-venue-sms`), a status webhook (`twilio-message-status`), an opt-out ledger pattern (`venue_sms_opt_out`), a preferences+quiet-hours+idempotency dispatcher (`notify-dispatch`), and an entire SMS-shaped marketing schema with the SMS path literally one `throw` away. **The real, hard work is NOT "wire Twilio."** It is three things: (1) a **legal consent/compliance foundation** (separate transactional vs marketing scopes, durable consent records, suppression honored from any channel, quiet hours, sender identity, Nigeria path); (2) the **reservation notification gap** (reservations notify NOBODY today — fully net-new); and (3) **collapsing 3 ad-hoc senders into one unified dispatcher** with a `can_send()` gate and a push-first/SMS-fallback waterfall that structurally minimizes Twilio spend.
+**The single biggest insight:** the SMS *plumbing already exists and is production-proven*. We hold a **Twilio-approved toll-free number (+1 888-250-5351)** behind `TWILIO_MESSAGING_SERVICE_SID`, a working send pattern (`send-venue-sms`), a status webhook (`twilio-message-status`), an opt-out ledger pattern (`venue_sms_opt_out`), a preferences+quiet-hours+idempotency dispatcher (`notify-dispatch`), and an entire SMS-shaped marketing schema with the SMS path literally one `throw` away. **The real, hard work is NOT "wire Twilio."** It is three things: (1) a **legal consent/compliance foundation** (separate transactional vs marketing scopes, durable consent records, suppression honored from any channel, quiet hours, sender identity, Nigeria path); (2) the **reservation notification gap** (reservations notify NOBODY today — fully net-new); and (3) **collapsing 3 ad-hoc senders into one unified dispatcher** with a `can_send()` gate that fires the category's policy channels simultaneously and reserves SMS for the curated eligible set (DEC-185).
 
 ---
 
 ## 2. Scope & non-goals
 
 ### In scope
-- **Sub-A (foundation, lands first):** unified `notify-dispatch` v2 dispatcher + consent/preference/suppression/deliveries data model + `can_send(user, category, channel)` gate + channel adapters (push/email/sms) + push-first/SMS-fallback waterfall + status webhooks (Twilio + Resend + OneSignal) + escalation worker + GSM-7 sanitizer + region routing + inbound STOP webhook → suppression sync. Markets: US + Nigeria.
-- **Sub-B (SMS marketing blasts):** replace the `marketing-send` `sms` throw with the Sub-A `smsAdapter`; enable the SMS tab; display SMS reach; phone-keyed suppression in the audience resolver; compliant **marketing** opt-in capture (separate scope, unchecked-by-default, full disclosure); quiet hours + segment/cost guard + branded short links + throughput throttling + deliverability thresholds.
-- **Sub-C (high-touch transactional):** the 3 SMS-eligible moments — (1) buyer purchase confirmation (event/trip/experience ticket), (2) buyer reservation confirmed/changed/cancelled (NET-NEW), (3) buyer pre-event/trip/reservation reminder (NET-NEW scheduled job) — each routed push-first/SMS-fallback through Sub-A with transactional consent + idempotency.
+- **Sub-A (foundation, lands first):** unified `notify-dispatch` v2 dispatcher + consent/preference/suppression/deliveries data model + `can_send(user, category, channel)` gate + channel adapters (push/email/sms) + **simultaneous per-channel send of the category's `default_channels` policy** (DEC-185 — no waterfall) + status webhooks (Twilio + Resend + OneSignal) + GSM-7 sanitizer + region routing + inbound STOP webhook → suppression sync. Markets: US + Nigeria.
+- **Sub-B (SMS marketing blasts):** replace the `marketing-send` `sms` throw with the Sub-A `smsAdapter`; enable the SMS tab; display SMS reach; phone-keyed suppression in the audience resolver; **add a push + in-app marketing delivery path for consumer-app users** (DEC-185 — marketing now also reaches push+inapp, not just email/SMS); compliant **marketing** opt-in capture (now bundled into the mandatory consent gate per DEC-186, recorded as `scope='marketing'`); quiet hours + segment/cost guard + branded short links + throughput throttling + deliverability thresholds.
+- **Sub-C (high-touch transactional):** the high-touch moments — (1) buyer purchase confirmation (event/trip/experience ticket — **NO text**, push+inapp+email), (2) buyer reservation confirmed (NO text) / changed / cancelled (NET-NEW), (3) buyer pre-event/trip/reservation reminder (NET-NEW scheduled job, 24h + ~2h), (4) waitlist ready/spot-open, refund issued, order cancelled, payment failed (NO text) — each dispatched through Sub-A using the category's policy channels SIMULTANEOUSLY (DEC-185), with transactional consent + idempotency. SMS fires only for the categories whose seed lists `sms`.
 
 ### Non-goals (explicit, with reason)
-- **Brand-side SMS alerts** — OUT. Brand new-sale/refund/inventory alerts stay PUSH-only (Decision 3; Seth explicitly did NOT select brand SMS). `businessNotifyTriggers.ts` push paths are untouched except to route through the dispatcher.
+- **Brand-side SMS alerts** — OUT *except `payout_paid`* (DEC-185 explicit). Every other brand category (new_sale/sold_out/low_inventory, refund_processed, new_reservation, reservation_change, payout_failed, stripe_account/bank_problem) is `{push,inapp,email}` — NO text — but gains EMAIL broadly (today push-only). `payout_paid` is the SINGLE brand SMS (`{push,inapp,email,sms}`). `businessNotifyTriggers.ts` push paths route through the dispatcher and now also fan out email; only `payout_paid` adds SMS. New-reservation / reservation-change to the brand are NET-NEW (today reservations notify the brand of nothing).
 - **RCS** — OUT for now. The schema already carries `rcs` enums; leave the `rcs` throw in place. Revisit only if trivially free post-1161.
 - **OTP / Twilio Verify** — UNCHANGED. `send-otp`/`verify-otp` stay on Twilio Verify (A2P-exempt — https://www.twilio.com/docs/verify). Do NOT route OTP through the dispatcher or the A2P sender.
 - **Admin-web** (`mingla-admin`) — OUT (no compose/receive surface; moderation deferred).
@@ -52,9 +68,9 @@ We are building Mingla's **one** notification + messaging system: free push/in-a
 ## 3. The 4 LOCKED decisions, restated as design constraints
 
 1. **DC-1 — META with 3 sub-bodies; Sub-A first.** Sub-A is the only thing that ships before B and C. B and C **must call** Sub-A; they may not duplicate consent/idempotency/retry/quiet-hours logic. Enforced by I-PROPOSED-1161-UNIFIED-DISPATCHER-SOLE-SEND-PATH.
-2. **DC-2 — push-first, SMS fallback is a LAW of the dispatcher, not a per-flow choice.** The channel-selection waterfall lives inside `notify-dispatch` v2's `can_send()` + the escalation algorithm (§5.4). No caller decides "send SMS"; a caller decides a *category* and a *payload*, and the dispatcher decides channels. Enforced by I-PROPOSED-1161-SMS-BEHIND-CONSENT-AND-FALLBACK-GATE.
-3. **DC-3 — SMS-eligible moments are a CLOSED set** (the 3 in §7). They are exactly the categories with `urgency='high'` AND `sms` in `default_channels`. No other category may ever reach SMS. Adding a new SMS moment = a new category row + a spec amendment. Enforced by the `can_send()` gate (only high-urgency time-sensitive categories pass the SMS leg) + a strict-grep gate on the category seed.
-4. **DC-4 — consent + carrier compliance is a BLOCKING prerequisite per market.** SMS sending for a market is OFF until that market's go/no-go gate (§8) fully passes. The kill-switch is per-market env (`SMS_LIVE_ENABLED_US`, `SMS_LIVE_ENABLED_NG`), defaulting false, mirroring `MARKETING_SEND_LIVE_ENABLED`.
+2. **DC-2 (REVISED per DEC-185) — curated per-category POLICY + SIMULTANEOUS send, NOT push-first/SMS-fallback.** The category's `default_channels` IS the policy. For every channel in that list, the dispatcher independently calls `can_send()` and, if it passes, sends — **all channels fire together, in one pass, with no waterfall, no escalation, no "SMS only if push undelivered."** No caller decides "send SMS"; a caller decides a *category* and a *payload*, and the dispatcher fires the category's policy channels. Cost discipline = the curated SMS-eligible set (the §5.2 seed), not a fallback. Each channel is additionally constrained by reach: push/in-app only for users who have the consumer app / an account; email always; SMS only for policy-eligible categories. Enforced by I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES (+ the consent/suppression/quiet-hours invariants).
+3. **DC-3 — SMS-eligible categories are a CLOSED set** — exactly the §5.2 seed rows whose `default_channels` contains `sms`. No other category may ever reach SMS. Adding a new SMS category = a new/edited seed row + a spec amendment. Enforced by the `can_send()` gate (channel ∈ `default_channels`) + a strict-grep gate on the category seed. (The closed SMS-eligible set is the seed itself — see §5.2.)
+4. **DC-4 — consent + carrier compliance is a BLOCKING prerequisite per market.** SMS sending for a market is OFF until that market's go/no-go gate (§8) fully passes. The kill-switch is per-market env (`SMS_LIVE_ENABLED_US`, `SMS_LIVE_ENABLED_NG`), defaulting false, mirroring `MARKETING_SEND_LIVE_ENABLED`. Per DEC-186, **explicit legal sign-off accepting the bundled-consent TCPA risk is an additional go-live gate item for SMS-MARKETING** (see §8).
 
 ---
 
@@ -88,16 +104,16 @@ Cited from `INVESTIGATE_META-ORCH-1161_CODE_RECON.md` §A–E; pinned to exact c
 - **No durable, scoped consent model** — `marketing_opt_in` lives only in `orders.metadata`; no transactional-vs-marketing separation; no disclosure-text/IP/timestamp audit; no buyer **country** capture.
 - **No app-side suppression honored from any channel** — only `venue_sms_opt_out` (venue scope) + `marketing_unsubscribes` (marketing scope), email-keyed for audience.
 - **No inbound STOP webhook** — `twilio-message-status` reads status only.
-- **No escalation worker** — nothing promotes an undelivered push to email/SMS.
 - **No GSM-7 sanitizer / Smart Encoding / segment guard.**
-- **No buyer purchase-confirmation PUSH** — buyer gets email (±SMS) but never a free push (recon §C).
+- **No buyer purchase-confirmation PUSH** — buyer gets email but never a free push or in-app row (recon §C). (Purchase confirmation is a NO-text category per DEC-185 — push+inapp+email.)
+- **No broad business-side email** — brand alerts are push-only today; DEC-185 adds `{push,inapp,email}` to every brand category and `sms` to `payout_paid`.
 - **No pre-event/trip/reservation reminder scheduled job.**
 
 ---
 
 ## 5. Target architecture — Sub-A foundation
 
-Sub-A = the unified dispatcher (`notify-dispatch` upgraded to v2 — same fn name, same route, extended contract) + its data model + `can_send()` + adapters + waterfall + webhooks + escalation worker. **Existing senders migrate onto it transitionally (§5.7) so nothing breaks mid-migration.**
+Sub-A = the unified dispatcher (`notify-dispatch` upgraded to v2 — same fn name, same route, extended contract) + its data model + `can_send()` + adapters + **simultaneous per-channel policy send** (DEC-185 — no waterfall, no escalation worker) + webhooks. **Existing senders migrate onto it transitionally (§5.7) so nothing breaks mid-migration.**
 
 ### 5.1 Data model (new tables, additive; `1161` migration series, version ≥ the current max on origin/main + monotonic)
 
@@ -106,15 +122,16 @@ notification_categories(
   key text PK,                       -- e.g. 'buyer_purchase_confirmation'
   section text NOT NULL,             -- grouping for the prefs UI
   is_transactional boolean NOT NULL, -- true = on-by-default, non-marketing
-  urgency text NOT NULL CHECK (urgency IN ('low','normal','high')),
-  default_channels text[] NOT NULL,  -- subset of {inapp,push,email,sms}
-  reach_mode text NOT NULL DEFAULT 'reach_once'
-    CHECK (reach_mode IN ('reach_once','escalate_on_no_engagement')),
+  urgency text NOT NULL CHECK (urgency IN ('low','normal','high')), -- prefs ordering/labels only; NOT an SMS gate (DEC-185)
+  default_channels text[] NOT NULL,  -- subset of {inapp,push,email,sms} = THE POLICY
   active boolean NOT NULL DEFAULT true,
   created_at timestamptz NOT NULL DEFAULT now()
 )
--- SEED is data, not code (the waterfall reads it). Only HIGH-urgency rows with
--- 'sms' in default_channels can EVER reach SMS (DC-3). See §5.2 seed.
+-- SEED is data, not code (the dispatcher reads default_channels = the policy and
+-- fires every listed channel SIMULTANEOUSLY, DEC-185). Only rows whose
+-- default_channels CONTAINS 'sms' can EVER reach SMS (DC-3). See §5.2 seed.
+-- NOTE (DEC-185): the v1 `reach_mode` column is REMOVED — there is no escalation;
+-- urgency is now metadata only (prefs UI ordering), not a send gate.
 
 notification_channel_prefs(
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -173,29 +190,56 @@ notification_deliveries(
   failed_reason text NULL,
   segments int NULL                  -- SMS segment count (cost observability)
 )
--- THE delivery ledger. Webhooks reconcile final status; the escalation worker
--- reads it to decide the next hop. One row per channel attempt.
+-- THE delivery ledger. Webhooks reconcile final status. One row per channel
+-- attempt (all of a category's policy channels are attempted in one dispatch pass).
 ```
 
 **Reuse, do NOT duplicate:** `notifications` (existing in-app inbox, `idempotency_key` UNIQUE) stays the dedupe backstop — add a `dedupe_key text UNIQUE` only if a distinct key from `idempotency_key` is needed; otherwise reuse `idempotency_key` (it is already UNIQUE-backed per L341 `23505` handling). `venue_sms_opt_out`/`venue_sms_log` (venue scope) and `marketing_unsubscribes` (marketing scope) stay; the inbound-STOP webhook (§5.6) writes BOTH the new `channel_suppressions` AND, for backward-compat, the venue ledger via `biz_sms_record_global_opt_out`.
 
-### 5.2 Category taxonomy seed (the closed SMS set — DC-3)
+### 5.2 Category taxonomy seed (SOURCE OF TRUTH — the closed SMS-eligible set, DC-3 / DEC-185)
 
-| key | section | is_transactional | urgency | default_channels | reach_mode | Sub |
+This seed IS the policy. The dispatcher fires every channel in `default_channels` simultaneously (DEC-185); `sms` appears ONLY in the rows below where the confirmed matrix lists it. The closed SMS-eligible set = exactly the rows whose `default_channels` contains `sms`.
+
+**EXPLORER (buyer).** Reach rules per channel: `push` only if the user has the consumer app / an active push token; `inapp` only if the user has an account; `email` always; `sms` per policy (the rows below).
+
+| key | section | is_transactional | urgency | text? | default_channels | Sub |
 |---|---|---|---|---|---|---|
-| `buyer_purchase_confirmation` | Purchases | true | high* | `{inapp,push,email,sms}` | reach_once | C |
-| `buyer_reservation_confirmed` | Reservations | true | high | `{inapp,push,email,sms}` | reach_once | C |
-| `buyer_reservation_changed` | Reservations | true | high | `{inapp,push,email,sms}` | reach_once | C |
-| `buyer_reservation_cancelled` | Reservations | true | high | `{inapp,push,email,sms}` | reach_once | C |
-| `buyer_event_reminder` | Reminders | true | high | `{inapp,push,email,sms}` | escalate_on_no_engagement | C |
-| `buyer_reservation_reminder` | Reminders | true | high | `{inapp,push,email,sms}` | escalate_on_no_engagement | C |
-| `buyer_refund_issued` | Purchases | true | normal | `{inapp,push,email}` | reach_once | (existing→migrate) |
-| `buyer_order_cancelled` | Purchases | true | normal | `{inapp,push,email}` | reach_once | (existing→migrate) |
-| `waitlist_spot_open` | Purchases | true | high | `{inapp,push,email,sms}` | reach_once | (existing→migrate) |
-| `marketing_blast` | Marketing | false | low | `{email,sms}` (per-campaign channel) | n/a | B |
-| (existing consumer-social categories: friend_requests, messages, collaboration_invites, reminders, marketing) | — | mixed | low/normal | `{inapp,push}` (+email for marketing) | reach_once | (map, §5.7) |
+| `buyer_purchase_confirmation` | Purchases | true | high | NO | `{push,inapp,email}` | C |
+| `buyer_reservation_confirmed` | Reservations | true | high | NO | `{push,inapp,email}` | C |
+| `buyer_reservation_changed` | Reservations | true | high | YES | `{push,inapp,email,sms}` | C |
+| `buyer_reservation_cancelled` | Reservations | true | high | YES | `{push,inapp,email,sms}` | C |
+| `buyer_event_reminder_24h` | Reminders | true | high | YES | `{push,inapp,email,sms}` | C |
+| `buyer_event_reminder_2h` | Reminders | true | high | YES | `{push,inapp,email,sms}` | C |
+| `buyer_reservation_reminder_24h` | Reminders | true | high | YES | `{push,inapp,email,sms}` | C |
+| `buyer_reservation_reminder_2h` | Reminders | true | high | YES | `{push,inapp,email,sms}` | C |
+| `waitlist_spot_open` | Purchases | true | high | YES | `{push,inapp,email,sms}` | (existing→migrate) |
+| `waitlist_table_ready` | Reservations | true | high | YES | `{push,inapp,email,sms}` | C |
+| `buyer_refund_issued` | Purchases | true | normal | YES | `{push,inapp,email,sms}` | (existing→migrate) |
+| `buyer_order_cancelled` | Purchases | true | normal | YES | `{push,inapp,email,sms}` | (existing→migrate) |
+| `buyer_payment_failed` | Purchases | true | high | NO | `{push,inapp,email}` | (existing→migrate) |
+| `marketing_blast` | Marketing | false | low | YES | `{push,inapp,email,sms}` (per-campaign channel select) | B |
+| `social_friend_request` | Social | false | normal | NO | `{push,inapp,email}` ← email ONLY for these two | (map, §5.7) |
+| `social_collab_invite` | Social | false | normal | NO | `{push,inapp,email}` ← email ONLY for these two | (map, §5.7) |
+| `social_message` / `social_rsvp` / `social_other` | Social | false | low | NO | `{push,inapp}` ← NO email per chat message (deliverability) | (map, §5.7) |
 
-\* §12 Q1/Q6 decides whether `buyer_purchase_confirmation` is `urgency='high'` (SMS-eligible as push-fallback) vs always-on SMS. The seed above sets it high (SMS as push-fallback). **Only the rows with `sms` in `default_channels` AND `urgency='high'` can ever reach SMS.**
+> **Social-email scope (OPEN, §12a):** the orchestrator default is `{push,inapp,email}` for `social_friend_request` + `social_collab_invite` and `{push,inapp}` (NO email) for `social_message`/`social_rsvp`/`social_other` — never email per chat message (deliverability). Seth may override to add or drop email for friend-requests/collab-invites.
+
+**BUSINESS user (business app).** Reach: `push` to the business app; `inapp`; `email`. SMS only on `payout_paid`.
+
+| key | section | is_transactional | urgency | text? | default_channels |
+|---|---|---|---|---|---|
+| `biz_new_sale` | Sales | true | normal | NO | `{push,inapp,email}` |
+| `biz_sold_out` | Sales | true | normal | NO | `{push,inapp,email}` |
+| `biz_low_inventory` | Sales | true | normal | NO | `{push,inapp,email}` |
+| `biz_refund_processed` | Sales | true | normal | NO | `{push,inapp,email}` |
+| `biz_new_reservation` (NET-NEW) | Reservations | true | high | NO | `{push,inapp,email}` |
+| `biz_reservation_change` (NET-NEW) | Reservations | true | high | NO | `{push,inapp,email}` |
+| `biz_payout_failed` | Payouts | true | high | NO | `{push,inapp,email}` |
+| `biz_stripe_account_problem` | Payouts | true | high | NO | `{push,inapp,email}` |
+| `biz_bank_problem` | Payouts | true | high | NO | `{push,inapp,email}` |
+| `payout_paid` | Payouts | true | high | YES | `{push,inapp,email,sms}` ← the SINGLE brand SMS (DEC-185) |
+
+**The complete closed SMS-eligible set** (DC-3): `buyer_reservation_changed`, `buyer_reservation_cancelled`, `buyer_event_reminder_24h`, `buyer_event_reminder_2h`, `buyer_reservation_reminder_24h`, `buyer_reservation_reminder_2h`, `waitlist_spot_open`, `waitlist_table_ready`, `buyer_refund_issued`, `buyer_order_cancelled`, `marketing_blast`, `payout_paid`. **No other category may ever send SMS.** Any addition = a seed edit + a spec amendment (enforced by the strict-grep gate on the seed + `can_send()`).
 
 ### 5.3 `can_send(p_user_id, p_category_key, p_channel, p_contact)` — Postgres SECURITY DEFINER fn
 
@@ -213,35 +257,36 @@ can_send(user, category, channel, contact) =
 - **Transactional categories** ignore the user pref for SMS *eligibility* of the high-value moment BUT still honor: a global `push_enabled=false` (suppresses push only, not email/SMS), an explicit per-(category,channel) opt-out row, and ALL suppressions. (Transactional confirmations are legally permitted but Mingla still lets a user turn off the SMS channel for a category via prefs — that writes an `enabled=false` row.)
 - **Suppression always wins** (a STOP/bounce/complaint beats any pref).
 - **Scope mapping:** transactional categories check suppression scope ∈ {`transactional`,`all`}; `marketing_blast` checks {`marketing`,`all`}. This is why a marketing STOP must NOT kill confirmations (I-PROPOSED-1161-TRANSACTIONAL-VS-MARKETING-CONSENT-SEPARATED).
+- **No fallback logic here (DEC-185).** `can_send()` is a pure per-channel yes/no. The dispatcher (§5.4) calls it once per channel in `default_channels` and sends every channel that passes — there is no "only if push failed" condition anywhere in the gate or the dispatcher.
 
-### 5.4 Push-first / SMS-fallback algorithm (pseudocode — lives in `notify-dispatch` v2)
+### 5.4 Simultaneous policy-send algorithm (pseudocode — lives in `notify-dispatch` v2) — DEC-185
+
+There is NO waterfall, NO escalation, NO "SMS only if push undelivered." The dispatcher loops the category's `default_channels` and sends every channel that `can_send()` admits — all in one pass.
 
 ```
 dispatch({user_id|contact, category_key, payload, idempotency_key, country_code?}):
   1. cat = load notification_categories[category_key]; assert active.
   2. INSERT notifications(idempotency_key,…) ON CONFLICT(idempotency_key) DO NOTHING.
      if conflict → return {duplicate:true}.                 -- idempotency (reuse existing 23505 path)
-  3. ALWAYS write in-app: notification_deliveries(channel='inapp', status='delivered').  -- free, durable
-  4. if can_send(user, cat, 'push', _) AND has-active-push-token(user):
-        ok = pushAdapter.send(user, payload)  → deliveries row (sent/failed)
-        if cat.reach_mode='reach_once' AND ok: mark notification awaiting-push-webhook(timeout T).
-  5. EMAIL leg (cheap, parallel-safe):
-        if can_send(user, cat, 'email', contact):
-           - reach_once + push-not-yet-failed → DEFER email to escalation only on push fail/timeout
-             EXCEPT confirmations where email is the system-of-record artifact (ticket PDF/ics) → send email NOW regardless (§7.1).
-        emailAdapter.send(contact, render(cat,payload)) → deliveries row.
-  6. SMS leg — TRIPLE GATE (the cost law, DC-2/DC-3):
-        send SMS ONLY IF:
-           cat.urgency='high'
-           AND 'sms' ∈ cat.default_channels
-           AND can_send(user, cat, 'sms', contact)        -- consent + suppression + quiet-hours
-           AND (push undelivered/not-subscribed/timeout  OR  no active push token)
-           AND time-sensitive(cat, payload)               -- e.g. reminder within lead-time; confirmation always time-sensitive
-        then smsAdapter.send(contact, sanitize(render(cat,payload))) → deliveries row(segments).
-  7. escalation worker (§5.5) reconciles webhook statuses and fires the next hop after timeout T.
+  3. for channel in cat.default_channels:                   -- the POLICY, fired simultaneously
+        if NOT can_send(user, cat, channel, contact):       -- consent + suppression + quiet-hours
+              deliveries row(channel, status='suppressed'); continue.
+        switch channel:
+           'inapp': requires an account → deliveries row(status='delivered').   -- free, durable
+           'push' : requires an active push token (consumer app for buyer cats /
+                    business app for biz cats); else deliveries row(status='skipped').
+                    ok = pushAdapter.send(user, payload)  → deliveries row(sent/failed).
+           'email': always reachable if a contact email exists.
+                    emailAdapter.send(contact, render(cat,payload)) → deliveries row.
+                    (For confirmations the email carries the PDF/ics artifact — §7.1.)
+           'sms'  : ONLY if 'sms' ∈ cat.default_channels (guaranteed by the loop) AND
+                    SMS_LIVE_ENABLED_<market> AND a contact phone exists.
+                    smsAdapter.send(contact, sanitize(render(cat,payload))) → deliveries row(segments).
+  4. webhooks (§5.6) reconcile each delivery's final status asynchronously. DONE — no next hop.
 ```
-- **Escalation timeout T** = per-category param (default 5 min; §12 Q5).
-- `escalate_on_no_engagement` (reminders) continues even if push delivered-but-unopened; `reach_once` stops at first confirmed delivery.
+- **Every passing channel sends now.** A user who has the consumer app AND consented to SMS on a text-eligible category gets BOTH the push and the SMS — by design (DEC-185), not a bug.
+- **Cost discipline** = the curated SMS-eligible seed (§5.2), the per-market kill-switch, and consent/suppression/quiet-hours — NOT a fallback condition.
+- **No `reach_mode`, no escalation timeout T, no `notify-escalate` worker** (all removed per DEC-185).
 
 ### 5.5 Channel adapters — uniform interface
 
@@ -276,16 +321,17 @@ This is the critical risk. Sequence:
 
 ---
 
-## 6. Sub-B — SMS marketing blasts
+## 6. Sub-B — marketing blasts (now push + in-app + email + SMS)
 
-**Goal:** brands send compliant SMS blasts alongside email, with cost + deliverability discipline.
+**Goal:** brands send compliant blasts across email, SMS, **and (NEW, DEC-185) push + in-app to consumer-app users**, with cost + deliverability discipline. The `marketing_blast` category is `{push,inapp,email,sms}` (§5.2): an opted-in consumer-app explorer can receive a blast as a free push + durable in-app row in addition to email/SMS.
 
 ### Exact changes
 1. **`marketing-send/index.ts`** — replace the `sms` throw (L261) with a real SMS dispatch through the Sub-A `smsAdapter` (marketing Messaging Service SID per §12 Q2). Write `marketing_messages(recipient_phone, channel='sms', status, provider_message_id, segments)`. Keep the `MARKETING_SEND_LIVE_ENABLED` gate AND add the per-market kill-switch (`SMS_LIVE_ENABLED_US`/`_NG`). Leave the `rcs` throw (L263) in place.
+1b. **NEW push + in-app marketing leg (DEC-185)** — for audience contacts resolvable to a `user_id` with the consumer app, ALSO dispatch the blast via the Sub-A `pushAdapter` + an in-app `notification_deliveries(channel='inapp')` row, gated by `can_send(user,'marketing_blast',channel,_)` (marketing scope, off-by-default consent). This delivers blasts to opted-in explorers in-app/push at zero marginal cost; SMS/email remain the contact-keyed paths for non-app or no-account recipients. Idempotent per (campaign, recipient).
 2. **`_shared/marketingAudience.ts`** — **fix the phone-keyed suppression gap.** Today suppression is email-keyed only; `smsOk` is computed but never actually checks a phone suppression. Add a phone-keyed lookup against `marketing_unsubscribes(contact_phone)` AND `channel_suppressions(channel='sms', scope ∈ {marketing,all})`. `reach.reachable_sms` becomes truthful. (I-PROPOSED-1161-SMS-OPT-OUT-HONORED-ANY-CHANNEL.)
 3. **`ChannelTabs.tsx`** L42 — flip `{kind:"sms", enabled:true, caption:""}`. Keep RCS disabled.
 4. **`blasts.tsx`** L85/191 + composer — display `reachable_sms` when the SMS channel is selected; show **estimated segment count + cost preview** (GSM-7 vs UCS-2) before send (cost guard). Pass `reachable_sms` to the CTA.
-5. **Compliant MARKETING opt-in capture (separate scope)** — marketing consent is `scope='marketing'` in `consent_records` + `channel_suppressions`; it is SEPARATE from transactional. The checkout checkbox (§7/§8) and the consumer prefs UI write marketing consent; a marketing STOP/unsubscribe writes `scope='marketing'` (or `'all'` only on explicit all-channels opt-out) — never killing transactional.
+5. **MARKETING opt-in capture (bundled-mandatory grant, separate suppression scope)** — per DEC-186 marketing consent is now captured INSIDE the single mandatory consent gate (the consumer-app OTP consent box + the anon checkout T&C checkbox — §8/§10): checking it grants marketing along with transactional+reminders, recorded as a `scope='marketing'` row in `consent_records` (with the EXACT bundled disclosure text). Marketing remains a SEPARATE *suppression* scope from transactional in `channel_suppressions`: a marketing STOP/unsubscribe writes `scope='marketing'` (or `'all'` only on explicit all-channels opt-out) — never killing transactional confirmations. (The grant is bundled; the opt-out scopes stay separate so a marketing STOP can never silence a booking confirmation — I-PROPOSED-1161-TRANSACTIONAL-VS-MARKETING-CONSENT-SEPARATED.)
 6. **Quiet hours (marketing only)** — block marketing SMS outside 8 AM–9 PM recipient-local (US) / 8 AM–8 PM WAT (NG). Derive TZ from country_code/area code; if unknown, conservative deny outside the window. (FCC quiet hours — see §8.2.)
 7. **Branded short links** — marketing SMS click links use the existing `/m/{tracking_id}` Mingla-hosted redirect (NOT bit.ly). Reuse `marketing-track-click`.
 8. **Throughput throttling** — batch + throttle SMS sends (mirror the email `BATCH_LIMIT=10` + backoff) to a predictable rate (no burst-blast); respect toll-free/10DLC throughput tier.
@@ -298,33 +344,34 @@ Sub-B SMS sending stays OFF until the §8 marketing gate passes per market. Emai
 
 ## 7. Sub-C — high-touch transactional
 
-Three moments. Each: trigger source → channels (push-first/SMS-fallback via Sub-A) → buyer copy contract → transactional consent → idempotency.
+Each moment: trigger source → channels (the category's `default_channels` fired SIMULTANEOUSLY via Sub-A, DEC-185) → buyer copy contract → transactional consent → idempotency.
 
-### 7.1 Buyer purchase confirmation (event/trip/experience ticket)
+### 7.1 Buyer purchase confirmation (event/trip/experience ticket) — NO text (DEC-185)
 - **Trigger source:** `stripeWebhookRouter.ts` order finalize (`fireOrderFinalizeNotifications`, the `business.order_paid` brand path at ~L1189) — ADD a buyer-side dispatch call to `notify-dispatch` v2 with `category_key='buyer_purchase_confirmation'`. (Today the buyer gets EMAIL via `ticket-confirmation-dispatch` but NO push — recon §C.)
-- **Channels:** in-app + push (NEW, free) immediately; **email is sent NOW regardless** (it carries the ticket PDF+ics artifact — the system-of-record; reach_once does not defer it); SMS only as push-fallback per the §5.4 triple gate.
-- **Buyer copy (SMS, GSM-7, ≤1 segment target):** `"{Brand}: You're in for {Event} on {date}. Tickets in the Mingla app. Reply STOP to opt out."` (no promotional content — pure transactional; sender identity present).
-- **Consent:** transactional — derived from the purchase action; recorded as `consent_records(scope='transactional', source='checkout', action='granted', disclosure_text=<the checkout SMS-notice copy>, country_code, ip_hash)`. Buyer phone = `orders.buyer_phone_e164`.
-- **Idempotency:** `idempotency_key='buyer_purchase_confirmation:{orderId}'`. Email/SMS retry rides the existing `ticket_order_notifications` backbone; cross-channel truth in `notification_deliveries`.
+- **Channels:** `{push,inapp,email}` — NO SMS (DEC-185 confirmed matrix). All three fire simultaneously: in-app + push (NEW, free) AND email (carries the ticket PDF+ics artifact — the system-of-record). No SMS leg for this category.
+- **Buyer copy:** in-app/push title + body only (no SMS body needed). E.g. push: `"{Brand}: You're in for {Event} on {date} — tickets in the Mingla app."`
+- **Consent:** transactional — derived from the purchase action; recorded as `consent_records(scope='transactional', source='checkout', action='granted', disclosure_text=<the bundled T&C/consent copy, §8>, country_code, ip_hash)`. (Buyer phone is still captured at checkout — `orders.buyer_phone_e164` — for the text-eligible reservation/reminder/refund categories.)
+- **Idempotency:** `idempotency_key='buyer_purchase_confirmation:{orderId}'`. Email retry rides the existing `ticket_order_notifications` backbone; cross-channel truth in `notification_deliveries`.
 
-### 7.2 Buyer reservation confirmed / changed / cancelled (NET-NEW)
-- **Trigger source:** `biz_reservation_transition(p_reservation_id, p_to_status, …)` (`20261010000001_orch_1148_reservation_lifecycle_rpcs.sql`) is `SECURITY DEFINER` plpgsql — **it cannot make HTTP calls.** Two viable wirings:
-  - **(Recommended) Edge-layer fan-out:** the callers of the transition (the business-app reservation hooks + the guest/consumer reserve RPC paths) ALSO invoke `notify-dispatch` v2 after a successful transition. Map: `confirmed`→`buyer_reservation_confirmed`; `seated`/table reassignment/time change→`buyer_reservation_changed`; `cancelled_by_guest`/`cancelled_by_venue`→`buyer_reservation_cancelled`.
-  - **(Alt) DB-trigger + outbox:** an `AFTER UPDATE` trigger on `reservations.status` writes a `notification_outbox` row; a 1-min cron drains it to the dispatcher. Use this if edge-layer fan-out cannot cover all transition entry points (operator, consumer, guest-web). **Decision deferred to IMPLEMENT/DESIGN — recommend the outbox** for completeness (the transition RPC is the single chokepoint; an edge fan-out risks missing a path). Surfaced in §12 Q7.
-- **Channels:** in-app + push (if `consumer_user_id` present) → email (`guest_email`) → SMS fallback (`guest_phone_e164`) per the triple gate. For an anon `created_via='guest'` reservation there is no push token → email + SMS fallback only.
-- **Buyer copy:**
-  - confirmed: `"{Brand}: Table for {party} confirmed {date} {time}. Reply STOP to opt out."`
-  - changed: `"{Brand}: Your reservation changed — now {date} {time}, party {party}. Reply STOP to opt out."`
-  - cancelled: `"{Brand}: Your reservation for {date} was cancelled. Reply STOP to opt out."`
+### 7.2 Buyer reservation confirmed (NO text) / changed / cancelled (text) (NET-NEW)
+- **Trigger source:** `biz_reservation_transition(p_reservation_id, p_to_status, …)` (`20261010000001_orch_1148_reservation_lifecycle_rpcs.sql`) is `SECURITY DEFINER` plpgsql — **it cannot make HTTP calls.** Wiring (DEC-185 resolved §12 Q7 → **DB-trigger + queue/outbox**):
+  - **DB-trigger + outbox (DECIDED):** an `AFTER UPDATE` trigger on `reservations.status` writes a `notification_outbox` row; a 1-min cron drains it to the dispatcher. The transition RPC is the single chokepoint, so the trigger guarantees coverage of ALL entry points (operator, consumer, guest-web). Map: `confirmed`→`buyer_reservation_confirmed`; `seated`/table reassignment/time change→`buyer_reservation_changed`; `cancelled_by_guest`/`cancelled_by_venue`→`buyer_reservation_cancelled`. Also fan out the NET-NEW brand-side `biz_new_reservation`/`biz_reservation_change` from the same outbox row. (Edge-layer fan-out is the rejected alternative — it risked missing a path.)
+- **Channels (DEC-185 confirmed matrix):**
+  - `buyer_reservation_confirmed` = `{push,inapp,email}` — **NO SMS.**
+  - `buyer_reservation_changed` / `buyer_reservation_cancelled` = `{push,inapp,email,sms}` — all fire simultaneously. push only if `consumer_user_id` present; email to `guest_email`; SMS to `guest_phone_e164`. For an anon `created_via='guest'` reservation there is no push token → in-app skipped/no-account, email + SMS only.
+- **Buyer copy (text categories, GSM-7, ≤1 segment target):**
+  - confirmed (push/inapp only): `"{Brand}: Table for {party} confirmed {date} {time}."`
+  - changed (SMS): `"{Brand}: Your reservation changed — now {date} {time}, party {party}. Reply STOP to opt out."`
+  - cancelled (SMS): `"{Brand}: Your reservation for {date} was cancelled. Reply STOP to opt out."`
 - **Consent:** transactional; recorded with `source='reservation'`. Phone = `reservations.guest_phone_e164`.
 - **Idempotency:** `idempotency_key='buyer_reservation_{status}:{reservationId}:{transitionAt}'` (transition timestamp distinguishes repeated changes).
 
-### 7.3 Buyer pre-event/trip/reservation reminder (NET-NEW scheduled job)
+### 7.3 Buyer pre-event/trip/reservation reminder (NET-NEW scheduled job) — text-eligible
 - **Trigger source:** NEW edge fn `notify-reminders` on a pg_cron schedule (reuse the `cron.schedule(... net.http_post(... '/functions/v1/notify-reminders'))` pattern from `20260603000000_orch_0815_b_marketing_send_cron.sql`). Runs every ~15 min; selects upcoming events/trips/experiences (from `events`/event_dates) and reservations (`reservations.reserved_for`) within a lead-time window, de-duped by `idempotency_key`.
-- **Lead-time params (§12 Q1):** default **24h-ahead reminder + a T-2h same-day nudge** (the architecture-research practical pattern). Configurable via env or a `reminder_lead_times` config.
-- **Channels:** `escalate_on_no_engagement` reach_mode — in-app + push; if push not delivered/unopened by the escalation timeout → email → SMS only for the high-urgency time-sensitive window (e.g. the T-2h nudge). The 24h reminder may be push+email only; the T-2h nudge is the SMS-eligible one (cost discipline).
+- **Lead-time params (§12 Q1 RESOLVED):** **24h-ahead reminder + a T-2h same-day nudge** (both buckets). Configurable via env or a `reminder_lead_times` config.
+- **Channels (DEC-185 confirmed matrix):** BOTH the 24h and 2h buckets are text-eligible — categories `buyer_event_reminder_24h`/`_2h` and `buyer_reservation_reminder_24h`/`_2h` are each `{push,inapp,email,sms}`. All listed channels fire simultaneously per bucket (no escalation, no "SMS only if push failed"). Cost discipline = the per-market kill-switch + consent/suppression/quiet-hours, not a fallback.
 - **Buyer copy:** `"{Brand}: {Event/Reservation} starts in {N}h — {time}. See you there! Reply STOP to opt out."` (generic — no sensitive detail).
-- **Consent:** transactional; `category_key='buyer_event_reminder'` / `'buyer_reservation_reminder'`.
+- **Consent:** transactional; `category_key='buyer_event_reminder_{24h|2h}'` / `'buyer_reservation_reminder_{24h|2h}'`.
 - **Idempotency:** `idempotency_key='{category}:{entityId}:{leadBucket}'` (leadBucket = `24h`|`2h`) — guarantees exactly one per bucket even across cron overlaps.
 
 ---
@@ -333,11 +380,20 @@ Three moments. Each: trigger source → channels (push-first/SMS-fallback via Su
 
 SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that market's gate items pass. This maps `INVESTIGATE_..._SMS_COMPLIANCE_RESEARCH.md` §6 checklist 1-on-1.
 
-### 8.1 Consent data model [HARD]
-- `consent_records` (§5.1) per (user/contact, channel, scope) with opt-in timestamp + EXACT disclosure_text + source/ip_hash + country_code. Marketing = unchecked-by-default checkbox + full disclosure; transactional = derived-from-action but RECORDED. ✅ build req: §5.1 + §7 record-on-grant.
+> ### ⚠️ CALLOUT — bundled-consent TCPA risk ACCEPTED (DEC-186), legal sign-off is a GO-LIVE BLOCKER
+> Per DEC-186 (Seth, 2026-06-19, AskUserQuestion = "Bundle everything as mandatory"), the consumer-app OTP consent box and the anon checkout T&C checkbox each gate continuation on **ONE mandatory checkbox** covering T&Cs + transactional + reminders + EMAIL marketing + **SMS marketing**. Every signup/checkout auto-enrolls in marketing.
+>
+> **This is a known TCPA violation on the SMS-marketing portion.** US TCPA / 47 CFR 64.1200 bars making PROMOTIONAL-text consent a *condition of purchase/signup* — promotional-text consent must be "freely given" and "not required as a condition of purchase." Bundling SMS-marketing consent into a required-to-continue checkbox violates this (email marketing = CAN-SPAM opt-out, fine to bundle; transactional + reminders fine to require). Exposure: ~$500–$1,500 per text + carrier filtering. The orchestrator-recommended-but-not-taken alternative was a "compliant split" (gate on T&C+transactional+reminders+email; SMS-marketing a SEPARATE non-blocking opt-in). **Seth accepted the risk.**
+>
+> **Mitigations REQUIRED in the build (mostly already in this spec):** record EXACT disclosure text + timestamp + ip_hash + country into `consent_records` at every grant; instant STOP from any channel; separate transactional vs marketing senders; quiet hours; per-market kill-switch stays false until the §8 gate passes.
+>
+> **GO-LIVE BLOCKER:** explicit **legal sign-off accepting the TCPA risk before SMS-MARKETING flips live** (US especially). `mingla-product` owns the T&C + disclosure copy; counsel review recommended. See risk **R-8** (§13) and the Go/No-Go gate item #8 below.
 
-### 8.2 US TCPA/CTIA/FCC [HARD]
-- Marketing → prior express **WRITTEN** consent (affirmative checkbox + disclosure). Transactional → prior express consent, **NO promotional content mixed in** (every Sub-C copy in §7 is pure transactional). ✅
+### 8.1 Consent data model [HARD] — now bundled-mandatory grant (DEC-186)
+- `consent_records` (§5.1) per (user/contact, channel, scope) with opt-in timestamp + EXACT disclosure_text + source/ip_hash + country_code. Per DEC-186, marketing is **bundled into the single mandatory consent checkbox** (NOT unchecked-by-default) alongside transactional + reminders + email-marketing; the grant writes BOTH a `scope='transactional'` and a `scope='marketing'` record with the EXACT bundled disclosure text. Transactional = also recorded. ✅ build req: §5.1 + §7 + §10 record-on-grant. (Suppression scopes stay SEPARATE — a marketing STOP never kills transactional.)
+
+### 8.2 US TCPA/CTIA/FCC [HARD] — risk-accepted bundling (DEC-186)
+- Marketing → TCPA requires prior express **WRITTEN, freely-given** consent that is NOT a condition of purchase. **DEC-186 knowingly bundles SMS-marketing consent into the required checkbox — a known violation, risk ACCEPTED by Seth, gated on legal sign-off (callout above + R-8).** Transactional → prior express consent, **NO promotional content mixed in** (every Sub-C transactional copy in §7 is pure transactional). ✅
 - Revocation by **any reasonable means** + the **7 FCC keywords** (stop, quit, revoke, opt out, cancel, unsubscribe, end) honored within **10 business days** → `channel_suppressions` written by the inbound-STOP webhook (§5.6), the unsubscribe link, AND the prefs UI. Build for **cross-channel revocation** (one opt-out = all) by supporting `scope='all'`. ✅
 - STOP + HELP supported (Twilio auto + app-side sync); HELP returns sender identity + support. ✅
 - **Brand name (sender ID) in every message body.** ✅ (smsAdapter requirement.)
@@ -358,9 +414,9 @@ SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that marke
 - Deliverability: spam complaints <0.3% (target <0.1%), bounces <2% → suppress hard bounces/complainers immediately via the Resend webhook (§5.6). ✅
 - Penalty exposure noted (CAN-SPAM ~$53k/email).
 
-### 8.6 Consent capture UX [HARD] (per-surface in §10)
-- Marketing checkbox **unchecked by default**, SEPARATE from ToS/booking, disclosure shows: brand name + "agree to receive marketing texts" + expected frequency + "Msg & data rates may apply" + STOP/HELP. The EXACT disclosure string is recorded into `consent_records.disclosure_text`.
-- Transactional: a short notice at checkout ("We'll text you booking updates at this number. Reply STOP to opt out.") whose copy is recorded as the transactional grant's disclosure.
+### 8.6 Consent capture UX [HARD] (per-surface in §10) — bundled-mandatory (DEC-186)
+- Per DEC-186 the marketing opt-in is NO LONGER an unchecked-by-default separate checkbox; it is **bundled into the single mandatory "I agree to all terms and conditions" gate**. The bundled disclosure (opened via a sheet/expander) MUST still surface the SMS-marketing-specific elements for the legal record: brand/Mingla identity + "agree to receive marketing texts + reminders + transactional updates" + expected frequency + "Msg & data rates may apply" + STOP/HELP + a link to full T&Cs. The EXACT disclosure string shown is recorded into `consent_records.disclosure_text` (both scopes).
+- Pay/Continue is GREYED OUT until the box is checked (§10). The recorded disclosure is the legal burden-of-proof artifact backing the risk-accepted bundling.
 
 ### Go/No-Go gate (per market) — ALL must be GREEN before `SMS_LIVE_ENABLED_<MKT>=true`
 1. Sender registered/verified (toll-free or 10DLC for US; Sender ID + NOCs for NG).
@@ -370,6 +426,7 @@ SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that marke
 5. StatusCallback + inbound webhook + Resend webhook live; 30034/30007/30032 alarms wired.
 6. A live test SMS to a staff number delivered + a STOP round-trip suppresses.
 7. Separate transactional vs marketing sender confirmed (a marketing STOP does not block a transactional send — proven).
+8. **(SMS-MARKETING ONLY, DEC-186) Explicit legal sign-off obtained accepting the bundled-consent TCPA risk** — recorded before `SMS_LIVE_ENABLED_<MKT>=true` is flipped for any MARKETING SMS in that market (US especially). Transactional SMS does not require this item; marketing SMS is blocked until it's GREEN. mingla-product owns the T&C/disclosure copy; counsel review recommended.
 
 ---
 
@@ -378,7 +435,7 @@ SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that marke
 | ID | Rule | Enforcement | Regression test (fails-on-revert) |
 |---|---|---|---|
 | **I-PROPOSED-1161-UNIFIED-DISPATCHER-SOLE-SEND-PATH** | No push/email/SMS send originates outside `notify-dispatch` v2 or its adapters. No new direct `sendPush`/`sendTwilioSms`/`api.resend.com` call in product code outside `_shared/adapters/*` (+ the labeled transitional `marketing-send`/`ticket-confirmation-dispatch` owners). | strict-grep gate `.github/scripts/strict-grep/i-proposed-1161-unified-dispatcher-sole-send-path.mjs` (ORCH-0863-style; COMMS-0002) | Adding a raw `sendTwilioSms(` outside an adapter → grep FAILS. |
-| **I-PROPOSED-1161-SMS-BEHIND-CONSENT-AND-FALLBACK-GATE** | An SMS is sent ONLY when `can_send(...,'sms',...)` is true AND push is undelivered/absent AND category urgency=high AND time-sensitive. | test (dispatcher unit) | Test: push-delivered reach_once category → SMS NOT sent; push-failed high-urgency → SMS sent. Reverting the gate → test fails. |
+| **I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES** (DEC-185) | An SMS sends ONLY for a category whose §5.2 seed lists `sms` in `default_channels` AND only after `can_send(...,'sms',...)` passes (consent + suppression + quiet-hours + per-market kill-switch). There is NO fallback/escalation condition — SMS fires simultaneously with the other policy channels. The closed SMS-eligible set IS the seed. | test (dispatcher unit) + strict-grep on the seed | Test: dispatch a category with `sms` in its policy + consent → SMS sent alongside push/email; dispatch a NO-text category (e.g. `buyer_purchase_confirmation`) → SMS NEVER attempted regardless of push status. Adding `sms` to a non-eligible seed row, or sending SMS for a row without `sms`, → fails. |
 | **I-PROPOSED-1161-TRANSACTIONAL-VS-MARKETING-CONSENT-SEPARATED** | A `scope='marketing'` suppression/opt-out NEVER blocks a transactional send, and vice-versa (except explicit `scope='all'`). | test + migration (CHECK on `consent_records.scope`/`channel_suppressions.scope`) | Test: insert marketing STOP → `can_send(transactional,'sms')` still true. Revert scope-mapping → fails. |
 | **I-PROPOSED-1161-SMS-OPT-OUT-HONORED-ANY-CHANNEL** | An opt-out captured via SMS reply, web unsubscribe, OR the prefs UI suppresses subsequent SMS regardless of capture channel; the audience resolver checks phone-keyed suppression. | test + migration | Test: web-unsubscribe a phone → audience `reachable_sms` excludes it AND `can_send` denies. Revert the marketingAudience phone-suppression fix → fails. |
 | **I-PROPOSED-1161-QUIET-HOURS-ENFORCED-FOR-MARKETING** | Marketing SMS/email is not sent outside 8 AM–9 PM recipient-local (US) / 8 AM–8 PM WAT (NG). | test | Test: marketing send at recipient-local 10 PM → deferred/blocked. Revert quiet-hours check → fails. |
@@ -392,12 +449,12 @@ SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that marke
 
 | Surface | Covered | User-visible behavior | Files touched | Parity |
 |---|---|---|---|---|
-| **1. Consumer iOS** (`app-mobile`) | YES | Receives buyer push for purchase/reservation/reminder (NEW); per-category × per-channel notification prefs incl. SMS toggles + transactional categories + reminder/reservation categories; marketing SMS opt-in toggle. | `app-mobile/src/components/profile/AccountSettings.tsx` (extend L694-806 prefs section); a new prefs hook/service writing `notification_channel_prefs` + `consent_records`; OneSignal already wired. | Shared RN code → auto Android parity. |
+| **1. Consumer iOS** (`app-mobile`) | YES | Receives buyer push for purchase/reservation/reminder (NEW) + push/in-app marketing blasts (NEW, DEC-185); per-category × per-channel notification prefs incl. SMS toggles + transactional categories + reminder/reservation categories. **OTP/consent screen: the consent box copy is UPDATED (DEC-186)** to include agreement to T&Cs + transactional + reminders + email marketing + SMS marketing — every signup auto-enrolls in marketing. | `app-mobile` OTP/consent onboarding step (find the consent step in onboarding — see note below) for the bundled copy; `app-mobile/src/components/profile/AccountSettings.tsx` (extend L694-806 prefs section, incl. a marketing opt-OUT toggle since enrollment is now automatic); a new prefs hook/service writing `notification_channel_prefs` + `consent_records` (both scopes, with disclosure_text); OneSignal already wired. | Shared RN code → auto Android parity. |
 | **2. Consumer Android** (`app-mobile`) | YES | Same as iOS. | Same files. | Auto (shared). |
-| **3. Buyer/anon Web** (`mingla-business` checkout + public pages) | YES | Compliant marketing opt-in capture (separate, unchecked, full disclosure) + a transactional-SMS notice; buyer **country** capture at checkout; unsubscribe/STOP landing (reuse `marketing-unsubscribe`). | `mingla-business/app/checkout/[eventId]/buyer.tsx` (L550-574 checkbox → split into transactional notice + marketing checkbox + country field); finalize RPC writes `consent_records` + `country_code`; `marketing-unsubscribe` (already supports phone+sms). | Web-specific (manual parity vs native checkout). |
-| **4. Business iOS** (`mingla-business`) | YES | Marketing Hub blast composer SMS tab ENABLED; SMS reach + segment/cost preview; (brand alerts stay push-only — unchanged). | `mingla-business/src/components/marketing/ChannelTabs.tsx` (L42 enable), `app/brand/[id]/blasts.tsx` (L85/191 reach), composer compose route, `src/services/marketing/*`, `src/types/marketing.ts`. | Shared RN → auto Android. |
+| **3. Buyer/anon Web** (`mingla-business` checkout + public pages) | YES | **Bundled-mandatory consent gate (DEC-186):** name + email + phone become REQUIRED; the old "Email me about this organiser's future events" checkbox becomes an underlined **"I agree to all terms and conditions"** that opens a sheet with full T&Cs (protect + absolve Mingla; enroll in reminders for this event + future events + marketing blasts; copy phrased to also cover marketing). **Pay/Continue is GREYED OUT until checked.** Buyer **country** capture at checkout; unsubscribe/STOP landing (reuse `marketing-unsubscribe`). | `mingla-business/app/checkout/[eventId]/buyer.tsx` (L550-574 checkbox → required name/email/phone + the underlined T&C checkbox → T&C sheet + country field + Pay-button disabled-until-checked); finalize RPC writes `consent_records` (both scopes + disclosure_text + ip_hash + `country_code`); `marketing-unsubscribe` (already supports phone+sms). | Web-specific (manual parity vs native checkout). |
+| **4. Business iOS** (`mingla-business`) | YES | Marketing Hub blast composer SMS tab ENABLED; SMS reach + segment/cost preview; **brand alerts now ALSO deliver via email** (DEC-185 — `{push,inapp,email}` on all brand categories; NET-NEW `biz_new_reservation`/`biz_reservation_change`), and **`payout_paid` is the single brand SMS**. | `mingla-business/src/components/marketing/ChannelTabs.tsx` (L42 enable), `app/brand/[id]/blasts.tsx` (L85/191 reach), composer compose route, `src/services/marketing/*`, `src/types/marketing.ts`; brand-alert email+payout-SMS via `_shared/businessNotifyTriggers.ts` re-route (backend). | Shared RN → auto Android. |
 | **5. Business Android** (`mingla-business`) | YES | Same as Business iOS. | Same. | Auto (shared). |
-| **6. Backend** (`supabase/`) | YES (heaviest) | `notify-dispatch` v2 + tables + `can_send()` + adapters + webhooks + escalation worker + `notify-reminders` cron + reservation notify wiring + `marketing-send` SMS leg + audience phone-suppression fix. | `supabase/functions/notify-dispatch`, `_shared/adapters/*`, `twilio-message-status`, NEW `twilio-inbound-sms`, NEW `resend-email-status`, NEW `notify-reminders`, NEW `notify-escalate`, `marketing-send`, `_shared/marketingAudience.ts`, `1161` migrations. | N/A. |
+| **6. Backend** (`supabase/`) | YES (heaviest) | `notify-dispatch` v2 (simultaneous policy send) + tables + `can_send()` + adapters + webhooks + `notify-reminders` cron + reservation notify wiring (DB-trigger + outbox) + `marketing-send` SMS + push/inapp legs + audience phone-suppression fix. (No escalation worker — DEC-185.) | `supabase/functions/notify-dispatch`, `_shared/adapters/*`, `twilio-message-status`, NEW `twilio-inbound-sms`, NEW `resend-email-status`, NEW `notify-reminders`, `marketing-send`, `_shared/marketingAudience.ts`, reservation `notification_outbox` trigger + drain cron, `1161` migrations. | N/A. |
 | Admin Web (`mingla-admin`) | **NO** | reason: no compose/receive surface. | — | — |
 | Business Web preview (adjacent) | **NO** | reason: blast composer is native-first; web preview not a 1161 deliverable. | — | — |
 
@@ -406,12 +463,12 @@ SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that marke
 ## 11. Phased rollout / sequencing
 
 ### Sub-A FIRST (hard gate — DC-1). Recommended thin first END-TO-END ship (the "thin booking loop" analog):
-**THIN SLICE = one moment, end-to-end, push-first/SMS-fallback, US-only, real consent.** Recommend **buyer reservation confirmed** (`buyer_reservation_confirmed`) as the thin slice: it is the clearest net-new gap, exercises the full stack (category seed → `can_send` → push adapter → email adapter → smsAdapter fallback → status webhook → suppression), reuses the live toll-free, and proves the reservation-notify wiring — without needing the marketing sender or the reminder cron. Ship that one moment to staff devices, prove the waterfall + a STOP round-trip, THEN fan out the other Sub-C moments + Sub-B.
+**THIN SLICE = one moment, end-to-end, simultaneous policy send, US-only, real consent.** Recommend **buyer reservation CHANGED** (`buyer_reservation_changed`) as the thin slice (DEC-185-revised — the v1 pick `buyer_reservation_confirmed` is now a NO-text category, so it would NOT exercise SMS). `buyer_reservation_changed` is `{push,inapp,email,sms}`, so it exercises the FULL stack end-to-end including the SMS leg: category seed → `can_send` per channel → push adapter + email adapter + smsAdapter firing simultaneously → status webhook → inbound STOP round-trip → suppression. It reuses the live toll-free and proves the reservation-notify wiring (DB-trigger + outbox) — without needing the marketing sender or the reminder cron. Ship that one moment to staff devices, prove simultaneous delivery + a STOP round-trip suppresses the next SMS, THEN fan out the other Sub-C categories + Sub-B. (Pair it with `buyer_reservation_confirmed` if you want the NO-text path proven in the same slice.)
 
 ### Per-sub pipeline
-- **Sub-A:** DESIGN (consumer prefs-UI redesign via `mingla-designer` — per-category×channel matrix; checkout consent UX) → IMPLEMENT (tables + dispatcher v2 + adapters + webhooks + transitional migration) → TEST (mingla-tester: `can_send` matrix, waterfall, idempotency, STOP round-trip, transactional-vs-marketing isolation) → CLOSE (flip invariants; close the dual-write window).
+- **Sub-A:** DESIGN (consumer prefs-UI redesign via `mingla-designer` — per-category×channel matrix; bundled-consent UX for the OTP screen + checkout T&C sheet) → IMPLEMENT (tables + dispatcher v2 simultaneous policy send + adapters + webhooks + transitional migration) → TEST (mingla-tester: `can_send` per-channel matrix, simultaneous-send, idempotency, STOP round-trip, transactional-vs-marketing isolation) → CLOSE (flip invariants; close the dual-write window).
 - **Sub-B:** DESIGN (composer SMS tab + cost/segment preview + marketing consent copy) → IMPLEMENT (marketing-send SMS leg + audience phone-suppression fix + quiet hours + throttling) → TEST → CLOSE. **BLOCKED on §8 US marketing gate.**
-- **Sub-C:** DESIGN (buyer copy + reminder lead-time config) → IMPLEMENT (purchase-confirm push + reservation notify wiring/outbox + `notify-reminders` cron + `notify-escalate`) → TEST (reminder bucketing, reservation transition coverage, escalation timeout) → CLOSE.
+- **Sub-C:** DESIGN (buyer copy + reminder lead-time config) → IMPLEMENT (purchase-confirm push+inapp + reservation notify wiring via DB-trigger+outbox + `notify-reminders` cron, 24h+2h buckets) → TEST (reminder bucketing, reservation transition coverage, simultaneous per-channel send) → CLOSE.
 
 ### Edge-deploy / OTA hazards (COMMS-0015/0018/0027)
 - Deploy edge fns from MERGED `main` only (clobber risk) — never from a stale worktree.
@@ -421,35 +478,42 @@ SMS for a market is OFF (`SMS_LIVE_ENABLED_<MKT>=false`) until ALL of that marke
 
 ---
 
-## 12. OPEN PRODUCT DECISIONS FOR SETH (genuine forks — my recommendation each)
+## 12. PRODUCT DECISIONS — mostly RESOLVED (DEC-185/DEC-186); 2 remain OPEN
 
-1. **Reminder lead times.** Q: exactly when do pre-event/reservation reminders fire? **REC: 24h-ahead (push+email) + a T-2h same-day nudge (SMS-eligible).** Make it env-configurable so you can tune without a deploy.
-2. **US marketing sender: toll-free vs 10DLC.** Q: marketing SMS on a second toll-free or register 10DLC? **REC: separate Messaging Service for marketing (reputation isolation); start with a toll-free second number (fast, already a proven path) and register 10DLC only if marketing volume outgrows toll-free throughput. Transactional stays on the existing approved toll-free.** Note 10DLC vetting is ~10–15 days lead time.
-3. **Nigeria SMS: v1 or phased?** **REC: PHASED — build the region-routing seam now, ship US first; NG transactional in v1.x, NG marketing later** (alphanumeric Sender ID + 4 NOCs + DND is real lead time and one-way opt-out complexity).
-4. **Buyer phone OTP verification before transactional SMS?** Q: require an OTP round-trip on the checkout phone before we'll SMS it? **REC: NO for v1 — transactional consent is derived from the booking action and the number is the buyer's own; an OTP gate adds checkout friction. Add it only if delivery-error rates on bad numbers prove costly.** (OTP stays on Verify regardless.)
-5. **Escalation timeout (push→email/SMS).** Q: how long to wait on a push delivery webhook before falling through? **REC: 5 min default per category; 0 min (immediate) for confirmations' email artifact (sent now), and tighter for the T-2h reminder.**
-6. **Purchase-confirmation SMS: push-fallback-only or always-on?** Q: this is the highest-value moment — always text it, or only when push fails? **REC: push-fallback-only (consistent with the cost law) BUT send the email always (PDF/ics artifact). If you want guaranteed SMS receipt for purchases, flip `buyer_purchase_confirmation` to always-on SMS — at a known per-SMS cost. Defaulting to fallback-only.**
-7. **Reservation notify wiring: edge fan-out vs DB-trigger outbox.** Q: how do reservation transitions reach the dispatcher (the transition RPC can't call HTTP)? **REC: DB-trigger → `notification_outbox` → 1-min cron drain.** It guarantees coverage of ALL transition entry points (operator, consumer, guest-web) from the single RPC chokepoint; edge fan-out risks missing a path. (This is an architecture pick I'm recommending, not silently deciding — it has a small latency cost.)
+### RESOLVED (recorded answers — no longer open)
+1. **Reminder lead times — RESOLVED:** 24h-ahead + a T-2h same-day nudge (both buckets text-eligible per the DEC-185 matrix). Env-configurable via `reminder_lead_times`.
+2. **US marketing sender — RESOLVED:** SEPARATE marketing Messaging Service (reputation isolation); start with a toll-free second number, register 10DLC only if volume outgrows it. Transactional stays on the existing approved toll-free.
+3. **Nigeria SMS — RESOLVED:** PHASED — region-routing seam now, US first; NG transactional in v1.x, NG marketing later. `SMS_LIVE_ENABLED_NG=false` until the NG gate passes.
+4. **Buyer phone OTP before transactional SMS — RESOLVED:** NO. Consent is derived from the booking action; no OTP round-trip gate (OTP stays on Verify for auth).
+5. **Escalation timeout (push→email/SMS) — MOOT (DEC-185).** There is no escalation/waterfall; all policy channels fire simultaneously. No timeout exists.
+6. **Purchase-confirmation SMS fallback-only vs always-on — MOOT (DEC-185).** `buyer_purchase_confirmation` is a NO-text category (`{push,inapp,email}`); there is no SMS leg for it at all, so the fork no longer exists.
+7. **Reservation notify wiring — RESOLVED:** DB-trigger → `notification_outbox` → 1-min cron drain (guarantees coverage of all transition entry points from the single RPC chokepoint).
+- **Consent model — RESOLVED (DEC-186):** bundled into a single mandatory gate; TCPA risk ACCEPTED (see §8 callout + R-8).
+
+### STILL OPEN (genuine forks for Seth)
+- **(a) Social-email scope.** For `social_friend_request` + `social_collab_invite`: keep email (orchestrator default `{push,inapp,email}`) or drop it to `{push,inapp}` only? `social_message`/`social_rsvp`/`social_other` are firmly `{push,inapp}` (NEVER email per chat message — deliverability). **Default = add email for friend-requests + collab-invites; Seth may override.**
+- **(b) Legal sign-off owner + timing for the TCPA risk** before SMS-MARKETING go-live (DEC-186). WHO signs off (counsel? Seth on counsel advice?) and WHEN relative to the US marketing-SMS flip. This is a Go/No-Go gate item (§8 #8) and a go-live BLOCKER for marketing SMS; mingla-product owns the T&C/disclosure copy.
 
 ---
 
 ## 13. Risks & blast radius
 
 - **R-1 — STALE LOCAL ANCHOR (process risk).** The anchor checkout local `main` is BEHIND `origin/main` (HEAD `84d583e87` vs origin `a58f46ffa`); META-ORCH-1148 2.1b (#508) + ORCH-1157 are on `origin/main` but NOT local `main`. **Every Sub-C reservation dependency (`reservations`, `biz_reservation_transition`, `send-venue-sms`, `venue_sms_opt_out`) exists on `origin/main` and this spec is written against it.** The implementor's worktree MUST `git fetch origin && git rebase origin/main` before any work, or it will build against phantom-absent dependencies.
-- **R-2 — Twilio cost runaway.** A loop/misconfigured fallback could blast SMS. Mitigation: the triple gate + per-market kill-switch + Twilio Messaging Insights/Intelligent Alerts + a deliveries-table cost dashboard + segment-count recording.
+- **R-2 — Twilio cost runaway.** A loop or a mis-seeded category (`sms` added to a high-volume row) could blast SMS — and since all policy channels fire simultaneously (DEC-185, no fallback), an SMS-eligible category texts EVERY consented recipient on every send. Mitigation: the curated closed SMS-eligible seed (§5.2) + the seed strict-grep gate + per-market kill-switch + Twilio Messaging Insights/Intelligent Alerts + a deliveries-table cost dashboard + segment-count recording + idempotency.
 - **R-3 — Transactional kill from a marketing STOP.** If scopes leak, a marketing opt-out could silence booking confirmations (legal + UX disaster). Mitigation: I-PROPOSED-1161-TRANSACTIONAL-VS-MARKETING-CONSENT-SEPARATED + separate senders + the §8 gate item #7 proof.
 - **R-4 — Mid-migration double-send / silent drop.** Routing existing senders onto v2 while keeping them live risks duplicate or lost notifications. Mitigation: dual-write + idempotency_key + the transitional labeling + a TEST pass on every existing notification type before closing the dual-write window.
 - **R-5 — Unregistered/unverified sender → zero delivery (30034/30032).** Mitigation: the §8 go/no-go gate blocks `SMS_LIVE_ENABLED` until the sender is verified + a live test send delivered.
 - **R-6 — Inbound STOP webhook is net-new** (today only status callbacks exist). If it's not live, app-side suppression drifts from Twilio's carrier-level STOP → we keep texting opted-out users (TCPA exposure). Mitigation: gate item #3.
-- **R-7 — Anon/guest reservations have no push token + may lack email.** Email+SMS fallback only; ensure `can_send` handles `user_id IS NULL` (contact-keyed) paths.
+- **R-7 — Anon/guest reservations have no push token + may lack email.** push/inapp skipped (no token/no account) → only the email + SMS channels in the category policy reach them; ensure `can_send` handles `user_id IS NULL` (contact-keyed) paths.
+- **R-8 — Bundled-consent TCPA violation (DEC-186, risk ACCEPTED).** Bundling SMS-marketing consent into a required-to-continue checkbox (consumer-app OTP box + anon checkout T&C gate) violates US TCPA / 47 CFR 64.1200 — promotional-text consent cannot be a condition of purchase/signup and must be freely given. Exposure: ~$500–$1,500/text + carrier filtering. **Seth accepted the risk.** Mitigations (required, mostly in-spec): record EXACT disclosure text + timestamp + ip_hash + country into `consent_records`; instant STOP from any channel; separate transactional vs marketing senders; quiet hours; per-market kill-switch. **GO-LIVE BLOCKER: explicit legal sign-off accepting the TCPA risk before SMS-MARKETING flips live (US especially)** — §8 Go/No-Go gate item #8; mingla-product owns the T&C/disclosure copy; counsel review recommended. The orchestrator-recommended-but-not-taken alternative was a "compliant split" (SMS-marketing as a separate non-blocking opt-in).
 - **Cross-ORCH:** sibling META-ORCH-1160 (Growth OS = measurement/analytics) is complementary (no channel-delivery overlap). META-ORCH-1148 (venue suite) is the upstream provider of the reservation model + the approved toll-free pattern — coordinate any change to `venue_sms_opt_out`/`twilio-message-status` (this spec EXTENDS, not replaces, both).
 
 ### Allowlist (implementor may touch) / DO-NOT-TOUCH
-**Allowlist:** `supabase/functions/notify-dispatch/**`, `supabase/functions/_shared/adapters/**` (new), `supabase/functions/twilio-message-status/**`, `supabase/functions/twilio-inbound-sms/**` (new), `supabase/functions/resend-email-status/**` (new), `supabase/functions/notify-reminders/**` (new), `supabase/functions/notify-escalate/**` (new), `supabase/functions/marketing-send/**`, `supabase/functions/_shared/marketingAudience.ts`, `supabase/migrations/2026111*_orch_1161_*.sql` (new), `mingla-business/src/components/marketing/ChannelTabs.tsx`, `mingla-business/app/brand/[id]/blasts.tsx`, `mingla-business/src/services/marketing/*`, `mingla-business/src/types/marketing.ts`, `mingla-business/app/checkout/[eventId]/buyer.tsx` + the finalize RPC consent write, `app-mobile/src/components/profile/AccountSettings.tsx` + new prefs hook/service, `.github/scripts/strict-grep/i-proposed-1161-*.mjs` (new).
-**DO-NOT-TOUCH:** `send-otp`/`verify-otp` (Twilio Verify — A2P-exempt), `send-venue-sms`/`venue_sms_opt_out`/`venue_sms_log` semantics (EXTEND via the inbound webhook only; do not change the venue send path), the Stripe webhook money seam in `stripeWebhookRouter.ts` (add ONLY the buyer-notify dispatch call; do not touch finalize/refund money logic), the reservation lifecycle RPC money/transition logic (add notify via outbox/trigger only), `businessNotifyTriggers.ts` brand-push semantics (route through the dispatcher but keep push-only — no brand SMS). Any change outside the allowlist → stop-and-amend (`SPEC_AMENDMENT_META-ORCH-1161_*.md`).
+**Allowlist:** `supabase/functions/notify-dispatch/**`, `supabase/functions/_shared/adapters/**` (new), `supabase/functions/twilio-message-status/**`, `supabase/functions/twilio-inbound-sms/**` (new), `supabase/functions/resend-email-status/**` (new), `supabase/functions/notify-reminders/**` (new), `supabase/functions/marketing-send/**`, `supabase/functions/_shared/marketingAudience.ts`, `supabase/migrations/2026111*_orch_1161_*.sql` (new), `mingla-business/src/components/marketing/ChannelTabs.tsx`, `mingla-business/app/brand/[id]/blasts.tsx`, `mingla-business/src/services/marketing/*`, `mingla-business/src/types/marketing.ts`, `mingla-business/app/checkout/[eventId]/buyer.tsx` + the finalize RPC consent write, `app-mobile/src/components/profile/AccountSettings.tsx` + new prefs hook/service, the `app-mobile` OTP/consent onboarding step (DEC-186 bundled copy), `supabase/functions/_shared/businessNotifyTriggers.ts` (re-route brand notifs through the dispatcher: add `{push,inapp,email}` fan-out + `payout_paid` SMS per DEC-185), the reservation `notification_outbox` trigger + drain cron (new migration), `stripeWebhookRouter.ts` (ADD the buyer-notify dispatch call ONLY), `.github/scripts/strict-grep/i-proposed-1161-*.mjs` (new).
+**DO-NOT-TOUCH:** `send-otp`/`verify-otp` (Twilio Verify — A2P-exempt), `send-venue-sms`/`venue_sms_opt_out`/`venue_sms_log` semantics (EXTEND via the inbound webhook only; do not change the venue send path), the Stripe webhook money seam in `stripeWebhookRouter.ts` (add ONLY the buyer-notify dispatch call; do not touch finalize/refund money logic), the reservation lifecycle RPC money/transition logic (add notify via outbox/trigger only), `businessNotifyTriggers.ts` brand-push *delivery* semantics (route through the dispatcher; per DEC-185 add the `{push,inapp,email}` fan-out to all brand categories and `sms` to `payout_paid` ONLY — no other brand SMS; `businessNotifyTriggers.ts` itself is in the allowlist for this re-routing). Any change outside the allowlist → stop-and-amend (`SPEC_AMENDMENT_META-ORCH-1161_*.md`).
 
 ---
 
 ## Downstream routing
 
-Next = **Seth REVIEW** of this canonical spec (especially §12). On approval → per-sub DESIGN (mingla-designer for the consumer prefs matrix + checkout consent UX + composer SMS tab) → mingla-implementor (Sub-A first, thin slice = buyer_reservation_confirmed) → mingla-tester → orchestrator CLOSE (flip I-PROPOSED-1161-* ACTIVE, close dual-write window). Each sub runs in its own per-ORCH worktree off `origin/main`.
+Next = **Seth REVIEW** of this v2 canonical spec (especially the 2 remaining §12 OPEN items: social-email scope + legal-sign-off owner/timing). On approval → per-sub DESIGN (mingla-designer for the consumer prefs matrix + bundled-consent UX (OTP box + checkout T&C sheet) + composer SMS tab) → mingla-implementor (Sub-A first, thin slice = `buyer_reservation_changed` so the SMS leg + STOP round-trip are proven end-to-end) → mingla-tester → orchestrator CLOSE (flip I-PROPOSED-1161-* ACTIVE incl. the renamed SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES invariant, close dual-write window). Each sub runs in its own per-ORCH worktree off `origin/main`. The legal sign-off (DEC-186) gates SMS-MARKETING go-live only.

--- a/app-mobile/src/components/OnboardingFlow.tsx
+++ b/app-mobile/src/components/OnboardingFlow.tsx
@@ -31,6 +31,9 @@ import { locationService } from '../services/locationService'
 import { throttledReverseGeocode, clearGeocodeCache } from '../utils/throttledGeocode'
 import { geocodingService } from '../services/geocodingService'
 import { sendOtp, verifyOtp, OtpChannel } from '../services/otpService'
+// META-ORCH-1161 Sub-A.2 (DEC-186) — bundled-mandatory consent writer + verbatim disclosure.
+import { recordConsent } from '../services/consentService'
+import { CONSENT_DISCLOSURE_TEXT, DISCLOSURE_VERSION } from '../constants/consentDisclosure'
 import { logger } from '../utils/logger'
 import { saveOnboardingData, clearOnboardingData } from '../utils/onboardingPersistence'
 import { resolveOnboardingLocationOverride } from '../utils/onboardingLocationOverride'
@@ -1395,6 +1398,33 @@ const OnboardingFlow = ({
       if (result.success) {
         logger.onboarding('OTP verified successfully')
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
+
+        // META-ORCH-1161 Sub-A.2 (DEC-186) — record the bundled consent grant the
+        // moment the phone is verified (the user now has a session). Writes
+        // transactional + marketing consent_records with the EXACT §1b disclosure
+        // VERBATIM. Non-blocking: a consent-audit write failure must NOT block
+        // finishing onboarding (the checkbox act already constitutes consent), so
+        // we log and proceed (Constitution #3: surfaced, never silently swallowed).
+        try {
+          const { data: authData } = await supabase.auth.getUser()
+          const grantedUserId = authData?.user?.id ?? null
+          const grantedEmail = authData?.user?.email ?? null
+          const consentResult = await recordConsent({
+            source: 'onboarding',
+            disclosureText: CONSENT_DISCLOSURE_TEXT,
+            disclosureVersion: DISCLOSURE_VERSION,
+            phone: buildE164(),
+            email: grantedEmail,
+            countryCode: data.phoneCountryCode,
+            userId: grantedUserId,
+          })
+          if (!consentResult.ok) {
+            logger.onboarding('consent_records write failed (proceeding; checkbox act stands)')
+          }
+        } catch (consentErr) {
+          logger.onboarding('consent write threw', { error: String(consentErr) })
+        }
+
         // Pre-populate identity defaults from phone context (atomic update)
         setData((prev) => ({
           ...prev,
@@ -1429,7 +1459,7 @@ const OnboardingFlow = ({
         }
       }
     },
-    [buildE164, goNext, otpAttempts, goToSubStep]
+    [buildE164, goNext, otpAttempts, goToSubStep, data.phoneCountryCode]
   )
 
   // ─── Location Capture ───
@@ -2365,34 +2395,25 @@ const OnboardingFlow = ({
               size="md"
               style={styles.consentCheckbox}
             />
+            {/* META-ORCH-1161 Sub-A.2 (DEC-186) — bundled-mandatory consent:
+                ONE underlined "terms and conditions" link opening the full
+                T&C view. The single checkbox covers T&Cs + transactional +
+                reminders + email + SMS marketing. */}
             <Text style={styles.consentText}>
               {t('onboarding:phone.consent_text')}
               <Text
-                style={styles.consentLink}
+                style={styles.consentLinkUnderlined}
                 onPress={() => {
                   setLegalBrowserUrl(LEGAL_URLS.termsOfService)
-                  setLegalBrowserTitle(t('onboarding:phone.terms_of_service'))
+                  setLegalBrowserTitle(t('onboarding:phone.terms_and_conditions'))
                   setLegalBrowserVisible(true)
                 }}
                 accessibilityRole="link"
-                accessibilityLabel={t('onboarding:phone.terms_of_service')}
+                accessibilityLabel={t('onboarding:phone.terms_and_conditions')}
               >
-                {t('onboarding:phone.terms_of_service')}
+                {t('onboarding:phone.consent_terms_link')}
               </Text>
-              {t('onboarding:phone.and')}
-              <Text
-                style={styles.consentLink}
-                onPress={() => {
-                  setLegalBrowserUrl(LEGAL_URLS.privacyPolicy)
-                  setLegalBrowserTitle(t('onboarding:phone.privacy_policy'))
-                  setLegalBrowserVisible(true)
-                }}
-                accessibilityRole="link"
-                accessibilityLabel={t('onboarding:phone.privacy_policy')}
-              >
-                {t('onboarding:phone.privacy_policy')}
-              </Text>
-              .
+              {t('onboarding:phone.consent_text_suffix')}
             </Text>
           </Pressable>
         </View>
@@ -3478,6 +3499,14 @@ const styles = StyleSheet.create({
   consentLink: {
     color: colors.primary[700],
     fontWeight: fontWeights.medium,
+  },
+  // META-ORCH-1161 Sub-A.2 — the underlined "terms and conditions" link
+  // (DEC-186 / DESIGN §S2.2). Keeps the established settings-link orange,
+  // adds the required underline (two non-color affordances).
+  consentLinkUnderlined: {
+    color: colors.primary[700],
+    fontWeight: fontWeights.medium,
+    textDecorationLine: 'underline' as const,
   },
   captionCentered: {
     ...typography.sm,

--- a/app-mobile/src/constants/consentDisclosure.ts
+++ b/app-mobile/src/constants/consentDisclosure.ts
@@ -1,0 +1,103 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — consent disclosure copy.
+ *
+ * SINGLE SOURCE OF TRUTH for the legally-binding consent strings on the
+ * mingla-business buyer-checkout surface (S3). The §1b disclosure string is
+ * recorded VERBATIM into `consent_records.disclosure_text` (both scopes) at
+ * every grant — it is the legal burden-of-proof artifact backing the
+ * risk-accepted bundled-mandatory consent (DEC-186). DO NOT paraphrase.
+ *
+ * Copy authority (verbatim):
+ *   Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md
+ *     §1a — visible checkbox label
+ *     §1b — EXACT disclosure string (recorded)
+ *     §2  — full Terms & Conditions / consent sheet body
+ *
+ * The app-mobile consumer surface (S2) carries a byte-identical copy in
+ * `mingla-business/src/constants/consentDisclosure.ts` — the two cannot share a
+ * module (separate apps), so any edit MUST be mirrored in both (and re-record
+ * `disclosure_text`). DISCLOSURE_VERSION pins the wording for the audit trail.
+ */
+
+/**
+ * Pins the exact wording for the legal record. Bump ONLY when the §1b string or
+ * §2 body changes; the server stores both the version and the resolved text so
+ * the burden-of-proof artifact cannot drift with a stale client (DESIGN §6 / OQ-4).
+ */
+export const DISCLOSURE_VERSION = "2026-06-19" as const;
+
+/**
+ * §1b — the EXACT disclosure string recorded VERBATIM into
+ * `consent_records.disclosure_text` for BOTH scope='transactional' AND
+ * scope='marketing'. No paraphrase. (COPY §1b, all placeholders FILLED.)
+ */
+export const CONSENT_DISCLOSURE_TEXT =
+  "I agree to Mingla's Terms & Conditions and Privacy Policy, and I consent to receive from Mingla LLC and the businesses I book with: (1) transactional and account messages including booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, and payment notices; (2) event and reservation reminders for this booking and for future events; and (3) marketing and promotional messages, including offers and announcements from venues and experience brands. These messages may be sent by email, in-app notification, push notification, and recurring automated text message (SMS) to the phone number I provide. Message frequency varies. Msg & data rates may apply. Consent to texts is not a condition of any purchase. Reply STOP to any text to opt out, or HELP for help; you can also unsubscribe from email via the link in any message or change your preferences in the Mingla app at any time. Full terms: https://www.usemingla.com/terms-of-service | Privacy: https://www.usemingla.com/privacy-policy | SMS terms: https://www.usemingla.com/sms-terms.";
+
+/**
+ * §2 — the full Terms & Conditions / consent sheet body (verbatim, FILLED).
+ * Rendered in the T&C sheet opened from the underlined "all terms and
+ * conditions" link. Plain-language product copy; the linked ToS/Privacy remain
+ * the controlling documents.
+ */
+export const CONSENT_TERMS_BODY = `Mingla — Terms, Notifications & Consent
+
+Last updated: 2026-06-19
+
+By creating a Mingla account or completing a booking, you agree to these terms and to Mingla's full Terms of Service and Privacy Policy, which are incorporated here by reference. If you do not agree, do not create an account or complete a booking.
+
+1. Who you're agreeing with.
+Mingla is operated by Mingla LLC, 700 Corporate Center Dr, Raleigh, NC 27607, USA ("Mingla," "we," "us"). Questions: support@usemingla.com · +1 888-250-5351.
+
+2. What Mingla is — and is not.
+Mingla helps you discover places, events, experiences, and trips and connects you with venues and experience brands ("Businesses"). Mingla is a platform; the Businesses are independent third parties. Events, reservations, menus, prices, availability, and experiences are created and controlled by the Businesses, not by Mingla. Mingla does not own, operate, host, or supervise any venue, event, or experience, and is not a party to your agreement with a Business.
+
+3. No guarantee; you assume the risks of real-world activity.
+We work to keep listings accurate, but Mingla does not guarantee the accuracy, availability, quality, safety, legality, or outcome of any listing, event, reservation, experience, or Business, or that any event will occur as described. You attend events and experiences and visit venues at your own risk. You are responsible for your own conduct and safety and for evaluating any Business before you go.
+
+4. Third-party responsibility.
+Any dispute about an event, reservation, experience, refund, service, injury, or loss is between you and the relevant Business. Mingla is not responsible or liable for the acts, omissions, products, services, or content of any Business or other user. Where Mingla processes a payment, it does so as a technical facilitator; the Business remains the merchant of record for what it sells unless stated otherwise at checkout.
+
+5. Limitation of liability; release.
+To the fullest extent permitted by law, Mingla and its officers, employees, and partners are not liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss arising from your use of the app, any listing, any Business, or any event or experience. To the fullest extent permitted by law, you release Mingla from claims arising out of disputes with Businesses or other users or from your participation in any real-world activity discovered through Mingla. Mingla's total liability for any claim is limited to the greater of the amount you paid Mingla (not the Business) for the transaction at issue or the amount permitted by applicable law. Some jurisdictions do not allow certain limitations; where that applies, the limitation applies to the maximum extent permitted.
+
+6. Communications & consent — what you're signing up for.
+When you create an account or complete a booking and check the consent box, you agree to receive the following from Mingla and from the Businesses you book with:
+
+- Transactional & account messages — booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, payment notices, and account/security messages. These are required to use Mingla and are tied to your activity.
+- Reminders — reminders for the event, experience, trip, or reservation you book, and for future events you may be interested in.
+- Marketing & promotional messages — offers, announcements, new events, and promotions from Mingla and from venues and experience brands, including via marketing blasts.
+
+These may be delivered by email, in-app notification, push notification, and recurring automated text message (SMS) to the contact details you provide. Message frequency varies. Msg & data rates may apply. Consent to receive marketing texts is not a condition of any purchase.
+
+7. How to opt out.
+- Text (SMS): reply STOP to any text to stop texts, or HELP for help. We also honor quit, end, cancel, unsubscribe, revoke, and opt out.
+- Email: use the unsubscribe link in any marketing email.
+- In-app: open the Mingla app and adjust your notification preferences at any time, per channel and per category.
+- Outside the US: opt-out may also run through your local registry (for example, in Nigeria, the NCC DND service by texting STOP to 2442) and the in-app preference center.
+
+We honor opt-out requests received by any reasonable means and process them promptly (within the timeframes required by law). Opting out of marketing does not stop transactional or account messages, which are required to deliver what you booked. You may still receive a single confirmation message after you opt out.
+
+8. Data handling.
+We collect and use the contact details and information you provide (including your name, email, phone number, and country) to operate Mingla, deliver the messages above, process bookings and payments, prevent fraud, and improve the service, as described in our Privacy Policy. We share necessary booking details with the Business you book with so it can fulfill your reservation or order. We do not sell your personal information except as described in the Privacy Policy. Where required, our lawful basis for marketing is your consent, which you may withdraw at any time as described in section 7. We record the date, time, exact text of this disclosure, and your country at the time you consent, as proof of your consent.
+
+9. Payments, refunds & cancellations.
+Prices, fees, taxes, refund eligibility, and cancellation terms are set by the Business and shown at checkout. Refunds, where offered, are handled under the Business's policy and applicable law. Mingla is not obligated to issue refunds for a Business's products or services.
+
+10. Eligibility & acceptable use.
+You must be the age of majority in your location (and at least 18) to enter into these terms and to receive marketing messages. You agree to provide accurate information, to use Mingla lawfully, and not to misuse the platform or other users.
+
+11. Changes; governing law; contact.
+We may update these terms; material changes will be notified in-app or by email, and continued use means acceptance. These terms are governed by the laws of the State of North Carolina, USA. Disputes are resolved per the full Terms of Service (including any arbitration or venue clause stated there). Contact us at support@usemingla.com or 700 Corporate Center Dr, Raleigh, NC 27607, USA.
+
+Full Terms of Service: https://www.usemingla.com/terms-of-service · Privacy Policy: https://www.usemingla.com/privacy-policy · SMS Terms: https://www.usemingla.com/sms-terms`;
+
+/**
+ * §1a — the short visible label rendered next to the checkbox. The
+ * "[terms and conditions]" token is replaced by an underlined tappable link in
+ * the component; the surrounding text is rendered verbatim.
+ */
+export const CONSENT_VISIBLE_LABEL_PREFIX = "I agree to Mingla's ";
+export const CONSENT_VISIBLE_LABEL_LINK = "terms and conditions";
+export const CONSENT_VISIBLE_LABEL_SUFFIX =
+  " and to receive booking confirmations, reminders, account updates, and marketing from Mingla and the businesses I book with — by email, push, and text. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out of texts, HELP for help.";

--- a/app-mobile/src/i18n/locales/en/onboarding.json
+++ b/app-mobile/src/i18n/locales/en/onboarding.json
@@ -25,14 +25,17 @@
     "body": "We'll send a code. Takes two seconds.",
     "verified_headline": "You're all set.",
     "verified_body": "Your number's locked in. One less thing.",
-    "consent_text": "I agree to receive messages from Mingla via SMS or phone call, including verification codes, friend invitations, and experience reminders. Reply STOP to opt out or HELP for help. See our ",
+    "consent_text": "I agree to Mingla's ",
     "terms_of_service": "Terms of Service",
     "and": " and ",
     "privacy_policy": "Privacy Policy",
-    "consent_accessibility": "Agree to receive messages from Mingla",
+    "consent_accessibility": "I agree to Mingla's terms and conditions and to receive booking confirmations, reminders, account updates, and marketing by email, push, and text.",
     "cta_send_code": "Send code",
     "placeholder_phone": "(555) 123-4567",
-    "country_accessibility": "Selected country: {{name}}. Tap to change."
+    "country_accessibility": "Selected country: {{name}}. Tap to change.",
+    "consent_terms_link": "terms and conditions",
+    "consent_text_suffix": " and to receive booking confirmations, reminders, account updates, and marketing from Mingla and the businesses I book with — by email, push, and text. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out of texts, HELP for help.",
+    "terms_and_conditions": "Terms & Conditions"
   },
   "otp": {
     "headline": "Enter the code",

--- a/app-mobile/src/services/consentService.ts
+++ b/app-mobile/src/services/consentService.ts
@@ -1,0 +1,61 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — onboarding consent writer.
+ *
+ * Calls the shared `record-consent` edge function to append the bundled-mandatory
+ * consent audit rows at signup (DEC-186, source='onboarding'). One call writes a
+ * transactional AND a marketing `consent_records` row per provided channel/contact;
+ * the EXACT §1b disclosure string (CONSENT_DISCLOSURE_TEXT) is recorded VERBATIM.
+ *
+ * Non-blocking by contract at the call site: a failed consent-audit write MUST NOT
+ * block the user finishing onboarding (the affirmative checkbox act already
+ * happened). The caller proceeds and logs the gap.
+ */
+
+import { supabase } from "./supabase";
+
+export interface RecordConsentInput {
+  source: "onboarding" | "checkout";
+  /** EXACT §1b disclosure string the user saw (CONSENT_DISCLOSURE_TEXT). */
+  disclosureText: string;
+  /** Pins the disclosure wording version (DISCLOSURE_VERSION). */
+  disclosureVersion: string;
+  /** E.164 phone — produces the 'sms' consent rows. */
+  phone?: string | null;
+  /** Email — produces the 'email' consent rows. */
+  email?: string | null;
+  /** ISO-2 country at grant (the phone country at onboarding). */
+  countryCode?: string | null;
+  /** The just-created user id. */
+  userId?: string | null;
+}
+
+export interface RecordConsentResult {
+  ok: boolean;
+  inserted: number;
+  deduped: number;
+}
+
+export const recordConsent = async (
+  input: RecordConsentInput,
+): Promise<RecordConsentResult> => {
+  const { data, error } = await supabase.functions.invoke("record-consent", {
+    body: {
+      source: input.source,
+      disclosureText: input.disclosureText,
+      disclosureVersion: input.disclosureVersion,
+      phone: input.phone ?? null,
+      email: input.email ?? null,
+      countryCode: input.countryCode ?? null,
+      userId: input.userId ?? null,
+    },
+  });
+  if (error) {
+    return { ok: false, inserted: 0, deduped: 0 };
+  }
+  const payload = (data ?? {}) as { inserted?: number; deduped?: number };
+  return {
+    ok: true,
+    inserted: payload.inserted ?? 0,
+    deduped: payload.deduped ?? 0,
+  };
+};

--- a/mingla-business/app/checkout/[eventId]/buyer.tsx
+++ b/mingla-business/app/checkout/[eventId]/buyer.tsx
@@ -727,6 +727,8 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
             onPress fires; the outer onPress is a no-op while enabled. */}
         <Pressable
           onPress={continueDisabled ? showConsentHint : undefined}
+          accessibilityRole="button"
+          accessibilityLabel={continueLabel}
           accessibilityElementsHidden={false}
         >
           <View pointerEvents={continueDisabled ? "none" : "auto"}>

--- a/mingla-business/app/checkout/[eventId]/buyer.tsx
+++ b/mingla-business/app/checkout/[eventId]/buyer.tsx
@@ -55,6 +55,16 @@ import { resolveCheckoutBrandAccent } from "../../../src/utils/checkoutBrandAcce
 import { formatCurrency } from "../../../src/utils/currency";
 import { isValidE164, composeE164 } from "../../../src/utils/phone";
 import { createTicketCheckout } from "../../../src/services/ticketCheckoutService";
+// META-ORCH-1161 Sub-A.2 — bundled-mandatory consent (DEC-186): shared writer +
+// verbatim disclosure copy + the §2 T&C sheet.
+import { recordConsent } from "../../../src/services/consentService";
+import {
+  CONSENT_DISCLOSURE_TEXT,
+  CONSENT_VISIBLE_LABEL_PREFIX,
+  CONSENT_VISIBLE_LABEL_LINK,
+  CONSENT_VISIBLE_LABEL_SUFFIX,
+  DISCLOSURE_VERSION,
+} from "../../../src/constants/consentDisclosure";
 
 import { Button } from "../../../src/components/ui/Button";
 import { GlassCard } from "../../../src/components/ui/GlassCard";
@@ -66,6 +76,8 @@ import {
   useCartTotals,
 } from "../../../src/components/checkout/CartContext";
 import { CheckoutHeader } from "../../../src/components/checkout/CheckoutHeader";
+import { ConsentTermsSheet } from "../../../src/components/checkout/ConsentTermsSheet";
+import { isContinueDisabled } from "../../../src/components/checkout/checkoutConsentGate";
 
 // ORCH-0847 Phase B — country-picker phone input shared with app-mobile
 // auth onboarding. Replaces the prior single-text-field phone Input which
@@ -199,6 +211,27 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
   const totals = useCartTotals();
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // META-ORCH-1161 Sub-A.2 (DEC-186) — bundled-mandatory consent gate state.
+  const termsAccepted = buyer.termsAccepted === true;
+  const [termsSheetVisible, setTermsSheetVisible] = useState<boolean>(false);
+  // Shown after the buyer taps a disabled Pay button with fields valid but the
+  // box unchecked — never a silent dead tap (DESIGN §S3.4).
+  const [consentHintVisible, setConsentHintVisible] = useState<boolean>(false);
+
+  // Checking the box constitutes the bundled grant: DEC-186 folds marketing into
+  // the single mandatory consent, so `marketingOptIn` rides with `termsAccepted`
+  // (the downstream payment payload reads `marketingOptIn`).
+  const acceptTerms = useCallback((): void => {
+    setBuyer({ termsAccepted: true, marketingOptIn: true });
+    setConsentHintVisible(false);
+  }, [setBuyer]);
+
+  const toggleTerms = useCallback((): void => {
+    const next = !(buyer.termsAccepted === true);
+    setBuyer({ termsAccepted: next, marketingOptIn: next });
+    if (next) setConsentHintVisible(false);
+  }, [buyer.termsAccepted, setBuyer]);
 
   // Touched flags — show validation errors only after first focus blur,
   // so a fresh-mount form doesn't immediately scream red.
@@ -342,8 +375,40 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
     setEmailTouched(true);
     setPhoneTouched(true);
     if (!validation.isValid) return;
+    // META-ORCH-1161 Sub-A.2 (DEC-186) — the bundled consent box is mandatory.
+    // Fields valid but box unchecked → surface the helper (no dead tap).
+    if (!termsAccepted) {
+      setConsentHintVisible(true);
+      return;
+    }
     if (eventId === null) return;
     setSubmitError(null);
+
+    // META-ORCH-1161 Sub-A.2 — record the bundled consent grant (transactional +
+    // marketing, both channels) with the EXACT §1b disclosure VERBATIM. The phone
+    // country supplies country_code; ip_hash is computed server-side. Non-blocking:
+    // the checkbox act already constitutes consent, so an audit-write failure must
+    // not deadlock checkout — we log and proceed (Constitution #3: surfaced via
+    // console, never silently swallowed).
+    try {
+      const consentResult = await recordConsent({
+        source: "checkout",
+        disclosureText: CONSENT_DISCLOSURE_TEXT,
+        disclosureVersion: DISCLOSURE_VERSION,
+        phone: buyer.phone,
+        email: buyer.email,
+        countryCode: phoneCountry,
+        userId: null,
+      });
+      if (!consentResult.ok) {
+        console.error(
+          "[checkout-buyer] consent_records write failed (proceeding; checkbox act stands)",
+        );
+      }
+    } catch (consentErr) {
+      console.error("[checkout-buyer] consent write threw", consentErr);
+    }
+
     if (totals.isFree) {
       try {
         setSubmitting(true);
@@ -379,6 +444,8 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
     router.push(`/checkout/${eventId}/payment` as never);
   }, [
     validation.isValid,
+    termsAccepted,
+    phoneCountry,
     eventId,
     totals.isFree,
     totals.currency,
@@ -558,12 +625,14 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
           />
         </View>
 
-        {/* Marketing opt-in */}
+        {/* META-ORCH-1161 Sub-A.2 (DEC-186) — bundled-mandatory consent gate.
+            ONE checkbox covering T&Cs + transactional + reminders + email +
+            SMS marketing; the underlined link opens the §2 T&C sheet. */}
         <Pressable
-          onPress={() => setBuyer({ marketingOptIn: !buyer.marketingOptIn })}
+          onPress={toggleTerms}
           accessibilityRole="checkbox"
-          accessibilityState={{ checked: buyer.marketingOptIn }}
-          accessibilityLabel="Email me about this organiser's future events"
+          accessibilityState={{ checked: termsAccepted }}
+          accessibilityLabel="I agree to all terms and conditions and to receive booking confirmations, reminders, account updates, and marketing from Mingla and the businesses I book with by email, push, and text."
           style={({ pressed }) => [
             styles.checkboxRow,
             pressed && styles.checkboxRowPressed,
@@ -572,17 +641,32 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
           <View
             style={[
               styles.checkboxBox,
-              buyer.marketingOptIn && styles.checkboxBoxChecked,
+              termsAccepted && styles.checkboxBoxChecked,
+              consentHintVisible && !termsAccepted && styles.checkboxBoxFlash,
             ]}
           >
-            {buyer.marketingOptIn ? (
+            {termsAccepted ? (
               <Icon name="check" size={14} color={textTokens.primary} />
             ) : null}
           </View>
           <Text style={styles.checkboxLabel}>
-            Email me about this organiser&apos;s future events
+            {CONSENT_VISIBLE_LABEL_PREFIX}
+            <Text
+              style={styles.checkboxLinkUnderlined}
+              onPress={() => setTermsSheetVisible(true)}
+              accessibilityRole="link"
+              accessibilityLabel="Open all terms and conditions"
+            >
+              {CONSENT_VISIBLE_LABEL_LINK}
+            </Text>
+            {CONSENT_VISIBLE_LABEL_SUFFIX}
           </Text>
         </Pressable>
+        {consentHintVisible && !termsAccepted ? (
+          <Text style={styles.consentRequiredHint}>
+            Please agree to continue.
+          </Text>
+        ) : null}
         {submitError !== null ? (
           <Text style={styles.errorText}>{submitError}</Text>
         ) : null}
@@ -610,10 +694,23 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
           size="lg"
           fullWidth
           loading={submitting}
-          disabled={!validation.isValid || submitting}
+          disabled={isContinueDisabled({
+            fieldsValid: validation.isValid,
+            termsAccepted,
+            submitting,
+          })}
         />
       </View>
 
+      {/* META-ORCH-1161 Sub-A.2 — the §2 T&C sheet (shared overlay). */}
+      <ConsentTermsSheet
+        visible={termsSheetVisible}
+        onClose={() => setTermsSheetVisible(false)}
+        onAgree={() => {
+          acceptTerms();
+          setTermsSheetVisible(false);
+        }}
+      />
     </View>
   );
 }
@@ -763,6 +860,24 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: textTokens.secondary,
     lineHeight: 20,
+  },
+  // META-ORCH-1161 Sub-A.2 — underlined "terms and conditions" link on the dark
+  // checkout canvas (warm-orange + underline = two non-color affordances).
+  checkboxLinkUnderlined: {
+    color: accent.warm,
+    fontWeight: "600",
+    textDecorationLine: "underline",
+  },
+  // Red flash on the box when the buyer taps a disabled Pay with the box
+  // unchecked (DESIGN §S3.4 — never a silent dead tap).
+  checkboxBoxFlash: {
+    borderColor: semantic.error,
+  },
+  consentRequiredHint: {
+    marginTop: 6,
+    fontSize: 12,
+    color: semantic.error,
+    fontWeight: "500",
   },
   // Sticky bottom bar
   bottomBar: {

--- a/mingla-business/app/checkout/[eventId]/buyer.tsx
+++ b/mingla-business/app/checkout/[eventId]/buyer.tsx
@@ -77,7 +77,10 @@ import {
 } from "../../../src/components/checkout/CartContext";
 import { CheckoutHeader } from "../../../src/components/checkout/CheckoutHeader";
 import { ConsentTermsSheet } from "../../../src/components/checkout/ConsentTermsSheet";
-import { isContinueDisabled } from "../../../src/components/checkout/checkoutConsentGate";
+import {
+  isContinueDisabled,
+  shouldShowConsentHintOnDisabledTap,
+} from "../../../src/components/checkout/checkoutConsentGate";
 
 // ORCH-0847 Phase B — country-picker phone input shared with app-mobile
 // auth onboarding. Replaces the prior single-text-field phone Input which
@@ -369,6 +372,26 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
     }
   }, [router, eventId]);
 
+  // META-ORCH-1161 Sub-A.2 (DEC-186) — surface why the Pay button is greyed when
+  // the buyer taps it while it is disabled. Marks every field touched (so any
+  // field error renders) and, when the only missing thing is the consent box,
+  // flashes the box + shows the "Please agree to continue." helper. The Pay
+  // button stays VISUALLY disabled (DESIGN §S3.4) but the tap is captured by a
+  // Pressable overlay below — never a silent dead tap (Constitution Rule 1).
+  const showConsentHint = useCallback((): void => {
+    setNameTouched(true);
+    setEmailTouched(true);
+    setPhoneTouched(true);
+    if (
+      shouldShowConsentHintOnDisabledTap({
+        fieldsValid: validation.isValid,
+        termsAccepted,
+      })
+    ) {
+      setConsentHintVisible(true);
+    }
+  }, [validation.isValid, termsAccepted]);
+
   const handleContinue = useCallback(async (): Promise<void> => {
     // Mark all fields touched so any validation errors render
     setNameTouched(true);
@@ -458,6 +481,15 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
   const continueLabel = totals.isFree
     ? "Reserve free ticket"
     : "Continue to payment";
+
+  // META-ORCH-1161 Sub-A.2 (DEC-186) — single source of the Pay-button gate so
+  // the visual disabled state, the pointer-events pass-through, and the
+  // tap-capture overlay all agree.
+  const continueDisabled = isContinueDisabled({
+    fieldsValid: validation.isValid,
+    termsAccepted,
+    submitting,
+  });
 
   if (event === null || hasNoLines) {
     // Render an empty shell — useEffect above redirects on the next tick.
@@ -686,20 +718,30 @@ export default function CheckoutBuyerScreen(): React.ReactElement {
             {totals.isFree ? "Free" : formatCurrency(totals.total, totals.currency)}
           </Text>
         </View>
-        <Button
-          label={continueLabel}
-          onPress={handleContinue}
-          variant="primary"
-          accentColor={ctaAccent}
-          size="lg"
-          fullWidth
-          loading={submitting}
-          disabled={isContinueDisabled({
-            fieldsValid: validation.isValid,
-            termsAccepted,
-            submitting,
-          })}
-        />
+        {/* META-ORCH-1161 Sub-A.2 (DEC-186) — the Pay button stays VISUALLY
+            greyed until fields are valid AND the consent box is checked, but a
+            tap on the greyed button is CAPTURED by this Pressable overlay and
+            surfaces the "Please agree to continue." helper + checkbox flash
+            (DESIGN §S3.4 — never a silent dead tap). When the button is
+            enabled, the inner Button claims the touch responder and its own
+            onPress fires; the outer onPress is a no-op while enabled. */}
+        <Pressable
+          onPress={continueDisabled ? showConsentHint : undefined}
+          accessibilityElementsHidden={false}
+        >
+          <View pointerEvents={continueDisabled ? "none" : "auto"}>
+            <Button
+              label={continueLabel}
+              onPress={handleContinue}
+              variant="primary"
+              accentColor={ctaAccent}
+              size="lg"
+              fullWidth
+              loading={submitting}
+              disabled={continueDisabled}
+            />
+          </View>
+        </Pressable>
       </View>
 
       {/* META-ORCH-1161 Sub-A.2 — the §2 T&C sheet (shared overlay). */}

--- a/mingla-business/playwright/orch-1161-consent-capture.mjs
+++ b/mingla-business/playwright/orch-1161-consent-capture.mjs
@@ -1,0 +1,265 @@
+// ORCH-1161 — capture a REAL screenshot of the buyer-web consent UI.
+// Serves the static web-build-1161 export, mocks the Supabase REST/RPC layer
+// with a fixture paid event, drives index -> add ticket -> buyer, then
+// screenshots the consent checkbox in its key states.
+import { createReadStream, existsSync, statSync, mkdirSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
+import { createServer } from "node:http";
+import { chromium } from "playwright";
+
+const ROOT = resolve(process.argv[2] ?? "web-build-1161");
+const PORT = Number(process.argv[3] ?? 43161);
+const OUT = resolve(process.argv[4] ?? "/Users/sethogieva/Desktop/mingla-main/Mingla_Artifacts/evidence/ORCH-1161");
+mkdirSync(OUT, { recursive: true });
+
+const EVENT_ID = "orch1161-event";
+const BRAND_ID = "orch1161-brand";
+const TICKET_ID = "orch1161-ticket-ga";
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".ico", "image/x-icon"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".map", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".wasm", "application/wasm"],
+  [".webp", "image/webp"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+  [".ttf", "font/ttf"],
+]);
+
+const resolveAsset = (url) => {
+  const parsed = new URL(url, `http://127.0.0.1:${PORT}`);
+  const cleanPath = decodeURIComponent(parsed.pathname).replace(/^\/+/, "");
+  const candidate = resolve(ROOT, cleanPath);
+  if (candidate.startsWith(ROOT) && existsSync(candidate) && statSync(candidate).isFile()) {
+    return candidate;
+  }
+  return join(ROOT, "index.html"); // SPA fallback for deep routes
+};
+
+const server = createServer((req, res) => {
+  const assetPath = resolveAsset(req.url ?? "/");
+  const ct = contentTypes.get(extname(assetPath)) ?? "application/octet-stream";
+  res.writeHead(200, { "Content-Type": ct, "Cache-Control": "no-store" });
+  createReadStream(assetPath).pipe(res);
+});
+
+// ---- Fixture rows -----------------------------------------------------------
+const viewRow = {
+  id: EVENT_ID,
+  brand_id: BRAND_ID,
+  brand_slug: "orch1161-brand",
+  brand_name: "The Lantern Room",
+  brand_description: null,
+  brand_profile_photo_url: null,
+  brand_display_attendee_count: false,
+  event_type: "event",
+  title: "Rooftop Jazz Night",
+  description: "An evening of live jazz.",
+  slug: "rooftop-jazz-night",
+  location_text: "Raleigh, NC",
+  online_url: null,
+  is_online: false,
+  is_recurring: false,
+  is_multi_date: false,
+  recurrence_rules: null,
+  cover_media_url: null,
+  cover_media_type: null,
+  cover_media_provider: null,
+  cover_media_source_url: null,
+  cover_media_credit: null,
+  cover_media_credit_url: null,
+  cover_media_alt: null,
+  currency: "USD",
+  visibility: "public",
+  show_on_discover: true,
+  status: "scheduled",
+  published_at: "2026-06-01T12:00:00.000Z",
+  timezone: "America/New_York",
+  created_at: "2026-05-01T12:00:00.000Z",
+  updated_at: "2026-06-01T12:00:00.000Z",
+  public_theme: {
+    business_event: {
+      format: "in_person",
+      whenMode: "single",
+      location: { venueName: "The Lantern Room", address: "Raleigh, NC" },
+      settings: {},
+    },
+  },
+  master_start_at: "2026-07-01T23:00:00.000Z",
+  master_end_at: "2026-07-02T02:00:00.000Z",
+  master_timezone: "America/New_York",
+  master_event_date_id: "orch1161-date",
+  min_price_cents: 2500,
+};
+
+const ticketRow = {
+  id: TICKET_ID,
+  event_id: EVENT_ID,
+  name: "General Admission",
+  description: "Standing room",
+  price_cents: 2500,
+  currency: "USD",
+  quantity_total: 100,
+  is_unlimited: false,
+  is_free: false,
+  sale_start_at: null,
+  sale_end_at: null,
+  min_purchase_qty: 1,
+  max_purchase_qty: 10,
+  is_hidden: false,
+  is_disabled: false,
+  requires_approval: false,
+  allow_transfers: true,
+  password_protected: false,
+  available_online: true,
+  available_in_person: false,
+  waitlist_enabled: false,
+  display_order: 0,
+};
+
+const brandRow = {
+  id: BRAND_ID,
+  slug: "orch1161-brand",
+  name: "The Lantern Room",
+  description: null,
+  cover_media_url: null,
+};
+
+const jsonHeaders = { "access-control-allow-origin": "*", "content-type": "application/json" };
+
+async function installMocks(page) {
+  await page.route("**/functions/v1/**", (route) =>
+    route.fulfill({ status: 200, headers: jsonHeaders, body: "{}" }),
+  );
+  await page.route("**/rest/v1/rpc/**", (route) => {
+    const name = new URL(route.request().url()).pathname.split("/").pop() ?? "";
+    let body = "null";
+    if (name === "pg_brand_can_charge") body = "true";
+    else if (name === "pg_brands_can_charge") body = "[]";
+    else if (name === "pg_public_ticket_types_remaining")
+      body = JSON.stringify([{ ticket_type_id: TICKET_ID, remaining: 50 }]);
+    else if (name === "pg_public_event_tier_allin")
+      body = JSON.stringify([{ ticket_type_id: TICKET_ID, all_in_cents: 2750 }]);
+    else if (name === "pg_public_event_by_slug") body = "null";
+    else body = "[]";
+    route.fulfill({ status: 200, headers: jsonHeaders, body });
+  });
+  await page.route("**/rest/v1/**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname.includes("/rpc/")) return route.fallback();
+    const table = url.pathname.split("/").pop() ?? "";
+    const wantsObject =
+      route.request().headers().accept?.includes("application/vnd.pgrst.object+json") === true;
+    let rows = [];
+    if (table === "business_public_events_view") rows = [viewRow];
+    else if (table === "ticket_types") rows = [ticketRow];
+    else if (table === "brands") rows = [brandRow];
+    const body = wantsObject ? JSON.stringify(rows[0] ?? null) : JSON.stringify(rows);
+    route.fulfill({ status: 200, headers: jsonHeaders, body });
+  });
+}
+
+const log = (...a) => console.log("[orch-1161]", ...a);
+
+async function main() {
+  await new Promise((r) => server.listen(PORT, "127.0.0.1", r));
+  log("static server on", PORT, "root", ROOT);
+
+  const browser = await chromium.launch();
+  // iPhone-ish viewport so the dark mobile checkout looks right.
+  const page = await browser.newPage({
+    viewport: { width: 430, height: 932 },
+    deviceScaleFactor: 3,
+  });
+  page.on("console", (m) => {
+    if (m.type() === "error") log("PAGE-ERR", m.text());
+  });
+  await installMocks(page);
+
+  // 1. Land on the checkout index (deep route → SPA fallback to index.html).
+  await page.goto(`http://127.0.0.1:${PORT}/checkout/${EVENT_ID}`, {
+    waitUntil: "domcontentloaded",
+  });
+  log("navigated to checkout index");
+
+  // Wait for the ticket selector to render.
+  await page
+    .getByText("Select your tickets", { exact: false })
+    .waitFor({ timeout: 30000 })
+    .catch(() => log("WARN: 'Select your tickets' not seen"));
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: join(OUT, "_debug_index.png") });
+
+  // 2. Add one ticket via the "+" stepper.
+  const plus =
+    (await page.getByRole("button", { name: /add|increase|increment/i }).count()) > 0
+      ? page.getByRole("button", { name: /add|increase|increment/i }).first()
+      : page.locator('[aria-label*="dd" i], [aria-label*="ncrease" i]').first();
+  await plus.click({ timeout: 15000 }).catch(async (e) => {
+    log("plus click via role failed, trying any button near price", e.message);
+  });
+  await page.waitForTimeout(1000);
+
+  // 3. Continue → buyer page.
+  const cont = page.getByRole("button", { name: /continue/i }).first();
+  await cont.click({ timeout: 15000 });
+  log("clicked Continue");
+
+  // 4. Wait for the buyer page consent checkbox.
+  await page
+    .getByText("terms and conditions", { exact: false })
+    .first()
+    .waitFor({ timeout: 30000 });
+  await page.waitForTimeout(1200);
+  log("buyer page consent label visible");
+
+  // STATE A: buyer page as landed — empty fields, greyed Pay, unchecked box.
+  await page.screenshot({ path: join(OUT, "consent_checkout_web_unchecked.png") });
+  log("saved consent_checkout_web_unchecked.png");
+
+  // STATE B: fill ALL fields valid, box still unchecked, tap greyed Pay to
+  // trigger the red "Please agree to continue." flash. Use the exact a11y
+  // labels the Inputs expose.
+  await page.getByLabel("Full name, required", { exact: true }).fill("Jordan Rivera").catch((e) => log("name fill", e.message));
+  await page.getByLabel("Email address, required", { exact: true }).fill("jordan@example.com").catch((e) => log("email fill", e.message));
+  const phone = page.getByLabel("Mobile number, required", { exact: true }).first();
+  await phone.fill("9195550123").catch((e) => log("phone fill", e.message));
+  // blur so validation clears any touched errors
+  await page.keyboard.press("Tab").catch(() => {});
+  await page.waitForTimeout(600);
+  // tap the greyed Pay (captured by the overlay Pressable → shows the hint)
+  const payBtn = page.getByRole("button", { name: /continue to payment|reserve free/i }).first();
+  await payBtn.click({ force: true, timeout: 8000 }).catch(() => log("pay tap (greyed) noop"));
+  await page.waitForTimeout(900);
+  await page.screenshot({ path: join(OUT, "consent_checkout_web_required_flash.png") });
+  log("saved consent_checkout_web_required_flash.png");
+
+  // STATE C: check the box → Pay enabled (orange), fields valid.
+  const box = page.getByRole("checkbox").first();
+  await box.click({ timeout: 8000 }).catch(() => log("checkbox click noop"));
+  await page.waitForTimeout(800);
+  await page.screenshot({ path: join(OUT, "consent_checkout_web_checked.png") });
+  log("saved consent_checkout_web_checked.png");
+
+  // STATE D: open the T&C sheet via the underlined link.
+  await page.getByText("terms and conditions", { exact: false }).first().click({ timeout: 8000 }).catch(() => log("link tap noop"));
+  await page.waitForTimeout(1200);
+  await page.screenshot({ path: join(OUT, "consent_checkout_web_terms_sheet.png") });
+  log("saved consent_checkout_web_terms_sheet.png");
+
+  await browser.close();
+  server.close();
+  log("done");
+}
+
+main().catch((e) => {
+  console.error("[orch-1161] FATAL", e);
+  server.close();
+  process.exit(1);
+});

--- a/mingla-business/src/components/checkout/CartContext.tsx
+++ b/mingla-business/src/components/checkout/CartContext.tsx
@@ -63,6 +63,15 @@ export interface BuyerDetails {
   /** Required for production checkout. Edge functions normalise to E.164. */
   phone: string;
   marketingOptIn: boolean;
+  /**
+   * META-ORCH-1161 Sub-A.2 (DEC-186) — the single bundled-mandatory consent
+   * gate. TRUE means the buyer checked "I agree to all terms and conditions",
+   * which (per DEC-186 bundling) also constitutes the marketing grant. The Pay
+   * button is disabled until this is true AND fields are valid. When set true,
+   * the buyer surface ALSO sets `marketingOptIn=true` (the bundled grant) so the
+   * downstream payment payload carries it. Default false (affirmative act).
+   */
+  termsAccepted?: boolean;
   address?: {
     line1: string;
     line2?: string;
@@ -189,6 +198,7 @@ const EMPTY_BUYER: BuyerDetails = {
   email: "",
   phone: "",
   marketingOptIn: false,
+  termsAccepted: false,
   address: {
     line1: "",
     city: "",

--- a/mingla-business/src/components/checkout/ConsentTermsSheet.tsx
+++ b/mingla-business/src/components/checkout/ConsentTermsSheet.tsx
@@ -1,0 +1,110 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — shared Terms & Conditions
+ * sheet for the bundled-mandatory consent gate (DEC-186 / DESIGN §S3.5).
+ *
+ * Renders the §2 T&C/consent body (CONSENT_TERMS_BODY, verbatim) in a scrollable
+ * overlay opened from the underlined "all terms and conditions" link in the buyer
+ * checkout. Built on the existing `Modal` primitive (web + web-phone + native,
+ * scrim, Escape, reduced-motion) — does NOT introduce a new gorhom bottom-sheet
+ * consumer (the sole-gorhom-consumer gate stays intact).
+ *
+ * OQ-3 (design recommendation YES): a sticky "I agree" footer button checks the
+ * consent box AND closes — a faster path than read-then-hunt-the-checkbox.
+ * Reading the sheet is NOT required to agree.
+ */
+
+import React from "react";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+
+import {
+  accent,
+  radius as radiusTokens,
+  spacing,
+  text as textTokens,
+} from "../../constants/designSystem";
+import { CONSENT_TERMS_BODY } from "../../constants/consentDisclosure";
+import { Button } from "../ui/Button";
+import { Modal } from "../ui/Modal";
+
+export interface ConsentTermsSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  /** OQ-3 — "I agree" checks the box AND closes. */
+  onAgree: () => void;
+}
+
+export const ConsentTermsSheet: React.FC<ConsentTermsSheetProps> = ({
+  visible,
+  onClose,
+  onAgree,
+}) => {
+  return (
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      maxWidth={560}
+      testID="consent-terms-sheet"
+    >
+      <View style={styles.container}>
+        <Text style={styles.title} accessibilityRole="header">
+          Terms &amp; Conditions
+        </Text>
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator
+        >
+          <Text style={styles.body}>{CONSENT_TERMS_BODY}</Text>
+        </ScrollView>
+        <View style={styles.footer}>
+          <Button
+            label="I agree"
+            onPress={onAgree}
+            variant="primary"
+            accentColor={accent.warm}
+            size="lg"
+            fullWidth
+          />
+          <Button
+            label="Close"
+            onPress={onClose}
+            variant="ghost"
+            size="md"
+            fullWidth
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    maxHeight: "100%",
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: textTokens.primary,
+    marginBottom: spacing.sm,
+  },
+  scroll: {
+    maxHeight: 420,
+    borderRadius: radiusTokens.md,
+  },
+  scrollContent: {
+    paddingBottom: spacing.md,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: textTokens.secondary,
+  },
+  footer: {
+    marginTop: spacing.md,
+    gap: spacing.sm,
+  },
+});
+
+export default ConsentTermsSheet;

--- a/mingla-business/src/components/checkout/__tests__/checkoutConsentGate.deadtap.orch1161.test.ts
+++ b/mingla-business/src/components/checkout/__tests__/checkoutConsentGate.deadtap.orch1161.test.ts
@@ -1,0 +1,69 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (P1-1 REWORK) — disabled-Pay dead-tap regression test.
+ *
+ * Context: the tester (TEST_META-ORCH-1161_SUBA2_CONSENT_CAPTURE.md §3 P1-1)
+ * found that tapping the GREYED Pay button with the consent box unchecked gave
+ * ZERO feedback — the specced red flash + "Please agree to continue." helper
+ * (DESIGN §S3.4) was unreachable dead code, a Constitution Rule 1 dead-tap.
+ *
+ * The fix wraps the Pay button in a tap-capturing Pressable that, while the
+ * button is disabled, routes the tap to `showConsentHint`, whose show/no-show
+ * decision is the pure predicate `shouldShowConsentHintOnDisabledTap`. This test
+ * pins that predicate: a disabled-Pay tap with valid fields + unchecked box MUST
+ * surface the helper, and MUST NOT surface it when fields are still invalid
+ * (the field errors carry the message there).
+ *
+ * fails-on-revert: delete the `!params.termsAccepted` term in
+ * `shouldShowConsentHintOnDisabledTap` (so it returns `params.fieldsValid`) →
+ * the "checked box → no helper" assertion fails; delete the `params.fieldsValid`
+ * term → the "fields invalid → no helper (errors carry it)" assertion fails.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  isContinueDisabled,
+  shouldShowConsentHintOnDisabledTap,
+} from "../checkoutConsentGate";
+
+describe("META-ORCH-1161 Sub-A.2 — disabled-Pay tap surfaces the consent hint (P1-1)", () => {
+  test("the exact dead-tap case: fields valid, box UNCHECKED → button disabled AND a captured tap shows the helper", () => {
+    const fieldsValid = true;
+    const termsAccepted = false;
+
+    // The button is greyed in this case...
+    expect(
+      isContinueDisabled({ fieldsValid, termsAccepted, submitting: false }),
+    ).toBe(true);
+
+    // ...and a tap on the greyed button MUST surface the consent helper
+    // (no silent dead tap — Constitution Rule 1 / DESIGN §S3.4).
+    expect(
+      shouldShowConsentHintOnDisabledTap({ fieldsValid, termsAccepted }),
+    ).toBe(true);
+  });
+
+  test("box already checked → no consent helper (the box is not the blocker)", () => {
+    expect(
+      shouldShowConsentHintOnDisabledTap({
+        fieldsValid: true,
+        termsAccepted: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("fields still invalid → no consent helper (the field errors carry the message, no double-messaging)", () => {
+    expect(
+      shouldShowConsentHintOnDisabledTap({
+        fieldsValid: false,
+        termsAccepted: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowConsentHintOnDisabledTap({
+        fieldsValid: false,
+        termsAccepted: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/mingla-business/src/components/checkout/checkoutConsentGate.ts
+++ b/mingla-business/src/components/checkout/checkoutConsentGate.ts
@@ -17,3 +17,21 @@ export interface ContinueGateParams {
 
 export const isContinueDisabled = (params: ContinueGateParams): boolean =>
   !params.fieldsValid || !params.termsAccepted || params.submitting;
+
+/**
+ * META-ORCH-1161 Sub-A.2 (P1-1 rework) — when the buyer taps the VISUALLY
+ * disabled Pay button, the tap is captured (never a silent dead tap,
+ * Constitution Rule 1) and we must decide whether to surface the
+ * "Please agree to continue." consent helper + checkbox flash (DESIGN §S3.4).
+ *
+ * The helper is shown ONLY when the single blocker is the unchecked consent box
+ * — i.e. all required fields are valid but `termsAccepted` is false. When fields
+ * are still invalid, the field-level errors carry the message instead (marking
+ * the fields touched is the caller's job), so the consent helper stays hidden to
+ * avoid double-messaging.
+ *
+ * Returns true ⇔ show the consent helper for this captured disabled-Pay tap.
+ */
+export const shouldShowConsentHintOnDisabledTap = (
+  params: Pick<ContinueGateParams, "fieldsValid" | "termsAccepted">,
+): boolean => params.fieldsValid && !params.termsAccepted;

--- a/mingla-business/src/components/checkout/checkoutConsentGate.ts
+++ b/mingla-business/src/components/checkout/checkoutConsentGate.ts
@@ -1,0 +1,19 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (DEC-186) — the buyer-checkout Pay/Continue gate.
+ *
+ * The Pay/Continue button is GREYED OUT until all required fields are valid AND
+ * the single bundled-mandatory consent box is checked (DESIGN §S3.4 — a buyer
+ * cannot proceed to payment unconsented). Extracted as a pure predicate so the
+ * regression test proves "disabled until checked" directly, in isolation from
+ * the route file's heavy import graph (fails-on-revert if the `!termsAccepted`
+ * term is removed).
+ */
+
+export interface ContinueGateParams {
+  fieldsValid: boolean;
+  termsAccepted: boolean;
+  submitting: boolean;
+}
+
+export const isContinueDisabled = (params: ContinueGateParams): boolean =>
+  !params.fieldsValid || !params.termsAccepted || params.submitting;

--- a/mingla-business/src/constants/consentDisclosure.ts
+++ b/mingla-business/src/constants/consentDisclosure.ts
@@ -1,0 +1,103 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — consent disclosure copy.
+ *
+ * SINGLE SOURCE OF TRUTH for the legally-binding consent strings on the
+ * mingla-business buyer-checkout surface (S3). The §1b disclosure string is
+ * recorded VERBATIM into `consent_records.disclosure_text` (both scopes) at
+ * every grant — it is the legal burden-of-proof artifact backing the
+ * risk-accepted bundled-mandatory consent (DEC-186). DO NOT paraphrase.
+ *
+ * Copy authority (verbatim):
+ *   Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md
+ *     §1a — visible checkbox label
+ *     §1b — EXACT disclosure string (recorded)
+ *     §2  — full Terms & Conditions / consent sheet body
+ *
+ * The app-mobile consumer surface (S2) carries a byte-identical copy in
+ * `app-mobile/src/constants/consentDisclosure.ts` — the two cannot share a
+ * module (separate apps), so any edit MUST be mirrored in both (and re-record
+ * `disclosure_text`). DISCLOSURE_VERSION pins the wording for the audit trail.
+ */
+
+/**
+ * Pins the exact wording for the legal record. Bump ONLY when the §1b string or
+ * §2 body changes; the server stores both the version and the resolved text so
+ * the burden-of-proof artifact cannot drift with a stale client (DESIGN §6 / OQ-4).
+ */
+export const DISCLOSURE_VERSION = "2026-06-19" as const;
+
+/**
+ * §1b — the EXACT disclosure string recorded VERBATIM into
+ * `consent_records.disclosure_text` for BOTH scope='transactional' AND
+ * scope='marketing'. No paraphrase. (COPY §1b, all placeholders FILLED.)
+ */
+export const CONSENT_DISCLOSURE_TEXT =
+  "I agree to Mingla's Terms & Conditions and Privacy Policy, and I consent to receive from Mingla LLC and the businesses I book with: (1) transactional and account messages including booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, and payment notices; (2) event and reservation reminders for this booking and for future events; and (3) marketing and promotional messages, including offers and announcements from venues and experience brands. These messages may be sent by email, in-app notification, push notification, and recurring automated text message (SMS) to the phone number I provide. Message frequency varies. Msg & data rates may apply. Consent to texts is not a condition of any purchase. Reply STOP to any text to opt out, or HELP for help; you can also unsubscribe from email via the link in any message or change your preferences in the Mingla app at any time. Full terms: https://www.usemingla.com/terms-of-service | Privacy: https://www.usemingla.com/privacy-policy | SMS terms: https://www.usemingla.com/sms-terms.";
+
+/**
+ * §2 — the full Terms & Conditions / consent sheet body (verbatim, FILLED).
+ * Rendered in the T&C sheet opened from the underlined "all terms and
+ * conditions" link. Plain-language product copy; the linked ToS/Privacy remain
+ * the controlling documents.
+ */
+export const CONSENT_TERMS_BODY = `Mingla — Terms, Notifications & Consent
+
+Last updated: 2026-06-19
+
+By creating a Mingla account or completing a booking, you agree to these terms and to Mingla's full Terms of Service and Privacy Policy, which are incorporated here by reference. If you do not agree, do not create an account or complete a booking.
+
+1. Who you're agreeing with.
+Mingla is operated by Mingla LLC, 700 Corporate Center Dr, Raleigh, NC 27607, USA ("Mingla," "we," "us"). Questions: support@usemingla.com · +1 888-250-5351.
+
+2. What Mingla is — and is not.
+Mingla helps you discover places, events, experiences, and trips and connects you with venues and experience brands ("Businesses"). Mingla is a platform; the Businesses are independent third parties. Events, reservations, menus, prices, availability, and experiences are created and controlled by the Businesses, not by Mingla. Mingla does not own, operate, host, or supervise any venue, event, or experience, and is not a party to your agreement with a Business.
+
+3. No guarantee; you assume the risks of real-world activity.
+We work to keep listings accurate, but Mingla does not guarantee the accuracy, availability, quality, safety, legality, or outcome of any listing, event, reservation, experience, or Business, or that any event will occur as described. You attend events and experiences and visit venues at your own risk. You are responsible for your own conduct and safety and for evaluating any Business before you go.
+
+4. Third-party responsibility.
+Any dispute about an event, reservation, experience, refund, service, injury, or loss is between you and the relevant Business. Mingla is not responsible or liable for the acts, omissions, products, services, or content of any Business or other user. Where Mingla processes a payment, it does so as a technical facilitator; the Business remains the merchant of record for what it sells unless stated otherwise at checkout.
+
+5. Limitation of liability; release.
+To the fullest extent permitted by law, Mingla and its officers, employees, and partners are not liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss arising from your use of the app, any listing, any Business, or any event or experience. To the fullest extent permitted by law, you release Mingla from claims arising out of disputes with Businesses or other users or from your participation in any real-world activity discovered through Mingla. Mingla's total liability for any claim is limited to the greater of the amount you paid Mingla (not the Business) for the transaction at issue or the amount permitted by applicable law. Some jurisdictions do not allow certain limitations; where that applies, the limitation applies to the maximum extent permitted.
+
+6. Communications & consent — what you're signing up for.
+When you create an account or complete a booking and check the consent box, you agree to receive the following from Mingla and from the Businesses you book with:
+
+- Transactional & account messages — booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, payment notices, and account/security messages. These are required to use Mingla and are tied to your activity.
+- Reminders — reminders for the event, experience, trip, or reservation you book, and for future events you may be interested in.
+- Marketing & promotional messages — offers, announcements, new events, and promotions from Mingla and from venues and experience brands, including via marketing blasts.
+
+These may be delivered by email, in-app notification, push notification, and recurring automated text message (SMS) to the contact details you provide. Message frequency varies. Msg & data rates may apply. Consent to receive marketing texts is not a condition of any purchase.
+
+7. How to opt out.
+- Text (SMS): reply STOP to any text to stop texts, or HELP for help. We also honor quit, end, cancel, unsubscribe, revoke, and opt out.
+- Email: use the unsubscribe link in any marketing email.
+- In-app: open the Mingla app and adjust your notification preferences at any time, per channel and per category.
+- Outside the US: opt-out may also run through your local registry (for example, in Nigeria, the NCC DND service by texting STOP to 2442) and the in-app preference center.
+
+We honor opt-out requests received by any reasonable means and process them promptly (within the timeframes required by law). Opting out of marketing does not stop transactional or account messages, which are required to deliver what you booked. You may still receive a single confirmation message after you opt out.
+
+8. Data handling.
+We collect and use the contact details and information you provide (including your name, email, phone number, and country) to operate Mingla, deliver the messages above, process bookings and payments, prevent fraud, and improve the service, as described in our Privacy Policy. We share necessary booking details with the Business you book with so it can fulfill your reservation or order. We do not sell your personal information except as described in the Privacy Policy. Where required, our lawful basis for marketing is your consent, which you may withdraw at any time as described in section 7. We record the date, time, exact text of this disclosure, and your country at the time you consent, as proof of your consent.
+
+9. Payments, refunds & cancellations.
+Prices, fees, taxes, refund eligibility, and cancellation terms are set by the Business and shown at checkout. Refunds, where offered, are handled under the Business's policy and applicable law. Mingla is not obligated to issue refunds for a Business's products or services.
+
+10. Eligibility & acceptable use.
+You must be the age of majority in your location (and at least 18) to enter into these terms and to receive marketing messages. You agree to provide accurate information, to use Mingla lawfully, and not to misuse the platform or other users.
+
+11. Changes; governing law; contact.
+We may update these terms; material changes will be notified in-app or by email, and continued use means acceptance. These terms are governed by the laws of the State of North Carolina, USA. Disputes are resolved per the full Terms of Service (including any arbitration or venue clause stated there). Contact us at support@usemingla.com or 700 Corporate Center Dr, Raleigh, NC 27607, USA.
+
+Full Terms of Service: https://www.usemingla.com/terms-of-service · Privacy Policy: https://www.usemingla.com/privacy-policy · SMS Terms: https://www.usemingla.com/sms-terms`;
+
+/**
+ * §1a — the short visible label rendered next to the checkbox. The
+ * "[terms and conditions]" token is replaced by an underlined tappable link in
+ * the component; the surrounding text is rendered verbatim.
+ */
+export const CONSENT_VISIBLE_LABEL_PREFIX = "I agree to Mingla's ";
+export const CONSENT_VISIBLE_LABEL_LINK = "terms and conditions";
+export const CONSENT_VISIBLE_LABEL_SUFFIX =
+  " and to receive booking confirmations, reminders, account updates, and marketing from Mingla and the businesses I book with — by email, push, and text. Message frequency varies. Msg & data rates may apply. Reply STOP to opt out of texts, HELP for help.";

--- a/mingla-business/src/services/__tests__/consentDisclosureDrift.tester.orch1161.test.ts
+++ b/mingla-business/src/services/__tests__/consentDisclosureDrift.tester.orch1161.test.ts
@@ -1,0 +1,87 @@
+/**
+ * META-ORCH-1161 Sub-A.2 — TESTER adversarial regression test (different angle).
+ *
+ * The implementor's happy-path test (consentService.orch1161.test.ts) proves the
+ * service PASSES the constant THROUGH verbatim. It does NOT detect drift in the
+ * constant ITSELF: if a future edit paraphrases, truncates, or re-words
+ * CONSENT_DISCLOSURE_TEXT, that test still passes (it compares the call payload
+ * to the same — now-drifted — constant). The legal burden-of-proof artifact
+ * would silently degrade.
+ *
+ * This adversarial test PINS the constant to a FROZEN, char-for-char snapshot of
+ * the COPY §1b legal-authority string (length 1071), so ANY edit to the recorded
+ * disclosure text fails CI loudly — a true drift detector independent of the
+ * pass-through path.
+ *
+ * fails-on-revert: change a single character / truncate / paraphrase
+ * CONSENT_DISCLOSURE_TEXT in `consentDisclosure.ts` → this test FAILS.
+ *
+ * Authority: Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md §1b
+ * Contract:  SPEC §8.1 / DEC-186 / R-8 — disclosure_text recorded VERBATIM, no paraphrase.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  CONSENT_DISCLOSURE_TEXT,
+  CONSENT_TERMS_BODY,
+  CONSENT_VISIBLE_LABEL_LINK,
+  CONSENT_VISIBLE_LABEL_PREFIX,
+  CONSENT_VISIBLE_LABEL_SUFFIX,
+  DISCLOSURE_VERSION,
+} from "../../constants/consentDisclosure";
+
+// FROZEN snapshot of COPY §1b with all placeholders FILLED (Mingla LLC / URLs).
+// Char-for-char copy of the legal authority. Do NOT "fix" this to match a drifted
+// constant — if they diverge, the CONSTANT changed and that is the defect.
+const FROZEN_DISCLOSURE_1B =
+  "I agree to Mingla's Terms & Conditions and Privacy Policy, and I consent to receive from Mingla LLC and the businesses I book with: (1) transactional and account messages including booking and reservation confirmations, changes, cancellations, refunds, waitlist updates, and payment notices; (2) event and reservation reminders for this booking and for future events; and (3) marketing and promotional messages, including offers and announcements from venues and experience brands. These messages may be sent by email, in-app notification, push notification, and recurring automated text message (SMS) to the phone number I provide. Message frequency varies. Msg & data rates may apply. Consent to texts is not a condition of any purchase. Reply STOP to any text to opt out, or HELP for help; you can also unsubscribe from email via the link in any message or change your preferences in the Mingla app at any time. Full terms: https://www.usemingla.com/terms-of-service | Privacy: https://www.usemingla.com/privacy-policy | SMS terms: https://www.usemingla.com/sms-terms.";
+
+describe("META-ORCH-1161 Sub-A.2 — TESTER: disclosure-text drift guard (legal authority)", () => {
+  test("CONSENT_DISCLOSURE_TEXT is BYTE-IDENTICAL to the frozen COPY §1b string (no paraphrase, no truncation)", () => {
+    // Length first — catches truncation immediately with a clean diff.
+    expect(CONSENT_DISCLOSURE_TEXT.length).toBe(FROZEN_DISCLOSURE_1B.length);
+    expect(CONSENT_DISCLOSURE_TEXT.length).toBe(1071);
+    // Full byte-for-byte equality — catches ANY single-char paraphrase.
+    expect(CONSENT_DISCLOSURE_TEXT).toBe(FROZEN_DISCLOSURE_1B);
+  });
+
+  test("the recorded disclosure carries EVERY hard-required element (INVESTIGATE §3 / COPY §1b checklist)", () => {
+    const required = [
+      "Mingla LLC", // legal entity / sender identity
+      "transactional and account messages", // transactional scope
+      "marketing and promotional messages", // marketing scope
+      "recurring automated text message (SMS)", // SMS auto-dial disclosure
+      "Message frequency varies.", // frequency
+      "Msg & data rates may apply.", // rate disclosure
+      "Consent to texts is not a condition of any purchase.", // TCPA mitigation
+      "Reply STOP to any text to opt out, or HELP for help", // STOP/HELP
+      "https://www.usemingla.com/terms-of-service", // T&C URL
+      "https://www.usemingla.com/privacy-policy", // privacy URL
+      "https://www.usemingla.com/sms-terms.", // SMS terms URL + terminal period (no truncation)
+    ];
+    for (const element of required) {
+      expect(CONSENT_DISCLOSURE_TEXT).toContain(element);
+    }
+    // Must terminate exactly with the SMS-terms URL + period — proves no tail truncation.
+    expect(
+      CONSENT_DISCLOSURE_TEXT.endsWith(
+        "SMS terms: https://www.usemingla.com/sms-terms.",
+      ),
+    ).toBe(true);
+  });
+
+  test("supporting consent strings are non-empty and carry the legal entity + version pin", () => {
+    // §2 body must name the legal entity + address (burden-of-proof body).
+    expect(CONSENT_TERMS_BODY.length).toBeGreaterThan(1000);
+    expect(CONSENT_TERMS_BODY).toContain("Mingla LLC");
+    expect(CONSENT_TERMS_BODY).toContain("700 Corporate Center Dr, Raleigh, NC 27607");
+    // §1a visible label parts present + the underlined link token is the exact phrase.
+    expect(CONSENT_VISIBLE_LABEL_PREFIX.length).toBeGreaterThan(0);
+    expect(CONSENT_VISIBLE_LABEL_LINK).toBe("terms and conditions");
+    expect(CONSENT_VISIBLE_LABEL_SUFFIX).toContain("Reply STOP to opt out");
+    // Version pin is a non-empty constant (audit-trail anchor).
+    expect(typeof DISCLOSURE_VERSION).toBe("string");
+    expect(DISCLOSURE_VERSION.length).toBeGreaterThan(0);
+  });
+});

--- a/mingla-business/src/services/__tests__/consentService.orch1161.test.ts
+++ b/mingla-business/src/services/__tests__/consentService.orch1161.test.ts
@@ -1,0 +1,136 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — happy-path regression test.
+ *
+ * The implementor-owned happy path proves the load-bearing legal contract:
+ *   1. A checkout consent grant sends the EXACT §1b disclosure string VERBATIM
+ *      (the legal burden-of-proof artifact, DEC-186 / SPEC §8.1) to the shared
+ *      `record-consent` edge fn, with source='checkout' + both contacts + the
+ *      pinned disclosure version.
+ *   2. The Pay/Continue button is DISABLED until the bundled consent box is
+ *      checked AND fields are valid (DESIGN §S3.4 — never proceed unconsented).
+ *
+ * fails-on-revert:
+ *   - delete the `disclosureText: input.disclosureText` line in consentService →
+ *     the verbatim assertion fails.
+ *   - delete the `!params.termsAccepted` term in isContinueDisabled
+ *     (checkoutConsentGate.ts) → the "disabled until checked" assertion fails.
+ */
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+import { recordConsent } from "../consentService";
+import { supabase } from "../supabase";
+import {
+  CONSENT_DISCLOSURE_TEXT,
+  DISCLOSURE_VERSION,
+} from "../../constants/consentDisclosure";
+import { isContinueDisabled } from "../../components/checkout/checkoutConsentGate";
+
+jest.mock("../supabase", () => ({
+  supabase: {
+    functions: {
+      invoke: jest.fn(),
+    },
+  },
+}));
+
+const invokeMock = supabase.functions.invoke as unknown as jest.Mock<
+  (...args: unknown[]) => Promise<{ data: unknown; error: unknown }>
+>;
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue({
+    data: { ok: true, inserted: 4, deduped: 0 },
+    error: null,
+  });
+});
+
+describe("META-ORCH-1161 Sub-A.2 — consent capture (checkout)", () => {
+  test("records the EXACT §1b disclosure VERBATIM with source='checkout' + both contacts", async () => {
+    const result = await recordConsent({
+      source: "checkout",
+      disclosureText: CONSENT_DISCLOSURE_TEXT,
+      disclosureVersion: DISCLOSURE_VERSION,
+      phone: "+14155550123",
+      email: "Buyer@Example.com",
+      countryCode: "US",
+      userId: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const [fnName, opts] = invokeMock.mock.calls[0] as [
+      string,
+      { body: Record<string, unknown> },
+    ];
+    expect(fnName).toBe("record-consent");
+    // The disclosure string is the legal artifact — it must pass through VERBATIM,
+    // not paraphrased or truncated.
+    expect(opts.body.disclosureText).toBe(CONSENT_DISCLOSURE_TEXT);
+    // Sanity: the verbatim string carries the TCPA-mitigating sentence + STOP/HELP.
+    expect(opts.body.disclosureText).toContain(
+      "Consent to texts is not a condition of any purchase.",
+    );
+    expect(opts.body.disclosureText).toContain("Msg & data rates may apply.");
+    expect(opts.body.source).toBe("checkout");
+    expect(opts.body.phone).toBe("+14155550123");
+    expect(opts.body.email).toBe("Buyer@Example.com");
+    expect(opts.body.countryCode).toBe("US");
+    expect(opts.body.disclosureVersion).toBe(DISCLOSURE_VERSION);
+  });
+
+  test("returns ok=false (does NOT throw) when the edge fn errors — checkout must not deadlock", async () => {
+    invokeMock.mockResolvedValueOnce({
+      data: null,
+      error: { message: "boom" },
+    });
+    const result = await recordConsent({
+      source: "checkout",
+      disclosureText: CONSENT_DISCLOSURE_TEXT,
+      disclosureVersion: DISCLOSURE_VERSION,
+      phone: "+14155550123",
+      email: "buyer@example.com",
+      countryCode: "US",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("Pay/Continue is DISABLED until the bundled consent box is checked", () => {
+    // Fields valid, box UNCHECKED → disabled (the gate).
+    expect(
+      isContinueDisabled({
+        fieldsValid: true,
+        termsAccepted: false,
+        submitting: false,
+      }),
+    ).toBe(true);
+
+    // Fields valid, box CHECKED → enabled.
+    expect(
+      isContinueDisabled({
+        fieldsValid: true,
+        termsAccepted: true,
+        submitting: false,
+      }),
+    ).toBe(false);
+
+    // Box checked but fields invalid → still disabled.
+    expect(
+      isContinueDisabled({
+        fieldsValid: false,
+        termsAccepted: true,
+        submitting: false,
+      }),
+    ).toBe(true);
+
+    // Submitting always disables (no double-submit).
+    expect(
+      isContinueDisabled({
+        fieldsValid: true,
+        termsAccepted: true,
+        submitting: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/mingla-business/src/services/consentService.ts
+++ b/mingla-business/src/services/consentService.ts
@@ -1,0 +1,69 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — buyer-checkout consent writer.
+ *
+ * Calls the shared `record-consent` edge function (verify_jwt=false, anon-tolerant)
+ * to append the bundled-mandatory consent audit rows (DEC-186). One call writes a
+ * transactional AND a marketing `consent_records` row per provided channel/contact;
+ * the EXACT §1b disclosure string is recorded VERBATIM server-side, and ip_hash is
+ * computed from the request IP by the edge fn (never sent from the client).
+ *
+ * Non-blocking by contract at the call site: the buyer's purchase MUST NOT be
+ * blocked by a consent-audit write failure (the affirmative checkbox act already
+ * happened); the caller logs the error but proceeds. The legal record is the
+ * primary artifact, but losing it must not deadlock checkout — surfaced via the
+ * returned result so the caller can log/monitor.
+ */
+
+import { supabase } from "./supabase";
+
+export interface RecordConsentInput {
+  source: "checkout" | "onboarding";
+  /** EXACT §1b disclosure string the buyer saw (CONSENT_DISCLOSURE_TEXT). */
+  disclosureText: string;
+  /** Pins the disclosure wording version (DISCLOSURE_VERSION). */
+  disclosureVersion: string;
+  /** E.164 phone — produces the 'sms' consent rows. */
+  phone?: string | null;
+  /** Email — produces the 'email' consent rows. */
+  email?: string | null;
+  /** ISO-2 buyer country derived from the phone country at checkout. */
+  countryCode?: string | null;
+  /** The authenticated user id, when present (anon checkout = null). */
+  userId?: string | null;
+}
+
+export interface RecordConsentResult {
+  ok: boolean;
+  inserted: number;
+  deduped: number;
+}
+
+/**
+ * Records the bundled consent grant. Returns the write result; on failure it
+ * returns ok=false rather than throwing, so the caller can proceed with the
+ * purchase (the checkbox act already constitutes consent) while logging the gap.
+ */
+export const recordConsent = async (
+  input: RecordConsentInput,
+): Promise<RecordConsentResult> => {
+  const { data, error } = await supabase.functions.invoke("record-consent", {
+    body: {
+      source: input.source,
+      disclosureText: input.disclosureText,
+      disclosureVersion: input.disclosureVersion,
+      phone: input.phone ?? null,
+      email: input.email ?? null,
+      countryCode: input.countryCode ?? null,
+      userId: input.userId ?? null,
+    },
+  });
+  if (error) {
+    return { ok: false, inserted: 0, deduped: 0 };
+  }
+  const payload = (data ?? {}) as { inserted?: number; deduped?: number };
+  return {
+    ok: true,
+    inserted: payload.inserted ?? 0,
+    deduped: payload.deduped ?? 0,
+  };
+};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -234,6 +234,13 @@ verify_jwt = false
 [functions.rsvp-notify]
 verify_jwt = true
 
+# META-ORCH-1161 Sub-A.2 — record-consent is the SHARED bundled-consent writer
+# called by BOTH the consumer onboarding (authenticated) AND the anonymous buyer
+# checkout (anon), so verify_jwt=false (anon-tolerant). It writes consent_records
+# via the service-role client and computes ip_hash server-side. DEC-186.
+[functions.record-consent]
+verify_jwt = false
+
 # META-ORCH-1148 2.1b — send-venue-sms is the OPERATOR-triggered "table's ready"
 # waitlist SMS. verify_jwt=true: the gateway verifies the caller's user JWT; the
 # fn ADDITIONALLY gates on manager-plus brand membership, validates E.164, honors

--- a/supabase/functions/record-consent/index.ts
+++ b/supabase/functions/record-consent/index.ts
@@ -44,6 +44,40 @@ const corsHeaders = {
 
 const DEDUPE_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
 
+// META-ORCH-1161 Sub-A.2 (P2-1 hardening) — record-consent is an anon
+// (verify_jwt=false) write path: anyone can POST fabricated consent rows. The
+// dedupe above only blocks an IDENTICAL (contact,channel,scope,source) tuple,
+// so an attacker rotating distinct fabricated contacts bypasses it entirely.
+// This lightweight per-IP sliding-window throttle blunts the cheap-burst abuse
+// vector (audit-log pollution / cost-spam) without adding a JWT requirement
+// (the legit buyer/onboarding callers are anon). It is a per-instance in-memory
+// guard — see "Residual" in the rework note: it does not coordinate across
+// warm instances or survive a cold start, but it caps a single hot client's
+// burst, which is the realistic abuse shape. Fail-OPEN on a missing IP so a
+// legitimate caller behind a stripped header is never blocked.
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX_PER_WINDOW = 12; // a real grant is 1 call → 12/min is generous
+const rateBuckets = new Map<string, number[]>();
+
+/**
+ * Returns true when the caller (keyed by IP) is OVER the per-window cap.
+ * Prunes timestamps outside the window on each call so the map stays bounded
+ * for active keys. `null` IP → never rate-limited (fail-open, can't attribute).
+ */
+function isRateLimited(ipKey: string | null): boolean {
+  if (ipKey === null) return false;
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const hits = (rateBuckets.get(ipKey) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= RATE_LIMIT_MAX_PER_WINDOW) {
+    rateBuckets.set(ipKey, hits); // keep the pruned window; do NOT record this call
+    return true;
+  }
+  hits.push(now);
+  rateBuckets.set(ipKey, hits);
+  return false;
+}
+
 type ConsentSource =
   | "onboarding"
   | "checkout"
@@ -95,6 +129,24 @@ serve(async (req: Request): Promise<Response> => {
     return new Response(
       JSON.stringify({ error: "method_not_allowed" }),
       { status: 405, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  // META-ORCH-1161 Sub-A.2 (P2-1) — per-IP abuse guard BEFORE any parse/DB work
+  // so a burst is rejected as cheaply as possible.
+  const requestIp = clientIp(req);
+  if (isRateLimited(requestIp)) {
+    console.warn("[record-consent] rate-limited", { ip: requestIp });
+    return new Response(
+      JSON.stringify({ error: "rate_limited" }),
+      {
+        status: 429,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          "Retry-After": String(Math.ceil(RATE_LIMIT_WINDOW_MS / 1000)),
+        },
+      },
     );
   }
 
@@ -157,8 +209,7 @@ serve(async (req: Request): Promise<Response> => {
     "marketing",
   ];
 
-  const ip = clientIp(req);
-  const ipHash = ip !== null ? await hashIp(ip) : null;
+  const ipHash = requestIp !== null ? await hashIp(requestIp) : null;
   const countryCode =
     typeof body.countryCode === "string" && body.countryCode.trim().length > 0
       ? body.countryCode.trim().toUpperCase()

--- a/supabase/functions/record-consent/index.ts
+++ b/supabase/functions/record-consent/index.ts
@@ -1,0 +1,234 @@
+/**
+ * META-ORCH-1161 Sub-A.2 (consent-capture slice) — record-consent
+ *
+ * The SHARED, surface-agnostic consent writer for the bundled-mandatory consent
+ * gate (DEC-186). Both consent-capture surfaces call this one function:
+ *   - S2 consumer onboarding (app-mobile, source='onboarding', authenticated)
+ *   - S3 anon buyer checkout (mingla-business, source='checkout', anon)
+ *
+ * It appends `consent_records` rows via the service-role client (RLS is
+ * service-role-only for writes). For ONE grant it writes the cartesian product
+ * of {scope: transactional, marketing} × {provided channel/contact}:
+ *   - an 'sms'   row per provided phone (E.164)
+ *   - an 'email' row per provided email (lowercased)
+ * so a single bundled grant produces a transactional AND a marketing audit row
+ * per channel (DESIGN §6 / SPEC §8.1).
+ *
+ * The disclosure_text is recorded VERBATIM (the §1b string, the legal
+ * burden-of-proof artifact backing the risk-accepted bundling, R-8). The server
+ * also computes ip_hash from the request IP (web) — the client never sends it.
+ *
+ * Idempotent-ish: append-only audit is acceptable to duplicate, but to avoid
+ * spamming the table on retries/double-taps we dedupe on
+ * (contact, channel, scope, source) within a short window (DEDUPE_WINDOW_MS).
+ *
+ * verify_jwt = false (config.toml) — the checkout buyer is ANON; this is an
+ * anon-tolerant write path. It does NOT trust a client-supplied user_id beyond
+ * recording it; the legal record is keyed by contact + disclosure_text.
+ *
+ * Cross-refs:
+ *   SPEC:   Mingla_Artifacts/specs/SPEC_META-ORCH-1161_NOTIFICATION_MESSAGING_SYSTEM.md §5.1, §8.6
+ *   DESIGN: Mingla_Artifacts/design/ORCH-1161/DESIGN_META-ORCH-1161_SUBA_CONSENT_AND_PREFS_UX.md §6
+ *   COPY:   Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md §1b
+ */
+
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const DEDUPE_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+type ConsentSource =
+  | "onboarding"
+  | "checkout"
+  | "prefs_ui"
+  | "stop_keyword"
+  | "unsubscribe_link"
+  | "reservation";
+
+interface RecordConsentRequest {
+  source: ConsentSource;
+  /** EXACT §1b disclosure string the user saw — recorded VERBATIM. */
+  disclosureText: string;
+  /** Pins the disclosure wording version for the audit trail (DESIGN §6). */
+  disclosureVersion?: string;
+  /** The just-created user (S2) or NULL (anon checkout, S3). */
+  userId?: string | null;
+  /** E.164 phone — produces the 'sms' consent rows. */
+  phone?: string | null;
+  /** Email — lowercased, produces the 'email' consent rows. */
+  email?: string | null;
+  /** ISO-2 buyer country at grant (e.g. derived from the phone country). */
+  countryCode?: string | null;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+async function hashIp(ip: string): Promise<string> {
+  const data = new TextEncoder().encode(ip);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function clientIp(req: Request): string | null {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) {
+    const first = fwd.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get("x-real-ip");
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return new Response(
+      JSON.stringify({ error: "method_not_allowed" }),
+      { status: 405, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  let body: RecordConsentRequest;
+  try {
+    body = (await req.json()) as RecordConsentRequest;
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "invalid_json" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  const source = body.source;
+  const disclosureText = (body.disclosureText ?? "").trim();
+  if (!source || disclosureText.length === 0) {
+    return new Response(
+      JSON.stringify({ error: "source_and_disclosure_required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  // Normalize contacts. SMS rows key off the phone, email rows off the email.
+  const phone =
+    typeof body.phone === "string" && body.phone.trim().length > 0
+      ? body.phone.trim()
+      : null;
+  const email =
+    typeof body.email === "string" && EMAIL_REGEX.test(body.email.trim())
+      ? body.email.trim().toLowerCase()
+      : null;
+
+  if (phone === null && email === null) {
+    return new Response(
+      JSON.stringify({ error: "at_least_one_contact_required" }),
+      { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceKey) {
+    console.error("[record-consent] missing SUPABASE_URL / service key");
+    return new Response(
+      JSON.stringify({ error: "server_misconfigured" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  // Build the channel/contact pairs for this grant.
+  const channelContacts: Array<{ channel: "sms" | "email"; contact: string }> = [];
+  if (phone !== null) channelContacts.push({ channel: "sms", contact: phone });
+  if (email !== null) channelContacts.push({ channel: "email", contact: email });
+
+  const scopes: Array<"transactional" | "marketing"> = [
+    "transactional",
+    "marketing",
+  ];
+
+  const ip = clientIp(req);
+  const ipHash = ip !== null ? await hashIp(ip) : null;
+  const countryCode =
+    typeof body.countryCode === "string" && body.countryCode.trim().length > 0
+      ? body.countryCode.trim().toUpperCase()
+      : null;
+  const userId =
+    typeof body.userId === "string" && body.userId.length > 0
+      ? body.userId
+      : null;
+
+  const sinceIso = new Date(Date.now() - DEDUPE_WINDOW_MS).toISOString();
+  const toInsert: Array<Record<string, unknown>> = [];
+  let deduped = 0;
+
+  for (const { channel, contact } of channelContacts) {
+    for (const scope of scopes) {
+      // Dedupe: skip if an identical (contact, channel, scope, source) grant
+      // landed within the window (double-tap / retry guard).
+      const { data: recent, error: recentErr } = await admin
+        .from("consent_records")
+        .select("id")
+        .eq("contact", contact)
+        .eq("channel", channel)
+        .eq("scope", scope)
+        .eq("source", source)
+        .eq("action", "granted")
+        .gte("created_at", sinceIso)
+        .limit(1);
+      if (recentErr) {
+        console.error("[record-consent] dedupe query failed", recentErr);
+        return new Response(
+          JSON.stringify({ error: "consent_write_failed" }),
+          { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
+      if (recent && recent.length > 0) {
+        deduped += 1;
+        continue;
+      }
+      toInsert.push({
+        user_id: userId,
+        contact,
+        channel,
+        scope,
+        action: "granted",
+        source,
+        disclosure_text: disclosureText,
+        ip_hash: ipHash,
+        country_code: countryCode,
+      });
+    }
+  }
+
+  let inserted = 0;
+  if (toInsert.length > 0) {
+    const { data, error } = await admin
+      .from("consent_records")
+      .insert(toInsert)
+      .select("id");
+    if (error) {
+      console.error("[record-consent] insert failed", error);
+      return new Response(
+        JSON.stringify({ error: "consent_write_failed", detail: error.message }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+    inserted = data?.length ?? 0;
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, inserted, deduped, version: body.disclosureVersion ?? null }),
+    { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+  );
+});

--- a/supabase/migrations/20261110000005_orch_1161_seed_corrections.sql
+++ b/supabase/migrations/20261110000005_orch_1161_seed_corrections.sql
@@ -1,0 +1,40 @@
+-- META-ORCH-1161 Sub-A.2 (consent-capture slice) — seed corrections per DEC-185.
+--
+-- The thin-slice seed (20261110000001_orch_1161_seed_notification_categories.sql)
+-- omitted three SMS/email channels that the confirmed DEC-185 matrix (SPEC §5.2)
+-- requires for the closed SMS-eligible set:
+--   - buyer_refund_issued   : ADD 'sms'   (was {inapp,push,email})  → SPEC §5.2
+--   - buyer_order_cancelled : ADD 'sms'   (was {inapp,push,email})  → SPEC §5.2
+--   - payout_paid           : ADD 'email' (was {inapp,push,sms})    → SPEC §5.2
+--
+-- This brings the live seed into parity with the SPEC §5.2 matrix + the closed
+-- SMS-eligible set in §5.2 ("buyer_refund_issued, buyer_order_cancelled, ...,
+-- payout_paid"). These categories were already in the SMS-eligible enumeration;
+-- only the seed rows themselves lagged.
+--
+-- IDEMPOTENT: each statement is an UPDATE that re-derives default_channels from
+-- the current value, adding the missing channel ONLY when absent (array_append
+-- guarded by NOT (... = ANY(...))). Re-running is a no-op once corrected.
+--
+-- Cross-refs:
+--   SPEC:    Mingla_Artifacts/specs/SPEC_META-ORCH-1161_NOTIFICATION_MESSAGING_SYSTEM.md §5.2
+--   Decision: DEC-185 (channel matrix) in Mingla_Artifacts/DECISION_LOG.md
+--   Invariant: I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES (the seed IS the closed set)
+
+-- buyer_refund_issued → ensure 'sms' is present.
+UPDATE public.notification_categories
+   SET default_channels = array_append(default_channels, 'sms')
+ WHERE key = 'buyer_refund_issued'
+   AND NOT ('sms' = ANY(default_channels));
+
+-- buyer_order_cancelled → ensure 'sms' is present.
+UPDATE public.notification_categories
+   SET default_channels = array_append(default_channels, 'sms')
+ WHERE key = 'buyer_order_cancelled'
+   AND NOT ('sms' = ANY(default_channels));
+
+-- payout_paid → ensure 'email' is present (the single brand SMS already has sms).
+UPDATE public.notification_categories
+   SET default_channels = array_append(default_channels, 'email')
+ WHERE key = 'payout_paid'
+   AND NOT ('email' = ANY(default_channels));


### PR DESCRIPTION
## META-ORCH-1161 Sub-A.2 — consent-capture surface

Bundled-mandatory consent gate (DEC-186) on consumer onboarding + anonymous buyer checkout, building on the merged Sub-A foundation.

**What ships:**
- Consumer onboarding phone step: one mandatory "I agree to Mingla's terms and conditions…" consent box, underlined link → §2 Terms sheet, "Send code" disabled until checked.
- Buyer-web checkout (`buyer.tsx`): name/email/phone REQUIRED; mandatory "I agree to all terms and conditions" link → Terms sheet; Pay greyed until checked + valid; tapping greyed Pay surfaces red flash + "Please agree to continue." (no dead tap).
- `record-consent` edge fn (verify_jwt=false) writes verbatim §1b disclosure to `consent_records` (transactional + marketing scopes), with country + hashed IP; 12/min per-IP rate limit.
- Seed-correction migration `20261110000005` — per DEC-185: +sms on buyer_refund_issued/buyer_order_cancelled, +email on payout_paid.
- Shared Terms sheet rendering §2 verbatim (real Mingla LLC / 700 Corporate Center Dr, Raleigh NC 27607 / usemingla.com URLs / support@usemingla.com / +1 888-250-5351).

**QA:** mingla-tester RETEST CONDITIONAL PASS — CLEAR TO CLOSE (P0:0 P1:0). Disclosure verified byte-identical across app/web/copy-source; dual-scope write + seed migration proven on real Postgres; dead-tap fixed (fails-on-revert proven); rate-limit verified. Seth eyeballed the checkout consent screenshots and approved.

**SMS stays OFF** (kill-switch). Operator/CLOSE: apply migration 20261110000005, deploy record-consent from merged main.

Closes: META-ORCH-1161 Sub-A.2 consent-capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)