### PR TITLE
ORCH-1163 R2: RSVP page = structurally identical to the event page — floating Going/Maybe/Can't bar + single-owner box + z-layering fix [deploy]

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1163_R2_FLOATING_PARITY.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_ORCH-1163_R2_FLOATING_PARITY.md
@@ -1,0 +1,150 @@
+# IMPLEMENT — ORCH-1163-R2 [rsvp-shared-body / floating-parity]
+
+**Branch:** `ORCH-1163-r2-rsvp-floating-parity` (off latest main `e4bb8e7ba`)
+**Scope:** UI-only. Make the public RSVP page STRUCTURALLY IDENTICAL to the standard
+event page. No schema / RPC / edge / migration changes. No merge/deploy/OTA.
+
+---
+
+## Proven root cause (from the dispatch)
+
+The RSVP page rendered Going/Maybe/Can't via the ORCH-1157 momentum **dock**
+(`RsvpOfferingDecisionDock` → `RsvpMomentumDecision`) inside a `styles.floatingDock`
+wrapper that was `position:absolute; bottom:0` with **NO zIndex**. The event page
+instead pins a clean `EventOfferingFloatingBar` via a `floatWrap` with **`zIndex:6`**
+as a sibling of `ParallaxCoverShell`. Because the web `ParallaxCoverShell` establishes
+a stacking context where the scrolling body is `position:relative; zIndex:CONTENT_Z(2)`,
+an un-z-indexed absolute overlay (effective z=0) loses to the body on web (paints
+UNDER) while business-native painted it ON TOP — the inconsistent layering. The inline
+§5 decision and the floating dock were also separate instances, unlike the event page's
+single-owner `EventTicketBox`.
+
+---
+
+## The three changes (event-page parity, across all 3 surfaces)
+
+### 1. FLOATING BAR — zIndex:6 parity (fixes the layering on web + business)
+- `packages/offering-rendering/RsvpOfferingBody.tsx`: added
+  **`RsvpOfferingFloatingBar`** (parallel to `EventOfferingFloatingBar`) — renders the
+  shared `DecisionUnit` (`showMomentum={false}`), i.e. the Going / Maybe / Can't
+  controls as a floating segmented bar (all three shown together). The decision LOGIC
+  stays in `RsvpMomentumDecision` (single owner — reused, not forked).
+  `RsvpOfferingDecisionDock` is retained as a **back-compat alias** of the floating bar.
+- `mingla-business/src/components/event/FoundationRsvpPreview.tsx`: replaced the
+  old `floatingDock` (bottom:0, no zIndex, full-width panel chrome) with the
+  event-identical **`floatWrap`** style: `{ position:absolute, left:16, right:16,
+  bottom:24, zIndex:6 }`, rendered as a SIBLING of `ParallaxCoverShell`. This is the
+  load-bearing fix on BOTH web + business.
+- consumer `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx`: the RSVP
+  branch now pins `RsvpOfferingFloatingBar` in the SAME `styles.nativeFloatWrap`
+  (`zIndex:60`, `bottom: floatBarBottom`) the standard event branch uses — removed the
+  bespoke `rsvpStyles.dock` panel so the wrapper is byte-identical to the event branch.
+
+### 2. SINGLE-OWNER INLINE BOX — `RsvpDecisionBox` (parallel to `EventTicketBox`)
+- Extracted the inline §5 decision into **`RsvpDecisionBox`** (contact form +
+  per-guest plus-one mini-forms + the shared `DecisionUnit` w/ momentum + error node).
+  Rendered inline on phone AND in the desktop sticky panel — the SAME instance pattern
+  as `EventTicketBox`. Added **`hideDecisionBox`** to the body (parallel to
+  `hideTicketBox`) so the inline box collapses on desktop.
+- The inline box + the floating bar read ONE lifted decision state
+  (`useRsvpOfferingState`) — the dual-instance split is eliminated (mirrors how the
+  event page lifts `ticketQuantities` / `onProceedToCart`).
+- `FoundationRsvpPreview` now renders `RsvpDecisionBox` in the desktop sticky panel
+  (in a `deskPanel`/`deskAccent`/`deskInner` frame mirroring the event page's
+  `EventTicketBox` sticky panel) and passes `hideDecisionBox={isDesktop}` to the body.
+
+### 3. IDENTICAL SHELL / SCROLL / INSET
+- `mingla-business/src/components/event/PublicEventPage.tsx`: the RSVP branch's
+  `contentBottomInset` is now `isDesktop ? 0 : FLOATING_BAR_CLEARANCE + insets.bottom`
+  — BYTE-IDENTICAL to the standard event body (replaces the bespoke
+  `insets.bottom + spacing.xxl` runway; removed the now-unused `spacing` import).
+- consumer: the RSVP + event branches already share the one gorhom scroll host with
+  `reserveBarClearance = 177 + insets.bottom` and the `nativeFloatWrap` z-order
+  (`COVER_Z 1 < CONTENT_Z 2 < CHROME_Z 70`); the RSVP float now uses the same wrapper.
+- `FoundationRsvpPreview` keeps `ParallaxCoverShell` (shell-agnostic body unchanged).
+
+---
+
+## Changed files
+- `packages/offering-rendering/RsvpOfferingBody.tsx` — `RsvpDecisionBox` +
+  `RsvpOfferingFloatingBar` exports; `hideDecisionBox` prop; dock→bar alias.
+- `packages/offering-rendering/index.ts` — barrel exports the 2 new symbols
+  (kept `RsvpOfferingDecisionDock` / `useRsvpOfferingState` for the gates).
+- `mingla-business/src/components/event/FoundationRsvpPreview.tsx` — event-style
+  `floatWrap` (zIndex:6) + desktop sticky `RsvpDecisionBox` panel.
+- `mingla-business/src/components/event/PublicEventPage.tsx` — RSVP
+  `contentBottomInset` parity; removed unused `spacing` import.
+- `app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx` — RSVP float uses
+  `RsvpOfferingFloatingBar` in `nativeFloatWrap`; removed `rsvpStyles.dock`.
+- `packages/offering-rendering/__tests__/orch_1163_r2_floating_parity.test.ts` — NEW
+  regression (6 tests, fails-on-revert).
+- `packages/offering-rendering/__tests__/orch_1157_round2_rsvp_fixes.test.ts` — ONE
+  assertion retargeted dock→floating-bar literal, tagged `[TEST-MOD-APPROVED ORCH-1163]`.
+
+---
+
+## Hard guards preserved
+- All RSVP behavior intact: Going-confirm dialog → success popup, per-guest plus-ones,
+  per-guest QR/email/push, Calendar card, `resolveRsvpCta`, `RsvpMomentumDecision`
+  going-count/capacity/momentum visuals (now live INSIDE `RsvpDecisionBox` /
+  floating bar). `RsvpMomentumDecision` remains the SINGLE owner of the decision logic.
+- No standard-event/trip/experience changes.
+- Body stays shell-agnostic (no `ParallaxCoverShell` import/render).
+- Append-only tests: 1 new file ADDED; 1 existing assertion modified WITH the
+  `[TEST-MOD-APPROVED ORCH-1163]` token (the consumer floating control was renamed
+  dock→bar — same aliased component, no behavior change).
+
+---
+
+## Gate / test results
+
+### 7 ORCH-1163 gates — ALL PASS
+`one-shared-body`, `shell-agnostic`, `one-read-path`, `going-confirm`,
+`plus-one-per-guest`, `going-calendar-qr`, `guest-notify-match` — all PASS.
+
+### I-MOR-0827 + related gates — PASS
+- `meta-orch-0827-package-isolation.mjs` — PASS
+- `orch-1138-mor-isolation.mjs` — PASS
+- `i-proposed-1137-biz-web-lucide-real.mjs` — PASS
+
+### Deno source-contract tests
+- NEW `orch_1163_r2_floating_parity.test.ts` — 6/6 PASS (fails-on-revert PROVEN:
+  flipping the RSVP `floatWrap` zIndex 6→0 failed §1; restored → green).
+- `orch_1163_rsvp_shared_body.test.ts` — 8/8 PASS (NO modification needed).
+- RSVP/event source-contract suite (1157 round2/6/7/momentum, 1159, 1163×2) —
+  61/61 PASS.
+
+### Typecheck
+- `packages/offering-rendering` (own tsconfig) — **0 errors** (clean).
+- `mingla-business tsc` — the +5 "new" entries vs baseline are all spurious
+  implicit-any downstream of a PRE-EXISTING `Cannot find module 'react'` reach-in
+  (the business tsc resolves package sources without the package's React types; same
+  artifact at a shifted line on baseline). No real type error in any changed file.
+
+### Jest (mingla-business)
+- `RsvpPublicBody.maybeCta.orch1150r2` — PASS
+- `PublicEventPage.closeButton.test.tsx` — PASS
+- 3 suites FAIL identically on baseline (`PublicEventPage.closeButton.adversarial`,
+  `orch_1138_event_foundation`, `brand/PublicEventPage.orch_0964`) — their custom
+  `customRequire` dependency mocks predate the ORCH-1163 leg-2 `FoundationRsvpPreview`
+  import and throw "Unexpected dependency". PRE-EXISTING; not introduced by R2.
+
+### Not run (build-heavy, low risk)
+- `orch-1083-initial-bundle-budget.mjs` (needs a full web export). R2 adds no new
+  heavy imports — the new components reuse `RsvpMomentumDecision` + RN primitives — so
+  the `__common` budget is unaffected.
+
+---
+
+## Confirmation
+- ✅ The RSVP floating bar is **zIndex:6** on web + business (`FoundationRsvpPreview`
+  `floatWrap`), byte-equal to the event page's `floatWrap` — the on-top/under
+  layering is fixed on BOTH surfaces.
+- ✅ The inline decision box is **single-owner** (`RsvpDecisionBox`, rendered inline
+  on phone AND in the desktop sticky panel; `hideDecisionBox` collapses the inline
+  instance on desktop). Inline box + floating bar share ONE `useRsvpOfferingState`.
+- ✅ The shell / scroll / inset match the event page: `FLOATING_BAR_CLEARANCE +
+  insets.bottom` on phone, 0 on desktop; same `ParallaxCoverShell` usage; same
+  `COVER_Z < CONTENT_Z < CHROME_Z` contract on all three surfaces.
+
+**Blockers:** none.

