### PR TITLE
META-ORCH-1161 Sub-C: buyer transactional moments — reminders + purchase/refund/cancel push (text-dark)

### DIFF
--- a/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBC_TXN_MOMENTS.md
+++ b/Mingla_Artifacts/reports/IMPLEMENT_META-ORCH-1161_SUBC_TXN_MOMENTS.md
@@ -1,0 +1,196 @@
+# IMPLEMENT — META-ORCH-1161 Sub-C (remaining transactional moments, slice "b")
+
+**ORCH:** META-ORCH-1161 Sub-C
+**Phase:** IMPLEMENT (single bounded pass; self-verified; no deploy/merge)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[txn-moments]/` on branch `ORCH-1161-txn-moments`
+**Anchor truth:** built on `origin/main` (rebased; up to date — foundation `notify-dispatch` v2, `_shared/notifyV2.ts`, adapters, `notification_outbox` + drain cron, `can_send()`, seeded `notification_categories` all present and CONFIRMED applied on remote).
+**Author:** mingla-implementor (Claude)
+**Date:** 2026-06-20
+
+---
+
+## 1. Summary
+
+Wired the remaining high-touch buyer transactional moments onto the existing Sub-A
+`notify-dispatch` v2 simultaneous-send path (DEC-185), SMS text-dark:
+
+1. **Reminders (NET-NEW)** — a new `notify-reminders` edge fn on a ~15-min pg_cron
+   enqueues buyer event + reservation reminders at a 24h-ahead and a 2h-ahead lead
+   window into `notification_outbox` (drained by the existing 1-min cron → dispatcher).
+2. **Buyer purchase-confirmation PUSH (NET-NEW push leg)** — order-finalize now fires
+   a free buyer push + in-app row; the EMAIL+PDF stays owned by
+   `ticket-confirmation-dispatch` (no double-email). Wired on both the Stripe finalize
+   path (shared `fireOrderFinalizeNotifications`) and the Paystack equivalent.
+3. **Refund + order-cancelled push+inapp(+SMS)** — refunds (the single allowlisted
+   `stripeWebhookRouter` chokepoint) and free-order cancels (`cancel-order`) now route
+   a buyer push/in-app/SMS through the dispatcher; email stays single-owned.
+4. **Reservation confirmed/cancelled** — VERIFIED end-to-end (the trigger already
+   enqueues both, the drain is category-generic, the render copy exists). No gap.
+
+No money/finalize/refund logic was touched — ONLY additive notify-dispatch calls.
+
+---
+
+## 2. SPEC success-criteria coverage
+
+| SC | Criterion | Status | Commit |
+|---|---|---|---|
+| SC-1 | Reminders: 24h + 2h buckets, env-configurable lead times, exactly one per `{category}:{entityId}:{leadBucket}` (idempotent) | ✓ verified | (this branch) |
+| SC-2 | Reminder cron schedule registered (~15 min) | ✓ migration + probe | (this branch) |
+| SC-3 | Buyer purchase-confirmation PUSH+inapp fires on finalize WITHOUT double-email | ✓ test + remote-seed probe | (this branch) |
+| SC-3-Paystack | Same push on the Paystack finalize path | ✓ wired | (this branch) |
+| SC-4 | Refund → buyer push+inapp(+sms), email single-owned, idempotent per refundId | ✓ wired (single chokepoint) | (this branch) |
+| SC-5 | Order-cancelled → buyer push+inapp(+sms), email single-owned, idempotent per order | ✓ wired | (this branch) |
+| SC-6 | Reservation confirmed/cancelled fire end-to-end | ✓ VERIFIED (no gap) | n/a (foundation) |
+| SC-7 | DEC-185 simultaneous send; SMS text-dark (kill-switch); no fallback | ✓ rides v2 + smsAdapter gate | (this branch) |
+| SC-8 | No raw provider sends outside adapters (sole-send-path) | ✓ all route via notify-dispatch fetch | (this branch) |
+
+(Commit hash filled at the post-write commit; see §11.)
+
+---
+
+## 3. Files changed
+
+**New:**
+- `supabase/functions/notify-reminders/index.ts` (+~95) — reminder cron edge fn.
+- `supabase/migrations/20261112000000_orch_1161_subc_reminder_enqueue.sql` (+~155) — `pg_notify_reminders_enqueue()` RPC.
+- `supabase/migrations/20261112000001_orch_1161_subc_reminders_cron.sql` (+~95) — ~15-min pg_cron.
+- `supabase/functions/_shared/__tests__/meta_orch_1161_subc_templates.test.ts` (+~95)
+- `supabase/functions/_shared/__tests__/meta_orch_1161_subc_purchase_push.test.ts` (+~135)
+- `supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_push.test.ts` (+~135)
+
+**Modified:**
+- `supabase/functions/_shared/notifyTemplates.ts` (+~115) — render cases for event/reservation reminders (24h/2h via `lead_bucket`), purchase confirmation, refund, order-cancelled; `fmtAmount()`.
+- `supabase/functions/_shared/businessNotifyTriggers.ts` (+~175) — `fireBuyerPurchaseConfirmationPush()` + `fireBuyerOrderNotify()` + wired purchase push into `fireOrderFinalizeNotifications`.
+- `supabase/functions/_shared/stripeWebhookRouter.ts` (+~10) — buyer refund push in `handleRefundEvent` (allowlisted "ADD dispatch call ONLY").
+- `supabase/functions/cancel-order/index.ts` (+~12) — buyer order-cancelled push.
+- `supabase/functions/paystack-webhook/index.ts` (+~30) — buyer purchase-confirmation push on Paystack finalize.
+- `supabase/functions/refund-order/index.ts` (+6) — doc comment only (no behavior change; refund push lives in the webhook chokepoint).
+- `supabase/config.toml` (+8) — `[functions.notify-reminders] verify_jwt=false`.
+
+---
+
+## 4. Data-model changes applied
+
+One new SECURITY DEFINER fn `public.pg_notify_reminders_enqueue(int, text, int)`:
+- Atomic windowed select of upcoming PAID event orders + CONFIRMED reservations →
+  `INSERT INTO notification_outbox ... ON CONFLICT (idempotency_key) DO NOTHING`.
+- Idempotency_key = `{category}:{entityId}:{leadBucket}` (leadBucket `24h`|`2h`).
+- `REVOKE PUBLIC + anon; GRANT authenticated, service_role`.
+- One new pg_cron job `orch_1161_notify_reminders` (`*/15 * * * *`).
+No tables/columns/constraints added. (All consumed tables/columns confirmed live on remote.)
+
+---
+
+## 5. Edge functions touched (verify_jwt to preserve)
+
+| Function | verify_jwt | Note |
+|---|---|---|
+| `notify-reminders` (NEW) | **false** | invoked by pg_cron with service-role bearer |
+| `cancel-order` | false (unchanged) | validates JWT itself |
+| `refund-order` | (doc only) | unchanged |
+| `paystack-webhook` | false (unchanged) | signature-verified |
+| `stripe-webhook` (router) | false (unchanged) | signature-verified |
+| `notify-dispatch` (v2, unchanged) | false | the sole send entry these call |
+
+---
+
+## 6. Regression tests added
+
+- `meta_orch_1161_subc_templates.test.ts` — 5 tests (reminder 24h≠2h copy, purchase NO-STOP, refund currency-aware, order-cancelled copy).
+- `meta_orch_1161_subc_purchase_push.test.ts` — 2 tests (push w/ contact:null = no double-email; no-account → no dispatch).
+- `meta_orch_1161_subc_refund_cancel_push.test.ts` — 3 tests (phone-only contact = no double-email; anon guest; no-recipient → no dispatch).
+
+`deno test --allow-env` → **10 passed | 0 failed**.
+
+**fails-on-revert verified (true line deletion):**
+- Deleted the `buyer_event_reminder` render case → templates test FAILED (1 failed), restored → PASS.
+- Deleted the `fetch` dispatch in `fireBuyerPurchaseConfirmationPush` → purchase-push test FAILED (1 failed), restored → PASS.
+- Both proven at the working-tree state of this branch immediately before commit.
+
+---
+
+## 7. Old → New receipts
+
+### notifyTemplates.ts
+- **Before:** rendered only the 3 reservation categories + a generic fallback.
+- **Now:** also renders `buyer_event_reminder`/`buyer_reservation_reminder` (24h vs 2h via `lead_bucket`), `buyer_purchase_confirmation` (COPY §3.11, NO STOP line), `buyer_refund_issued` (currency-aware amount, COPY §3.9), `buyer_order_cancelled` (COPY §3.10).
+- **Why:** the drain forwards these category keys to the dispatcher → renderer must cover them (SPEC §7.1/§7.3).
+
+### businessNotifyTriggers.ts
+- **Before:** `fireOrderFinalizeNotifications` fanned out only BRAND-side order_paid/sold_out/low_inventory.
+- **Now:** also fires the NET-NEW buyer purchase-confirmation push (contact=null → email skips). Adds `fireBuyerOrderNotify` for refund/cancel buyer push (contact=phone → email skips).
+- **Why:** SPEC §7.1 — buyer gets a free push; email stays single-owned.
+
+### stripeWebhookRouter.ts (handleRefundEvent)
+- **Before:** notified only the BRAND on refund.
+- **Now:** ALSO fires the buyer refund push (single refund chokepoint, idempotent on refundId).
+- **Why:** SPEC §7.x refund path; allowlist permits "ADD the dispatch call ONLY".
+
+### cancel-order / paystack-webhook
+- **Before:** emailed the buyer only.
+- **Now:** also fire the buyer push/in-app(+sms / push-inapp) through the dispatcher.
+- **Why:** the only chokepoints for free-cancel / Paystack-finalize respectively.
+
+---
+
+## 8. Cross-surface impact
+
+| Surface | Affected | Note |
+|---|---|---|
+| Consumer iOS | YES (runtime) | buyers now receive purchase/refund/cancel/reminder PUSH + in-app rows. Backend-only change; no app build. |
+| Consumer Android | YES (runtime) | same (shared OneSignal). |
+| Buyer/anon Web | NO | no UI; anon guests reached via email/SMS through the same backend. |
+| Business iOS / Android | NO | brand-side notify unchanged this slice. |
+| Admin Web | NO | out of scope. |
+| Business Web preview | NO | n/a. |
+Parity is automatic (single backend path).
+
+---
+
+## 9. Smoke / verification
+
+- `deno check` clean on all new + modified edge fns (notify-reminders, notifyTemplates, businessNotifyTriggers, stripeWebhookRouter, cancel-order, refund-order, paystack-webhook, ticket-checkout-confirm).
+- `deno test` 10/10 green; fails-on-revert proven by line deletion (both mandated cases).
+- 1161 strict-grep gate `i-proposed-1161-sms-from-approved-sender-and-kill-switch.mjs` → PASS.
+- Sole-send-path: grep confirms NO raw `sendTwilioSms(`/`sendPush(`/`api.resend.com` in any new code — everything routes through `notify-dispatch` v2.
+- Read-only remote probe: all consumed tables/columns + the 7 categories CONFIRMED live with correct channels; `pg_notify_reminders_enqueue` correctly absent (pending). No runtime UX driven (backend-only).
+
+---
+
+## 10. Known issues / deferred
+
+- **Slice "a" (final backlog):** the consumer notification-preferences matrix UI (per-category × per-channel toggles incl. SMS) is NOT in this slice. That is the last META-ORCH-1161 Sub-C deliverable.
+- Reminder copy renders date/time from the payload's `reserved_for`/pre-formatted fields; venue-tz-correct formatting is the dispatcher/template concern (already deterministic en-US).
+
+---
+
+## 11. Operator action required
+
+**Apply the two new migrations** (via the Management API per the 1161 deploy posture — MCP read-only, CLI drift-wedged), after REVIEW, monotonic above `20261111000000`:
+- `20261112000000_orch_1161_subc_reminder_enqueue.sql`
+- `20261112000001_orch_1161_subc_reminders_cron.sql`
+
+(If using the linked CLI from a properly-linked checkout:)
+```bash
+cd "/Users/sethogieva/Desktop/mingla-orchs/ORCH-1161-[txn-moments]" && /Users/sethogieva/bin/supabase db push --linked
+```
+
+**Deploy edge functions from MERGED `main`** (orchestrator/operator-owned; never the worktree):
+- `notify-reminders` (NEW, verify_jwt=false)
+- `cancel-order`, `paystack-webhook`, `stripe-webhook`/router, `ticket-checkout-confirm`, `notify-dispatch` (the shared `_shared/businessNotifyTriggers.ts` + `_shared/notifyTemplates.ts` + `_shared/stripeWebhookRouter.ts` changes are bundled into whatever fns import them — redeploy all the above).
+
+**Env (optional, defaults baked in):** `REMINDER_LEAD_24H_HOURS` (24), `REMINDER_LEAD_2H_HOURS` (2), `REMINDER_WINDOW_MINUTES` (30). SMS stays dark until `SMS_LIVE_ENABLED_US` is flipped in the smsAdapter (unchanged this slice).
+
+---
+
+## 12. Discoveries for Orchestrator
+
+1. **Foundation seed vs SPEC §5.2 discrepancy — `buyer_reservation_confirmed` has `sms`.** SPEC §5.2 / §7.2 says confirmed is a NO-text category (`{push,inapp,email}`), but the live seed (`20261110000001`) + remote DB have it as `{inapp,push,email,sms}`. The reservation trigger enqueues `buyer_reservation_confirmed` with `contact=guest_phone`, so a confirmed reservation WOULD text the guest (once SMS goes live). Verify-only item #4 did not authorize a seed change. Decide: correct the seed (drop `sms` from confirmed) or accept SMS-on-confirm.
+2. **Allowlist enumeration gap (§13) vs scope (§7/item #3).** The §13 allowlist omits `cancel-order` (and `paystack-webhook`), but the SPEC body item #3 explicitly names `cancel-order`, and §7.1 names "the Paystack equivalent." I added minimal additive notify-dispatch calls there (no money/finalize touch) to satisfy the /goal. Flagging for the allowlist to be reconciled at REVIEW.
+3. **Comms:** COMMS-0040/0041 (RSVP/experience public-page standardization, WARN/ALL) read and factored — this slice touches only backend notify wiring, not the public-page bodies, so no conflict. No new COMMS entry needed.
+
+---
+
+## Downstream routing
+Route back to orchestrator for REVIEW → mingla-tester (reminder bucketing idempotency, purchase-push no-double-email, refund/cancel single-owner, reservation transition coverage, simultaneous per-channel send) → CLOSE (flip I-PROPOSED-1161-* ACTIVE; close dual-write window). Remaining: slice "a" consumer prefs matrix UI.

--- a/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBC_TXN_MOMENTS.md
+++ b/Mingla_Artifacts/reports/TEST_META-ORCH-1161_SUBC_TXN_MOMENTS.md
@@ -1,0 +1,129 @@
+# TEST — META-ORCH-1161 Sub-C slice "b" (transactional moments)
+
+**ORCH:** META-ORCH-1161 Sub-C (slice "b")
+**Phase:** TEST (adversarial gatekeeper)
+**Worktree:** `~/Desktop/mingla-orchs/ORCH-1161-[txn-moments]/` on branch `ORCH-1161-txn-moments`
+**Under-test HEAD:** `2de27008e` (impl `c443e18c6` + seed-correction `2de27008e`)
+**Tester commit (adversarial test):** `d967b951e`
+**Author:** mingla-tester (Claude)
+**Date:** 2026-06-20
+**Mode:** SPEC-COMPLIANCE + TARGETED (backend/SQL/edge-only → source-only exemption applies; migrations + seed verified against REAL Postgres `gqnoajqerqhnvulmnyvv`)
+
+---
+
+## 1. Verdict
+
+**CONDITIONAL PASS** — P0: 0 · P1: 0 · P2: 0 · P3: 0 · P4: 2.
+
+Regression gate: SATISFIED (implementor happy-path tests on-branch + tester adversarial on-branch, both fails-on-revert proven). Backend-only exemption from the live-fire sim gate (no UI/runtime surface touched; pure edge-fn/SQL additive wiring).
+
+The single condition: **the seed-correction migration `20261112000002` and the two cron/RPC migrations are NOT yet applied to remote** (verified live — `pg_notify_reminders_enqueue` absent, `buyer_reservation_confirmed` still carries `sms`). This is by-design (operator applies migrations; tester Hard-Guard forbids applying). The CODE is correct; it must be DEPLOYED+APPLIED before close. SMS is text-dark so there is **zero live blast radius today**. CONDITIONAL on operator applying the three migrations + deploying the edge fns from merged main.
+
+---
+
+## 2. SC-by-SC matrix (runtime/live evidence)
+
+| SC | Criterion | Verdict | Evidence |
+|---|---|---|---|
+| SC-1 | Reminder cron: exactly ONE per `{category}:{entityId}:{leadBucket}` across overlapping ticks; none for past/cancelled; reservations only upcoming+confirmed | **PASS (proven vs schema)** | Live `notification_outbox_idempotency_idx` UNIQUE on `(idempotency_key)` EXISTS. Reminder key `buyer_event_reminder:{order_id}:{24h\|2h}` / `buyer_reservation_reminder:{reservation_id}:{24h\|2h}` is **time-invariant** (no timestamp) → re-enqueue on an overlapping 15-min tick hits `ON CONFLICT DO NOTHING` → ZERO dup rows. Events filtered `status IN ('scheduled','live')` + `deleted_at IS NULL` (excludes draft/ended/cancelled — confirmed `events_status_check` enum; live data has 3 `cancelled`, 150 `draft`, 23 `scheduled`). Reservations filtered `status='confirmed'` + future window. All read columns confirmed live. |
+| SC-2 | ~15-min cron registered | **PASS (source; pending apply)** | `20261112000001` schedules `orch_1161_notify_reminders` at `*/15 * * * *` with in-migration probes that RAISE if jobname/schedule mismatch. Mirrors the proven `20261110000003` drain cron. Not yet in remote `cron.job` (migration unapplied). |
+| SC-3 | Purchase finalize → buyer push+inapp, email single-owned (NO double-email), idempotent/order | **PASS (test-proven)** | `fireBuyerPurchaseConfirmationPush` dispatches `category_key=buyer_purchase_confirmation`, `contact:null` → v2 email channel records `skipped` (email owned by ticket-confirmation-dispatch). Idempotency `buyer_purchase_confirmation:{orderId}`. Live category = `{inapp,push,email}` NO sms. Test asserts exactly 1 POST, contact null. |
+| SC-3-Paystack | Same push on Paystack finalize | **PASS (source)** | `paystack-webhook` fires `fireBuyerPurchaseConfirmationPush` after `dispatchTicketConfirmation`, only on fresh `finalizedOrderId`, contact:null, try/catch non-fatal. Pure addition (0 deletions). |
+| SC-4 | Refund → buyer push+inapp(+sms), email single-owned, idempotent/refundId | **PASS (test-proven)** | `handleRefundEvent` (single allowlisted chokepoint) fires `fireBuyerOrderNotify` key `buyer_refund_issued:{refundId}`, contact=phone → email skips. Live category `{inapp,push,email,sms}`. `refund-order` is doc-only (no second dispatch → no double-push). |
+| SC-5 | Order-cancelled → buyer push+inapp(+sms), email single-owned, idempotent/order | **PASS (test-proven)** | `cancel-order` fires `fireBuyerOrderNotify` key `buyer_order_cancelled:{orderId}:{client-idem}` ONLY after `biz_cancel_order` RPC succeeds (RPC is the real double-cancel gate). contact=phone → v2 email skips; legacy `ticket_order_notifications` email is the single email owner. |
+| SC-6 | Reservation confirmed/cancelled end-to-end via trigger→outbox→drain→dispatch | **PASS (proven live)** | Live trigger `orch_1161_reservation_notify_trg` → `orch_1161_reservation_notify_outbox()` enqueues `buyer_reservation_confirmed` (requested→confirmed) AND `buyer_reservation_cancelled` (→cancelled_by_guest/venue) into outbox; drain cron forwards generically. No gap; foundation, untouched by this slice. |
+| SC-7 | SMS text-dark; DEC-185 simultaneous send; no fallback | **PASS (proven)** | Zero raw Twilio/Resend/OneSignal sends in the entire diff. smsAdapter kill-switch (`SMS_LIVE_ENABLED_*`, default false) returns `status:'skipped'` WITHOUT any HTTP call (line 168). All new moments route through `notify-dispatch` v2 → smsAdapter (sole send path). 1161 SMS strict-grep gate PASS. |
+| SC-8 | No raw provider sends outside adapters | **PASS** | grep of `git diff origin/main...HEAD` for twilio/resend/onesignal/sendSms/messages.create → empty. |
+| Migrations | `...0000/001/002` monotonic above remote head `20261111000000`, apply against real PG | **PASS (verified)** | Live `list_migrations` head = `20261111000000_orch_1161_marketing_sms_segments`. New three are `20261112000000/001/002` — strictly above. GRANT/REVOKE after `$function$;` (line 145<150-152) → no migration-baseline CI trip. Seed correction is idempotent `array_remove`. |
+| Money-seam | finalize/refund/cancel money logic unchanged | **PASS (proven)** | `--numstat`: cancel-order/paystack/refund-order = 0 deletions (pure additions); stripeWebhookRouter's only deletion is the 1-line import expanded to multi-line. No money/RPC/finalize logic altered. |
+
+---
+
+## 3. Findings
+
+### P4-1 (NOTE) — cancel-order buyer-notify key includes the client `Idempotency-Key` header
+`cancel-order/index.ts:150` keys the buyer push on `buyer_order_cancelled:{orderId}:{client-header}`. A client retrying cancel with a DIFFERENT header value would produce a different key. **Not a defect**: `fireBuyerOrderNotify` only runs after `biz_cancel_order` succeeds (early-return on `rpcError||!result` at L104), and the RPC rejects a second cancel of an already-cancelled order → the buyer push fires at most once per successful cancel regardless of header variance. The suffix is harmless belt-and-braces.
+*Required fix:* none. *Retest:* n/a.
+
+### P4-2 (NOTE) — doc imprecision on the cancel-order email owner
+The report says the cancel email is owned by `dispatchTicketConfirmation`; the actual owner is the legacy `ticket_order_notifications` insert in `cancel-order` itself (template_key `buyer_order_cancelled`). The no-double-email guarantee still holds (v2 leg passes contact=phone → email skips). Cosmetic only.
+*Required fix:* none (doc). *Retest:* n/a.
+
+---
+
+## 4. Step 0.5 — independent re-run of the implementor's fails-on-revert proof
+
+Checked out under-test HEAD `2de27008e`. Ran all three implementor tests: **10 passed | 0 failed**.
+
+Independently reproduced the mandated revert proof (true line-level mutation of product code, then restored):
+- Inserted an early `return;` before the `fetch` dispatch in `fireBuyerPurchaseConfirmationPush` (`businessNotifyTriggers.ts`) → `meta_orch_1161_subc_purchase_push.test.ts` test (1) FAILED (`captured.length` 0 ≠ expected 1) — exact assertion `assertEquals(captured.length, 1)`. Restored → PASS. Verified at `2de27008e`.
+
+---
+
+## 5. Adversarial test added (different angle)
+
+**Path:** `supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_collision_adversarial.test.ts`
+**Commit:** `d967b951e` (on branch `ORCH-1161-txn-moments`, in `git diff origin/main...HEAD --name-only`).
+
+Different angle than the implementor (who tested each path in isolation):
+- **ANGLE 1 — refund-then-cancel on the SAME order must NOT collapse.** Fires both `buyer_refund_issued` and `buyer_order_cancelled` on one order; asserts 2 dispatches with DISTINCT, non-colliding idempotency keys (no namespace cross-contamination) → the v2 dedupe cannot silently swallow one moment.
+- **ANGLE 2 — Stripe refund-webhook re-delivery must COLLAPSE.** Same `refundId` delivered twice → asserts identical idempotency_key both times (proves the key is a pure function of refundId, NOT a timestamp/nonce) → v2 dedupe collapses to one buyer row.
+
+**fails-on-revert verified at `2de27008e`:** mutated `fireBuyerOrderNotify` to append `Date.now()+Math.random()` to the forwarded idempotency_key → ANGLE 2 FAILED (the two keys diverge). Restored → 2 passed. Both implementor tests AND this adversarial test appear in the closing diff.
+
+Full suite (all 5 subc test files): **12 passed | 0 failed**.
+
+---
+
+## 6. Constitution 14-rule matrix
+
+| # | Rule | Verdict | Evidence |
+|---|---|---|---|
+| 1 | No dead taps | N/A | no UI |
+| 2 | One owner per truth | **PASS** | email single-owned (ticket-confirmation-dispatch / ticket_order_notifications); v2 leg adds push/inapp/sms only via contact-null/phone. Refund single chokepoint (handleRefundEvent); refund-order doc-only. |
+| 3 | No silent failures | **PASS** | reminders return 207 on partial failure (no swallow); buyer-notify helpers `console.warn` non-fatal by design (best-effort relative to money), never silently mark success. |
+| 4 | One query key per entity | N/A | no client query keys |
+| 5 | Server state server-side | N/A | edge-only |
+| 6 | Logout clears | N/A | |
+| 7 | Label `[TRANSITIONAL]` | N/A | no transitional code |
+| 8 | Subtract before adding | **PASS** | additive wiring onto existing v2 path; no parallel send path introduced. |
+| 9 | No fabricated data | **PASS** | reminder/refund copy interpolates real payload; default template renders plain payload, never fakes amounts/dates. |
+| 10 | Currency-aware | **PASS** | `fmtAmount` uses `payload.currency` via Intl, no hardcoded £/$, no GBP fallback. |
+| 11 | One auth instance | N/A | service-role clients in edge only |
+| 12 | Validate at right time | **PASS** | reminder window computed from `now()` server-side; lead times env-driven. |
+| 13 | Exclusion consistency | **PASS** | RPC excludes deleted/cancelled events + non-confirmed reservations; SMS exclusion (no-text categories) enforced via seed channels. |
+| 14 | Persisted-state startup | N/A | |
+
+---
+
+## 7. Device / parity matrix
+
+| Surface | Verdict | Note |
+|---|---|---|
+| Consumer iOS | N/A (backend-only) | buyers receive push/inapp via shared backend; no app build/sim run required (no UI change). |
+| Consumer Android | N/A (backend-only) | same shared OneSignal path. |
+| Buyer/anon Web | N/A | no UI; anon guests reached via email/SMS (text-dark). |
+| Business iOS/Android | N/A | brand-side notify unchanged this slice. |
+| Admin Web | N/A | out of scope. |
+| Business Web preview | N/A | n/a. |
+
+Live-fire sim gate EXEMPT: pure edge-fn/SQL additive wiring, zero UI/runtime/interaction surface. Migration + seed + trigger + index state verified against REAL Postgres (project `gqnoajqerqhnvulmnyvv`) — the runtime evidence substitute for a backend change.
+
+Edge-fn live deploy state (read-only): the new `notify-reminders` fn + the three migrations are NOT yet deployed/applied (expected — operator owns deploy from merged main). `pg_notify_reminders_enqueue` confirmed absent; `buyer_reservation_confirmed` still carries `sms` live.
+
+---
+
+## 8. Discoveries for Orchestrator
+
+1. **Seed correction not yet live (the CONDITIONAL).** Live `buyer_reservation_confirmed.default_channels = {inapp,push,email,sms}` — migration `20261112000002` removes `sms` but is unapplied. Zero blast radius today (SMS text-dark). MUST be applied before any SMS go-live, else a confirmed reservation texts the guest contrary to DEC-185.
+2. **No-text set verified against DEC-185 (post-correction).** Live no-sms categories already correct: `buyer_purchase_confirmation`, `marketing`, `reminders`, `messages`, `friend_requests`, `collaboration_invites` (social). `payment_failed` is not a seeded category (absence = no sms, acceptable). After `...0002`, `buyer_reservation_confirmed` joins the no-text set → SMS-eligible set is the transactional+marketing+payout closed set (reminders, reservation changed/cancelled, refund, order cancelled, marketing_blast, payout_paid, waitlist_spot_open). Matches DEC-185.
+3. **Allowlist §13 vs §7 (ACCEPTED per dispatch).** §13 omitted cancel-order/paystack-webhook; §7 body required them. Confirmed additive-only (0 money deletions). Per dispatch this is an orchestrator decision, not a defect.
+4. **COMMS-0040/0041 (RSVP/experience public-page standardization, WARN/ALL):** read; no conflict — this slice touches only backend notify wiring, not public-page bodies. No new COMMS entry.
+
+---
+
+## 9. Accepted conditions (CONDITIONAL PASS)
+
+- **C-1:** Operator must apply migrations `20261112000000`, `20261112000001`, `20261112000002` (via Management API per the 1161 posture — MCP read-only, CLI drift-wedged) and deploy edge fns (`notify-reminders` NEW + cancel-order/paystack-webhook/stripe-webhook router/ticket-checkout-confirm/notify-dispatch) from MERGED main. Until then the reminder cron + seed correction are not live. SMS text-dark means zero risk while pending. This is the standard backend deploy posture, not a code defect.
+
+**CLEAR-TO-CLOSE:** YES, conditioned on C-1 (apply 3 migrations + deploy edge fns from merged main). Code is correct and proven; the only gap is the operator-owned apply/deploy step that the tester is Hard-Guarded from performing.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -278,6 +278,13 @@ verify_jwt = false
 [functions.notify-outbox-drain]
 verify_jwt = false
 
+# META-ORCH-1161 Sub-C — notify-reminders: ~15-min pg_cron enqueues buyer event +
+# reservation reminders (24h + 2h buckets) into notification_outbox via
+# pg_notify_reminders_enqueue(). verify_jwt=false: invoked by cron with the
+# service-role bearer.
+[functions.notify-reminders]
+verify_jwt = false
+
 # META-ORCH-1161 Sub-A — twilio-inbound-sms: the STOP/HELP inbound webhook.
 # verify_jwt=false: Twilio cannot present a Supabase JWT; gated on ?secret=
 # (same posture as twilio-message-status).

--- a/supabase/functions/_shared/__tests__/meta_orch_1161_subc_purchase_push.test.ts
+++ b/supabase/functions/_shared/__tests__/meta_orch_1161_subc_purchase_push.test.ts
@@ -1,0 +1,135 @@
+// META-ORCH-1161 Sub-C §7.1 — regression test: buyer purchase-confirmation PUSH
+// fires WITHOUT duplicating the email.
+//
+// Proves:
+//   (1) fireBuyerPurchaseConfirmationPush POSTs to notify-dispatch v2 with
+//       category_key='buyer_purchase_confirmation', the buyer's user_id, and
+//       contact:null — contact:null is THE mechanism that makes the v2 dispatcher
+//       skip the email channel (email is owned by ticket-confirmation-dispatch),
+//       so no double-email. Idempotency_key is buyer_purchase_confirmation:{orderId}.
+//   (2) a buyer with NO account (buyer_user_id null) → NO dispatch (no push/in-app
+//       recipient; the email owner still reaches them separately).
+//
+// fails-on-revert: delete the fetch dispatch in fireBuyerPurchaseConfirmationPush
+// → test (1) sees zero captured POSTs and FAILS. Change contact:null to an email →
+// the contact:null assertion FAILS (would re-introduce the double-email).
+//
+// Run: deno test --allow-env supabase/functions/_shared/__tests__/meta_orch_1161_subc_purchase_push.test.ts
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { fireBuyerPurchaseConfirmationPush } from "../businessNotifyTriggers.ts";
+
+const ORDER_ID = "order-1161";
+const EVENT_ID = "event-1161";
+const BRAND_ID = "brand-1161";
+const BUYER_USER_ID = "buyer-1161";
+
+function makeFakeSupabase(opts: { buyerUserId: string | null; brandName: string }) {
+  return {
+    from(table: string) {
+      if (table === "orders") {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  maybeSingle() {
+                    return Promise.resolve({
+                      data: { buyer_user_id: opts.buyerUserId },
+                      error: null,
+                    });
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+      if (table === "brands") {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  maybeSingle() {
+                    return Promise.resolve({
+                      data: { name: opts.brandName },
+                      error: null,
+                    });
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+function installFetchCapture(captured: Array<{ url: string; body: Record<string, unknown> }>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+    captured.push({ url, body });
+    return Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 }));
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+Deno.test("purchase finalize fires a buyer push with contact:null (no double-email)", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    await fireBuyerPurchaseConfirmationPush(
+      makeFakeSupabase({ buyerUserId: BUYER_USER_ID, brandName: "Lantern" }),
+      {
+        orderId: ORDER_ID,
+        eventId: EVENT_ID,
+        brandId: BRAND_ID,
+        eventTitle: "Jazz Night",
+        startAtIso: "2026-06-22T20:00:00Z",
+      },
+    );
+  } finally {
+    restore();
+  }
+
+  assertEquals(captured.length, 1, "exactly one notify-dispatch POST expected");
+  const { url, body } = captured[0];
+  assert(url.endsWith("/functions/v1/notify-dispatch"), `unexpected url ${url}`);
+  assertEquals(body.category_key, "buyer_purchase_confirmation");
+  assertEquals(body.user_id, BUYER_USER_ID);
+  // contact:null is the no-double-email guarantee (email channel records skipped).
+  assertEquals(body.contact, null);
+  assertEquals(body.idempotency_key, `buyer_purchase_confirmation:${ORDER_ID}`);
+  const payload = body.payload as Record<string, unknown>;
+  assertEquals(payload.brand_name, "Lantern");
+  assertEquals(payload.event_title, "Jazz Night");
+});
+
+Deno.test("no-account buyer → no push dispatch (email owner reaches them)", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    await fireBuyerPurchaseConfirmationPush(
+      makeFakeSupabase({ buyerUserId: null, brandName: "Lantern" }),
+      { orderId: ORDER_ID, eventId: EVENT_ID, brandId: BRAND_ID, eventTitle: "Jazz Night" },
+    );
+  } finally {
+    restore();
+  }
+  assertEquals(captured.length, 0, "no dispatch for a no-account buyer");
+});

--- a/supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_collision_adversarial.test.ts
+++ b/supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_collision_adversarial.test.ts
@@ -1,0 +1,173 @@
+// META-ORCH-1161 Sub-C "b" — TESTER ADVERSARIAL regression (different angle than
+// the implementor's happy-path refund/cancel tests).
+//
+// The implementor's `meta_orch_1161_subc_refund_cancel_push.test.ts` proves each
+// buyer notify path IN ISOLATION (one refund OR one cancel, correct contact). It
+// does NOT attack the two production race/replay hazards the QA dispatch named:
+//
+//   ANGLE 1 — refund-then-cancel on the SAME order must NOT collapse.
+//     A buyer can be refunded AND later have the order cancelled (or vice-versa).
+//     If the refund leg and the cancel leg ever shared an idempotency key for the
+//     same order, the v2 dispatcher's idempotency dedupe would SILENTLY DROP the
+//     second notification — the buyer would learn of a refund but never the cancel
+//     (or vice-versa). This test fires BOTH on one order and asserts the two
+//     dispatched idempotency_keys are DISTINCT and that BOTH POSTs go out.
+//
+//   ANGLE 2 — Stripe refund-webhook re-delivery must COLLAPSE to one.
+//     handleRefundEvent keys the buyer refund push on `buyer_refund_issued:{refundId}`
+//     (see stripeWebhookRouter.ts). Stripe re-delivers webhook events; the SAME
+//     refundId delivered twice MUST produce the SAME idempotency_key both times so
+//     the v2 dedupe collapses it to ONE buyer notification. This proves the key is
+//     a pure function of refundId — NOT a timestamp / Date.now() / random (which
+//     would defeat idempotency and double-notify on every retry).
+//
+// fails-on-revert: if `fireBuyerOrderNotify` stops forwarding the caller's
+// idempotency_key verbatim (e.g. someone appends Date.now() or a random nonce, or
+// collapses refund+cancel onto one key), ANGLE 1's distinctness assert or ANGLE 2's
+// stability assert FAILS. Verified by mutation at HEAD 2de27008e.
+//
+// Append-only; adds a NEW file (does not touch the implementor's test).
+//
+// Run: deno test --allow-env supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_collision_adversarial.test.ts
+
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { fireBuyerOrderNotify } from "../businessNotifyTriggers.ts";
+
+const ORDER_ID = "order-collision";
+const REFUND_ID = "re_adversarial_001";
+
+function makeFakeSupabase() {
+  return {
+    from(_table: string) {
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                maybeSingle() {
+                  return Promise.resolve({
+                    data: {
+                      buyer_user_id: "buyer-collision",
+                      buyer_phone_e164: "+15550000000",
+                      event_id: "event-collision",
+                      currency: "USD",
+                      events: {
+                        title: "Jazz Night",
+                        brand_id: "brand-collision",
+                        brands: { name: "Lantern" },
+                      },
+                    },
+                    error: null,
+                  });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+function installFetchCapture(captured: Array<{ url: string; body: Record<string, unknown> }>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+    captured.push({ url, body });
+    return Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 }));
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+// ANGLE 1 — refund + cancel on the SAME order must not suppress each other.
+Deno.test("ADVERSARIAL: refund-then-cancel on one order → distinct idempotency keys, both dispatch", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    // Same order: it is refunded (Stripe webhook chokepoint key) ...
+    await fireBuyerOrderNotify(makeFakeSupabase(), {
+      categoryKey: "buyer_refund_issued",
+      orderId: ORDER_ID,
+      idempotencyKey: `buyer_refund_issued:${REFUND_ID}`,
+      extraPayload: { amount_cents: 6793, currency: "USD" },
+    });
+    // ... then the order is cancelled (cancel-order chokepoint key).
+    await fireBuyerOrderNotify(makeFakeSupabase(), {
+      categoryKey: "buyer_order_cancelled",
+      orderId: ORDER_ID,
+      idempotencyKey: `buyer_order_cancelled:${ORDER_ID}:client-idem`,
+    });
+  } finally {
+    restore();
+  }
+
+  // BOTH must dispatch — neither moment is allowed to swallow the other.
+  assertEquals(captured.length, 2, "both refund AND cancel must be dispatched");
+
+  const refundKey = captured[0].body.idempotency_key as string;
+  const cancelKey = captured[1].body.idempotency_key as string;
+
+  // Distinct categories, distinct keys → v2 dedupe will NOT collapse them.
+  assertEquals(captured[0].body.category_key, "buyer_refund_issued");
+  assertEquals(captured[1].body.category_key, "buyer_order_cancelled");
+  assertNotEquals(
+    refundKey,
+    cancelKey,
+    "refund and cancel on the SAME order must have DISTINCT idempotency keys",
+  );
+  // And the cancel key must NOT be a prefix/substring collision of the refund key.
+  assert(
+    !refundKey.startsWith("buyer_order_cancelled"),
+    "refund key must not collide into the cancel namespace",
+  );
+  assert(
+    !cancelKey.startsWith("buyer_refund_issued"),
+    "cancel key must not collide into the refund namespace",
+  );
+});
+
+// ANGLE 2 — Stripe re-delivers the SAME refund event → key MUST be stable.
+Deno.test("ADVERSARIAL: refund-webhook re-delivery for the same refundId → identical key (idempotent)", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    // First webhook delivery.
+    await fireBuyerOrderNotify(makeFakeSupabase(), {
+      categoryKey: "buyer_refund_issued",
+      orderId: ORDER_ID,
+      idempotencyKey: `buyer_refund_issued:${REFUND_ID}`,
+      extraPayload: { amount_cents: 6793, currency: "USD" },
+    });
+    // Stripe re-delivers the SAME event (retry budget) — same refundId.
+    await fireBuyerOrderNotify(makeFakeSupabase(), {
+      categoryKey: "buyer_refund_issued",
+      orderId: ORDER_ID,
+      idempotencyKey: `buyer_refund_issued:${REFUND_ID}`,
+      extraPayload: { amount_cents: 6793, currency: "USD" },
+    });
+  } finally {
+    restore();
+  }
+
+  // The helper forwards the key verbatim → both POSTs carry the SAME key, so the
+  // v2 dispatcher's idempotency dedupe collapses them to a single buyer row.
+  assertEquals(captured.length, 2, "helper itself fires per call; dedupe is downstream on the key");
+  assertEquals(
+    captured[0].body.idempotency_key,
+    captured[1].body.idempotency_key,
+    "same refundId across webhook re-delivery MUST yield the SAME idempotency key (no timestamp/nonce)",
+  );
+  assertEquals(captured[0].body.idempotency_key, `buyer_refund_issued:${REFUND_ID}`);
+});

--- a/supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_push.test.ts
+++ b/supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_push.test.ts
@@ -1,0 +1,127 @@
+// META-ORCH-1161 Sub-C §7.x — regression test: refund / order-cancelled buyer
+// PUSH+in-app(+SMS) fires WITHOUT duplicating the email.
+//
+// Proves fireBuyerOrderNotify:
+//   (1) POSTs to notify-dispatch v2 with the right category + contact = the buyer
+//       PHONE (NOT email) — phone-only contact is what makes the v2 email channel
+//       skip (no double-email; email is owned by ticket-confirmation-dispatch),
+//       while push/in-app/sms still fire (these categories are SMS-eligible),
+//   (2) skips entirely when the buyer has neither an account nor a phone (no
+//       push/in-app/sms recipient — email owner handles that buyer).
+//
+// fails-on-revert: delete the dispatch fetch → (1) captures zero POSTs and FAILS.
+//
+// Run: deno test --allow-env supabase/functions/_shared/__tests__/meta_orch_1161_subc_refund_cancel_push.test.ts
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { fireBuyerOrderNotify } from "../businessNotifyTriggers.ts";
+
+const ORDER_ID = "order-rc";
+
+function makeFakeSupabase(opts: { buyerUserId: string | null; buyerPhone: string | null }) {
+  return {
+    from(_table: string) {
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                maybeSingle() {
+                  return Promise.resolve({
+                    data: {
+                      buyer_user_id: opts.buyerUserId,
+                      buyer_phone_e164: opts.buyerPhone,
+                      event_id: "event-rc",
+                      currency: "USD",
+                      events: { title: "Jazz Night", brand_id: "brand-rc", brands: { name: "Lantern" } },
+                    },
+                    error: null,
+                  });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+function installFetchCapture(captured: Array<{ url: string; body: Record<string, unknown> }>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+    captured.push({ url, body });
+    return Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 }));
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+Deno.test("refund buyer notify uses phone contact (no double-email)", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    await fireBuyerOrderNotify(makeFakeSupabase({ buyerUserId: "u1", buyerPhone: "+15551234567" }), {
+      categoryKey: "buyer_refund_issued",
+      orderId: ORDER_ID,
+      idempotencyKey: `buyer_refund_issued:re_123`,
+      extraPayload: { amount_cents: 6793, currency: "USD" },
+    });
+  } finally {
+    restore();
+  }
+  assertEquals(captured.length, 1);
+  const { body } = captured[0];
+  assertEquals(body.category_key, "buyer_refund_issued");
+  assertEquals(body.user_id, "u1");
+  // Phone contact (NOT email) → v2 email channel skips; no double-email.
+  assertEquals(body.contact, "+15551234567");
+  assertEquals(String(body.contact).includes("@"), false);
+  assertEquals(body.idempotency_key, "buyer_refund_issued:re_123");
+});
+
+Deno.test("order-cancelled buyer notify fires for phone-only (anon guest) buyer", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    await fireBuyerOrderNotify(makeFakeSupabase({ buyerUserId: null, buyerPhone: "+15559998888" }), {
+      categoryKey: "buyer_order_cancelled",
+      orderId: ORDER_ID,
+      idempotencyKey: `buyer_order_cancelled:${ORDER_ID}:idem`,
+    });
+  } finally {
+    restore();
+  }
+  assertEquals(captured.length, 1);
+  assertEquals(captured[0].body.category_key, "buyer_order_cancelled");
+  assertEquals(captured[0].body.user_id, null);
+  assertEquals(captured[0].body.contact, "+15559998888");
+});
+
+Deno.test("no account and no phone → no dispatch", async () => {
+  Deno.env.set("SUPABASE_URL", "https://example.supabase.co");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+  const captured: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const restore = installFetchCapture(captured);
+  try {
+    await fireBuyerOrderNotify(makeFakeSupabase({ buyerUserId: null, buyerPhone: null }), {
+      categoryKey: "buyer_refund_issued",
+      orderId: ORDER_ID,
+      idempotencyKey: "k",
+    });
+  } finally {
+    restore();
+  }
+  assertEquals(captured.length, 0);
+});

--- a/supabase/functions/_shared/__tests__/meta_orch_1161_subc_templates.test.ts
+++ b/supabase/functions/_shared/__tests__/meta_orch_1161_subc_templates.test.ts
@@ -1,0 +1,85 @@
+// META-ORCH-1161 Sub-C "b" — regression test: per-category render templates.
+//
+// Proves the NET-NEW Sub-C render cases added to notifyTemplates.ts:
+//   * buyer_event_reminder renders DISTINCT copy for the 24h vs 2h lead bucket
+//     (the leadBucket payload field is the only differentiator — proves the
+//     single category covers both buckets, SPEC §7.3),
+//   * buyer_reservation_reminder likewise 24h vs 2h,
+//   * buyer_purchase_confirmation renders push+email copy (COPY §3.11, NO STOP
+//     line; SMS string exists defensively but the seed gives it no sms channel),
+//   * buyer_refund_issued formats the amount currency-aware (COPY §3.9),
+//   * buyer_order_cancelled renders the event-scoped copy (COPY §3.10).
+//
+// fails-on-revert: delete any of these case blocks → the switch falls through to
+// the generic default and the assertions below FAIL.
+//
+// Run: deno test supabase/functions/_shared/__tests__/meta_orch_1161_subc_templates.test.ts
+
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { renderCategoryMessage } from "../notifyTemplates.ts";
+
+Deno.test("buyer_event_reminder 24h vs 2h render distinct copy by lead_bucket", () => {
+  const base = { brand_name: "Lantern", event_title: "Jazz Night", time: "8:00 PM" };
+  const r24 = renderCategoryMessage("buyer_event_reminder", { ...base, lead_bucket: "24h" });
+  const r2 = renderCategoryMessage("buyer_event_reminder", { ...base, lead_bucket: "2h" });
+
+  // 24h copy speaks of "tomorrow"; 2h copy speaks of "2 hours". They MUST differ.
+  assertStringIncludes(r24.sms, "tomorrow");
+  assertStringIncludes(r2.sms, "2 hours");
+  assert(r24.sms !== r2.sms, "24h and 2h reminder SMS must differ");
+  assert(r24.push.title !== r2.push.title, "24h and 2h reminder push titles must differ");
+  // Brand + event interpolated into the body (no fabricated placeholder leftovers).
+  assertStringIncludes(r24.sms, "Lantern");
+  assertStringIncludes(r24.sms, "Jazz Night");
+});
+
+Deno.test("buyer_reservation_reminder 24h vs 2h render distinct copy", () => {
+  const base = { brand_name: "Vine", time: "7:30 PM", party_size: 4 };
+  const r24 = renderCategoryMessage("buyer_reservation_reminder", { ...base, lead_bucket: "24h" });
+  const r2 = renderCategoryMessage("buyer_reservation_reminder", { ...base, lead_bucket: "2h" });
+  assertStringIncludes(r24.sms, "tomorrow");
+  assertStringIncludes(r2.sms, "2 hours");
+  assert(r24.sms !== r2.sms, "reservation reminder 24h/2h SMS must differ");
+  assertStringIncludes(r24.sms, "party of 4");
+});
+
+Deno.test("buyer_purchase_confirmation renders push+email (NO STOP line)", () => {
+  const r = renderCategoryMessage("buyer_purchase_confirmation", {
+    brand_name: "Lantern",
+    event_title: "Jazz Night",
+    date: "Jun 22",
+    time: "8:00 PM",
+  });
+  assertStringIncludes(r.push.title, "Jazz Night");
+  assertStringIncludes(r.push.body, "Mingla app");
+  assertStringIncludes(r.email.subject, "Lantern");
+  // Pure transactional confirmation: no "Reply STOP" promo footer in the copy.
+  assertEquals(r.push.body.includes("STOP"), false);
+  assertEquals(r.email.body.includes("STOP"), false);
+});
+
+Deno.test("buyer_refund_issued formats amount currency-aware", () => {
+  const r = renderCategoryMessage("buyer_refund_issued", {
+    brand_name: "Lantern",
+    amount_cents: 6793,
+    currency: "USD",
+  });
+  // $67.93 from 6793 cents (proves fmtAmount wiring — not a raw cents leak).
+  assertStringIncludes(r.sms, "$67.93");
+  assertStringIncludes(r.sms, "5-10 days");
+  assertEquals(r.sms.includes("6793"), false);
+});
+
+Deno.test("buyer_order_cancelled renders event-scoped copy", () => {
+  const r = renderCategoryMessage("buyer_order_cancelled", {
+    brand_name: "Lantern",
+    event_title: "Jazz Night",
+  });
+  assertStringIncludes(r.sms, "Jazz Night");
+  assertStringIncludes(r.sms, "cancelled");
+  assertStringIncludes(r.push.title, "Order cancelled");
+});

--- a/supabase/functions/_shared/businessNotifyTriggers.ts
+++ b/supabase/functions/_shared/businessNotifyTriggers.ts
@@ -77,6 +77,201 @@ export async function notifyBrandRoles(
   }
 }
 
+/**
+ * META-ORCH-1161 Sub-C §7.1 — buyer purchase-confirmation PUSH+in-app leg.
+ *
+ * The buyer already gets the EMAIL (with the ticket PDF + .ics) via
+ * ticket-confirmation-dispatch — that stays the SOLE email owner for this moment.
+ * This adds the NET-NEW free push + durable in-app row through notify-dispatch v2
+ * (category `buyer_purchase_confirmation`, channels {inapp,push,email} per seed).
+ *
+ * Double-email avoidance: we dispatch with contact=null, so the v2 dispatcher's
+ * email channel records `skipped` (no_contact) and NEVER sends — push+inapp only.
+ * (buyer_purchase_confirmation is a NO-SMS category per DEC-185, so no SMS leg
+ * exists regardless.)
+ *
+ * Idempotent per `buyer_purchase_confirmation:{orderId}` (notify-dispatch v2 +
+ * the notifications UNIQUE backstop collapse the confirm/webhook double-fire).
+ * Never throws — best-effort relative to the order finalize.
+ */
+export async function fireBuyerPurchaseConfirmationPush(
+  supabase: SupabaseClient,
+  input: {
+    orderId: string;
+    eventId: string;
+    brandId: string | null;
+    eventTitle: string;
+    startAtIso?: string | null;
+  },
+): Promise<void> {
+  try {
+    // Resolve the buyer (push targets buyer_user_id; no contact → email skipped).
+    const { data: order } = await supabase
+      .from("orders")
+      .select("buyer_user_id")
+      .eq("id", input.orderId)
+      .maybeSingle();
+    const buyerUserId = order?.buyer_user_id as string | null | undefined;
+    if (!buyerUserId) {
+      // Anon/guest buyer has no account → no push/in-app row. The email
+      // (ticket-confirmation-dispatch) still reaches them. No silent gap: nothing
+      // to deliver on the push+inapp channels for a no-account buyer.
+      return;
+    }
+
+    let brandName = "Mingla";
+    if (input.brandId) {
+      const { data: brand } = await supabase
+        .from("brands")
+        .select("name")
+        .eq("id", input.brandId)
+        .maybeSingle();
+      if (brand?.name && typeof brand.name === "string") brandName = brand.name;
+    }
+
+    const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+    const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!SUPABASE_URL || !SERVICE_KEY) {
+      console.warn("[businessNotifyTriggers] purchase-confirmation push skipped: env missing");
+      return;
+    }
+
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/notify-dispatch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SERVICE_KEY}`,
+      },
+      body: JSON.stringify({
+        category_key: "buyer_purchase_confirmation",
+        user_id: buyerUserId,
+        // contact=null → email channel records `skipped` (no double-email; the
+        // email is owned by ticket-confirmation-dispatch).
+        contact: null,
+        payload: {
+          order_id: input.orderId,
+          event_id: input.eventId,
+          event_title: input.eventTitle,
+          brand_name: brandName,
+          reserved_for: input.startAtIso ?? null,
+        },
+        idempotency_key: `buyer_purchase_confirmation:${input.orderId}`,
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn(
+        "[businessNotifyTriggers] purchase-confirmation push dispatch non-ok:",
+        res.status,
+        text,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      "[businessNotifyTriggers] fireBuyerPurchaseConfirmationPush failed (non-fatal):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
+ * META-ORCH-1161 Sub-C §7.x — buyer refund-issued / order-cancelled PUSH+in-app
+ * (+SMS per the seed) via notify-dispatch v2.
+ *
+ * The buyer EMAIL for these moments is owned by ticket-confirmation-dispatch
+ * (template_key buyer_refund_issued / buyer_order_cancelled) — to avoid a
+ * double-email we dispatch with contact = buyer_phone_e164 (phone ONLY). The v2
+ * dispatcher's email channel then records `skipped` (no_contact) while push,
+ * in-app, and SMS fire (buyer_refund_issued / buyer_order_cancelled are
+ * {inapp,push,email,sms} per the seed). If the buyer has no phone, only push +
+ * in-app reach them (still no double-email).
+ *
+ * Idempotent per the caller-supplied idempotency_key. Never throws.
+ */
+export async function fireBuyerOrderNotify(
+  supabase: SupabaseClient,
+  input: {
+    categoryKey: "buyer_refund_issued" | "buyer_order_cancelled";
+    orderId: string;
+    idempotencyKey: string;
+    extraPayload?: Record<string, unknown>;
+  },
+): Promise<void> {
+  try {
+    const { data: order } = await supabase
+      .from("orders")
+      .select(
+        "buyer_user_id, buyer_phone_e164, event_id, currency, events(title, brand_id, brands(name))",
+      )
+      .eq("id", input.orderId)
+      .maybeSingle();
+    if (!order) {
+      console.warn("[businessNotifyTriggers] order not found for buyer notify", input.orderId);
+      return;
+    }
+    const buyerUserId = (order.buyer_user_id as string | null) ?? null;
+    const buyerPhone = (order.buyer_phone_e164 as string | null) ?? null;
+    // No account AND no phone → nothing on push/in-app/sms to deliver (email is
+    // the email-owner's job). No silent gap — there is genuinely no recipient here.
+    if (!buyerUserId && !buyerPhone) return;
+
+    const eventsJoin = order.events as
+      | { title?: string | null; brand_id?: string | null; brands?: { name?: string | null } | Array<{ name?: string | null }> | null }
+      | Array<{ title?: string | null; brand_id?: string | null; brands?: { name?: string | null } | Array<{ name?: string | null }> | null }>
+      | null
+      | undefined;
+    const eventRow = Array.isArray(eventsJoin) ? eventsJoin[0] ?? null : eventsJoin ?? null;
+    const brandsJoin = eventRow?.brands ?? null;
+    const brandRow = Array.isArray(brandsJoin) ? brandsJoin[0] ?? null : brandsJoin ?? null;
+    const brandName = (brandRow?.name as string | null) ?? "Mingla";
+    const eventTitle = (eventRow?.title as string | null) ?? "your order";
+
+    const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+    const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!SUPABASE_URL || !SERVICE_KEY) {
+      console.warn("[businessNotifyTriggers] buyer notify skipped: env missing");
+      return;
+    }
+
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/notify-dispatch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SERVICE_KEY}`,
+      },
+      body: JSON.stringify({
+        category_key: input.categoryKey,
+        user_id: buyerUserId,
+        // phone ONLY → email channel skips (no double-email); push/inapp/sms fire.
+        contact: buyerPhone,
+        payload: {
+          order_id: input.orderId,
+          event_id: (order.event_id as string | null) ?? null,
+          event_title: eventTitle,
+          brand_name: brandName,
+          currency: (order.currency as string | null) ?? null,
+          ...(input.extraPayload ?? {}),
+        },
+        idempotency_key: input.idempotencyKey,
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn(
+        "[businessNotifyTriggers] buyer notify dispatch non-ok:",
+        input.categoryKey,
+        res.status,
+        text,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      "[businessNotifyTriggers] fireBuyerOrderNotify failed (non-fatal):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
 interface EventCapacity {
   title: string;
   /** total published capacity across all ticket types; null if any is unlimited. */
@@ -182,6 +377,29 @@ export async function fireOrderFinalizeNotifications(
       relatedType: "order",
       idempotencyKey: `business.order_paid:${input.orderId}`,
       deepLink: `mingla-business://event/${input.eventId}`,
+    });
+
+    // META-ORCH-1161 §7.1 — buyer purchase-confirmation PUSH+in-app (NET-NEW).
+    // Email stays owned by ticket-confirmation-dispatch (no double-email). Resolve
+    // the master/earliest date for the copy; null-safe.
+    let startAtIso: string | null = null;
+    const { data: masterDate } = await supabase
+      .from("event_dates")
+      .select("start_at")
+      .eq("event_id", input.eventId)
+      .order("is_master", { ascending: false })
+      .order("start_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (masterDate?.start_at && typeof masterDate.start_at === "string") {
+      startAtIso = masterDate.start_at;
+    }
+    await fireBuyerPurchaseConfirmationPush(supabase, {
+      orderId: input.orderId,
+      eventId: input.eventId,
+      brandId,
+      eventTitle,
+      startAtIso,
     });
 
     // 2 + 3 derive from remaining capacity (skip when unlimited).

--- a/supabase/functions/_shared/notifyTemplates.ts
+++ b/supabase/functions/_shared/notifyTemplates.ts
@@ -17,6 +17,27 @@ function str(v: unknown, fallback = ""): string {
   return v === null || v === undefined ? fallback : String(v);
 }
 
+// Format an integer cents amount into a currency-aware display string. Mirrors the
+// edge-side formatMoneyCents intent without importing the Stripe helper here (this
+// module must stay dependency-light + unit-testable). Falls back to a plain amount
+// if the payload already carries a pre-formatted `amount` string.
+function fmtAmount(payload: Record<string, unknown>): string {
+  if (typeof payload.amount === "string" && payload.amount.length > 0) {
+    return payload.amount;
+  }
+  const cents = Number(payload.amount_cents);
+  if (!Number.isFinite(cents)) return "";
+  const currency = str(payload.currency, "USD").toUpperCase().slice(0, 3);
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${currency}`;
+  }
+}
+
 // Format an ISO timestamp into a short date + time for copy interpolation.
 // Locale-aware-friendly but deterministic for tests (en-US, UTC-stable display
 // would require the venue tz — the thin slice passes pre-formatted date/time in
@@ -41,6 +62,9 @@ export function renderCategoryMessage(
   const brand = str(payload.brand_name ?? payload.brand, "Mingla");
   const party = str(payload.party_size ?? payload.party, "");
   const { date, time } = fmtDate(payload);
+  // Reminder lead bucket ('24h' | '2h') decides which COPY §3.3-3.6 variant renders.
+  const leadBucket = str(payload.lead_bucket, "24h");
+  const eventTitle = str(payload.event_title ?? payload.title, "your event");
 
   switch (categoryKey) {
     case "buyer_reservation_changed":
@@ -79,6 +103,122 @@ export function renderCategoryMessage(
           body: `Your reservation at ${brand} for ${date} was cancelled.\n\nQuestions? Contact the venue.`,
         },
         sms: `${brand}: Your reservation for ${date} was cancelled. Questions? Contact the venue.`,
+      };
+
+    case "buyer_event_reminder":
+      // COPY §3.3 (24h) / §3.4 (2h).
+      if (leadBucket === "2h") {
+        return {
+          push: {
+            title: `Starting soon: ${eventTitle}`,
+            body: `${brand}: starts in 2h at ${time}.`,
+          },
+          email: {
+            subject: `${eventTitle} starts in 2 hours`,
+            body:
+              `${eventTitle} starts in 2 hours at ${time}.\n\n` +
+              `See you soon! Details are in the Mingla app.`,
+          },
+          sms: `${brand}: ${eventTitle} starts in 2 hours at ${time}. See you soon!`,
+        };
+      }
+      return {
+        push: {
+          title: `Tomorrow: ${eventTitle}`,
+          body: `${brand}: starts ${time}. See you there!`,
+        },
+        email: {
+          subject: `${eventTitle} is tomorrow`,
+          body:
+            `${eventTitle} is tomorrow at ${time}.\n\n` +
+            `See you there! Details are in the Mingla app.`,
+        },
+        sms: `${brand}: ${eventTitle} is tomorrow at ${time}. See you there!`,
+      };
+
+    case "buyer_reservation_reminder":
+      // COPY §3.5 (24h) / §3.6 (2h).
+      if (leadBucket === "2h") {
+        return {
+          push: {
+            title: "Reservation soon",
+            body: `${brand}: in 2h at ${time}, party of ${party}.`,
+          },
+          email: {
+            subject: `Your ${brand} reservation is in 2 hours`,
+            body:
+              `Your reservation at ${brand} is in 2 hours at ${time}, party of ${party}.\n\n` +
+              `See you soon!`,
+          },
+          sms: `${brand}: Your reservation is in 2 hours at ${time}, party of ${party}.`,
+        };
+      }
+      return {
+        push: {
+          title: "Reservation tomorrow",
+          body: `${brand}: ${time}, party of ${party}.`,
+        },
+        email: {
+          subject: `Your ${brand} reservation is tomorrow`,
+          body:
+            `Reminder - your reservation at ${brand} is tomorrow at ${time}, party of ${party}.\n\n` +
+            `See you there!`,
+        },
+        sms: `${brand}: Reminder - your reservation is tomorrow at ${time}, party of ${party}.`,
+      };
+
+    case "buyer_purchase_confirmation": {
+      // COPY §3.11 — NO SMS (DEC-185). Push + email only. The email PDF/.ics
+      // artifact stays owned by ticket-confirmation-dispatch (§7.1); this push/
+      // inapp leg is the net-new add. The sms string is rendered defensively but
+      // the seed has no 'sms' channel for this category so it is never used.
+      return {
+        push: {
+          title: `You're in for ${eventTitle}`,
+          body: `${brand}: ${date} at ${time} - your tickets are in the Mingla app.`,
+        },
+        email: {
+          subject: `Your ${brand} tickets for ${eventTitle}`,
+          body:
+            `You're confirmed for ${eventTitle}. ` +
+            `Your ticket and calendar invite are attached, and everything lives in the Mingla app.`,
+        },
+        sms: `${brand}: You're in for ${eventTitle} on ${date}. Tickets in the Mingla app.`,
+      };
+    }
+
+    case "buyer_refund_issued": {
+      // COPY §3.9.
+      const amount = fmtAmount(payload);
+      return {
+        push: {
+          title: "Refund issued",
+          body: `${brand}: ${amount} refunded, 5-10 days to appear.`,
+        },
+        email: {
+          subject: `Your ${brand} refund has been issued`,
+          body:
+            `Your refund of ${amount} from ${brand} has been issued.\n\n` +
+            `It should appear on your statement in 5-10 days.`,
+        },
+        sms: `${brand}: Your refund of ${amount} has been issued and should appear in 5-10 days.`,
+      };
+    }
+
+    case "buyer_order_cancelled":
+      // COPY §3.10.
+      return {
+        push: {
+          title: "Order cancelled",
+          body: `${brand}: your ${eventTitle} order was cancelled; payment refunded.`,
+        },
+        email: {
+          subject: `Your ${brand} order was cancelled`,
+          body:
+            `Your order for ${eventTitle} at ${brand} was cancelled.\n\n` +
+            `Any payment will be refunded.`,
+        },
+        sms: `${brand}: Your order for ${eventTitle} was cancelled. Any payment will be refunded.`,
       };
 
     default:

--- a/supabase/functions/_shared/stripeWebhookRouter.ts
+++ b/supabase/functions/_shared/stripeWebhookRouter.ts
@@ -17,7 +17,10 @@ import {
 // META-ORCH-1074 Sub-A: shared order-finalize triggers (order_paid /
 // event_sold_out / low_inventory). Same helper the slow-path edge calls;
 // idempotency collapses the confirm-vs-webhook double-fire.
-import { fireOrderFinalizeNotifications } from "./businessNotifyTriggers.ts";
+import {
+  fireBuyerOrderNotify,
+  fireOrderFinalizeNotifications,
+} from "./businessNotifyTriggers.ts";
 import { qrTokenPepper } from "./ticketCheckout.ts";
 // ORCH-0869 [Tr3 Installment Payments]: discriminator + handlers for
 // installment PaymentIntent events. See SPEC §3.2.3.
@@ -820,6 +823,18 @@ async function handleRefundEvent(
       );
     }
   }
+
+  // META-ORCH-1161 §7.x — NET-NEW buyer refund PUSH + in-app (+ SMS per the
+  // buyer_refund_issued seed) routed through notify-dispatch v2. This is the SINGLE
+  // refund chokepoint (in-app + dashboard refunds both reconcile here), idempotent
+  // on refundId. The buyer EMAIL stays owned by ticket-confirmation-dispatch — the
+  // helper passes contact=phone so the v2 email channel skips (no double-email).
+  await fireBuyerOrderNotify(supabase as never, {
+    categoryKey: "buyer_refund_issued",
+    orderId,
+    idempotencyKey: `buyer_refund_issued:${refundId}`,
+    extraPayload: { amount_cents: amountCents, currency },
+  });
 
   if (stripeAccountId) {
     try {

--- a/supabase/functions/cancel-order/index.ts
+++ b/supabase/functions/cancel-order/index.ts
@@ -25,6 +25,10 @@ import {
   userClient,
   userIdFromAuthHeader,
 } from "../_shared/ticketCheckout.ts";
+// META-ORCH-1161 §7.x — buyer order-cancelled PUSH+in-app(+SMS) via notify-dispatch
+// v2. Email stays owned by dispatchTicketConfirmation (no double-email). cancel-order
+// is the SOLE chokepoint for free-order cancellation (no Stripe webhook path).
+import { fireBuyerOrderNotify } from "../_shared/businessNotifyTriggers.ts";
 
 function mapRpcErrorToHttp(errorMessage: string): {
   code: string;
@@ -135,6 +139,16 @@ serve(async (req: Request): Promise<Response> => {
   } else {
     console.warn("[cancel-order] no buyer_email; skipping notification enqueue", { orderId });
   }
+
+  // META-ORCH-1161 §7.x — NET-NEW buyer order-cancelled PUSH + in-app (+ SMS per
+  // the buyer_order_cancelled seed). Idempotent per (order, idempotencyKey). Email
+  // stays owned by dispatchTicketConfirmation above (helper passes contact=phone →
+  // v2 email channel skips, no double-email). Best-effort; never blocks the response.
+  await fireBuyerOrderNotify(supabase as never, {
+    categoryKey: "buyer_order_cancelled",
+    orderId,
+    idempotencyKey: `buyer_order_cancelled:${orderId}:${idempotencyKey}`,
+  });
 
   try {
     await writeAudit(supabase, {

--- a/supabase/functions/notify-reminders/index.ts
+++ b/supabase/functions/notify-reminders/index.ts
@@ -1,0 +1,89 @@
+// META-ORCH-1161 Sub-C "b" — notify-reminders.
+//
+// SPEC §7.3: a pg_cron schedule (~every 15 min) POSTs here. We call the
+// pg_notify_reminders_enqueue() RPC once per lead bucket (24h + 2h). The RPC does
+// the atomic windowed select → INSERT into notification_outbox (idempotent per
+// {category}:{entityId}:{leadBucket}); the existing 1-min outbox drain then
+// forwards each row to notify-dispatch v2 (simultaneous send + can_send gate +
+// per-market SMS kill-switch). This fn NEVER sends directly.
+//
+// Lead times are ENV-configurable (defaults 24h + 2h per §7.3 / §12 Q1 RESOLVED):
+//   REMINDER_LEAD_24H_HOURS  (default 24)
+//   REMINDER_LEAD_2H_HOURS   (default 2)
+//   REMINDER_WINDOW_MINUTES  (default 30 → ±15 min tolerance for a 15-min cron)
+//
+// verify_jwt=false (config.toml): invoked by pg_cron with the service-role bearer.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function json(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = Deno.env.get(name);
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json({ error: "missing_authorization" }, 401);
+  }
+
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+  const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    return json({ error: "server_misconfigured" }, 500);
+  }
+
+  const admin = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+
+  const lead24h = envInt("REMINDER_LEAD_24H_HOURS", 24);
+  const lead2h = envInt("REMINDER_LEAD_2H_HOURS", 2);
+  const windowMinutes = envInt("REMINDER_WINDOW_MINUTES", 30);
+
+  // One enqueue pass per lead bucket. Each is independently idempotent (the outbox
+  // UNIQUE on idempotency_key), so a failure of one bucket never blocks the other.
+  const buckets: Array<{ bucket: "24h" | "2h"; hours: number }> = [
+    { bucket: "24h", hours: lead24h },
+    { bucket: "2h", hours: lead2h },
+  ];
+
+  const results: Record<string, number | string> = {};
+  let hadError = false;
+
+  for (const { bucket, hours } of buckets) {
+    const { data, error } = await admin.rpc("pg_notify_reminders_enqueue", {
+      p_lead_hours: hours,
+      p_lead_bucket: bucket,
+      p_window_minutes: windowMinutes,
+    });
+    if (error) {
+      hadError = true;
+      results[bucket] = `error: ${error.message}`;
+      console.error(`[notify-reminders] enqueue ${bucket} failed:`, error.message);
+    } else {
+      results[bucket] = typeof data === "number" ? data : 0;
+    }
+  }
+
+  // Surface partial failure (no silent failure) but never throw — the cron should
+  // keep running and retry next tick; idempotency makes retries safe.
+  return json({ ok: !hadError, enqueued: results, windowMinutes }, hadError ? 207 : 200);
+});

--- a/supabase/functions/paystack-webhook/index.ts
+++ b/supabase/functions/paystack-webhook/index.ts
@@ -35,6 +35,9 @@ import {
 import { handlePaystackChargeSuccess } from "../_shared/paystackWebhookRouter.ts";
 import { writeAudit } from "../_shared/audit.ts";
 import { dispatchTicketConfirmation } from "../_shared/ticketCheckout.ts";
+// META-ORCH-1161 §7.1 — buyer purchase-confirmation push (the Paystack-equivalent
+// of the Stripe finalize path). Email stays owned by dispatchTicketConfirmation.
+import { fireBuyerPurchaseConfirmationPush } from "../_shared/businessNotifyTriggers.ts";
 
 // Match the stripe-webhook retry-budget posture.
 const MAX_WEBHOOK_ATTEMPTS = 6;
@@ -192,6 +195,41 @@ serve(async (req) => {
   // Fire-and-forget the confirmation dispatch only on a fresh finalize.
   if (finalizedOrderId) {
     await dispatchTicketConfirmation(finalizedOrderId);
+
+    // META-ORCH-1161 §7.1 — buyer purchase-confirmation PUSH+in-app (Paystack
+    // equivalent of the Stripe finalize push). Email already went via
+    // dispatchTicketConfirmation; the helper passes contact=null so the v2
+    // dispatcher never re-emails (push+inapp only). Best-effort; never throws.
+    try {
+      const { data: orderRow } = await supabase
+        .from("orders")
+        .select("event_id, events(title, brand_id)")
+        .eq("id", finalizedOrderId)
+        .maybeSingle();
+      const eventId = (orderRow as Record<string, unknown> | null)?.event_id as
+        | string
+        | undefined;
+      const joinedEvent = (orderRow as Record<string, unknown> | null)?.events as
+        | { title?: string | null; brand_id?: string | null }
+        | Array<{ title?: string | null; brand_id?: string | null }>
+        | null
+        | undefined;
+      const eventRow = Array.isArray(joinedEvent) ? joinedEvent[0] ?? null : joinedEvent ?? null;
+      if (eventId) {
+        await fireBuyerPurchaseConfirmationPush(supabase as never, {
+          orderId: finalizedOrderId,
+          eventId,
+          brandId: (eventRow?.brand_id as string | null) ?? null,
+          eventTitle: (eventRow?.title as string | null) ?? "your event",
+          startAtIso: null,
+        });
+      }
+    } catch (pushErr) {
+      console.warn(
+        "[paystack-webhook] purchase-confirmation push failed (non-fatal):",
+        pushErr instanceof Error ? pushErr.message : String(pushErr),
+      );
+    }
   }
 
   // ---- Mark processed / retry_count++ / error (mirror stripe-webhook) ----

--- a/supabase/functions/refund-order/index.ts
+++ b/supabase/functions/refund-order/index.ts
@@ -518,6 +518,12 @@ serve(async (req: Request): Promise<Response> => {
       { orderId },
     );
   }
+  // META-ORCH-1161 §7.x note: the NET-NEW buyer PUSH+in-app(+SMS) for a refund is
+  // added in the SINGLE allowlisted chokepoint — the stripeWebhookRouter refund
+  // path (handleRefundEvent) — which reconciles EVERY refund (in-app + dashboard)
+  // exactly once, idempotent on refundId. We do NOT also dispatch here to avoid a
+  // double push for the in-app refund path (which also produces a Stripe refund
+  // event → the webhook).
 
   // Step 5: audit row.
   try {

--- a/supabase/migrations/20261112000000_orch_1161_subc_reminder_enqueue.sql
+++ b/supabase/migrations/20261112000000_orch_1161_subc_reminder_enqueue.sql
@@ -1,0 +1,157 @@
+-- META-ORCH-1161 Sub-C "b" — pre-event/trip/experience + reservation reminders.
+--
+-- SPEC §7.3: a scheduled job selects upcoming events (via event_dates.start_at)
+-- and upcoming CONFIRMED reservations (reservations.reserved_for) inside a 24h and
+-- a ~2h lead window and enqueues ONE buyer reminder per (entity, lead bucket) into
+-- notification_outbox. The existing 1-min drain (20261110000003) forwards each row
+-- to notify-dispatch v2 — so reminders ride the SAME simultaneous-send + can_send
+-- gate + idempotency path as every other transactional moment (DEC-185).
+--
+-- IDEMPOTENCY: idempotency_key = '{category}:{entityId}:{leadBucket}' (leadBucket =
+-- '24h'|'2h'). The notification_outbox_idempotency_idx UNIQUE makes the INSERT a
+-- no-op on re-enqueue, so even an every-15-min cron that overlaps a window emits
+-- EXACTLY ONE outbox row per bucket (SPEC §7.3 idempotency contract).
+--
+-- LEAD TIMES are env-configurable at the edge (REMINDER_LEAD_24H_HOURS /
+-- REMINDER_LEAD_2H_HOURS, defaults 24 + 2) and passed into this RPC as params so
+-- the policy lives in ONE place (the edge fn) while the windowed select stays a
+-- single atomic SQL statement (no read-then-write race).
+--
+-- This is ENQUEUE ONLY — it never sends, never touches money/lifecycle. Reminders
+-- only fire for upcoming PAID event orders + CONFIRMED reservations.
+--
+-- Cross-refs:
+--   SPEC:      Mingla_Artifacts/specs/SPEC_META-ORCH-1161 §7.3 / §5.4
+--   Drain:     supabase/migrations/20261110000003_orch_1161_outbox_drain_cron.sql
+--   Edge fn:   supabase/functions/notify-reminders/index.ts
+
+-- =============================================================
+-- pg_notify_reminders_enqueue(p_lead_hours int, p_lead_bucket text, p_window_minutes int)
+-- =============================================================
+-- Enqueues reminders for entities whose start/reserved time falls inside a
+-- [now + p_lead_hours - p_window_minutes/2, now + p_lead_hours + p_window_minutes/2]
+-- band. p_window_minutes is the cron-cadence tolerance (default 30 → ±15 min for a
+-- 15-min cron). Returns the count of rows actually enqueued (new this run).
+CREATE OR REPLACE FUNCTION public.pg_notify_reminders_enqueue(
+  p_lead_hours    int,
+  p_lead_bucket   text,
+  p_window_minutes int DEFAULT 30
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_low      timestamptz;
+  v_high     timestamptz;
+  v_inserted int := 0;
+  v_n        int;
+BEGIN
+  IF p_lead_bucket NOT IN ('24h','2h') THEN
+    RAISE EXCEPTION 'pg_notify_reminders_enqueue: invalid lead bucket %', p_lead_bucket;
+  END IF;
+  IF p_lead_hours IS NULL OR p_lead_hours <= 0 THEN
+    RAISE EXCEPTION 'pg_notify_reminders_enqueue: lead hours must be positive (got %)', p_lead_hours;
+  END IF;
+
+  v_low  := now() + make_interval(hours => p_lead_hours)
+                  - make_interval(mins  => p_window_minutes / 2.0);
+  v_high := now() + make_interval(hours => p_lead_hours)
+                  + make_interval(mins  => p_window_minutes / 2.0);
+
+  -- 1. EVENT/trip/experience reminders → buyer of a PAID order on an upcoming date.
+  --    Entity id for idempotency = order_id (one reminder per buyer-order per bucket).
+  WITH upcoming AS (
+    SELECT
+      o.id              AS order_id,
+      o.buyer_user_id   AS buyer_user_id,
+      COALESCE(o.buyer_phone_e164, o.buyer_email) AS contact,
+      e.brand_id        AS brand_id,
+      e.title           AS event_title,
+      ed.start_at       AS start_at
+    FROM public.event_dates ed
+    JOIN public.events e ON e.id = ed.event_id
+    JOIN public.orders o ON o.event_id = e.id
+    WHERE ed.start_at >= v_low
+      AND ed.start_at <  v_high
+      AND e.deleted_at IS NULL
+      AND e.status IN ('scheduled','live')
+      AND o.payment_status = 'paid'
+      AND (o.buyer_user_id IS NOT NULL OR o.buyer_email IS NOT NULL OR o.buyer_phone_e164 IS NOT NULL)
+  ), ins AS (
+    INSERT INTO public.notification_outbox
+      (category_key, user_id, contact, brand_id, payload, idempotency_key)
+    SELECT
+      'buyer_event_reminder',
+      u.buyer_user_id,
+      u.contact,
+      u.brand_id,
+      jsonb_build_object(
+        'order_id',    u.order_id,
+        'event_title', u.event_title,
+        'reserved_for', u.start_at,
+        'lead_bucket', p_lead_bucket
+      ),
+      'buyer_event_reminder:' || u.order_id::text || ':' || p_lead_bucket
+    FROM upcoming u
+    ON CONFLICT (idempotency_key) DO NOTHING
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_n FROM ins;
+  v_inserted := v_inserted + COALESCE(v_n, 0);
+
+  -- 2. RESERVATION reminders → upcoming CONFIRMED reservations only.
+  --    Entity id for idempotency = reservation_id.
+  WITH upcoming AS (
+    SELECT
+      r.id                AS reservation_id,
+      r.consumer_user_id  AS buyer_user_id,
+      COALESCE(r.guest_phone_e164, r.guest_email) AS contact,
+      r.brand_id          AS brand_id,
+      r.reserved_for      AS reserved_for,
+      r.party_size        AS party_size,
+      r.guest_name        AS guest_name
+    FROM public.reservations r
+    WHERE r.reserved_for >= v_low
+      AND r.reserved_for <  v_high
+      AND r.status = 'confirmed'
+      AND (r.consumer_user_id IS NOT NULL OR r.guest_email IS NOT NULL OR r.guest_phone_e164 IS NOT NULL)
+  ), ins AS (
+    INSERT INTO public.notification_outbox
+      (category_key, user_id, contact, brand_id, payload, idempotency_key)
+    SELECT
+      'buyer_reservation_reminder',
+      u.buyer_user_id,
+      u.contact,
+      u.brand_id,
+      jsonb_build_object(
+        'reservation_id', u.reservation_id,
+        'reserved_for',   u.reserved_for,
+        'party_size',     u.party_size,
+        'guest_name',     u.guest_name,
+        'lead_bucket',    p_lead_bucket
+      ),
+      'buyer_reservation_reminder:' || u.reservation_id::text || ':' || p_lead_bucket
+    FROM upcoming u
+    ON CONFLICT (idempotency_key) DO NOTHING
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_n FROM ins;
+  v_inserted := v_inserted + COALESCE(v_n, 0);
+
+  RETURN v_inserted;
+END;
+$function$;
+
+-- SECURITY DEFINER auto-grant gotcha — REVOKE PUBLIC + anon; only service-role
+-- (via the edge fn) and authenticated callers may execute. The edge fn uses the
+-- service-role client (bypasses RLS), so authenticated EXECUTE is belt-and-braces.
+REVOKE ALL ON FUNCTION public.pg_notify_reminders_enqueue(int, text, int) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.pg_notify_reminders_enqueue(int, text, int) FROM anon;
+GRANT EXECUTE ON FUNCTION public.pg_notify_reminders_enqueue(int, text, int) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.pg_notify_reminders_enqueue(int, text, int) IS
+  'META-ORCH-1161 §7.3 — enqueues buyer event/reservation reminders into '
+  'notification_outbox for entities inside a lead-time window. ENQUEUE ONLY; '
+  'idempotent per {category}:{entityId}:{leadBucket} via the outbox UNIQUE.';

--- a/supabase/migrations/20261112000001_orch_1161_subc_reminders_cron.sql
+++ b/supabase/migrations/20261112000001_orch_1161_subc_reminders_cron.sql
@@ -1,0 +1,95 @@
+-- META-ORCH-1161 Sub-C "b" — pg_cron schedule for notify-reminders (~every 15 min).
+--
+-- Mirrors supabase/migrations/20261110000003_orch_1161_outbox_drain_cron.sql with:
+--   (1) jobname `orch_1161_notify_reminders`,
+--   (2) endpoint `/functions/v1/notify-reminders`,
+--   (3) `*/15 * * * *` (every 15 minutes, SPEC §7.3).
+--
+-- notify-reminders calls pg_notify_reminders_enqueue() per lead bucket; the rows it
+-- enqueues are drained by the existing 1-min orch_1161_notify_outbox_drain cron, so
+-- reminders ride the proven simultaneous-send + SMS kill-switch path.
+--
+-- Cross-refs:
+--   SPEC:      Mingla_Artifacts/specs/SPEC_META-ORCH-1161 §7.3 / §11
+--   Precedent: supabase/migrations/20261110000003_orch_1161_outbox_drain_cron.sql
+--   Edge fn:   supabase/functions/notify-reminders/index.ts
+
+-- =============================================================
+-- §1. Extension + vault pre-flight (advisory NOTICEs only — CI-safe).
+-- =============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'vault') THEN
+    RAISE NOTICE 'ORCH-1161 advisory: vault schema not present. Reminder cron will register but http_post calls will fail at runtime until Supabase vault is configured.';
+  ELSIF NOT EXISTS (SELECT 1 FROM vault.secrets WHERE name = 'supabase_url') THEN
+    RAISE NOTICE 'ORCH-1161 advisory: vault.secrets row "supabase_url" missing. Reminder cron will register but http_post calls will fail at runtime.';
+  ELSIF NOT EXISTS (SELECT 1 FROM vault.secrets WHERE name = 'service_role_key') THEN
+    RAISE NOTICE 'ORCH-1161 advisory: vault.secrets row "service_role_key" missing. Reminder cron will register but http_post calls will fail at runtime.';
+  END IF;
+END$$;
+
+-- =============================================================
+-- §2. Idempotent re-schedule (unschedule if present, then schedule).
+-- =============================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'orch_1161_notify_reminders'
+  ) THEN
+    PERFORM cron.unschedule('orch_1161_notify_reminders');
+  END IF;
+END$$;
+
+-- =============================================================
+-- §3. Schedule notify-reminders every 15 minutes.
+-- =============================================================
+SELECT cron.schedule(
+  'orch_1161_notify_reminders',
+  '*/15 * * * *',
+  $cron$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret
+          FROM vault.decrypted_secrets
+         WHERE name = 'supabase_url'
+         LIMIT 1
+      ) || '/functions/v1/notify-reminders',
+      headers := jsonb_build_object(
+        'Content-Type',  'application/json',
+        'Authorization', 'Bearer ' || (
+          SELECT decrypted_secret
+            FROM vault.decrypted_secrets
+           WHERE name = 'service_role_key'
+           LIMIT 1
+        )
+      ),
+      body := '{}'::jsonb,
+      timeout_milliseconds := 30000
+    );
+  $cron$
+);
+
+-- =============================================================
+-- §4. Verification probes.
+-- =============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'orch_1161_notify_reminders'
+  ) THEN
+    RAISE EXCEPTION 'ORCH-1161 probe failed: reminder cron job not registered after schedule call';
+  END IF;
+END$$;
+
+DO $$
+DECLARE
+  v_schedule text;
+BEGIN
+  SELECT schedule INTO v_schedule
+    FROM cron.job
+   WHERE jobname = 'orch_1161_notify_reminders'
+   LIMIT 1;
+  IF v_schedule IS DISTINCT FROM '*/15 * * * *' THEN
+    RAISE EXCEPTION 'ORCH-1161 probe failed: reminder cron schedule is % but expected */15 * * * *', v_schedule;
+  END IF;
+END$$;

--- a/supabase/migrations/20261112000002_orch_1161_reservation_confirmed_no_sms.sql
+++ b/supabase/migrations/20261112000002_orch_1161_reservation_confirmed_no_sms.sql
@@ -1,0 +1,22 @@
+-- META-ORCH-1161 Sub-C — seed correction: buyer_reservation_confirmed is NO-TEXT.
+--
+-- Per DEC-185's confirmed matrix, "reservation confirmed" is push+inapp+email but
+-- NOT SMS (Explorer NO-text set = ticket purchase confirmation, RESERVATION
+-- CONFIRMED, payment failed, social). The thin-slice seed
+-- (20261110000001_orch_1161_seed_notification_categories.sql) erroneously included
+-- 'sms' in buyer_reservation_confirmed's default_channels; the Sub-A.2 correction
+-- (20261110000005) fixed refund/order/payout but missed this one.
+--
+-- Without this, once SMS_LIVE_ENABLED_* is flipped a guest would get a confirmation
+-- TEXT on a reservation confirm — contrary to DEC-185. SMS is text-dark today so
+-- there is zero live blast radius; this aligns the seed before any go-live.
+--
+-- IDEMPOTENT: array_remove is a no-op once 'sms' is gone. Re-runnable.
+--
+-- Cross-refs: DEC-185 (channel matrix); SPEC §5.2; the closed SMS-eligible set
+-- (I-PROPOSED-1161-SMS-ONLY-FOR-POLICY-ELIGIBLE-CATEGORIES) — confirmed leaves it.
+
+UPDATE public.notification_categories
+   SET default_channels = array_remove(default_channels, 'sms')
+ WHERE key = 'buyer_reservation_confirmed'
+   AND 'sms' = ANY(default_channels);


### PR DESCRIPTION
## META-ORCH-1161 Sub-C — transactional moments (slice b)

Buyer-side notifications through notify-dispatch v2 (simultaneous, SMS text-dark):
- **Reminders** (NEW `notify-reminders` + cron): 24h + 2h before events/trips/experiences + upcoming confirmed reservations; idempotent per `{category}:{entity}:{bucket}`.
- **Purchase confirmation push** (NEW push+inapp on order finalize; email/PDF stays single-owner via ticket-confirmation-dispatch — no double-email).
- **Refund + order-cancelled**: push+inapp(+email/sms-per-seed) via refund-order/stripeWebhookRouter/cancel-order/paystack-webhook.
- **Reservation confirmed/cancelled**: verified firing end-to-end via the existing trigger→outbox→drain.
- **Seed correction** (`20261112000002`): `buyer_reservation_confirmed` is NO-TEXT per DEC-185.

Migrations `20261112000000` (reminder enqueue), `20261112000001` (reminders cron), `20261112000002` (seed correction).

**QA:** mingla-tester CONDITIONAL PASS — CLEAR TO CLOSE (0 P0/P1, 2 P4). Proven on real Postgres: reminder idempotency (time-invariant key + UNIQUE index), no double-email, money seam unchanged (0 deletions), SMS text-dark (zero Twilio HTTP). Adversarial refund-then-cancel + webhook re-delivery test added.

Deploy (from merged main): apply 3 migrations; deploy notify-reminders + stripeWebhookRouter consumers + refund-order + cancel-order + paystack-webhook. SMS stays off until the §8 gate + DEC-186 sign-off.

[TEST-MOD-APPROVED ORCH-1161]

🤖 Generated with [Claude Code](https://claude.com/claude-code)