### PR TITLE
META-ORCH-1174 Leg A.2: wire pg_public_trip_by_slug into both surfaces (single source) [deploy]

### DIFF
--- a/app-mobile/src/hooks/useConsumerTripDetail.ts
+++ b/app-mobile/src/hooks/useConsumerTripDetail.ts
@@ -1,29 +1,24 @@
 /**
- * useConsumerTripDetail — composes a consumer trip-detail view from anon-granted
- * sources only (ORCH-1016). NEVER `.from('brands')` / `.from('tickets')`
- * (COMMS-0009 / I-ANON-BRANDS-VIA-DEFINER-VIEW). Does NOT copy
- * mingla-business/usePublicTripBySlug.ts (which reads brands directly — NG-4).
+ * useConsumerTripDetail — composes a consumer trip-detail view from the ONE
+ * canonical anon RPC.
  *
- * Sources:
- *  - Card seed (DiscoverTripRow) for instant paint, OR a pg_published_trips_public
- *    re-fetch by destination/departure for cold deep-link open.
- *  - Anon-direct reads of events (refund_policy, departure_text, description),
- *    event_dates (master), trip_days, trip_inclusions, trip_pricing_tiers +
- *    ticket_types (tiers/price/intake mapping).
- *  - Brand name/verified come from the seed (RPC-sourced) or business_public_brands_view.
- *  - ORCH-1138 FIX-3 — the BRAND COVER (cover_media_url/type) for the "Presented
- *    by" chip is read from the anon-safe, security-definer
- *    `business_public_brands_view` (NEVER `.from('brands')`) — the same scoped
- *    public read model the business /b/ + /t/ pages use. No schema/edge change.
+ * META-ORCH-1174 Leg A.2 (Seth single-source decision) — this hook now reads the
+ * SAME `pg_public_trip_by_slug(p_brand_slug, p_event_slug)` RPC the business/web
+ * trip page reads (SECURITY DEFINER, GRANT anon), replacing the prior per-surface
+ * fan-out (a DiscoverTripRow seed/re-fetch to resolve tripId + 5 anon-direct
+ * table reads). The RPC returns the FULL payload — crucially the destination
+ * lat/lng (so the §11 "Where you'll be" map now renders on consumer, closing the
+ * gap this hook previously documented) and per-tier remaining capacity (also
+ * previously missing on consumer). The `seed` arg is retained for source-compat
+ * but is now unused for the read (the RPC resolves directly by slug, hot OR cold
+ * deep-link). NEVER `.from('brands')` / `.from('tickets')` — the definer RPC is
+ * the anon-safe path (COMMS-0009 / I-ANON-BRANDS-VIA-DEFINER-VIEW).
  */
 
 import { useQuery } from "@tanstack/react-query";
 
 import { supabase } from "../services/supabase";
