### PR TITLE
META-ORCH-1161: /sms-terms + /unsubscribe compliance pages + self-serve opt-out [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_COMPLIANCE_PAGES.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_COMPLIANCE_PAGES.md
@@ -1,0 +1,153 @@
+# IMPLEMENT — META-ORCH-1161 — COMPLIANCE-PAGES slice
+
+**ORCH:** META-ORCH-1161 (multi-channel notification & messaging system) — COMPLIANCE-PAGES slice
+**Phase:** mingla-implementor (single bounded pass)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[compliance-pages]/` on branch `ORCH-1161-compliance-pages` (based on origin/main, up to date)
+**Date:** 2026-06-20
+**Status:** implemented and verified (web build + deno tests green; live edge write is UNVERIFIED until deploy — see §9)
+
+---
+
+## 1. Summary
+
+Built the two marketing-site compliance pages Seth asked for plus the public opt-out backend they depend on:
+
+1. **`/sms-terms`** — a static SMS program-terms page (carrier/toll-free-verification grade), mirroring the existing `/terms-of-service` page structure + styling.
+2. **`/unsubscribe`** — a self-serve, no-login opt-out page: enter email and/or phone (E.164), choose "Marketing only" or "All messages", submit → suppressed immediately. Reads `?token=` (one-click email link) and pre-fills/uses the tokenized path server-side. Full idle/submitting/success/error/validation states.
+3. **`self-serve-unsubscribe`** edge function (new, `verify_jwt = false`) — accepts `{email?, phone?, scope, token?}`, validates, and writes BOTH `channel_suppressions` (per channel) AND legacy `marketing_unsubscribes` (global, for audience-resolver back-compat), idempotently, via the service role, behind a per-IP rate limit.
+
+No migration was needed — `channel_suppressions`, `marketing_unsubscribes`, and the `verifyUnsubscribeToken` helper all already exist on origin/main (Sub-A foundation + ORCH-0815-B).
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Evidence |
+|----|-----------|--------|----------|
+| SC-1 | `/sms-terms` renders compliant SMS program terms (identity, address, message types, frequency, "Msg & data rates may apply", STOP/HELP, support, links to ToS/Privacy/unsubscribe) | ✓ | `mingla-marketing/app/sms-terms/page.tsx` + `lib/smsTermsContent.ts`; build emits `○ /sms-terms`; all required elements present (§7 receipts) |
+| SC-2 | `/unsubscribe` self-serve form: email AND/OR phone + marketing-vs-all choice, POSTs to backend, success/error states, opt-out honored immediately stated, works standalone (no login) | ✓ | `mingla-marketing/app/unsubscribe/page.tsx` + `UnsubscribeForm.tsx`; build emits `○ /unsubscribe` (2.92 kB) |
+| SC-3 | `?token=` pre-fill / tokenized path | ✓ | `UnsubscribeForm` reads `useSearchParams().get('token')`; passes `token` to fn; fn calls `verifyUnsubscribeToken` and uses `recipient_email` |
+| SC-4 | Backend endpoint writes channel_suppressions (email row if email, sms row if phone; scope as chosen; reason='unsubscribe') AND marketing_unsubscribes, idempotent ON CONFLICT DO NOTHING, per-IP rate limit (~12/min fail-open), service-role | ✓ | `supabase/functions/self-serve-unsubscribe/{index,suppress}.ts`; behavioral test (§6); `[functions.self-serve-unsubscribe] verify_jwt=false` added to config.toml |
+| SC-5 (Step 0.5) | Test proves the endpoint writes both tables for email and phone, idempotently, fails-on-revert | ✓ | `suppress.test.ts` 6/6 green; fails-on-revert proven (§6) |
+
+---
+
+## 3. Files changed
+
+| File | Type | ~Lines |
+|------|------|--------|
+| `mingla-marketing/lib/smsTermsContent.ts` | new | 95 |
+| `mingla-marketing/app/sms-terms/page.tsx` | new | 160 |
+| `mingla-marketing/lib/unsubscribe-submit.ts` | new | 97 |
+| `mingla-marketing/app/unsubscribe/UnsubscribeForm.tsx` | new | 270 |
+| `mingla-marketing/app/unsubscribe/page.tsx` | new | 85 |
+| `supabase/functions/self-serve-unsubscribe/suppress.ts` | new | 165 |
+| `supabase/functions/self-serve-unsubscribe/index.ts` | new | 205 |
+| `supabase/functions/self-serve-unsubscribe/suppress.test.ts` | new (test) | 175 |
+| `supabase/config.toml` | edit (+10) | 10 |
+
+No existing product code modified (config.toml is append-only registration). No existing test modified/deleted (append-only rule honored).
+
+---
+
+## 4. Data-model changes applied
+
+NONE. No migration. Writes target existing tables:
+- `public.channel_suppressions` — `{user_id:null, contact, channel:'email'|'sms', scope:'marketing'|'all', reason:'unsubscribe', brand_id:null}`. All values CHECK-valid (verified against `20261110000000_orch_1161_notification_foundation_tables.sql`).
+- `public.marketing_unsubscribes` — `{contact_email|contact_phone (exactly one per CHECK), channel:'all', scope:'global', brand_id:null, account_id:null, reason:'self_serve_unsubscribe'}`. CHECK-valid; `channel='all'` so the audience resolver (`_shared/marketingAudience.ts`, which expands `'all'`→email+sms+rcs and filters `scope.eq.global`) honors it.
+
+---
+
+## 5. Edge functions touched
+
+| Function | verify_jwt | Note |
+|----------|-----------|------|
+| `self-serve-unsubscribe` | **false** (preserve) | NEW. Public/anon by design (CAN-SPAM: page must work with no login). Per-IP throttle + service-role write. Registered in config.toml. |
+
+Deploy from MERGED main (not the worktree). No other edge fn touched.
+
+---
+
+## 6. Regression test (implementor-owned happy-path)
+
+- **Path:** `supabase/functions/self-serve-unsubscribe/suppress.test.ts` (6 Deno tests).
+- **Command:** `deno test --allow-read supabase/functions/self-serve-unsubscribe/` → `ok | 6 passed | 0 failed`.
+- **Coverage:** email-only writes channel_suppressions(email)+marketing_unsubscribes(email) with exact CHECK-valid row shapes; phone-only writes channel_suppressions(sms)+marketing_unsubscribes(phone); email+phone writes all 4 rows; idempotent (all-keys-conflict → 0 new rows, reported as already-suppressed, 200-equivalent); non-unique DB error throws (no silent failure); `isUniqueViolation` unit.
+- **fails-on-revert verified at `a5d4a03c2bfa84839dff5c9ce2409caf2dc1767e`** (HEAD before the slice commit): true line-deletion of the `marketing_unsubscribes` write loop in `suppress.ts` → 4 of 6 tests FAILED; restoring the loop → 6/6 PASS again. (Deletion, not comment-out.)
+
+---
+
+## 7. Old → New receipts
+
+### supabase/functions/self-serve-unsubscribe/ (new)
+**Before:** no public no-login opt-out endpoint existed; only the tokenized one-click `marketing-unsubscribe` (requires a signed email token) and the in-app/STOP paths.
+**Now:** a public fn accepts a typed email/phone + scope (and optionally a token), validates (email regex, E.164 regex, scope allowlist), and writes both suppression models via the service role, idempotently, behind a 12/min per-IP fail-open throttle mirroring `record-consent`.
+**Why:** SC-4 / COPY §4 §5.1 — the CAN-SPAM footer + consent line reference `https://www.usemingla.com/unsubscribe`, which must actually suppress for anyone, with no login.
+
+### mingla-marketing/app/sms-terms/ (new)
+**Before:** route 404'd; COPY §5.1 flagged `/sms-terms` as a page-to-create; consent line referenced a dead URL.
+**Now:** static program-terms page (9 sections) with Mingla LLC identity + 700 Corporate Center Dr address + support@usemingla.com + +1 888-250-5351, message types, "Message frequency varies", "Msg & data rates may apply", STOP/HELP, carrier-liability + privacy language, and footer links to ToS/Privacy/Unsubscribe.
+**Why:** SC-1 / COPY §5.1 — often required for carrier/toll-free verification.
+
+### mingla-marketing/app/unsubscribe/ (new)
+**Before:** route 404'd; COPY §5.1 page-to-create; CAN-SPAM footer + email unsubscribe links had no destination.
+**Now:** server shell (matches the ToS page chrome) wrapping a `'use client'` form in `<Suspense>` (lets the route prerender statically despite `useSearchParams`). Form: email + phone inputs (inline validation), marketing/all radios, submit→`self-serve-unsubscribe`, success state ("You're opted out … honored immediately"), distinct error copy per failure (validation / invalid_token / rate_limited / server / network), reads `?token=`.
+**Why:** SC-2/SC-3 / COPY §4 §5.1.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected? | Detail |
+|---------|-----------|--------|
+| Consumer iOS | No | marketing-site + edge fn only |
+| Consumer Android | No | same |
+| Buyer/anon Web (mingla-business) | No | separate app; the CAN-SPAM footer links here but is authored elsewhere |
+| Business iOS | No | — |
+| Business Android | No | — |
+| Admin Web | No | — |
+| **Marketing Web (mingla-marketing)** | **YES** | two new public routes `/sms-terms`, `/unsubscribe`; deploys via Vercel `[deploy]` |
+| **Backend (supabase edge)** | **YES** | new `self-serve-unsubscribe` fn; deploys from merged main |
+
+Parity: automatic — single marketing app, single edge fn. No manual multi-surface mirroring.
+
+---
+
+## 9. Smoke result / verification matrix
+
+- **Marketing app typecheck:** `npm run typecheck` (tsc --noEmit) → clean, whole app incl. 4 new files.
+- **Marketing app production build:** `npm run build` → ✓ Compiled successfully; `○ /sms-terms` (175 B) and `○ /unsubscribe` (2.92 kB) both prerendered; 12/12 static pages generated.
+- **Edge fn typecheck:** `deno check` on `index.ts` and `suppress.ts` → both Check OK.
+- **Edge fn tests:** `deno test` → 6/6 pass; fails-on-revert proven (§6).
+- **Strict-grep gates:** `orch-0847-marketing-opt-in-default-unchecked`, `orch-0863-marketing-hub-phase-b`, `i-proposed-1161-sms-from-approved-sender-and-kill-switch` → all PASS.
+- **UNVERIFIED (needs deploy):** the live edge write to the real DB (no live-fire against the deployed fn yet). The behavioral test proves the write LOGIC with a fake client + asserts CHECK-valid row shapes against the real DDL; the live round-trip is for the tester post-deploy. `lint` (next lint) is interactive-unconfigured in this repo and was not run; typecheck + build cover the same surface.
+
+---
+
+## 10. Known issues / deferred (backlog for orchestrator)
+
+- **Notification-preferences matrix UI** — OUT OF SCOPE (Sub-A prefs UI). Not built.
+- **Sub-C moments** (reminders cron, purchase push) and **Sub-B marketing SMS send** — OUT OF SCOPE.
+- **In-app preference center deep-link** — the success copy points opted-out users to `support@usemingla.com`; an in-app "manage preferences" deep-link can be added when the prefs UI ships.
+- **Live-fire DB round-trip** — defer to tester after the fn is deployed (verify a real `channel_suppressions` + `marketing_unsubscribes` row lands for a test email/phone, and that a re-submit is idempotent).
+- No `[TRANSITIONAL]` code introduced.
+
+---
+
+## 11. Operator action required
+
+1. **Deploy the edge function from MERGED main** (NOT the worktree):
+   ```bash
+   cd /Users/sethogieva/Desktop/mingla-main && /Users/sethogieva/bin/supabase functions deploy self-serve-unsubscribe
+   ```
+   Preserve `verify_jwt = false` (already in config.toml). It requires `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (already set for the project) and, for the tokenized path, the existing `UNSUBSCRIBE_TOKEN_SECRET`.
+2. **Deploy the marketing pages via Vercel** — these ship on a `[deploy]`-tagged commit to main (mind the Vercel `[deploy]`-gate cancel trap: if a non-`[deploy]` commit lands after, push an empty `[deploy]` commit). Confirm `NEXT_PUBLIC_SUPABASE_FUNCTIONS_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set in the Vercel env (they are, per `.env.example` defaults).
+3. **No migration to push** — none was added.
+
+---
+
+## 12. Discoveries for Orchestrator
+
+- **COMMS scan:** no BLOCK+OPEN row addressed to mingla-implementor / ORCH-1161 / ALL. The open WARN-to-ALL rows (RSVP-page standardization 0040/0041, Stripe seller copy 0021, etc.) do not touch the marketing `/sms-terms` `/unsubscribe` routes or the unsubscribe edge fn. No new COMMS entry warranted.
+- **Two suppression models coexist** (`channel_suppressions` new + `marketing_unsubscribes` legacy). This slice writes BOTH per the dispatch. When Sub-B/C migrate the send-path fully onto `channel_suppressions`, the legacy `marketing_unsubscribes` write here can be retired — flag for that ORCH.
+- **`marketing_unsubscribes` CHECK forbids both contacts in one row** — handled by splitting into one row per contact. Anyone extending this table must respect that constraint.

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1161_COMPLIANCE_PAGES.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1161_COMPLIANCE_PAGES.md
@@ -1,0 +1,125 @@
+# TEST — META-ORCH-1161 — COMPLIANCE-PAGES slice
+
+**ORCH:** META-ORCH-1161 — COMPLIANCE-PAGES slice (`/sms-terms` + `/unsubscribe` + `self-serve-unsubscribe` edge fn)
+**Skill:** mingla-tester (canonical TEST owner)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[compliance-pages]/` on branch `ORCH-1161-compliance-pages`
+**HEAD tested:** `10df8081f` (dispatch named `495c1f297`; `10df8081f` is the rebased-on-main sibling with byte-identical slice content — see note below)
+**Date:** 2026-06-20
+
+---
+
+## 1. Verdict
+
+**CONDITIONAL PASS** — 0 P0 · 0 P1 · 0 P2 · 1 P3 · 2 P4.
+
+CLEAR-TO-CLOSE after merge, with ONE post-deploy confirmation the orchestrator must perform (the live edge-fn round-trip — explicitly a post-deploy step per the dispatch, NOT a pre-merge blocker). The single non-blocking condition is the post-deploy live-fire; no P1/P2 defects exist, so this is a clean conditional gated only on the deploy step the dispatch already carved out.
+
+**Commit note (non-defect):** the dispatch cites `495c1f297`; the worktree HEAD is `10df8081f`. Verified `git cat-file` content of both: same slice, `10df8081f` is `495c1f297` rebased on top of `00710f41b` (RSVP) + `a5d4a03c2` (consent). The slice files are identical. Tested against HEAD `10df8081f`.
+
+**Exemption posture:** the marketing pages are web-static (no interactive runtime state machine beyond the form, which I exercised by source + build-prerender + transport trace); the edge fn + DB writes are backend-only → source + live-Postgres evidence is the correct evidence class. No simulator surface (no app-mobile / business-app change). Live device matrix N/A; live edge round-trip deferred to post-deploy per dispatch.
+
+---
+
+## 2. SC-by-SC matrix
+
+| SC | Criterion | Verdict | Evidence |
+|----|-----------|---------|----------|
+| SC-1 | `/sms-terms` renders compliant SMS program terms (Mingla LLC identity, address, msg types, frequency, "Msg & data rates may apply", STOP/HELP, support, ToS/Privacy/unsubscribe links) | **PASS** | `lib/smsTermsContent.ts` 9 sections — Mingla LLC + "700 Corporate Center Dr, Raleigh, NC 27607" + support@usemingla.com + +1 888-250-5351 + msg types + "Message frequency varies" + "Msg & data rates may apply" + STOP(+QUIT/END/CANCEL/UNSUBSCRIBE/REVOKE/OPT OUT) + HELP + carrier-liability + privacy/terms; page links to /sms-terms/privacy/terms. Build prerenders `○ /sms-terms` (106kB). |
+| SC-2 | `/unsubscribe` self-serve form: email AND/OR phone + marketing-vs-all, POSTs to backend, success/error/validation states, "honored immediately" stated, works no-login | **PASS** | `UnsubscribeForm.tsx` — email+phone inputs (inline EMAIL/E.164 validation, aria-invalid), marketing/all radios, submit→`submitUnsubscribe`, idle/submitting/success/error states, distinct error copy per failure (validation/invalid_token/rate_limited/server/network), "honored immediately" success + footer copy, no `useAuth`. Build prerenders `○ /unsubscribe` (115kB). |
+| SC-3 | `?token=` pre-fill / tokenized one-click path | **PASS** | Form reads `useSearchParams().get('token')`, passes it to the fn; with a token present `hasContact=true` so no typed contact is needed (one-click works). Edge fn `verifyUnsubscribeToken(token)` → uses `recipient_email` (lowercased) when no typed email; bad token + no contact → `invalid_token` (page falls back to manual form). |
+| SC-4 | Backend writes channel_suppressions (email row if email, sms row if phone, scope-as-chosen, reason='unsubscribe') AND marketing_unsubscribes (one row per contact, scope='global', channel='all'), idempotent, per-IP rate limit fail-open, service-role | **PASS** | `suppress.ts` writes exactly those rows. **Verified against LIVE Postgres** that every value is CHECK-valid: `channel_suppressions` channel∈{email,sms}, scope∈{transactional,marketing,all}, reason∈{...,unsubscribe}; `marketing_unsubscribes` channel∈{...,all}, scope∈{...,global}, "exactly one of email/phone" CHECK + scope='global'⇒brand/account NULL CHECK. Idempotency via real unique indexes `channel_suppressions_uniq_idx` + `uq_unsub_email_channel_scope` + `uq_unsub_phone_channel_scope` → 23505 tolerated. Rate limit 12/min per-IP sliding window, fail-OPEN on null IP (index.ts:55-67), runs BEFORE parse/DB. |
+| SC-5 | Test proves both-table write for email + phone, idempotent, fails-on-revert | **PASS** | `suppress.test.ts` 6/6 green; fails-on-revert independently re-run (§4). |
+
+---
+
+## 3. Findings
+
+### P3-1 — `console.warn` on rate-limit logs the raw client IP (PII-adjacent)
+**Evidence:** `index.ts:107` `console.warn("[self-serve-unsubscribe] rate-limited", { ip: requestIp })`.
+**Impact:** raw IP in edge logs. Low — operational logs, short retention, no user-facing exposure; matches the `record-consent` precedent. Not a blocker.
+**Required fix (optional):** hash/truncate the IP in the log line, or drop the `ip` field.
+**Retest:** grep the deployed fn log line.
+
+### P4-1 (praise) — Idempotency designed against the REAL unique indexes
+The COALESCE-based `channel_suppressions_uniq_idx` (`(COALESCE(user_id,contact),channel,scope,COALESCE(brand_id,'global'))`) means a re-submit of the same anon contact/channel/scope collides → 23505 → counted as `alreadySuppressed`, returns 200. Verified the index expression matches the written row shape exactly. Clean Constitution-#3 posture: non-unique errors throw (no silent failure), unique violations are tolerated.
+
+### P4-2 (praise) — Email lowercasing closes a real case-mismatch suppression bypass
+`index.ts` lowercases the email on BOTH the typed-email (`:134`) and token-recipient (`:144`) paths, and `can_send()` matches `s.contact = lower(p_contact)`. I proved on live Postgres (§5) that this is load-bearing: a mixed-case stored contact would let a normalized-case send slip through. Correctly fenced.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+- Checked out worktree HEAD `10df8081f`. Ran `deno test --allow-read supabase/functions/self-serve-unsubscribe/` → **`ok | 6 passed | 0 failed`**.
+- **True line-deletion** of the `for (const row of legacyRows) { ... }` marketing_unsubscribes write loop in `suppress.ts` (deletion, not comment-out) → re-ran tests → **`FAILED | 2 passed | 4 failed`** (the email-only, phone-only, email+phone, and idempotent tests fail at their row-shape assertions). Restored the file → `git diff` empty (clean). **Implementor's fails-on-revert claim independently CONFIRMED** at `10df8081f`.
+
+---
+
+## 5. Adversarial test added (tester-owned, different angle)
+
+- **Angle:** email-case-mismatch suppression **bypass** — an angle the implementor's happy-path suite did not cover.
+- **Live-Postgres proof (read-only, BEGIN/ROLLBACK):**
+  - Edge-fn behavior (lowercased contact stored) → `can_send(NULL,'buyer_event_reminder','email','Adversary@Example.COM')` = **false** AND for the lowercased address = **false** → suppression honored for ANY casing. ✓
+  - Regression sim (lowercasing removed → mixed-case `Adversary@Example.COM` stored) → `can_send(...,'adversary@example.com')` = **true** (NOT suppressed) → the opted-out user still receives mail = the **BYPASS**. ✓ proven.
+  - (Side discovery, §7) `can_send` returns false for any non-transactional category with a NULL user even with no suppression row — the marketing anon-send path relies on the `marketing_unsubscribes` audience resolver, not `can_send`. The resolver lowercases both the unsub email (`marketingAudience.ts:214`) and the buyer email (`:240`) → case-insensitive there too.
+- **Test path:** `supabase/functions/self-serve-unsubscribe/case_bypass.test.ts` (NEW, append-only). Two asserts: (1) writer stores `contact` verbatim → proves normalization MUST be upstream; (2) `index.ts` lowercases on BOTH email-resolution paths (the actual bypass fence).
+- **fails-on-revert verified at `10df8081f`:** removed `.toLowerCase()` from both `index.ts` email lines → adversarial test → **`FAILED | 1 passed | 1 failed`** (the enforcement-guard assertion fails). Restored → `git diff` empty; test → 2/2 pass.
+- **In closing diff:** confirmed both `suppress.test.ts` and `case_bypass.test.ts` appear in `git diff main...HEAD --name-only`. Adversarial test committed to the branch.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|------|---------|----------|
+| 1 | No dead taps | PASS | Opt-out button wired→`submitUnsubscribe`; disabled only when no valid contact/submitting. |
+| 2 | One owner per truth | PASS | `suppress.ts` is the SOLE DB-write path; index.ts only validates/normalizes. |
+| 3 | No silent failures | PASS | Non-unique DB error throws→500; bad token w/no contact→`invalid_token`; missing env→`server_misconfigured`; unique violation correctly tolerated (not a failure). |
+| 4 | One query key per entity | N/A | No React Query. |
+| 5 | Server state stays server-side | PASS | Form uses local `useState` for form fields only. |
+| 6 | Logout clears everything | N/A | Anon/no-login by design. |
+| 7 | `[TRANSITIONAL]` labeled | N/A | None introduced. |
+| 8 | Subtract before adding | PASS | No migration; reuses existing tables + token helper. |
+| 9 | No fabricated data | PASS | Real Mingla LLC identity/address/phone; no placeholders. |
+| 10 | Currency-aware | N/A | No money. |
+| 11 | One auth instance | PASS | Marketing app uses raw fetch + anon key; no Supabase client/auth. |
+| 12 | Validate at right time | PASS | E.164 + email regex client AND server; scope allowlist server-side. |
+| 13 | Exclusion consistency | PASS | Writes BOTH suppression models so every send-path (can_send + audience resolver) honors the opt-out, case-insensitively. |
+| 14 | Persisted-state startup | N/A | No hydration gate. |
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Note |
+|---------|---------|------|
+| Consumer iOS | N/A | not touched |
+| Consumer Android | N/A | not touched |
+| Buyer/anon Web (mingla-business) | N/A | separate app; CAN-SPAM footer links here but authored elsewhere |
+| Business iOS / Android | N/A | not touched |
+| Admin Web | N/A | not touched |
+| **Marketing Web (mingla-marketing)** | **PASS (build/prerender)** | `npm run build` ✓ Compiled successfully; `○ /sms-terms` + `○ /unsubscribe` prerendered static; no `--clear` needed (the prior 1161 web-export gotcha did not recur). Runtime form behavior traced by source; live Vercel render = post-deploy. |
+| **Backend (supabase edge)** | **PASS (logic) / NOT-YET-DEPLOYED** | `list_edge_functions` shows only legacy `marketing-unsubscribe` deployed; `self-serve-unsubscribe` not yet live. `verify_jwt=false` correctly set in config.toml:294-295 (public no-login path; fn self-validates — worst-case abuse is suppressing a contact = self-harm, low risk, rate-limited). |
+
+**No-regression to existing fns:** `git diff main...HEAD` does NOT touch `marketing-unsubscribe`, `marketingAudience.ts`, or `marketingTokens.ts` — all untouched. Legacy tokenized unsubscribe + audience resolver unaffected.
+
+---
+
+## 8. Discoveries for Orchestrator
+
+1. **Post-deploy live-fire (REQUIRED before declaring the page live, NOT a merge blocker):** after deploying `self-serve-unsubscribe` from MERGED main, POST a test `{email}` and `{phone}` → confirm one `channel_suppressions` row (lowercased contact) + one `marketing_unsubscribes` row each land; re-POST → 200 with `already_suppressed>0` and no dup rows; load the live `/unsubscribe` + `/sms-terms` on Vercel.
+2. **`can_send` is opt-IN for anon marketing:** a NULL-user non-transactional category returns false regardless of suppression rows. The anon marketing SEND path therefore depends on the `marketing_unsubscribes` audience resolver, which this slice writes correctly (scope='global', channel='all', lowercased). Confirm Sub-B's blast send-path actually consults the resolver (out of this slice's scope).
+3. **Two suppression models coexist** (`channel_suppressions` + legacy `marketing_unsubscribes`); the implementor flagged the legacy write can be retired when Sub-B/C fully migrate the send path. Track for that ORCH.
+4. **P3-1** raw-IP log line — optional hardening.
+
+---
+
+## 9. Accepted conditions (CONDITIONAL PASS)
+
+- **C-1 (post-deploy, dispatch-carved-out):** live edge-fn round-trip + live Vercel page render — orchestrator performs after merge+deploy. NOT a P1/P2; explicitly a post-deploy confirmation per the dispatch. No defect blocks merge.
+
+---
+
+## 10. Comms ledger
+
+Read `COMMS_LEDGER.md` on entry. No BLOCK+OPEN row addressed to mingla-tester / ORCH-1161 / ALL. The open WARN-to-ALL row COMMS-0040 (RSVP-page standardization) does not touch `/sms-terms`, `/unsubscribe`, or the unsubscribe edge fn. No ack required; no new entry warranted (FYI only, as expected by the dispatch).

--- a/mingla-marketing/app/sms-terms/page.tsx
+++ b/mingla-marketing/app/sms-terms/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SMS_TERMS_SECTIONS, SMS_TERMS_EFFECTIVE_DATE } from '@/lib/smsTermsContent'
+import { cn } from '@/lib/cn'
+
+export const metadata: Metadata = {
+  title: 'SMS Terms',
+  description:
+    'Mingla’s SMS messaging program terms — message types, frequency, rates, and how to reply STOP to opt out or HELP for help.',
+}
+
+export default function SmsTermsPage() {
+  return (
+    <main
+      id="main"
+      className="relative min-h-screen overflow-hidden bg-[#08090b] px-5 py-8 text-text-primary sm:px-8 sm:py-10"
+    >
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_18%_12%,rgba(235,120,37,0.18),transparent_32%),radial-gradient(ellipse_at_84%_18%,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#08090b_0%,#0d0d10_58%,#07080a_100%)]" />
+        <div className="absolute inset-0 opacity-[0.09] [background-image:linear-gradient(rgba(235,120,37,0.22)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.14)_1px,transparent_1px)] [background-size:72px_72px]" />
+        <div className="absolute left-[-18%] top-[12%] h-[34rem] w-[70%] rotate-[-14deg] rounded-[50%] border border-dashed border-warm/20" />
+        <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-black to-transparent" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-3xl">
+        <Link
+          href="/"
+          className="mb-8 inline-flex w-fit min-h-10 items-center rounded-full border border-white/12 bg-white/8 px-4 text-sm font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+        >
+          Back to Mingla
+        </Link>
+
+        <article className="rounded-[28px] border border-white/12 bg-[#0d0d10]/94 p-6 shadow-[0_40px_120px_rgba(0,0,0,0.52),inset_0_1px_0_rgba(255,255,255,0.08)] sm:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-warm">
+            Effective Date: {SMS_TERMS_EFFECTIVE_DATE}
+          </p>
+          <h1 className="mt-3 font-display text-4xl leading-tight text-white sm:text-6xl">
+            SMS Terms
+          </h1>
+          <p className="mt-4 text-sm leading-7 text-white/72 sm:text-base">
+            By providing your phone number to Mingla, you agree to the terms of
+            our SMS messaging program described below. Reply{' '}
+            <span className="font-semibold text-white/95">STOP</span> to any text
+            to opt out, or <span className="font-semibold text-white/95">HELP</span>{' '}
+            for help.
+          </p>
+
+          <div className="mt-8 space-y-6">
+            {SMS_TERMS_SECTIONS.map((section) => {
+              const hasContact = 'contact' in section
+
+              return (
+                <section
+                  key={section.title}
+                  className={cn(
+                    'space-y-3',
+                    hasContact &&
+                      'rounded-3xl border border-warm/25 bg-warm/10 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
+                  )}
+                >
+                  <h2 className="font-display text-xl leading-tight text-white/95 sm:text-2xl">
+                    {section.title}
+                  </h2>
+                  <div className="space-y-3 text-sm leading-7 text-white/72 sm:text-base">
+                    {section.paragraphs.map((paragraph) => (
+                      <p key={paragraph}>{paragraph}</p>
+                    ))}
+                    {'bullets' in section ? (
+                      <ul className="space-y-2 pl-5">
+                        {section.bullets.map((bullet) => (
+                          <li key={bullet} className="list-disc marker:text-warm/80">
+                            {bullet}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                    {hasContact ? (
+                      <div className="space-y-3 rounded-2xl border border-white/12 bg-black/20 p-4 text-white/82">
+                        <p className="font-semibold text-white">
+                          {section.contact.name}
+                        </p>
+                        <p>{section.contact.address}</p>
+                        <p>
+                          Email:{' '}
+                          <a
+                            href={`mailto:${section.contact.email}`}
+                            className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                          >
+                            {section.contact.email}
+                          </a>
+                        </p>
+                        <p>
+                          Phone:{' '}
+                          <a
+                            href={`tel:${section.contact.phone.replace(/[^+\d]/g, '')}`}
+                            className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                          >
+                            {section.contact.phone}
+                          </a>
+                        </p>
+                        <p>
+                          Website:{' '}
+                          <a
+                            href={section.contact.website}
+                            className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+                          >
+                            {section.contact.website}
+                          </a>
+                        </p>
+                      </div>
+                    ) : null}
+                  </div>
+                </section>
+              )
+            })}
+          </div>
+
+          <div className="mt-8 flex flex-wrap gap-3 border-t border-white/10 pt-6 text-sm">
+            <Link
+              href="/terms-of-service"
+              className="inline-flex min-h-10 items-center rounded-full border border-white/14 bg-white/8 px-4 font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+            >
+              Terms of Service
+            </Link>
+            <Link
+              href="/privacy-policy"
+              className="inline-flex min-h-10 items-center rounded-full border border-white/14 bg-white/8 px-4 font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="/unsubscribe"
+              className="inline-flex min-h-10 items-center rounded-full border border-warm/30 bg-warm/12 px-4 font-semibold text-warm transition hover:bg-warm/20 focus-ring"
+            >
+              Unsubscribe / manage messages
+            </Link>
+          </div>
+        </article>
+      </div>
+    </main>
+  )
+}

--- a/mingla-marketing/app/unsubscribe/UnsubscribeForm.tsx
+++ b/mingla-marketing/app/unsubscribe/UnsubscribeForm.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { cn } from '@/lib/cn'
+import {
+  submitUnsubscribe,
+  type UnsubscribeSubmitResult,
+} from '@/lib/unsubscribe-submit'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const PHONE_REGEX = /^\+[1-9]\d{6,14}$/
+
+type Status = 'idle' | 'submitting' | 'success' | 'error'
+
+const ERROR_COPY: Record<
+  Exclude<UnsubscribeSubmitResult & { ok: false }, never>['error'],
+  string
+> = {
+  validation:
+    'Enter a valid email address or a phone number in international format (e.g. +19195551234).',
+  invalid_token:
+    'That one-click link is invalid or expired. Enter your email or phone below and we’ll opt you out.',
+  rate_limited: 'Too many attempts. Wait a minute and try again.',
+  server:
+    'Something went wrong on our end. Email support@usemingla.com and we’ll honor your opt-out manually.',
+  network:
+    'We couldn’t reach our servers. Check your connection and try again, or email support@usemingla.com.',
+}
+
+export function UnsubscribeForm() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token') ?? ''
+
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [scope, setScope] = useState<'marketing' | 'all'>('marketing')
+  const [status, setStatus] = useState<Status>('idle')
+  const [errorKey, setErrorKey] = useState<
+    keyof typeof ERROR_COPY | null
+  >(null)
+  const [successScope, setSuccessScope] = useState<'marketing' | 'all'>(
+    'marketing',
+  )
+
+  const trimmedEmail = email.trim()
+  const trimmedPhone = phone.trim()
+  const emailValid = trimmedEmail.length === 0 || EMAIL_REGEX.test(trimmedEmail)
+  const phoneValid = trimmedPhone.length === 0 || PHONE_REGEX.test(trimmedPhone)
+  // With a token present, the email is filled server-side, so no typed contact
+  // is required. Without a token, at least one valid contact must be entered.
+  const hasContact =
+    token.length > 0 ||
+    (trimmedEmail.length > 0 && EMAIL_REGEX.test(trimmedEmail)) ||
+    (trimmedPhone.length > 0 && PHONE_REGEX.test(trimmedPhone))
+  const canSubmit =
+    status !== 'submitting' && hasContact && emailValid && phoneValid
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setStatus('submitting')
+    setErrorKey(null)
+
+    const result = await submitUnsubscribe({
+      ...(trimmedEmail.length > 0 ? { email: trimmedEmail } : {}),
+      ...(trimmedPhone.length > 0 ? { phone: trimmedPhone } : {}),
+      ...(token.length > 0 ? { token } : {}),
+      scope,
+    })
+
+    if (result.ok) {
+      setSuccessScope(result.scope)
+      setStatus('success')
+      return
+    }
+    setErrorKey(result.error)
+    setStatus('error')
+  }
+
+  if (status === 'success') {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="rounded-2xl border border-warm/30 bg-warm/10 p-5 text-white/85"
+      >
+        <p className="font-display text-xl text-white">You’re opted out.</p>
+        <p className="mt-2 text-sm leading-7 text-white/76 sm:text-base">
+          {successScope === 'all'
+            ? 'You won’t receive marketing or non-essential messages from Mingla or the businesses you’ve booked with anymore.'
+            : 'You won’t receive marketing messages from Mingla or the businesses you’ve booked with anymore. You may still get essential messages about bookings you make (confirmations, changes, refunds).'}
+        </p>
+        <p className="mt-3 text-sm leading-7 text-white/60">
+          Your request is honored immediately. If you opted out by mistake or
+          have questions, email{' '}
+          <a
+            href="mailto:support@usemingla.com"
+            className="font-semibold text-warm underline-offset-4 hover:underline focus-ring"
+          >
+            support@usemingla.com
+          </a>
+          .
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={onSubmit} noValidate className="space-y-6">
+      <p className="text-sm leading-7 text-white/72 sm:text-base">
+        Enter the email address or phone number you’d like to opt out, choose
+        what to stop, and we’ll honor it right away. You don’t need an account or
+        to log in.
+      </p>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="unsub-email"
+          className="block text-xs font-semibold uppercase tracking-[0.16em] text-white/60"
+        >
+          Email address
+        </label>
+        <input
+          id="unsub-email"
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          aria-invalid={!emailValid}
+          className={cn(
+            'min-h-12 w-full rounded-2xl border bg-black/30 px-4 text-base text-white placeholder:text-white/35 focus-ring',
+            emailValid ? 'border-white/14' : 'border-red-400/60',
+          )}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="unsub-phone"
+          className="block text-xs font-semibold uppercase tracking-[0.16em] text-white/60"
+        >
+          Phone number (international format)
+        </label>
+        <input
+          id="unsub-phone"
+          type="tel"
+          inputMode="tel"
+          autoComplete="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          placeholder="+19195551234"
+          aria-invalid={!phoneValid}
+          className={cn(
+            'min-h-12 w-full rounded-2xl border bg-black/30 px-4 text-base text-white placeholder:text-white/35 focus-ring',
+            phoneValid ? 'border-white/14' : 'border-red-400/60',
+          )}
+        />
+        <p className="text-xs text-white/45">
+          Enter at least one — email or phone. Phone must start with + and your
+          country code.
+        </p>
+      </div>
+
+      <fieldset className="space-y-3">
+        <legend className="text-xs font-semibold uppercase tracking-[0.16em] text-white/60">
+          What would you like to stop?
+        </legend>
+        <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-white/12 bg-black/20 p-4 text-sm text-white/80 has-[:checked]:border-warm/40 has-[:checked]:bg-warm/10">
+          <input
+            type="radio"
+            name="scope"
+            value="marketing"
+            checked={scope === 'marketing'}
+            onChange={() => setScope('marketing')}
+            className="mt-1 accent-warm"
+          />
+          <span>
+            <span className="font-semibold text-white">Marketing only</span> —
+            stop promotions and announcements. You’ll still get essential
+            messages about bookings you make.
+          </span>
+        </label>
+        <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-white/12 bg-black/20 p-4 text-sm text-white/80 has-[:checked]:border-warm/40 has-[:checked]:bg-warm/10">
+          <input
+            type="radio"
+            name="scope"
+            value="all"
+            checked={scope === 'all'}
+            onChange={() => setScope('all')}
+            className="mt-1 accent-warm"
+          />
+          <span>
+            <span className="font-semibold text-white">All messages</span> — stop
+            all non-essential messages on this email/phone.
+          </span>
+        </label>
+      </fieldset>
+
+      {status === 'error' && errorKey ? (
+        <p
+          role="alert"
+          className="rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+        >
+          {ERROR_COPY[errorKey]}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="inline-flex min-h-12 w-full items-center justify-center rounded-full bg-warm px-6 text-base font-semibold text-black transition hover:bg-warm/90 focus-ring disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {status === 'submitting' ? 'Opting you out…' : 'Opt out'}
+      </button>
+
+      <p className="text-center text-xs leading-6 text-white/45">
+        Opt-out requests are honored immediately. Mingla LLC, 700 Corporate
+        Center Dr, Raleigh, NC 27607, USA.
+      </p>
+    </form>
+  )
+}

--- a/mingla-marketing/app/unsubscribe/page.tsx
+++ b/mingla-marketing/app/unsubscribe/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { UnsubscribeForm } from './UnsubscribeForm'
+
+export const metadata: Metadata = {
+  title: 'Unsubscribe',
+  description:
+    'Opt out of Mingla marketing messages by email or text. No login required — your request is honored immediately.',
+}
+
+export default function UnsubscribePage() {
+  return (
+    <main
+      id="main"
+      className="relative min-h-screen overflow-hidden bg-[#08090b] px-5 py-8 text-text-primary sm:px-8 sm:py-10"
+    >
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_18%_12%,rgba(235,120,37,0.18),transparent_32%),radial-gradient(ellipse_at_84%_18%,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#08090b_0%,#0d0d10_58%,#07080a_100%)]" />
+        <div className="absolute inset-0 opacity-[0.09] [background-image:linear-gradient(rgba(235,120,37,0.22)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.14)_1px,transparent_1px)] [background-size:72px_72px]" />
+        <div className="absolute left-[-18%] top-[12%] h-[34rem] w-[70%] rotate-[-14deg] rounded-[50%] border border-dashed border-warm/20" />
+        <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-black to-transparent" />
+      </div>
+
+      <div className="relative mx-auto w-full max-w-2xl">
+        <Link
+          href="/"
+          className="mb-8 inline-flex w-fit min-h-10 items-center rounded-full border border-white/12 bg-white/8 px-4 text-sm font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+        >
+          Back to Mingla
+        </Link>
+
+        <article className="rounded-[28px] border border-white/12 bg-[#0d0d10]/94 p-6 shadow-[0_40px_120px_rgba(0,0,0,0.52),inset_0_1px_0_rgba(255,255,255,0.08)] sm:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-warm">
+            Manage your messages
+          </p>
+          <h1 className="mt-3 font-display text-4xl leading-tight text-white sm:text-5xl">
+            Unsubscribe
+          </h1>
+
+          <div className="mt-8">
+            <Suspense
+              fallback={
+                <p className="text-sm text-white/55">Loading the opt-out form…</p>
+              }
+            >
+              <UnsubscribeForm />
+            </Suspense>
+          </div>
+
+          <div className="mt-8 flex flex-wrap gap-3 border-t border-white/10 pt-6 text-sm">
+            <Link
+              href="/sms-terms"
+              className="inline-flex min-h-10 items-center rounded-full border border-white/14 bg-white/8 px-4 font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+            >
+              SMS Terms
+            </Link>
+            <Link
+              href="/privacy-policy"
+              className="inline-flex min-h-10 items-center rounded-full border border-white/14 bg-white/8 px-4 font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="/terms-of-service"
+              className="inline-flex min-h-10 items-center rounded-full border border-white/14 bg-white/8 px-4 font-semibold text-text-secondary transition hover:bg-white/12 hover:text-text-primary focus-ring"
+            >
+              Terms of Service
+            </Link>
+          </div>
+        </article>
+      </div>
+    </main>
+  )
+}

--- a/mingla-marketing/lib/smsTermsContent.ts
+++ b/mingla-marketing/lib/smsTermsContent.ts
@@ -1,0 +1,81 @@
+// META-ORCH-1161 COMPLIANCE-PAGES — SMS program terms content.
+//
+// Static program-terms page for Mingla's SMS messaging, mirroring the shape of
+// termsContent.ts / privacyContent.ts so app/sms-terms/page.tsx reuses the same
+// section renderer. This page is commonly required for carrier / toll-free
+// verification. Copy is grounded in the real Mingla LLC values from
+// Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md
+// (§1b, §2.5–§2.7, §4). No placeholders.
+
+export const SMS_TERMS_EFFECTIVE_DATE = 'June 19, 2026'
+
+export const SMS_TERMS_SECTIONS = [
+  {
+    title: '1. Program description',
+    paragraphs: [
+      'Mingla is operated by Mingla LLC ("Mingla," "we," "us"). When you provide your phone number and agree to receive texts — for example when you create a Mingla account, complete a booking or reservation, or join a waitlist — you consent to receive recurring automated text messages (SMS) from Mingla and from the venues and experience brands you book with ("Businesses").',
+      'This page describes Mingla’s SMS messaging program, the types of messages you may receive, and how to get help or stop messages at any time.',
+    ],
+  },
+  {
+    title: '2. Types of messages you may receive',
+    paragraphs: ['Depending on how you use Mingla, you may receive:'],
+    bullets: [
+      'Booking and reservation confirmations, changes, cancellations, refunds, and waitlist updates',
+      'Event, experience, trip, and reservation reminders for bookings you make and for future events you may be interested in',
+      'Account and security notices related to your activity',
+      'Marketing and promotional messages, including offers and announcements from Mingla and from the Businesses you book with',
+    ],
+  },
+  {
+    title: '3. Message frequency',
+    paragraphs: [
+      'Message frequency varies and depends on your activity — for example, how often you book, reserve, or join waitlists, and the reminders and promotions tied to those bookings. We do not send a fixed number of messages per period.',
+    ],
+  },
+  {
+    title: '4. Cost',
+    paragraphs: [
+      'Msg & data rates may apply. Mingla does not charge you for receiving SMS messages, but your mobile carrier’s standard message and data rates may apply. Check with your carrier for details about your plan.',
+    ],
+  },
+  {
+    title: '5. How to opt out (STOP)',
+    paragraphs: [
+      'You can cancel the SMS program at any time. Reply STOP to any text message from the program to stop receiving further texts. We also honor QUIT, END, CANCEL, UNSUBSCRIBE, REVOKE, and OPT OUT.',
+      'After you send a STOP message, you will receive one final message confirming that you have been unsubscribed. After that, you will no longer receive SMS messages from that program. Opting out of marketing texts does not stop transactional or account messages that are required to deliver what you booked.',
+      'You can also opt out of all marketing messages — by email and text — at https://www.usemingla.com/unsubscribe, or adjust your notification preferences in the Mingla app at any time.',
+    ],
+  },
+  {
+    title: '6. How to get help (HELP)',
+    paragraphs: [
+      'For help with the SMS program, reply HELP to any text message, email us at support@usemingla.com, or call +1 888-250-5351.',
+    ],
+  },
+  {
+    title: '7. Carrier liability',
+    paragraphs: [
+      'Carriers are not liable for delayed or undelivered messages. Message delivery is subject to effective transmission from your wireless service provider and is not guaranteed by Mingla or your carrier.',
+    ],
+  },
+  {
+    title: '8. Privacy and terms',
+    paragraphs: [
+      'Your information is handled in accordance with our Privacy Policy, and your use of Mingla is governed by our Terms of Service. We do not sell your personal information except as described in the Privacy Policy. For full details, see the links below.',
+    ],
+  },
+  {
+    title: '9. Contact us',
+    paragraphs: [
+      'If you have any questions about Mingla’s SMS program, please contact us at:',
+    ],
+    contact: {
+      name: 'Mingla LLC',
+      address: '700 Corporate Center Dr, Raleigh, NC 27607, USA',
+      email: 'support@usemingla.com',
+      phone: '+1 888-250-5351',
+      website: 'https://www.usemingla.com',
+    },
+  },
+] as const

--- a/mingla-marketing/lib/unsubscribe-submit.ts
+++ b/mingla-marketing/lib/unsubscribe-submit.ts
@@ -1,0 +1,92 @@
+// META-ORCH-1161 COMPLIANCE-PAGES — client submit transport for /unsubscribe.
+//
+// Thin, anon-safe POST to the public `self-serve-unsubscribe` edge function.
+// The marketing app has NO Supabase client (no @supabase/supabase-js dependency),
+// so this uses a raw `fetch` with the public anon key in the Authorization +
+// apikey headers — mirroring lib/beta-access-submit.ts exactly. The anon key is
+// public by design: RLS denies anon writes and the edge fn writes via the service
+// role. The edge fn re-validates everything; this transport only shapes the call.
+
+export interface UnsubscribeInput {
+  /** Lowercased on the server; either email or phone (or both) must be present. */
+  email?: string
+  /** E.164 (e.g. +19195551234). */
+  phone?: string
+  /** marketing = stop promos, keep transactional; all = stop everything. */
+  scope: 'marketing' | 'all'
+  /** Optional one-click email token (?token=). When present, pre-fills email server-side. */
+  token?: string
+}
+
+export type UnsubscribeSubmitResult =
+  | { ok: true; scope: 'marketing' | 'all' }
+  | {
+      ok: false
+      error: 'validation' | 'invalid_token' | 'rate_limited' | 'server' | 'network'
+    }
+
+const FUNCTIONS_URL = process.env.NEXT_PUBLIC_SUPABASE_FUNCTIONS_URL ?? ''
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
+
+export async function submitUnsubscribe(
+  input: UnsubscribeInput,
+  signal?: AbortSignal,
+): Promise<UnsubscribeSubmitResult> {
+  if (!FUNCTIONS_URL || !ANON_KEY) {
+    if (typeof console !== 'undefined') {
+      console.error(
+        '[unsubscribe-submit] Missing NEXT_PUBLIC_SUPABASE_FUNCTIONS_URL or ' +
+          'NEXT_PUBLIC_SUPABASE_ANON_KEY — see mingla-marketing/.env.example',
+      )
+    }
+    return { ok: false, error: 'network' }
+  }
+
+  let response: Response
+  try {
+    response = await fetch(
+      `${FUNCTIONS_URL.replace(/\/$/, '')}/self-serve-unsubscribe`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${ANON_KEY}`,
+          apikey: ANON_KEY,
+        },
+        body: JSON.stringify(input),
+        signal,
+      },
+    )
+  } catch {
+    return { ok: false, error: 'network' }
+  }
+
+  if (response.ok) {
+    try {
+      const body = (await response.json()) as {
+        ok?: boolean
+        scope?: 'marketing' | 'all'
+      }
+      if (body?.ok) {
+        return { ok: true, scope: body.scope ?? input.scope }
+      }
+      return { ok: false, error: 'server' }
+    } catch {
+      return { ok: false, error: 'server' }
+    }
+  }
+
+  if (response.status === 400) {
+    // Distinguish a dead one-click token from a plain validation miss so the
+    // page can fall back to the manual form with the right message.
+    try {
+      const body = (await response.json()) as { error?: string }
+      if (body?.error === 'invalid_token') return { ok: false, error: 'invalid_token' }
+    } catch {
+      // fall through to generic validation
+    }
+    return { ok: false, error: 'validation' }
+  }
+  if (response.status === 429) return { ok: false, error: 'rate_limited' }
+  return { ok: false, error: 'server' }
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -283,3 +283,13 @@ verify_jwt = false
 # (same posture as twilio-message-status).
 [functions.twilio-inbound-sms]
 verify_jwt = false
