### PR TITLE
META-ORCH-1174 Leg A.4: lucide pill icons across trip/event/rsvp + compact trip pills + UTC date fix [deploy]

### DIFF
--- a/packages/offering-rendering/EventOfferingBody.tsx
+++ b/packages/offering-rendering/EventOfferingBody.tsx
@@ -55,6 +55,7 @@ import {
 } from "react-native";
 
 import { boldFontFamily, offeringSurfaceStyles, type ThemePalette } from "./themePalette";
+import { Calendar, Globe, MapPin, Minus, Plus } from "./LucideIcons";
 import {
   computeOfferingVariant,
   resolveOfferingCta,
@@ -299,7 +300,7 @@ export const EventOfferingBody: React.FC<EventOfferingBodyProps> = ({
           style={[styles.dateRow, { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }]}
           testID="orch-1167-date-row"
         >
-          <Text style={[styles.dateGlyph, { color: palette.accent }]}>◷</Text>
+          <Calendar size={18} color={palette.accent} />
           <View style={styles.dateTextCol}>
             {event.dateLine.length > 0 ? (
               <Text
@@ -469,7 +470,7 @@ export const EventOfferingBody: React.FC<EventOfferingBodyProps> = ({
           </Text>
           <View style={[styles.venueCard, surface.card]}>
             <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
-              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>◯</Text>
+              <Globe size={18} color={palette.accentText} />
             </View>
             <View style={styles.venueTextCol}>
               <Text
@@ -509,7 +510,7 @@ export const EventOfferingBody: React.FC<EventOfferingBodyProps> = ({
             style={[styles.venueCard, surface.card]}
           >
             <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
-              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>⌖</Text>
+              <MapPin size={18} color={palette.accentText} />
             </View>
             <View style={styles.venueTextCol}>
               <Text
@@ -923,7 +924,7 @@ const TicketStepperRow: React.FC<{
                 !canDecrement ? styles.stepBtnDisabled : null,
               ]}
             >
-              <Text style={[styles.stepGlyph, { color: palette.primaryText }]}>−</Text>
+              <Minus size={18} color={palette.primaryText} />
             </Pressable>
             <Text
               style={[styles.stepQty, surface.primaryText, { fontFamily: boldFamily }]}
@@ -942,7 +943,7 @@ const TicketStepperRow: React.FC<{
                 !canIncrement ? styles.stepBtnDisabled : null,
               ]}
             >
-              <Text style={[styles.stepGlyph, { color: palette.primaryText }]}>+</Text>
+              <Plus size={18} color={palette.primaryText} />
             </Pressable>
           </View>
         ) : (

--- a/packages/offering-rendering/LucideIcons.tsx
+++ b/packages/offering-rendering/LucideIcons.tsx
@@ -1,0 +1,136 @@
+/**
+ * LucideIcons — META-ORCH-1174 Leg A.4 [trip-page polish · lucide pills].
+ *
+ * The ONE shared, pure-presentational lucide-icon module consumed by the three
+ * shared offering bodies (TripOfferingBody / EventOfferingBody / RsvpOfferingBody)
+ * to replace the prior emoji / geometric-glyph `<Text>` icons (📅 ✈ ⏱ 👥 ◷ ◯ ⌖
+ * − + ✓) with crisp, theme-tinted vector icons that render IDENTICALLY on every
+ * surface (buyer-web react-native-web + business iOS/Android + consumer iOS/Android).
+ *
+ * WHY hand-drawn paths, not the `lucide-react-native` dependency:
+ *   - The package stays dependency-isolated (I-MOR-0827-PACKAGE-ISOLATION) and adds
+ *     NO new runtime dep — it already peer-depends on `react-native-svg` (see the
+ *     `RsvpMomentumDecision` glyph pattern). We render the EXACT lucide path data
+ *     (lucide is MIT-licensed) inside a 24×24 viewBox via react-native-svg, the same
+ *     way every other glyph in this package is drawn.
+ *   - lucide's standard stroke styling: a 24×24 viewBox, `fill="none"`,
+ *     `stroke={color}`, `strokeWidth={2}` (overridable), round caps + round joins.
+ *
+ * Each icon is a small pure component taking `{ size, color, strokeWidth? }` and
+ * scales the 24×24 art to the requested footprint (so it slots into the same space
+ * the prior glyph occupied). No state, no data, no app-src import. Renders on
+ * react-native-web AND native RN.
+ */
+
+import React from "react";
+import Svg, { Circle, Path } from "react-native-svg";
+
+export interface LucideIconProps {
+  /** Rendered width = height in px (the 24×24 art scales to fit). */
+  size: number;
+  /** Stroke color (theme token — palette.accent / palette.accentText / etc.). */
+  color: string;
+  /** lucide's standard stroke width is 2; callers may thin/thicken it. */
+  strokeWidth?: number;
+}
+
+/**
+ * Shared lucide frame — a 24×24-viewBox SVG with `fill="none"` and the canonical
+ * lucide stroke styling. Children are the per-icon `<Path>` / `<Circle>` art (which
+ * inherit `stroke`/`strokeWidth`/`strokeLinecap`/`strokeLinejoin` from here).
+ */
+const LucideFrame: React.FC<
+  LucideIconProps & { children: React.ReactNode }
+> = ({ size, color, strokeWidth = 2, children }) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={color}
+    strokeWidth={strokeWidth}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {children}
+  </Svg>
+);
+
+// ───────────────────────────── the 9 icons ──────────────────────────────────
+// Each uses the REAL lucide path data (24×24 grid). Stroke styling is inherited
+// from <LucideFrame>; per-element overrides are avoided so the whole icon shares
+// the one color/width.
+
+/** lucide `calendar` — rounded rect body + two top ticks + a horizontal divider. */
+export const Calendar: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M8 2v4" />
+    <Path d="M16 2v4" />
+    <Path d="M3 10h18" />
+    <Path d="M5 4h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" />
+  </LucideFrame>
+);
+
+/** lucide `plane` — the airplane silhouette. */
+export const Plane: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2Z" />
+  </LucideFrame>
+);
+
+/** lucide `moon` — the crescent (used for the nights pill). */
+export const Moon: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+  </LucideFrame>
+);
+
+/** lucide `users` — two overlapping person shapes (seats / headcount). */
+export const Users: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <Circle cx={9} cy={7} r={4} />
+    <Path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+    <Path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  </LucideFrame>
+);
+
+/** lucide `globe` — circle + meridian + the two horizontal lat lines. */
+export const Globe: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Circle cx={12} cy={12} r={10} />
+    <Path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+    <Path d="M2 12h20" />
+  </LucideFrame>
+);
+
+/** lucide `map-pin` — the pin teardrop + the inner circle. */
+export const MapPin: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+    <Circle cx={12} cy={10} r={3} />
+  </LucideFrame>
+);
+
+/** lucide `minus` — a single horizontal stroke (stepper decrement). */
+export const Minus: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M5 12h14" />
+  </LucideFrame>
+);
+
+/** lucide `plus` — a horizontal + vertical stroke cross (stepper increment). */
+export const Plus: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M5 12h14" />
+    <Path d="M12 5v14" />
+  </LucideFrame>
+);
+
+/** lucide `badge-check` — the scalloped verification badge + the inner check. */
+export const BadgeCheck: React.FC<LucideIconProps> = (props) => (
+  <LucideFrame {...props}>
+    <Path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
+    <Path d="m9 12 2 2 4-4" />
+  </LucideFrame>
+);

