### PR TITLE
ORCH-1163 R3: RSVP floating Going/Maybe/Can't = fully self-sufficient (details + +1s) + bar clearance

### DIFF
--- a/Mingla_Artifacts/specs/SPEC_ORCH-1163_R3_RSVP_FLOATING_ACTIVE.md
+++ b/Mingla_Artifacts/specs/SPEC_ORCH-1163_R3_RSVP_FLOATING_ACTIVE.md
@@ -1,0 +1,66 @@
+# SPEC — ORCH-1163-R3 [rsvp-shared-body] · floating decision = fully self-sufficient + bar clearance
+
+**Leg of:** META-ORCH-1166 (offering-page standardization), RSVP leg.
+**Builds on:** ORCH-1163 (shared body) + R2 (floating-parity / z-layering).
+**Surfaces:** consumer iOS/Android (`app-mobile`), business iOS/Android + buyer/anon web (`mingla-business`). Backend: none. Migration: none.
+
+## Problem (Seth, 2026-06-20, on the R2 dev build)
+
+1. **Scroll doesn't clear the floating bar.** The last section (§8 Where-you'll-be) scrolls *under* the floating Going/Maybe/Can't bar — the bottom content is occluded.
+2. **The floating Going/Maybe/Can't buttons are dormant.** They do nothing (Going + Maybe are rendered *disabled* whenever `contactReady` is false; the contact form + per-guest +1 forms that would satisfy `contactReady` live ONLY in the inline §5 box, so from the floating bar there is no path forward).
+3. **The floating bar must collect details itself.** Tapping a floating button must prompt the guest for their name/email/phone AND the +1s' name/email/phone — exactly like the inline §5 box — then proceed (Going → confirm dialog → success; Maybe/Can't → record). One decision owner, two entry points (inline box + floating bar), identical flow.
+
+## Root cause (verified on origin/main R2)
+
+- `RsvpMomentumDecision.tsx` `goingDisabled`/`maybeDisabled` include `!contactReady`. The floating bar (`RsvpOfferingFloatingBar`) passes the real `contactReady`, so for anon/web users (and any not-yet-filled state) Going+Maybe paint disabled. Only "Can't go" (not gated on contactReady) is live.
+- The contact + +1 mini-forms are produced by `useRsvpOfferingState` as `contactForm`/`guestForms` and rendered ONLY inside `RsvpDecisionBox` (the inline §5 box / desktop sticky panel). The floating bar has no form host.
+- Clearances were tuned for the event page's ~56px single button: consumer `reserveBarClearance = 177 + insets.bottom` (`ConsumerEventDetailScreen.tsx`), business/web `FLOATING_BAR_CLEARANCE = 96` (`PublicEventPage.tsx`). The RSVP bar is taller (3 glyph+label buttons ≈69px + a wrapping micro subcopy ≈24px ≈ **~93px**, variable) → under-reserved → occlusion.
+
+## The fix — shell-agnostic, single owner (`packages/offering-rendering/RsvpOfferingBody.tsx`)
+
+### A. Floating bar becomes self-sufficient via a details modal
+
+Extend `useRsvpOfferingState`:
+
+1. Add modal state: `detailsOpen: boolean`, `pendingDecision: "going" | "maybe" | "not_going" | null`.
+2. Add **floating-entry handlers** (distinct from the inline `onGoingTap`/`onMaybe`/`onNotGoing`):
+   - `onFloatingGoing()`: if `contactReady` → existing `onGoingTap()` (opens confirm dialog). Else → set `pendingDecision="going"`, `detailsOpen=true`.
+   - `onFloatingMaybe()`: if `contactReady` → `submitDirect("maybe")`. Else → set `pendingDecision="maybe"`, `detailsOpen=true`.
+   - `onFloatingNotGoing()`: if `isLoggedIn || contactReady` → `submitDirect("not_going")`. Else → set `pendingDecision="not_going"`, `detailsOpen=true`.
+3. Build a `detailsModal` node (a portal `<Modal>` like `confirmDialog`/`successPopup`, gorhom-safe). Contents:
+   - Title: "Add your details" / sub "We'll only use this to update you about this event."
+   - Reuse the EXACT SAME `contactForm` node (already built — shares state, so values sync with the inline box).
+   - Reuse `guestForms` ONLY when `pendingDecision !== "not_going"` (Can't-go needs no +1s).
+   - `errorNode`.
+   - A primary "Continue" button, disabled until `contactReady`. On press: close the modal, then dispatch the pending decision — `"going"` → open the confirm dialog (`setConfirmOpen(true)`); `"maybe"` → `submitDirect("maybe")`; `"not_going"` → `submitDirect("not_going")`. Clear `pendingDecision`.
+   - A "Cancel"/close affordance that clears `detailsOpen` + `pendingDecision` (does NOT clear typed values).
+4. Expose on `RsvpOfferingState`: `onFloatingGoing`, `onFloatingMaybe`, `onFloatingNotGoing`, `detailsModal`.
+5. Render `{state.detailsModal}` in `RsvpOfferingBody` next to `{state.confirmDialog}{state.successPopup}` (body is always mounted, even when `hideDecisionBox` on desktop).
+
+### B. Floating bar renders ENABLED buttons routed through the floating handlers
+
+In `RsvpOfferingFloatingBar`, the `DecisionUnit` must:
+- pass `contactReady={true}` (so Going/Maybe are NOT disabled into a dead end — readiness is enforced by the floating handlers, which open the details modal instead),
+- wire `onGoing={state.onFloatingGoing}`, `onMaybe={state.onFloatingMaybe}`, `onNotGoing={state.onFloatingNotGoing}`.
+
+Do this WITHOUT disturbing the inline `RsvpDecisionBox`, which keeps the real `contactReady` + the inline handlers (`onGoingTap`/`onMaybe`/`onNotGoing`) so the inline box behaves exactly as today. `DecisionUnit` needs an optional `contactReadyOverride?: boolean` + explicit `onGoing/onMaybe/onNotGoing` props, OR the floating bar passes a derived state object — keep the change minimal and typed; the resolved-state disabling (going/pending/waitlisted/maybe) MUST remain intact (those depend on `guestStatus`, not `contactReady`).
+
+Guard: do NOT regress the inline box. The `orch-1163-rsvp-inline-box` + `orch-1157-rsvp-floating-dock` testID anchors stay.
+
+### C. Clear the floating bar (per surface — measure, don't guess)
+
+- **`FoundationRsvpPreview.tsx`** (business/web): add `onLayout` to the `floatWrap` → store measured bar height `h`. Compute the shell's `contentBottomInset = Math.max(props.contentBottomInset, h + 24 /*floatWrap bottom*/ + 16 /*gap*/ + safeAreaBottom)`. (Take the max so the adapter's value is a floor.)
+- **`PublicEventPage.tsx`**: the RSVP branch may keep passing `FLOATING_BAR_CLEARANCE + insets.bottom` as the floor — the measured override in FoundationRsvpPreview does the real work. (If simpler, bump the RSVP-path floor to a dedicated `RSVP_FLOATING_BAR_CLEARANCE = 150`.)
+- **`ConsumerEventDetailScreen.tsx`**: for the RSVP branch, measure the `nativeFloatWrap` height (the wrap already has `onLayout={handleDockLayout}` — extend it to store the RSVP bar height) and set the `BottomSheetScrollView` `contentContainerStyle.paddingBottom = floatBarBottom + measuredBarHeight + FLOAT_GAP` for `isRsvp`. Keep the event-branch `reserveBarClearance=177` path unchanged.
+
+## Acceptance
+
+- Anon web + business preview + logged-in consumer: tapping the floating **Going** with no details → details modal asks name/email/phone (+ +1 forms) → Continue → confirm dialog → success popup. **Maybe** → details modal → Continue → recorded as Maybe. **Can't go** → records (logged-in/ready) or details modal (anon) → recorded.
+- When details ARE already filled (inline box or a prior modal), the floating buttons skip the modal and go straight to confirm/submit.
+- No section is occluded by the floating bar at full scroll on any of the 5 surfaces (phone bar measured; desktop uses the sticky panel, no floating bar).
+- Inline §5 box behavior unchanged. No second decision flow, no divergence (one state machine).
+- Typecheck clean (`packages/offering-rendering`, `app-mobile`, `mingla-business`). All strict-grep gates green (esp. the RSVP canonical-order + no-checkout-affordance gates).
+
+## Out of scope
+
+Backend/RPC, QR/notify, the two carried follow-ups (web/business RPC read; consumer doors line). No new invariants beyond what R3 needs.