+
+# META-ORCH-1161 COMPLIANCE-PAGES — self-serve-unsubscribe: the PUBLIC no-login
+# opt-out endpoint behind the marketing-site /unsubscribe page + CAN-SPAM email
+# footers. Accepts {email?, phone?, scope, token?} and writes BOTH
+# channel_suppressions (per channel) AND legacy marketing_unsubscribes (global)
+# via the service role. verify_jwt=false: CAN-SPAM requires the page to work
+# standalone with no login; per-IP throttle blunts burst abuse (mirrors
+# record-consent).
+[functions.self-serve-unsubscribe]
+verify_jwt = false

--- a/supabase/functions/self-serve-unsubscribe/case_bypass.test.ts
+++ b/supabase/functions/self-serve-unsubscribe/case_bypass.test.ts
@@ -1,0 +1,96 @@
+/**
+ * META-ORCH-1161 COMPLIANCE-PAGES — TESTER adversarial regression.
+ *
+ * ANGLE the implementor's happy-path suite did NOT cover: an email-case-mismatch
+ * suppression BYPASS.
+ *
+ * The DB function `public.can_send(...)` matches a stored suppression with
+ * `s.contact = lower(p_contact)` (case-insensitive on the SEND side). Proven
+ * against the live Postgres in TEST_META-ORCH-1161_COMPLIANCE_PAGES.md §5:
+ *   - When the opt-out row's `contact` is stored LOWERCASED (what the edge fn
+ *     does today at index.ts:134 / :144), a later send to ANY casing of that
+ *     address is correctly suppressed (can_send → false).
+ *   - When the opt-out row's `contact` is stored with MIXED CASE (the regression
+ *     that would happen if the `.toLowerCase()` normalization were removed from
+ *     index.ts), a send to the normalized-case address is NOT suppressed
+ *     (can_send → true) → the user is opted out yet still receives messages.
+ *
+ * Therefore the security invariant is: the email contact MUST be lowercased
+ * BEFORE it is written, on BOTH resolution paths (typed email AND token-derived
+ * recipient_email). suppress.ts trusts its caller (it writes `contact` verbatim),
+ * so the only enforcement point is index.ts. This test guards that enforcement.
+ *
+ * Two assertions:
+ *  1. Contract boundary — writeSuppressions stores `contact` VERBATIM (it does not
+ *     normalize), proving normalization MUST live upstream. (If a future edit made
+ *     the writer lowercase too that's harmless, but this documents the boundary.)
+ *  2. Enforcement guard — index.ts lowercases the email on BOTH the typed-email and
+ *     the token recipient_email paths. Deleting either `.toLowerCase()` (the bypass
+ *     regression) makes this test FAIL.
+ *
+ * fails-on-revert: remove `.toLowerCase()` from either email-resolution line in
+ * index.ts → assertion (2) fails.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  type SupabaseLike,
+  writeSuppressions,
+} from "./suppress.ts";
+
+// (1) Contract boundary: the writer persists `contact` exactly as handed to it.
+Deno.test("ADVERSARIAL: writeSuppressions stores email contact VERBATIM (normalization is the caller's job)", async () => {
+  const inserts: Array<{ table: string; row: Record<string, unknown> }> = [];
+  const client: SupabaseLike = {
+    from(table: string) {
+      return {
+        insert(row: Record<string, unknown>) {
+          inserts.push({ table, row });
+          return Promise.resolve({ error: null });
+        },
+      };
+    },
+  };
+
+  // Hand it a NON-normalized email (the bypass shape). The writer must NOT silently
+  // "fix" it — it writes what it's given, which is why index.ts must normalize first.
+  await writeSuppressions(client, {
+    email: "Adversary@Example.COM",
+    phone: null,
+    scope: "all",
+  });
+
+  const cs = inserts.find((i) => i.table === "channel_suppressions");
+  assert(cs, "expected a channel_suppressions insert");
+  // Documents the boundary: the stored value equals the input exactly.
+  assertEquals(cs!.row.contact, "Adversary@Example.COM");
+  const mu = inserts.find((i) => i.table === "marketing_unsubscribes");
+  assert(mu, "expected a marketing_unsubscribes insert");
+  assertEquals(mu!.row.contact_email, "Adversary@Example.COM");
+});
+
+// (2) Enforcement guard: index.ts lowercases on BOTH email-resolution paths.
+// This is the actual bypass fence — see the live-Postgres proof in the TEST report.
+Deno.test("ADVERSARIAL: index.ts lowercases the email on BOTH typed-email and token paths (anti-case-bypass)", async () => {
+  const src = await Deno.readTextFile(
+    new URL("./index.ts", import.meta.url),
+  );
+
+  // Typed-email path: `body.email.trim().toLowerCase()`.
+  assertStringIncludes(
+    src,
+    "body.email.trim().toLowerCase()",
+    "typed-email contact must be lowercased before write — removing this reopens the case-mismatch suppression bypass",
+  );
+
+  // Token recipient path: `payload.recipient_email.trim().toLowerCase()`.
+  assertStringIncludes(
+    src,
+    "payload.recipient_email.trim().toLowerCase()",
+    "token-derived recipient_email must be lowercased before write — removing this reopens the case-mismatch suppression bypass on the one-click link",
+  );
+});

--- a/supabase/functions/self-serve-unsubscribe/index.ts
+++ b/supabase/functions/self-serve-unsubscribe/index.ts
@@ -1,0 +1,199 @@
+/**
+ * META-ORCH-1161 COMPLIANCE-PAGES — self-serve-unsubscribe
+ *
+ * The PUBLIC, no-login opt-out endpoint behind the marketing-site /unsubscribe
+ * page (https://www.usemingla.com/unsubscribe) and CAN-SPAM email footers.
+ *
+ * Accepts `{ email?, phone?, scope: 'marketing'|'all', token? }`:
+ *   - email   — lowercased; produces an 'email' channel_suppressions row + a
+ *               legacy marketing_unsubscribes (contact_email) row.
+ *   - phone   — E.164; produces an 'sms' channel_suppressions row + a legacy
+ *               marketing_unsubscribes (contact_phone) row.
+ *   - scope   — 'marketing' (stop promos, keep transactional) or 'all'.
+ *   - token   — OPTIONAL. When present (one-click email link), the HS256 signed
+ *               unsubscribe token is verified and its recipient_email is used as
+ *               the email contact, so the link works with no typing. A token is
+ *               additive: the resolver still requires at least one valid contact.
+ *
+ * Writes via the service role (RLS is service-role-only for writes) to BOTH
+ * suppression models so every downstream consumer honors it (see suppress.ts).
+ * Idempotent: a re-submit tolerates the unique-violation and still returns 200.
+ *
+ * verify_jwt = false (config.toml) — this is an anon, no-login path by design
+ * (CAN-SPAM: the page must work standalone). A lightweight per-IP sliding-window
+ * throttle (mirrors record-consent: 12/min, fail-OPEN on a missing IP) blunts
+ * cheap-burst abuse without requiring a JWT.
+ *
+ * Cross-refs:
+ *   COPY:   Mingla_Artifacts/design/ORCH-1161/COPY_META-ORCH-1161_CONSENT_AND_MESSAGE_TEMPLATES.md §4, §5.1
+ *   SCHEMA: supabase/migrations/20261110000000_orch_1161_notification_foundation_tables.sql (channel_suppressions)
+ *           supabase/migrations/20260602000003_orch_0815_marketing_hub_phase_a.sql (marketing_unsubscribes)
+ *   WRITER: ./suppress.ts (DB-write logic, behaviorally tested)
+ */
+
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { verifyUnsubscribeToken } from "../_shared/marketingTokens.ts";
+import {
+  type SuppressionScope,
+  writeSuppressions,
+} from "./suppress.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+// Per-IP sliding-window throttle (mirrors record-consent §P2-1). Per-instance,
+// in-memory; caps a single hot client's burst. Fail-OPEN on a missing IP.
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX_PER_WINDOW = 12; // a real opt-out is 1 call → 12/min is generous
+const rateBuckets = new Map<string, number[]>();
+
+function isRateLimited(ipKey: string | null): boolean {
+  if (ipKey === null) return false;
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const hits = (rateBuckets.get(ipKey) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= RATE_LIMIT_MAX_PER_WINDOW) {
+    rateBuckets.set(ipKey, hits);
+    return true;
+  }
+  hits.push(now);
+  rateBuckets.set(ipKey, hits);
+  return false;
+}
+
+function clientIp(req: Request): string | null {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) {
+    const first = fwd.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get("x-real-ip");
+}
+
+// E.164: leading +, 1 non-zero digit, up to 14 more digits.
+const PHONE_REGEX = /^\+[1-9]\d{6,14}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface UnsubscribeRequest {
+  email?: string | null;
+  phone?: string | null;
+  scope?: string | null;
+  token?: string | null;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method_not_allowed" }, 405);
+  }
+
+  // Abuse guard BEFORE any parse/DB work.
+  const requestIp = clientIp(req);
+  if (isRateLimited(requestIp)) {
+    console.warn("[self-serve-unsubscribe] rate-limited", { ip: requestIp });
+    return new Response(
+      JSON.stringify({ error: "rate_limited" }),
+      {
+        status: 429,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          "Retry-After": String(Math.ceil(RATE_LIMIT_WINDOW_MS / 1000)),
+        },
+      },
+    );
+  }
+
+  let body: UnsubscribeRequest;
+  try {
+    body = (await req.json()) as UnsubscribeRequest;
+  } catch {
+    return jsonResponse({ error: "invalid_json" }, 400);
+  }
+
+  // Scope: default to 'marketing' (the safe, narrow choice) if absent.
+  const scope: SuppressionScope = body.scope === "all" ? "all" : "marketing";
+
+  // Resolve the email contact: an explicit email OR a verified token's recipient.
+  let email: string | null =
+    typeof body.email === "string" && EMAIL_REGEX.test(body.email.trim())
+      ? body.email.trim().toLowerCase()
+      : null;
+
+  const tokenRaw = typeof body.token === "string" ? body.token.trim() : "";
+  if (tokenRaw.length > 0) {
+    try {
+      const payload = await verifyUnsubscribeToken(tokenRaw);
+      // The token binds a recipient_email; honor it if no explicit email given,
+      // and never let an invalid token silently no-op a one-click link.
+      if (email === null && typeof payload.recipient_email === "string") {
+        email = payload.recipient_email.trim().toLowerCase();
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      if (reason.startsWith("unsubscribe_token_secret_missing")) {
+        console.error("[self-serve-unsubscribe]", reason);
+        return jsonResponse({ error: "server_misconfigured" }, 503);
+      }
+      // Bad/expired token with NO usable typed contact → tell the caller so the
+      // page can fall back to the manual email/phone form (no silent failure).
+      if (email === null) {
+        return jsonResponse({ error: "invalid_token" }, 400);
+      }
+      // A typed email is present → proceed with it; the bad token is ignored.
+    }
+  }
+
+  const phone: string | null =
+    typeof body.phone === "string" && PHONE_REGEX.test(body.phone.trim())
+      ? body.phone.trim()
+      : null;
+
+  if (email === null && phone === null) {
+    return jsonResponse({ error: "at_least_one_contact_required" }, 400);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceKey) {
+    console.error("[self-serve-unsubscribe] missing SUPABASE_URL / service key");
+    return jsonResponse({ error: "server_misconfigured" }, 500);
+  }
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  try {
+    const result = await writeSuppressions(admin, { email, phone, scope });
+    return jsonResponse(
+      {
+        ok: true,
+        scope,
+        suppressed_email: email !== null,
+        suppressed_phone: phone !== null,
+        channel_suppressions_written: result.channelSuppressionsWritten,
+        marketing_unsubscribes_written: result.marketingUnsubscribesWritten,
+        already_suppressed: result.alreadySuppressed,
+      },
+      200,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[self-serve-unsubscribe] suppression write failed", message);
+    return jsonResponse({ error: "suppression_write_failed" }, 500);
+  }
+});