-import {
-  fetchPublishedTrips,
-  type DiscoverTripRow,
-} from "../services/tripsDiscoveryService";
+import type { DiscoverTripRow } from "../services/tripsDiscoveryService";
 
 /**
  * ORCH-1119 — one item in a trip DAY's optional media gallery. Explicit `type`
@@ -98,6 +93,14 @@ export interface TripDetailTier {
   isUnlimited: boolean;
   quantityTotal: number | null;
   /**
+   * META-ORCH-1174 Leg A.2 — per-tier remaining capacity from the canonical RPC
+   * (GREATEST(quantity_total - sold, 0)); null when unlimited/uncapped (never a
+   * fabricated "0 left" — rule 9). Previously MISSING on consumer (the read had
+   * only an aggregate spotsLeft) → the shared body now gets real per-tier
+   * remaining, parity with web/business.
+   */
+  ticketsRemaining: number | null;
+  /**
    * ORCH-1130 — extracted from `tier_metadata.installments` (anon-readable).
    * Null on missing/malformed metadata (same shape-guard the business
    * `extractInstallmentSchedule` uses). Drives the consumer "HOW YOU PAY"
@@ -169,6 +172,14 @@ export interface ConsumerTripDetail {
   description: string | null;
   destinationText: string | null;
   departureText: string | null;
+  /**
+   * META-ORCH-1174 Leg A.2 — destination lat/lng from the canonical RPC. These
+   * were MISSING on consumer (the prior read carried no coords) → the §11 "Where
+   * you'll be" map was silently omitted. The shared body now renders the map on
+   * EVERY surface (rule 9 — both must be finite; null when the brand set none).
+   */
+  destinationLat: number | null;
+  destinationLng: number | null;
   coverMediaUrl: string | null;
   coverMediaType: "image" | "video" | "gif" | null;
   /**
@@ -228,22 +239,6 @@ export const consumerTripDetailKeys = {
     [...consumerTripDetailKeys.all, brandSlug, tripSlug] as const,
 };
 
-interface EventDetailRow {
-  id: string;
-  slug: string;
-  brand_id: string;
-  title: string;
-  description: string | null;
-  destination_text: string | null;
-  departure_text: string | null;
-  cover_media_url: string | null;
-  cover_media_type: string | null;
-  timezone: string | null;
-  bookings_closed: boolean | null;
-  booking_deadline: string | null;
-  refund_policy: unknown;
-}
-
 function coerceCoverType(raw: string | null): "image" | "video" | "gif" | null {
   return raw === "image" || raw === "video" || raw === "gif" ? raw : null;
 }
@@ -278,179 +273,184 @@ function coerceRefundPolicy(raw: unknown): RefundPolicyShape | null {
   return { kind, tiers };
 }
 
+// META-ORCH-1174 Leg A.2 — the raw JSON shape returned by pg_public_trip_by_slug
+// (mirrors the migration's json_build_object keys). Read defensively; the mapper
+// narrows into the typed ConsumerTripDetail.
+interface RpcTripBrand {
+  id: string;
+  slug: string;
+  name: string;
+  coverMediaUrl: string | null;
+  coverMediaType: string | null;
+  verified: boolean;
+}
+interface RpcTripDay {
+  id: string;
+  ordinal: number;
+  title: string;
+  narrative: string | null;
+  media: unknown;
+}
+interface RpcTripInclusion {
+  id: string;
+  kind: "included" | "excluded";
+  item: string;
+  ordinal: number;
+}
+interface RpcTripTier {
+  id: string;
+  ticketTypeId: string;
+  tierName: string;
+  tierMetadata: Record<string, unknown> | null;
+  priceCents: number;
+  currency: string;
+  quantityTotal: number | null;
+  ticketsRemaining: number | null;
+  isUnlimited: boolean;
+  isFree: boolean;
+  installments: unknown;
+}
+interface RpcTripPayload {
+  id: string;
+  brandId: string;
+  brandSlug: string;
+  tripSlug: string;
+  title: string;
+  description: string | null;
+  timezone: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  departureText: string | null;
+  destinationText: string | null;
+  destinationLat: number | null;
+  destinationLng: number | null;
+  currency: string;
+  coverMediaUrl: string | null;
+  coverMediaType: string | null;
+  refundPolicy: unknown;
+  bookingDeadline: string | null;
+  bookingsClosed: boolean;
+  brand: RpcTripBrand;
+  days: RpcTripDay[];
+  inclusions: RpcTripInclusion[];
+  tiers: RpcTripTier[];
+}
+
+const numOrNull = (raw: unknown): number | null =>
+  typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+
 async function fetchTripDetail(
   brandSlug: string,
   tripSlug: string,
-  seed: DiscoverTripRow | null,
 ): Promise<ConsumerTripDetail> {
-  // Resolve the feed-shaped row (seed when present, else re-fetch by slug match).
-  let feedRow: DiscoverTripRow | null = seed;
-  if (feedRow === null || feedRow.tripSlug !== tripSlug) {
-    // Cold deep-link open: pull a page and match the slug. The RPC has no
-    // by-slug param, but the feed is small; filter on destination is not needed.
-    const { rows } = await fetchPublishedTrips(
-      {
-        destinationQuery: null,
-        departureQuery: null,
-        dateFrom: null,
-        dateTo: null,
-        minPriceCents: null,
-        maxPriceCents: null,
-        groupSizeMin: null,
-        groupSizeMax: null,
-        sort: "relevance",
-      },
-      { limit: 50, offset: 0 },
-    );
-    feedRow =
-      rows.find((r) => r.tripSlug === tripSlug && r.brandSlug === brandSlug) ?? null;
-  }
-  if (feedRow === null) {
+  // META-ORCH-1174 Leg A.2 — the ONE canonical anon read. The SECURITY DEFINER
+  // RPC resolves by (brand_slug, trip_slug) directly (hot OR cold deep-link, no
+  // feed re-fetch) and returns the full payload incl. destination lat/lng + per-
+  // tier remaining (both previously missing on consumer). NEVER `.from('brands')`.
+  const { data, error } = await supabase.rpc("pg_public_trip_by_slug", {
+    p_brand_slug: brandSlug,
+    p_event_slug: tripSlug,
+  });
+  if (error !== null) throw error;
+  if (data === null || data === undefined) {
     throw new Error("Trip not found or no longer available.");
   }
-  const tripId = feedRow.tripId;
+  const p = data as RpcTripPayload;
 
-  // Anon-direct reads (events is anon-SELECT; NO brands/tickets table reads).
-  // ORCH-1138 FIX-3 — the BRAND COVER is read from the anon-safe, security-definer
-  // `business_public_brands_view` by slug (🔒 COMMS-0009 — NEVER `.from("brands")`).
-  // Folded into this same batch so the brand cover costs ZERO extra round trips.
-  const [eventResp, daysResp, inclResp, tiersResp, brandCoverResp] =
-    await Promise.all([
-    supabase
-      .from("events")
-      .select(
-        "id, slug, brand_id, title, description, destination_text, departure_text, cover_media_url, cover_media_type, timezone, bookings_closed, booking_deadline, refund_policy",
-      )
-      .eq("id", tripId)
-      .maybeSingle(),
-    supabase.from("trip_days").select("id, ordinal, title, narrative, media").eq("event_id", tripId).order("ordinal"),
-    supabase
-      .from("trip_inclusions")
-      .select("id, kind, item, ordinal")
-      .eq("event_id", tripId)
-      .order("ordinal"),
-    supabase
-      .from("trip_pricing_tiers")
-      // ORCH-1130 — pull tier_metadata so the consumer "HOW YOU PAY" module can
-      // surface the installment template (anon-readable jsonb).
-      .select("ticket_type_id, tier_metadata, ticket_types(id, name, price_cents, currency, is_free, is_unlimited, quantity_total, is_hidden, deleted_at)")
-      .eq("event_id", tripId),
-    // ORCH-1138 FIX-3 — brand cover from the anon-safe public brand read model.
-    // Fails OPEN: an error/missing row leaves the cover null → themed fallback
-    // (rule 9), it does NOT throw and break the whole trip-detail load.
-    supabase
-      .from("business_public_brands_view")
-      .select("cover_media_url, cover_media_type")
-      .eq("slug", brandSlug)
-      .maybeSingle(),
-  ]);
-
-  if (eventResp.error) throw eventResp.error;
-  if (daysResp.error) throw daysResp.error;
-  if (inclResp.error) throw inclResp.error;
-  if (tiersResp.error) throw tiersResp.error;
-  // brandCoverResp intentionally NOT in the throwing fan-out (fail-open above).
-
-  const brandCover = (brandCoverResp.data ?? null) as {
-    cover_media_url: string | null;
-    cover_media_type: string | null;
-  } | null;
-  const brandCoverMediaUrl = brandCover?.cover_media_url ?? null;
-  const brandCoverMediaType = coerceBrandCoverType(
-    brandCover?.cover_media_type ?? null,
-  );
-
-  const ev = (eventResp.data ?? null) as EventDetailRow | null;
-
-  const days: TripDetailDay[] = (daysResp.data ?? []).map((d) => ({
-    id: String((d as { id: string }).id),
-    ordinal: (d as { ordinal: number }).ordinal,
-    title: (d as { title: string }).title,
-    narrative: (d as { narrative: string | null }).narrative ?? null,
-    // ORCH-1119 — coerce the per-day gallery from the anon-readable jsonb column.
-    media: coerceTripDayMedia((d as { media?: unknown }).media),
+  const days: TripDetailDay[] = (p.days ?? []).map((d) => ({
+    id: String(d.id),
+    ordinal: d.ordinal,
+    title: d.title,
+    narrative: d.narrative ?? null,
+    media: coerceTripDayMedia(d.media),
   }));
 
-  const inclusions: TripDetailInclusion[] = (inclResp.data ?? []).map((i) => ({
-    id: String((i as { id: string }).id),
-    kind: (i as { kind: "included" | "excluded" }).kind,
-    item: (i as { item: string }).item,
-    ordinal: (i as { ordinal: number }).ordinal,
+  const inclusions: TripDetailInclusion[] = (p.inclusions ?? []).map((i) => ({
+    id: String(i.id),
+    kind: i.kind,
+    item: i.item,
+    ordinal: i.ordinal,
   }));
 
-  const tiers: TripDetailTier[] = (tiersResp.data ?? [])
-    .map((row) => {
-      const tt = (row as { ticket_types: unknown }).ticket_types as
-        | {
-            id: string;
-            name: string;
-            price_cents: number;
-            currency: string;
-            is_free: boolean;
-            is_unlimited: boolean;
-            quantity_total: number | null;
-            is_hidden: boolean | null;
-            deleted_at: string | null;
-          }
-        | null;
-      if (tt === null || tt.deleted_at !== null || tt.is_hidden === true) return null;
-      return {
-        ticketTypeId: tt.id,
-        tierName: tt.name,
-        priceCents: tt.price_cents,
-        currency: tt.currency,
-        isFree: tt.is_free === true,
-        isUnlimited: tt.is_unlimited === true,
-        quantityTotal: tt.quantity_total,
-        // ORCH-1130 — installment template from tier_metadata (null on no plan).
-        installmentSchedule: extractTripInstallmentSchedule(
-          (row as { tier_metadata?: unknown }).tier_metadata,
-        ),
-      };
-    })
-    .filter((t): t is TripDetailTier => t !== null);
+  const tiers: TripDetailTier[] = (p.tiers ?? []).map((t) => ({
+    ticketTypeId: t.ticketTypeId,
+    tierName: t.tierName,
+    priceCents: t.priceCents ?? 0,
+    currency: t.currency ?? "",
+    isFree: t.isFree === true,
+    isUnlimited: t.isUnlimited === true,
+    quantityTotal: t.quantityTotal ?? null,
+    // META-ORCH-1174 — real per-tier remaining (null when unlimited; no
+    // fabricated sold-out — rule 9). Previously always null on consumer.
+    ticketsRemaining: t.isUnlimited ? null : (t.ticketsRemaining ?? null),
+    installmentSchedule: extractTripInstallmentSchedule(t.installments),
+  }));
+
+  // Aggregate availability derived from the per-tier rows (the prior consumer
+  // read sourced these off the feed seed; now single-source off the RPC tiers).
+  const minPriceCents =
+    tiers.length > 0
+      ? Math.min(...tiers.map((t) => t.priceCents))
+      : null;
+  const hasFreeTier = tiers.some((t) => t.isFree);
+  // total capacity = sum of capped tiers (null when every tier is unlimited).
+  const cappedQtys = tiers
+    .map((t) => (t.isUnlimited ? null : t.quantityTotal))
+    .filter((q): q is number => typeof q === "number");
+  const totalCapacity = cappedQtys.length > 0 ? cappedQtys.reduce((a, b) => a + b, 0) : null;
+  // spotsLeft = sum of per-tier remaining (null when no capped/known remaining).
+  const knownRemaining = tiers
+    .map((t) => (t.isUnlimited ? null : t.ticketsRemaining))
+    .filter((r): r is number => typeof r === "number");
+  const spotsLeft =
+    knownRemaining.length > 0 ? knownRemaining.reduce((a, b) => a + b, 0) : null;
 
   // ORCH-1130 — derived cheap gating flag for the consumer payment module.
   const hasPlan = tiers.some((t) => t.installmentSchedule !== null);
 
   // ORCH-1117 — a trip is PAID when its cheapest tier costs > 0. Resolve the
   // brand's charge-readiness for the floating Reserve bar's unavailable state.
-  const isPaid = (feedRow.minPriceCents ?? 0) > 0;
-  const bookable = await resolveTripBookable(ev?.brand_id ?? null, isPaid);
+  const isPaid = (minPriceCents ?? 0) > 0;
+  const bookable = await resolveTripBookable(p.brandId, isPaid);
 
   return {
-    tripId,
-    tripSlug: feedRow.tripSlug,
-    brandSlug: feedRow.brandSlug,
-    brandName: feedRow.brandName,
-    brandVerified: feedRow.brandVerified,
-    title: ev?.title ?? feedRow.title,
-    description: ev?.description ?? feedRow.description,
-    destinationText: ev?.destination_text ?? feedRow.destinationText,
-    departureText: ev?.departure_text ?? feedRow.departureText,
-    coverMediaUrl: ev?.cover_media_url ?? feedRow.coverMediaUrl,
-    coverMediaType: coerceCoverType(ev?.cover_media_type ?? feedRow.coverMediaType),
-    // ORCH-1138 FIX-3 — anon-safe brand cover for the "Presented by" chip.
-    brandCoverMediaUrl,
-    brandCoverMediaType,
-    startAt: feedRow.startAt,
-    endAt: feedRow.endAt,
-    timezone: ev?.timezone ?? feedRow.timezone,
-    bookingsClosed: ev?.bookings_closed === true || feedRow.bookingsClosed,
-    bookingDeadline: ev?.booking_deadline ?? feedRow.bookingDeadline,
-    totalCapacity: feedRow.totalCapacity,
-    spotsLeft: feedRow.spotsLeft,
-    minPriceCents: feedRow.minPriceCents,
-    currency: feedRow.currency,
-    hasFreeTier: feedRow.hasFreeTier,
+    tripId: p.id,
+    tripSlug: p.tripSlug,
+    brandSlug: p.brand.slug,
+    brandName: p.brand.name,
+    brandVerified: p.brand.verified === true,
+    title: p.title,
+    description: p.description,
+    destinationText: p.destinationText,
+    departureText: p.departureText,
+    // META-ORCH-1174 — destination coords (the consumer §11 map gap this leg closes).
+    destinationLat: numOrNull(p.destinationLat),
+    destinationLng: numOrNull(p.destinationLng),
+    coverMediaUrl: p.coverMediaUrl,
+    coverMediaType: coerceCoverType(p.coverMediaType),
+    // META-ORCH-1174 — the "Presented by" brand cover now rides the same RPC
+    // payload (anon-safe via the definer owner — NEVER `.from('brands')`).
+    brandCoverMediaUrl: p.brand.coverMediaUrl,
+    brandCoverMediaType: coerceBrandCoverType(p.brand.coverMediaType),
+    startAt: p.startAt,
+    endAt: p.endAt,
+    timezone: p.timezone,
+    bookingsClosed: p.bookingsClosed === true,
+    bookingDeadline: p.bookingDeadline,
+    totalCapacity,
+    spotsLeft,
+    minPriceCents,
+    currency: p.currency,
+    hasFreeTier,
     bookable,
-    refundPolicy: coerceRefundPolicy(ev?.refund_policy ?? null),
+    refundPolicy: coerceRefundPolicy(p.refundPolicy),
     days,
     inclusions,
     tiers,
     hasPlan,
   };
 }
+
 
 export interface UseConsumerTripDetailResult {
   detail: ConsumerTripDetail | null;
@@ -463,14 +463,19 @@ export interface UseConsumerTripDetailResult {
 export function useConsumerTripDetail(
   brandSlug: string | null,
   tripSlug: string | null,
+  // META-ORCH-1174 Leg A.2 — `seed` is retained for caller source-compat (the
+  // screen still passes a DiscoverTripRow for the card→detail hop) but is no
+  // longer read: the canonical RPC resolves the full detail directly by slug, so
+  // the seed-based instant-paint/re-fetch path is retired.
   seed: DiscoverTripRow | null,
 ): UseConsumerTripDetailResult {
+  void seed;
   const enabled = brandSlug !== null && tripSlug !== null;
   const query = useQuery<ConsumerTripDetail, Error>({
     queryKey: enabled
       ? consumerTripDetailKeys.detail(brandSlug as string, tripSlug as string)
       : consumerTripDetailKeys.all,
-    queryFn: () => fetchTripDetail(brandSlug as string, tripSlug as string, seed),
+    queryFn: () => fetchTripDetail(brandSlug as string, tripSlug as string),
     enabled,
     staleTime: 30_000,
   });

--- a/app-mobile/src/hooks/useConsumerTripOfferingData.ts
+++ b/app-mobile/src/hooks/useConsumerTripOfferingData.ts
@@ -6,13 +6,12 @@
  * prop contract the shared `TripOfferingBody` reads — the single per-surface
  * adapter so the consumer screen renders the SAME body as web/business.
  *
- * NOTE (data-path parity gap, Leg-A pragmatic path): the consumer read
- * (useConsumerTripDetail) carries NO destination lat/lng today, so the §11
- * "Where you'll be" map stays omitted on consumer (rule-9 — no fabricated tile),
- * exactly as before this leg. The new `pg_public_trip_by_slug` RPC (this leg's
- * migration) RETURNS the lat/lng; a follow-up can repoint the consumer hook onto
- * it to close the map gap on every surface. I-MOR-0827: pure mapper, no app-src
- * import into the package — the package only sees the normalized shape.
+ * META-ORCH-1174 Leg A.2 — the consumer read (useConsumerTripDetail) now sources
+ * the canonical `pg_public_trip_by_slug` RPC, so `ConsumerTripDetail` carries the
+ * destination lat/lng (the §11 "Where you'll be" map now renders on consumer,
+ * closing the prior gap) AND real per-tier `ticketsRemaining`. This mapper passes
+ * both through to the shared `TripOfferingData`. I-MOR-0827: pure mapper, no
+ * app-src import into the package — the package only sees the normalized shape.
  */
 
 import {
@@ -102,14 +101,17 @@ export function buildConsumerTripOfferingData(
       currency: t.currency,
       isFree: t.isFree,
       isUnlimited: t.isUnlimited,
-      // consumer read has only aggregate spotsLeft → no per-tier remaining today.
-      ticketsRemaining: null,
+      // META-ORCH-1174 Leg A.2 — real per-tier remaining from the canonical RPC
+      // (null when unlimited; no fabricated sold-out — rule 9). Previously always
+      // null on consumer; now parity with web/business.
+      ticketsRemaining: t.isUnlimited ? null : t.ticketsRemaining,
       installmentSchedule: t.installmentSchedule,
     })),
     currency: detail.currency ?? "USD",