--- a/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
+++ b/app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx
@@ -239,8 +239,15 @@ export default function ConsumerEventDetailScreen({
   // so the prior float→dock scroll/viewport tracking is retired (subtract before
   // adding). These handlers stay as no-op sinks for the body's onTicketBoxLayout +
   // the gorhom scroll's onScroll/onLayout so the wiring is intact + lint-clean.
-  const handleDockLayout = useCallback((_e: LayoutChangeEvent): void => {
-    // No-op: the bar is persistent; retained for future float→dock re-enable.
+  // ORCH-1163-R3 — for the RSVP branch the floating decision bar is TALLER + variable
+  // (3 glyph+label buttons + a wrapping micro subcopy) than the event Get-tickets
+  // bar, so the fixed `reserveBarClearance=177` under-reserves and the last section
+  // scrolls UNDER the bar. We now MEASURE the nativeFloatWrap height (event branch
+  // still ignores it — its clearance is the constant 177 path).
+  const [rsvpFloatBarHeight, setRsvpFloatBarHeight] = useState<number>(0);
+  const handleDockLayout = useCallback((e: LayoutChangeEvent): void => {
+    const h = e.nativeEvent.layout.height;
+    setRsvpFloatBarHeight((prev) => (Math.abs(prev - h) > 1 ? h : prev));
   }, []);
   const handleScroll = useCallback(
     (_e: NativeSyntheticEvent<NativeScrollEvent>): void => {
@@ -690,11 +697,21 @@ export default function ConsumerEventDetailScreen({
   // FLOAT_GAP`; adding the bar height (~56) + a small gap gives a constant runway
   // ON TOP OF the device safe-area that always clears the raised bar (the prior
   // `72 + insets.bottom` under-cleared it once the bar was lifted).
-  void floatBarBottom; // applied to the float wrapper's `bottom` below.
+  // (floatBarBottom is applied to the float wrapper's `bottom` below + drives the
+  // RSVP measured runway.)
   // 177 = HOME_INDICATOR_FLOOR(34) + SHEET_BOTTOM_OVERSHOOT(63) + FLOAT_GAP(16) +
   // bar-height-and-gap(64) — the constant runway above the device safe-area that
   // always clears the raised float bar (whose bottom ≤ insets.bottom + 177).
   const reserveBarClearance = 177 + insets.bottom;
+  // ORCH-1163-R3 — the RSVP branch's bar is taller + variable, so its runway is
+  // MEASURED: the wrapper's lifted `bottom` (floatBarBottom) + the measured bar
+  // height + a FLOAT_GAP. Falls back to the event-branch constant until onLayout
+  // fires (so the first paint never under-clears).
+  const rsvpBarClearance =
+    rsvpFloatBarHeight > 0
+      ? floatBarBottom + rsvpFloatBarHeight + FLOAT_GAP
+      : reserveBarClearance;
+  const scrollPaddingBottom = isRsvp ? rsvpBarClearance : reserveBarClearance;
 
   return (
     <>
@@ -735,7 +752,7 @@ export default function ConsumerEventDetailScreen({
           style={styles.nativeScroll}
           contentContainerStyle={[
             styles.nativeScrollContent,
-            { paddingBottom: reserveBarClearance },
+            { paddingBottom: scrollPaddingBottom },
           ]}
           showsVerticalScrollIndicator={false}
           onScroll={handleScroll}

--- a/mingla-business/src/components/event/FoundationRsvpPreview.tsx
+++ b/mingla-business/src/components/event/FoundationRsvpPreview.tsx
@@ -17,7 +17,7 @@
  * doors + SEO. Android: opaque glass via the shared primitives.
  */
 
-import React from "react";
+import React, { useCallback, useState } from "react";
 import {
   Platform,
   StyleSheet,
@@ -98,14 +98,26 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
     safeAreaBottom = 0,
     testID,
   } = props;
-  // ORCH-1163-R2 — the floating bar now uses the event-style fixed bottom offset
-  // (floatWrap bottom:24) + the surface's contentBottomInset (FLOATING_BAR_CLEARANCE
-  // + insets.bottom) for runway; `safeAreaBottom` is retained on the props contract
-  // for call-site parity but no longer drives a bespoke dock-panel inset.
-  void safeAreaBottom;
-
   const { isDesktop } = useResponsiveLayout();
   const boldFamily = boldFontFamily(theme);
+
+  // ORCH-1163-R3 — the RSVP floating bar is TALLER + variable (3 glyph+label
+  // buttons + a wrapping micro subcopy) vs the event page's ~56px single button, so
+  // a fixed clearance under-reserves and the last section scrolls UNDER the bar.
+  // MEASURE the floatWrap height and make the shell's bottom inset the MAX of the
+  // adapter's value (a floor) and `measured + floatWrap-bottom(24) + gap(16) +
+  // safeAreaBottom`. The adapter value remains a floor for the first paint (before
+  // onLayout fires) and for desktop (0).
+  const [floatBarHeight, setFloatBarHeight] = useState(0);
+  const onFloatWrapLayout = useCallback((e: LayoutChangeEvent): void => {
+    const h = e.nativeEvent.layout.height;
+    setFloatBarHeight((prev) => (Math.abs(prev - h) > 1 ? h : prev));
+  }, []);
+  const measuredBottomInset =
+    floatBarHeight > 0 ? floatBarHeight + 24 + 16 + safeAreaBottom : 0;
+  const resolvedBottomInset = isDesktop
+    ? contentBottomInset
+    : Math.max(contentBottomInset, measuredBottomInset);
 
   // Lift the ONE decision/submit/dialog state machine; share it with body + dock.
   const state = useRsvpOfferingState({
@@ -176,7 +188,7 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
           </Text>
         }
         stickyPanel={stickyPanel}
-        contentBottomInset={contentBottomInset}
+        contentBottomInset={resolvedBottomInset}
         safeAreaTop={safeAreaTop}
         onScroll={onScroll}
         onScrollViewLayout={onScrollViewLayout}
@@ -208,7 +220,11 @@ export const FoundationRsvpPreview: React.FC<FoundationRsvpPreviewProps> = (prop
           but ABOVE the scrolling body's content stacking context on BOTH surfaces.
           Hidden on desktop (the sticky panel carries the decision). */}
       {!isDesktop ? (
-        <View style={styles.floatWrap} pointerEvents="box-none">
+        <View
+          style={styles.floatWrap}
+          pointerEvents="box-none"
+          onLayout={onFloatWrapLayout}
+        >
           <RsvpOfferingFloatingBar
             palette={palette}
             theme={theme}

--- a/mingla-business/src/components/event/PublicEventPage.tsx
+++ b/mingla-business/src/components/event/PublicEventPage.tsx
@@ -631,12 +631,13 @@ export const PublicEventPage: React.FC<PublicEventPageAdapterProps> = ({
           onOpenMaps={openMapsForQuery}
           staticMapUrl={staticMapUrl}
           onSubmit={rsvpSubmit}
-          // ORCH-1163-R2 [floating-parity] — scroll-runway is now BYTE-IDENTICAL to
-          // the standard event page: FLOATING_BAR_CLEARANCE + insets.bottom on phone
-          // (so the last section clears the pinned floating decision bar, exactly as
-          // the event page clears its Get-tickets bar), 0 on desktop (the sticky
-          // panel + shell desktop padding own clearance). Replaces the bespoke
-          // `insets.bottom + spacing.xxl` runway.
+          // ORCH-1163-R3 — this FLOATING_BAR_CLEARANCE + insets.bottom expression is
+          // the scroll-runway FLOOR (byte-identical to the event page). The RSVP bar
+          // is TALLER + variable than the event Get-tickets bar, so FoundationRsvpPreview
+          // onLayout-MEASURES the real bar height and takes the MAX of this floor and
+          // `measured + 24 + 16 + safeAreaBottom` — that measured override does the
+          // real clearance work so the last section always clears the bar even when
+          // the micro subcopy wraps. 0 on desktop (sticky panel owns clearance).
           contentBottomInset={isDesktop ? 0 : FLOATING_BAR_CLEARANCE + insets.bottom}
           onScroll={handleScroll}
           onScrollViewLayout={handleScrollLayout}

--- a/packages/offering-rendering/RsvpDetailsModal.tsx
+++ b/packages/offering-rendering/RsvpDetailsModal.tsx
@@ -1,0 +1,182 @@
+/**
+ * RsvpDetailsModal — ORCH-1163-R3 [rsvp-shared-body / floating-active] · §A.
+ *
+ * The shared, shell-agnostic "Add your details" modal for the floating decision
+ * bar. The floating Going/Maybe/Can't bar has NO form host of its own (the contact
+ * + per-guest +1 mini-forms live only in the inline §5 box). When a guest taps a
+ * floating decision with no contact details, useRsvpOfferingState opens THIS modal,
+ * which RE-HOSTS the SAME contactForm / guestForms nodes (they share the hook's
+ * state, so values sync with the inline box), then dispatches the pinned decision on
+ * Continue (Going → confirm dialog; Maybe/Can't → record). One decision owner, two
+ * entry points (inline box + floating bar), identical flow.
+ *
+ * Extracted into its OWN file (mirroring RsvpGoingConfirmDialog) so the BODY file
+ * (RsvpOfferingBody.tsx) hosts NO scroll root — the shell-agnostic invariant §A.2
+ * (a scroll root in the body re-triggers the consumer gorhom freeze). This modal is
+ * a portal <Modal> that mounts OUTSIDE the gorhom scroll tree, so its scrollable
+ * content area is gorhom-safe.
+ *
+ * Package-isolated (I-MOR-0827-PACKAGE-ISOLATION): React-Native's native <Modal> +
+ * <ScrollView> (work on react-native-web AND native RN), themed via ThemePalette
+ * ONLY — NO designSystem import, NO app-src import. Android-opaque card fill per
+ * ANDROID_GLASS_USES_OPAQUE_FALLBACK. testID: orch-1163-rsvp-details-modal.
+ */
+
+import React from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+} from "react-native";
+
+import { boldFontFamily, type ThemePalette } from "./themePalette";
+import { type ResolvedTheme } from "./designTokens";
+
+export interface RsvpDetailsModalProps {
+  visible: boolean;
+  palette: ThemePalette;
+  theme: ResolvedTheme;
+  /** The contact mini-form node (shared with the inline §5 box). */
+  contactForm: React.ReactNode;
+  /** The per-guest +1 mini-forms node — null for Can't-go (no +1s). */
+  guestForms: React.ReactNode;
+  /** The validation/submit error node (shared). */
+  errorNode: React.ReactNode;
+  /** Primary-button label, decision-aware. */
+  continueLabel: string;
+  /** Enable the Continue button (mirrors the hook's contactReady). */
+  continueEnabled: boolean;
+  submitting: boolean;
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+export const RsvpDetailsModal: React.FC<RsvpDetailsModalProps> = ({
+  visible,
+  palette,
+  theme,
+  contactForm,
+  guestForms,
+  errorNode,
+  continueLabel,
+  continueEnabled,
+  submitting,
+  onContinue,
+  onCancel,
+}) => {
+  const boldFamily = boldFontFamily(theme);
+  const disabled = !continueEnabled || submitting;
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onCancel}
+      accessibilityViewIsModal
+    >
+      <Pressable
+        style={styles.scrim}
+        onPress={submitting ? undefined : onCancel}
+        accessibilityLabel="Dismiss"
+      >
+        <Pressable
+          style={[
+            styles.card,
+            {
+              // ANDROID_GLASS_USES_OPAQUE_FALLBACK — opaque page fill on Android.
+              backgroundColor: Platform.OS === "android" ? palette.page : palette.card,
+              borderColor: palette.panelBorder,
+            },
+          ]}
+          onPress={() => undefined}
+          testID="orch-1163-rsvp-details-modal"
+        >
+          <Text style={[styles.title, { color: palette.primaryText, fontFamily: boldFamily }]}>
+            Add your details
+          </Text>
+          <Text style={[styles.sub, { color: palette.secondaryText }]}>
+            We&rsquo;ll only use this to update you about this event.
+          </Text>
+          <ScrollView
+            style={styles.scrollArea}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator
+            keyboardShouldPersistTaps="handled"
+          >
+            {contactForm}
+            {guestForms}
+            {errorNode}
+          </ScrollView>
+          <Pressable
+            onPress={disabled ? undefined : onContinue}
+            disabled={disabled}
+            accessibilityRole="button"
+            accessibilityState={{ disabled }}
+            accessibilityLabel={continueLabel}
+            style={[
+              styles.primaryBtn,
+              { backgroundColor: palette.accent, opacity: disabled ? 0.5 : 1 },
+            ]}
+            testID="orch-1163-rsvp-details-continue"
+          >
+            <Text style={[styles.primaryBtnText, { color: palette.accentText, fontFamily: boldFamily }]}>
+              {continueLabel}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={submitting ? undefined : onCancel}
+            disabled={submitting}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel"
+            style={styles.secondaryBtn}
+            testID="orch-1163-rsvp-details-cancel"
+          >
+            <Text style={[styles.secondaryBtnText, { color: palette.secondaryText }]}>
+              Cancel
+            </Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrim: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.55)",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  card: {
+    width: "100%",
+    maxWidth: 460,
+    maxHeight: "86%",
+    borderRadius: 20,
+    borderWidth: 1,
+    padding: 22,
+    overflow: "hidden",
+  },
+  title: { fontSize: 20, fontWeight: "900", letterSpacing: -0.3, marginBottom: 6 },
+  sub: { fontSize: 14, lineHeight: 20, marginBottom: 14 },
+  scrollArea: { flexGrow: 0, flexShrink: 1 },
+  scrollContent: { paddingBottom: 4 },
+  primaryBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    borderRadius: 14,
+    paddingVertical: 15,
+    marginTop: 14,
+  },
+  primaryBtnText: { fontSize: 16, fontWeight: "900" },
+  secondaryBtn: { alignItems: "center", justifyContent: "center", paddingVertical: 12, marginTop: 4 },
+  secondaryBtnText: { fontSize: 14, fontWeight: "700" },
+});
+
+export default RsvpDetailsModal;

--- a/packages/offering-rendering/RsvpOfferingBody.tsx
+++ b/packages/offering-rendering/RsvpOfferingBody.tsx
@@ -74,6 +74,7 @@ import { normalizeCityCountry } from "./normalizeCityCountry";
 import { RsvpMomentumDecision } from "./RsvpMomentumDecision";
 import { RsvpGoingConfirmDialog } from "./RsvpGoingConfirmDialog";
 import { RsvpSuccessPopup, type RsvpConfirmationDetails } from "./RsvpSuccessPopup";
+import { RsvpDetailsModal } from "./RsvpDetailsModal";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^\+?[0-9\s()-]{7,20}$/;
@@ -166,6 +167,14 @@ interface RsvpDecisionState {
   onGoingTap: () => void;
   onMaybe: () => void;
   onNotGoing: () => void;
+  // ORCH-1163-R3 — floating-bar entry handlers. Distinct from the inline handlers:
+  // when contact details are NOT yet ready, these open the self-sufficient details
+  // modal (asking name/email/phone + per-guest +1 forms) instead of surfacing a
+  // dead error, then dispatch the pending decision on Continue. When details ARE
+  // ready, they fall straight through to the inline behavior (confirm/submit).
+  onFloatingGoing: () => void;
+  onFloatingMaybe: () => void;
+  onFloatingNotGoing: () => void;
 }
 
 export interface RsvpOfferingState extends RsvpDecisionState {
@@ -173,6 +182,9 @@ export interface RsvpOfferingState extends RsvpDecisionState {
   guestForms: React.ReactNode;
   confirmDialog: React.ReactNode;
   successPopup: React.ReactNode;
+  // ORCH-1163-R3 — the floating-bar details modal (portal <Modal>, gorhom-safe).
+  // Rendered ONCE in RsvpOfferingBody next to confirmDialog/successPopup.
+  detailsModal: React.ReactNode;
 }
 
 /**
@@ -208,6 +220,16 @@ export const useRsvpOfferingState = (
   const [successDetails, setSuccessDetails] = useState<RsvpConfirmationDetails | null>(
     null,
   );
+
+  // ORCH-1163-R3 — floating-bar details modal. The floating bar has no form host,
+  // so when a guest taps a floating decision with no contact details, we open this
+  // modal (which re-hosts the SAME contactForm/guestForms nodes — shared state, so
+  // values sync with the inline §5 box), then dispatch the pending decision on
+  // Continue. `pendingDecision` is the decision awaiting its details.
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [pendingDecision, setPendingDecision] = useState<
+    "going" | "maybe" | "not_going" | null
+  >(null);
 
   const capacityFull =
     config.capacity !== null && config.goingCount >= config.capacity;
@@ -326,6 +348,69 @@ export const useRsvpOfferingState = (
     setConfirmError(null);
     setConfirmOpen(true);
   }, [submitting, contactReady]);
+
+  // ── ORCH-1163-R3 — floating-bar entry handlers ──
+  // The floating bar forces contactReady=true on its DecisionUnit so the buttons
+  // are never disabled into a dead end; readiness is enforced HERE instead. If the
+  // guest already has details (inline box / a prior modal), fall straight through
+  // to the inline behavior; otherwise open the self-sufficient details modal with
+  // the decision pinned, to dispatch once the contact + +1 forms are filled.
+  const onFloatingGoing = useCallback((): void => {
+    if (submitting) return;
+    if (contactReady) {
+      onGoingTap();
+      return;
+    }
+    setErrorMsg(null);
+    setPendingDecision("going");
+    setDetailsOpen(true);
+  }, [submitting, contactReady, onGoingTap]);
+
+  const onFloatingMaybe = useCallback((): void => {
+    if (submitting) return;
+    if (contactReady) {
+      void submitDirect("maybe");
+      return;
+    }
+    setErrorMsg(null);
+    setPendingDecision("maybe");
+    setDetailsOpen(true);
+  }, [submitting, contactReady, submitDirect]);
+
+  const onFloatingNotGoing = useCallback((): void => {
+    if (submitting) return;
+    // Can't-go needs no +1s and no contact gate for a logged-in guest. Anon guests
+    // still need a reachable identity so the host can attribute the decline.
+    if (isLoggedIn || contactReady) {
+      void submitDirect("not_going");
+      return;
+    }
+    setErrorMsg(null);
+    setPendingDecision("not_going");
+    setDetailsOpen(true);
+  }, [submitting, isLoggedIn, contactReady, submitDirect]);
+
+  // Continue inside the details modal — dispatch the pinned decision. Disabled in
+  // the UI until contactReady, so values are valid here.
+  const closeDetails = useCallback((): void => {
+    setDetailsOpen(false);
+    setPendingDecision(null);
+  }, []);
+  const onDetailsContinue = useCallback((): void => {
+    if (!contactReady) return;
+    const decision = pendingDecision;
+    setDetailsOpen(false);
+    setPendingDecision(null);
+    if (decision === "going") {
+      setErrorMsg(null);
+      setConfirmError(null);
+      setConfirmOpen(true);
+    } else if (decision === "maybe") {
+      void submitDirect("maybe");
+    } else if (decision === "not_going") {
+      void submitDirect("not_going");
+    }
+  }, [contactReady, pendingDecision, submitDirect]);
 
   const onConfirmGoing = useCallback(async (): Promise<void> => {
     if (submitting) return;
@@ -585,6 +670,33 @@ export const useRsvpOfferingState = (
     />
   );
 
+  // ── ORCH-1163-R3 — floating-bar details modal (extracted to RsvpDetailsModal,
+  // a portal <Modal> mirroring RsvpGoingConfirmDialog so the BODY file hosts NO
+  // scroll root — shell-agnostic invariant §A.2). Re-hosts the SAME contactForm /
+  // guestForms nodes (shared state → values sync with the inline §5 box). The +1
+  // forms are omitted for Can't-go. Continue is disabled until contactReady. ──
+  const detailsContinueLabel =
+    pendingDecision === "maybe"
+      ? "Save as Maybe"
+      : pendingDecision === "not_going"
+        ? "Mark Can't go"
+        : "Continue";
+  const detailsModal = (
+    <RsvpDetailsModal
+      visible={detailsOpen}
+      palette={palette}
+      theme={theme}
+      contactForm={contactForm}
+      guestForms={pendingDecision !== "not_going" ? guestForms : null}
+      errorNode={errorNode}
+      continueLabel={detailsContinueLabel}
+      continueEnabled={contactReady}
+      submitting={submitting}
+      onContinue={onDetailsContinue}
+      onCancel={closeDetails}
+    />
+  );
+
   return {
     surface,
     boldFamily,
@@ -599,10 +711,14 @@ export const useRsvpOfferingState = (
     onGoingTap,
     onMaybe: () => void submitDirect("maybe"),
     onNotGoing: () => void submitDirect("not_going"),
+    onFloatingGoing,
+    onFloatingMaybe,
+    onFloatingNotGoing,
     contactForm,
     guestForms,
     confirmDialog,
     successPopup,
+    detailsModal,
   };
 };
 
@@ -616,8 +732,35 @@ const DecisionUnit: React.FC<{
   config: RsvpOfferingConfig;
   state: RsvpDecisionState;
   showMomentum: boolean;
+  /**
+   * ORCH-1163-R3 — the floating bar forces this true so Going/Maybe paint ENABLED
+   * (readiness is enforced by the floating handlers, which open the details modal).
+   * The inline box omits it and uses the real `state.contactReady`. The resolved-
+   * state disabling (going/pending/waitlisted/maybe) is independent of this — it
+   * depends on guestStatus and stays intact.
+   */
+  contactReadyOverride?: boolean;
+  /**
+   * ORCH-1163-R3 — explicit handler overrides. The floating bar wires the
+   * onFloating* entry handlers; the inline box omits these (defaults to the inline
+   * onGoingTap/onMaybe/onNotGoing).
+   */
+  onGoing?: () => void;
+  onMaybe?: () => void;
+  onNotGoing?: () => void;
   testID?: string;
-}> = ({ palette, theme, config, state, showMomentum, testID }) => {
+}> = ({
+  palette,
+  theme,
+  config,
+  state,
+  showMomentum,
+  contactReadyOverride,
+  onGoing,
+  onMaybe,
+  onNotGoing,
+  testID,
+}) => {
   return (
     <RsvpMomentumDecision
       palette={palette}
@@ -637,10 +780,10 @@ const DecisionUnit: React.FC<{
       hideStepper
       waitlistEnabled={config.waitlistEnabled}
       submitting={state.submitting}
-      contactReady={state.contactReady}
-      onGoing={state.onGoingTap}
-      onMaybe={state.onMaybe}
-      onNotGoing={state.onNotGoing}
+      contactReady={contactReadyOverride ?? state.contactReady}
+      onGoing={onGoing ?? state.onGoingTap}
+      onMaybe={onMaybe ?? state.onMaybe}
+      onNotGoing={onNotGoing ?? state.onNotGoing}
       variant="floating-dock"
       showMomentum={showMomentum}
       micro={state.subcopy ?? undefined}
@@ -718,12 +861,20 @@ export const RsvpOfferingFloatingBar: React.FC<RsvpOfferingFloatingBarProps> = (
   state,
   testID,
 }) => (
+  // ORCH-1163-R3 — the floating bar is SELF-SUFFICIENT: force contactReady so
+  // Going/Maybe are never disabled into a dead end, and route through the floating
+  // entry handlers (which open the details modal when contact info is missing).
+  // The inline RsvpDecisionBox is untouched (real contactReady + inline handlers).
   <DecisionUnit
     palette={palette}
     theme={theme}
     config={config}
     state={state}
     showMomentum={false}
+    contactReadyOverride
+    onGoing={state.onFloatingGoing}
+    onMaybe={state.onFloatingMaybe}
+    onNotGoing={state.onFloatingNotGoing}
     testID={testID ?? "orch-1157-rsvp-floating-dock"}
   />
 );
@@ -810,10 +961,13 @@ export const RsvpOfferingBody: React.FC<
 
   return (
     <View testID={testID}>
-      {/* FLOW A modals — both <Modal> (portal to root), gorhom-safe regardless of
-          where in the tree they mount. The surface need not re-pin them. */}
+      {/* FLOW A modals — all <Modal> (portal to root), gorhom-safe regardless of
+          where in the tree they mount. The surface need not re-pin them.
+          ORCH-1163-R3 — detailsModal hosts the floating-bar's self-sufficient
+          name/email/phone + +1 forms (same shared state as the inline §5 box). */}
       {state.confirmDialog}
       {state.successPopup}
+      {state.detailsModal}
 
       {/* (2) Event name lead block. */}
       <View style={styles.leadBlock}>

--- a/packages/offering-rendering/__tests__/orch_1163_r3_rsvp_floating_active.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1163_r3_rsvp_floating_active.test.ts
@@ -1,0 +1,250 @@
+// ORCH-1163-R3 [rsvp-shared-body / floating-active] — regression (implementor-owned).
+//
+// Seth, on the R2 dev build: (1) the last section scrolls UNDER the floating
+// Going/Maybe/Can't bar (occlusion); (2) the floating Going/Maybe buttons are
+// DORMANT (rendered disabled whenever contactReady is false — and the contact + +1
+// forms that would satisfy contactReady live ONLY in the inline §5 box, so from the
+// floating bar there is no path forward); (3) tapping a floating button must collect
+// the guest's name/email/phone AND each +1's, exactly like the inline box, then
+// proceed. ONE decision owner, two entry points (inline box + floating bar).
+//
+// THE FIX (this test pins it, FAIL-ON-REVERT):
+//   §1 — the floating bar forces contactReady (contactReadyOverride) so Going/Maybe
+//        paint ENABLED, and routes through the onFloating* entry handlers.
+//   §2 — the floating handlers: when contactReady is FALSE they open the details
+//        modal (pendingDecision set); when TRUE they fall straight through to the
+//        inline behavior (Going → confirm dialog; Maybe/Can't → submitDirect).
+//   §3 — Continue inside the modal dispatches the PINNED decision: going →
+//        setConfirmOpen(true); maybe → submitDirect("maybe"); not_going →
+//        submitDirect("not_going") — disabled until contactReady.
+//   §4 — the body renders {state.detailsModal} next to confirmDialog/successPopup;
+//        the details modal re-hosts the SAME contactForm/guestForms (shared state);
+//        the guestForms are OMITTED for Can't-go.
+//   §5 — the inline RsvpDecisionBox is UNDISTURBED (real contactReady, inline
+//        handlers) and both testID anchors (orch-1163-rsvp-inline-box +
+//        orch-1157-rsvp-floating-dock) stay.
+//   §6 — bar clearance is MEASURED per surface (onLayout) — business/web shell inset
+//        is max(floor, measured + 24 + 16 + safeAreaBottom); consumer scroll
+//        paddingBottom for isRsvp is floatBarBottom + measuredBarHeight + FLOAT_GAP.
+//   §7 — RSVP stays ticketless: no price / Reserve / Get tickets / cart / checkout
+//        anywhere in the new modal or the body (I-PROPOSED-1157-RSVP-NO-CHECKOUT).
+//
+// Deno source-contract style (the established offering-rendering pattern — these
+// component files pull react-native; there is no renderer bed here, so the contract
+// is asserted on the source). Comments are stripped so prose that merely NAMES a
+// token never satisfies an assertion.
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const read = async (rel: string): Promise<string> =>
+  await Deno.readTextFile(new URL(rel, import.meta.url));
+
+const strip = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+const bodyRaw = await read("../RsvpOfferingBody.tsx");
+const body = strip(bodyRaw);
+const modal = strip(await read("../RsvpDetailsModal.tsx"));
+const barrel = await read("../index.ts");
+const foundationRsvp = strip(
+  await read("../../../mingla-business/src/components/event/FoundationRsvpPreview.tsx"),
+);
+const publicEventPage = strip(
+  await read("../../../mingla-business/src/components/event/PublicEventPage.tsx"),
+);
+const consumer = strip(
+  await read("../../../app-mobile/src/screens/Event/ConsumerEventDetailScreen.tsx"),
+);
+
+// ── §1 — the floating bar forces contactReady + routes the floating handlers ──
+Deno.test("ORCH-1163-R3 §1 — floating bar renders ENABLED buttons routed through the floating handlers", () => {
+  // The DecisionUnit accepts a contactReadyOverride + explicit on* handler overrides.
+  assertStringIncludes(body, "contactReadyOverride");
+  assert(
+    /contactReady=\{contactReadyOverride \?\? state\.contactReady\}/.test(body),
+    "DecisionUnit must use contactReadyOverride ?? state.contactReady (real readiness on the inline box)",
+  );
+  assert(
+    /onGoing=\{onGoing \?\? state\.onGoingTap\}/.test(body),
+    "DecisionUnit onGoing must default to the inline state.onGoingTap when no override",
+  );
+  // The FLOATING BAR forces contactReady and wires the onFloating* handlers.
+  assert(
+    /RsvpOfferingFloatingBar[\s\S]*?<DecisionUnit[\s\S]*?contactReadyOverride[\s\S]*?onGoing=\{state\.onFloatingGoing\}[\s\S]*?onMaybe=\{state\.onFloatingMaybe\}[\s\S]*?onNotGoing=\{state\.onFloatingNotGoing\}/.test(
+      body,
+    ),
+    "RsvpOfferingFloatingBar must force contactReady + wire onFloatingGoing/Maybe/NotGoing",
+  );
+});
+
+// ── §2 — floating handlers: open the modal when NOT ready, fall through when ready ──
+Deno.test("ORCH-1163-R3 §2 — floating handlers open the details modal when contactReady is false", () => {
+  // onFloatingGoing: ready → onGoingTap(); else pendingDecision='going' + open.
+  assert(
+    /onFloatingGoing[\s\S]*?if \(contactReady\)[\s\S]*?onGoingTap\(\)[\s\S]*?setPendingDecision\("going"\)[\s\S]*?setDetailsOpen\(true\)/.test(
+      body,
+    ),
+    "onFloatingGoing must call onGoingTap when ready, else set pendingDecision='going' + open modal",
+  );
+  // onFloatingMaybe: ready → submitDirect('maybe'); else pending='maybe' + open.
+  assert(
+    /onFloatingMaybe[\s\S]*?if \(contactReady\)[\s\S]*?submitDirect\("maybe"\)[\s\S]*?setPendingDecision\("maybe"\)[\s\S]*?setDetailsOpen\(true\)/.test(
+      body,
+    ),
+    "onFloatingMaybe must submitDirect('maybe') when ready, else open modal pinned to maybe",
+  );
+  // onFloatingNotGoing: logged-in OR ready → submitDirect('not_going'); else open.
+  assert(
+    /onFloatingNotGoing[\s\S]*?if \(isLoggedIn \|\| contactReady\)[\s\S]*?submitDirect\("not_going"\)[\s\S]*?setPendingDecision\("not_going"\)[\s\S]*?setDetailsOpen\(true\)/.test(
+      body,
+    ),
+    "onFloatingNotGoing must submitDirect when logged-in/ready, else open modal pinned to not_going",
+  );
+  // The three handlers are EXPOSED on the state for the floating bar to consume.
+  assertStringIncludes(body, "onFloatingGoing,");
+  assertStringIncludes(body, "onFloatingMaybe,");
+  assertStringIncludes(body, "onFloatingNotGoing,");
+});
+
+// ── §3 — Continue dispatches the PINNED decision; disabled until contactReady ──
+Deno.test("ORCH-1163-R3 §3 — modal Continue dispatches the pending decision (going→dialog; maybe/not_going→submit)", () => {
+  assert(
+    /onDetailsContinue[\s\S]*?if \(!contactReady\) return/.test(body),
+    "onDetailsContinue must early-return until contactReady (no dead dispatch)",
+  );
+  assert(
+    /decision === "going"[\s\S]*?setConfirmOpen\(true\)/.test(body),
+    "Continue on a 'going' decision must open the confirm dialog (setConfirmOpen(true))",
+  );
+  assert(
+    /decision === "maybe"[\s\S]*?submitDirect\("maybe"\)/.test(body),
+    "Continue on a 'maybe' decision must submitDirect('maybe')",
+  );
+  assert(
+    /decision === "not_going"[\s\S]*?submitDirect\("not_going"\)/.test(body),
+    "Continue on a 'not_going' decision must submitDirect('not_going')",
+  );
+  // Cancel clears state WITHOUT clearing typed values (no setGuestName/setGuestEmail
+  // reset in closeDetails).
+  assert(
+    /closeDetails[\s\S]*?setDetailsOpen\(false\)[\s\S]*?setPendingDecision\(null\)/.test(body),
+    "closeDetails must clear detailsOpen + pendingDecision (and never reset typed values)",
+  );
+});
+
+// ── §4 — the body renders the details modal; modal re-hosts the SHARED forms ──
+Deno.test("ORCH-1163-R3 §4 — body renders state.detailsModal; modal re-hosts shared forms; +1s omitted for Can't-go", () => {
+  // The body mounts {state.detailsModal} next to confirmDialog + successPopup.
+  assert(
+    /\{state\.confirmDialog\}[\s\S]*?\{state\.successPopup\}[\s\S]*?\{state\.detailsModal\}/.test(body),
+    "RsvpOfferingBody must render {state.detailsModal} alongside confirmDialog + successPopup",
+  );
+  // detailsModal is built from the SAME contactForm + guestForms nodes (shared state).
+  assert(
+    /<RsvpDetailsModal[\s\S]*?contactForm=\{contactForm\}/.test(body),
+    "detailsModal must re-host the SAME contactForm node (shared state syncs with the inline box)",
+  );
+  // guestForms OMITTED for Can't-go.
+  assert(
+    /guestForms=\{pendingDecision !== "not_going" \? guestForms : null\}/.test(body),
+    "detailsModal must omit guestForms when pendingDecision is 'not_going' (Can't-go needs no +1s)",
+  );
+  // The modal is a portal <Modal> with a scrollable content area (gorhom-safe; the
+  // tall +1 forms need scroll) — and it is its OWN file so the body hosts NO scroll
+  // root (shell-agnostic §A.2).
+  assertStringIncludes(modal, "<Modal");
+  assertStringIncludes(modal, "<ScrollView");
+  assert(
+    !body.includes("<ScrollView") && !body.includes("<BottomSheetScrollView"),
+    "the BODY file must host NO scroll root (the modal owns the scroll, in its own file)",
+  );
+  assertStringIncludes(modal, 'testID="orch-1163-rsvp-details-modal"');
+  assertStringIncludes(modal, 'testID="orch-1163-rsvp-details-continue"');
+  // Barrel exports it.
+  assertStringIncludes(barrel, "RsvpDetailsModal");
+  // Continue is disabled until ready (continueEnabled wired from contactReady).
+  assert(
+    /const disabled = !continueEnabled \|\| submitting/.test(modal),
+    "the Continue button must be disabled until continueEnabled (contactReady) + not submitting",
+  );
+});
+
+// ── §5 — the inline box is UNDISTURBED + the testID anchors stay ──
+Deno.test("ORCH-1163-R3 §5 — inline box keeps real contactReady + inline handlers; anchors intact", () => {
+  // The inline RsvpDecisionBox renders its DecisionUnit with NO contactReadyOverride
+  // and NO floating handler overrides → it uses state.contactReady + onGoingTap etc.
+  assert(
+    /export const RsvpDecisionBox[\s\S]*?<DecisionUnit[\s\S]*?showMomentum\s*\n?\s*testID="orch-1157-rsvp-inline-momentum"/.test(
+      body,
+    ),
+    "the inline RsvpDecisionBox DecisionUnit must NOT pass contactReadyOverride/onFloating* (keeps inline behavior)",
+  );
+  // Both canonical anchors stay.
+  assertStringIncludes(body, 'testID ?? "orch-1163-rsvp-inline-box"');
+  assertStringIncludes(body, 'testID ?? "orch-1157-rsvp-floating-dock"');
+});
+
+// ── §6 — bar clearance is MEASURED per surface (no occlusion) ──
+Deno.test("ORCH-1163-R3 §6a — business/web shell inset is max(floor, measured floatWrap height)", () => {
+  // The floatWrap is onLayout-measured and the shell inset takes the MAX of the
+  // adapter floor and measured + 24 + 16 + safeAreaBottom.
+  assertStringIncludes(foundationRsvp, "onFloatWrapLayout");
+  assert(
+    /onLayout=\{onFloatWrapLayout\}/.test(foundationRsvp),
+    "the floatWrap must carry onLayout={onFloatWrapLayout}",
+  );
+  assert(
+    /floatBarHeight \+ 24 \+ 16 \+ safeAreaBottom/.test(foundationRsvp),
+    "measured inset must be floatBarHeight + 24 + 16 + safeAreaBottom",
+  );
+  assert(
+    /Math\.max\(contentBottomInset, measuredBottomInset\)/.test(foundationRsvp),
+    "the shell inset must be Math.max(contentBottomInset floor, measuredBottomInset)",
+  );
+  assertStringIncludes(foundationRsvp, "contentBottomInset={resolvedBottomInset}");
+});
+
+Deno.test("ORCH-1163-R3 §6b — consumer RSVP scroll paddingBottom is measured (floatBarBottom + measured + FLOAT_GAP)", () => {
+  // The nativeFloatWrap onLayout stores the RSVP bar height; the scroll padding for
+  // isRsvp is floatBarBottom + measuredBarHeight + FLOAT_GAP (event branch unchanged).
+  assertStringIncludes(consumer, "setRsvpFloatBarHeight");
+  assert(
+    /rsvpFloatBarHeight > 0[\s\S]*?floatBarBottom \+ rsvpFloatBarHeight \+ FLOAT_GAP/.test(consumer),
+    "rsvpBarClearance must be floatBarBottom + rsvpFloatBarHeight + FLOAT_GAP when measured",
+  );
+  assert(
+    /scrollPaddingBottom = isRsvp \? rsvpBarClearance : reserveBarClearance/.test(consumer),
+    "the scroll paddingBottom must branch isRsvp → rsvpBarClearance, else the event reserveBarClearance",
+  );
+  assert(
+    /paddingBottom: scrollPaddingBottom/.test(consumer),
+    "the BottomSheetScrollView contentContainerStyle must use scrollPaddingBottom",
+  );
+  // Event branch floor 177 is unchanged.
+  assertStringIncludes(consumer, "const reserveBarClearance = 177 + insets.bottom");
+});
+
+// ── §6c — the business/web floor expression stays byte-identical to the event page ──
+Deno.test("ORCH-1163-R3 §6c — RSVP shell inset FLOOR stays the event-parity expression", () => {
+  // R2 contract preserved: the floor is FLOATING_BAR_CLEARANCE + insets.bottom (the
+  // measured override in FoundationRsvpPreview does the real clearance work).
+  const insetExpr = "contentBottomInset={isDesktop ? 0 : FLOATING_BAR_CLEARANCE + insets.bottom}";
+  const count = publicEventPage.split(insetExpr).length - 1;
+  assert(count >= 2, `event + RSVP bodies must both use the floor expr (found ${count})`);
+});
+
+// ── §7 — RSVP stays ticketless (no checkout affordance in the new surfaces) ──
+Deno.test("ORCH-1163-R3 §7 — I-PROPOSED-1157-RSVP-NO-CHECKOUT-AFFORDANCE holds in the modal + body", () => {
+  const forbidden = ["Reserve", "Get tickets", "Get Tickets", "/checkout", "/cart", "price", "Price"];
+  for (const tok of forbidden) {
+    assert(
+      !modal.includes(tok),
+      `the details modal must carry NO checkout affordance (found '${tok}')`,
+    );
+  }
+  // The body adds no price/Reserve either (the §0-4 pills already exclude tickets-left).
+  assert(!body.includes("Get tickets") && !body.includes("Reserve"), "the body must add no Reserve/Get-tickets affordance");
+});

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -103,6 +103,10 @@ export type {
 } from "./RsvpOfferingBody";
 export { RsvpGoingConfirmDialog } from "./RsvpGoingConfirmDialog";
 export type { RsvpGoingConfirmDialogProps } from "./RsvpGoingConfirmDialog";
+// ORCH-1163-R3 — the floating-bar "Add your details" modal (self-sufficient
+// contact + +1 forms; one decision owner, two entry points).
+export { RsvpDetailsModal } from "./RsvpDetailsModal";
+export type { RsvpDetailsModalProps } from "./RsvpDetailsModal";
 export { RsvpSuccessPopup } from "./RsvpSuccessPopup";
 export type {
   RsvpSuccessPopupProps,


### PR DESCRIPTION
## ORCH-1163-R3 [rsvp-shared-body] — floating decision is now active, not dormant

Follow-on to R2 (#549). Seth, testing the R2 dev build, found three defects on the public RSVP page:

1. **Scroll didn't clear the floating bar** — §8 (Where you'll be) scrolled *under* the floating Going/Maybe/Can't bar.
2. **Floating Going/Maybe/Can't were dormant** — Going+Maybe rendered *disabled* whenever `contactReady` was false, and the only contact + +1 forms lived in the inline §5 box → no path forward from the floating bar.
3. **Floating bar must collect details itself** — tapping a floating button now prompts for name/email/phone + each +1's details, exactly like the inline box, then proceeds.

### Fix (one decision owner, two entry points)
- `useRsvpOfferingState` gains `onFloating{Going,Maybe,NotGoing}` + a `detailsModal`. When `contactReady` is false, a floating tap opens a portal `<Modal>` (`RsvpDetailsModal`) that **re-hosts the SAME contact + +1 form nodes** (shared state, syncs with the inline box; +1s omitted for Can't-go). Continue → dispatches the pending decision (Going → confirm dialog → success; Maybe/Can't → record). When details are already filled, the floating buttons skip the modal.
- `RsvpOfferingFloatingBar` renders **enabled** buttons (readiness enforced by the floating handlers, not by disabling). Inline `RsvpDecisionBox` is untouched — real `contactReady` + inline handlers. Resolved-state disabling (going/pending/waitlisted/maybe via `guestStatus`) intact.
- **Clearance, measured (not guessed):** business/web shell inset = `max(adapter floor, measured floatWrap height + 24 + 16 + safeAreaBottom)`; consumer RSVP scroll `paddingBottom = floatBarBottom + measured bar height + FLOAT_GAP`. Event branch unchanged.

### Tests
New `orch_1163_r3_rsvp_floating_active.test.ts` (9) — floating routing, modal Continue dispatch per decision, shared-form re-host, +1-omit-for-Can't-go, inline-box-undisturbed, per-surface measured clearance, no-checkout-affordance. R2 (6) + shared-body (8) stay green = 23/23. fails-on-revert proven. RSVP is ticketless — no price/cart/checkout anywhere (I-PROPOSED-1157-RSVP-NO-CHECKOUT-AFFORDANCE preserved).

Surfaces: consumer iOS/Android, business iOS/Android, buyer/anon web. No backend, no migration.

[deploy]

🤖 Generated with [Claude Code](https://claude.com/claude-code)