--- a/supabase/functions/self-serve-unsubscribe/suppress.test.ts
+++ b/supabase/functions/self-serve-unsubscribe/suppress.test.ts
@@ -1,0 +1,172 @@
+/**
+ * META-ORCH-1161 COMPLIANCE-PAGES — behavioral test for the self-serve opt-out writer.
+ *
+ * Step 0.5 (implementor-owned happy-path regression): proves the opt-out path
+ * WRITES the correct channel_suppressions AND marketing_unsubscribes rows for an
+ * email and for a phone, and is idempotent (a re-submit tolerates the unique
+ * violation and still reports success). Drives suppress.ts with a fake supabase
+ * client that records every insert — no live edge runtime / DB needed.
+ *
+ * fails-on-revert: delete the marketing_unsubscribes loop (or the scope mapping)
+ * in suppress.ts and the row-shape assertions below fail.
+ */
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  isUniqueViolation,
+  type SupabaseLike,
+  writeSuppressions,
+} from "./suppress.ts";
+
+interface Recorded {
+  table: string;
+  row: Record<string, unknown>;
+}
+
+/**
+ * Fake client recording inserts. `conflictKeys` simulates already-present unique
+ * keys: any insert whose computed key is in the set returns a 23505 error.
+ */
+function makeFakeClient(conflictKeys: Set<string> = new Set()): {
+  client: SupabaseLike;
+  inserts: Recorded[];
+} {
+  const inserts: Recorded[] = [];
+  const client: SupabaseLike = {
+    from(table: string) {
+      return {
+        insert(row: Record<string, unknown>) {
+          // Synthetic conflict key per table to mimic the unique indexes.
+          const key = table === "channel_suppressions"
+            ? `cs:${row.contact}:${row.channel}:${row.scope}`
+            : `mu:${row.contact_email ?? row.contact_phone}:${row.channel}:${row.scope}`;
+          if (conflictKeys.has(key)) {
+            return Promise.resolve({
+              error: { code: "23505", message: "duplicate key value" },
+            });
+          }
+          inserts.push({ table, row });
+          return Promise.resolve({ error: null });
+        },
+      };
+    },
+  };
+  return { client, inserts };
+}
+
+Deno.test("writeSuppressions: email-only writes channel_suppressions(email) + marketing_unsubscribes(email)", async () => {
+  const { client, inserts } = makeFakeClient();
+  const res = await writeSuppressions(client, {
+    email: "buyer@example.com",
+    phone: null,
+    scope: "marketing",
+  });
+
+  assertEquals(res.channelSuppressionsWritten, 1);
+  assertEquals(res.marketingUnsubscribesWritten, 1);
+  assertEquals(res.alreadySuppressed, 0);
+
+  const cs = inserts.find((i) => i.table === "channel_suppressions");
+  assert(cs, "expected a channel_suppressions insert");
+  assertEquals(cs!.row.channel, "email");
+  assertEquals(cs!.row.contact, "buyer@example.com");
+  assertEquals(cs!.row.scope, "marketing"); // CHECK-valid
+  assertEquals(cs!.row.reason, "unsubscribe"); // CHECK-valid
+  assertEquals(cs!.row.brand_id, null); // global
+  assertEquals(cs!.row.user_id, null);
+
+  const mu = inserts.find((i) => i.table === "marketing_unsubscribes");
+  assert(mu, "expected a marketing_unsubscribes insert");
+  assertEquals(mu!.row.contact_email, "buyer@example.com");
+  assertEquals(mu!.row.contact_phone, null); // CHECK: exactly one contact
+  assertEquals(mu!.row.channel, "all"); // resolver expands to email+sms+rcs
+  assertEquals(mu!.row.scope, "global"); // CHECK-valid legacy scope
+});
+
+Deno.test("writeSuppressions: phone-only writes channel_suppressions(sms) + marketing_unsubscribes(phone)", async () => {
+  const { client, inserts } = makeFakeClient();
+  const res = await writeSuppressions(client, {
+    email: null,
+    phone: "+19195551234",
+    scope: "all",
+  });
+
+  assertEquals(res.channelSuppressionsWritten, 1);
+  assertEquals(res.marketingUnsubscribesWritten, 1);
+
+  const cs = inserts.find((i) => i.table === "channel_suppressions");
+  assert(cs, "expected a channel_suppressions insert");
+  assertEquals(cs!.row.channel, "sms");
+  assertEquals(cs!.row.contact, "+19195551234");
+  assertEquals(cs!.row.scope, "all"); // CHECK-valid
+
+  const mu = inserts.find((i) => i.table === "marketing_unsubscribes");
+  assert(mu, "expected a marketing_unsubscribes insert");
+  assertEquals(mu!.row.contact_phone, "+19195551234");
+  assertEquals(mu!.row.contact_email, null); // CHECK: exactly one contact
+});
+
+Deno.test("writeSuppressions: email AND phone writes BOTH channels in BOTH tables (4 rows)", async () => {
+  const { client, inserts } = makeFakeClient();
+  const res = await writeSuppressions(client, {
+    email: "both@example.com",
+    phone: "+19195550000",
+    scope: "all",
+  });
+  assertEquals(res.channelSuppressionsWritten, 2);
+  assertEquals(res.marketingUnsubscribesWritten, 2);
+  assertEquals(inserts.length, 4);
+});
+
+Deno.test("writeSuppressions: idempotent — a re-submit (all keys conflict) reports success, writes nothing new", async () => {
+  // Seed conflicts for every key this input would produce.
+  const conflicts = new Set<string>([
+    "cs:repeat@example.com:email:marketing",
+    "mu:repeat@example.com:all:global",
+  ]);
+  const { client, inserts } = makeFakeClient(conflicts);
+  const res = await writeSuppressions(client, {
+    email: "repeat@example.com",
+    phone: null,
+    scope: "marketing",
+  });
+  assertEquals(res.channelSuppressionsWritten, 0);
+  assertEquals(res.marketingUnsubscribesWritten, 0);
+  assertEquals(res.alreadySuppressed, 2); // both honored as already-suppressed
+  assertEquals(inserts.length, 0); // nothing newly recorded
+});
+
+Deno.test("writeSuppressions: a NON-unique DB error throws (no silent failure)", async () => {
+  const client: SupabaseLike = {
+    from() {
+      return {
+        insert() {
+          return Promise.resolve({
+            error: { code: "42P01", message: "relation does not exist" },
+          });
+        },
+      };
+    },
+  };
+  let threw = false;
+  try {
+    await writeSuppressions(client, {
+      email: "x@example.com",
+      phone: null,
+      scope: "all",
+    });
+  } catch {
+    threw = true;
+  }
+  assert(threw, "non-unique DB error must propagate, not be swallowed");
+});
+
+Deno.test("isUniqueViolation: detects 23505 and duplicate-key text", () => {
+  assert(isUniqueViolation({ code: "23505" }));
+  assert(isUniqueViolation({ message: "duplicate key value violates unique constraint" }));
+  assert(!isUniqueViolation({ code: "42P01", message: "relation does not exist" }));
+  assert(!isUniqueViolation(null));
+});