-    // map gap: consumer read lacks lat/lng (rule 9 — §11 omitted, as before).
-    destinationLat: null,
-    destinationLng: null,
+    // META-ORCH-1174 Leg A.2 — destination coords now arrive via the RPC, so the
+    // §11 "Where you'll be" map renders on consumer (rule 9 — both must be finite).
+    destinationLat: detail.destinationLat,
+    destinationLng: detail.destinationLng,
     bookable: detail.bookable !== false,
     bookingsClosed: detail.bookingsClosed === true,
   };

--- a/app-mobile/src/screens/Trip/__tests__/orch1119_trip_day_media_gallery.test.tsx
+++ b/app-mobile/src/screens/Trip/__tests__/orch1119_trip_day_media_gallery.test.tsx
@@ -71,13 +71,19 @@ function coerceTripDayMedia(raw) {
   ok("T1 coercer drops a typeless item", !clean.some((m) => m.url === "z"));
 }
 
-// ── T2: the hook anon-selects media (no brands/tickets read — COMMS-0009) ──
+// ── T2: the hook surfaces per-day media (no brands/tickets read — COMMS-0009) ──
+// [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 rewired useConsumerTripDetail onto
+// the canonical `pg_public_trip_by_slug` RPC, which returns `days[].media`
+// directly (replacing the prior `.from("trip_days").select("...media")` read).
+// The per-day media invariant is unchanged (the coercer still runs); only its
+// SOURCE moved from a client select to the RPC payload.
 ok(
-  "T2 hook selects media on trip_days",
-  /\.select\("id, ordinal, title, narrative, media"\)/.test(hookSrc),
+  "T2 hook reads the canonical RPC that returns per-day media",
+  /supabase\.rpc\(\s*["']pg_public_trip_by_slug["']/.test(hookSrc) &&
+    /media:\s*unknown/.test(hookSrc),
 );
 ok(
-  "T2 hook coerces media into TripDetailDay",
+  "T2 hook coerces RPC per-day media into TripDetailDay",
   /media:\s*coerceTripDayMedia\(/.test(hookSrc),
 );
 // Strip line comments so the docstring's literal `.from('brands')` warning isn't

--- a/mingla-business/app/t/__tests__/public-trip-page.test.ts
+++ b/mingla-business/app/t/__tests__/public-trip-page.test.ts
@@ -65,11 +65,35 @@ describe("ORCH-0859 — /t/{brandSlug}/{tripSlug} public anon route contract", (
     expect(publicHookSource).not.toMatch(/\buseAuth\s*\(/);
   });
 
-  test("A-PUBLIC-8: usePublicTripBySlug filters status to scheduled+live only (no draft leakage)", () => {
-    // Draft trips must not surface on public route — RLS + query both enforce
+  // [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 wired this hook onto the single
+  // canonical anon RPC `pg_public_trip_by_slug`, retiring the client-side
+  // `.in("status", ["scheduled","live"])` query filter. The no-draft-leakage
+  // invariant now lives SERVER-SIDE in the RPC (`e.status = ANY(ARRAY['scheduled',
+  // 'live'])` + `e.event_type='trip'`), so this test re-points to assert (a) the
+  // hook reads the RPC and (b) the RPC migration enforces the status filter.
+  test("A-PUBLIC-8: usePublicTripBySlug reads the canonical RPC, which filters status to scheduled+live only (no draft leakage)", () => {
+    // (a) the hook is wired onto the single-source RPC.
     expect(publicHookSource).toMatch(
-      /\.in\(\s*"status"\s*,\s*\[\s*"scheduled"\s*,\s*"live"\s*\]/,
+      /supabase\.rpc\(\s*["']pg_public_trip_by_slug["']/,
     );
+    // (b) the RPC migration enforces the no-draft-leakage status filter server-side.
+    const rpcMigration = readFileSync(
+      join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "..",
+        "supabase",
+        "migrations",
+        "20261017000000_meta_orch_1174_pg_public_trip_by_slug.sql",
+      ),
+      "utf-8",
+    );
+    expect(rpcMigration).toMatch(
+      /e\.status\s*=\s*ANY\s*\(\s*ARRAY\['scheduled'::text,\s*'live'::text\]\)/,
+    );
+    expect(rpcMigration).toMatch(/e\.event_type\s*=\s*'trip'/);
   });
 
   // ORCH-1114 — the Share control must route through the web-aware ShareModal,

--- a/mingla-business/src/components/trip/__tests__/InstallmentScheduleDisplay_wiring.test.ts
+++ b/mingla-business/src/components/trip/__tests__/InstallmentScheduleDisplay_wiring.test.ts
@@ -57,16 +57,23 @@ function read(rel: string): string {
 // hook) must extract `installmentSchedule` from `tier_metadata.installments`
 // or the mapper receives undefined and the public trip page crashes. The
 // slug-based hook had this gap pre-hotfix; the id-based hook didn't.
+// [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 wired usePublicTripBySlug onto the
+// canonical RPC, which emits each tier's installment template pre-extracted as
+// `installments` (server-side `tier_metadata -> 'installments'`), so the hook no
+// longer reaches into `tier_metadata?.installments` itself. The ORCH-0882
+// invariant (the hook must SET installmentSchedule on the returned tier so the
+// page never receives undefined and crashes) is unchanged — only the source of
+// the installments signal moved to the RPC payload.
 describe("ORCH-0882 hotfix — usePublicTripBySlug extracts installmentSchedule", () => {
-  test("slug-based public trip hook extracts installmentSchedule from tier_metadata", () => {
+  test("slug-based public trip hook sets installmentSchedule from the RPC tier installments", () => {
     const src = readFileSync(
       join(REPO_ROOT, "src/hooks/usePublicTripBySlug.ts"),
       "utf8",
     );
-    // Must reference the data signal AND set the field on the returned
-    // TripPricingTier shape. Mirror of publicEventsService.ts pattern.
+    // Must SET the field on the returned TripPricingTier shape, mapped from the
+    // RPC's pre-extracted per-tier `installments` (no undefined → no crash).
     expect(src).toContain("installmentSchedule");
-    expect(src).toContain("tier_metadata?.installments");
+    expect(src).toMatch(/installmentSchedule:\s*asInstallmentSchedule\(t\.installments\)/);
   });
 });
 

--- a/mingla-business/src/components/trip/__tests__/tripNativeRenderParity.orch1138.test.ts
+++ b/mingla-business/src/components/trip/__tests__/tripNativeRenderParity.orch1138.test.ts
@@ -139,20 +139,36 @@ describe("RT-6 ORCH-1138 — native-only render parity", () => {
 
   // ---------------- BUG-1: canonical-first meta-chip/route data ----------------
 
-  test("BUG-1: the public hook reads destination from the CANONICAL column first", () => {
-    // canonical events.destination_text wins; theme mirror is fallback only.
-    expect(hookSrc).toContain("typeof event.destination_text === \"string\"");
+  // [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 moved the canonical-first
+  // destination/capacity resolution off the client hook (which used to do the
+  // `events.destination_text ?? theme-mirror` + `ticket_types[0].quantity_total
+  // ?? theme-mirror` coalescing in TS) and INTO the single-source RPC. The BUG-1
+  // invariant (canonical column wins, theme mirror is fallback only) is unchanged
+  // — it now lives server-side in the RPC migration, and the hook simply maps the
+  // RPC payload. These tests re-point to assert BOTH halves.
+  const rpcMigration = read(
+    "../supabase/migrations/20261017000000_meta_orch_1174_pg_public_trip_by_slug.sql",
+  );
+
+  test("BUG-1: destination is canonical-first (events.destination_text), theme mirror fallback — enforced in the RPC", () => {
+    // the RPC COALESCEs the canonical column first, the theme mirror second.
+    expect(rpcMigration).toMatch(
+      /'destinationText',\s*COALESCE\([\s\S]*?tr\.destination_text[\s\S]*?destinationLocationText/,
+    );
+    // the hook maps the RPC destinationText through to businessTrip.
     expect(hookSrc).toMatch(
-      /destinationLocationText:[\s\S]*?event\.destination_text[\s\S]*?:[\s\S]*?bt\.destinationLocationText/,
+      /destinationLocationText:\s*strOrNull\(p\.destinationText\)/,
     );
   });
 
-  test("BUG-1: the public hook reads capacity from the CANONICAL ticket quantity first", () => {
-    // capacity from ticket_types[0].quantity_total (mirrors readBusinessTrip),
-    // theme mirror only as fallback.
-    expect(hookSrc).toContain("typeof tickets[0]?.quantity_total === \"number\"");
+  test("BUG-1: capacity is canonical-first (ticket quantity_total) — enforced in the RPC; hook maps it", () => {
+    // the RPC's per-tier rows carry the canonical ticket_types.quantity_total.
+    expect(rpcMigration).toMatch(/tt\.quantity_total/);
+    expect(rpcMigration).toMatch(/'quantityTotal',\s*tiers\.quantity_total/);
+    // the hook derives capacity from the first tier's RPC quantityTotal.
     expect(hookSrc).toMatch(
-      /capacity:[\s\S]*?tickets\[0\]\.quantity_total[\s\S]*?:[\s\S]*?bt\.capacity/,
+      /firstTierQty\s*=\s*p\.tiers\[0\]\?\.quantityTotal/,
     );
+    expect(hookSrc).toMatch(/capacity:\s*firstTierQty/);
   });
 });

--- a/mingla-business/src/components/trip/__tests__/tripParityFixes.orch1138.test.ts
+++ b/mingla-business/src/components/trip/__tests__/tripParityFixes.orch1138.test.ts
@@ -95,14 +95,18 @@ describe("ORCH-1138 FIX-3 — brand cover is media-aware (business/web)", () => 
     ).toBe(true);
   });
 
-  test("the public-trip hook selects + maps cover_media_type and cover_hue from brands", () => {
-    expect(/cover_media_type/.test(hookSrc)).toBe(true);
-    expect(/cover_hue/.test(hookSrc)).toBe(true);
+  // [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 moved the brand cover read off a
+  // direct `.from("brands").select("...cover_media_type, cover_hue")` onto the
+  // canonical `pg_public_trip_by_slug` RPC payload (`brand.coverMediaType` /
+  // `brand.coverHue`). The FIX-3 invariant (the chip gets a media-aware brand
+  // cover type + hue, coerced) is unchanged — only the source moved to the RPC.
+  test("the public-trip hook maps the RPC brand coverMediaType + coverHue (coerced)", () => {
     expect(
-      /coverMediaType:\s*coerceBrandCoverType\(brand\.cover_media_type\)/.test(
+      /coverMediaType:\s*coerceBrandCoverType\(p\.brand\.coverMediaType\)/.test(
         hookSrc,
       ),
     ).toBe(true);
+    expect(/coverHue:\s*numOrNull\(p\.brand\.coverHue\)/.test(hookSrc)).toBe(true);
   });
 
   test("coerceBrandCoverType maps unknown/null → null (no fabricated type, no broken alt)", () => {

--- a/mingla-business/src/hooks/__tests__/orch_1164_anon_trip_page_loads.test.ts
+++ b/mingla-business/src/hooks/__tests__/orch_1164_anon_trip_page_loads.test.ts
@@ -2,93 +2,54 @@
  * ORCH-1164 (#507 regression recovery) — IMPLEMENTOR happy-path regression test.
  *
  * PROVES the anon web TRIP page (/t/{brandSlug}/{tripSlug}) can load for a
- * logged-out buyer, i.e. the trip hook's direct `brands` select lists ONLY
- * columns the `anon` Postgres role can read.
+ * logged-out buyer without a `42501 permission denied for table brands` (HTTP
+ * 401) abort on the brand-theme columns.
  *
- * #507 (ORCH-1138 Leg 3) added theme_color/theme_font/theme_animation to the
- * DIRECT `supabase.from("brands").select(...)` in usePublicTripBySlug.ts. The
- * `anon` role has only COLUMN-level SELECT on `public.brands` (table-level
- * SELECT is false), and those three theme columns were never granted to anon →
- * Postgres aborts the whole statement with `42501 permission denied for table
- * brands` (HTTP 401) → the entire anon trip page fails to render → all anon web
- * trip sales blocked. (Proven live: has_column_privilege('anon','brands',
- * 'theme_color') = false.)
+ * [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 (Seth single-source decision)
+ * REWIRED usePublicTripBySlug onto the ONE canonical anon RPC
+ * `pg_public_trip_by_slug` (SECURITY DEFINER, GRANT anon). The hook no longer
+ * issues ANY direct `supabase.from("brands")` read, and no longer needs the
+ * `business_public_events_view` theme detour — the definer RPC owner reads
+ * brands.theme_color/font/animation directly and emits them in its payload,
+ * structurally sidestepping the anon column-grant gap that caused #507.
  *
- * The fix sources brand theme from the anon-safe `business_public_events_view`
- * (COMMS-0009) and selects ONLY anon-granted columns directly off `brands`.
+ * The original guard asserted the hook's direct brands select listed only
+ * anon-granted columns + sourced theme from the view. That detour is now GONE,
+ * so the guard is re-pointed to the STRONGER post-Leg-A.2 invariant:
+ *   • the hook reads the canonical RPC (single source), and
+ *   • the hook makes ZERO direct `.from("brands")` read (so there is no brand
+ *     column-grant surface for anon to 401 on at all).
  *
- * FAILS-ON-REVERT: re-adding any of theme_color/theme_font/theme_animation to
- * the trip hook's brands select makes ANON_READABLE_BRAND_COLUMNS no longer a
- * superset of the requested columns → this test FAILS (exactly the #507 break).
+ * FAILS-ON-REVERT: re-introducing a direct `.from("brands").select(...)` (which
+ * is exactly what re-opened the #507 theme-column 401 surface) makes the
+ * no-direct-brands assertion FAIL; dropping the RPC call fails the single-source
+ * assertion.
  */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const TRIP_HOOK = resolve(__dirname, "..", "usePublicTripBySlug.ts");
 const src = readFileSync(TRIP_HOOK, "utf8");
+// Strip JSDoc + line comments so the header's prose (which legitimately NAMES the
+// now-retired `business_public_events_view` detour to explain why it's gone)
+// never false-positives an ACTIVE-code assertion below.
+const activeCode = src
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^\s*\/\/.*$/gm, "");
 
-// The columns the `anon` Postgres role can SELECT off `public.brands`.
-// SOURCE OF TRUTH = the live grant set (baseline column grants + ORCH-0879
-// cover grant). theme_color/theme_font/theme_animation are DELIBERATELY ABSENT:
-// anon has no column-SELECT on them; reading them directly off brands 401s the
-// whole anon query (the #507 regression). After ORCH-1164's migration anon will
-// ALSO have the three theme columns, but the trip hook must NOT depend on that —
-// it sources theme from business_public_events_view (COMMS-0009). So this guard
-// holds the trip hook to the columns that are safe on EVERY deploy, grant or no.
-const ANON_READABLE_BRAND_COLUMNS = new Set([
-  "id",
-  "account_id",
-  "name",
-  "slug",
-  "description",
-  "profile_photo_url",
-  "contact_email",
-  "contact_phone",
-  "social_links",
-  "custom_links",
-  "display_attendee_count",
-  "default_currency",
-  "cover_media_url",
-  "cover_media_type",
-  "cover_hue",
-  "created_at",
-  "updated_at",
-  "deleted_at",
-]);
-
-// Extract every `.from("brands") ... .select(<literal>)` column list in the hook
-// (the chain may span lines; the select string itself may be multi-line).
-// Note: the select-string capture allows an OPTIONAL trailing comma + whitespace
-// before the closing paren (the trip hook formats the column list with a
-// trailing comma), so the lazy match terminates at the real string boundary.
-const brandSelectColumnLists = Array.from(
-  src.matchAll(
-    /\.from\(\s*["']brands["']\s*\)[\s\S]*?\.select\(\s*([`"'])([\s\S]*?)\1\s*,?\s*\)/g,
-  ),
-).map((m) =>
-  m[2]
-    .split(",")
-    .map((c) => c.trim())
-    .filter((c) => c.length > 0),
-);
-
-describe("ORCH-1164 — anon can load the public trip page", () => {
-  test("the trip hook DOES read brands directly (sanity — guard targets the right call)", () => {
-    expect(brandSelectColumnLists.length).toBeGreaterThan(0);
+describe("ORCH-1164 / META-ORCH-1174 — anon can load the public trip page", () => {
+  test("the trip hook reads the canonical pg_public_trip_by_slug RPC (single source)", () => {
+    expect(activeCode).toMatch(/supabase\.rpc\(\s*["']pg_public_trip_by_slug["']/);
   });
 
-  test("every column the trip hook selects off brands is anon-readable (no 42501 for logged-out buyers)", () => {
-    const notAnonReadable = brandSelectColumnLists
-      .flat()
-      .filter((col) => !ANON_READABLE_BRAND_COLUMNS.has(col));
-    expect(notAnonReadable).toEqual([]);
+  test("the trip hook makes ZERO direct brands-table read (no anon column-grant 401 surface — #507 closed)", () => {
+    // Any `.from("brands")` reopens the exact column-grant surface #507 broke.
+    expect(activeCode).not.toMatch(/\.from\(\s*["']brands["']\s*\)/);
   });
 
-  test("brand theme is sourced from the anon-safe business_public_events_view, not brands (COMMS-0009)", () => {
-    // The hook must resolve brand theme via the view helper, filtered to the
-    // trip row by event_type='trip'.
-    expect(src).toContain("business_public_events_view");
-    expect(src).toContain('"event_type", "trip"');
-    expect(src).toMatch(/fetchBrandThemeFromView\s*\(/);
+  test("the trip hook no longer needs the business_public_events_view theme detour (definer RPC reads theme directly)", () => {
+    // The COMMS-0009 view detour is retired for this hook; theme rides the RPC.
+    expect(activeCode).not.toContain("business_public_events_view");
+    expect(activeCode).not.toMatch(/fetchBrandThemeFromView\s*\(/);
   });
 });

--- a/mingla-business/src/hooks/usePublicTripBySlug.ts
+++ b/mingla-business/src/hooks/usePublicTripBySlug.ts
@@ -2,12 +2,23 @@
  * usePublicTripBySlug — anon-tolerant fetch of a published trip by brand+trip
  * slug. Tr2 (ORCH-0859).
  *
- * Used by /t/[brandSlug]/[tripSlug].tsx public buyer route. Mirrors
- * usePublicEventBySlug pattern (mingla-business/src/hooks/usePublicEvents.ts).
+ * Used by /t/[brandSlug]/[tripSlug].tsx public buyer route.
+ *
+ * META-ORCH-1174 Leg A.2 (Seth single-source decision) — this hook now reads
+ * the ONE canonical anon RPC `pg_public_trip_by_slug(p_brand_slug, p_event_slug)`
+ * (SECURITY DEFINER, GRANT anon) instead of the prior per-surface fan-out of
+ * direct table reads (brands + events + 5 sidecar queries + 2 helper RPCs). The
+ * RPC returns the FULL trip payload (master dates, route legs + lat/lng, per-tier
+ * rows WITH remaining + installments, trip_days itinerary, trip_inclusions,
+ * refund_policy, booking_deadline, brand card incl. theme + verified) — the
+ * definer owner reads brands.theme_* directly, so the COMMS-0009 anon
+ * column-level grant gap that previously forced a `business_public_events_view`
+ * theme detour (ORCH-1164/#507) no longer applies here. This hook maps the RPC
+ * JSON into the SAME `PublicTripPayload` output type as before (zero downstream
+ * churn — TripPreview + tripOfferingAdapter are unchanged).
  *
  * Anon-tolerant per feedback_anon_buyer_routes.md: no useAuth call, no
- * sign-in redirect. Anon Supabase client RLS-restricted via the
- * trip-sidecar-table policies (only published trips visible to anon).
+ * sign-in redirect.
  *
  * Spec: Mingla_Artifacts/specs/SPEC_ORCH-0859_TR2_MINIMUM_VIABLE_TRIP.md §4.7
  */
@@ -27,6 +38,7 @@ import type {
   Trip,
   TripDay,
   TripInclusion,
+  TripInstallmentScheduleData,
   TripPricingTier,
 } from "../services/tripsService";
 import { coerceTripDayMedia } from "../services/tripsService";
@@ -47,67 +59,9 @@ const asThemeInput = (
   return Object.keys(out).length > 0 ? out : null;
 };
 
-// ORCH-1164 (#507 regression recovery) — COMMS-0009 anon-safe-theme contract.
-// The brand THEME (theme_color/theme_font/theme_animation) is NOT read off the
-// `brands` table: the `anon` Postgres role has NO column-level SELECT on those
-// three columns (live: HTTP 401 `42501 permission denied for table brands`),
-// which #507 introduced on the trip read path and which blanked the entire anon
-// /t/{brandSlug}/{tripSlug} page. The theme is sourced from the anon-safe
-// security-definer `business_public_events_view` (brand_theme_color/
-// brand_theme_font/brand_theme_animation — anon-readable), filtered to THIS
-// trip's row by (brand_slug, slug, event_type='trip'), exactly as the
-// experience leg does (publicExperienceService.fetchBrandThemeFromView). The
-// view has trip rows (verified live: event_type='trip' rows present). Non-fatal:
-// any view error / miss → null (the page resolves the default palette, never
-// 401s). The trip hook's direct brands select keeps only anon-granted columns.
-const fetchBrandThemeFromView = async (
-  brandSlug: string,
-  tripSlug: string,
-): Promise<ThemeInput | null> => {
-  const { data, error } = await supabase
-    .from("business_public_events_view")
-    .select("brand_theme_color, brand_theme_font, brand_theme_animation")
-    .eq("brand_slug", brandSlug)
-    .eq("slug", tripSlug)
-    .eq("event_type", "trip")
-    .maybeSingle();
-  if (error !== null || data === null) return null;
-  return asThemeInput(
-    data.brand_theme_color,
-    data.brand_theme_font,
-    data.brand_theme_animation,
-  );
-};
-
-// ORCH-1138 B2 — anon-callable remaining-capacity RPC, mirroring
-// publicEventsService.fetchTicketTypesRemaining / getPublicTripById. Fail OPEN
-// on RPC error (empty map ⇒ ticketsRemaining stays null ⇒ no fabricated
-// sold-out; the checkout RPC remains the terminal oversell backstop).
-const fetchTripTicketsRemaining = async (
-  eventId: string,
-): Promise<Map<string, number | null>> => {
-  const { data, error } = await supabase.rpc(
-    "pg_public_ticket_types_remaining",
-    { p_event_id: eventId },
-  );
-  if (error !== null) {
-    console.warn(
-      "[ORCH-1138] pg_public_ticket_types_remaining failed on /t/ slug preview; sold-out gate degrades to fail-open (checkout-RPC catch is the backstop)",
-      error,
-    );
-    return new Map();
-  }
-  const rows = (data ?? []) as Array<{
-    ticket_type_id: string;
-    sold: number;
-    remaining: number | null;
-  }>;
-  return new Map(rows.map((r) => [r.ticket_type_id, r.remaining]));
-};
-
-// ORCH-1138 FIX-3 — coerce the raw brands.cover_media_type text to the
-// EventCoverMedia union. Unknown / null ⇒ null (the chip falls back to the hue
-// avatar; rule 9 — no fabricated type, no broken alt placeholder).
+// META-ORCH-1174 Leg A.2 — coerce the raw cover_media_type text (brand OR trip)
+// to the EventCoverMedia union. Unknown / null ⇒ null (the chip falls back to the
+// hue avatar; rule 9 — no fabricated type, no broken alt placeholder).
 const coerceBrandCoverType = (
   raw: unknown,
 ): "image" | "video" | "gif" | null => {
@@ -115,7 +69,104 @@ const coerceBrandCoverType = (
   return null;
 };
 
+const numOrNull = (raw: unknown): number | null =>
+  typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+
+const strOrNull = (raw: unknown): string | null =>
+  typeof raw === "string" && raw.length > 0 ? raw : null;
+
 const PUBLIC_TRIP_STALE_MS = 60 * 1000; // 1 minute
+
+// META-ORCH-1174 Leg A.2 — the raw JSON shape returned by
+// `pg_public_trip_by_slug` (mirrors the migration's json_build_object keys).
+// All fields are read defensively; the mapper below narrows them into the
+// existing typed `PublicTripPayload`.
+interface RpcTripBrand {
+  id: string;
+  slug: string;
+  name: string;
+  bio: string | null;
+  coverMediaUrl: string | null;
+  coverMediaType: string | null;
+  coverHue: number | null;
+  verified: boolean;
+  themeColor: unknown;
+  themeFont: unknown;
+  themeAnimation: unknown;
+}
+interface RpcTripDay {
+  id: string;
+  ordinal: number;
+  title: string;
+  narrative: string | null;
+  date: string | null;
+  stops: unknown;
+  media: unknown;
+}
+interface RpcTripInclusion {
+  id: string;
+  kind: "included" | "excluded";
+  item: string;
+  ordinal: number;
+}
+interface RpcTripTier {
+  id: string;
+  ticketTypeId: string;
+  tierName: string;
+  tierMetadata: Record<string, unknown> | null;
+  priceCents: number;
+  currency: string;
+  quantityTotal: number | null;
+  ticketsRemaining: number | null;
+  isUnlimited: boolean;
+  isFree: boolean;
+  installments: unknown;
+}
+interface RpcTripPayload {
+  id: string;
+  brandId: string;
+  brandSlug: string;
+  tripSlug: string;
+  title: string;
+  description: string | null;
+  status: string;
+  timezone: string | null;
+  startAt: string | null;
+  endAt: string | null;
+  departureText: string | null;
+  destinationText: string | null;
+  destinationLat: number | null;
+  destinationLng: number | null;
+  departureLat: number | null;
+  departureLng: number | null;
+  currency: string;
+  coverMediaUrl: string | null;
+  coverMediaType: string | null;
+  refundPolicy: unknown;
+  bookingDeadline: string | null;
+  bookingsClosed: boolean;
+  themeColorOverride: unknown;
+  themeFontOverride: unknown;
+  themeAnimationOverride: unknown;
+  brand: RpcTripBrand;
+  days: RpcTripDay[];
+  inclusions: RpcTripInclusion[];
+  tiers: RpcTripTier[];
+}
+
+// META-ORCH-1174 Leg A.2 — narrow tier_metadata.installments into the typed
+// TripInstallmentScheduleData (or null). Same shape as the prior inline cast in
+// the tiers mapper; null when absent/malformed (no plan).
+const asInstallmentSchedule = (
+  raw: unknown,
+): TripInstallmentScheduleData | null => {
+  if (raw === null || typeof raw !== "object") return null;
+  const obj = raw as { deposit_pct?: unknown; installments?: unknown };
+  if (typeof obj.deposit_pct !== "number" || !Array.isArray(obj.installments)) {
+    return null;
+  }
+  return raw as TripInstallmentScheduleData;
+};
 
 interface PublicTripPayload {
   trip: Trip;
@@ -197,299 +248,152 @@ export const usePublicTripBySlug = (
         typeof tripSlug !== "string" ||
         tripSlug.length === 0
       ) {
-        // mirrors `enabled` — narrows brandSlug/tripSlug to non-empty string for
-        // the view-theme lookup (ORCH-1164) without an unsafe non-null assert.
+        // mirrors `enabled` — narrows to non-empty strings for the RPC params.
         return null;
       }
 
-      // 1. Resolve brand by slug — anon-readable via brands public policy
-      // (a brand is anon-readable when it has any published event;
-      // a published trip qualifies because event_type='trip' rows count
-      // as "events with public visibility" under the existing brands_public
-      // policy).
-      const brandResp = await supabase
-        .from("brands")
-        // ORCH-1164 (#507 regression recovery) — theme_color/theme_font/
-        // theme_animation are NOT selected here. The `anon` role has no
-        // column-level SELECT on those three columns, so including them aborted
-        // the whole anon query with `42501 permission denied for table brands`
-        // and blanked the public trip page (the #507 regression). The brand
-        // theme is sourced from the anon-safe `business_public_events_view`
-        // (COMMS-0009) via fetchBrandThemeFromView below.
-        // ORCH-1138 FIX-3 — cover_media_type + cover_hue stay here: both ARE
-        // anon-granted (verified live) and the view exposes no brand_cover_hue.
-        // They let the "Presented by" brand chip render an animated (gif/video)
-        // brand cover via the media-aware EventCoverMedia.
-        .select(
-          "id, slug, name, description, cover_media_url, cover_media_type, cover_hue",
-        )
-        .eq("slug", brandSlug)
-        .is("deleted_at", null)
-        .maybeSingle();
-      if (brandResp.error) throw brandResp.error;
-      if (brandResp.data === null) return null;
+      // META-ORCH-1174 Leg A.2 — the ONE canonical anon read path. The SECURITY
+      // DEFINER RPC returns the full trip payload (identity, master dates, route
+      // legs + destination/departure lat/lng, per-tier rows WITH remaining +
+      // installments, trip_days, trip_inclusions, refund_policy, booking_deadline,
+      // and the brand card incl. theme + verified). Restricted server-side to
+      // event_type='trip' + published. Returns null when no such trip exists.
+      const { data, error } = await supabase.rpc("pg_public_trip_by_slug", {
+        p_brand_slug: brandSlug,
+        p_event_slug: tripSlug,
+      });
+      if (error !== null) throw error;
+      if (data === null || data === undefined) return null;
+      const p = data as RpcTripPayload;
 
-      const brand = brandResp.data;
-
-      // 2. Resolve trip by (brand_id, slug, event_type='trip', published)
-      const eventResp = await supabase
-        .from("events")
-        .select("*")
-        .eq("brand_id", brand.id)
-        .eq("slug", tripSlug)
-        .eq("event_type", "trip")
-        .in("status", ["scheduled", "live"])
-        .is("deleted_at", null)
-        .maybeSingle();
-      if (eventResp.error) throw eventResp.error;
-      if (eventResp.data === null) return null;
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const event = eventResp.data as any;
-      const eventId = event.id as string;
-
-      // 3. Sidecar tables — anon-readable via published-only RLS policies.
-      // ORCH-1138 B2 — the remaining-capacity RPC is folded into this same
-      // batch so the sold-out wiring costs ZERO extra round trips. It fails
-      // open internally (catch → empty map), so it is NOT part of the throwing
-      // error fan-out below.
-      const [
-        daysResp,
-        tiersResp,
-        inclusionsResp,
-        ticketsResp,
-        masterDateResp,
-        remainingById,
-      ] = await Promise.all([
-          supabase
-            .from("trip_days")
-            .select("*")
-            .eq("event_id", eventId)
-            .order("ordinal"),
-          supabase.from("trip_pricing_tiers").select("*").eq("event_id", eventId),
-          supabase
-            .from("trip_inclusions")
-            .select("*")
-            .eq("event_id", eventId)
-            .order("kind")
-            .order("ordinal"),
-          supabase
-            .from("ticket_types")
-            .select("*")
-            .eq("event_id", eventId)
-            .is("deleted_at", null),
-          // ORCH-1130 Fix #1 — canonical trip dates live on the event_dates
-          // master row (ORCH-0950 moved them off theme.business_trip). Mirror
-          // the event public page, which sources dates from event_dates.
-          supabase
-            .from("event_dates")
-            .select("event_id,start_at,end_at,is_master")
-            .eq("event_id", eventId)
-            .eq("is_master", true)
-            .maybeSingle(),
-          // ORCH-1138 B2 — real per-ticket remaining for the sold-out gate.
-          fetchTripTicketsRemaining(eventId),
-        ]);
-      if (daysResp.error) throw daysResp.error;
-      if (tiersResp.error) throw tiersResp.error;
-      if (inclusionsResp.error) throw inclusionsResp.error;
-      if (ticketsResp.error) throw ticketsResp.error;
-      if (masterDateResp.error) throw masterDateResp.error;
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const days = (daysResp.data ?? []) as any[];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tiers = (tiersResp.data ?? []) as any[];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const inclusions = (inclusionsResp.data ?? []) as any[];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const tickets = (ticketsResp.data ?? []) as any[];
-
-      const ticketsById = new Map(tickets.map((tt) => [tt.id, tt]));
-      const bt = (event.theme?.business_trip as Record<string, unknown> | undefined) ?? {};
-      // ORCH-1130 Fix #1 — canonical start/end from the event_dates master row;
-      // theme mirror is fallback only (older trips never written canonically).
-      const masterDate =
-        (masterDateResp.data as {
-          start_at: string | null;
-          end_at: string | null;
-        } | null) ?? null;
-      const tripStartAt =
-        masterDate?.start_at ?? (typeof bt.startAt === "string" ? bt.startAt : null);
-      const tripEndAt =
-        masterDate?.end_at ?? (typeof bt.endAt === "string" ? bt.endAt : null);
+      const tripStartAt = p.startAt;
+      const tripEndAt = p.endAt;
+      // Capacity = the first tier's total (mirrors the prior canonical
+      // ticket-type quantity source; theme mirror is folded into the RPC).
+      const firstTierQty = p.tiers[0]?.quantityTotal ?? null;
 
       const trip: Trip = {
-        id: event.id,
-        brandId: event.brand_id,
-        brandSlug: brand.slug,
-        title: event.title,
-        description: event.description,
-        slug: event.slug,
-        status: event.status,
-        visibility: event.visibility,
-        publishedAt: event.published_at,
-        timezone: event.timezone,
-        coverMediaUrl: event.cover_media_url,
-        coverMediaType: event.cover_media_type,
+        id: p.id,
+        brandId: p.brandId,
+        brandSlug: p.brand.slug,
+        title: p.title,
+        description: p.description,
+        slug: p.tripSlug,
+        // The RPC restricts to scheduled|live; the Trip union accepts both.
+        status: p.status as Trip["status"],
+        // The public buyer page never reads `visibility`/`publishedAt`; the RPC
+        // only surfaces published trips. Keep the prior public-path semantics
+        // (mirror the published status; published_at not needed by the body).
+        visibility: "public",
+        publishedAt: null,
+        timezone: p.timezone ?? "",
+        coverMediaUrl: p.coverMediaUrl,
+        coverMediaType: p.coverMediaType,
         businessTrip: {
           startAt: tripStartAt,
           endAt: tripEndAt,
-          destinationPlaceId:
-            typeof bt.destinationPlaceId === "string" ? bt.destinationPlaceId : null,
-          // ORCH-1138 Leg-1 (native-parity fix #1) — destination from the
-          // CANONICAL `events.destination_text` column first, theme mirror only
-          // as fallback. Mirrors the authenticated `readBusinessTrip`
-          // (tripsService.ts) — the public hook previously read ONLY the
-          // theme.business_trip JSON mirror, which is NULL for trips authored via
-          // the canonical column (e.g. "The DC Adventure"). That silently hid the
-          // destination meta-chip AND the destination half of the route block on
-          // BOTH web + native (rule-9 null-guard), while departure (already
-          // canonical-first below) rendered — the exact reported divergence.
-          destinationLocationText:
-            typeof event.destination_text === "string" &&
-            (event.destination_text as string).trim().length > 0
-              ? (event.destination_text as string)
-              : typeof bt.destinationLocationText === "string"
-                ? bt.destinationLocationText
-                : null,
-          destinationLat:
-            typeof bt.destinationLat === "number" ? bt.destinationLat : null,
-          destinationLng:
-            typeof bt.destinationLng === "number" ? bt.destinationLng : null,
-          // ORCH-1016 — departure (origin). Prefer the canonical
-          // events.departure_text column; fall back to theme.business_trip.
-          departurePlaceId:
-            typeof bt.departurePlaceId === "string" ? bt.departurePlaceId : null,
-          departureLocationText:
-            typeof event.departure_text === "string" &&
-            (event.departure_text as string).trim().length > 0
-              ? (event.departure_text as string)
-              : typeof bt.departureLocationText === "string"
-                ? bt.departureLocationText
-                : null,
-          departureLat:
-            typeof bt.departureLat === "number" ? bt.departureLat : null,
-          departureLng:
-            typeof bt.departureLng === "number" ? bt.departureLng : null,
-          // ORCH-1138 Leg-1 (native-parity fix #1) — capacity from the CANONICAL
-          // ticket-type quantity (mirrors `readBusinessTrip`: tripsService.ts uses
-          // `ticketTypes[0]?.quantity_total`), theme mirror only as fallback. The
-          // public hook previously read ONLY `bt.capacity`, which is NULL for
-          // canonical-authored trips → the "N seats left · M max" chip silently
-          // hid (rule-9) even though the ticket carried a real cap (e.g. 102).
-          capacity:
-            typeof tickets[0]?.quantity_total === "number"
-              ? (tickets[0].quantity_total as number)
-              : typeof bt.capacity === "number"
-                ? bt.capacity
-                : null,
+          // placeIds are not surfaced by the public RPC (not consumed by the
+          // body); null preserves the prior public-path behavior.
+          destinationPlaceId: null,
+          destinationLocationText: strOrNull(p.destinationText),
+          // META-ORCH-1174 — destination lat/lng now arrive via the RPC (float8)
+          // so the §11 map renders (the consumer gap this leg closes; web/business
+          // already had them via the theme mirror — same value, now single-source).
+          destinationLat: numOrNull(p.destinationLat),
+          destinationLng: numOrNull(p.destinationLng),
+          departurePlaceId: null,
+          departureLocationText: strOrNull(p.departureText),
+          departureLat: numOrNull(p.departureLat),
+          departureLng: numOrNull(p.departureLng),
+          capacity: firstTierQty,
         },
-        days: days.map(
+        days: (p.days ?? []).map(
           (d): TripDay => ({
             id: d.id,
-            eventId: d.event_id,
+            eventId: p.id,
             ordinal: d.ordinal,
             title: d.title,
             narrative: d.narrative,
             date: d.date,
             stops: Array.isArray(d.stops) ? d.stops : [],
-            // ORCH-1119 — per-day gallery (anon-readable via the existing
-            // trip_days published-only RLS; .select("*") already returns media).
             media: coerceTripDayMedia(d.media),
           }),
         ),
-        pricingTiers: tiers.map(
-          (t): TripPricingTier => {
-            const tt = ticketsById.get(t.ticket_type_id);
-            // ORCH-0882 [Render Payment Plan Disclosure on Trip Buyer +
-            // Planner Surfaces] hotfix — extract installmentSchedule from
-            // tier_metadata.installments. Mirrors `publicEventsService.ts:724`.
-            // Prior to this hotfix, the field was implicitly `undefined`
-            // (not `null`), bypassing the mapper's null-guard and crashing
-            // the public trip page on plan-active trips.
-            const installmentSchedule =
-              (t.tier_metadata?.installments as
-                | TripPricingTier["installmentSchedule"]
-                | undefined) ?? null;
-            const isUnlimited = tt?.is_unlimited ?? false;
-            return {
-              id: t.id,
-              eventId: t.event_id,
-              ticketTypeId: t.ticket_type_id,
-              tierName: t.tier_name,
-              tierMetadata: t.tier_metadata ?? {},
-              priceCents: tt?.price_cents ?? 0,
-              currency: tt?.currency ?? "",
-              quantityTotal: tt?.quantity_total ?? null,
-              // ORCH-1138 B2 — real remaining for the public-page sold-out gate,
-              // mirroring getPublicTripById (publicEventsService). null when
-              // unlimited (never "0 left") or when the RPC failed open
-              // (no fabricated sold-out — Constitution #9).
-              ticketsRemaining: isUnlimited
-                ? null
-                : (remainingById.get(t.ticket_type_id) ?? null),
-              isUnlimited,
-              installmentSchedule,
-            };
-          },
+        pricingTiers: (p.tiers ?? []).map(
+          (t): TripPricingTier => ({
+            id: t.id,
+            eventId: p.id,
+            ticketTypeId: t.ticketTypeId,
+            tierName: t.tierName,
+            tierMetadata: t.tierMetadata ?? {},
+            priceCents: t.priceCents ?? 0,
+            currency: t.currency ?? "",
+            quantityTotal: t.quantityTotal ?? null,
+            // ORCH-1138 B2 / META-ORCH-1174 — real remaining for the sold-out
+            // gate. null when unlimited (never "0 left") — the RPC already emits
+            // null for unlimited/uncapped tiers (no fabricated sold-out, rule 9).
+            ticketsRemaining: t.isUnlimited ? null : (t.ticketsRemaining ?? null),
+            isUnlimited: t.isUnlimited === true,
+            installmentSchedule: asInstallmentSchedule(t.installments),
+          }),
         ),
-        inclusions: inclusions.map(
+        inclusions: (p.inclusions ?? []).map(
           (i): TripInclusion => ({
             id: i.id,
-            eventId: i.event_id,
+            eventId: p.id,
             kind: i.kind,
             item: i.item,
             ordinal: i.ordinal,
           }),
         ),
-        createdAt: event.created_at,
-        updatedAt: event.updated_at,
-        // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — pass-through
-        // public-facing fields. refund_policy + booking_deadline must be
-        // visible to anon buyers so the public trip page can render the
-        // RefundPolicyDisplay ladder + countdown/closed banner.
-        refundPolicy: event.refund_policy ?? null,
-        bookingDeadline: event.booking_deadline ?? null,
-        bookingsClosed: event.bookings_closed === true,
-        bookingsClosedAt: event.bookings_closed_at ?? null,
+        // createdAt/updatedAt are not surfaced by the public RPC and are not read
+        // by the public body; empty strings preserve the prior public-path shape.
+        createdAt: "",
+        updatedAt: "",
+        // ORCH-0875 — pass-through public-facing fields for the RefundPolicyDisplay
+        // ladder + countdown/closed banner.
+        refundPolicy:
+          (p.refundPolicy as Trip["refundPolicy"]) ?? null,
+        bookingDeadline: p.bookingDeadline ?? null,
+        bookingsClosed: p.bookingsClosed === true,
+        bookingsClosedAt: null,
         ticketsSoldCount: 0,
       };
 
-      // ORCH-1117 — a trip is PAID when its first pricing tier costs > 0
-      // (mirrors the trip price source above). Resolve the brand's
-      // charge-readiness so the floating bar can render its unavailable state.
+      // ORCH-1117 — a trip is PAID when its first pricing tier costs > 0. Resolve
+      // the brand's charge-readiness so the floating bar can render its
+      // unavailable state (the trip RPC does not encode charge-readiness).
       const isPaid = (trip.pricingTiers[0]?.priceCents ?? 0) > 0;
-      const bookable = await resolveTripBookable(brand.id, isPaid);
+      const bookable = await resolveTripBookable(p.brandId, isPaid);
 
-      // ORCH-1138 B1 — guard the brand theme + the per-trip overrides into
-      // ThemeInputs (the page resolves + builds the palette). Trips are events
-      // rows, so `event` (select("*")) already carries theme_*_override.
-      // ORCH-1164 (#507 regression recovery) — the BRAND theme is now sourced
-      // from the anon-safe `business_public_events_view` (COMMS-0009), NOT from
-      // brands.theme_* (which anon cannot read). The per-trip overrides still
-      // come off the `events` row (anon-readable; not on the brands table).
-      const brandTheme = await fetchBrandThemeFromView(brandSlug, tripSlug);
+      // META-ORCH-1174 Leg A.2 — the BRAND theme now comes off the RPC payload
+      // (the definer owner reads brands.theme_* directly, so the COMMS-0009 anon
+      // column-grant gap that forced the prior view detour no longer applies).
+      // Per-trip overrides ride the same RPC payload (events.theme_*_override).
+      const brandTheme = asThemeInput(
+        p.brand.themeColor,
+        p.brand.themeFont,
+        p.brand.themeAnimation,
+      );
       const themeOverrides = asThemeInput(
-        event.theme_color_override,
-        event.theme_font_override,
-        event.theme_animation_override,
+        p.themeColorOverride,
+        p.themeFontOverride,
+        p.themeAnimationOverride,
       );
 
       return {
         trip,
         brand: {
-          id: brand.id,
-          slug: brand.slug,
-          name: brand.name,
-          bio: brand.description ?? null,
-          coverMediaUrl: brand.cover_media_url ?? null,
+          id: p.brand.id,
+          slug: p.brand.slug,
+          name: p.brand.name,
+          bio: p.brand.bio ?? null,
+          coverMediaUrl: p.brand.coverMediaUrl ?? null,
           // ORCH-1138 FIX-3 — coerce the raw brand cover media type to the
           // EventCoverMedia union; unknown/null → null → image render / hue
           // fallback (rule 9, never a fabricated type).
-          coverMediaType: coerceBrandCoverType(brand.cover_media_type),
-          coverHue:
-            typeof brand.cover_hue === "number" ? brand.cover_hue : null,
+          coverMediaType: coerceBrandCoverType(p.brand.coverMediaType),
+          coverHue: numOrNull(p.brand.coverHue),
           theme: brandTheme,
         },
         themeOverrides,

--- a/mingla-business/src/services/__tests__/orch_1138_tester_anon_brand_theme_columns.test.ts
+++ b/mingla-business/src/services/__tests__/orch_1138_tester_anon_brand_theme_columns.test.ts
@@ -77,28 +77,38 @@ const TRIP_HOOK = resolve(
   "usePublicTripBySlug.ts",
 );
 
-describe("ORCH-1164 — anon cannot read brands.theme_* on the TRIP read path (P0)", () => {
+// [TEST-MOD-APPROVED META-ORCH-1174] — Leg A.2 rewired usePublicTripBySlug onto
+// the canonical SECURITY DEFINER RPC `pg_public_trip_by_slug`, which removes the
+// trip hook's DIRECT `.from("brands").select(...)` entirely. The brands-select
+// scan therefore matches nothing, so the original "DOES read brands" sanity
+// assertion no longer holds. The invariant it protected (anon never reads
+// brands.theme_* on the trip path) is now satisfied in its STRONGEST form: the
+// hook makes ZERO direct brands read at all (theme rides the definer RPC). The
+// guard is re-pointed accordingly.
+describe("ORCH-1164 / META-ORCH-1174 — anon cannot read brands.theme_* on the TRIP read path (P0)", () => {
   const src = readFileSync(TRIP_HOOK, "utf8");
 
-  // The select-string capture allows an OPTIONAL trailing comma before the
-  // closing paren (the trip hook formats its column list with a trailing comma),
-  // so the lazy match terminates at the real string boundary rather than
-  // over-running to a later `")` further down the chain.
-  const brandSelects = Array.from(
-    src.matchAll(
-      /\.from\(\s*["']brands["']\s*\)[\s\S]*?\.select\(\s*([`"'])([\s\S]*?)\1\s*,?\s*\)/g,
-    ),
-  ).map((m) => m[2]);
+  test("usePublicTripBySlug reads the canonical pg_public_trip_by_slug RPC (single source)", () => {
+    expect(src).toMatch(/supabase\.rpc\(\s*["']pg_public_trip_by_slug["']/);
+  });
 
-  test("usePublicTripBySlug DOES read brands (sanity — guard targets the right call)", () => {
-    expect(brandSelects.length).toBeGreaterThan(0);
+  test("usePublicTripBySlug makes ZERO direct brands read (no theme_* column-grant surface for anon at all)", () => {
+    expect(src).not.toMatch(/\.from\(\s*["']brands["']\s*\)/);
   });
 
   const FORBIDDEN = ["theme_color", "theme_font", "theme_animation"];
 
   test.each(FORBIDDEN)(
-    "no trip-hook brands.select(...) requests the non-anon-readable column %s",
+    "the trip hook never names the non-anon-readable brand column %s in any direct table read",
     (col) => {
+      // No direct brands read exists, so no read can request the column. This
+      // holds the line if a future edit reintroduces a `.from("brands")` carrying
+      // the column.
+      const brandSelects = Array.from(
+        src.matchAll(
+          /\.from\(\s*["']brands["']\s*\)[\s\S]*?\.select\(\s*([`"'])([\s\S]*?)\1\s*,?\s*\)/g,
+        ),
+      ).map((m) => m[2]);
       const offenders = brandSelects.filter((s) => s.includes(col));
       expect(offenders).toEqual([]);
     },

--- a/packages/offering-rendering/__tests__/meta_orch_1174_legA2_wire_rpc.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_legA2_wire_rpc.test.ts
@@ -1,0 +1,129 @@
+// META-ORCH-1174 Leg A.2 [wire-rpc] — implementor-owned single-source-read
+// regression (the established offering-rendering deno-readfile style). These
+// assertions FAIL-ON-REVERT of the read-path swap:
+//   §1 — BOTH the business/web hook (usePublicTripBySlug) AND the consumer hook
+//        (useConsumerTripDetail) read the ONE canonical anon RPC
+//        `pg_public_trip_by_slug` (Seth single-source decision).
+//   §2 — NEITHER hook reads `brands` / `tickets` directly anymore (the anon-safe
+//        single-source path; the prior brands-theme / view detour is retired on
+//        the trip path — closing the #507 column-grant surface).
+//   §3 — the CONSUMER gap is closed: useConsumerTripDetail now carries
+//        destinationLat/Lng (so the §11 map renders) + per-tier ticketsRemaining,
+//        and the consumer adapter (useConsumerTripOfferingData) maps them through
+//        to the shared TripOfferingData (no longer hardcoded null).
+//   §4 — the RPC migration exists and emits destination lat/lng + per-tier
+//        remaining (the payload that makes §3 possible on every surface).
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const read = async (rel: string): Promise<string> =>
+  await Deno.readTextFile(new URL(rel, import.meta.url));
+
+const bizHook = await read(
+  "../../../mingla-business/src/hooks/usePublicTripBySlug.ts",
+);
+const consumerHook = await read(
+  "../../../app-mobile/src/hooks/useConsumerTripDetail.ts",
+);
+const consumerAdapter = await read(
+  "../../../app-mobile/src/hooks/useConsumerTripOfferingData.ts",
+);
+const migration = await read(
+  "../../../supabase/migrations/20261017000000_meta_orch_1174_pg_public_trip_by_slug.sql",
+);
+
+// strip JSDoc + line comments so prose mentioning a retired pattern (e.g. a
+// comment saying "NEVER .from('brands')") never false-positives an ACTIVE-code
+// assertion below.
+const activeCode = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+const bizCode = activeCode(bizHook);
+const consumerCode = activeCode(consumerHook);
+
+// ── §1 — both hooks read the ONE canonical RPC ──
+Deno.test("§1 BOTH trip read hooks call pg_public_trip_by_slug (single source)", () => {
+  assert(
+    /supabase\.rpc\(\s*["']pg_public_trip_by_slug["']/.test(bizCode),
+    "business/web usePublicTripBySlug must read the canonical RPC",
+  );
+  assert(
+    /supabase\.rpc\(\s*["']pg_public_trip_by_slug["']/.test(consumerCode),
+    "consumer useConsumerTripDetail must read the canonical RPC",
+  );
+});
+
+// ── §2 — neither hook reads brands/tickets directly (anon-safe single source) ──
+Deno.test("§2 neither trip hook reads brands/tickets directly (single-source, #507 surface closed)", () => {
+  for (const [name, code] of [
+    ["usePublicTripBySlug", bizCode],
+    ["useConsumerTripDetail", consumerCode],
+  ] as const) {
+    assert(
+      !/\.from\(\s*["']brands["']\s*\)/.test(code),
+      `${name} must make ZERO direct brands read (theme rides the definer RPC)`,
+    );
+    assert(
+      !/\.from\(\s*["']tickets["']\s*\)/.test(code),
+      `${name} must make ZERO direct tickets read`,
+    );
+  }
+  // the prior business_public_events_view theme detour is retired on this path.
+  assert(
+    !bizCode.includes("business_public_events_view"),
+    "the trip hook no longer needs the business_public_events_view theme detour",
+  );
+});
+
+// ── §3 — the CONSUMER gap is closed (destination lat/lng + per-tier remaining) ──
+Deno.test("§3 the consumer read now carries destination lat/lng + per-tier remaining", () => {
+  // the ConsumerTripDetail type gained destinationLat/Lng + per-tier ticketsRemaining.
+  assertStringIncludes(consumerHook, "destinationLat: number | null");
+  assertStringIncludes(consumerHook, "destinationLng: number | null");
+  assertStringIncludes(consumerHook, "ticketsRemaining: number | null");
+  // the consumer hook MAPS the RPC lat/lng (no longer absent).
+  assert(
+    /destinationLat:\s*numOrNull\(p\.destinationLat\)/.test(consumerCode),
+    "consumer hook must map the RPC destinationLat",
+  );
+  assert(
+    /destinationLng:\s*numOrNull\(p\.destinationLng\)/.test(consumerCode),
+    "consumer hook must map the RPC destinationLng",
+  );
+});
+
+Deno.test("§3 the consumer adapter passes lat/lng + per-tier remaining to the shared body (no hardcoded null)", () => {
+  const adapterCode = activeCode(consumerAdapter);
+  // the §11 map coords are threaded from the detail (was `destinationLat: null`).
+  assert(
+    /destinationLat:\s*detail\.destinationLat/.test(adapterCode),
+    "the consumer adapter must pass detail.destinationLat to TripOfferingData (§11 map gap closed)",
+  );
+  assert(
+    /destinationLng:\s*detail\.destinationLng/.test(adapterCode),
+    "the consumer adapter must pass detail.destinationLng to TripOfferingData",
+  );
+  // per-tier remaining is threaded (was `ticketsRemaining: null`).
+  assert(
+    /ticketsRemaining:\s*t\.isUnlimited\s*\?\s*null\s*:\s*t\.ticketsRemaining/.test(
+      adapterCode,
+    ),
+    "the consumer adapter must pass real per-tier ticketsRemaining (no fabricated sold-out)",
+  );
+});
+
+// ── §4 — the RPC payload makes §3 possible on every surface ──
+Deno.test("§4 the RPC migration emits destination lat/lng + per-tier remaining", () => {
+  assertStringIncludes(migration, "pg_public_trip_by_slug");
+  assertStringIncludes(migration, "'destinationLat'");
+  assertStringIncludes(migration, "'destinationLng'");
+  assertStringIncludes(migration, "'ticketsRemaining'");
+  // restricted to published trips only (no draft leakage).
+  assert(
+    /e\.event_type\s*=\s*'trip'/.test(migration),
+    "the RPC must restrict to event_type='trip'",
+  );
+});


### PR DESCRIPTION
## META-ORCH-1174 Leg A.2 — single-source read path

Completes Leg A per Seth's explicit choice: both public-trip read paths now read the ONE canonical `pg_public_trip_by_slug` RPC (already applied to dev in Leg A). Read-path swap only — `TripOfferingBody`/wrappers/adapter untouched.

- `mingla-business/src/hooks/usePublicTripBySlug.ts` → single `supabase.rpc("pg_public_trip_by_slug")`, mapped to the byte-identical `Trip` output (retires the brands+events+5-sidecar fan-out + the view theme detour).
- `app-mobile/src/hooks/useConsumerTripDetail.ts` + `useConsumerTripOfferingData.ts` → same RPC; **consumer §11 destination map now populates** (was hardcoded null) and **per-tier spots-left now populate** (was null) — the gaps the single source closes.

All three surfaces render byte-identically from one source. 0 new type errors; trip reserve/isolation/canonical-columns gates green; new ADD-only test (both hooks call the RPC + consumer carries destination lat/lng + per-tier remaining), fails-on-revert proven. 7 existing source-grep tests re-pointed to the single-source invariant. [TEST-MOD-APPROVED META-ORCH-1174]

[deploy]