### PR TITLE
ORCH-1172 R2: persist hideAddressUntilTicket on RSVP edit (hide-address toggle was silently dropped)

### DIFF
--- a/mingla-business/src/utils/__tests__/editRsvpParity.orch1172.test.ts
+++ b/mingla-business/src/utils/__tests__/editRsvpParity.orch1172.test.ts
@@ -17,7 +17,9 @@
  * assertion throws (BUG-A regression). Revert the privateGuestList /
  * hideRemainingCount lines in buildRsvpUpdatePayload (the BUG-C theme-settings
  * persistence gap, migration 20261113000000) → the "payload carries the two
- * privacy toggles" assertion throws.
+ * privacy toggles" assertion throws. Revert the hideAddressUntilTicket line
+ * (the R2 theme.business_event.hideAddressUntilTicket persistence gap, migration
+ * 20261114000000) → the two "carries hideAddressUntilTicket" assertions throw.
  */
 
 import { describe, expect, test } from "@jest/globals";
@@ -275,5 +277,45 @@ describe("ORCH-1172 — edit-RSVP parity", () => {
     );
     expect(payload.privateGuestList).toBe(false);
     expect(payload.hideRemainingCount).toBe(false);
+  });
+
+  // ----- ORCH-1172 R2 — hideAddressUntilTicket reaches the RPC so it can
+  //        persist into theme.business_event.hideAddressUntilTicket
+  //        (migration 20261114000000) -------------------------------------
+  //
+  // Fails-on-revert: remove the `hideAddressUntilTicket: draft.hideAddressUntilTicket`
+  // line from buildRsvpUpdatePayload → both assertions below throw. Without it
+  // the edit save (publish with address shown → edit to "hide address until
+  // RSVP'd going" → save) silently drops the flag and the address keeps showing
+  // on every public surface (Seth, live).
+
+  test("buildRsvpUpdatePayload carries hideAddressUntilTicket = true when toggled on (R2 fix)", () => {
+    const original = rsvpLiveEvent({ hideAddressUntilTicket: false });
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      hideAddressUntilTicket: true,
+    };
+
+    const payload = buildRsvpUpdatePayload(edited);
+
+    // NOT a DB column — biz_update_live_rsvp writes it at
+    // theme.business_event.hideAddressUntilTicket (direct child, NOT under
+    // settings). The RPC can only persist what the client sends.
+    expect(payload.hideAddressUntilTicket).toBe(true);
+  });
+
+  test("buildRsvpUpdatePayload carries hideAddressUntilTicket = false when toggled off (R2 round-trip)", () => {
+    const original = rsvpLiveEvent({ hideAddressUntilTicket: true });
+    const edited: DraftEvent = {
+      ...liveEventToEditableDraft(original),
+      hideAddressUntilTicket: false,
+    };
+
+    const payload = buildRsvpUpdatePayload(edited);
+
+    // The false case must round-trip too — the RPC defaults to the stored value
+    // when the key is ABSENT, so an explicit false must be emitted to clear a
+    // previously-hidden address.
+    expect(payload.hideAddressUntilTicket).toBe(false);
   });
 });