--- a/supabase/functions/self-serve-unsubscribe/suppress.ts
+++ b/supabase/functions/self-serve-unsubscribe/suppress.ts
@@ -1,0 +1,157 @@
+/**
+ * META-ORCH-1161 COMPLIANCE-PAGES — self-serve opt-out writer (pure-ish, injectable).
+ *
+ * This module contains the ONLY DB-write logic for the public self-serve
+ * /unsubscribe page. It is factored out of index.ts so the behavioral test can
+ * drive it with a fake supabase client and assert the EXACT rows produced for an
+ * email, for a phone, and idempotently — without standing up a live edge runtime.
+ *
+ * It writes to BOTH suppression models so every downstream consumer honors it:
+ *
+ *   1. public.channel_suppressions — the META-ORCH-1161 §5.1 ledger that OVERRIDES
+ *      preferences (a STOP/unsubscribe beats any toggle). One row per provided
+ *      channel:
+ *        - channel='email' when an email is given,
+ *        - channel='sms'   when a phone  is given,
+ *      with scope = the caller's choice ('marketing' | 'all'), reason='unsubscribe',
+ *      brand_id NULL (global). `contact` holds the lowercased email or E.164 phone.
+ *
+ *   2. public.marketing_unsubscribes — the legacy ORCH-0815-B audience-resolver
+ *      suppression the marketing send-path filters on. Its CHECK constraint allows
+ *      exactly ONE of contact_email / contact_phone per row, channel IN
+ *      ('email','sms','rcs','all'), scope IN ('account','brand','global'). Self-serve
+ *      opt-out is a GLOBAL suppression, so we write scope='global', channel='all'
+ *      (resolver expands 'all' → email+sms+rcs), one row per provided contact.
+ *
+ * Idempotency: both tables have unique indexes; a re-submit of the same contact
+ * raises a 23505 unique violation which we tolerate (treat as success), mirroring
+ * the ON CONFLICT DO NOTHING posture of the tokenized marketing-unsubscribe fn.
+ */
+
+/** Minimal structural contract of the supabase-js insert path we use. */
+export interface InsertResult {
+  error: { code?: string; message?: string } | null;
+}
+export interface SupabaseLike {
+  from(table: string): {
+    // supabase-js returns an awaitable PostgrestFilterBuilder, not a bare
+    // Promise — PromiseLike keeps the contract honest for both the real client
+    // and the fake test client (which returns a real Promise).
+    insert(row: Record<string, unknown>): PromiseLike<InsertResult>;
+  };
+}
+
+export type SuppressionScope = "marketing" | "all";
+
+export interface SuppressInput {
+  /** Lowercased email, or null. */
+  email: string | null;
+  /** E.164 phone, or null. */
+  phone: string | null;
+  /** The user's choice: marketing-only, or all messages. */
+  scope: SuppressionScope;
+}
+
+export interface SuppressResult {
+  channelSuppressionsWritten: number;
+  marketingUnsubscribesWritten: number;
+  /** Rows that hit a unique-violation (already suppressed) — counted as honored. */
+  alreadySuppressed: number;
+}
+
+/** Postgres unique-violation detection (code 23505 or message text). */
+export function isUniqueViolation(
+  err: { code?: string; message?: string } | null,
+): boolean {
+  if (err === null) return false;
+  if (err.code === "23505") return true;
+  const m = err.message ?? "";
+  return m.includes("duplicate key") || m.includes("unique constraint");
+}
+
+/**
+ * Writes the suppression rows. Throws on any NON-unique-violation DB error so the
+ * caller can surface a 500 (no silent failure — Constitution #3). A unique
+ * violation is NOT an error: the contact is already suppressed, which is the
+ * desired end-state, so it is counted in `alreadySuppressed`.
+ */
+export async function writeSuppressions(
+  client: SupabaseLike,
+  input: SuppressInput,
+): Promise<SuppressResult> {
+  const result: SuppressResult = {
+    channelSuppressionsWritten: 0,
+    marketingUnsubscribesWritten: 0,
+    alreadySuppressed: 0,
+  };
+
+  // --- channel_suppressions: one row per provided channel, scope as chosen. ---
+  const channelRows: Array<{ channel: "email" | "sms"; contact: string }> = [];
+  if (input.email !== null) {
+    channelRows.push({ channel: "email", contact: input.email });
+  }
+  if (input.phone !== null) {
+    channelRows.push({ channel: "sms", contact: input.phone });
+  }
+
+  for (const { channel, contact } of channelRows) {
+    const { error } = await client.from("channel_suppressions").insert({
+      user_id: null,
+      contact,
+      channel,
+      scope: input.scope, // 'marketing' | 'all' — both CHECK-valid
+      reason: "unsubscribe", // CHECK-valid
+      brand_id: null, // global
+    });
+    if (isUniqueViolation(error)) {
+      result.alreadySuppressed += 1;
+    } else if (error !== null) {
+      throw new Error(
+        `channel_suppressions insert failed (${channel}): ${error.message ?? "unknown"}`,
+      );
+    } else {
+      result.channelSuppressionsWritten += 1;
+    }
+  }
+
+  // --- marketing_unsubscribes: legacy global suppression, one row per contact. ---
+  // CHECK allows exactly ONE of contact_email/contact_phone per row → split.
+  const legacyRows: Array<Record<string, unknown>> = [];
+  if (input.email !== null) {
+    legacyRows.push({
+      contact_email: input.email,
+      contact_phone: null,
+      channel: "all", // resolver expands 'all' → email+sms+rcs
+      scope: "global",
+      brand_id: null,
+      account_id: null,
+      reason: "self_serve_unsubscribe",
+    });
+  }
+  if (input.phone !== null) {
+    legacyRows.push({
+      contact_email: null,
+      contact_phone: input.phone,
+      channel: "all",
+      scope: "global",
+      brand_id: null,
+      account_id: null,
+      reason: "self_serve_unsubscribe",
+    });
+  }
+
+  for (const row of legacyRows) {
+    const { error } = await client.from("marketing_unsubscribes").insert(row);
+    if (isUniqueViolation(error)) {
+      result.alreadySuppressed += 1;
+    } else if (error !== null) {
+      throw new Error(
+        `marketing_unsubscribes insert failed: ${error.message ?? "unknown"}`,
+      );
+    } else {
+      result.marketingUnsubscribesWritten += 1;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## META-ORCH-1161 — compliance pages slice

The two marketing-site compliance pages (Seth-directed) + their opt-out backend.

- **`/sms-terms`** (`mingla-marketing`): static SMS program-terms (Mingla LLC + Raleigh address, message types, frequency, "Msg & data rates may apply", STOP/HELP, support@usemingla.com / +1 888-250-5351, links to Terms/Privacy/Unsubscribe). Matches existing Terms page styling.
- **`/unsubscribe`** (`mingla-marketing`): no-login self-serve opt-out (email and/or phone, marketing-vs-all, confirmation/error states, `?token=` one-click path).
- **`self-serve-unsubscribe`** edge fn (verify_jwt=false): writes `channel_suppressions` (lowercased contact, CHECK-valid scope/channel/reason) + legacy `marketing_unsubscribes`; idempotent; per-IP rate limit (fail-open).

**QA:** mingla-tester CONDITIONAL PASS — CLEAR TO CLOSE (0 P0/P1/P2). Live-Postgres proof that opt-out → suppressed regardless of email casing; adversarial case-bypass guard test committed (fails-on-revert). Idempotency + rate-limit verified; existing tokenized unsubscribe + audience resolver untouched. Post-deploy live round-trip is the one accepted condition (orchestrator-owned). P3: raw IP in a log line (deferred).

Deploy: Vercel [deploy] for the pages; self-serve-unsubscribe deploys from merged main.

Closes: META-ORCH-1161 compliance-pages slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)