### PR TITLE
ORCH-1172: edit-RSVP event = 100% parity with create wizard (all 9 host-controls editable + fixes silent save)

### DIFF
--- a/mingla-business/src/components/event/EditPublishedScreen.tsx
+++ b/mingla-business/src/components/event/EditPublishedScreen.tsx
@@ -120,6 +120,8 @@ import {
   patchPublishedEventWhen,
 } from "../../services/businessEvents";
 import { updateLiveRsvp } from "../../services/rsvpEvents";
+import { buildRsvpUpdatePayload } from "../../utils/serverDraftEventMapper";
+import { RsvpStep5Setup } from "../rsvp/RsvpStep5Setup";
 import { rsvpEditNoticeCopy } from "../../utils/rsvpHubMetrics";
 import { businessEventKeys } from "../../hooks/useBusinessEvents";
 import { publicEventKeys } from "../../hooks/usePublicEvents";
@@ -128,34 +130,24 @@ import {
   useEventReconciliation,
 } from "../../hooks/useEventOrders";
 import { ThemeEditorSection } from "../theme/ThemeEditorSection";
+// ORCH-1172 — the section model lives in a pure sibling module so the
+// ticketed-vs-RSVP section-list logic is unit-testable without importing this
+// react-native component. Re-exported below for back-compat.
+import {
+  SECTIONS,
+  sectionsForMode,
+  type SectionConfig,
+  type SectionKey,
+} from "./editPublishedSections";
 
 // ---- Section configuration -----------------------------------------
 
-type SectionKey =
-  | "basics"
-  | "when"
-  | "where"
-  | "cover"
-  | "visual"
-  | "tickets"
-  | "settings";
-
-interface SectionConfig {
-  key: SectionKey;
-  label: string;
-  /** Step index for `validateStep(N, draft)`. */
-  stepIndex: number | null;
-}
-
-const SECTIONS: readonly SectionConfig[] = [
-  { key: "basics", label: "Basics", stepIndex: 0 },
-  { key: "when", label: "When", stepIndex: 1 },
-  { key: "where", label: "Where", stepIndex: 2 },
-  { key: "cover", label: "Cover", stepIndex: 3 },
-  { key: "visual", label: "Visual", stepIndex: null },
-  { key: "tickets", label: "Tickets", stepIndex: 4 },
-  { key: "settings", label: "Settings", stepIndex: 5 },
-];
+export {
+  SECTIONS,
+  RSVP_SECTIONS,
+  sectionsForMode,
+} from "./editPublishedSections";
+export type { SectionConfig, SectionKey } from "./editPublishedSections";
 
 const SAVE_PROCESSING_MS = 800;
 const TOAST_NAV_DELAY_MS = 600;
@@ -382,10 +374,13 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     [],
   );
 
-  // ORCH-1150 — an RSVP edit drops the Tickets section entirely (RSVP has zero
-  // tickets + no money). Every SECTIONS iteration below uses this filtered list.
+  // ORCH-1172 — RSVP edit uses the dedicated RSVP section list (Tickets +
+  // generic Settings dropped; the RsvpStep5Setup card added after Cover, which
+  // owns visibility/discoverable/privacy). Ticketed edit is byte-identical.
+  // Supersedes the ORCH-1150 tickets-only filter, which left the mislabeled
+  // ticketed Settings card in place and exposed only 3 of 9 RSVP controls.
   const sections = useMemo<readonly SectionConfig[]>(
-    () => (rsvpMode ? SECTIONS.filter((s) => s.key !== "tickets") : SECTIONS),
+    () => sectionsForMode(rsvpMode),
     [rsvpMode],
   );
 
@@ -399,6 +394,9 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       visual: [],
       tickets: [],
       settings: [],
+      // ORCH-1172 — RSVP host-control section. stepIndex null → never validated
+      // by the ticketed validateStep (validateRsvpStep(4) returns []).
+      "rsvp-setup": [],
     };
     for (const sec of sections) {
       out[sec.key] =
@@ -430,7 +428,10 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
   // patches; the new name reflects the broadened set.
   const canSaveServerCoverMediaOnly =
     disableLocalSaveReason !== undefined &&
-    isServerEditableOnlyPatch(currentPatch);
+    // ORCH-1172 — an RSVP edit has its OWN complete server write path
+    // (biz_update_live_rsvp), so the ticketed Zustand-only disable gate must
+    // not apply: every RSVP change is server-routable regardless of patch keys.
+    (rsvpMode || isServerEditableOnlyPatch(currentPatch));
 
   // ---- Save flow ----
   const handleSavePress = useCallback((): void => {
@@ -462,6 +463,9 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     }
     if (
       disableLocalSaveReason !== undefined &&
+      // ORCH-1172 — RSVP edits route through biz_update_live_rsvp (a full server
+      // write), so they bypass the ticketed Zustand-only disable gate entirely.
+      !rsvpMode &&
       !isServerEditableOnlyPatch(patch)
     ) {
       // ORCH-0824 hotfix: only block when the patch contains a field
@@ -494,6 +498,8 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
     editState,
     fieldDiffs,
     liveEvent.tickets,
+    rsvpMode,
+    sections,
     sectionErrors,
     showToast,
   ]);
@@ -763,7 +769,19 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
           return;
         }
         try {
-          await updateLiveRsvp(liveEvent.serverEventId, patch, reason);
+          // ORCH-1172 — send the publish-style payload (title + when +
+          // requestedVisibility + snake_case location/cover + the 6 camelCase
+          // rsvp* host-controls), NOT the raw camelCase patch. The patch never
+          // carried `title`, so the RPC raised rsvp_title_required on EVERY save
+          // (BUG-A) and the host-controls were never diffed into it (BUG-B) — so
+          // nothing persisted. buildRsvpUpdatePayload reads the full editState so
+          // `title` is always present + every control is emitted (idempotent:
+          // the RPC defaults absent keys to the existing column).
+          await updateLiveRsvp(
+            liveEvent.serverEventId,
+            buildRsvpUpdatePayload(editState),
+            reason,
+          );
         } catch (error) {
           setSubmitting(false);
           setModal((prev) => ({ ...prev, visible: false }));
@@ -776,6 +794,14 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
           showToast(message);
           return;
         }