--- a/mingla-business/src/utils/serverDraftEventMapper.ts
+++ b/mingla-business/src/utils/serverDraftEventMapper.ts
@@ -408,6 +408,14 @@ export interface RsvpUpdatePayload {
   // columns; without them in the payload the edit silently drops the toggles.
   privateGuestList: boolean;
   hideRemainingCount: boolean;
+  // ORCH-1172 R2 — hide-address-until-RSVP'd-going. Like the two toggles above
+  // this is NOT a DB column: the publish path stores it at
+  // theme.business_event.hideAddressUntilTicket (a DIRECT child of
+  // business_event, NOT under settings) and pg_public_rsvp_by_slug reads it
+  // from there. Without it in the payload the edit silently drops it and the
+  // address keeps showing publicly. biz_update_live_rsvp (migration
+  // 20261114000000) deep-merges it back into that leaf.
+  hideAddressUntilTicket: boolean;
 }
 
 /**
@@ -442,6 +450,7 @@ export const buildRsvpUpdatePayload = (
   rsvpDiscoverable: draft.rsvpDiscoverable,
   privateGuestList: draft.privateGuestList,
   hideRemainingCount: draft.hideRemainingCount,
+  hideAddressUntilTicket: draft.hideAddressUntilTicket,
 });
 
 const recurrenceRulesForDraft = (draft: DraftEvent): unknown =>

--- a/supabase/migrations/20261114000000_orch_1172_r2_rsvp_edit_hide_address.sql
+++ b/supabase/migrations/20261114000000_orch_1172_r2_rsvp_edit_hide_address.sql
@@ -1,0 +1,282 @@
+-- ===========================================================================
+-- ORCH-1172 R2 — edit-RSVP parity: persist hideAddressUntilTicket on edit.
+--
+-- hideAddressUntilTicket is NOT a DB column. The CREATE publish RPC
+-- (business_publish_rsvp_draft) stores the whole draft object under
+-- events.theme.business_event, so on publish it lands at
+--   theme.business_event.hideAddressUntilTicket
+-- (see serverDraftEventMapper.buildBusinessDraftPayload — a DIRECT child of
+-- business_event, NOT under settings). pg_public_rsvp_by_slug reads the flag
+-- from there to gate the public address on every surface.
+--
+-- biz_update_live_rsvp (20261113000000) persisted the two settings toggles
+-- (privateGuestList / hideRemainingCount under theme.business_event.settings)
+-- but never touched theme.business_event.hideAddressUntilTicket. So a host who
+-- published with the address shown, then edited to "hide address until RSVP'd
+-- going" and saved, had the flag silently dropped — the address kept showing
+-- on the public page (Seth, live).
+--
+-- This migration CREATE OR REPLACEs biz_update_live_rsvp with the IDENTICAL
+-- signature (uuid, jsonb, text). The ONLY behavioral change vs 20261113000000:
+-- when the payload carries hideAddressUntilTicket, write it into
+-- theme.business_event.hideAddressUntilTicket via jsonb_set, PRESERVING every
+-- other theme key, the business_event.settings object, and every settings key.
+-- Defaults to the existing stored value when the key is absent (idempotent,
+-- mirrors the settings-toggle passthrough already present).
+--
+-- NOTE the nesting difference: hideAddressUntilTicket is a DIRECT child of
+-- business_event (theme.business_event.hideAddressUntilTicket), NOT under
+-- settings — distinct from the two toggles above.
+--
+-- Safe-migration rules (matching 20261113000000): $$ body delimiter,
+-- CREATE OR REPLACE (return type unchanged → no DROP needed), re-GRANT EXECUTE
+-- to authenticated (the only grantee the function has).
+-- ===========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.biz_update_live_rsvp(
+  p_event_id uuid,
+  p_payload jsonb,
+  p_reason text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_user_id        uuid;
+  v_existing       public.events%ROWTYPE;
+  v_brand          record;
+  v_now            timestamptz := now();
+  v_trimmed_reason text;
+  v_title          text;
+  v_description    text;
+  v_location_text  text;
+  v_online_url     text;
+  v_timezone       text;
+  v_visibility     text;
+  v_when           jsonb;
+  v_date_iso       text;
+  v_doors          text;
+  v_ends           text;
+  v_new_start      timestamptz;
+  v_new_end        timestamptz;
+  v_old_start      timestamptz;
+  v_rsvp_capacity  integer;
+  v_rsvp_allow_plus_ones boolean;
+  v_rsvp_plus_ones_max integer;
+  v_rsvp_waitlist_enabled boolean;
+  v_rsvp_approval_mode text;
+  v_rsvp_discoverable boolean;
+  v_material_change boolean := false;
+  v_going_count    integer;
+  v_notified_count integer := 0;
+  v_event          public.events%ROWTYPE;
+  v_guest          record;
+  -- ORCH-1172 — theme.business_event.settings privacy toggles.
+  v_private_guest_list boolean;
+  v_hide_remaining_count boolean;
+  -- ORCH-1172 R2 — theme.business_event.hideAddressUntilTicket (direct child).
+  v_hide_address boolean;
+  v_theme          jsonb;
+  v_settings       jsonb;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated';
+  END IF;
+
+  v_trimmed_reason := btrim(COALESCE(p_reason, ''));
+  IF v_trimmed_reason = '' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'missing_edit_reason');
+  END IF;
+  IF char_length(v_trimmed_reason) < 10 OR char_length(v_trimmed_reason) > 200 THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_edit_reason');
+  END IF;
+
+  SELECT * INTO v_existing FROM public.events
+   WHERE id = p_event_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'rsvp_not_found';
+  END IF;
+  IF v_existing.event_type <> 'rsvp' THEN
+    RAISE EXCEPTION 'event_not_an_rsvp'
+      USING HINT = 'biz_update_live_rsvp only handles event_type=rsvp rows.';
+  END IF;
+  IF v_existing.status NOT IN ('scheduled', 'live') THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'rsvp_not_editable_status');
+  END IF;
+  IF public.biz_brand_effective_rank(v_existing.brand_id, v_user_id) < public.biz_role_rank('event_manager'::text) THEN
+    RAISE EXCEPTION 'insufficient_event_permission';
+  END IF;
+
+  SELECT id, slug, name INTO v_brand FROM public.brands
+   WHERE id = v_existing.brand_id AND deleted_at IS NULL;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found';
+  END IF;
+
+  v_title := NULLIF(btrim(COALESCE(p_payload->>'title', '')), '');
+  IF v_title IS NULL THEN
+    RAISE EXCEPTION 'rsvp_title_required';
+  END IF;
+  v_description := NULLIF(p_payload->>'description', '');
+  v_location_text := NULLIF(p_payload->>'location_text', '');
+  v_online_url := NULLIF(p_payload->>'online_url', '');
+  v_timezone := COALESCE(NULLIF(p_payload->>'timezone', ''), v_existing.timezone, 'UTC');
+
+  v_visibility := CASE COALESCE(p_payload->>'requestedVisibility', NULL)
+    WHEN 'private' THEN 'private'
+    WHEN 'unlisted' THEN 'hidden'
+    WHEN 'public' THEN 'public'
+    ELSE v_existing.visibility
+  END;
+
+  -- RSVP host-control (default to existing when key absent).
+  v_rsvp_capacity := CASE WHEN p_payload ? 'rsvpCapacity'
+    THEN NULLIF(p_payload->>'rsvpCapacity', '')::integer ELSE v_existing.rsvp_capacity END;
+  v_rsvp_allow_plus_ones := COALESCE((p_payload->>'rsvpAllowPlusOnes')::boolean, v_existing.rsvp_allow_plus_ones);
+  v_rsvp_plus_ones_max := COALESCE(NULLIF(p_payload->>'rsvpPlusOnesMax', '')::integer, v_existing.rsvp_plus_ones_max);
+  v_rsvp_waitlist_enabled := COALESCE((p_payload->>'rsvpWaitlistEnabled')::boolean, v_existing.rsvp_waitlist_enabled);
+  v_rsvp_approval_mode := COALESCE(NULLIF(p_payload->>'rsvpApprovalMode', ''), v_existing.rsvp_approval_mode);
+  IF v_rsvp_approval_mode NOT IN ('auto', 'manual') THEN
+    RAISE EXCEPTION 'rsvp_approval_mode_invalid';
+  END IF;
+  v_rsvp_discoverable := COALESCE((p_payload->>'rsvpDiscoverable')::boolean, v_existing.rsvp_discoverable);
+  IF v_visibility = 'private' THEN
+    v_rsvp_discoverable := false;
+  END IF;
+
+  -- ORCH-1172 — privacy toggles live in theme.business_event.settings, NOT in a
+  -- column. Default to the currently stored value when a key is absent so the
+  -- write is idempotent and never clobbers a value the client didn't send.
+  v_theme := COALESCE(v_existing.theme, '{}'::jsonb);
+  v_private_guest_list := COALESCE(
+    (p_payload->>'privateGuestList')::boolean,
+    (v_theme #>> '{business_event,settings,privateGuestList}')::boolean,
+    false);
+  v_hide_remaining_count := COALESCE(
+    (p_payload->>'hideRemainingCount')::boolean,
+    (v_theme #>> '{business_event,settings,hideRemainingCount}')::boolean,
+    false);
+  -- ORCH-1172 R2 — hideAddressUntilTicket lives at
+  -- theme.business_event.hideAddressUntilTicket (a DIRECT child of
+  -- business_event, NOT under settings). Same default-to-existing pattern.
+  v_hide_address := COALESCE(
+    (p_payload->>'hideAddressUntilTicket')::boolean,
+    (v_theme #>> '{business_event,hideAddressUntilTicket}')::boolean,
+    false);
+
+  -- Single-date when (optional in payload; default to existing master).
+  SELECT start_at INTO v_old_start FROM public.event_dates
+   WHERE event_id = p_event_id AND is_master = true LIMIT 1;
+
+  v_when := p_payload->'when';
+  IF v_when IS NOT NULL AND NULLIF(v_when->>'date', '') IS NOT NULL THEN
+    v_date_iso := NULLIF(v_when->>'date', '');
+    v_doors := COALESCE(NULLIF(v_when->>'doorsOpen', ''), '00:00');
+    v_ends := COALESCE(NULLIF(v_when->>'endsAt', ''), v_doors);
+    v_new_start := (v_date_iso || ' ' || v_doors || ':00')::timestamp AT TIME ZONE v_timezone;
+    v_new_end := (v_date_iso || ' ' || v_ends || ':00')::timestamp AT TIME ZONE v_timezone;
+    IF v_new_end <= v_new_start THEN
+      v_new_end := v_new_end + INTERVAL '1 day';
+    END IF;
+    DELETE FROM public.event_dates WHERE event_id = p_event_id;
+    INSERT INTO public.event_dates (event_id, start_at, end_at, timezone, is_master)
+    VALUES (p_event_id, v_new_start, v_new_end, v_timezone, true);
+    IF v_old_start IS DISTINCT FROM v_new_start THEN
+      v_material_change := true;
+    END IF;
+  END IF;
+
+  -- Material change = date/time OR venue/location text changed.
+  IF v_location_text IS DISTINCT FROM v_existing.location_text THEN
+    v_material_change := true;
+  END IF;
+
+  -- ORCH-1172 — deep-merge the two privacy toggles into
+  -- theme.business_event.settings, PRESERVING every other theme key and every
+  -- other settings key. jsonb_set with create_missing=true builds the nested
+  -- path if it doesn't exist yet (e.g. a legacy row that never had a settings
+  -- object), and only ever replaces the two leaf keys we own.
+  v_settings := COALESCE(v_theme #> '{business_event,settings}', '{}'::jsonb);
+  v_settings := jsonb_set(v_settings, '{privateGuestList}', to_jsonb(v_private_guest_list), true);
+  v_settings := jsonb_set(v_settings, '{hideRemainingCount}', to_jsonb(v_hide_remaining_count), true);
+  -- Ensure the business_event container exists before writing into it.
+  IF v_theme -> 'business_event' IS NULL OR jsonb_typeof(v_theme -> 'business_event') <> 'object' THEN
+    v_theme := jsonb_set(v_theme, '{business_event}', '{}'::jsonb, true);
+  END IF;
+  v_theme := jsonb_set(v_theme, '{business_event,settings}', v_settings, true);
+  -- ORCH-1172 R2 — write the hideAddressUntilTicket leaf directly under
+  -- business_event (NOT under settings). The container guard above already ran,
+  -- so business_event is a guaranteed object; this replaces ONLY that one leaf
+  -- and leaves settings + every other business_event/theme key untouched.
+  v_theme := jsonb_set(v_theme, '{business_event,hideAddressUntilTicket}', to_jsonb(v_hide_address), true);
+
+  UPDATE public.events
+  SET
+    title = v_title,
+    description = v_description,
+    location_text = v_location_text,
+    online_url = v_online_url,
+    cover_media_url = NULLIF(p_payload->>'cover_media_url', ''),
+    cover_media_type = NULLIF(p_payload->>'cover_media_type', ''),
+    visibility = v_visibility,
+    timezone = v_timezone,
+    rsvp_capacity = v_rsvp_capacity,
+    rsvp_allow_plus_ones = v_rsvp_allow_plus_ones,
+    rsvp_plus_ones_max = CASE WHEN v_rsvp_allow_plus_ones THEN GREATEST(v_rsvp_plus_ones_max, 0) ELSE 0 END,
+    rsvp_waitlist_enabled = v_rsvp_waitlist_enabled,
+    rsvp_approval_mode = v_rsvp_approval_mode,
+    rsvp_discoverable = v_rsvp_discoverable,
+    theme = v_theme,
+    updated_at = v_now
+  WHERE id = p_event_id;
+
+  -- Enqueue rsvp_event_updated for every going+approved guest on material change.
+  IF v_material_change THEN
+    FOR v_guest IN
+      SELECT r.id FROM public.event_rsvps r
+       WHERE r.event_id = p_event_id
+         AND r.rsvp_status = 'going' AND r.approval_status = 'approved'
+    LOOP
+      INSERT INTO public.rsvp_notifications
+        (event_id, rsvp_id, channel, recipient, status, template_key, payload,
+         idempotency_key, attempt_count)
+      VALUES
+        (p_event_id, v_guest.id, NULL, NULL, 'pending', 'rsvp_event_updated',
+         jsonb_build_object('template_key', 'rsvp_event_updated',
+                            'rsvp_id', v_guest.id, 'event_id', p_event_id),
+         'rsvp_update:' || p_event_id::text || ':' || extract(epoch FROM v_now)::bigint::text
+           || ':' || v_guest.id::text,
+         0)
+      ON CONFLICT (idempotency_key) DO NOTHING;
+      v_notified_count := v_notified_count + 1;
+    END LOOP;
+  END IF;
+
+  SELECT * INTO v_event FROM public.events WHERE id = p_event_id;
+  SELECT COALESCE(SUM(1 + plus_count), 0) INTO v_going_count
+    FROM public.event_rsvps
+   WHERE event_id = p_event_id AND rsvp_status = 'going' AND approval_status = 'approved';
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'event', to_jsonb(v_event),
+    'going_count', v_going_count,
+    'notified_count', v_notified_count
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_update_live_rsvp(uuid, jsonb, text) TO authenticated;
+
+COMMENT ON FUNCTION public.biz_update_live_rsvp(uuid, jsonb, text) IS
+  'ORCH-1150 + ORCH-1172 (+R2) — edit a published RSVP. No refund gate, no '
+  'ticket diff. ORCH-1172: persists privateGuestList / hideRemainingCount into '
+  'theme.business_event.settings. ORCH-1172 R2: also persists '
+  'hideAddressUntilTicket into theme.business_event.hideAddressUntilTicket '
+  '(direct child of business_event, deep-merge, preserves all other theme keys).';
+
+COMMIT;


### PR DESCRIPTION
## ORCH-1172 R2 [edit-rsvp-parity follow-on]

Live bug: publish an RSVP event with the address shown, edit it to hide-address-until-RSVP'd-going, save → the address STILL shows on every surface. Not a caching delay — the toggle was never persisted.

Root cause (same class as the 1172 privacy toggles, one key missed): for RSVP, `hideAddressUntilTicket` is stored in the JSONB column at `theme.business_event.hideAddressUntilTicket` (the publish path writes it there; `pg_public_rsvp_by_slug` reads it from there). The edit dropped it at BOTH layers — `buildRsvpUpdatePayload` never sent it, and `biz_update_live_rsvp` (1172's migration) only merged the two `settings.*` privacy toggles into theme, not `hideAddressUntilTicket`.

### Fix
- Client: `RsvpUpdatePayload` + `buildRsvpUpdatePayload` now carry `hideAddressUntilTicket` (full-state, like the other toggles).
- Migration `20261114000000`: `CREATE OR REPLACE biz_update_live_rsvp` (identical signature, body reproduced from 20261113000000) + ONE add — merge `theme.business_event.hideAddressUntilTicket` from the payload via `jsonb_set`, non-clobbering (defaults to the stored value when omitted; preserves `business_event.settings` and every other theme key). No new columns.

Once persisted, every surface already reads & applies the flag (consumer RSVP via the server-redacting RPC; web/business via the loaded event), so the address hides within the normal refetch window (~30–60s / on reload).

Tests: 12/12 (incl. true-on + false-off round-trip). fails-on-revert proven. 0 new type errors. Business app + migration; no buyer-web rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)