### PR TITLE
ORCH-1163 R3.1: RSVP details modal opaque on web (was translucent) [deploy]

### DIFF
--- a/packages/offering-rendering/RsvpDetailsModal.tsx
+++ b/packages/offering-rendering/RsvpDetailsModal.tsx
@@ -86,8 +86,10 @@ export const RsvpDetailsModal: React.FC<RsvpDetailsModalProps> = ({
           style={[
             styles.card,
             {
-              // ANDROID_GLASS_USES_OPAQUE_FALLBACK — opaque page fill on Android.
-              backgroundColor: Platform.OS === "android" ? palette.page : palette.card,
+              // ANDROID_GLASS_USES_OPAQUE_FALLBACK — opaque page fill on web AND Android
+              // (neither has a native blur backdrop, so the translucent glass card bleeds
+              // through); only iOS keeps the native glass card.
+              backgroundColor: Platform.OS === "ios" ? palette.card : palette.page,
               borderColor: palette.panelBorder,
             },
           ]}


### PR DESCRIPTION
Follow-on to R3 (#551). The new "Add your details" popup sheet on the public RSVP **web** page was too transparent — the page bled through it.

Root cause: `RsvpDetailsModal` filled the card with `palette.card` (translucent glass token, alpha 0.10 dark / 0.72 light) and only substituted the opaque `palette.page` on Android. Web has no native blur backdrop, so the translucent card looked see-through.

Fix (1 line): opaque `palette.page` fill on web AND Android; iOS keeps its native glass. R3 tests stay green (17/17); `orch-1105-web-glass-opaque-fallback` gate passes.

Surfaces: buyer/anon web (visible), business/consumer Android (same opaque path). No backend, no migration.

[deploy]

🤖 Generated with [Claude Code](https://claude.com/claude-code)