### PR TITLE
ORCH-1172 R5: editor reads fresh on mount (bulletproof RSVP no-clobber vs stale cache)

### DIFF
--- a/mingla-business/src/hooks/__tests__/orch1172r5_editorFreshRead.test.ts
+++ b/mingla-business/src/hooks/__tests__/orch1172r5_editorFreshRead.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ORCH-1172 R5 — the managed-event detail query reads FRESH on every mount.
+ *
+ * R4 made EditPublishedScreen seed its local editState from the server event
+ * only once useBusinessEventById has SETTLED (serverEventSettled = isAuthReady
+ * && !isLoading && !isFetching). But that gate is only meaningful if a mount
+ * actually triggers a NETWORK fetch. With the previous `staleTime: 30s` +
+ * default `refetchOnMount`, a mount within 30s of viewing the event resolved
+ * INSTANTLY from STALE cache → R4 seeded stale → a full-state/diff save could
+ * still clobber a server field that had diverged (the rsvp_discoverable revert
+ * edge).
+ *
+ * This source-contract test pins the fix: `useBusinessEventById` MUST configure
+ * `staleTime: 0` + `refetchOnMount: "always"` so every mount forces a fresh DB
+ * read, and R4's `!isFetching` gate holds the editor's Loading shell until the
+ * fresh row arrives.
+ *
+ * FAILS-ON-REVERT: if either `staleTime: 0` or `refetchOnMount: "always"` is
+ * reverted (e.g. back to `staleTime: STALE_TIME_MS` with no refetchOnMount),
+ * the assertions below fail — re-arming the stale-cache clobber.
+ */
+import { readFileSync } from "fs";
+import path from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const repoFile = (relativePath: string): string =>
+  readFileSync(path.join(process.cwd(), relativePath), "utf8");
+
+// Isolate the body of `useBusinessEventById` so the assertions cannot be
+// satisfied by config that belongs to a sibling hook in the same file.
+const useBusinessEventByIdBody = (source: string): string => {
+  const start = source.indexOf("export const useBusinessEventById");
+  expect(start).toBeGreaterThanOrEqual(0);
+  const next = source.indexOf("export const ", start + 1);
+  return next === -1 ? source.slice(start) : source.slice(start, next);
+};
+
+describe("ORCH-1172 R5 — managed-event editor reads fresh on mount", () => {
+  const source = repoFile("src/hooks/useBusinessEvents.ts");
+  const body = useBusinessEventByIdBody(source);
+
+  test("useBusinessEventById sets staleTime: 0 (no 30s stale window)", () => {
+    expect(body).toContain("staleTime: 0");
+    expect(body).not.toContain("staleTime: STALE_TIME_MS");
+  });
+
+  test("useBusinessEventById sets refetchOnMount: \"always\" (fresh fetch each mount)", () => {
+    expect(body).toContain('refetchOnMount: "always"');
+  });
+
+  test("the hot brand-list feed is NOT made fresh-on-mount (scope guard)", () => {
+    // useBusinessEventsForBrand is the LIST feed — it must keep its 30s
+    // staleTime and must NOT gain refetchOnMount:"always" (would storm the
+    // hub list). Confirm the fresh-read config is scoped to the detail hook.
+    const listStart = source.indexOf("export const useBusinessEventsForBrand");
+    const listEnd = source.indexOf("export const useBusinessEventById");
+    const listBody = source.slice(listStart, listEnd);
+    expect(listBody).toContain("staleTime: STALE_TIME_MS");
+    expect(listBody).not.toContain('refetchOnMount: "always"');
+  });
+});

--- a/mingla-business/src/hooks/useBusinessEvents.ts
+++ b/mingla-business/src/hooks/useBusinessEvents.ts
@@ -140,7 +140,23 @@ export const useBusinessEventById = (
     queryKey:
       enabled && eventId !== null ? businessEventKeys.detail(eventId) : DISABLED_KEY,
     enabled,
-    staleTime: STALE_TIME_MS,
+    // ORCH-1172 R5 — fetch FRESH on every mount. This hook feeds ONLY managed-
+    // event surfaces (the edit-published editor via /rsvp|/event[id]/edit, the
+    // event/rsvp dashboards + scanner/orders/guests/door/recon sub-screens via
+    // useManagedEventRoute) — never the hot brand-list feed (that is
+    // useBusinessEventsForBrand). On those surfaces you ALWAYS want current DB
+    // state. R4 made the editor hold its Loading shell until this query SETTLES
+    // (serverEventSettled = isAuthReady && !isLoading && !isFetching) before
+    // seeding editState from the server event. But with the previous 30s
+    // staleTime + default refetchOnMount, a mount within 30s of viewing the
+    // event resolved INSTANTLY from STALE cache → R4 seeded stale → a
+    // full-state/diff save could still clobber a field that diverged on the
+    // server (the rsvp_discoverable revert edge). staleTime:0 +
+    // refetchOnMount:"always" force a network fetch on each mount; combined with
+    // R4's !isFetching gate the editor waits for the FRESH row, then seeds from
+    // it — killing the last stale-cache clobber.
+    staleTime: 0,
+    refetchOnMount: "always",
     queryFn: async (): Promise<BusinessEventDetail | null> => {
       if (!enabled || eventId === null) return null;
       return fetchBusinessEventById(eventId);


### PR DESCRIPTION
## ORCH-1172 R5 [edit-rsvp-parity] — final hardening

R3+R4 fixed the hydration + seed-timing, but a 30s React Query staleTime meant the editor could still seed from a STALE cached event (if the event was viewed within 30s), re-opening the clobber edge for fields like `rsvp_discoverable`.

### Fix
`useBusinessEventById` now sets `staleTime: 0` + `refetchOnMount: "always"`. Combined with R4's "seed once the server query has settled (incl. !isFetching)", the editor holds its Loading shell until a genuinely FRESH DB read arrives, then seeds from it. Every consumer is a management/edit/dashboard surface (the hot list is the separate `useBusinessEventsForBrand`, untouched), so fresh-on-mount is correct everywhere.

3/3 source-contract tests (ADD-only); 0 new type errors; fails-on-revert proven. No migration, no RPC change. Business app only.