### PR TITLE
ORCH-1173: brand-switcher list scrolls on Android (scroll-gated TopSheet dismiss)

### DIFF
--- a/mingla-business/src/__tests__/orch1173BrandSwitcherAndroidScroll.gate.test.ts
+++ b/mingla-business/src/__tests__/orch1173BrandSwitcherAndroidScroll.gate.test.ts
@@ -1,0 +1,113 @@
+/**
+ * ORCH-1173 [brand-switcher Android scroll] — scroll-gated dismiss-pan
+ * coordination gate.
+ *
+ * # Bug
+ * On Android the brand-switcher TopSheet's brand list could not be scrolled —
+ * swiping up dismissed the sheet instead of scrolling, so brands below the fold
+ * were unreachable. Root cause: `TopSheetNative` wrapped its children (incl. the
+ * inner `ScrollView`) in a bare `Gesture.Pan()` that translated the panel up on
+ * ANY upward drag, which won vertical-drag arbitration over the ScrollView.
+ *
+ * # Fix (asserted here — SOURCE CONTRACT)
+ * 1. TopSheetNative tracks the consumer's scroll offset in a UI-thread shared
+ *    value (`scrollOffset`) via `useAnimatedScrollHandler`, and gates the
+ *    dismiss-pan on `scrollOffset.value <= 0` (list at top) so the pan only
+ *    dismisses from the top; otherwise the ScrollView consumes the drag.
+ * 2. The dismiss-pan is composed `Gesture.Simultaneous(...)` with a
+ *    `Gesture.Native()` representing the inner scroll, so both run.
+ * 3. The handle is exposed via `TopSheetScrollProvider`; BrandSwitcherSheet
+ *    consumes it (`useTopSheetScroll`) and renders an `Animated.ScrollView`
+ *    wired with the gate's `onScroll` + the native gesture.
+ *
+ * # Fails-on-revert
+ * Reverting any leg — restoring the bare `Gesture.Pan()` wrap (drop the
+ * `scrollOffset` gate / the `Gesture.Simultaneous` / the
+ * `useAnimatedScrollHandler`), or reverting BrandSwitcherSheet's
+ * `Animated.ScrollView`/`useTopSheetScroll` back to a plain `ScrollView` —
+ * removes the asserted token(s) and FAILS the corresponding test below.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BUSINESS_ROOT = path.resolve(__dirname, "..", "..");
+const TOPSHEET_PATH = path.join(
+  BUSINESS_ROOT,
+  "src",
+  "components",
+  "ui",
+  "TopSheet.tsx",
+);
+const CONTEXT_PATH = path.join(
+  BUSINESS_ROOT,
+  "src",
+  "components",
+  "ui",
+  "TopSheetScrollContext.tsx",
+);
+const SWITCHER_PATH = path.join(
+  BUSINESS_ROOT,
+  "src",
+  "components",
+  "brand",
+  "BrandSwitcherSheet.tsx",
+);
+
+/** Strip comments so we assert on EXECUTABLE source only. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+describe("ORCH-1173 brand-switcher Android scroll gate", () => {
+  // ---- T-1: the scroll-gating context module exists + exports the contract --
+  test("T-1 — TopSheetScrollContext exposes onScroll + nativeGesture handle", () => {
+    expect(fs.existsSync(CONTEXT_PATH)).toBe(true);
+    const code = stripComments(fs.readFileSync(CONTEXT_PATH, "utf8"));
+    expect(code).toContain("onScroll");
+    expect(code).toContain("nativeGesture");
+    expect(code).toContain("useTopSheetScroll");
+    expect(code).toContain("TopSheetScrollProvider");
+  });
+
+  // ---- T-2: TopSheetNative gates the dismiss-pan on scroll offset -----------
+  test("T-2 — TopSheetNative tracks scrollOffset and gates the dismiss-pan on it (at-top only)", () => {
+    const code = stripComments(fs.readFileSync(TOPSHEET_PATH, "utf8"));
+    // UI-thread scroll-offset tracking.
+    expect(code).toContain("useAnimatedScrollHandler");
+    expect(code).toMatch(/scrollOffset\s*=\s*useSharedValue\(0\)/);
+    // The gate predicate: pan only dismisses when the list is at the top.
+    expect(code).toMatch(/scrollOffset\.value\s*<=\s*0/);
+  });
+
+  // ---- T-3: dismiss-pan composed SIMULTANEOUS with the inner native scroll --
+  test("T-3 — dismiss-pan is composed Gesture.Simultaneous with a Gesture.Native scroll gesture", () => {
+    const code = stripComments(fs.readFileSync(TOPSHEET_PATH, "utf8"));
+    expect(code).toContain("Gesture.Native()");
+    expect(code).toContain("Gesture.Simultaneous(");
+    expect(code).toContain("simultaneousWithExternalGesture");
+    // The composed gesture (not the bare panGesture) drives the detector.
+    expect(code).toContain("gesture={composedGesture}");
+    // The dismiss-pan must NOT be wired bare anymore (the reverted bug shape).
+    expect(code).not.toContain("gesture={panGesture}");
+  });
+
+  // ---- T-4: TopSheet provides the scroll handle to its children -------------
+  test("T-4 — TopSheetNative wraps children in TopSheetScrollProvider", () => {
+    const code = stripComments(fs.readFileSync(TOPSHEET_PATH, "utf8"));
+    expect(code).toContain("TopSheetScrollProvider");
+  });
+
+  // ---- T-5: BrandSwitcherSheet consumes the gate via Animated.ScrollView ----
+  test("T-5 — BrandSwitcherSheet wires Animated.ScrollView to the TopSheet scroll gate", () => {
+    const code = stripComments(fs.readFileSync(SWITCHER_PATH, "utf8"));
+    expect(code).toContain("useTopSheetScroll");
+    expect(code).toContain("Animated.ScrollView");
+    // It must hand the gate's onScroll + native gesture to the scrollable.
+    expect(code).toContain("topSheetScroll.onScroll");
+    expect(code).toContain("topSheetScroll.nativeGesture");
+    expect(code).toContain("GestureDetector");
+  });
+});

--- a/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
+++ b/mingla-business/src/components/brand/BrandSwitcherSheet.tsx
@@ -1,5 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import type { StyleProp, ViewStyle } from "react-native";
+import { GestureDetector } from "react-native-gesture-handler";
+import Animated from "react-native-reanimated";
 
 import {
   accent,
@@ -8,6 +11,10 @@ import {
   text as textTokens,
   typography,
 } from "../../constants/designSystem";
+import {
+  useTopSheetScroll,
+  type TopSheetScrollContextValue,
+} from "../ui/TopSheetScrollContext";
 import { useAuth } from "../../context/AuthContext";
 import { useBrandListState } from "../../hooks/useBrandListShim";
 import { useUpdateCreatorAccount } from "../../hooks/useCreatorAccount";
@@ -47,6 +54,10 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
   const [mode, setMode] = useState<Mode>(
     brandList.isTrueEmpty ? "create" : "switch",
   );
+  // ORCH-1173: scroll-coordination handle from the enclosing TopSheet. Non-null
+  // on native fixed-70 (the brand-switcher path) → wires the dismiss-pan gate;
+  // null on web / compact → falls back to a plain ScrollView.
+  const topSheetScroll = useTopSheetScroll();
 
   useEffect(() => {
     if (visible) setMode(brandList.isTrueEmpty ? "create" : "switch");
@@ -103,10 +114,10 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
                 <Text style={styles.emptyText}>Loading your brands…</Text>
               </View>
             ) : (
-              <ScrollView
+              <BrandListScrollBody
+                topSheetScroll={topSheetScroll}
                 style={styles.scrollArea}
                 contentContainerStyle={styles.scrollContent}
-                showsVerticalScrollIndicator={false}
               >
                 {brands.map((brand) => {
                   const isActive = currentBrandId === brand.id;
@@ -158,7 +169,7 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
                     </View>
                   );
                 })}
-              </ScrollView>
+              </BrandListScrollBody>
             )}
             <View style={styles.footer}>
               <Button
@@ -174,6 +185,59 @@ export const BrandSwitcherSheet: React.FC<BrandSwitcherSheetProps> = ({
         )}
       </View>
     </TopSheet>
+  );
+};
+
+/**
+ * ORCH-1173 — the scrollable brand list body.
+ *
+ * When rendered inside a native `TopSheet` (fixed-70), `topSheetScroll` is the
+ * coordination handle: this swaps the plain `ScrollView` for a reanimated
+ * `Animated.ScrollView` whose `onScroll` writes the live offset into TopSheet's
+ * dismiss-pan gate, and attaches TopSheet's `Gesture.Native()` (composed
+ * `Gesture.Simultaneous` with the dismiss-pan) via a `<GestureDetector>`. The
+ * net effect: the list scrolls; the sheet only dismisses on an upward drag when
+ * the list is at the top.
+ *
+ * When `topSheetScroll` is null (web variant — no dismiss-pan; or any context-
+ * less host) it renders a plain `ScrollView`, which already scrolls fine.
+ */
+interface BrandListScrollBodyProps {
+  topSheetScroll: TopSheetScrollContextValue | null;
+  style: StyleProp<ViewStyle>;
+  contentContainerStyle: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+}
+
+const BrandListScrollBody: React.FC<BrandListScrollBodyProps> = ({
+  topSheetScroll,
+  style,
+  contentContainerStyle,
+  children,
+}) => {
+  if (topSheetScroll === null) {
+    return (
+      <ScrollView
+        style={style}
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator={false}
+      >
+        {children}
+      </ScrollView>
+    );
+  }
+  return (
+    <GestureDetector gesture={topSheetScroll.nativeGesture}>
+      <Animated.ScrollView
+        style={style}
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator={false}
+        onScroll={topSheetScroll.onScroll}
+        scrollEventThrottle={16}
+      >
+        {children}
+      </Animated.ScrollView>
+    </GestureDetector>
   );
 };
 

