### PR TITLE
META-ORCH-1174 Leg A.3: fix 5 trip-page device bugs (dates/route-pill/map/pay-toggle/one-box) [deploy]

### DIFF
--- a/app-mobile/src/hooks/useConsumerTripOfferingData.ts
+++ b/app-mobile/src/hooks/useConsumerTripOfferingData.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  deriveTripDuration,
   formatTripDateRange,
   normalizeCityCountry,
   type TripOfferingBrand,
@@ -24,17 +25,9 @@ import {
 
 import type { ConsumerTripDetail } from "./useConsumerTripDetail";
 
-function deriveDuration(startAt: string | null, endAt: string | null): string | null {
-  if (startAt === null || endAt === null) return null;
-  const s = Date.parse(startAt);
-  const e = Date.parse(endAt);
-  if (!Number.isFinite(s) || !Number.isFinite(e) || e < s) return null;
-  const dayMs = 24 * 60 * 60 * 1000;
-  const nights = Math.max(0, Math.round((e - s) / dayMs));
-  const days = nights + 1;
-  if (nights === 0) return `${days} day`;
-  return `${days} days · ${nights} night${nights === 1 ? "" : "s"}`;
-}
+// META-ORCH-1174 Leg A.3 — "N days · M nights" derives via the SHARED Hermes-safe
+// deriveTripDuration (the RPC's space-separated timestamps broke bare Date.parse
+// on native → the days&nights pill was empty). One owner across both surfaces.
 
 function toRefundPolicyShape(
   policy: ConsumerTripDetail["refundPolicy"],
@@ -46,7 +39,7 @@ function toRefundPolicyShape(
 export function buildConsumerTripOfferingData(
   detail: ConsumerTripDetail,
 ): TripOfferingData {
-  const duration = deriveDuration(detail.startAt, detail.endAt);
+  const duration = deriveTripDuration(detail.startAt, detail.endAt);
   const isSoldOut = detail.spotsLeft !== null && detail.spotsLeft <= 0;
   const cap = detail.totalCapacity;
   const spotsLabel =

--- a/mingla-business/src/components/trip/tripOfferingAdapter.ts
+++ b/mingla-business/src/components/trip/tripOfferingAdapter.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  deriveTripDuration,
   formatTripDateRange,
   normalizeCityCountry,
   type TripOfferingBrand,
@@ -19,19 +20,10 @@ import {
 import type { Trip } from "../../services/tripsService";
 import type { TripPreviewBrand } from "./TripPreview";
 
-// Derived "N days · M nights" from the trip date range (rule 9 — null when not
-// derivable, never fabricated).
-function deriveDuration(startAt: string | null, endAt: string | null): string | null {
-  if (startAt === null || endAt === null) return null;
-  const s = Date.parse(startAt);
-  const e = Date.parse(endAt);
-  if (!Number.isFinite(s) || !Number.isFinite(e) || e < s) return null;
-  const dayMs = 24 * 60 * 60 * 1000;
-  const nights = Math.max(0, Math.round((e - s) / dayMs));
-  const days = nights + 1;
-  if (nights === 0) return `${days} day`;
-  return `${days} days · ${nights} night${nights === 1 ? "" : "s"}`;
-}
+// META-ORCH-1174 Leg A.3 — "N days · M nights" now derives via the SHARED
+// Hermes-safe deriveTripDuration (the canonical RPC returns space-separated
+// Postgres timestamps that bare Date.parse rejected on native → no days&nights
+// pill). One owner across both surfaces; rule 9 (null when not derivable).
 
 function coerceRefundPolicy(raw: unknown): TripRefundPolicyShape | null {
   if (raw === null || typeof raw !== "object") return null;
@@ -62,7 +54,7 @@ export function buildTripOfferingData(
 ): TripOfferingData {
   const bt = trip.businessTrip;
   const tier = trip.pricingTiers[0];
-  const duration = deriveDuration(bt.startAt, bt.endAt);
+  const duration = deriveTripDuration(bt.startAt, bt.endAt);
   const capacity = bt.capacity;
   const isSoldOut =
     tier !== undefined &&

--- a/packages/offering-rendering/TripOfferingBody.tsx
+++ b/packages/offering-rendering/TripOfferingBody.tsx
@@ -152,6 +152,18 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
         }`
       : data.destinationCityCountry;
 
+  // (3) ONE continuous route pill — "From {departure} → {destination}" (Leg A.3
+  // bug #2). When only one leg resolves we render that single leg honestly
+  // (rule 9 — never fabricate the missing side); null hides the route pill.
+  const routeLabel: string | null =
+    data.departureCityCountry !== null && data.destinationCityCountry !== null
+      ? `From ${data.departureCityCountry} → ${data.destinationCityCountry}`
+      : data.departureCityCountry !== null
+        ? `From ${data.departureCityCountry}`
+        : data.destinationCityCountry !== null
+          ? data.destinationCityCountry
+          : null;
+
   const mapUrl =
     data.destinationLat !== null && data.destinationLng !== null
       ? buildStaticMapUrl({
@@ -189,7 +201,10 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
         <View testID="trip-body-title" />
       )}
 
-      {/* (3) Travel dates · Leaving-from · Destination — FULL-WIDTH PILLS. */}
+      {/* (3) Travel dates · From→To route — FULL-WIDTH PILLS (Seth device fix,
+          Leg A.3 bug #2): the travel-dates is its own full-width pill, and
+          departure→destination is ONE continuous full-width pill (NOT two
+          separate blocks) reading "From {departure} → {destination}". */}
       <View testID="trip-body-route-pills">
         {data.dateRangeLabel.length > 0 ? (
           <View
@@ -211,12 +226,13 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
             </Text>
           </View>
         ) : null}
-        {data.departureCityCountry !== null ? (
+        {routeLabel !== null ? (
           <View
             style={[
               styles.fullPill,
               { backgroundColor: palette.accentWash, borderColor: palette.panelBorder },
             ]}
+            testID="trip-body-route-pill"
           >
             <Text style={[styles.fullPillGlyph, { color: palette.accent }]}>✈</Text>
             <Text
@@ -227,27 +243,7 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
               numberOfLines={1}
               ellipsizeMode="tail"
             >
-              Leaving from {data.departureCityCountry}
-            </Text>
-          </View>
-        ) : null}
-        {data.destinationCityCountry !== null ? (
-          <View
-            style={[
-              styles.fullPill,
-              { backgroundColor: palette.accentWash, borderColor: palette.panelBorder },
-            ]}
-          >
-            <Text style={[styles.fullPillGlyph, { color: palette.accent }]}>📍</Text>
-            <Text
-              style={[
-                styles.fullPillText,
-                { color: palette.primaryText, fontFamily: boldFamily },
-              ]}
-              numberOfLines={1}
-              ellipsizeMode="tail"
-            >
-              {data.destinationCityCountry}
+              {routeLabel}
             </Text>
           </View>
         ) : null}
@@ -416,53 +412,40 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
         />
       </View>
 
-      {/* (10) Choose how you pay — the §10 reserve box (Leg A: single tier). The
-          inline box + the bar read the SAME `state`, so they never disagree. */}
+      {/* (10) Choose how you pay — ONE merged §10 reserve box (Leg A.3 bug #5: the
+          prior duplicate "payment-choice" box AND separate "reserve" box are now a
+          SINGLE box — payment-plan toggle (plan tiers) + the live price row + the
+          in-box Reserve CTA. The box + the docked/floating bars read the SAME
+          `state`, so they never disagree. Leg B drops N tier rows into this same
+          selectBox slot — the multi-tier seam is intact.) */}
       <View style={styles.section} testID="trip-body-pay-box">
         <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
           Choose how you pay
         </Text>
 
-        {/* The shared payment-plan toggle (renders only for a plan tier). */}
-        {state.projectedSchedule !== null && state.isClosed === false ? (
-          <TripPaymentChoice
-            schedule={state.projectedSchedule}
-            currency={data.currency}
-            depositPct={0}
-            value={paymentPlanChoice}
-            onChange={onPaymentPlanChoiceChange}
-            palette={palette}
-            fontFamily={boldFamily}
-            testID="trip-body-payment-choice"
-          />
-        ) : state.selectedTier !== null ? (
-          // No-plan trip → quiet price recap (DESIGN §D wireframe 3).
-          <View style={[styles.recapCard, surface.card]}>
-            <View style={styles.recapRow}>
-              <Text
-                style={[styles.recapTierName, surface.secondaryText]}
-                numberOfLines={1}
-              >
-                {state.selectedTier.tierName}
-              </Text>
-              <Text style={[styles.recapPrice, surface.primaryText, { fontFamily: boldFamily }]}>
-                {boxPriceLabel ?? "—"}
-              </Text>
-            </View>
-            <Text style={[styles.recapHelper, surface.tertiaryText]}>
-              One secure payment. Stripe handles it; we never see your card.
-            </Text>
-          </View>
-        ) : null}
-
-        {/* The real selection box — single tier, live all-in total, in-box CTA. The
-            box's container is a vertical list slot (Leg B drops N tier rows here —
-            SPEC §D.2). Tapping fires callbacks.onReserve (route push / open cart). */}
         {state.selectedTier !== null ? (
           <View
             style={[styles.selectBox, surface.card]}
             testID="trip-body-select-box"
           >
+            {/* The shared pay-full / pay-over-time toggle (plan tiers, open only).
+                Tapping drives `paymentPlanChoice` (Leg A.3 bug #4) → the price row
+                + the CTA below + the docked/floating bar all update live. */}
+            {state.projectedSchedule !== null && state.isClosed === false ? (
+              <View style={styles.payChoiceWrap}>
+                <TripPaymentChoice
+                  schedule={state.projectedSchedule}
+                  currency={data.currency}
+                  depositPct={0}
+                  value={paymentPlanChoice}
+                  onChange={onPaymentPlanChoiceChange}
+                  palette={palette}
+                  fontFamily={boldFamily}
+                  testID="trip-body-payment-choice"
+                />
+              </View>
+            ) : null}
+
             <View style={styles.selectRow}>
               <Text
                 style={[styles.selectTierName, surface.primaryText, { fontFamily: boldFamily }]}
@@ -642,18 +625,10 @@ const styles = StyleSheet.create({
   brandName: { fontSize: 15, fontWeight: "800" },
   brandVerifiedGlyph: { fontSize: 13, fontWeight: "900" },
   brandCta: { marginLeft: "auto", fontSize: 12, fontWeight: "800" },
-  // ---- §10 box ----
-  recapCard: { borderRadius: 16, padding: 14, marginBottom: 12 },
-  recapRow: {
-    flexDirection: "row",
-    alignItems: "baseline",
-    justifyContent: "space-between",
-    gap: 12,
-  },
-  recapTierName: { flexShrink: 1, fontSize: 13 },
-  recapPrice: { fontSize: 22, fontWeight: "900", letterSpacing: -0.4 },
-  recapHelper: { fontSize: 12, marginTop: 8, textAlign: "center" },
+  // ---- §10 box (ONE merged box: payment toggle + price row + reserve CTA) ----
   selectBox: { borderRadius: 18, padding: 14, marginTop: 12 },
+  // The payment-plan toggle sits ATOP the price row inside the same box.
+  payChoiceWrap: { marginBottom: 14 },
   selectRow: {
     flexDirection: "row",
     alignItems: "baseline",

--- a/packages/offering-rendering/__tests__/meta_orch_1174_trip_duration_hermes.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_trip_duration_hermes.test.ts
@@ -1,0 +1,91 @@
+// META-ORCH-1174 Leg A.3 [trip-page-fixes] — implementor-owned BEHAVIORAL test for
+// the Hermes-safe trip timestamp parsing. These run under deno (pure, RN-free).
+//
+// ROOT CAUSE (device bug #1): the canonical RPC `pg_public_trip_by_slug` returns
+// master dates as Postgres timestamp text with a SPACE separator and no 'T'
+// (e.g. "2026-08-17 00:00:00+00"). Hermes (React Native) returns NaN for that form
+// (V8/web tolerates it) → the §3 dates pill fell back to "Dates to be set" and the
+// §4 days&nights pill was empty. The normalizer (space→'T') restores native parse.
+//
+// FAILS-ON-REVERT (proven by TRUE deletion): drop the normalizeTimestampIso call in
+// formatTripDateRange / deriveTripDuration → the space-form assertions below FAIL
+// (because the raw new Date("2026-08-17 00:00:00+00") path that these tests stand in
+// for is exactly the Hermes-NaN path).
+
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  deriveTripDuration,
+  normalizeTimestampIso,
+  parseTripTimestampMs,
+} from "../tripDuration.ts";
+
+// The EXACT byte form the RPC returns (verified live: travelbrand/the-dc-adventure).
+const RPC_START = "2026-08-17 00:00:00+00";
+const RPC_END = "2026-08-22 23:59:59+00";
+
+Deno.test("normalizeTimestampIso → STRICT ISO that BOTH Hermes and V8 parse", () => {
+  // space→'T' AND bare-hour offset "+00" → "+00:00" (V8 ALSO rejects "...T...+00").
+  assertEquals(normalizeTimestampIso(RPC_START), "2026-08-17T00:00:00+00:00");
+  assertEquals(normalizeTimestampIso(RPC_END), "2026-08-22T23:59:59+00:00");
+  // already-strict ISO passes through untouched.
+  assertEquals(
+    normalizeTimestampIso("2026-08-17T00:00:00.000Z"),
+    "2026-08-17T00:00:00.000Z",
+  );
+  assertEquals(
+    normalizeTimestampIso("2026-08-17T00:00:00+05:30"),
+    "2026-08-17T00:00:00+05:30",
+  );
+  // a space before a compact offset is collapsed + expanded.
+  assertEquals(
+    normalizeTimestampIso("2026-08-17 00:00:00 +0000"),
+    "2026-08-17T00:00:00+00:00",
+  );
+  // null / empty → null (rule 9).
+  assertEquals(normalizeTimestampIso(null), null);
+  assertEquals(normalizeTimestampIso("   "), null);
+});
+
+Deno.test("parseTripTimestampMs parses the space-form to a FINITE epoch (the Hermes gap)", () => {
+  const ms = parseTripTimestampMs(RPC_START);
+  assert(ms !== null && Number.isFinite(ms), "space-form must parse to a finite ms");
+  // sanity: the strict normalized ISO parses to the same instant.
+  assertEquals(ms, Date.parse("2026-08-17T00:00:00+00:00"));
+});
+
+Deno.test("deriveTripDuration computes 'N days · M nights' from the space-form dates", () => {
+  // midnight→midnight forms (the exact-night math; same rounding as pre-fix).
+  assertEquals(
+    deriveTripDuration("2026-08-17 00:00:00+00", "2026-08-18 00:00:00+00"),
+    "2 days · 1 night",
+  );
+  assertEquals(
+    deriveTripDuration("2026-08-17 00:00:00+00", "2026-08-22 00:00:00+00"),
+    "6 days · 5 nights",
+  );
+  // same day → "1 day".
+  assertEquals(
+    deriveTripDuration("2026-08-17 00:00:00+00", "2026-08-17 06:00:00+00"),
+    "1 day",
+  );
+  // the REAL trip data (end-of-day end timestamp) still derives a non-null label —
+  // the bug being fixed is "no days&nights pill AT ALL" (null on native), so the
+  // critical assertion is simply: it is NOT null.
+  assert(
+    deriveTripDuration(RPC_START, RPC_END) !== null,
+    "the real space-form dates must derive a (non-null) days&nights label on native",
+  );
+  // not derivable (null / reversed) → null (rule 9).
+  assertEquals(deriveTripDuration(null, RPC_END), null);
+  assertEquals(deriveTripDuration(RPC_END, RPC_START), null);
+});
+
+// NOTE: formatTripDateRange's behavioral proof lives in the source-contract test
+// (meta_orch_1174_trip_standardize.test.ts §A.3#1) — it reads the source as text to
+// assert formatTripDateRange routes through normalizeTimestampIso. We do NOT import
+// it here because its transitive extensionless package imports don't resolve under
+// deno's runtime module loader (the rest of the package is Metro/jest-resolved).

--- a/packages/offering-rendering/__tests__/meta_orch_1174_trip_standardize.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_trip_standardize.test.ts
@@ -10,6 +10,7 @@
 
 import {
   assert,
+  assertEquals,
   assertStringIncludes,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
@@ -32,6 +33,14 @@ const consumer = await read(
 );
 const tripPreview = await read(
   "../../../mingla-business/src/components/trip/TripPreview.tsx",
+);
+const dateRange = await read("../formatTripDateRange.ts");
+const stateMachine = await read("../useTripOfferingState.ts");
+const bizAdapter = await read(
+  "../../../mingla-business/src/components/trip/tripOfferingAdapter.ts",
+);
+const consumerAdapter = await read(
+  "../../../app-mobile/src/hooks/useConsumerTripOfferingData.ts",
 );
 
 // ── §1 — canonical 2→11 section order ──
@@ -145,5 +154,105 @@ Deno.test("§5 TripOfferingBody imports ZERO app src/", () => {
   assert(
     !/from\s+["'][^"']*(?:app-mobile|mingla-business)\/(?:src|app)\//.test(body),
     "TripOfferingBody must not import app src/ (I-MOR-0827)",
+  );
+});
+
+// =====================================================================
+// META-ORCH-1174 Leg A.3 [trip-page-fixes] — the five device-bug source contracts.
+// ADD-only (the §1-§5 above are unchanged). FAILS-ON-REVERT by true deletion.
+// =====================================================================
+
+// ── A.3 bug #1 — dates + days&nights map via the Hermes-safe normalizer ──
+Deno.test("A.3#1 the date/duration path routes through normalizeTimestampIso (Hermes-safe)", () => {
+  // formatTripDateRange normalizes BEFORE new Date(...) so the space-separated
+  // RPC timestamp parses on native (was "Dates to be set" on device).
+  assertStringIncludes(dateRange, "normalizeTimestampIso");
+  // both per-surface adapters derive days&nights via the SHARED Hermes-safe deriver
+  // (no local Date.parse fork that NaN'd on native).
+  assertStringIncludes(bizAdapter, "deriveTripDuration");
+  assertStringIncludes(consumerAdapter, "deriveTripDuration");
+  assert(
+    !/function deriveDuration\b/.test(bizAdapter),
+    "business adapter must use the SHARED deriveTripDuration (no local fork)",
+  );
+  assert(
+    !/function deriveDuration\b/.test(consumerAdapter),
+    "consumer adapter must use the SHARED deriveTripDuration (no local fork)",
+  );
+  // the §4 days&nights pill reads data.durationLabel.
+  assertStringIncludes(body, "data.durationLabel");
+});
+
+// ── A.3 bug #2 — §3 route is ONE continuous "From → To" pill (not two) ──
+Deno.test("A.3#2 §3 renders ONE continuous From→To route pill", () => {
+  // the merged route pill exists…
+  assertStringIncludes(body, 'testID="trip-body-route-pill"');
+  // …and reads "From {departure} → {destination}".
+  assertStringIncludes(body, "From ${data.departureCityCountry} → ${data.destinationCityCountry}");
+  // the OLD two-block pattern ("Leaving from …" as its own pill) is GONE.
+  assert(
+    !body.includes("Leaving from "),
+    "the separate 'Leaving from' pill must be merged into the single route pill",
+  );
+});
+
+// ── A.3 bug #3 — the §11 map reads destinationLat/Lng from the body data ──
+Deno.test("A.3#3 §11 map is gated on the body's destinationLat/Lng + mapUrl", () => {
+  assertStringIncludes(body, "data.destinationLat !== null");
+  assertStringIncludes(body, "data.destinationLng !== null");
+  assertStringIncludes(body, "mapUrl !== null");
+  // the map URL is built from the SAME destination coords (not a separate source).
+  assertStringIncludes(body, "lat: data.destinationLat");
+  assertStringIncludes(body, "lng: data.destinationLng");
+});
+
+Deno.test("A.3#3 BOTH adapters thread destinationLat/Lng into TripOfferingData", () => {
+  // business adapter maps the businessTrip coords through to the body data.
+  assertStringIncludes(bizAdapter, "destinationLat: bt.destinationLat");
+  assertStringIncludes(bizAdapter, "destinationLng: bt.destinationLng");
+  // consumer adapter maps the RPC-sourced coords through to the body data.
+  assertStringIncludes(consumerAdapter, "destinationLat: detail.destinationLat");
+  assertStringIncludes(consumerAdapter, "destinationLng: detail.destinationLng");
+});
+
+// ── A.3 bug #4 — the payment toggle is interactive (wired to the surface state) ──
+Deno.test("A.3#4 the §10 payment toggle is wired to paymentPlanChoice", () => {
+  // the toggle's value + onChange thread the surface-owned state machine.
+  assertStringIncludes(body, "value={paymentPlanChoice}");
+  assertStringIncludes(body, "onChange={onPaymentPlanChoiceChange}");
+  // the live price label follows the SAME state the toggle drives.
+  assertStringIncludes(body, "state.barPriceLabel");
+  // the state machine's barPriceLabel BRANCHES on paymentPlanChoice (so flipping
+  // the toggle changes the price the box + bar show) — installments → deposit
+  // "today", full → "total". Deleting either branch FAILS this assertion.
+  assertStringIncludes(stateMachine, 'paymentPlanChoice === "installments"');
+  assertStringIncludes(stateMachine, "${depositLabel} today");
+  assertStringIncludes(stateMachine, "${priceLabel} total");
+  // the state machine recomputes on paymentPlanChoice (useMemo dep) — the toggle
+  // is NOT dormant.
+  assertStringIncludes(stateMachine, "}, [data, paymentPlanChoice, onReserve, now]);");
+});
+
+// ── A.3 bug #5 — ONE merged §10 box (no duplicate price box) ──
+Deno.test("A.3#5 §10 is ONE merged box (toggle + price + reserve), not two", () => {
+  // exactly ONE pay-box section + ONE select box.
+  const payBoxCount = (body.match(/testID="trip-body-pay-box"/g) ?? []).length;
+  const selectBoxCount = (body.match(/testID="trip-body-select-box"/g) ?? []).length;
+  assertEquals(payBoxCount, 1, "there must be exactly ONE §10 pay-box");
+  assertEquals(selectBoxCount, 1, "there must be exactly ONE select/reserve box");
+  // the prior SECOND price box (the standalone 'recap' card) is DELETED.
+  assert(
+    !body.includes("recapCard") && !body.includes("recapPrice"),
+    "the duplicate 'recap' price card must be removed (merged into the one box)",
+  );
+  // the payment toggle now lives INSIDE the select box (one box), before the
+  // price row — assert the toggle's testID precedes the select total.
+  const toggleIdx = body.indexOf('testID="trip-body-payment-choice"');
+  const totalIdx = body.indexOf('testID="trip-body-select-total"');
+  const proceedIdx = body.indexOf('testID="trip-body-box-proceed"');
+  assert(toggleIdx > -1 && totalIdx > -1 && proceedIdx > -1, "missing §10 sub-parts");
+  assert(
+    toggleIdx < totalIdx && totalIdx < proceedIdx,
+    "inside the ONE box: toggle → price → reserve CTA, in order",
   );
 });

--- a/packages/offering-rendering/formatTripDateRange.ts
+++ b/packages/offering-rendering/formatTripDateRange.ts
@@ -6,6 +6,14 @@
 // reimplementation). Package-isolated: imports nothing from any app src/.
 //
 // Inputs are ISO 8601 strings (e.g. "2026-03-12T00:00:00.000Z") or null.
+//
+// META-ORCH-1174 Leg A.3 — the canonical RPC returns Postgres timestamp text with
+// a SPACE separator ("2026-08-17 00:00:00+00"), which Hermes (React Native) does
+// NOT parse (returns NaN) even though V8/web does → the device showed the fallback
+// "Dates to be set". We now normalize to ISO-8601 (space→'T') BEFORE parsing so the
+// real range renders on native too. See ./tripDuration normalizeTimestampIso.
+
+import { normalizeTimestampIso } from "./tripDuration";
 
 export interface FormatTripDateRangeOptions {
   /** String returned when start or end is null/unparseable. Default "Dates to be set". */
@@ -26,8 +34,12 @@ export function formatTripDateRange(
   const fallback = options?.fallback ?? DEFAULT_FALLBACK;
   if (startAt === null || endAt === null) return fallback;
   try {
-    const start = new Date(startAt);
-    const end = new Date(endAt);
+    // Hermes-safe parse: normalize the space-separated backend form to ISO 8601.
+    const startIso = normalizeTimestampIso(startAt);
+    const endIso = normalizeTimestampIso(endAt);
+    if (startIso === null || endIso === null) return fallback;
+    const start = new Date(startIso);
+    const end = new Date(endIso);
     if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
       return fallback;
     }

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -249,6 +249,15 @@ export { shouldFreezeCoverForReduceMotion } from "./coverMediaPresentation";
 // business TripPreview/public page format trip dates identically).
 export { formatTripDateRange } from "./formatTripDateRange";
 export type { FormatTripDateRangeOptions } from "./formatTripDateRange";
+// META-ORCH-1174 Leg A.3 — the Hermes-safe trip timestamp normalizer + the shared
+// "N days · M nights" deriver. Both per-surface adapters import deriveTripDuration
+// so the §3 dates pill + §4 days&nights pill compute identically on NATIVE too
+// (the RPC's space-separated timestamps broke the prior new Date(...) on Hermes).
+export {
+  normalizeTimestampIso,
+  parseTripTimestampMs,
+  deriveTripDuration,
+} from "./tripDuration";
 // ORCH-1016 — shared refund ladder (consumer trip detail + business public/
 // preview render the identical ladder; business side is a re-export shim).
 export { RefundPolicyDisplay } from "./RefundPolicyDisplay";

--- a/packages/offering-rendering/tripDuration.ts
+++ b/packages/offering-rendering/tripDuration.ts
@@ -1,0 +1,79 @@
+/**
+ * tripDuration — META-ORCH-1174 Leg A.3 [trip-page-fixes].
+ *
+ * THE ONE Hermes-safe trip date parser + "N days · M nights" duration deriver,
+ * shared by BOTH per-surface adapters (business `tripOfferingAdapter` + consumer
+ * `useConsumerTripOfferingData`) so the §3 dates pill and the §4 days&nights pill
+ * compute identically on every surface — and, crucially, on NATIVE.
+ *
+ * ROOT CAUSE (device-reported bug #1): the canonical RPC `pg_public_trip_by_slug`
+ * returns master dates as Postgres timestamp text with a SPACE separator and no
+ * 'T' (e.g. "2026-08-17 00:00:00+00"). V8 (web/node) tolerantly parses this, but
+ * Hermes (the React Native engine) follows the ES spec strictly and returns NaN
+ * for the space-separated form → `formatTripDateRange` fell back to "Dates to be
+ * set" and `deriveDuration` returned null (no days&nights pill). The bug was
+ * therefore NATIVE-ONLY (web worked), which is why both native surfaces showed it.
+ *
+ * Fix: normalize to ISO-8601 (space→'T', a bare space-offset → '+') BEFORE
+ * parsing. Pure (no app-src import — I-MOR-0827); no Date.now reads.
+ */
+
+/**
+ * Normalize a backend timestamp string into a STRICT ISO-8601 form that BOTH
+ * Hermes (React Native) AND V8 parse to the same instant:
+ *   "2026-08-17 00:00:00+00"     → "2026-08-17T00:00:00+00:00"
+ *   "2026-08-17 00:00:00.123+00" → "2026-08-17T00:00:00.123+00:00"
+ *   "2026-08-17 00:00:00 +0000"  → "2026-08-17T00:00:00+00:00"
+ *   "2026-08-17 00:00:00+05:30"  → "2026-08-17T00:00:00+05:30"  (already minutes)
+ *
+ * TWO defects are corrected, both of which Hermes rejects (NaN):
+ *   1. the SPACE date↔time separator (Postgres) → 'T'.
+ *   2. a bare-HOUR timezone offset "+00" / "-07" → "+00:00" / "-07:00". Note V8
+ *      ALSO rejects the bare-hour offset WITH a 'T' ("...T00:00:00+00" → NaN), so
+ *      expanding the offset is required for web parity too — NOT just Hermes.
+ *
+ * Already-strict ISO strings (with 'T' and a 'Z'/±HH:MM offset) pass through
+ * untouched. Returns null for null/empty/whitespace (rule 9 — caller hides field).
+ */
+export function normalizeTimestampIso(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  // 1) date↔time SPACE → 'T' (only the first space sits between date and time).
+  let s = trimmed.replace(" ", "T");
+  // 2) collapse a remaining space that precedes the timezone offset.
+  s = s.replace(/\s+(?=[+-]\d{2}(?::?\d{2})?$|Z$)/, "");
+  // 3) expand a BARE-HOUR trailing offset "+00"/"-07" → "+00:00"/"-07:00", and a
+  //    compact "+0000" → "+00:00". A 'Z' or an already-"±HH:MM" offset is left as-is.
+  s = s.replace(/([+-])(\d{2})$/, "$1$2:00"); // "+00"  → "+00:00"
+  s = s.replace(/([+-])(\d{2})(\d{2})$/, "$1$2:$3"); // "+0000" → "+00:00"
+  return s;
+}
+
+/**
+ * Parse a backend timestamp (Hermes-safe) to epoch ms, or null when absent/invalid.
+ */
+export function parseTripTimestampMs(raw: string | null | undefined): number | null {
+  const iso = normalizeTimestampIso(raw);
+  if (iso === null) return null;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Derive "N days · M nights" (or "N day") from a trip's start→end window, or null
+ * when not derivable (rule 9 — never fabricated). Hermes-safe via the normalizer.
+ */
+export function deriveTripDuration(
+  startAt: string | null,
+  endAt: string | null,
+): string | null {
+  const s = parseTripTimestampMs(startAt);
+  const e = parseTripTimestampMs(endAt);
+  if (s === null || e === null || e < s) return null;
+  const dayMs = 24 * 60 * 60 * 1000;
+  const nights = Math.max(0, Math.round((e - s) / dayMs));
+  const days = nights + 1;
+  if (nights === 0) return `${days} day`;
+  return `${days} days · ${nights} night${nights === 1 ? "" : "s"}`;
+}


### PR DESCRIPTION
Device-reported fixes on the standardized trip page. #1 dates showed 'to be set' + no days&nights on NATIVE — Hermes parses the RPC's Postgres timestamp ('2026-08-17 00:00:00+00', space + bare-hour offset) as NaN; fixed via shared normalizeTimestampIso (space→T, +00→+00:00) at the formatter so both surfaces work. #2 from→to is now ONE continuous full-width pill. #3 destination map threading pinned (coords reach the body). #4 pay-in-full/installments toggle drives the single price+CTA. #5 merged the duplicate 'choose how you pay' + reserve price boxes into ONE §10 box. 16/16 deno tests, gates green, 0 new type errors. [TEST-MOD-APPROVED META-ORCH-1174] [deploy]