--- a/packages/offering-rendering/RsvpOfferingBody.tsx
+++ b/packages/offering-rendering/RsvpOfferingBody.tsx
@@ -67,6 +67,7 @@ import {
 } from "react-native";
 
 import { boldFontFamily, offeringSurfaceStyles, type ThemePalette } from "./themePalette";
+import { Calendar, Globe, MapPin, Minus, Plus } from "./LucideIcons";
 import { resolveRsvpCta, type RsvpCtaState } from "./offeringCta";
 import { type PublicBrandProps, type PublicEventProps } from "./types";
 import { type ResolvedTheme } from "./designTokens";
@@ -574,7 +575,7 @@ export const useRsvpOfferingState = (
             style={[styles.stepBtn, { borderColor: palette.panelBorder, opacity: guests.length <= 0 ? 0.4 : 1 }]}
             testID="orch-1157-rsvp-plus-minus"
           >
-            <Text style={[styles.stepGlyph, { color: palette.accent }]}>–</Text>
+            <Minus size={18} color={palette.accent} />
           </Pressable>
           <Text style={[styles.stepCount, { color: palette.primaryText, fontFamily: boldFamily }]}>
             +{guests.length}
@@ -587,7 +588,7 @@ export const useRsvpOfferingState = (
             style={[styles.stepBtn, { borderColor: palette.panelBorder, opacity: guests.length >= config.plusOnesMax ? 0.4 : 1 }]}
             testID="orch-1157-rsvp-plus-plus"
           >
-            <Text style={[styles.stepGlyph, { color: palette.accent }]}>+</Text>
+            <Plus size={18} color={palette.accent} />
           </Pressable>
         </View>
       </View>
@@ -983,7 +984,7 @@ export const RsvpOfferingBody: React.FC<
           style={[styles.dateRow, { backgroundColor: palette.accentWash, borderColor: palette.panelBorder }]}
           testID="orch-1167-date-row"
         >
-          <Text style={[styles.dateGlyph, { color: palette.accent }]}>◷</Text>
+          <Calendar size={18} color={palette.accent} />
           <View style={styles.dateTextCol}>
             {event.dateLine.length > 0 ? (
               <Text
@@ -1108,7 +1109,7 @@ export const RsvpOfferingBody: React.FC<
           </Text>
           <View style={[styles.venueCard, surface.card]}>
             <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
-              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>◯</Text>
+              <Globe size={18} color={palette.accentText} />
             </View>
             <View style={styles.venueTextCol}>
               <Text style={[styles.venueName, surface.primaryText, { fontFamily: boldFamily }]}>Online</Text>
@@ -1140,7 +1141,7 @@ export const RsvpOfferingBody: React.FC<
             style={[styles.venueCard, surface.card]}
           >
             <View style={[styles.venueDisk, { backgroundColor: palette.accent }]}>
-              <Text style={[styles.venueGlyph, { color: palette.accentText }]}>⌖</Text>
+              <MapPin size={18} color={palette.accentText} />
             </View>
             <View style={styles.venueTextCol}>
               {event.venueName !== null && event.venueName.length > 0 ? (

--- a/packages/offering-rendering/TripOfferingBody.tsx
+++ b/packages/offering-rendering/TripOfferingBody.tsx
@@ -57,6 +57,7 @@ import { DayByDay } from "./DayByDay";
 import { TripRefundLadder } from "./TripRefundLadder";
 import { TripPaymentChoice } from "./TripPaymentChoice";
 import { TripCountdownPill } from "./TripCountdownPill";
+import { BadgeCheck, Calendar, Moon, Plane, Users } from "./LucideIcons";
 import { buildStaticMapUrl } from "./mapboxStaticImage";
 import type {
   TripOfferingBrand,
@@ -213,7 +214,7 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
               { backgroundColor: palette.accentWash, borderColor: palette.panelBorder },
             ]}
           >
-            <Text style={[styles.fullPillGlyph, { color: palette.accent }]}>📅</Text>
+            <Calendar size={17} color={palette.accent} />
             <Text
               style={[
                 styles.fullPillText,
@@ -234,7 +235,7 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
             ]}
             testID="trip-body-route-pill"
           >
-            <Text style={[styles.fullPillGlyph, { color: palette.accent }]}>✈</Text>
+            <Plane size={17} color={palette.accent} />
             <Text
               style={[
                 styles.fullPillText,
@@ -249,17 +250,26 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
         ) : null}
       </View>
 
-      {/* (4) Pills row — days&nights · spots-left · animated live countdown. */}
+      {/* (4) Pills row — days&nights · spots-left · animated live countdown.
+          Leg A.4: the days&nights + seats-left pills are now COMPACT (tighter
+          padding/font + a lucide icon) so they sit side-by-side on ONE line
+          instead of stacking; the live countdown wraps after them as before. */}
       <View style={styles.pillsRow} testID="trip-body-meta-pills">
         {data.durationLabel !== null ? (
-          <Pill palette={palette} font={boldFamily}>
-            ⏱ {data.durationLabel}
-          </Pill>
+          <MetaPill
+            palette={palette}
+            font={boldFamily}
+            icon={<Moon size={13} color={palette.accent} />}
+            label={data.durationLabel}
+          />
         ) : null}
         {data.spotsLabel !== null ? (
-          <Pill palette={palette} font={boldFamily}>
-            👥 {data.spotsLabel}
-          </Pill>
+          <MetaPill
+            palette={palette}
+            font={boldFamily}
+            icon={<Users size={13} color={palette.accent} />}
+            label={data.spotsLabel}
+          />
         ) : null}
         {data.bookingDeadlineIso !== null && !data.bookingsClosed ? (
           <TripCountdownPill
@@ -324,9 +334,7 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
                 {brand.name}
               </Text>
               {brand.verified ? (
-                <Text style={[styles.brandVerifiedGlyph, { color: palette.accent }]}>
-                  ✓
-                </Text>
+                <BadgeCheck size={15} color={palette.accent} />
               ) : null}
             </View>
           </View>
@@ -539,19 +547,27 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
   );
 };
 
-const Pill: React.FC<{
+// Leg A.4 — the §4 meta pill: a COMPACT icon + label row (tighter padding/font
+// than the §3 full-width pills) so days&nights + seats-left sit side-by-side on
+// ONE line. The lucide icon replaces the prior leading emoji glyph.
+const MetaPill: React.FC<{
   palette: ThemePalette;
   font: string;
-  children: React.ReactNode;
-}> = ({ palette, font, children }) => (
+  icon: React.ReactNode;
+  label: string;
+}> = ({ palette, font, icon, label }) => (
   <View
     style={[
       styles.pill,
       { backgroundColor: palette.accentWash, borderColor: palette.panelBorder },
     ]}
   >
-    <Text style={[styles.pillText, { color: palette.primaryText, fontFamily: font }]}>
-      {children}
+    {icon}
+    <Text
+      style={[styles.pillText, { color: palette.primaryText, fontFamily: font }]}
+      numberOfLines={1}
+    >
+      {label}
     </Text>
   </View>
 );
@@ -579,17 +595,20 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     marginTop: 12,
   },
-  fullPillGlyph: { fontSize: 16, fontWeight: "900" },
   fullPillText: { flex: 1, minWidth: 0, fontSize: 15, fontWeight: "800", letterSpacing: -0.2 },
-  // ---- §4 meta pills ----
-  pillsRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 12 },
+  // ---- §4 meta pills (Leg A.4: COMPACT icon+label row — tighter padding/font so
+  //      days&nights + seats-left sit side-by-side on one line) ----
+  pillsRow: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginTop: 12 },
   pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
     borderRadius: 999,
     borderWidth: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
   },
-  pillText: { fontSize: 13, fontWeight: "700" },
+  pillText: { fontSize: 12, fontWeight: "700" },
   // ---- sections ----
   section: { marginTop: 24 },
   secTitle: { fontSize: 20, fontWeight: "900", letterSpacing: -0.3, marginBottom: 12 },
@@ -623,7 +642,6 @@ const styles = StyleSheet.create({
   },
   brandNameRow: { flexDirection: "row", alignItems: "center", gap: 6, marginTop: 1 },
   brandName: { fontSize: 15, fontWeight: "800" },
-  brandVerifiedGlyph: { fontSize: 13, fontWeight: "900" },
   brandCta: { marginLeft: "auto", fontSize: 12, fontWeight: "800" },
   // ---- §10 box (ONE merged box: payment toggle + price row + reserve CTA) ----
   selectBox: { borderRadius: 18, padding: 14, marginTop: 12 },

--- a/packages/offering-rendering/__tests__/meta_orch_1174_legA4_lucide_pills.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_legA4_lucide_pills.test.ts
@@ -1,0 +1,157 @@
+// META-ORCH-1174 Leg A.4 [trip-page polish · lucide pills + date-tz fix] —
+// implementor-owned source-contract regression (the established offering-rendering
+// deno-readfile style). These assertions FAIL-ON-REVERT:
+//   §1 — the shared LucideIcons module exports all 9 icons, drawn as react-native-
+//        svg paths (NO lucide dependency — I-MOR-0827 isolation) on a 24×24 frame.
+//   §2 — the three shared bodies render the lucide icon components (Calendar/Plane/
+//        Moon/Users/Globe/MapPin/Minus/Plus/BadgeCheck) and NO LONGER carry the
+//        prior emoji / geometric-glyph icon `<Text>` (📅 ✈ ⏱ 👥 ◷ ◯ ⌖ + the bare
+//        ✓ verified glyph + the stepper −/+/–).
+//   §3 — the §4 trip meta pills are COMPACT (a MetaPill icon+label row) so
+//        days&nights + seats-left sit side-by-side on one line.
+//   §4 — the trip date formatter formats the calendar date in UTC (timeZone:"UTC"),
+//        so a UTC-midnight start is NOT shifted back a day by the device timezone
+//        ("Aug 17", never "Aug 16").
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const read = async (rel: string): Promise<string> =>
+  await Deno.readTextFile(new URL(rel, import.meta.url));
+
+const lucide = await read("../LucideIcons.tsx");
+const barrel = await read("../index.ts");
+const trip = await read("../TripOfferingBody.tsx");
+const event = await read("../EventOfferingBody.tsx");
+const rsvp = await read("../RsvpOfferingBody.tsx");
+const rsvpMomentum = await read("../RsvpMomentumDecision.tsx");
+const dateRange = await read("../formatTripDateRange.ts");
+
+const ICONS = [
+  "Calendar",
+  "Plane",
+  "Moon",
+  "Users",
+  "Globe",
+  "MapPin",
+  "Minus",
+  "Plus",
+  "BadgeCheck",
+];
+
+// ── §1 — the LucideIcons module exports all 9 icons, SVG-path, no lucide dep ──
+Deno.test("§1 LucideIcons exports all 9 icons", () => {
+  for (const name of ICONS) {
+    assertStringIncludes(
+      lucide,
+      `export const ${name}`,
+      `LucideIcons must export ${name}`,
+    );
+    assertStringIncludes(barrel, name);
+  }
+});
+
+Deno.test("§1 LucideIcons draws react-native-svg paths — NO lucide dependency", () => {
+  assertStringIncludes(lucide, 'from "react-native-svg"');
+  // The exact lucide path data for the distinctive icons (proves real art, not a
+  // placeholder): the moon crescent + the minus/plus strokes.
+  assertStringIncludes(lucide, "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"); // Moon
+  assertStringIncludes(lucide, "M5 12h14"); // Minus + Plus horizontal
+  assertStringIncludes(lucide, "M12 5v14"); // Plus vertical
+  // lucide-standard frame: 24×24 viewBox, fill="none", round caps/joins.
+  assertStringIncludes(lucide, 'viewBox="0 0 24 24"');
+  assertStringIncludes(lucide, 'fill="none"');
+  assertStringIncludes(lucide, 'strokeLinecap="round"');
+  assertStringIncludes(lucide, 'strokeLinejoin="round"');
+  // NO runtime lucide dependency anywhere (I-MOR-0827 isolation — SVG paths only).
+  assert(
+    !/from\s+["']lucide(-react|-react-native)?["']/.test(lucide),
+    "LucideIcons must NOT import the lucide library (hand-drawn SVG paths only)",
+  );
+});
+
+// ── §2 — the three bodies use the lucide components + dropped the glyphs ──
+Deno.test("§2 TripOfferingBody swaps its pill/verified glyphs to lucide", () => {
+  assertStringIncludes(trip, 'from "./LucideIcons"');
+  assertStringIncludes(trip, "<Calendar"); // §3 date pill
+  assertStringIncludes(trip, "<Plane"); // §3 route pill
+  assertStringIncludes(trip, "<Moon"); // §4 days·nights
+  assertStringIncludes(trip, "<Users"); // §4 seats-left
+  assertStringIncludes(trip, "<BadgeCheck"); // brand verified tick
+  for (const glyph of ["📅", "✈", "⏱", "👥"]) {
+    assert(!trip.includes(glyph), `TripOfferingBody must not keep the "${glyph}" glyph`);
+  }
+  // The bare "✓" verified glyph in a <Text> is gone (BadgeCheck replaces it).
+  assert(
+    !/<Text[^>]*>\s*✓\s*<\/Text>/.test(trip),
+    "TripOfferingBody must not render the bare ✓ verified glyph",
+  );
+});
+
+Deno.test("§2 EventOfferingBody swaps date/where/stepper glyphs to lucide", () => {
+  assertStringIncludes(event, 'from "./LucideIcons"');
+  assertStringIncludes(event, "<Calendar"); // date row
+  assertStringIncludes(event, "<Globe"); // online
+  assertStringIncludes(event, "<MapPin"); // location pin
+  assertStringIncludes(event, "<Minus"); // stepper −
+  assertStringIncludes(event, "<Plus"); // stepper +
+  for (const glyph of ["◷", "◯", "⌖", "−"]) {
+    assert(!event.includes(glyph), `EventOfferingBody must not keep the "${glyph}" glyph`);
+  }
+});
+
+Deno.test("§2 RsvpOfferingBody swaps date/where/stepper glyphs to lucide", () => {
+  assertStringIncludes(rsvp, 'from "./LucideIcons"');
+  assertStringIncludes(rsvp, "<Calendar"); // date row
+  assertStringIncludes(rsvp, "<Globe"); // online
+  assertStringIncludes(rsvp, "<MapPin"); // location pin
+  assertStringIncludes(rsvp, "<Minus"); // +1 stepper –
+  assertStringIncludes(rsvp, "<Plus"); // +1 stepper +
+  // The date/where geometric glyphs are gone entirely.
+  for (const glyph of ["◷", "◯", "⌖"]) {
+    assert(!rsvp.includes(glyph), `RsvpOfferingBody must not keep the "${glyph}" glyph`);
+  }
+  // The bare stepGlyph "–"/"+" Text steppers are gone (lucide replaces them). We
+  // target the stepGlyph Text element specifically — the en-dash also legitimately
+  // appears in prose comments ("sections 2–8"), so a blanket char-scan over-matches.
+  assert(
+    !/<Text[^>]*styles\.stepGlyph[^>]*>\s*[–+]\s*<\/Text>/.test(rsvp),
+    "RsvpOfferingBody must not render the bare –/+ stepGlyph Text steppers",
+  );
+});
+
+Deno.test("§2 the RSVP decision-button glyphs are LEFT UNTOUCHED (out of scope)", () => {
+  // The Going/Maybe/Can't SVG glyphs live in RsvpMomentumDecision and stay as-is.
+  assertStringIncludes(rsvpMomentum, "CheckGlyph");
+  assertStringIncludes(rsvpMomentum, "MaybeGlyph");
+  assertStringIncludes(rsvpMomentum, "XGlyph");
+});
+
+// ── §3 — the §4 trip pills are compacted onto one row ──
+Deno.test("§3 trip §4 meta pills are a COMPACT icon+label row (side-by-side)", () => {
+  // The new MetaPill carries the lucide icon + a one-line label in a flex-ROW pill.
+  assertStringIncludes(trip, "MetaPill");
+  // The pill style is a flexDirection:'row' (icon next to label) — the compaction.
+  assert(
+    /pill:\s*\{[^}]*flexDirection:\s*"row"/s.test(trip),
+    "the §4 pill must be a flexDirection:'row' icon+label row (compacted)",
+  );
+  // Tighter footprint than the §3 full-width pills (smaller padding + font).
+  assert(
+    /pillText:\s*\{\s*fontSize:\s*12/.test(trip),
+    "the §4 compact pill text must use the tighter fontSize 12",
+  );
+});
+
+// ── §4 — the trip date formatter is timezone-safe (UTC calendar date) ──
+Deno.test("§4 formatTripDateRange formats the calendar date in UTC (no tz shift)", () => {
+  // The Aug-16-vs-Aug-17 device bug: a UTC-midnight start formatted in the device
+  // tz slips back a day west of UTC. The fix passes timeZone:"UTC" to the
+  // Intl/toLocaleDateString formatter so the displayed date == the stored date.
+  assert(
+    /toLocaleDateString\([^)]*timeZone:\s*"UTC"/s.test(dateRange),
+    "formatTripDateRange must format with timeZone:'UTC' (calendar date, no device shift)",
+  );
+});

--- a/packages/offering-rendering/formatTripDateRange.ts
+++ b/packages/offering-rendering/formatTripDateRange.ts
@@ -12,6 +12,12 @@
 // NOT parse (returns NaN) even though V8/web does → the device showed the fallback
 // "Dates to be set". We now normalize to ISO-8601 (space→'T') BEFORE parsing so the
 // real range renders on native too. See ./tripDuration normalizeTimestampIso.
+//
+// META-ORCH-1174 Leg A.4 — trip travel dates are CALENDAR DATES, not moments. The
+// master start is stored as UTC midnight ("2026-08-17 00:00:00+00"); formatting it
+// in the DEVICE timezone shifted it BACK a day west of UTC (a US viewer saw "Aug
+// 16" for a stored "Aug 17"). We now format the Y-M-D in UTC (`timeZone: "UTC"`),
+// so the displayed date always matches the stored calendar date on every surface.
 
 import { normalizeTimestampIso } from "./tripDuration";
 
@@ -43,11 +49,16 @@ export function formatTripDateRange(
     if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
       return fallback;
     }
+    // Leg A.4 — format the Y-M-D in UTC so a UTC-midnight calendar date is NOT
+    // pulled back a day by a west-of-UTC device timezone (the "Aug 16 vs Aug 17"
+    // device bug). Calendar dates are timezone-free facts; the stored instant is
+    // always 00:00:00Z, so reading its UTC Y-M-D yields the stored calendar date.
     const fmt = (d: Date): string =>
       d.toLocaleDateString(undefined, {
         month: "short",
         day: "numeric",
         year: "numeric",
+        timeZone: "UTC",
       });
     return `${fmt(start)} – ${fmt(end)}`;
   } catch {

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -120,6 +120,24 @@ export type {
 export { normalizeCityCountry } from "./normalizeCityCountry";
 export type { StructuredPlaceParts } from "./normalizeCityCountry";
 
+// META-ORCH-1174 Leg A.4 [trip-page polish · lucide pills] — the shared lucide-icon
+// module (Calendar/Plane/Moon/Users/Globe/MapPin/Minus/Plus/BadgeCheck), drawn as
+// react-native-svg paths (NO lucide dep — I-MOR-0827 isolation). Replaces the emoji
+// / geometric-glyph pill+row icons across the three shared offering bodies. Each is a
+// pure `{ size, color, strokeWidth? }` component on a 24×24 lucide-standard frame.
+export {
+  Calendar,
+  Plane,
+  Moon,
+  Users,
+  Globe,
+  MapPin,
+  Minus,
+  Plus,
+  BadgeCheck,
+} from "./LucideIcons";
+export type { LucideIconProps } from "./LucideIcons";
+
 // ===========================================================================
 // META-ORCH-1174 Leg A [trip-page-standardize] — THE ONE shared, shell-agnostic
 // body for the public TRIP page (event_type='trip'). Rendered byte-identically on


### PR DESCRIPTION
## META-ORCH-1174 Leg A.4 — icon + pill polish (all 3 offering pages)

New shared `LucideIcons.tsx` (9 pure components drawing real lucide MIT SVG paths via react-native-svg — no lucide dependency, package-isolation safe). Swaps emoji/geometric glyphs → lucide across the three shared bodies:
- **Trip**: date 📅→Calendar, route ✈→Plane, days·nights ⏱→Moon, seats 👥→Users, brand verified ✓→BadgeCheck
- **Event**: date ◷→Calendar, where-online ◯→Globe, pin ⌖→MapPin, ticket stepper −/+→Minus/Plus
- **RSVP**: date ◷→Calendar, where-online ◯→Globe, pin ⌖→MapPin, +1 stepper –/+→Minus/Plus

Trip §4: days·nights + seats-left pills compacted onto ONE line. UTC date fix: trip travel dates now format in UTC (calendar dates) so the stored 2026-08-17 renders "Aug 17" (was "Aug 16" via device-tz shift). RSVP decision-button glyphs left as-is (out of scope).

8 ADD-only source-contract tests, fails-on-revert proven; canonical-order/isolation/orch-1138 gates green; 0 new type errors. Icons + layout + date-format only — no logic/data/RPC change.

[deploy]