--- a/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
+++ b/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
@@ -72,11 +72,13 @@ import {
   EventOfferingFloatingBar,
   OfferingChrome,
   // ORCH-1163 [rsvp-shared-body] — THE ONE shared RSVP body + floating decision
-  // dock + the lifted decision-state hook. Replaces the bespoke RSVP-branch nodes
+  // bar + the lifted decision-state hook. Replaces the bespoke RSVP-branch nodes
   // (rsvpDock / rsvpMomentumUnit / brand/about/venue mirror) with byte-parity to
-  // buyer-web + business.
+  // buyer-web + business. ORCH-1163-R2 — the floating control is the
+  // RsvpOfferingFloatingBar (parallel to EventOfferingFloatingBar), pinned in the
+  // SAME nativeFloatWrap (zIndex:60) slot as the event branch.
   RsvpOfferingBody,
-  RsvpOfferingDecisionDock,
+  RsvpOfferingFloatingBar,
   useRsvpOfferingState,
   type RsvpOfferingConfig,
   type RsvpGuestContact,
@@ -820,20 +822,18 @@ export default function ConsumerEventDetailScreen({
 
         {/* (4) FLOATING decision — ORCH-1167 the standard branch pins the shared
             EventOfferingFloatingBar (live Σ-all-in total + handleProceedToCart);
-            ORCH-1163 the RSVP branch pins the shared RsvpOfferingDecisionDock
+            ORCH-1163-R2 the RSVP branch pins the shared RsvpOfferingFloatingBar
             (Going/Maybe/Can't, driven by the SAME rsvpState as the inline box) in
-            the SAME bottom-overlay slot. Both sit in the same float wrapper math. */}
+            the SAME bottom-overlay slot — BYTE-IDENTICAL wrapper to the event branch
+            (styles.nativeFloatWrap, zIndex:60, bottom:floatBarBottom) so the z-order
+            + float positioning match the standard event page on consumer too. */}
         {isRsvp ? (
           <View
-            style={[
-              styles.nativeFloatWrap,
-              rsvpStyles.dock,
-              { bottom: floatBarBottom, paddingBottom: insets.bottom + 8 },
-            ]}
+            style={[styles.nativeFloatWrap, { bottom: floatBarBottom }]}
             pointerEvents="box-none"
             onLayout={handleDockLayout}
           >
-            <RsvpOfferingDecisionDock
+            <RsvpOfferingFloatingBar
               palette={palette}
               theme={theme}
               config={rsvpConfig}
@@ -1083,9 +1083,6 @@ const styles = StyleSheet.create({
 // ORCH-1157 — RSVP decision dock wrapper. The Going/Maybe/Can't buttons + their
 // opaque-Android fills now live in the shared RsvpMomentumDecision; this is just
 // the dock padding (matches the float→dock pattern of the reserve bar).
-const rsvpStyles = StyleSheet.create({
-  dock: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
-  },
-});
+// ORCH-1163-R2 — the bespoke RSVP dock-panel style was REMOVED: the RSVP floating
+// bar now reuses styles.nativeFloatWrap byte-identically with the event branch (the
+// decision controls carry their own opaque fills, so no separate panel chrome).

--- a/mingla-business/src/components/event/FoundationRsvpPreview.tsx
+++ b/mingla-business/src/components/event/FoundationRsvpPreview.tsx
@@ -31,7 +31,8 @@ import {
 import {
   ParallaxCoverShell,
   RsvpOfferingBody,
-  RsvpOfferingDecisionDock,
+  RsvpDecisionBox,
+  RsvpOfferingFloatingBar,
   useResponsiveLayout,
   useRsvpOfferingState,
   boldFontFamily,
@@ -97,6 +98,11 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
     safeAreaBottom = 0,
     testID,
   } = props;
+  // ORCH-1163-R2 — the floating bar now uses the event-style fixed bottom offset
+  // (floatWrap bottom:24) + the surface's contentBottomInset (FLOATING_BAR_CLEARANCE
+  // + insets.bottom) for runway; `safeAreaBottom` is retained on the props contract
+  // for call-site parity but no longer drives a bespoke dock-panel inset.
+  void safeAreaBottom;
 
   const { isDesktop } = useResponsiveLayout();
   const boldFamily = boldFontFamily(theme);
@@ -124,14 +130,25 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
           ? "image"
           : null;
 
-  const dock = (
-    <RsvpOfferingDecisionDock
-      palette={palette}
-      theme={theme}
-      config={config}
-      state={state}
-    />
-  );
+  // ORCH-1163-R2 [floating-parity] — desktop hosts the SINGLE-OWNER inline decision
+  // box (RsvpDecisionBox) in the STICKY right panel (PARITY with the event page's
+  // EventTicketBox in deskPanel). The phone keeps the inline box in the body and
+  // pins the separate floating bar below.
+  const stickyPanel = isDesktop ? (
+    <View
+      style={[styles.deskPanel, { backgroundColor: palette.card, borderColor: palette.panelBorder }]}
+    >
+      <View style={[styles.deskAccent, { backgroundColor: palette.accent }]} />
+      <View style={styles.deskInner}>
+        <RsvpDecisionBox
+          palette={palette}
+          theme={theme}
+          config={config}
+          state={state}
+        />
+      </View>
+    </View>
+  ) : undefined;
 
   return (
     <View style={[styles.host, { backgroundColor: palette.page }]}>
@@ -158,9 +175,7 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
             {event.name.length > 0 ? event.name : "Untitled event"}
           </Text>
         }
-        // Desktop hosts the decision in the sticky right panel; phone uses the
-        // pinned floating dock below.
-        stickyPanel={isDesktop ? dock : undefined}
+        stickyPanel={stickyPanel}
         contentBottomInset={contentBottomInset}
         safeAreaTop={safeAreaTop}
         onScroll={onScroll}
@@ -179,24 +194,27 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
           onOpenMaps={onOpenMaps}
           staticMapUrl={staticMapUrl}
           state={state}
+          // ORCH-1163-R2 — desktop relocates the inline box to the sticky panel
+          // (PARITY with FoundationEventPreview's hideTicketBox).
+          hideDecisionBox={isDesktop}
           testID="orch-1163-rsvp-body"
         />
       </ParallaxCoverShell>
 
-      {/* (9) Phone floating decision dock — surface-pinned overlay above the safe
-          area. Hidden on desktop (the sticky panel carries the decision). */}
+      {/* (9) Phone FLOATING decision bar — the shared RsvpOfferingFloatingBar pinned
+          as an absolute-bottom SIBLING of ParallaxCoverShell with zIndex:6, EXACTLY
+          like the event page's floatWrap (PublicEventPage). This fixes the
+          business-on-top / web-under layering: a positioned overlay below the chrome
+          but ABOVE the scrolling body's content stacking context on BOTH surfaces.
+          Hidden on desktop (the sticky panel carries the decision). */}
       {!isDesktop ? (
-        <View
-          style={[
-            styles.floatingDock,
-            {
-              backgroundColor: palette.page,
-              borderTopColor: palette.panelBorder,
-              paddingBottom: 12 + safeAreaBottom,
-            },
-          ]}
-        >
-          {dock}
+        <View style={styles.floatWrap} pointerEvents="box-none">
+          <RsvpOfferingFloatingBar
+            palette={palette}
+            theme={theme}
+            config={config}
+            state={state}
+          />
         </View>
       ) : null}
     </View>
@@ -222,14 +240,32 @@ const styles = StyleSheet.create({
     textShadowColor: "rgba(0,0,0,0.5)",
     textShadowRadius: 10,
   },
-  floatingDock: {
+  // ORCH-1163-R2 [floating-parity] — the floating decision-bar wrapper, BYTE-
+  // IDENTICAL to the event page's floatWrap (PublicEventPage.styles.floatWrap):
+  // absolute, left/right:16, bottom:24, zIndex:6. The zIndex:6 is the load-bearing
+  // fix — it pins the bar ABOVE the scrolling body's content stacking context
+  // (CONTENT_Z=2) on web (where the body was painting over the old un-z-indexed
+  // dock) and stays consistent on business-native, so the layering matches the
+  // event page on BOTH surfaces.
+  floatWrap: {
     position: "absolute",
-    left: 0,
-    right: 0,
-    bottom: 0,
-    paddingHorizontal: 16,
-    paddingTop: 12,
-    borderTopWidth: StyleSheet.hairlineWidth,
+    left: 16,
+    right: 16,
+    bottom: 24,
+    zIndex: 6,
+  },
+  // ORCH-1163-R2 — the DESKTOP sticky right-panel frame hosting the single-owner
+  // RsvpDecisionBox (mirrors the event page's deskPanel hosting EventTicketBox).
+  deskPanel: {
+    borderRadius: 22,
+    borderWidth: 1,
+    overflow: "hidden",
+  },
+  deskAccent: {
+    height: 4,
+  },
+  deskInner: {
+    padding: 20,
   },
 });
 

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -64,7 +64,6 @@ import {
   EventTicketBox,
 } from "@mingla/offering-rendering";
 
-import { spacing } from "../../constants/designSystem";
 import { FoundationEventPreview } from "./FoundationEventPreview";
 import { FoundationRsvpPreview } from "./FoundationRsvpPreview";
 import { submitPublicRsvp } from "../../services/rsvpEvents";
@@ -632,13 +631,13 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
           onOpenMaps={openMapsForQuery}
           staticMapUrl={staticMapUrl}
           onSubmit={rsvpSubmit}
-          // ORCH-1150 R2 D-7b — scroll-runway parity with the trip / experience /
-          // ticketed routes. Those routes use `spacing.md` because a DOCKED reserve
-          // bar (or tier list) already adds height; the RSVP body has NEITHER, so it
-          // needs MORE bottom runway to guarantee a short page exceeds the viewport
-          // and the (correctly pinned) cover can be fully scrolled away. Safe-area
-          // bottom + a one-screen-safe pad.
-          contentBottomInset={insets.bottom + spacing.xxl}
+          // ORCH-1163-R2 [floating-parity] — scroll-runway is now BYTE-IDENTICAL to
+          // the standard event page: FLOATING_BAR_CLEARANCE + insets.bottom on phone
+          // (so the last section clears the pinned floating decision bar, exactly as
+          // the event page clears its Get-tickets bar), 0 on desktop (the sticky
+          // panel + shell desktop padding own clearance). Replaces the bespoke
+          // `insets.bottom + spacing.xxl` runway.
+          contentBottomInset={isDesktop ? 0 : FLOATING_BAR_CLEARANCE + insets.bottom}
           onScroll={handleScroll}
           onScrollViewLayout={handleScrollLayout}
           safeAreaTop={insets.top}

--- a/packages/offering-rendering/RsvpOfferingBody.tsx
+++ b/packages/offering-rendering/RsvpOfferingBody.tsx
@@ -26,12 +26,28 @@
  *   3. Date & Time      (FULL-WIDTH solid-fill row — orch-1167-date-row parity)
  *   4. Pills row        (format → ALL vibes → ALL party-types → ALL music-genres;
  *                        NO tickets-left; party chips PROMOTED here from the momentum)
- *   5. Going/Maybe/Not  (INLINE decision box — shared RsvpMomentumDecision + the
- *                        per-guest plus-one mini-forms; Going → confirm dialog)
+ *   5. DECISION BOX     (INLINE <RsvpDecisionBox> — parallel to EventTicketBox: the
+ *                        Going/Maybe/Can't selector + contact + per-guest plus-one
+ *                        mini-forms; rendered inline on phone AND in the desktop
+ *                        sticky panel — ONE instance pattern, `hideDecisionBox` on
+ *                        desktop exactly like EventTicketBox's `hideTicketBox`)
  *   6. Presented By     (brand card → onOpenBrand)
  *   7. About            (collapsible read-more/show-less)
  *   8. Where you'll be  (server-proxied static map; city-level when hidden)
- *   9. Floating button  (<RsvpOfferingDecisionDock>, surface-pinned)
+ *   9. Floating button  (<RsvpOfferingFloatingBar> — a SEPARATE clean floating
+ *                        segmented bar mirroring EventOfferingFloatingBar; the
+ *                        surface pins it absolute-bottom with zIndex:6 as a sibling
+ *                        of ParallaxCoverShell, exactly like the event floatWrap.
+ *                        <RsvpOfferingDecisionDock> is retained as a back-compat
+ *                        alias of the floating bar.)
+ *
+ * ORCH-1163-R2 [rsvp-shared-body / floating-parity] — the RSVP page is now made
+ * STRUCTURALLY IDENTICAL to the standard event page (EventOfferingBody): the inline
+ * decision is the single-owner <RsvpDecisionBox> (parallel to <EventTicketBox>),
+ * and the floating control is the separate <RsvpOfferingFloatingBar> the surface
+ * pins with zIndex:6 (parallel to <EventOfferingFloatingBar> + the floatWrap). Both
+ * read ONE lifted decision state (useRsvpOfferingState) so the inline box + floating
+ * bar never diverge. The decision LOGIC stays in RsvpMomentumDecision (single owner).
  */
 
 import React, { useCallback, useMemo, useState } from "react";
@@ -118,6 +134,16 @@ export interface RsvpOfferingBodyProps {
   onScrollViewLayout?: (event: LayoutChangeEvent) => void;
   safeAreaTop?: number;
   safeAreaBottom?: number;
+  /**
+   * ORCH-1163-R2 — desktop two-column reflow (PARITY with EventOfferingBody's
+   * `hideTicketBox`). When true (web ≥ DESKTOP_BREAKPOINT) the inline §5 decision
+   * box is relocated to the STICKY right panel by the surface (which renders the
+   * SAME <RsvpDecisionBox> there), so the in-body section 5 collapses to nothing
+   * here — exactly one decision-box instance paints. Phones + both native apps
+   * keep the inline box (false). The `orch-1163-rsvp-inline-box` anchor stays in
+   * source for the canonical-order gate.
+   */
+  hideDecisionBox?: boolean;
   testID?: string;
 }
 
@@ -627,14 +653,17 @@ const DecisionUnit: React.FC<{
 };
 
 // ───────────────────────────────────────────────────────────────────────────
-// (9) RsvpOfferingDecisionDock — the floating decision (Going/Maybe/Not-going),
-// surface-pinned overlay (mirrors EventOfferingFloatingBar). The surface pins it
-// absolutely at the bottom on phone (gorhom-safe — the body never owns the scroll
-// root or the dock). Takes the SHARED state from useRsvpOfferingState so the dock
-// and the inline box drive one state machine.
+// (5) RsvpDecisionBox — the INLINE decision box. ORCH-1163-R2: extracted so it
+// renders BOTH inline in the body (phone + native) AND inside the desktop sticky
+// panel (web ≥ DESKTOP_BREAKPOINT) — ONE owner, one state, one decision-control
+// copy (PARITY with EventTicketBox). Carries the contact form + per-guest plus-one
+// mini-forms + the shared momentum/decision unit (showMomentum) + the error node.
+// Reads the SHARED state from useRsvpOfferingState (the inline box + the floating
+// bar drive one state machine — no duplicate writes). Hosts the
+// `orch-1163-rsvp-inline-box` testID anchor the canonical-order gate reads.
 // ───────────────────────────────────────────────────────────────────────────
 
-export interface RsvpOfferingDecisionDockProps {
+export interface RsvpDecisionBoxProps {
   palette: ThemePalette;
   theme: ResolvedTheme;
   config: RsvpOfferingConfig;
@@ -642,7 +671,47 @@ export interface RsvpOfferingDecisionDockProps {
   testID?: string;
 }
 
-export const RsvpOfferingDecisionDock: React.FC<RsvpOfferingDecisionDockProps> = ({
+export const RsvpDecisionBox: React.FC<RsvpDecisionBoxProps> = ({
+  palette,
+  theme,
+  config,
+  state,
+  testID,
+}) => (
+  <View testID={testID ?? "orch-1163-rsvp-inline-box"}>
+    {state.contactForm}
+    {state.guestForms}
+    <DecisionUnit
+      palette={palette}
+      theme={theme}
+      config={config}
+      state={state}
+      showMomentum
+      testID="orch-1157-rsvp-inline-momentum"
+    />
+    {state.errorNode}
+  </View>
+);
+
+// ───────────────────────────────────────────────────────────────────────────
+// (9) RsvpOfferingFloatingBar — the floating decision control (Going/Maybe/Can't),
+// surface-pinned overlay (mirrors EventOfferingFloatingBar EXACTLY). ALL THREE
+// controls show together as a floating segmented bar; the surface pins it
+// absolute-bottom with zIndex:6 as a sibling of ParallaxCoverShell (the event
+// `floatWrap` contract). Gorhom-safe — the body never owns the scroll root or the
+// bar. Takes the SHARED state from useRsvpOfferingState so the bar + the inline box
+// drive ONE state machine. The decision LOGIC stays in RsvpMomentumDecision.
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface RsvpOfferingFloatingBarProps {
+  palette: ThemePalette;
+  theme: ResolvedTheme;
+  config: RsvpOfferingConfig;
+  state: RsvpOfferingState;
+  testID?: string;
+}
+
+export const RsvpOfferingFloatingBar: React.FC<RsvpOfferingFloatingBarProps> = ({
   palette,
   theme,
   config,
@@ -659,6 +728,12 @@ export const RsvpOfferingDecisionDock: React.FC<RsvpOfferingDecisionDockProps> =
   />
 );
 
+// Back-compat alias — RsvpOfferingDecisionDock IS the floating bar (kept so the
+// barrel re-export + existing imports stay valid; the surface now pins it with the
+// event-style floatWrap zIndex:6 sibling rather than a full-width bottom panel).
+export type RsvpOfferingDecisionDockProps = RsvpOfferingFloatingBarProps;
+export const RsvpOfferingDecisionDock = RsvpOfferingFloatingBar;
+
 // ───────────────────────────────────────────────────────────────────────────
 // The body. Renders sections 2–8 content + the inline decision box (§0-5) + the
 // confirm dialog + success popup (both <Modal>, portal-safe). The surface pins the
@@ -669,7 +744,7 @@ export const RsvpOfferingDecisionDock: React.FC<RsvpOfferingDecisionDockProps> =
 export const RsvpOfferingBody: React.FC<
   RsvpOfferingBodyProps & { state: RsvpOfferingState }
 > = (props) => {
-  const { event, brand, palette, theme, config, onOpenBrand, onOpenMaps, staticMapUrl = null, testID, state } =
+  const { event, brand, palette, theme, config, onOpenBrand, onOpenMaps, staticMapUrl = null, hideDecisionBox = false, testID, state } =
     props;
   const { surface, boldFamily } = state;
   const [aboutCollapsed, setAboutCollapsed] = useState(true);
@@ -795,21 +870,25 @@ export const RsvpOfferingBody: React.FC<
         ))}
       </View>
 
-      {/* (5) Going / Maybe / Not-going box — INLINE. Contact form (anon) + per-guest
-          mini-forms + the shared decision (Going → confirm dialog). */}
-      <View style={styles.section} testID="orch-1163-rsvp-inline-box">
-        {state.contactForm}
-        {state.guestForms}
-        <DecisionUnit
-          palette={palette}
-          theme={theme}
-          config={config}
-          state={state}
-          showMomentum
-          testID="orch-1157-rsvp-inline-momentum"
-        />
-        {state.errorNode}
-      </View>
+      {/* (5) DECISION BOX — INLINE single-owner <RsvpDecisionBox> (parallel to
+          EventTicketBox): contact form (anon) + per-guest mini-forms + the shared
+          decision (Going → confirm dialog). ORCH-1163-R2 (change 2): on desktop web
+          (hideDecisionBox=true) the box is relocated to the sticky right panel by
+          the surface (the SAME <RsvpDecisionBox>), so it does not paint a second
+          time inline. Phones + both native apps keep the inline box. The
+          `orch-1163-rsvp-inline-box` testID anchor stays in source for the
+          canonical-order gate (rendered by RsvpDecisionBox). */}
+      {hideDecisionBox ? null : (
+        <View style={styles.section}>
+          <RsvpDecisionBox
+            palette={palette}
+            theme={theme}
+            config={config}
+            state={state}
+            testID="orch-1163-rsvp-inline-box"
+          />
+        </View>
+      )}
 
       {/* (6) Presented By — brand card → onOpenBrand. */}
       <View style={styles.section}>

--- a/packages/offering-rendering/__tests__/orch_1157_round2_rsvp_fixes.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1157_round2_rsvp_fixes.test.ts
@@ -113,11 +113,18 @@ Deno.test("ISSUE 1: RsvpOfferingBody renders the Direction-C parity sections (br
   assertStringIncludes(code, "aboutText"); // about copy
 });
 
-Deno.test("ISSUE 1: consumer RSVP still consumes the shared momentum + decision dock (no checkout)", () => {
-  // prior 1157 work intact (single shared decision via the shared body/dock, no
-  // price/cart on the RSVP path).
+// ORCH-1163 [TEST-MOD-APPROVED ORCH-1163]: ORCH-1163-R2 renamed the consumer RSVP
+// floating control from <RsvpOfferingDecisionDock> to <RsvpOfferingFloatingBar>
+// (the dock is now a back-compat ALIAS of the floating bar — same shared, no-checkout
+// decision control, just made structurally identical to the event page's
+// EventOfferingFloatingBar). The protective intent is unchanged: the consumer RSVP
+// branch still consumes the ONE shared body + a single shared floating decision
+// control with NO price/cart. Retargeted the literal accordingly.
+Deno.test("ISSUE 1: consumer RSVP still consumes the shared momentum + decision control (no checkout)", () => {
+  // prior 1157 work intact (single shared decision via the shared body/floating bar,
+  // no price/cart on the RSVP path).
   assertStringIncludes(consumerScreen, "<RsvpOfferingBody");
-  assertStringIncludes(consumerScreen, "<RsvpOfferingDecisionDock");
+  assertStringIncludes(consumerScreen, "<RsvpOfferingFloatingBar");
   const bodyCode = stripComments(rsvpBody);
   assertStringIncludes(bodyCode, "<RsvpMomentumDecision");
   assert(!bodyCode.includes("ticket-checkout-create"));

--- a/packages/offering-rendering/__tests__/orch_1163_r2_floating_parity.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1163_r2_floating_parity.test.ts
@@ -1,0 +1,164 @@
+// ORCH-1163-R2 [rsvp-shared-body / floating-parity] — regression (implementor-owned).
+//
+// The public RSVP page is now STRUCTURALLY IDENTICAL to the standard event page:
+//   (1) FLOATING BAR — the Going/Maybe/Can't control is the separate
+//       <RsvpOfferingFloatingBar> (parallel to <EventOfferingFloatingBar>), pinned
+//       by the surface with zIndex:6 as a ParallaxCoverShell sibling EXACTLY like the
+//       event `floatWrap`. This fixes the business-on-top / web-under layering (the
+//       old RSVP dock had NO zIndex, so the web body's CONTENT_Z=2 stacking context
+//       painted over it).
+//   (2) SINGLE-OWNER INLINE BOX — the inline §5 decision is ONE <RsvpDecisionBox>
+//       (parallel to <EventTicketBox>), rendered inline on phone AND in the desktop
+//       sticky panel (hideDecisionBox on desktop like hideTicketBox). The inline box
+//       + floating bar read ONE lifted useRsvpOfferingState.
+//   (3) IDENTICAL SHELL/SCROLL/INSET — contentBottomInset is
+//       `FLOATING_BAR_CLEARANCE + insets.bottom` on phone / 0 on desktop, byte-equal
+//       to the event page on all three surfaces.
+//
+// Deno source-contract style (the established offering-rendering pattern). These
+// assertions FAIL-ON-REVERT:
+//   - drop zIndex:6 from the RSVP floatWrap → §1 fails.
+//   - re-fork the inline box (delete RsvpDecisionBox) → §2 fails.
+//   - revert the RSVP contentBottomInset to the bespoke spacing.xxl runway → §3 fails.
+//   - swap the consumer RSVP float out of nativeFloatWrap → §4 fails.
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const read = async (rel: string): Promise<string> =>
+  await Deno.readTextFile(new URL(rel, import.meta.url));
+
+const body = await read("../RsvpOfferingBody.tsx");
+const barrel = await read("../index.ts");
+const foundationRsvp = await read(
+  "../../../mingla-business/src/components/event/FoundationRsvpPreview.tsx",
+);
+const publicEventPage = await read(
+  "../../../mingla-business/src/components/event/PublicEventPage.tsx",
+);
+const consumer = await read(
+  "../../../app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx",
+);
+
+// Strip comments so prose that merely NAMES a token never satisfies an assertion.
+const strip = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+// ── §1 — FLOATING BAR: zIndex:6 parity with the event floatWrap ──
+Deno.test("ORCH-1163-R2 §1 — RSVP floating bar pinned with zIndex:6 (event floatWrap parity)", () => {
+  const fnd = strip(foundationRsvp);
+  // The surface exposes a `floatWrap` style with the event-identical positioning.
+  assertStringIncludes(fnd, "floatWrap:");
+  // It MUST carry zIndex:6 — the load-bearing layering fix (business-on-top /
+  // web-under). A floatWrap block with bottom:24 + zIndex:6 (whitespace-tolerant).
+  assert(
+    /floatWrap:\s*\{[\s\S]*?bottom:\s*24[\s\S]*?zIndex:\s*6[\s\S]*?\}/.test(fnd),
+    "FoundationRsvpPreview floatWrap must be { ... bottom:24 ... zIndex:6 } (event parity)",
+  );
+  // The OLD un-z-indexed full-width bottom dock panel is GONE.
+  assert(
+    !/floatingDock:/.test(fnd),
+    "the old floatingDock (bottom:0, no zIndex) panel must be removed",
+  );
+  // The phone pins the shared floating bar inside that wrapper.
+  assertStringIncludes(fnd, "styles.floatWrap");
+  assertStringIncludes(fnd, "<RsvpOfferingFloatingBar");
+});
+
+// ── §1b — the event page floatWrap is the zIndex:6 reference (parity anchor) ──
+Deno.test("ORCH-1163-R2 §1b — event page floatWrap is zIndex:6 (the parity reference)", () => {
+  const evt = strip(publicEventPage);
+  assert(
+    /floatWrap:\s*\{[\s\S]*?zIndex:\s*6[\s\S]*?\}/.test(evt),
+    "PublicEventPage floatWrap must be zIndex:6 (the RSVP bar mirrors this)",
+  );
+});
+
+// ── §2 — SINGLE-OWNER inline box: RsvpDecisionBox (parallel to EventTicketBox) ──
+Deno.test("ORCH-1163-R2 §2 — single-owner RsvpDecisionBox (inline + sticky panel, one instance)", () => {
+  // The box is its OWN exported component (parallel to EventTicketBox).
+  assertStringIncludes(body, "export const RsvpDecisionBox");
+  assertStringIncludes(barrel, "RsvpDecisionBox");
+  // It owns the contact form + per-guest forms + the shared decision + error node.
+  assert(
+    /RsvpDecisionBox[\s\S]*?state\.contactForm[\s\S]*?state\.guestForms[\s\S]*?DecisionUnit[\s\S]*?state\.errorNode/.test(
+      body,
+    ),
+    "RsvpDecisionBox must host contactForm + guestForms + DecisionUnit + errorNode",
+  );
+  // The body honors hideDecisionBox (PARITY with EventOfferingBody.hideTicketBox) so
+  // the inline box collapses on desktop and the surface renders the SAME box in the
+  // sticky panel — exactly one instance paints.
+  assertStringIncludes(body, "hideDecisionBox");
+  assert(
+    /hideDecisionBox\s*\?\s*null\s*:\s*\(/.test(body),
+    "the body must collapse the inline box when hideDecisionBox is true",
+  );
+  // The surface renders the SAME RsvpDecisionBox in the desktop sticky panel AND
+  // passes hideDecisionBox={isDesktop} to the body (the single-instance contract).
+  const fnd = strip(foundationRsvp);
+  assertStringIncludes(fnd, "<RsvpDecisionBox");
+  assertStringIncludes(fnd, "hideDecisionBox={isDesktop}");
+  assertStringIncludes(fnd, "deskPanel:");
+});
+
+// ── §2b — the decision LOGIC stays the single owner RsvpMomentumDecision ──
+Deno.test("ORCH-1163-R2 §2b — RsvpMomentumDecision remains the single decision-logic owner", () => {
+  // Both the inline box (showMomentum) and the floating bar (showMomentum={false})
+  // route through the ONE DecisionUnit → RsvpMomentumDecision; no forked decision.
+  assertStringIncludes(body, "RsvpMomentumDecision");
+  assert(
+    /RsvpOfferingFloatingBar[\s\S]*?<DecisionUnit[\s\S]*?showMomentum=\{false\}/.test(
+      body,
+    ),
+    "RsvpOfferingFloatingBar must render the shared DecisionUnit (showMomentum={false})",
+  );
+  // The floating bar is the value RsvpOfferingDecisionDock aliases (back-compat).
+  assertStringIncludes(body, "export const RsvpOfferingDecisionDock = RsvpOfferingFloatingBar");
+});
+
+// ── §3 — IDENTICAL inset: FLOATING_BAR_CLEARANCE + insets.bottom (phone) / 0 desktop ──
+Deno.test("ORCH-1163-R2 §3 — RSVP contentBottomInset byte-matches the event page", () => {
+  const evt = strip(publicEventPage);
+  // The event-page clearance constant exists and the RSVP branch reuses the EXACT
+  // same expression (phone: FLOATING_BAR_CLEARANCE + insets.bottom; desktop: 0).
+  assertStringIncludes(evt, "FLOATING_BAR_CLEARANCE");
+  const insetExpr = "contentBottomInset={isDesktop ? 0 : FLOATING_BAR_CLEARANCE + insets.bottom}";
+  // It must appear at least TWICE — once for the event body, once for the RSVP body.
+  const count = evt.split(insetExpr).length - 1;
+  assert(
+    count >= 2,
+    `both the event body AND the RSVP body must use '${insetExpr}' (found ${count})`,
+  );
+  // The bespoke RSVP-only runway is GONE.
+  assert(
+    !/contentBottomInset=\{insets\.bottom \+ spacing\.xxl\}/.test(evt),
+    "the bespoke RSVP `insets.bottom + spacing.xxl` runway must be removed",
+  );
+});
+
+// ── §4 — consumer RSVP branch: same nativeFloatWrap (zIndex:60) as the event ──
+Deno.test("ORCH-1163-R2 §4 — consumer RSVP floating bar shares the event nativeFloatWrap slot", () => {
+  const con = strip(consumer);
+  // The RSVP branch pins the shared RsvpOfferingFloatingBar in the SAME wrapper +
+  // bottom math as the standard event branch — no bespoke rsvpStyles.dock panel.
+  assertStringIncludes(con, "<RsvpOfferingFloatingBar");
+  assert(
+    /isRsvp\s*\?\s*\([\s\S]*?styles\.nativeFloatWrap[\s\S]*?bottom:\s*floatBarBottom[\s\S]*?<RsvpOfferingFloatingBar/.test(
+      con,
+    ),
+    "the consumer RSVP branch must pin RsvpOfferingFloatingBar in styles.nativeFloatWrap { bottom: floatBarBottom }",
+  );
+  // nativeFloatWrap carries the consumer z-order (parity with the event float).
+  assert(
+    /nativeFloatWrap:\s*\{[\s\S]*?zIndex:\s*60[\s\S]*?\}/.test(con),
+    "styles.nativeFloatWrap must keep zIndex:60 (shared by both branches)",
+  );
+  // The bespoke rsvpStyles.dock panel is removed.
+  assert(
+    !/rsvpStyles\.dock/.test(con),
+    "the bespoke consumer rsvpStyles.dock must be removed (event-parity wrapper now)",
+  );
+});

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -77,8 +77,17 @@ export type { RsvpMomentumModel } from "./rsvpMomentum";
 // <RsvpOfferingDecisionDock> (pinned floating dock §0-9). FLOW A (Going-confirm dialog
 // + success popup) + FLOW B (per-guest plus-one contacts) are owned here. RSVP is
 // ticketless: NO price/checkout/cart affordance.
+// ORCH-1163-R2 [floating-parity] — the inline box is now the single-owner
+// <RsvpDecisionBox> (parallel to EventTicketBox; rendered inline on phone AND in the
+// desktop sticky panel) and the floating control is the separate
+// <RsvpOfferingFloatingBar> (parallel to EventOfferingFloatingBar; the surface pins
+// it absolute-bottom with zIndex:6 as a ParallaxCoverShell sibling). Both read ONE
+// lifted useRsvpOfferingState. RsvpOfferingDecisionDock stays as a back-compat alias
+// of the floating bar.
 export {
   RsvpOfferingBody,
+  RsvpDecisionBox,
+  RsvpOfferingFloatingBar,
   RsvpOfferingDecisionDock,
   useRsvpOfferingState,
 } from "./RsvpOfferingBody";
@@ -86,6 +95,8 @@ export type {
   RsvpOfferingBodyProps,
   RsvpOfferingConfig,
   RsvpOfferingState,
+  RsvpDecisionBoxProps,
+  RsvpOfferingFloatingBarProps,
   RsvpOfferingDecisionDockProps,
   RsvpGuestContact,
   RsvpSubmitResult,


### PR DESCRIPTION
## ORCH-1163 R2 — RSVP floating/shell parity with the standard event page (UI-only)

Root cause (orchestrator investigation): the RSVP page used the old ORCH-1157 momentum DOCK (no zIndex) for Going/Maybe/Can't → rendered as a parallax card and layered inconsistently (business-on-top / web-under). Now mirrors the event page exactly.

- **Floating bar**: `RsvpOfferingFloatingBar` (parallel to `EventOfferingFloatingBar`) — Going/Maybe/Can't as a floating segmented bar, positioned `absolute, bottom:24, zIndex:6` (web/business) / `nativeFloatWrap zIndex:60` (consumer), byte-equal to the event `floatWrap`. **Fixes the business-on-top / web-under layering.**
- **Single-owner inline box**: `RsvpDecisionBox` (parallel to `EventTicketBox`) — one component inline on phone + desktop sticky panel (`hideDecisionBox`), sharing one `useRsvpOfferingState`. Eliminates the dual-instance split.
- **Identical shell/scroll/inset** on all 3 surfaces (`FLOATING_BAR_CLEARANCE + insets.bottom` phone / 0 desktop; same ParallaxCoverShell + z-order).
- `RsvpMomentumDecision` stays the single decision-logic owner; all RSVP behavior (going-confirm, plus-ones, QR/email/push, Calendar) preserved.

### Evidence
- 7 ORCH-1163 gates PASS; I-MOR-0827 PASS; parity test 6/6 (fails-on-revert: zIndex 6→0 fails); RSVP source-contract 61/61; package tsc 0 errors.
- UI-only — no schema/RPC/edge/migration. `[TEST-MOD-APPROVED ORCH-1163]` for one retargeted dock→bar assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)