--- a/mingla-business/src/components/ui/TopSheet.tsx
+++ b/mingla-business/src/components/ui/TopSheet.tsx
@@ -61,12 +61,16 @@ import Animated, {
   Easing,
   cancelAnimation,
   runOnJS,
+  useAnimatedScrollHandler,
   useAnimatedStyle,
   useReducedMotion,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { TopSheetScrollProvider } from "./TopSheetScrollContext";
+import type { TopSheetScrollContextValue } from "./TopSheetScrollContext";
 
 import {
   blurIntensity as blurIntensityTokens,
@@ -220,6 +224,16 @@ const TopSheetNative: React.FC<TopSheetProps> = ({
   const scrimOpacity = useSharedValue(0);
   const reduceMotion = useReducedMotion();
 
+  // ORCH-1173: live scroll offset of the consumer's inner scrollable, written
+  // on the UI thread from `useAnimatedScrollHandler`. Drives the dismiss-pan
+  // gate (pan only dismisses when the list is at the top: `scrollOffset <= 0`).
+  // Starts 0 (top) so a sheet with no inner scroll (e.g. compact, or a
+  // consumer that never wires `onScroll`) keeps dismiss-dragging from anywhere.
+  const scrollOffset = useSharedValue(0);
+  const scrollHandler = useAnimatedScrollHandler((event) => {
+    scrollOffset.value = event.contentOffset.y;
+  });
+
   useEffect(() => {
     if (visible) {
       setMounted(true);
@@ -325,26 +339,69 @@ const TopSheetNative: React.FC<TopSheetProps> = ({
     opacity: scrimOpacity.value,
   }));
 
+  // ORCH-1173: a `Gesture.Native()` representing the inner ScrollView's own
+  // native scroll recognizer. The consumer attaches this (via its
+  // `nativeGesture` context handle) to its scrollable so we can compose it
+  // SIMULTANEOUSLY with the dismiss-pan — both gestures run, and the pan can
+  // yield the upward drag to the scroll when the list isn't at its top.
+  const nativeScrollGesture = Gesture.Native();
+
+  // ORCH-1173 dismiss-pan GATE. Predicate for "this drag should dismiss the
+  // sheet (translate the panel up)":
+  //   panDismissesDrag := (scrollOffset.value <= 0) && (translationY < 0)
+  // i.e. the inner list is at the TOP and the finger is moving UP. When the
+  // list is scrolled (`scrollOffset > 0`), the pan no-ops so the ScrollView
+  // consumes the drag (the list scrolls instead of the sheet dismissing).
+  // `panDroveDismiss` records whether `onUpdate` ever actually translated the
+  // panel this gesture, so `onEnd`'s dismiss decision can't fire on a plain
+  // scroll-fling (which never satisfied the gate).
+  const panDroveDismiss = useSharedValue(false);
   const panGesture = Gesture.Pan()
+    .simultaneousWithExternalGesture(nativeScrollGesture)
+    .onBegin(() => {
+      panDroveDismiss.value = false;
+    })
     .onUpdate((event) => {
-      // Allow upward drag only (swipe-up to dismiss).
-      if (event.translationY < 0) {
+      // Dismiss-translate ONLY when the list is at the top AND dragging up.
+      // Otherwise leave the panel put and let the ScrollView scroll.
+      if (scrollOffset.value <= 0 && event.translationY < 0) {
+        panDroveDismiss.value = true;
         translateY.value = event.translationY;
       }
     })
     .onEnd((event) => {
+      // Only consider dismissing if this gesture actually drove a dismiss-drag
+      // from the top — a normal scroll-fling never set `panDroveDismiss`.
       const shouldClose =
-        event.translationY < -CLOSE_THRESHOLD_PX ||
-        event.velocityY < -CLOSE_VELOCITY;
+        panDroveDismiss.value &&
+        (event.translationY < -CLOSE_THRESHOLD_PX ||
+          event.velocityY < -CLOSE_VELOCITY);
       if (shouldClose) {
         runOnJS(onClose)();
-      } else {
+      } else if (panDroveDismiss.value) {
+        // Drove a (sub-threshold) dismiss-drag → snap the panel back open.
         translateY.value = withTiming(openY, {
           duration: 200,
           easing: Easing.out(Easing.cubic),
         });
       }
+      // else: the gesture only scrolled the list — leave the panel untouched.
     });
+
+  // ORCH-1173: run the dismiss-pan and the inner native scroll SIMULTANEOUSLY
+  // so the scroll-position gate above (not gesture arbitration) decides which
+  // wins. On Android this is what lets the list scroll at all; on iOS it is a
+  // no-op behavior-wise (scroll + at-top dismiss both already worked) but keeps
+  // the logic platform-agnostic.
+  const composedGesture = Gesture.Simultaneous(panGesture, nativeScrollGesture);
+
+  // ORCH-1173: the handle TopSheet hands its scrollable consumer (e.g.
+  // BrandSwitcherSheet). `null` outside this native fixed-70 path (web / no
+  // provider) → consumer falls back to a plain ScrollView.
+  const scrollContextValue: TopSheetScrollContextValue = {
+    onScroll: scrollHandler,
+    nativeGesture: nativeScrollGesture,
+  };
 
   const handleScrimPress = (): void => {
     if (dismissOnScrimTap) onClose();
@@ -398,7 +455,7 @@ const TopSheetNative: React.FC<TopSheetProps> = ({
         ]}
         pointerEvents="box-none"
       >
-        <WebSafeGestureDetector gesture={panGesture}>
+        <WebSafeGestureDetector gesture={composedGesture}>
           <Animated.View
             style={[
               styles.panel,
@@ -427,7 +484,13 @@ const TopSheetNative: React.FC<TopSheetProps> = ({
               handleAreaHeight={handleAreaHeight}
               handleCompactLayout={handleCompactLayout}
             >
-              {children}
+              {/* ORCH-1173: expose the scroll-coordination handle so a
+                  scrollable consumer (BrandSwitcherSheet) can wire its
+                  Animated.ScrollView's onScroll + attach the native scroll
+                  gesture, gating the dismiss-pan on scroll position. */}
+              <TopSheetScrollProvider value={scrollContextValue}>
+                {children}
+              </TopSheetScrollProvider>
             </TopSheetPanelInner>
           </Animated.View>
         </WebSafeGestureDetector>

--- a/mingla-business/src/components/ui/TopSheetScrollContext.tsx
+++ b/mingla-business/src/components/ui/TopSheetScrollContext.tsx
@@ -1,0 +1,81 @@
+/**
+ * TopSheetScrollContext — coordinates a TopSheet's dismiss-pan with the
+ * caller's inner scrollable (ORCH-1173).
+ *
+ * # Why this exists
+ * `TopSheetNative` wraps its arbitrary `children` in a `Gesture.Pan()` that
+ * translates the panel up to dismiss on any upward drag. On Android that Pan
+ * recognizer wins vertical-drag arbitration over an inner RN `ScrollView`, so a
+ * list inside the sheet (BrandSwitcherSheet's brand list) could never scroll —
+ * swiping up dismissed the sheet instead, leaving brands below the fold
+ * unreachable (Seth, device-confirmed; iOS happened to arbitrate the other way
+ * but the gating below makes BOTH platforms correct + deterministic).
+ *
+ * # The fix — scroll-position-gated dismiss-pan (the standard sheet pattern)
+ * TopSheet exposes, via this context:
+ *   - `onScroll`  — a reanimated `useAnimatedScrollHandler` the consumer wires
+ *                   onto its scrollable. It writes the live scroll offset into a
+ *                   UI-thread shared value owned by TopSheet.
+ *   - `nativeGestureRef` — a ref to a `Gesture.Native()` that TopSheet composes
+ *                   `Gesture.Simultaneous(...)` with its dismiss-pan. The
+ *                   consumer attaches this to its scrollable via
+ *                   `<GestureDetector gesture={nativeGesture}>` so the native
+ *                   scroll gesture and the dismiss-pan run simultaneously, and
+ *                   the dismiss-pan can yield to the scroll.
+ *
+ * TopSheet then gates its dismiss-pan to ONLY drive the dismiss-translate when
+ * the list is at the top (`scrollOffset <= 0`); once the list is scrolled, the
+ * pan no-ops and the ScrollView consumes the drag. (Because this is a TOP
+ * sheet, "drag up" means BOTH dismiss AND scroll-the-list-down — they MUST be
+ * arbitrated by scroll offset, which is exactly what the gate does.)
+ *
+ * # Default (no provider / compact mode)
+ * `useTopSheetScroll()` returns `null` outside a provider. The `compact`
+ * heightMode (UniversalCreatorSheet) renders no scrollable and provides no
+ * context, so its short content keeps dismiss-dragging from anywhere —
+ * unchanged. A consumer that does not consume the context (e.g. a future
+ * non-scrolling fixed-70 sheet) is also unaffected.
+ *
+ * Web: `WebSafeGestureDetector.web` mounts no gesture and `TopSheetWeb` has no
+ * dismiss-pan, so the web variant provides no context and consumers fall back
+ * to a plain `ScrollView` (which already scrolls fine on web).
+ */
+
+import React, { createContext, useContext } from "react";
+import type { GestureType } from "react-native-gesture-handler";
+import type { useAnimatedScrollHandler } from "react-native-reanimated";
+
+/** A reanimated scroll handler as produced by `useAnimatedScrollHandler`. */
+type AnimatedScrollHandler = ReturnType<typeof useAnimatedScrollHandler>;
+
+export interface TopSheetScrollContextValue {
+  /**
+   * Wire onto the consumer's scrollable (`Animated.ScrollView`'s `onScroll`).
+   * Writes the live scroll offset into TopSheet's UI-thread shared value so the
+   * dismiss-pan can gate on it.
+   */
+  onScroll: AnimatedScrollHandler;
+  /**
+   * Attach to the consumer's scrollable via
+   * `<GestureDetector gesture={nativeGesture}>` so the native scroll gesture is
+   * composed `Gesture.Simultaneous(...)` with TopSheet's dismiss-pan.
+   */
+  nativeGesture: GestureType;
+}
+
+const TopSheetScrollContext = createContext<TopSheetScrollContextValue | null>(
+  null,
+);
+
+export const TopSheetScrollProvider = TopSheetScrollContext.Provider;
+
+/**
+ * Returns the TopSheet scroll-coordination handle, or `null` when not rendered
+ * inside a `TopSheetNative` (web variant, compact mode, or no provider). A
+ * `null` return means the consumer must fall back to a plain `ScrollView`.
+ */
+export function useTopSheetScroll(): TopSheetScrollContextValue | null {
+  return useContext(TopSheetScrollContext);
+}
+
+export default TopSheetScrollContext;


### PR DESCRIPTION
## ORCH-1173 [brand-switcher-scroll]

On Android the brand-switcher sheet's list couldn't scroll — any up-swipe dismissed the sheet, so brands below the fold were unreachable. iOS worked.

Root cause: `TopSheetNative` wraps the whole panel (incl. the inner `ScrollView`) in a dismiss-only `Gesture.Pan()`. On a TOP sheet, "drag up" means both *dismiss* and *scroll-the-list-down*, and Android's gesture arbitration gave the Pan priority over the ScrollView, so the list never scrolled.

### Fix — scroll-position-gated dismiss
- A `scrollOffset` shared value is written on the UI thread (`useAnimatedScrollHandler`); the inner list is an `Animated.ScrollView` with a `Gesture.Native()`.
- The dismiss-pan is composed `Gesture.Simultaneous(pan, nativeScroll)` and **only** drives the dismiss translate when `scrollOffset <= 0` (list at top) AND the drag is upward. When the list is scrolled, the pan no-ops and the ScrollView consumes the drag. `onEnd` only dismisses if the pan actually drove a dismiss-drag, so a scroll-fling never dismisses.
- Plumbed via a small `TopSheetScrollContext` (consumer falls back to a plain ScrollView when absent — web/compact unaffected).

Result: Android list scrolls + all brands reachable; at-top up-drag still dismisses; scrim-tap, hardware-back, handle all still dismiss. iOS unchanged. Web (no pan) unchanged. `compact` mode (UniversalCreatorSheet) unaffected.

5/5 new gate tests; 0 new type errors; fails-on-revert proven; ADD-only tests. Native JS gesture change — OTA-able, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)