+        // ORCH-1172 — the RPC is the source of truth for an RSVP edit; it has
+        // already committed. Best-effort refresh the local Zustand mirror so a
+        // cached list stays fresh — but a server-loaded RSVP (the common case,
+        // where disableLocalSaveReason is set) has NO local row, so
+        // updateLiveEventFields returns ok:false (event_not_found). That must
+        // NOT surface as a save failure: the cache invalidation below refetches
+        // the freshly-written row. Only the local-store-backed path treats a
+        // mirror failure as a real failure.
         const rsvpResult = updateLiveEventFields(
           liveEvent.id,
           patch,
@@ -785,7 +811,8 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
         setSubmitting(false);
         setModal((prev) => ({ ...prev, visible: false }));
         invalidateServerEventCaches();
-        if (rsvpResult.ok) {
+        const localMirrorRequired = disableLocalSaveReason === undefined;
+        if (rsvpResult.ok || !localMirrorRequired) {
           showToast("Saved. Going guests will be notified.");
           setTimeout(() => router.back(), TOAST_NAV_DELAY_MS);
         } else {
@@ -1184,6 +1211,9 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
       submitting,
       liveEvent,
       currentPatch,
+      // ORCH-1172 — the RSVP save reads the full editState to build the
+      // publish-style payload (buildRsvpUpdatePayload).
+      editState,
       soldCountCtx,
       updateLiveEventFields,
       router,
@@ -1251,6 +1281,12 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
           return <CreatorStep5Tickets {...stepBodyProps} />;
         case "settings":
           return <CreatorStep6Settings {...stepBodyProps} />;
+        case "rsvp-setup":
+          // ORCH-1172 — mount the SAME Step-5 host-control body the create RSVP
+          // wizard uses. Cross-field logic (capacity→waitlist, private→discover-
+          // off, plus-ones-max) runs identically in edit: it only calls
+          // updateDraft, which is the local editState setter here.
+          return <RsvpStep5Setup {...stepBodyProps} />;
         default: {
           const _exhaust: never = key;
           return _exhaust;
@@ -1314,7 +1350,20 @@ export const EditPublishedScreen: React.FC<EditPublishedScreenProps> = ({
             changedKeys.has("hideRemainingCount") ||
             changedKeys.has("passwordProtected") ||
             // Cycle 12 — in-person payments toggle is a Settings field.
-            changedKeys.has("inPersonPaymentsEnabled")))
+            changedKeys.has("inPersonPaymentsEnabled"))) ||
+        // ORCH-1172 — the RSVP card owns the 6 host-controls PLUS visibility,
+        // privateGuestList + hideRemainingCount (the create wizard co-locates
+        // them in Step-5; in RSVP edit there is no generic Settings card).
+        (sec.key === "rsvp-setup" &&
+          (changedKeys.has("rsvpCapacity") ||
+            changedKeys.has("rsvpAllowPlusOnes") ||
+            changedKeys.has("rsvpPlusOnesMax") ||
+            changedKeys.has("rsvpWaitlistEnabled") ||
+            changedKeys.has("rsvpApprovalMode") ||
+            changedKeys.has("rsvpDiscoverable") ||
+            changedKeys.has("visibility") ||
+            changedKeys.has("privateGuestList") ||
+            changedKeys.has("hideRemainingCount")))
       ) {
         out.add(sec.key);
       }

--- a/mingla-business/src/components/event/editPublishedSections.ts
+++ b/mingla-business/src/components/event/editPublishedSections.ts
@@ -1,0 +1,64 @@
+/**
+ * ORCH-1172 — pure section-config model for EditPublishedScreen.
+ *
+ * Extracted from EditPublishedScreen.tsx so the section-list logic (which
+ * sections show for ticketed vs RSVP edit) is unit-testable WITHOUT pulling the
+ * react-native component module into the node/ts-jest default test config.
+ *
+ * Ticketed sections: Basics / When / Where / Cover / Visual / Tickets / Settings.
+ * RSVP sections (ORCH-1172): Basics / When / Where / Cover / Visual / RSVP —
+ *   Tickets + generic Settings DROPPED (RsvpStep5Setup owns visibility +
+ *   discoverable + the privacy toggles; RSVP has no ticket concept), and the
+ *   `rsvp-setup` card sits right after Cover (mirrors the create wizard order).
+ */
+
+export type SectionKey =
+  | "basics"
+  | "when"
+  | "where"
+  | "cover"
+  | "visual"
+  | "tickets"
+  | "settings"
+  // ORCH-1172 — RSVP-only host-control section (mounts RsvpStep5Setup, the
+  // SAME component the create RSVP wizard uses). Never shown in ticketed mode.
+  | "rsvp-setup";
+
+export interface SectionConfig {
+  key: SectionKey;
+  label: string;
+  /** Step index for `validateStep(N, draft)`. null → not validated by the ticketed validator. */
+  stepIndex: number | null;
+}
+
+export const SECTIONS: readonly SectionConfig[] = [
+  { key: "basics", label: "Basics", stepIndex: 0 },
+  { key: "when", label: "When", stepIndex: 1 },
+  { key: "where", label: "Where", stepIndex: 2 },
+  { key: "cover", label: "Cover", stepIndex: 3 },
+  { key: "visual", label: "Visual", stepIndex: null },
+  { key: "tickets", label: "Tickets", stepIndex: 4 },
+  { key: "settings", label: "Settings", stepIndex: 5 },
+];
+
+// ORCH-1172 — RSVP edit sections (RSVP setup right after Cover). `rsvp-setup`
+// is stepIndex null: the ticketed validateStep MUST NOT run against an RSVP
+// draft (validateRsvpStep(4) has no required fields; cross-field rules are
+// UI-enforced inside RsvpStep5Setup).
+export const RSVP_SECTIONS: readonly SectionConfig[] = [
+  { key: "basics", label: "Basics", stepIndex: 0 },
+  { key: "when", label: "When", stepIndex: 1 },
+  { key: "where", label: "Where", stepIndex: 2 },
+  { key: "cover", label: "Cover", stepIndex: 3 },
+  { key: "visual", label: "Visual", stepIndex: null },
+  { key: "rsvp-setup", label: "RSVP", stepIndex: null },
+];
+
+/**
+ * Pure section-list selector. rsvpMode → the RSVP section list (Tickets +
+ * generic Settings dropped, RSVP setup added after Cover); otherwise the
+ * byte-identical ticketed SECTIONS.
+ */
+export const sectionsForMode = (
+  rsvpMode: boolean,
+): readonly SectionConfig[] => (rsvpMode ? RSVP_SECTIONS : SECTIONS);

--- a/mingla-business/src/hooks/useRsvpEvents.ts
+++ b/mingla-business/src/hooks/useRsvpEvents.ts
@@ -16,6 +16,7 @@ import {
 } from "../services/rsvpEvents";
 import type { PublishedBusinessEvent } from "../services/businessEvents";
 import type { DraftEvent } from "../store/draftEventStore";
+import type { RsvpUpdatePayload } from "../utils/serverDraftEventMapper";
 
 export function usePublishRsvpDraft() {
   return useMutation<
@@ -32,7 +33,7 @@ export function useUpdateLiveRsvp() {
   return useMutation<
     UpdateLiveRsvpResult,
     Error,
-    { eventId: string; payload: Record<string, unknown>; reason: string }
+    { eventId: string; payload: RsvpUpdatePayload; reason: string }
   >({
     mutationFn: ({ eventId, payload, reason }) =>
       updateLiveRsvp(eventId, payload, reason),

--- a/mingla-business/src/services/rsvpEvents.ts
+++ b/mingla-business/src/services/rsvpEvents.ts
@@ -16,7 +16,11 @@ import {
   type PublishedBusinessEvent,
   type PublishRpcResponse,
 } from "./businessEvents";
-import { draftToServerUpdate, publishedVisibilityForDraft } from "../utils/serverDraftEventMapper";
+import {
+  draftToServerUpdate,
+  publishedVisibilityForDraft,
+  type RsvpUpdatePayload,
+} from "../utils/serverDraftEventMapper";
 import { logAppsFlyerEvent } from "./appsFlyerService";
 import type { DraftEvent } from "../store/draftEventStore";
 
@@ -63,7 +67,10 @@ export interface UpdateLiveRsvpResult {
 
 export const updateLiveRsvp = async (
   eventId: string,
-  payload: Record<string, unknown>,
+  // ORCH-1172 — the publish-style payload built by buildRsvpUpdatePayload (was
+  // a raw camelCase patch that the RPC rejected with rsvp_title_required —
+  // BUG-A). The typed contract keeps create + edit on one payload shape.
+  payload: RsvpUpdatePayload,
   reason: string,
 ): Promise<UpdateLiveRsvpResult> => {
   const { data, error } = await supabase.rpc("biz_update_live_rsvp", {

--- a/mingla-business/src/store/liveEventStore.ts
+++ b/mingla-business/src/store/liveEventStore.ts
@@ -117,6 +117,18 @@ export type EditableLiveEventFields = Pick<
   // protection guard rail; the post-sale lock is enforced server-side + the UI
   // renders read-only once sold).
   | "pricingSwitches"
+  // ORCH-1172 — RSVP host-controls editable post-publish (parity with the
+  // create RSVP wizard's Step-5). These live ONLY on RSVP rows; they are
+  // additive (no buyer-protection guard rail — RSVP is moneyless, no orders)
+  // and reach biz_update_live_rsvp via buildRsvpUpdatePayload. Listed as
+  // SAFE_KEYS below. Optional on LiveEvent (present only on event_type='rsvp');
+  // the Pick is legal because the keys exist on the type.
+  | "rsvpCapacity"
+  | "rsvpAllowPlusOnes"
+  | "rsvpPlusOnesMax"
+  | "rsvpWaitlistEnabled"
+  | "rsvpApprovalMode"
+  | "rsvpDiscoverable"
 >;
 
 /**

--- a/mingla-business/src/utils/__tests__/editRsvpParity.orch1172.test.ts
+++ b/mingla-business/src/utils/__tests__/editRsvpParity.orch1172.test.ts
@@ -14,7 +14,10 @@
  * Fails-on-revert: revert the editableDraftToPatch rsvp* diff branches → the
  * "edited controls reach the patch" assertions throw (BUG-B regression). Revert
  * buildRsvpUpdatePayload's `title` → the "payload carries a non-empty title"
- * assertion throws (BUG-A regression).
+ * assertion throws (BUG-A regression). Revert the privateGuestList /
+ * hideRemainingCount lines in buildRsvpUpdatePayload (the BUG-C theme-settings
+ * persistence gap, migration 20261113000000) → the "payload carries the two
+ * privacy toggles" assertion throws.
  */
 
 import { describe, expect, test } from "@jest/globals";
@@ -244,5 +247,33 @@ describe("ORCH-1172 — edit-RSVP parity", () => {
     expect(payload).toHaveProperty("cover_media_url");
     expect(payload).toHaveProperty("cover_media_type");
     expect(payload.location_text).toBe("Loft 5 · 5 Main St");
+  });
+
+  // ----- BUG-C: privacy toggles reach the RPC so it can persist them into
+  //             theme.business_event.settings (migration 20261113000000) -------
+
+  test("buildRsvpUpdatePayload carries privateGuestList + hideRemainingCount (BUG-C fixed)", () => {
+    const original = rsvpLiveEvent();
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      privateGuestList: true,
+      hideRemainingCount: true,
+    };
+
+    const payload = buildRsvpUpdatePayload(edited);
+
+    // These are NOT DB columns — biz_update_live_rsvp deep-merges them into
+    // theme.business_event.settings. The RPC can only persist what the client
+    // sends, so the payload MUST carry them or the toggle save silently no-ops.
+    expect(payload.privateGuestList).toBe(true);
+    expect(payload.hideRemainingCount).toBe(true);
+  });
+
+  test("buildRsvpUpdatePayload mirrors the unedited privacy toggles (default OFF round-trips)", () => {
+    const payload = buildRsvpUpdatePayload(
+      liveEventToEditableDraft(rsvpLiveEvent()),
+    );
+    expect(payload.privateGuestList).toBe(false);
+    expect(payload.hideRemainingCount).toBe(false);
   });
 });

--- a/mingla-business/src/utils/__tests__/editRsvpParity.orch1172.test.ts
+++ b/mingla-business/src/utils/__tests__/editRsvpParity.orch1172.test.ts
@@ -1,0 +1,248 @@
+/**
+ * ORCH-1172 — edit-RSVP parity regression suite.
+ *
+ * Proves the two blocking bugs the spec found are fixed:
+ *   BUG-A: the edit save passed a raw camelCase patch with NO `title`, so
+ *          biz_update_live_rsvp raised rsvp_title_required on EVERY save.
+ *   BUG-B: the 6 rsvp* host-controls were never diffed into the patch, so
+ *          capacity/approval/discoverable/etc. changes were silently dropped.
+ *
+ * It also locks the section-list parity: rsvpMode → RSVP section list (RsvpStep5
+ * `rsvp-setup` after Cover, NO `tickets`, NO generic `settings`); ticketed mode →
+ * the byte-identical SECTIONS (regression lock for D1-#8).
+ *
+ * Fails-on-revert: revert the editableDraftToPatch rsvp* diff branches → the
+ * "edited controls reach the patch" assertions throw (BUG-B regression). Revert
+ * buildRsvpUpdatePayload's `title` → the "payload carries a non-empty title"
+ * assertion throws (BUG-A regression).
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  computeRichFieldDiffs,
+  editableDraftToPatch,
+  liveEventToEditableDraft,
+  MATERIAL_KEYS,
+} from "../liveEventAdapter";
+import { buildRsvpUpdatePayload } from "../serverDraftEventMapper";
+import { sectionsForMode } from "../../components/event/editPublishedSections";
+import type { DraftEvent } from "../../store/draftEventStore";
+import type { LiveEvent } from "../../store/liveEventStore";
+
+// A published RSVP LiveEvent (event_type='rsvp') as the route hydrates it from
+// the server: capacity 20 / plus-ones off / auto approval / discoverable off.
+const rsvpLiveEvent = (patch: Partial<LiveEvent> = {}): LiveEvent =>
+  ({
+    id: "rsvp-1",
+    serverEventId: "server-rsvp-1",
+    brandId: "brand-1",
+    brandSlug: "brand",
+    eventSlug: "house-party",
+    status: "scheduled",
+    publishedAt: "2026-06-01T12:00:00.000Z",
+    cancelledAt: null,
+    endedAt: null,
+    event_type: "rsvp",
+    name: "House Party",
+    description: "BYOB.",
+    format: "in_person",
+    category: null,
+    whenMode: "single",
+    date: "2026-07-01",
+    doorsOpen: "19:00",
+    endsAt: "23:00",
+    timezone: "America/New_York",
+    recurrenceRule: null,
+    multiDates: null,
+    venueName: "Loft 5",
+    address: "5 Main St",
+    onlineUrl: null,
+    hideAddressUntilTicket: false,
+    coverHue: 25,
+    coverMediaUrl: null,
+    coverMediaType: null,
+    coverMediaProvider: null,
+    coverMediaSourceUrl: null,
+    coverMediaCredit: null,
+    coverMediaCreditUrl: null,
+    coverMediaAlt: null,
+    currency: "USD",
+    tickets: [],
+    visibility: "public",
+    requireApproval: false,
+    allowTransfers: true,
+    hideRemainingCount: false,
+    passwordProtected: false,
+    privateGuestList: false,
+    inPersonPaymentsEnabled: false,
+    orders: [],
+    // RSVP host-control snapshot (the route attaches these from the probe).
+    rsvpCapacity: 20,
+    rsvpAllowPlusOnes: false,
+    rsvpPlusOnesMax: 0,
+    rsvpWaitlistEnabled: false,
+    rsvpApprovalMode: "auto",
+    rsvpDiscoverable: false,
+    rsvpGoingCount: 4,
+    createdAt: "2026-06-01T11:00:00.000Z",
+    updatedAt: "2026-06-01T12:00:00.000Z",
+    ...patch,
+  }) as LiveEvent;
+
+describe("ORCH-1172 — edit-RSVP parity", () => {
+  // ----- Section-list parity (D1-#1 + D1-#8 regression lock) ----------------
+
+  test("rsvpMode section list mounts the RSVP setup card and drops tickets+settings", () => {
+    const keys = sectionsForMode(true).map((s) => s.key);
+    expect(keys).toEqual(["basics", "when", "where", "cover", "visual", "rsvp-setup"]);
+    // RSVP setup mirrors create order (after Cover; the edit-only Visual/theme
+    // card — which the create wizard has no equivalent of — sits between them).
+    expect(keys.indexOf("rsvp-setup")).toBeGreaterThan(keys.indexOf("cover"));
+    expect(keys[keys.length - 1]).toBe("rsvp-setup");
+    // Ticketed-only sections are gone in RSVP mode.
+    expect(keys).not.toContain("tickets");
+    expect(keys).not.toContain("settings");
+    // stepIndex null → the ticketed validateStep never runs against an RSVP draft.
+    const rsvpSetup = sectionsForMode(true).find((s) => s.key === "rsvp-setup");
+    expect(rsvpSetup?.stepIndex).toBeNull();
+  });
+
+  test("ticketed mode section list is byte-identical (no rsvp-setup, keeps tickets+settings)", () => {
+    const keys = sectionsForMode(false).map((s) => s.key);
+    expect(keys).toEqual([
+      "basics",
+      "when",
+      "where",
+      "cover",
+      "visual",
+      "tickets",
+      "settings",
+    ]);
+    expect(keys).not.toContain("rsvp-setup");
+  });
+
+  // ----- BUG-B: rsvp* controls now diff into the patch ----------------------
+
+  test("editing capacity + approval mode + discoverable produces a patch carrying all three (BUG-B fixed)", () => {
+    const original = rsvpLiveEvent();
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      rsvpCapacity: 50,
+      rsvpApprovalMode: "manual",
+      rsvpDiscoverable: true,
+    };
+
+    const patch = editableDraftToPatch(original, edited);
+
+    expect(patch.rsvpCapacity).toBe(50);
+    expect(patch.rsvpApprovalMode).toBe("manual");
+    expect(patch.rsvpDiscoverable).toBe(true);
+    // Unchanged controls must NOT appear in the patch.
+    expect(patch).not.toHaveProperty("rsvpAllowPlusOnes");
+    expect(patch).not.toHaveProperty("rsvpPlusOnesMax");
+    expect(patch).not.toHaveProperty("rsvpWaitlistEnabled");
+  });
+
+  test("each rsvp control diffs independently; an unchanged RSVP yields an empty patch", () => {
+    const original = rsvpLiveEvent();
+    const noChange = editableDraftToPatch(original, liveEventToEditableDraft(original));
+    expect(Object.keys(noChange)).toHaveLength(0);
+
+    const plusOnesOn: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      rsvpAllowPlusOnes: true,
+      rsvpPlusOnesMax: 3,
+    };
+    const patch = editableDraftToPatch(original, plusOnesOn);
+    expect(patch.rsvpAllowPlusOnes).toBe(true);
+    expect(patch.rsvpPlusOnesMax).toBe(3);
+  });
+
+  test("rsvp host-controls are SAFE (none are MATERIAL — no buyer SMS for moneyless RSVP)", () => {
+    const rsvpKeys = [
+      "rsvpCapacity",
+      "rsvpAllowPlusOnes",
+      "rsvpPlusOnesMax",
+      "rsvpWaitlistEnabled",
+      "rsvpApprovalMode",
+      "rsvpDiscoverable",
+    ] as const;
+    for (const k of rsvpKeys) {
+      expect(MATERIAL_KEYS).not.toContain(k);
+    }
+  });
+
+  // ----- rsvp* changes surface in the ChangeSummaryModal (labeled diffs) -----
+
+  test("computeRichFieldDiffs labels the rsvp changes (drives the RSVP 'Edited' indicator)", () => {
+    const original = rsvpLiveEvent();
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      rsvpCapacity: 50,
+      rsvpApprovalMode: "manual",
+    };
+    const diffs = computeRichFieldDiffs(original, edited);
+    const byKey = new Map(diffs.map((d) => [d.fieldKey, d]));
+    expect(byKey.get("rsvpCapacity")?.fieldLabel).toBe("Guest limit");
+    expect(byKey.get("rsvpApprovalMode")?.fieldLabel).toBe("Approval mode");
+    // RSVP fields are safe severity (additive), never material.
+    expect(byKey.get("rsvpCapacity")?.severity).toBe("safe");
+  });
+
+  // ----- BUG-A: payload always carries a title + the RPC-shape keys ----------
+
+  test("buildRsvpUpdatePayload always carries a non-empty title + when block (BUG-A fixed)", () => {
+    const original = rsvpLiveEvent();
+    // Edit only the capacity — the name is unchanged. The OLD code sent the
+    // sparse patch (no `name`/`title`) → rsvp_title_required. The fix reads the
+    // full editState so `title` is always present.
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      rsvpCapacity: 99,
+    };
+
+    const payload = buildRsvpUpdatePayload(edited);
+
+    expect(payload.title).toBe("House Party");
+    expect(payload.title.length).toBeGreaterThan(0);
+    expect(payload.when).toEqual({
+      date: "2026-07-01",
+      doorsOpen: "19:00",
+      endsAt: "23:00",
+    });
+  });
+
+  test("buildRsvpUpdatePayload maps visibility→requestedVisibility + carries all 6 rsvp* keys in RPC shape", () => {
+    const original = rsvpLiveEvent();
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      visibility: "private",
+      rsvpCapacity: 12,
+      rsvpAllowPlusOnes: true,
+      rsvpPlusOnesMax: 2,
+      rsvpWaitlistEnabled: true,
+      rsvpApprovalMode: "manual",
+      rsvpDiscoverable: false,
+    };
+
+    const payload = buildRsvpUpdatePayload(edited);
+
+    // visibility → requestedVisibility (the RPC reads requestedVisibility).
+    expect(payload.requestedVisibility).toBe("private");
+    // All 6 host-controls present in the camelCase shape the RPC reads.
+    expect(payload).toMatchObject({
+      rsvpCapacity: 12,
+      rsvpAllowPlusOnes: true,
+      rsvpPlusOnesMax: 2,
+      rsvpWaitlistEnabled: true,
+      rsvpApprovalMode: "manual",
+      rsvpDiscoverable: false,
+    });
+    // snake_case location/cover keys the RPC expects.
+    expect(payload).toHaveProperty("location_text");
+    expect(payload).toHaveProperty("cover_media_url");
+    expect(payload).toHaveProperty("cover_media_type");
+    expect(payload.location_text).toBe("Loft 5 · 5 Main St");
+  });
+});

--- a/mingla-business/src/utils/liveEventAdapter.ts
+++ b/mingla-business/src/utils/liveEventAdapter.ts
@@ -162,6 +162,14 @@ export const FIELD_LABELS: Record<keyof EditableLiveEventFields, string> = {
   locationGeo: "Map location",
   // ORCH-1006
   pricingSwitches: "Who covers costs",
+  // ORCH-1172 — RSVP host-control labels (surface in the ChangeSummaryModal
+  // + drive the rsvp-setup "Edited" indicator).
+  rsvpCapacity: "Guest limit",
+  rsvpAllowPlusOnes: "Allow extras",
+  rsvpPlusOnesMax: "Max extras per guest",
+  rsvpWaitlistEnabled: "Waitlist",
+  rsvpApprovalMode: "Approval mode",
+  rsvpDiscoverable: "Discoverable",
 };
 
 /**
@@ -215,6 +223,15 @@ export const SAFE_KEYS: ReadonlyArray<keyof EditableLiveEventFields> = [
   "musicGenres",
   "city",
   "locationGeo",
+  // ORCH-1172 — RSVP host-controls are additive (RSVP is moneyless — no buyers
+  // to protect). They must NOT be in MATERIAL_KEYS (which would imply ticket-
+  // buyer SMS). The biz_update_live_rsvp RPC owns its own going-guest notify.
+  "rsvpCapacity",
+  "rsvpAllowPlusOnes",
+  "rsvpPlusOnesMax",
+  "rsvpWaitlistEnabled",
+  "rsvpApprovalMode",
+  "rsvpDiscoverable",
 ];
 
 /**
@@ -365,6 +382,35 @@ export const editableDraftToPatch = (
     !deepEqual(origSwitches, edited.pricingSwitches)
   ) {
     patch.pricingSwitches = edited.pricingSwitches;
+  }
+  // ORCH-1172 — diff the 6 core RSVP host-controls so capacity/plus-ones/
+  // waitlist/approval/discoverable changes reach biz_update_live_rsvp (BUG-B:
+  // these were never diffed, so every change was silently dropped). Originals
+  // are undefined on non-RSVP / legacy LiveEvents → coalesce to the create-
+  // wizard defaults (null capacity / false / 0 / "auto") so the diff is honest.
+  const origRsvpCapacity = original.rsvpCapacity ?? null;
+  if (origRsvpCapacity !== edited.rsvpCapacity) {
+    patch.rsvpCapacity = edited.rsvpCapacity;
+  }
+  const origRsvpAllowPlusOnes = original.rsvpAllowPlusOnes ?? false;
+  if (origRsvpAllowPlusOnes !== edited.rsvpAllowPlusOnes) {
+    patch.rsvpAllowPlusOnes = edited.rsvpAllowPlusOnes;
+  }
+  const origRsvpPlusOnesMax = original.rsvpPlusOnesMax ?? 0;
+  if (origRsvpPlusOnesMax !== edited.rsvpPlusOnesMax) {
+    patch.rsvpPlusOnesMax = edited.rsvpPlusOnesMax;
+  }
+  const origRsvpWaitlistEnabled = original.rsvpWaitlistEnabled ?? false;
+  if (origRsvpWaitlistEnabled !== edited.rsvpWaitlistEnabled) {
+    patch.rsvpWaitlistEnabled = edited.rsvpWaitlistEnabled;
+  }
+  const origRsvpApprovalMode = original.rsvpApprovalMode ?? "auto";
+  if (origRsvpApprovalMode !== edited.rsvpApprovalMode) {
+    patch.rsvpApprovalMode = edited.rsvpApprovalMode;
+  }
+  const origRsvpDiscoverable = original.rsvpDiscoverable ?? false;
+  if (origRsvpDiscoverable !== edited.rsvpDiscoverable) {
+    patch.rsvpDiscoverable = edited.rsvpDiscoverable;
   }
   return patch;
 };

--- a/mingla-business/src/utils/serverDraftEventMapper.ts
+++ b/mingla-business/src/utils/serverDraftEventMapper.ts
@@ -371,6 +371,72 @@ const locationTextForDraft = (draft: DraftEvent): string | null => {
   return parts.length > 0 ? parts.join(" · ") : null;
 };
 
+/**
+ * ORCH-1172 — the `biz_update_live_rsvp` p_payload shape.
+ *
+ * The RPC reads `title` (REQUIRED — raises rsvp_title_required when blank),
+ * `requestedVisibility` (public|unlisted|private), the snake_case location /
+ * cover keys, a single-date `when{}` block, and the 6 camelCase rsvp host-
+ * control keys (defaulting absent keys to the existing column). This is the
+ * SAME publish-style shape `business_publish_rsvp_draft` consumes — the create
+ * publish path sends `title` + `requestedVisibility` + snake_case via
+ * draftToServerUpdate (see publishRsvpDraft). Keeping one builder here makes
+ * create + edit share a single source of truth for the payload contract.
+ */
+export interface RsvpUpdatePayload {
+  title: string;
+  description: string | null;
+  location_text: string | null;
+  online_url: string | null;
+  cover_media_url: string | null;
+  cover_media_type: EventCoverMediaType | null;
+  requestedVisibility: DraftEventVisibility;
+  timezone: string;
+  when: {
+    date: string | null;
+    doorsOpen: string | null;
+    endsAt: string | null;
+  };
+  rsvpCapacity: number | null;
+  rsvpAllowPlusOnes: boolean;
+  rsvpPlusOnesMax: number;
+  rsvpWaitlistEnabled: boolean;
+  rsvpApprovalMode: "auto" | "manual";
+  rsvpDiscoverable: boolean;
+}
+
+/**
+ * ORCH-1172 — build the publish-style RSVP edit payload from the FULL edit
+ * state (not a sparse patch). The RPC requires `title` unconditionally and
+ * defaults absent keys to the existing column, so emitting the full current
+ * values is safe + idempotent. Fixes BUG-A (title always present → no more
+ * rsvp_title_required) and BUG-B (the 6 rsvp* host-controls + when always
+ * present, correctly snake-cased location/cover + requestedVisibility).
+ */
+export const buildRsvpUpdatePayload = (
+  draft: DraftEvent,
+): RsvpUpdatePayload => ({
+  title: draft.name.trim(),
+  description: draft.description.trim().length > 0 ? draft.description : null,
+  location_text: locationTextForDraft(draft),
+  online_url: draft.onlineUrl,
+  cover_media_url: draft.coverMediaUrl,
+  cover_media_type: draft.coverMediaUrl === null ? null : draft.coverMediaType,
+  requestedVisibility: draft.visibility,
+  timezone: draft.timezone,
+  when: {
+    date: draft.date,
+    doorsOpen: draft.doorsOpen,
+    endsAt: draft.endsAt,
+  },
+  rsvpCapacity: draft.rsvpCapacity,
+  rsvpAllowPlusOnes: draft.rsvpAllowPlusOnes,
+  rsvpPlusOnesMax: draft.rsvpPlusOnesMax,
+  rsvpWaitlistEnabled: draft.rsvpWaitlistEnabled,
+  rsvpApprovalMode: draft.rsvpApprovalMode,
+  rsvpDiscoverable: draft.rsvpDiscoverable,
+});
+
 const recurrenceRulesForDraft = (draft: DraftEvent): unknown =>
   draft.recurrenceRule === null ? null : draft.recurrenceRule;
 

--- a/mingla-business/src/utils/serverDraftEventMapper.ts
+++ b/mingla-business/src/utils/serverDraftEventMapper.ts
@@ -403,6 +403,11 @@ export interface RsvpUpdatePayload {
   rsvpWaitlistEnabled: boolean;
   rsvpApprovalMode: "auto" | "manual";
   rsvpDiscoverable: boolean;
+  // ORCH-1172 — privacy toggles persisted into theme.business_event.settings
+  // by biz_update_live_rsvp (migration 20261113000000). These are NOT DB
+  // columns; without them in the payload the edit silently drops the toggles.
+  privateGuestList: boolean;
+  hideRemainingCount: boolean;
 }
 
 /**
@@ -435,6 +440,8 @@ export const buildRsvpUpdatePayload = (
   rsvpWaitlistEnabled: draft.rsvpWaitlistEnabled,
   rsvpApprovalMode: draft.rsvpApprovalMode,
   rsvpDiscoverable: draft.rsvpDiscoverable,
+  privateGuestList: draft.privateGuestList,
+  hideRemainingCount: draft.hideRemainingCount,
 });
 
 const recurrenceRulesForDraft = (draft: DraftEvent): unknown =>

--- a/supabase/migrations/20261113000000_orch_1172_rsvp_edit_privacy_settings.sql
+++ b/supabase/migrations/20261113000000_orch_1172_rsvp_edit_privacy_settings.sql
@@ -1,0 +1,258 @@
+-- ===========================================================================
+-- ORCH-1172 — edit-RSVP parity: persist the two privacy toggles on edit.
+--
+-- privateGuestList / hideRemainingCount are NOT DB columns. The CREATE publish
+-- RPC (business_publish_rsvp_draft, 20261004000000) stores the whole draft
+-- object under events.theme.business_event, so on publish they land at
+--   theme.business_event.settings.privateGuestList
+--   theme.business_event.settings.hideRemainingCount
+-- (see serverDraftEventMapper.buildBusinessDraftPayload — settings object).
+--
+-- biz_update_live_rsvp (same migration, §5.2) never touched events.theme, so
+-- editing those two toggles post-publish silently did not persist. The edit UI
+-- renders + diffs them (RsvpStep5Setup), so a user could toggle + save and have
+-- the value dropped — a silent-failure trap.
+--
+-- This migration CREATE OR REPLACEs biz_update_live_rsvp with the IDENTICAL
+-- signature (uuid, jsonb, text). The ONLY behavioral change: when the payload
+-- carries privateGuestList / hideRemainingCount, deep-merge them into
+-- theme.business_event.settings via jsonb_set, PRESERVING every other theme key
+-- and every other settings key. Defaults to the existing stored value when a
+-- key is absent (idempotent, mirrors the column passthrough above).
+--
+-- Safe-migration rules (matching 20261004000000): $$ body delimiter,
+-- CREATE OR REPLACE (return type unchanged → no DROP needed), re-GRANT EXECUTE
+-- to authenticated (the only grantee the current function has).
+-- ===========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.biz_update_live_rsvp(
+  p_event_id uuid,
+  p_payload jsonb,
+  p_reason text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_user_id        uuid;
+  v_existing       public.events%ROWTYPE;
+  v_brand          record;
+  v_now            timestamptz := now();
+  v_trimmed_reason text;
+  v_title          text;
+  v_description    text;
+  v_location_text  text;
+  v_online_url     text;
+  v_timezone       text;
+  v_visibility     text;
+  v_when           jsonb;
+  v_date_iso       text;
+  v_doors          text;
+  v_ends           text;
+  v_new_start      timestamptz;
+  v_new_end        timestamptz;
+  v_old_start      timestamptz;
+  v_rsvp_capacity  integer;
+  v_rsvp_allow_plus_ones boolean;
+  v_rsvp_plus_ones_max integer;
+  v_rsvp_waitlist_enabled boolean;
+  v_rsvp_approval_mode text;
+  v_rsvp_discoverable boolean;
+  v_material_change boolean := false;
+  v_going_count    integer;
+  v_notified_count integer := 0;
+  v_event          public.events%ROWTYPE;
+  v_guest          record;
+  -- ORCH-1172 — theme.business_event.settings privacy toggles.
+  v_private_guest_list boolean;
+  v_hide_remaining_count boolean;
+  v_theme          jsonb;
+  v_settings       jsonb;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  v_trimmed_reason := btrim(COALESCE(p_reason, ''));
+  IF v_trimmed_reason = '' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'missing_edit_reason');
+  END IF;
+  IF char_length(v_trimmed_reason) < 10 OR char_length(v_trimmed_reason) > 200 THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_edit_reason');
+  END IF;
+
+  SELECT * INTO v_existing FROM public.events
+   WHERE id = p_event_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'rsvp_not_found';
+  END IF;
+  IF v_existing.event_type <> 'rsvp' THEN
+    RAISE EXCEPTION 'event_not_an_rsvp'
+      USING HINT = 'biz_update_live_rsvp only handles event_type=rsvp rows.';
+  END IF;
+  IF v_existing.status NOT IN ('scheduled', 'live') THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'rsvp_not_editable_status');
+  END IF;
+  IF public.biz_brand_effective_rank(v_existing.brand_id, v_user_id) < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  SELECT id, slug, name INTO v_brand FROM public.brands
+   WHERE id = v_existing.brand_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found';
+  END IF;
+
+  v_title := NULLIF(btrim(COALESCE(p_payload->>'title', '')), '');
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'rsvp_title_required';
+  END IF;
+  v_description := NULLIF(p_payload->>'description', '');
+  v_location_text := NULLIF(p_payload->>'location_text', '');
+  v_online_url := NULLIF(p_payload->>'online_url', '');
+  v_timezone := COALESCE(NULLIF(p_payload->>'timezone', ''), v_existing.timezone, 'UTC');
+
+  v_visibility := CASE COALESCE(p_payload->>'requestedVisibility', NULL)
+    WHEN 'private' THEN 'private'
+    WHEN 'unlisted' THEN 'hidden'
+    WHEN 'public' THEN 'public'
+    ELSE v_existing.visibility
+  END;
+
+  -- RSVP host-control (default to existing when key absent).
+  v_rsvp_capacity := CASE WHEN p_payload ? 'rsvpCapacity'
+    THEN NULLIF(p_payload->>'rsvpCapacity', '')::integer ELSE v_existing.rsvp_capacity END;
+  v_rsvp_allow_plus_ones := COALESCE((p_payload->>'rsvpAllowPlusOnes')::boolean, v_existing.rsvp_allow_plus_ones);
+  v_rsvp_plus_ones_max := COALESCE(NULLIF(p_payload->>'rsvpPlusOnesMax', '')::integer, v_existing.rsvp_plus_ones_max);
+  v_rsvp_waitlist_enabled := COALESCE((p_payload->>'rsvpWaitlistEnabled')::boolean, v_existing.rsvp_waitlist_enabled);
+  v_rsvp_approval_mode := COALESCE(NULLIF(p_payload->>'rsvpApprovalMode', ''), v_existing.rsvp_approval_mode);
+  IF v_rsvp_approval_mode NOT IN ('auto', 'manual') THEN
+    RAISE EXCEPTION 'rsvp_approval_mode_invalid';
+  END IF;
+  v_rsvp_discoverable := COALESCE((p_payload->>'rsvpDiscoverable')::boolean, v_existing.rsvp_discoverable);
+  IF v_visibility = 'private' THEN
+    v_rsvp_discoverable := false;
+  END IF;
+
+  -- ORCH-1172 — privacy toggles live in theme.business_event.settings, NOT in a
+  -- column. Default to the currently stored value when a key is absent so the
+  -- write is idempotent and never clobbers a value the client didn't send.
+  v_theme := COALESCE(v_existing.theme, '{}'::jsonb);
+  v_private_guest_list := COALESCE(
+    (p_payload->>'privateGuestList')::boolean,
+    (v_theme #>> '{business_event,settings,privateGuestList}')::boolean,
+    false);
+  v_hide_remaining_count := COALESCE(
+    (p_payload->>'hideRemainingCount')::boolean,
+    (v_theme #>> '{business_event,settings,hideRemainingCount}')::boolean,
+    false);
+
+  -- Single-date when (optional in payload; default to existing master).
+  SELECT start_at INTO v_old_start FROM public.event_dates
+   WHERE event_id = p_event_id AND is_master = true LIMIT 1;
+
+  v_when := p_payload->'when';
+  IF v_when IS NOT NULL AND NULLIF(v_when->>'date', '') IS NOT NULL THEN
+    v_date_iso := NULLIF(v_when->>'date', '');
+    v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+    v_ends := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+    v_new_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+    v_new_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+    IF v_new_end <= v_new_start THEN
+      v_new_end := v_new_end + INTERVAL '1 day';
+    END IF;
+    DELETE FROM public.event_dates WHERE event_id = p_event_id;
+    INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+    VALUES (p_event_id, v_new_start, v_new_end, v_timezone, true);
+    IF v_old_start IS DISTINCT FROM v_new_start THEN
+      v_material_change := true;
+    END IF;
+  END IF;
+
+  -- Material change = date/time OR venue/location text changed.
+  IF v_location_text IS DISTINCT FROM v_existing.location_text THEN
+    v_material_change := true;
+  END IF;
+
+  -- ORCH-1172 — deep-merge the two privacy toggles into
+  -- theme.business_event.settings, PRESERVING every other theme key and every
+  -- other settings key. jsonb_set with create_missing=true builds the nested
+  -- path if it doesn't exist yet (e.g. a legacy row that never had a settings
+  -- object), and only ever replaces the two leaf keys we own.
+  v_settings := COALESCE(v_theme #> '{business_event,settings}', '{}'::jsonb);
+  v_settings := jsonb_set(v_settings, '{privateGuestList}', to_jsonb(v_private_guest_list), true);
+  v_settings := jsonb_set(v_settings, '{hideRemainingCount}', to_jsonb(v_hide_remaining_count), true);
+  -- Ensure the business_event container exists before writing into it.
+  IF v_theme -> 'business_event' IS NULL OR jsonb_typeof(v_theme -> 'business_event') <> 'object' THEN
+    v_theme := jsonb_set(v_theme, '{business_event}', '{}'::jsonb, true);
+  END IF;
+  v_theme := jsonb_set(v_theme, '{business_event,settings}', v_settings, true);
+
+  UPDATE public.events
+  SET
+    title = v_title,
+    description = v_description,
+    location_text = v_location_text,
+    online_url = v_online_url,
+    cover_media_url = NULLIF(p_payload->>'cover_media_url', ''),
+    cover_media_type = NULLIF(p_payload->>'cover_media_type', ''),
+    visibility = v_visibility,
+    timezone = v_timezone,
+    rsvp_capacity = v_rsvp_capacity,
+    rsvp_allow_plus_ones = v_rsvp_allow_plus_ones,
+    rsvp_plus_ones_max = CASE WHEN v_rsvp_allow_plus_ones THEN GREATEST(v_rsvp_plus_ones_max, 0) ELSE 0 END,
+    rsvp_waitlist_enabled = v_rsvp_waitlist_enabled,
+    rsvp_approval_mode = v_rsvp_approval_mode,
+    rsvp_discoverable = v_rsvp_discoverable,
+    theme = v_theme,
+    updated_at = v_now
+  WHERE id = p_event_id;
+
+  -- Enqueue rsvp_event_updated for every going+approved guest on material change.
+  IF v_material_change THEN
+    FOR v_guest IN
+      SELECT r.id FROM public.event_rsvps r
+       WHERE r.event_id = p_event_id
+         AND r.rsvp_status = 'going' AND r.approval_status = 'approved'
+    LOOP
+      INSERT INTO public.rsvp_notifications
+        (event_id, rsvp_id, channel, recipient, status, template_key, payload,
+         idempotency_key, attempt_count)
+      VALUES
+        (p_event_id, v_guest.id, NULL, NULL, 'pending', 'rsvp_event_updated',
+         jsonb_build_object('template_key', 'rsvp_event_updated',
+                            'rsvp_id', v_guest.id, 'event_id', p_event_id),
+         'rsvp_update:' || p_event_id::text || ':' || extract(epoch FROM v_now)::bigint::text
+           || ':' || v_guest.id::text,
+         0)
+      ON CONFLICT (idempotency_key) DO NOTHING;
+      v_notified_count := v_notified_count + 1;
+    END LOOP;
+  END IF;
+
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id;
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_going_count
+    FROM public.event_rsvps
+   WHERE event_id = p_event_id AND rsvp_status = 'going' AND approval_status = 'approved';
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'event', to_jsonb(v_event),
+    'going_count', v_going_count,
+    'notified_count', v_notified_count
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_update_live_rsvp(uuid, jsonb, text) TO authenticated;
+
+COMMENT ON FUNCTION public.biz_update_live_rsvp(uuid, jsonb, text) IS
+  'ORCH-1150 + ORCH-1172 — edit a published RSVP. No refund gate, no ticket '
+  'diff. ORCH-1172: also persists privateGuestList / hideRemainingCount into '
+  'theme.business_event.settings (deep-merge, preserves all other theme keys).';
+
+COMMIT;


### PR DESCRIPTION
## ORCH-1172 [edit-rsvp-parity]

A brand could not change RSVP settings after publishing. The edit screen showed a generic ticketed "Settings" card, 6 of 9 RSVP host-controls were absent, and — the lived symptom — the existing RSVP save path was **silently broken** (wrong payload shape → `biz_update_live_rsvp` raised `rsvp_title_required` on every save → nothing persisted).

### Fix — 100% parity with the create wizard
- Edit now mounts the SAME `RsvpStep5Setup` component the create wizard uses (new `rsvp-setup` section after Cover); the ticketed Tickets + generic Settings cards are dropped in rsvp mode. Non-rsvp ticketed edit flow unchanged.
- **Silent-save bug fixed:** `buildRsvpUpdatePayload(editState)` emits the RPC's publish-style shape (title/when/location/cover/requestedVisibility + the 6 rsvp* keys) instead of the raw camelCase patch.
- All 9 RSVP fields now flow through editState → field-diff → labels → `editedSectionKeys` (the RSVP card shows an "Edited" indicator) and persist + round-trip.
- Two latent save-gate bugs fixed so a server-loaded RSVP can actually save (the ticketed local-save gate + a false "couldn't save" toast on the no-local-row path).

### The two privacy toggles (private guest list, hide going count)
These aren't DB columns — they live in `events.theme.business_event.settings` (where the create publish RPC writes them). `biz_update_live_rsvp` never touched `theme`, so editing them was a silent no-op. **Migration `20261113000000`** `CREATE OR REPLACE`s the RPC (identical signature + re-GRANT) to deep-merge those two leaf keys into `theme.business_event.settings` via `jsonb_set`, preserving every sibling theme/settings key. Forward-compatible: old client omits the keys → RPC defaults to stored value; new client + old RPC → keys ignored. No new columns.

### Tests
`editRsvpParity.orch1172` — 10/10, incl. BUG-A (payload title/when), BUG-B (6 rsvp keys diffed), BUG-C (privacy toggles in payload). fails-on-revert proven. 0 new type errors vs baseline.

Surfaces: business iOS + Android (+ business web preview). Migration applied post-merge via Management API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)