### PR TITLE
META-ORCH-1174 Leg B: multi-tier trip packages (Standard/Premium/VIP) — engine + authoring + public selector [deploy]

### DIFF
--- a/Mingla_Artifacts/specs/SPEC_META-ORCH-1174_LEGB_MULTITIER.md
+++ b/Mingla_Artifacts/specs/SPEC_META-ORCH-1174_LEGB_MULTITIER.md
@@ -240,3 +240,23 @@ Either gate payment-plan reservations to one package per cart (no engine change)
 - Leg A not landed → seam coordination churn (DEC-1174-A). Building on current files means a future promotion re-touches the same code.
 - Trip pages display BASE price today, not all-in — wiring server all-in into §10 is itself net work even before multi-tier (the all-in only enters after Reserve in the cart today).
 - Per-tier capacity authoring breaks the Step-1→Step-4 read-only capacity mirror; capacity ownership moves into Step-4 per package (DEC-1174-D).
+
+---
+## SETH-LOCKED DECISIONS (2026-06-20)
+- **DEC-A:** Build on the SHIPPED Leg-A `TripOfferingBody`/`useTripOfferingState` + `pg_public_trip_by_slug` (they ARE on main; the forensics read a stale anchor). NOT TripPreview.
+- **DEC-B = MULTIPLE packages in one reservation** (Standard×1 + VIP×2), cart sums all lines (event model).
+- **DEC-C:** per-package quantity >1 allowed.
+- **DEC-D:** per-package capacity (each package its own spots/remaining), like event ticket_types.
+- **DEC-E:** soft cap (default 6 packages/trip; confirm in impl).
+- **DEC-F = FULL multi-package installments** — lift the `ticket_lines_mixed_with_installments` engine guard + make per-line installment math work across multiple lines (the real engine work). An installment package CAN sit alongside others in one cart.
+- **DEC-G:** inline add/remove package rows in the wizard pricing step; per-package fields: name, price, description, capacity, optional per-package installment terms.
+- **DEC-H:** edit-published can add/remove/reprice packages, reusing existing refund-gates (tier_delete_with_sales / tier_price_change_with_sales / capacity_below_sold); add an INSERT branch + make the live-edit capacity writer per-tier (drop the LIMIT 1).
+- **DEC-I:** mixed free + paid packages allowed.
+- **DEC-J:** floating bar = "From $X" until a package is selected, then the summed all-in.
+- **ALL-IN:** §10 shows server all-in upfront (wire fetchTierAllInCents/pg_public_event_tier_allin), matching the WYSIWYP all-in policy — today trips show base price.
+
+## PHASING
+- **B1 (engine foundation):** lift the single-tier service rule (tripsService) + the FULL multi-package installment engine (DB guard + per-line installment math in the checkout session/finalize RPCs + ticket-checkout-create edge fn) + confirm per-package capacity/remaining. Money-path; most careful.
+- **B2:** wizard multi-package authoring (add/remove rows + per-package fields incl. installments).
+- **B3:** public §10 multi-option selector (N rows + per-package qty + multi-select) + summed server all-in + cart wiring + floating bar.
+- **B4:** edit-published multi-tier (INSERT branch + per-tier capacity writer).

--- a/Mingla_Artifacts/specs/SPEC_META-ORCH-1174_LEGB_MULTITIER.md
+++ b/Mingla_Artifacts/specs/SPEC_META-ORCH-1174_LEGB_MULTITIER.md
@@ -1,0 +1,242 @@
+# SPEC — META-ORCH-1174 Leg B — Multi-Tier Reservation Packages for Trips
+
+**Status:** DRAFT (forensic spec, awaiting Seth product decisions in §D + Leg A landing)
+**Author:** mingla-forensics
+**Date:** 2026-06-20
+**Anchor:** `/Users/sethogieva/Desktop/mingla-main` (current code)
+**Depends on:** Leg A (public-trip-page standardization into `packages/offering-rendering`) — see §0.
+
+---
+
+## 0. CRITICAL PRECONDITION — Leg A has NOT landed yet
+
+The dispatch references `packages/offering-rendering/TripOfferingBody.tsx` and `useTripOfferingState.ts` as the Leg A seam. **Those files DO NOT EXIST in the current tree.** Leg A (public-trip-page standardization) is still mid-convergence — `COMMS-0041` announced a research/coordination hold to converge on `packages/offering-rendering` (commit `477675023`). The package today contains only shared chrome (`ParallaxCoverShell.tsx`, `OfferingChrome.tsx`, `RsvpMomentumDecision.tsx`, etc.), no `TripOfferingBody`.
+
+The **current** public trip page is:
+- Business-web: `mingla-business/src/components/trip/TripPreview.tsx` (dumb container) + route `mingla-business/app/t/[brandSlug]/[tripSlug].tsx` (owns all state/price) + `mingla-business/src/components/trip/TripReserveBar.tsx` (pure display).
+- Consumer-app: `app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx` + `app-mobile/src/components/offering/ConsumerTripReserveBar.tsx`.
+
+**Sequencing decision (DEC-1174-A, §D):** Leg B targets the CURRENT files and the Leg A team promotes them, OR Leg B waits for Leg A and targets `TripOfferingBody.tsx`. Recommended: **Leg B waits for Leg A to land the §10 vertical-list slot + `useTripOfferingState.selectedTier` seam**, then drops N rows into the already-built slot. This spec describes the seam in current-code terms so it survives the promotion.
+
+---
+
+## A. CURRENT MODEL (file:line)
+
+### A.1 The tiers table — `trip_pricing_tiers` (already N-capable)
+
+`supabase/migrations/20260608000000_orch_0859_trip_sidecar_tables.sql:84-97`
+
+```sql
+CREATE TABLE public.trip_pricing_tiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  ticket_type_id uuid NOT NULL REFERENCES public.ticket_types(id) ON DELETE CASCADE,
+  tier_name text NOT NULL CHECK (length(trim(tier_name)) > 0),
+  tier_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+-- idx_trip_pricing_tiers_event          (non-unique on event_id)        :96
+-- idx_trip_pricing_tiers_event_ticket   UNIQUE(event_id, ticket_type_id) :97
+```
+
+- A "tier" = one `trip_pricing_tiers` row joined 1:1 to one `ticket_types` row (the money/inventory carrier: `price_cents`, `currency`, `quantity_total`, `is_unlimited`, `is_free`).
+- **The unique index is `(event_id, ticket_type_id)` — it explicitly PERMITS N tiers per `event_id`.** There is NO `UNIQUE(event_id)`, no CHECK, no exclusion constraint forcing one tier.
+- `tier_metadata.installments` shape (`mingla-business/src/services/tripsService.ts:105-113`, `TripInstallmentScheduleData`):
+  ```
+  { deposit_pct: number,
+    installments: [ { ordinal, pct, days_after_booking?, fixed_date? }, ... ] }
+  ```
+  Authoring lives ONLY in `tier_metadata.installments` (per-tier). The runtime ledger is a separate `order_installments` table (`supabase/migrations/20260610000000_tr3_installments.sql:31-61`), keyed per-order, not the authoring shape.
+
+### A.2 WHERE the single-tier ("Tr2") rule is enforced — SERVICE + UI ONLY, never DB/RPC
+
+**Definitive answer: the single-tier limit is NOT a DB constraint and NOT a publish-RPC assertion. It is enforced ONLY by the service-layer create/read assumptions and the UI.**
+
+| Layer | Enforces single tier? | Evidence |
+|---|---|---|
+| DB constraint | **NO** — allows N | `20260608000000_orch_0859_trip_sidecar_tables.sql:96-97` (only `UNIQUE(event_id, ticket_type_id)`) |
+| Publish RPC `business_publish_trip_draft` | **NO** — asserts `>= 1` | `20260725000000_orch_0950_trip_capacity_single_source.sql:739-743` raises `trip_pricing_tier_required` only when `count = 0` |
+| Read hook `usePublicTripBySlug` | **NO** — returns ARRAY | `mingla-business/src/hooks/usePublicTripBySlug.ts:225` (`select("*")` all tiers), `:358-392` (maps all). But `:418` `isPaid` inspects only `pricingTiers[0]`. |
+| List RPC `pg_published_trips_public` | **NO** — aggregates N | `20260803000001_orch_1016_pg_published_trips_public.sql:100-128` (`SUM(quantity_total)`, `MIN(price)`) |
+| Service `createTripDraft` | de-facto (writes exactly 1) | `tripsService.ts:633-665` (one `ticket_types` + one `trip_pricing_tiers` insert, no loop) |
+| Service `updateTripPricing` | **runtime choke point** — `.maybeSingle()` throws on >1 | `tripsService.ts:1038-1048` |
+| Migration data-probe (ORCH-0950) | one-shot pre-migration check `<> 1`, NOT persistent | `20260725000000_...:739-743` for new; `...000002:18-49` for existing |
+| Wizard UI | hard single — no add/remove tier affordance | `TripCreatorStep4Pricing.tsx:42-74` (`Step4Draft` single), `:147` ("Single full-price tier") |
+| Capacity writer (live edit) | single-tier — `LIMIT 1` | `20260725000000_...:233-239` (capacity→`quantity_total` joins tiers `LIMIT 1`) |
+
+**Bottom line: there is NO DB or RPC barrier to multiple tiers.** The blockers are purely authoring-layer (wizard UI, `createTripDraft`, `updateTripPricing` `.maybeSingle()`, `pricingTiers[0]` consumers) plus the public selector + the live-edit capacity `LIMIT 1` writer.
+
+### A.3 The checkout engine ALREADY supports N tiers + per-tier qty — EVENTS PROVE IT ✅✅✅
+
+**THIS IS THE SINGLE BIGGEST SCOPE DETERMINANT. The reserve/cart/checkout engine is natively multi-line, end to end, because standard EVENTS already do multi-tier checkout through the identical path. Trips ride the same engine.**
+
+| Layer | Multi-tier today? | Proof |
+|---|---|---|
+| Cart sheet UI | **YES** | `app-mobile/src/components/expandedCard/TicketCartSheet.tsx:581-609` (maps `visibleTickets` → one `QuantityRow` stepper per tier), `:307-322` (Σ base + Σ all-in across lines) |
+| Cart model | **YES** | `app-mobile/src/hooks/useTicketCart.ts:54-79` (`CartLine[]` reducer, independent per-`ticketTypeId` lines), `:88-92` (Σ totals) |
+| Outbound payload | **YES** (array) | `TicketCartSheet.tsx:156-157` (`lines: Array<{ticketTypeId, quantity}>`), `:429-436` (emits all lines qty>0) |
+| Edge fn `ticket-checkout-create` | **YES** (array) | `supabase/functions/ticket-checkout-create/index.ts:52` (`CheckoutLine`), `:227-229` (parses `body.lines[]`), `:489-504` (`p_lines: lines`) |
+| Session RPC `biz_ticket_checkout_create_session` | **YES** (loops lines) | `20260610000002_tr3_ticket_checkout_session_installment_aware.sql:186-260` (`FOR v_line IN jsonb_array_elements(p_lines) LOOP`, per-line capacity + currency checks) |
+| Finalize RPC | **YES** (per-line) | same migration `:638-679` (per-line `order_line_items` + per-quantity ticket minting) |
+| Per-tier remaining-capacity RPC `pg_public_ticket_types_remaining` | **YES — already per-tier** | `20260724000006_orch_0946_public_ticket_types_remaining.sql:19-49` (`RETURNS TABLE(ticket_type_id, sold, remaining)`, one row per ticket_type) |
+| **Installments** | **SINGLE-LINE ONLY** ⚠️ | `20260610000002_...:276-278` (`IF v_line_count > 1 THEN RAISE EXCEPTION 'ticket_lines_mixed_with_installments'`) |
+
+**Events, trips, and experiences are the IDENTICAL engine path** — all three mount the same `TicketCartSheet` and call the same `useNativeCheckoutFlow()` → `runNativeCheckout({ lines })`:
+- Events: `ExpandedBusinessEventSheet.tsx:275` (hook), `:313-345` (`handleBuy` forwards `payload.lines`), `:664` (cart mount).
+- Trips: `ConsumerTripDetailScreen.tsx:325` (same hook), `:529` (same call), `:1505` (same cart). ORCH-1138 comments at `:116`,`:459-460` confirm "Reserve opens the cart DIRECTLY" and "single-tier trips just use tiers[0]" — trips are **artificially seeded to one tier**, not engine-limited.
+
+**The ONLY engine-level restriction is the installments single-line guard** (`ticket_lines_mixed_with_installments`). A multi-package trip whose tiers carry payment plans cannot mix tiers in one cart today. See §B.6.
+
+### A.4 Authoring (wizard + edit-published) — single-package, but edit is already clobber-safe
+
+**Wizard** `mingla-business/src/components/trip/TripCreatorStep4Pricing.tsx`:
+- Authors exactly ONE tier. `Step4Draft` state (`:42-74`): `tierName`, `priceMajor`, `currency` (read-only mirror), `capacity` (read-only mirror from Step 1), `paymentPlan` (`TripInstallmentSchedule | null`), `pricingSwitches` (pass/absorb tax/fee/service). Zero notion of multiple packages. Header: "Single full-price tier in this milestone." (`:147`).
+- Price field becomes read-only when sold (`:112` `priceLocked = editMode.soldCountForTier > 0`, `:167-170`).
+
+**Service** `mingla-business/src/services/tripsService.ts`:
+- `createTripDraft` (`:633-665`) — one `ticket_types` insert ("Standard", price 0, qty 1) + one `trip_pricing_tiers` insert.
+- `updateTripPricing` (`:1015-1105`) — `.maybeSingle()` (`:1038-1042`, **throws on >1 rows**), updates that one row's `ticket_types` (price/currency/qty, `:1051-1063`) + `trip_pricing_tiers` (tier_name + `tier_metadata.installments`, `:1090-1095`; null strips the installments key → single-payment).
+- `mapTrip` capacity read is first-tier-only (`:492` `ticketTypes[0]`).
+
+**Edit-published** `mingla-business/src/components/trip/EditPublishedTripScreen.tsx`:
+- Routes through `buildLiveTripPatch` (`:305-562`) → `biz_update_live_trip` RPC; never direct table writes (audit invariant `:37-39`).
+- Builds a **single-element** `pricing_tiers` patch keyed on `firstTier.ticketTypeId` (`:458-489`, comment "single-tier model"), emitting only changed sub-fields.
+- **NO clobber: pricing path is pure UPDATE-in-place** (unlike `upsertTripDays`/`upsertTripInclusions` which DELETE-then-INSERT, `tripsService.ts:945-1010`).
+
+**`biz_update_live_trip` RPC** (current authoritative = `20260929000000_orch_1120_trip_settings_refund_deadline.sql`):
+- §5d apply loop `:636-653` — `FOR each patch tier → UPDATE trip_pricing_tiers ... ; UPDATE ticket_types SET price_cents ...`. **No INSERT branch, no DELETE.** Sold tickets (FK to `ticket_types.id`) are never orphaned.
+- §4e refund-gate `:386-401` (orig `20260616000000_orch_0876_trip_published_edit.sql:317-352`):
+  - `tier_delete_with_sales` (`:392`) — a tier absent from the patch WITH sales → **reject**. (The removal-guard already exists — this is the ORCH-1172 no-clobber protection, pre-wired for trips.)
+  - `tier_price_change_with_sales` (`:401`) — price change on a sold tier → **reject**.
+- §4a capacity writer `:233-256` (ORCH-0950) — capacity → `ticket_types.quantity_total`, but the tier lookup is `LIMIT 1` (single-tier assumption). Guard `capacity_below_sold` (`:220`) rejects dropping below sold.
+
+### A.5 Per-package capacity
+
+Today: trip capacity is a single number stored canonically in `ticket_types.quantity_total` of the sole tier (ORCH-0950 single-source, `20260725000000_...` header + backfill `:83-96`, strips legacy `theme.business_trip.capacity` `:99-110`). Remaining is computed per-tier already by `pg_public_ticket_types_remaining` (§A.3). Events already model per-ticket-type capacity via each type's own `quantity_total` — **trips reuse the exact same column.** So per-package capacity is a natural extension: each tier's `ticket_types.quantity_total` is its own cap.
+
+---
+
+## B. THE GAP — exactly what must change to support multi-package
+
+The DB schema, checkout engine, per-tier remaining RPC, and edit-RPC refund-gates ALREADY support N tiers. The gap is concentrated in **authoring + the public selector**, plus two single-tier choke points in the live-edit RPC and one engine guard for installments.
+
+### B.1 Lift the single-tier rule (service-layer + UI only — no DB change)
+- `createTripDraft` (`tripsService.ts:633-665`): allow seeding 1..N tiers (or seed 1 and let edit add more).
+- `updateTripPricing` (`tripsService.ts:1038-1048`): replace `.maybeSingle()`-throws-on->1 with a per-tier upsert/insert/soft-remove loop keyed on `ticketTypeId`.
+- `mapTrip` capacity (`:492`) + all `pricingTiers[0]`/`ticketTypes[0]` consumers (`usePublicTripBySlug.ts:418` `isPaid`; `EditPublishedTripScreen.tsx:222,463`): make tier-aware.
+- **No migration required for the limit itself** — the DB already permits N.
+
+### B.2 Wizard multi-package authoring
+- `TripCreatorStep4Pricing.tsx` (whole component): replace single `Step4Draft` with a tier array + add/remove/reorder rows; per-row name, price, capacity (now per-tier, NOT a read-only Step-1 mirror), optional per-tier description, optional per-tier payment plan. `editMode.soldCountForTier` (`:89-91`) → per-tier `soldCountByTier`.
+- Decide: per-package capacity authored here vs. shared trip capacity allocated (DEC-1174-D).
+
+### B.3 Public §10 multi-option selector + qty + live summed all-in
+The §10 "Choose how you pay" box is single-tier by construction on BOTH surfaces. **No `selectedTier` state exists today** — selection + qty is net-new. Both reserve bars are PURE display of `cta.price` — so summing is a route-level change, the bars need no change.
+
+- **Business-web seam:** §10 slot is `paymentBlock` (built `app/t/[brandSlug]/[tripSlug].tsx:449-458`, slotted into the "Choose how you pay" section `TripPreview.tsx:662-670`). Render N selectable tier rows + per-tier `QuantityRow` here. Bar price: replace `barPrice` derivation (`[tripSlug].tsx:319-325`, currently `From {base}`) with the summed all-in. `formatTripPrice` (`:585-595`) explicitly "never recomputes fees" — **trip pages display BASE price today, not all-in** (the all-in only enters AFTER Reserve, inside `TicketCartSheet`). Wiring all-in is part of Leg B even for the single-tier case.
+- **Consumer-app seam:** §10 block `ConsumerTripDetailScreen.tsx:1035-1228` (title `:1064`). Today gated on single `planTier` (`:452-455`). Bar price `barPriceLabel` (`:1242-1249`) is `From {detail.minPriceCents}` (base, min). `detail.tiers[].priceAllInGbp` is already populated per-tier by `publicEventTicketsService.ts:84-120` → sum it.
+- **Reuse, don't rebuild, the sum math:** `TicketCartSheet.tsx:301-330` + `useTicketCart.ts:88-102` already compute Σ(per-tier all-in × qty). Leg B lifts that pattern into §10; the cart stays as the post-Reserve confirmation step.
+
+### B.4 Per-package capacity / remaining
+- Per-tier remaining already returned by `pg_public_ticket_types_remaining` (`20260724000006_...:19-49`). The public hook already surfaces `ticketsRemaining` per tier (`usePublicTripBySlug.ts:385-387`). Render per-row "X spots left" / sold-out from these.
+- **Live-edit capacity writer must change:** `biz_update_live_trip` §4a `LIMIT 1` (`20260725000000_...:233-239`) → per-tier `quantity_total` write. Keep `capacity_below_sold` guard per-tier.
+
+### B.5 Edit-published no-clobber (ORCH-1172 lessons)
+- Pricing edit is already UPDATE-in-place (no clobber) and the refund-gates `tier_delete_with_sales` + `tier_price_change_with_sales` already protect sold inventory. **What's missing for multi-tier:**
+  1. An **INSERT branch** in §5d apply loop (`20260929000000_...:636-653`) for genuinely-new tiers in the patch (today only UPDATE).
+  2. Client `buildLiveTripPatch` (`EditPublishedTripScreen.tsx:458-489`) must emit a multi-element `pricing_tiers` array, not single.
+  3. The §4e `tier_delete_with_sales` removal-guard already fires correctly once the client can omit a tier — no RPC change there, but verify it triggers on omission of a sold tier.
+- Soft-delete vs hard-delete of a tier with NO sales: prefer soft (a `deleted_at` on `trip_pricing_tiers` / the tier's `ticket_types`, mirroring `ticket_types.deleted_at` already used by the remaining RPC `WHERE tt.deleted_at IS NULL`) to keep historical orders coherent.
+
+### B.6 Cart/checkout — REUSES the events multi-tier engine (confirmed) — ONE exception
+- N-tier trip checkout works through the existing engine UNCHANGED for pay-in-full: stop force-seeding `tiers[0]` (`ConsumerTripDetailScreen.tsx:463-472` `openCart`/`openCartWithChoice`), seed the cart with the user's selected lines instead.
+- **The ONE engine change:** installments. `ticket_lines_mixed_with_installments` (`20260610000002_...:276-278`) hard-rejects a multi-line cart when any line maps to a tier with installments. For multi-package trips where a package offers a payment plan, EITHER (a) restrict payment-plan reservations to ONE package per cart (no engine change — just UX gating), OR (b) revisit the guard to allow per-line installment schedules (larger engine change, currency/schedule pinning complexity). **DEC-1174-F.**
+
+---
+
+## C. PROPOSED DESIGN (phased)
+
+### Phase 0 — Leg A landing + seam confirmation (blocking)
+Confirm Leg A's `TripOfferingBody.tsx` exposes `useTripOfferingState.selectedTier` + a §10 vertical-list slot rendering the sole tier. Leg B drops N rows + per-tier qty into that slot. If Leg A is not landing soon, Leg B targets the current `TripPreview.tsx` / `[tripSlug].tsx` / `ConsumerTripDetailScreen.tsx` directly and coordinates the promotion (DEC-1174-A).
+
+### Phase 1 — Data + authoring (business-app)
+1. `TripCreatorStep4Pricing.tsx`: tier-array UI (add/remove/reorder rows; per-row name, price, capacity, optional description, optional plan). Per-tier `soldCountByTier`.
+2. `tripsService.createTripDraft` + `updateTripPricing`: per-tier upsert loop (drop `.maybeSingle()` throw).
+3. `mapTrip` + edit-screen + `isPaid` consumers: tier-aware (no `[0]`).
+4. `biz_update_live_trip` RPC migration: add INSERT branch (§5d) + per-tier capacity writer (§4a, kill `LIMIT 1`); keep refund-gates. Apply via Management API (CLI drift-wedged per memory).
+5. Publish RPC `business_publish_trip_draft`: verify it validates an N-tier draft (it asserts `>= 1` today — fine; add max-tier cap if DEC-1174-E sets one).
+
+### Phase 2 — Public selector + summed all-in (ALL surfaces — mandatory parity)
+1. Business-web: §10 paymentBlock renders N tier rows + per-tier qty (`QuantityRow`), per-tier remaining badges; route computes Σ(all-in × qty) via `fetchTierAllInCents` (`publicEventsService.ts:840`) and feeds `barPrice`.
+2. Consumer-app: §10 block (`ConsumerTripDetailScreen.tsx:1035-1228`) renders the same; sum `detail.tiers[].priceAllInGbp`; feed `barPriceLabel`. Stop seeding `tiers[0]` — seed cart with selected lines.
+3. Buyer-web public page (deploys from main, NOT OTA — memory): same §10.
+4. Reserve bars unchanged (pure display).
+
+### Phase 3 — Installments policy for multi-package (DEC-1174-F)
+Either gate payment-plan reservations to one package per cart (no engine change) or extend the engine for per-line schedules.
+
+---
+
+## D. PRODUCT DECISIONS FOR SETH (enumerated — crisp)
+
+1. **DEC-1174-A — Sequencing vs Leg A.** Does Leg B WAIT for Leg A's `TripOfferingBody`/`useTripOfferingState` seam to land, then drop N rows in? Or proceed on current `TripPreview.tsx`/`ConsumerTripDetailScreen.tsx` and let Leg A promote? (Recommend: wait, to avoid double-promotion churn.)
+
+2. **DEC-1174-B — Multiple packages in one reservation, or ONE package only?** Can a buyer add Standard ×1 + VIP ×2 in a single cart (true multi-line, exactly like event tickets)? Or is a trip reservation locked to ONE package (qty N of the same package)? (Engine already supports multi-line; the question is product intent. Multi-line is "free" except for the installments interaction in DEC-1174-F.)
+
+3. **DEC-1174-C — Per-package quantity?** Within one package, can a buyer reserve qty > 1 (e.g. 3 VIP spots in one go), or strictly 1-per-reservation? (Events allow qty steppers; trips currently single-spot semantics.)
+
+4. **DEC-1174-D — Per-package capacity vs shared trip capacity.** Does each package get its OWN capacity/spots (Standard: 20, VIP: 5)? Or is there ONE trip capacity (25) drawn down across packages (sell-through)? (Per-package is the natural fit — each tier's `ticket_types.quantity_total`. Shared-pool needs a new allocation model + cross-tier remaining math.)
+
+5. **DEC-1174-E — Max packages per trip?** Hard cap (e.g. 3 = Standard/Premium/VIP, or up to N)? Affects wizard UI density + publish validation.
+
+6. **DEC-1174-F — Installments: per-package or trip-wide, and the mixed-cart rule.** Can each package carry its OWN payment plan, or is the plan trip-wide? AND: if a buyer selects a payment-plan package, may they ALSO add other packages in the same cart? (Engine today hard-rejects `ticket_lines_mixed_with_installments`. Simplest: payment-plan reservations are single-package. Richer: per-line schedules = real engine work.)
+
+7. **DEC-1174-G — Authoring UX: inline add-row vs separate screen?** In the wizard, are packages an inline add/remove list inside Step-4 pricing, or a dedicated "Packages" sub-screen? Per-package fields to expose: name, price, capacity, description, optional plan — confirm the set.
+
+8. **DEC-1174-H — Edit-published tier add/remove policy.** After publish: may a brand ADD a new package to a live trip? REMOVE one (only if it has no sales — already enforced by `tier_delete_with_sales`)? Change a sold package's price (blocked by `tier_price_change_with_sales` — confirm we keep that)? Soft-delete vs hard-delete for a no-sales tier.
+
+9. **DEC-1174-I — Mixed free + paid packages?** May a trip offer a free package alongside paid ones? (`isPaid` currently reads `pricingTiers[0]` only — needs per-tier logic; the cart/checkout already handles free vs paid per line.)
+
+10. **DEC-1174-J — Display semantics.** With N packages, what does the floating bar show when nothing is selected — "From $X" (min all-in)? And once selected — the summed all-in? Confirm the empty-state and selected-state copy.
+
+---
+
+## E. GUARDS + INVARIANTS
+
+- **I-PROPOSED-1174-NO-DB-SINGLE-TIER** — the limit was never a DB constraint; do NOT add one. Multi-tier is a service/UI lift.
+- **I-PROPOSED-1174-EDIT-NO-CLOBBER** — pricing edit stays UPDATE-in-place + INSERT-for-new; NEVER DELETE-then-reinsert a sold tier. Keep `tier_delete_with_sales` + `tier_price_change_with_sales` + `capacity_below_sold` refund-gates ACTIVE. (Strict-grep gate: no DELETE on `trip_pricing_tiers`/tier `ticket_types` with sales in the live-edit path.)
+- **I-PROPOSED-1174-CAPACITY-PER-TIER** — kill the `LIMIT 1` capacity writer (`20260725000000_...:233-239`); each tier's capacity = its own `ticket_types.quantity_total`. Remaining sourced from `pg_public_ticket_types_remaining` per tier — never recomputed in TS.
+- **I-PROPOSED-1174-ALLIN-SERVER-SOURCED** — summed all-in = Σ(server `pg_public_event_tier_allin` per tier × qty); ZERO fee math in TS (extends ORCH-1147 invariant). The cart's existing Σ at `TicketCartSheet.tsx:301-330` is the reference.
+- **I-PROPOSED-1174-SHARED-ENGINE** — trip multi-tier checkout reuses the events `lines[]` engine unchanged; no trip-specific checkout fork.
+- **I-PROPOSED-1174-INSTALLMENT-CART-RULE** — until DEC-1174-F resolves richer plans, keep `ticket_lines_mixed_with_installments` and gate payment-plan reservations to single-package in the UI (don't let the user assemble an illegal cart).
+- **PARITY (non-negotiable, per memory):** business iOS/Android + consumer app + buyer-web all match. Buyer-web deploys from main (NOT OTA-able); push an empty `[deploy]` commit to avoid the Vercel gate-cancel trap.
+
+---
+
+## F. TEST + ROLLOUT STRATEGY
+
+**Tests:**
+- DB/RPC: N-tier draft → publish succeeds; `updateTripPricing` writes/updates N tiers; `biz_update_live_trip` adds a new tier (INSERT branch) without touching sold tiers; per-tier capacity write; refund-gates still reject `tier_delete_with_sales`/`tier_price_change_with_sales`/`capacity_below_sold`. (Mirror the existing `__tests__/orch_0950_trip_capacity_canonical.test.ts` + `orch_1016_pg_published_trips_public.test.ts`.)
+- Engine: multi-line trip cart sums correctly; checkout creates per-line order items + tickets (already covered for events — add a trip-specific N-tier fixture). Installment + multi-line → still rejected (`ticket_lines_mixed_with_installments`).
+- Public selector: per-tier qty → summed all-in matches server; sold-out tier disabled; floating bar reflects sum on all surfaces.
+- **Synthetic pass-fee fixture required** (per memory ORCH-1147 gotcha): 0/8 charges-enabled brands pass any fee → all-in tests on prod data prove nothing. Build a fixture brand that passes a fee so the summed all-in is provably > base.
+- Edit-published clobber test: add tier → existing sold tier untouched; remove no-sales tier → ok; attempt remove sold tier → rejected.
+
+**Rollout:**
+1. Phase 1 (data+authoring) — business-app OTA (pure-JS where possible; native build only if needed).
+2. RPC migration via Management API (CLI drift-wedged; `$function$;` before GRANT, DROP before widening RETURNS TABLE per migration-baseline CI). Deploy edge fns (if `ticket-checkout-create` touched for installments) from MERGED main, not worktree.
+3. Phase 2 (public selector) — business+consumer OTA + buyer-web `[deploy]` from main.
+4. Device-prove on iOS + Android (sim + physical) — multi-package select → reserve → cart → PaymentSheet → ticket minted per tier. (Note from memory: 0 trip reservations completed e2e on-device yet — this needs the real card tap.)
+
+---
+
+## G. RISK / BIGGEST UNKNOWN
+
+**Biggest scope determinant (RESOLVED, favorable):** the checkout engine ALREADY does N tiers + per-tier qty in one reservation — events prove it in production (`TicketCartSheet` + `lines[]` payload + `FOR v_line LOOP` session/finalize RPCs). This collapses Leg B from "build a multi-tier checkout" to "lift the single-tier authoring rule + build the public selector + wire summed all-in." **Confirmed YES.**
+
+**Biggest remaining UNKNOWN — installments × multi-package (DEC-1174-F).** The `ticket_lines_mixed_with_installments` guard is the ONLY real engine-level barrier. If Seth wants per-package payment plans AND multi-package carts simultaneously, that requires reworking the installment session math to support per-line schedules (currency/schedule pinning, deposit aggregation, `order_installments` per-line) — genuinely larger than the rest of Leg B combined. The cheap path (gate plans to single-package reservations) sidesteps all of it. Recommend defaulting to the cheap path unless Seth explicitly needs mixed plan carts.
+
+**Secondary risks:**
+- Leg A not landed → seam coordination churn (DEC-1174-A). Building on current files means a future promotion re-touches the same code.
+- Trip pages display BASE price today, not all-in — wiring server all-in into §10 is itself net work even before multi-tier (the all-in only enters after Reserve in the cart today).
+- Per-tier capacity authoring breaks the Step-1→Step-4 read-only capacity mirror; capacity ownership moves into Step-4 per package (DEC-1174-D).

--- a/app-mobile/src/hooks/useConsumerTripOfferingData.ts
+++ b/app-mobile/src/hooks/useConsumerTripOfferingData.ts
@@ -36,8 +36,20 @@ function toRefundPolicyShape(
   return { kind: policy.kind, tiers: policy.tiers };
 }
 
+/**
+ * META-ORCH-1174 Leg B3 — optional per-tier enrichment from usePublicEventTickets
+ * (the SAME source the cart uses): the SERVER all-in (cents) the §10 box DISPLAYS +
+ * SUMS (WYSIWYP), plus the per-package description the consumer RPC doesn't carry.
+ * Keyed by ticket_type_id. Absent → the body falls back to base price + no desc.
+ */
+export interface ConsumerTripTierEnrichment {
+  allInCents: number | null;
+  description: string | null;
+}
+
 export function buildConsumerTripOfferingData(
   detail: ConsumerTripDetail,
+  enrichmentByTier?: Map<string, ConsumerTripTierEnrichment> | null,
 ): TripOfferingData {
   const duration = deriveTripDuration(detail.startAt, detail.endAt);
   const isSoldOut = detail.spotsLeft !== null && detail.spotsLeft <= 0;
@@ -86,20 +98,28 @@ export function buildConsumerTripOfferingData(
       item: i.item,
     })),
     refundPolicy: toRefundPolicyShape(detail.refundPolicy),
-    tiers: detail.tiers.map((t) => ({
-      id: t.ticketTypeId,
-      ticketTypeId: t.ticketTypeId,
-      tierName: t.tierName,
-      priceCents: t.priceCents,
-      currency: t.currency,
-      isFree: t.isFree,
-      isUnlimited: t.isUnlimited,
-      // META-ORCH-1174 Leg A.2 — real per-tier remaining from the canonical RPC
-      // (null when unlimited; no fabricated sold-out — rule 9). Previously always
-      // null on consumer; now parity with web/business.
-      ticketsRemaining: t.isUnlimited ? null : t.ticketsRemaining,
-      installmentSchedule: t.installmentSchedule,
-    })),
+    tiers: detail.tiers.map((t) => {
+      const enrich = enrichmentByTier?.get(t.ticketTypeId);
+      return {
+        id: t.ticketTypeId,
+        ticketTypeId: t.ticketTypeId,
+        tierName: t.tierName,
+        priceCents: t.priceCents,
+        // META-ORCH-1174 Leg B3 — server all-in (WYSIWYP) from the same tickets
+        // source the cart uses. Free → null ("Free"); miss → null → base fallback.
+        priceAllInCents:
+          t.isFree || t.priceCents === 0 ? null : (enrich?.allInCents ?? null),
+        description: enrich?.description ?? null,
+        currency: t.currency,
+        isFree: t.isFree,
+        isUnlimited: t.isUnlimited,
+        // META-ORCH-1174 Leg A.2 — real per-tier remaining from the canonical RPC
+        // (null when unlimited; no fabricated sold-out — rule 9). Previously always
+        // null on consumer; now parity with web/business.
+        ticketsRemaining: t.isUnlimited ? null : t.ticketsRemaining,
+        installmentSchedule: t.installmentSchedule,
+      };
+    }),
     currency: detail.currency ?? "USD",
     // META-ORCH-1174 Leg A.2 — destination coords now arrive via the RPC, so the
     // §11 "Where you'll be" map renders on consumer (rule 9 — both must be finite).

--- a/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
+++ b/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
@@ -81,6 +81,7 @@ import {
   useTripOfferingState,
   type TripOfferingData,
   type TripPaymentPlanChoice,
+  type TripReserveLine,
 } from "@mingla/offering-rendering";
 // ORCH-1138 Leg 1C — the shared Direction-A foundation primitives. The consumer
 // trip detail converges on the business/web trip page (TripPreview FOUNDATION
@@ -141,6 +142,7 @@ import { useConsumerThemeFont } from "../../theme/useConsumerThemeFont";
 import {
   buildConsumerTripOfferingBrand,
   buildConsumerTripOfferingData,
+  type ConsumerTripTierEnrichment,
 } from "../../hooks/useConsumerTripOfferingData";
 import type { DiscoverTripRow } from "../../services/tripsDiscoveryService";
 import type { BusinessEventCard } from "../../types/mergedDiscover";
@@ -287,6 +289,35 @@ export default function ConsumerTripDetailScreen({
   // server receives an EXPLICIT choice for plan trips (DISC-1130-A consent fix).
   const [paymentPlanChoice, setPaymentPlanChoice] =
     useState<"full" | "installments">("full");
+  // META-ORCH-1174 Leg B3 — the per-package selection (DEC-B/C) + per-package plan
+  // choice (DEC-F). The §10 multi-package box steppers write through these; the
+  // shared state derives the summed all-in / due-today / selected lines. Reserve
+  // seeds the cart with the selected lines via initialQuantities (the cart is still
+  // the confirmation step — never auto-charges).
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [planChoiceByTier, setPlanChoiceByTier] = useState<
+    Record<string, "full" | "installments">
+  >({});
+  const [seededQuantities, setSeededQuantities] = useState<
+    Record<string, number> | undefined
+  >(undefined);
+  const handleChangeQuantity = useCallback(
+    (ticketTypeId: string, qty: number): void => {
+      setQuantities((prev) => {
+        const next = { ...prev };
+        if (qty <= 0) delete next[ticketTypeId];
+        else next[ticketTypeId] = qty;
+        return next;
+      });
+    },
+    [],
+  );
+  const handleChangePlanChoice = useCallback(
+    (ticketTypeId: string, value: "full" | "installments"): void => {
+      setPlanChoiceByTier((prev) => ({ ...prev, [ticketTypeId]: value }));
+    },
+    [],
+  );
   // META-ORCH-1174 — the OS reduce-motion preference, threaded into the shared
   // TripOfferingBody (it owns the About collapse animation + the countdown pill).
   const [reduceMotion, setReduceMotion] = useState<boolean>(false);
@@ -420,15 +451,53 @@ export default function ConsumerTripDetailScreen({
   // loading/error/not-found early returns). The §10 box + the docked/floating bar
   // all read this state → never diverge. Reserve opens the cart DIRECTLY (the
   // gate-protected straight-to-cart flow, ORCH-1138).
+  // META-ORCH-1174 Leg B3 — the per-tier server all-in + description from the SAME
+  // tickets source the cart uses (usePublicEventTickets). The §10 box DISPLAYS +
+  // SUMS this all-in (WYSIWYP); the description rounds out each package row.
+  const tierEnrichment = useMemo<
+    Map<string, ConsumerTripTierEnrichment>
+  >(() => {
+    const map = new Map<string, ConsumerTripTierEnrichment>();
+    for (const t of ticketsQuery.data ?? []) {
+      map.set(t.id, {
+        allInCents:
+          typeof t.priceAllInGbp === "number"
+            ? Math.round(t.priceAllInGbp * 100)
+            : null,
+        description: t.description ?? null,
+      });
+    }
+    return map;
+  }, [ticketsQuery.data]);
+
   const offeringData = useMemo<TripOfferingData>(
     () =>
       detail !== null
-        ? buildConsumerTripOfferingData(detail)
+        ? buildConsumerTripOfferingData(detail, tierEnrichment)
         : EMPTY_TRIP_OFFERING_DATA,
-    [detail],
+    [detail, tierEnrichment],
   );
+  // META-ORCH-1174 Leg B3 — Reserve opens the cart DIRECTLY, seeded with the
+  // SELECTED LINES (DEC-B). `lines` carries the §10 multi-package selection; we
+  // stash it as initialQuantities so the cart lands pre-populated + editable (the
+  // confirmation step, never auto-charged). Empty selection → open un-seeded (the
+  // cart's own steppers let the buyer pick — never a dead tap). The split-button
+  // `choice` fast path is preserved for a single-package plan trip.
   const onReserveFromBody = useCallback(
-    (choice?: TripPaymentPlanChoice): void => {
+    (choice?: TripPaymentPlanChoice, lines?: TripReserveLine[]): void => {
+      if (lines !== undefined && lines.length > 0) {
+        const seed: Record<string, number> = {};
+        for (const l of lines) seed[l.ticketTypeId] = l.quantity;
+        setSeededQuantities(seed);
+        // If any selected line pays over time, lead the cart with the deposit.
+        const anyInstallments = lines.some(
+          (l) => l.paymentPlanChoice === "installments",
+        );
+        setPaymentPlanChoice(anyInstallments ? "installments" : "full");
+        openCart();
+        return;
+      }
+      setSeededQuantities(undefined);
       if (choice !== undefined) openCartWithChoice(choice);
       else openCart();
     },
@@ -437,6 +506,8 @@ export default function ConsumerTripDetailScreen({
   const offeringState = useTripOfferingState({
     data: offeringData,
     paymentPlanChoice,
+    quantities,
+    planChoiceByTier,
     onReserve: onReserveFromBody,
   });
 
@@ -559,6 +630,9 @@ export default function ConsumerTripDetailScreen({
   const handleCartCancel = useCallback((): void => {
     setCartVisible(false);
     setInitialTicketTypeId(null);
+    // META-ORCH-1174 Leg B3 — clear the multi-package seed so a later single-tier
+    // Reserve doesn't re-seed the prior multi-selection.
+    setSeededQuantities(undefined);
   }, []);
 
   // Floating close/share chrome — preserved from the prior overlay, now layered
@@ -782,6 +856,10 @@ export default function ConsumerTripDetailScreen({
               variant="phone"
               paymentPlanChoice={paymentPlanChoice}
               onPaymentPlanChoiceChange={setPaymentPlanChoice}
+              quantities={quantities}
+              onChangeQuantity={handleChangeQuantity}
+              planChoiceByTier={planChoiceByTier}
+              onChangePlanChoice={handleChangePlanChoice}
               dockedReserve={dockedReserve}
               reduceMotion={reduceMotion}
               testID="meta-orch-1174-consumer-trip-body"
@@ -829,6 +907,11 @@ export default function ConsumerTripDetailScreen({
         intakeSchemasByTier={intakeSchemasQuery.data}
         fallbackCurrency={detail.currency ?? "USD"}
         initialTicketTypeId={initialTicketTypeId}
+        // META-ORCH-1174 Leg B3 — when Reserve fired with a multi-package selection,
+        // seed the cart with ALL selected lines (takes precedence over the single
+        // initialTicketTypeId). The cart lands pre-populated + editable (the
+        // confirmation step). Empty/undefined → single-tier seed (Leg-A behavior).
+        initialQuantities={seededQuantities}
         buyerName={
           profile?.display_name?.trim() || user?.email?.split("@")[0] || "Guest"
         }

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -124,13 +124,51 @@ const formatTripDateLine = (
 export default function CheckoutTripTicketsScreen(): React.ReactElement {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const params = useLocalSearchParams<{ tripEventId: string; plan?: string }>();
+  const params = useLocalSearchParams<{
+    tripEventId: string;
+    plan?: string;
+    lines?: string;
+  }>();
   const tripEventId =
     typeof params.tripEventId === "string" ? params.tripEventId : null;
   // ORCH-1130 — the public-page pay-full vs pay-over-time choice arrives as a
   // route param. Seed CartContext from it once on mount (default "full").
   const planParam: TripPaymentPlanChoice =
     params.plan === "installments" ? "installments" : "full";
+
+  // META-ORCH-1174 Leg B3 — the §10 multi-package SELECTION arrives as a JSON
+  // `lines` param `[{ticketTypeId, quantity, paymentPlanChoice?}]` (DEC-B). When
+  // present we seed the cart with ALL selected packages (skipping tier-select),
+  // mirroring ORCH-1138 "Reserve opens the cart directly". Parsed once (stable
+  // string); malformed → empty (the auto-skip / tier-select path takes over).
+  const seededLinesParam = React.useMemo<
+    Array<{ ticketTypeId: string; quantity: number }>
+  >(() => {
+    if (typeof params.lines !== "string" || params.lines.length === 0) return [];
+    try {
+      const parsed: unknown = JSON.parse(params.lines);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.flatMap((row) => {
+        if (
+          row !== null &&
+          typeof row === "object" &&
+          typeof (row as { ticketTypeId?: unknown }).ticketTypeId === "string" &&
+          typeof (row as { quantity?: unknown }).quantity === "number" &&
+          (row as { quantity: number }).quantity > 0
+        ) {
+          return [
+            {
+              ticketTypeId: (row as { ticketTypeId: string }).ticketTypeId,
+              quantity: Math.floor((row as { quantity: number }).quantity),
+            },
+          ];
+        }
+        return [];
+      });
+    } catch {
+      return [];
+    }
+  }, [params.lines]);
 
   const publicTripQuery = usePublicTripById(tripEventId);
   const trip = publicTripQuery.data?.trip ?? null;
@@ -242,9 +280,68 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
   // on the commit where `lines` actually contains the sole tier (qty>=1), never
   // in the same body as the dispatch. This removes the empty-cart window the
   // pre-existing buyer.tsx guard ping-ponged against.
+  // META-ORCH-1174 Leg B3 — seed the cart with the public-page MULTI-PACKAGE
+  // selection (DEC-B), then advance to /buyer. Takes precedence over the single-
+  // tier auto-skip below (which is gated off when seeded lines are present). Same
+  // two-phase pattern as the auto-skip: dispatch the cart writes, and navigate only
+  // on a later commit once the cart actually holds them (no ping-pong with the
+  // /buyer empty-cart guard). Latched so it fires once per mount.
+  const multiSeedNavigatedRef = useRef(false);
+  useEffect(() => {
+    if (tripEventId === null || trip === null) return;
+    if (seededLinesParam.length === 0) return;
+    if (multiSeedNavigatedRef.current) return;
+    // Resolve each requested line against the trip's real tiers (drop unknown ids,
+    // clamp to remaining/unlimited). The cart already enforces capacity at commit;
+    // this keeps the seed honest (DEC-D per-package capacity).
+    const stubById = new Map(
+      trip.pricingTiers.map((t) => [t.ticketTypeId, tierToTicketStub(t)] as const),
+    );
+    const resolved = seededLinesParam.flatMap((line) => {
+      const stub = stubById.get(line.ticketTypeId);
+      if (stub === undefined) return [];
+      const cap =
+        stub.isUnlimited || stub.capacity === null
+          ? line.quantity
+          : Math.max(0, stub.capacity);
+      const qty = Math.min(line.quantity, cap);
+      if (qty <= 0) return [];
+      return [{ stub, qty }];
+    });
+    if (resolved.length === 0) return;
+
+    // Are all resolved lines already in the cart at the requested qty? If not,
+    // dispatch the writes and WAIT for the next commit (do NOT navigate here).
+    const allLanded = resolved.every(({ stub, qty }) =>
+      lines.some((l) => l.ticketTypeId === stub.id && l.quantity === qty),
+    );
+    if (!allLanded) {
+      for (const { stub, qty } of resolved) {
+        setLineQuantity({
+          ticketTypeId: stub.id,
+          ticketName: stub.name,
+          unitPrice: stub.priceGbp ?? 0,
+          unitPriceAllIn: stub.priceAllInGbp ?? stub.priceGbp ?? 0,
+          currency: stub.currency ?? trip.pricingTiers[0]?.currency ?? "USD",
+          isFree: stub.isFree,
+          quantity: qty,
+        });
+      }
+      return;
+    }
+    // All seeded lines have landed → /buyer reads a populated cart.
+    multiSeedNavigatedRef.current = true;
+    router.replace(`/checkout-trip/${tripEventId}/buyer` as never);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tripEventId, trip, seededLinesParam, lines, router]);
+
   const autoSkipNavigatedRef = useRef(false);
   useEffect(() => {
     if (tripEventId === null || trip === null) return;
+    // META-ORCH-1174 Leg B3 — when the public page passed an explicit multi-package
+    // selection, the seeding effect above owns the funnel entry; the single-tier
+    // auto-skip must NOT also fire (it would add tier[0] over the real selection).
+    if (seededLinesParam.length > 0) return;
     const skipTickets = trip.pricingTiers.map(tierToTicketStub);
     const sole = skipTickets[0];
     const outcome = decideAutoSkip({

--- a/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
+++ b/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
@@ -49,6 +49,7 @@ import {
   TripReserveBar,
   type CtaState,
   type TripPaymentPlanChoice,
+  type TripReserveLine,
 } from "@mingla/offering-rendering";
 import { useThemeFont } from "../../../src/theme/useThemeFont";
 import { ShareModal } from "../../../src/components/ui/ShareModal";
@@ -57,6 +58,7 @@ import {
   tripPublicUrl,
 } from "../../../src/constants/publicUrls";
 import { usePublicTripBySlug } from "../../../src/hooks/usePublicTripBySlug";
+import { useTripTierAllIn } from "../../../src/hooks/useTripTierAllIn";
 import { TripPreview } from "../../../src/components/trip/TripPreview";
 import {
   buildTripOfferingBrand,
@@ -92,6 +94,41 @@ export default function PublicTripRoute(): React.ReactElement {
     typeof brandSlug === "string" ? brandSlug : null,
     typeof tripSlug === "string" ? tripSlug : null,
   );
+
+  // META-ORCH-1174 Leg B3 — the per-package selection + per-package plan choice
+  // (the §10 multi-package box owns the values; the shared state derives the
+  // summed all-in / due-today / selected lines). Held here (above the body) so the
+  // floating bar + the box read the SAME selection. DEC-B/C/F.
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+  const [planChoiceByTier, setPlanChoiceByTier] = useState<
+    Record<string, TripPaymentPlanChoice>
+  >({});
+  const handleChangeQuantity = useCallback(
+    (ticketTypeId: string, qty: number): void => {
+      setQuantities((prev) => {
+        const next = { ...prev };
+        if (qty <= 0) delete next[ticketTypeId];
+        else next[ticketTypeId] = qty;
+        return next;
+      });
+    },
+    [],
+  );
+  const handleChangePlanChoice = useCallback(
+    (ticketTypeId: string, value: TripPaymentPlanChoice): void => {
+      setPlanChoiceByTier((prev) => ({ ...prev, [ticketTypeId]: value }));
+    },
+    [],
+  );
+
+  // META-ORCH-1174 Leg B3 — resolve the server all-in per ticket_type (WYSIWYP) so
+  // the §10 box shows what the buyer pays, not the bare base. Keyed on the trip's
+  // event id (the trip RPC returns it as `trip.id`).
+  const tripEventId =
+    query.data?.trip?.id !== undefined && query.data.trip.id.length > 0
+      ? query.data.trip.id
+      : null;
+  const allInQuery = useTripTierAllIn(tripEventId);
 
   const handleClose = useCallback((): void => {
     if (router.canGoBack()) {
@@ -159,6 +196,11 @@ export default function PublicTripRoute(): React.ReactElement {
       payload={payload}
       brandSlug={typeof brandSlug === "string" ? brandSlug : ""}
       tripSlug={typeof tripSlug === "string" ? tripSlug : ""}
+      allInByTicketType={allInQuery.data ?? null}
+      quantities={quantities}
+      onChangeQuantity={handleChangeQuantity}
+      planChoiceByTier={planChoiceByTier}
+      onChangePlanChoice={handleChangePlanChoice}
       muted={muted}
       onToggleMute={handleToggleMute}
       onClose={handleClose}
@@ -186,6 +228,11 @@ const ResolvedTripPage: React.FC<{
   payload: NonNullable<ReturnType<typeof usePublicTripBySlug>["data"]>;
   brandSlug: string;
   tripSlug: string;
+  allInByTicketType: Map<string, number> | null;
+  quantities: Record<string, number>;
+  onChangeQuantity: (ticketTypeId: string, qty: number) => void;
+  planChoiceByTier: Record<string, TripPaymentPlanChoice>;
+  onChangePlanChoice: (ticketTypeId: string, value: TripPaymentPlanChoice) => void;
   muted: boolean;
   onToggleMute: () => void;
   onClose: () => void;
@@ -202,6 +249,11 @@ const ResolvedTripPage: React.FC<{
   payload,
   brandSlug,
   tripSlug,
+  allInByTicketType,
+  quantities,
+  onChangeQuantity,
+  planChoiceByTier,
+  onChangePlanChoice,
   muted,
   onToggleMute,
   onClose,
@@ -235,35 +287,47 @@ const ResolvedTripPage: React.FC<{
   // build; the SAME object useTripOfferingState reads). The shared body never
   // touches the read hook.
   const data = useMemo(
-    () => buildTripOfferingData(trip, payload.bookable !== false),
-    [trip, payload.bookable],
+    () => buildTripOfferingData(trip, payload.bookable !== false, allInByTicketType),
+    [trip, payload.bookable, allInByTicketType],
   );
   const offeringBrand = useMemo(
     () => buildTripOfferingBrand(payload.brand),
     [payload.brand],
   );
 
-  // META-ORCH-1174 (Seth, ORCH-1138 preserved) — Reserve routes STRAIGHT to
-  // checkout with the payment choice in the `plan` param (the checkout-trip route
-  // seeds CartContext.paymentPlanChoice from it → byte-identical request). The
-  // single bar passes the live toggle; the SPLIT buttons pass their explicit choice.
+  // META-ORCH-1174 Leg B3 (Seth, ORCH-1138 preserved) — Reserve routes STRAIGHT to
+  // the trip checkout chain. DEC-B: the SELECTED LINES ride a JSON `lines` route
+  // param `[{ticketTypeId, quantity, paymentPlanChoice?}]` so the checkout index
+  // seeds the cart with ALL selected packages (skipping the tier-select step). The
+  // single `plan` param stays as the cart-level default (back-compat / single-tier).
+  // No address/tax form (venue-sourced, ORCH-1025/1130). When `lines` is empty (a
+  // dead-tap-guarded inert CTA never fires, but the split buttons may) the cart
+  // opens to pick — never a dead tap.
   const handleTripReserve = useCallback(
-    (choice?: TripPaymentPlanChoice): void => {
+    (choice?: TripPaymentPlanChoice, lines?: TripReserveLine[]): void => {
+      const linesParam =
+        lines !== undefined && lines.length > 0
+          ? { lines: JSON.stringify(lines) }
+          : {};
       router.push(
         {
           pathname: tripCheckoutPath(trip.id),
-          params: { plan: choice ?? paymentPlanChoice },
+          params: { plan: choice ?? paymentPlanChoice, ...linesParam },
         } as never,
       );
     },
     [router, trip.id, paymentPlanChoice],
   );
 
-  // META-ORCH-1174 Leg A — the ONE lifted buy-state machine (the inline §10 box +
-  // the docked/floating/desktop bars ALL read this; they can never diverge).
+  // META-ORCH-1174 Leg B3 — the ONE lifted buy-state machine (the inline §10 box +
+  // the docked/floating/desktop bars ALL read this; they can never diverge). The
+  // surface owns the selection (quantities + per-tier plan choice); the hook
+  // derives the summed all-in / due-today / selected lines.
   const offeringState = useTripOfferingState({
     data,
     paymentPlanChoice,
+    quantities,
+    planChoiceByTier,
     onReserve: handleTripReserve,
   });
 
@@ -340,10 +404,15 @@ const ResolvedTripPage: React.FC<{
   // ORCH-1138 — desktop sticky-panel Reserve control (phone uses the floating bar).
   const reserveTappable = offeringState.cta.tappable;
   const barPrice = offeringState.barPriceLabel;
+  // META-ORCH-1174 Leg B3 — the bars + desktop control fire Reserve with the SAME
+  // selected lines the §10 box reads (DEC-B). Empty selection → no lines → the cart
+  // opens to pick (never a dead tap; the CTA itself is gated by reserveTappable).
+  const reserveSelected = (): void =>
+    handleTripReserve(undefined, offeringState.selectedLines);
   const reserveControl = (
     <View>
       <Pressable
-        onPress={reserveTappable ? () => handleTripReserve() : undefined}
+        onPress={reserveTappable ? reserveSelected : undefined}
         disabled={!reserveTappable}
         accessibilityRole="button"
         accessibilityState={{ disabled: !reserveTappable }}
@@ -388,7 +457,7 @@ const ResolvedTripPage: React.FC<{
       palette={palette}
       kicker={offeringState.barKicker}
       fontFamily={boldFamily}
-      onPress={() => handleTripReserve()}
+      onPress={reserveSelected}
       splitCtas={offeringState.splitCtas}
       variant="docked"
       safeAreaBottom={safeAreaBottom}
@@ -415,6 +484,10 @@ const ResolvedTripPage: React.FC<{
         stateBanner={stateBanner}
         paymentPlanChoice={paymentPlanChoice}
         onPaymentPlanChoiceChange={onPaymentPlanChoiceChange}
+        quantities={quantities}
+        onChangeQuantity={onChangeQuantity}
+        planChoiceByTier={planChoiceByTier}
+        onChangePlanChoice={onChangePlanChoice}
         onReserve={handleTripReserve}
         reserveControl={reserveControl}
         contentBottomInset={contentBottomInset}
@@ -444,7 +517,7 @@ const ResolvedTripPage: React.FC<{
           palette={palette}
           kicker={offeringState.barKicker}
           fontFamily={boldFamily}
-          onPress={() => handleTripReserve()}
+          onPress={reserveSelected}
           splitCtas={offeringState.splitCtas}
           variant="floating"
           safeAreaBottom={safeAreaBottom}

--- a/mingla-business/src/components/offering/__tests__/publishStripeReadiness.adversarial.test.ts
+++ b/mingla-business/src/components/offering/__tests__/publishStripeReadiness.adversarial.test.ts
@@ -92,10 +92,11 @@ describe("ORCH-1076 adversarial — per-stop sub-cent client/server parity", () 
     expect(needsStripe).toBe(true); // over-block, the safe failure mode
   });
 
-  // Trip resolver has NO per-stop path (single tier) → already rounds to cents,
-  // so it is exactly server-faithful at the same boundary (control).
+  // Trip resolver rounds each package to cents, so it is exactly server-faithful
+  // at the same boundary (control). [TEST-MOD-APPROVED META-ORCH-1174] — the
+  // resolver now takes { packages: [{ priceMajor }] }; single-package N=1 case.
   test("trip resolver is exactly server-faithful at the 0.004/0.005 boundary", () => {
-    expect(tripDraftIsPaid({ priceMajor: "0.004" })).toBe(false);
-    expect(tripDraftIsPaid({ priceMajor: "0.005" })).toBe(true);
+    expect(tripDraftIsPaid({ packages: [{ priceMajor: "0.004" }] })).toBe(false);
+    expect(tripDraftIsPaid({ packages: [{ priceMajor: "0.005" }] })).toBe(true);
   });
 });

--- a/mingla-business/src/components/offering/__tests__/publishStripeReadiness.test.ts
+++ b/mingla-business/src/components/offering/__tests__/publishStripeReadiness.test.ts
@@ -69,6 +69,11 @@ describe("ORCH-1076 — offeringNeedsStripeToPublish (shared predicate)", () => 
   });
 });
 
+// [TEST-MOD-APPROVED META-ORCH-1174] — tripDraftIsPaid now takes { packages:
+// [{ priceMajor }] } (multi-package, DEC-B/I). The single-package case (N=1) is
+// the exact prior contract: paid iff that one package's round(price*100) > 0.
+// Each assertion below is preserved by wrapping the priceMajor in a 1-package
+// array. New multi-package coverage (any-priced + all-free) added below.
 describe("ORCH-1076 — tripDraftIsPaid", () => {
   test("T-05 truth-table mirrors round(price*100) > 0", () => {
     const rows: { priceMajor: string; expected: boolean }[] = [
@@ -80,7 +85,9 @@ describe("ORCH-1076 — tripDraftIsPaid", () => {
       { priceMajor: "10", expected: true },
     ];
     for (const r of rows) {
-      expect(tripDraftIsPaid({ priceMajor: r.priceMajor })).toBe(r.expected);
+      expect(
+        tripDraftIsPaid({ packages: [{ priceMajor: r.priceMajor }] }),
+      ).toBe(r.expected);
     }
   });
 
@@ -88,14 +95,28 @@ describe("ORCH-1076 — tripDraftIsPaid", () => {
     // 0.005 * 100 = 0.5 exactly in IEEE-754; Math.round(0.5) = 1 cent. The
     // PostgreSQL server predicate round(0.005*100) = round(0.5) = 1 cent too
     // (numeric round-half-away-from-zero). Client and server AGREE: paid=true.
-    // (SPEC §9 T-05's "rounds to 0" note assumed float imprecision that does
-    // not occur for 0.005 — the parity-faithful value is true. The resolver +
-    // the server move together, which is the binding INV-1 contract.)
-    expect(tripDraftIsPaid({ priceMajor: "0.005" })).toBe(true);
+    expect(tripDraftIsPaid({ packages: [{ priceMajor: "0.005" }] })).toBe(true);
   });
 
   test("0.01 (one cent) is paid", () => {
-    expect(tripDraftIsPaid({ priceMajor: "0.01" })).toBe(true);
+    expect(tripDraftIsPaid({ packages: [{ priceMajor: "0.01" }] })).toBe(true);
+  });
+
+  // META-ORCH-1174 Leg B2 — multi-package coverage.
+  test("ANY priced package → paid (free + paid mix, DEC-I)", () => {
+    expect(
+      tripDraftIsPaid({
+        packages: [{ priceMajor: "0" }, { priceMajor: "50" }],
+      }),
+    ).toBe(true);
+  });
+
+  test("ALL-free packages → NOT paid (no Stripe needed)", () => {
+    expect(
+      tripDraftIsPaid({
+        packages: [{ priceMajor: "0" }, { priceMajor: "0.00" }],
+      }),
+    ).toBe(false);
   });
 });
 
@@ -177,7 +198,10 @@ describe("ORCH-1076 — T-10 trip resolver matches server predicate", () => {
     "10.50",
     "999.99",
   ])("priceMajor=%s", (priceMajor) => {
-    expect(tripDraftIsPaid({ priceMajor })).toBe(serverTripPaid(priceMajor));
+    // [TEST-MOD-APPROVED META-ORCH-1174] — single-package parity (N=1).
+    expect(tripDraftIsPaid({ packages: [{ priceMajor }] })).toBe(
+      serverTripPaid(priceMajor),
+    );
   });
 });
 

--- a/mingla-business/src/components/offering/publishStripeReadiness.ts
+++ b/mingla-business/src/components/offering/publishStripeReadiness.ts
@@ -71,17 +71,22 @@ export const eventDraftIsPaid = (
 
 /**
  * TRIP paid mirror. Server (L2454-2473): paid iff
- * max(ticket_types.price_cents) WHERE available_online = true > 0. The trip
- * wizard has a SINGLE online-sellable tier whose price_cents is
- * `round(parseFloat(priceMajor) * 100)` (TripCreatorWizard.tsx:516,559). So
- * the client mirror is `round(parseFloat(priceMajor) * 100) > 0` — `parseFloat
- * || 0` matches the wizard's own parsing, and the cents-rounding matches the
- * server's integer comparison (so "0.005" rounds to 0 cents → not paid, just
- * like the server).
+ * max(ticket_types.price_cents) WHERE available_online = true > 0.
+ *
+ * META-ORCH-1174 Leg B2 [MULTI-PACKAGE]: a trip may now carry N packages, each
+ * online-sellable by construction. The server `max(...) > 0` is true iff ANY
+ * package has a positive price. So the client mirror is "ANY package's
+ * round(price*100) > 0". A trip with only free packages (DEC-I) is NOT paid and
+ * needs no Stripe — exactly mirroring the server. `parseFloat || 0` matches the
+ * wizard's own parsing; cents-rounding matches the server's integer comparison
+ * (so "0.005" rounds to 0 cents → not paid).
  */
 export const tripDraftIsPaid = (draft: {
-  priceMajor: string;
-}): boolean => Math.round((parseFloat(draft.priceMajor) || 0) * 100) > 0;
+  packages: readonly { priceMajor: string }[];
+}): boolean =>
+  draft.packages.some(
+    (p) => Math.round((parseFloat(p.priceMajor) || 0) * 100) > 0,
+  );
 
 /**
  * EXPERIENCE paid mirror. Server (L301-313 + L356-360 / L874-884 + L928-930):

--- a/mingla-business/src/components/trip/EditPublishedTripScreen.tsx
+++ b/mingla-business/src/components/trip/EditPublishedTripScreen.tsx
@@ -134,6 +134,7 @@ import { TripCreatorStep2Itinerary } from "./TripCreatorStep2Itinerary";
 import { TripCreatorStep3Inclusions } from "./TripCreatorStep3Inclusions";
 import {
   TripCreatorStep4Pricing,
+  makePackageKey,
   type Step4Draft,
 } from "./TripCreatorStep4Pricing";
 import { InstallmentScheduleDisplay } from "./InstallmentScheduleDisplay";
@@ -253,14 +254,27 @@ function tripToLocalEditState(trip: Trip): LocalTripEditState {
       item: i.item,
       ordinal: i.ordinal,
     })),
+    // META-ORCH-1174 Leg B2 — Step4Draft is now N-package. EditPublishedTripScreen
+    // (the B4 edit-published path) remains SINGLE-package: seed exactly one
+    // package from the trip's first tier so the existing single-tier edit flow
+    // is byte-for-byte preserved. Multi-package edit-published is B4 scope.
     pricing: {
-      tierName: firstTier?.tierName ?? "Standard",
-      priceMajor:
-        firstTier === undefined ? "" : (firstTier.priceCents / 100).toFixed(2),
+      packages: [
+        {
+          key: makePackageKey(),
+          ticketTypeId: firstTier?.ticketTypeId ?? null,
+          name: firstTier?.tierName ?? "Standard",
+          priceMajor:
+            firstTier === undefined
+              ? ""
+              : (firstTier.priceCents / 100).toFixed(2),
+          description: firstTier?.description ?? "",
+          capacity: trip.businessTrip.capacity,
+          paymentPlan: firstTier?.installmentSchedule ?? null,
+          soldCount: 0,
+        },
+      ],
       currency: firstTier?.currency ?? "USD",
-      capacity: trip.businessTrip.capacity,
-      paymentPlan: firstTier?.installmentSchedule ?? null,
-      paymentPlanLocked: false,
       // ORCH-1006 — seed switches from events.pass_* (NULL = inherit).
       pricingSwitches: {
         passTax: trip.pricingSwitches?.passTax ?? null,
@@ -455,33 +469,37 @@ function buildLiveTripPatch(
     .filter((d) => d.status === "removed")
     .map((d) => d.key);
 
-  // Pricing tiers — single-tier model. Only emit when tier_name or
-  // price_cents or installmentSchedule differs from the trip's current tier.
+  // Pricing tiers — single-tier model (B4 multi-tier is a later leg). Only emit
+  // when tier_name or price_cents or installmentSchedule differs from the trip's
+  // current tier. META-ORCH-1174 Leg B2 — read the sole edited package.
+  const editPkg = state.pricing.packages[0];
   const newPriceCents = Math.round(
-    (parseFloat(state.pricing.priceMajor) || 0) * 100,
+    (parseFloat(editPkg?.priceMajor ?? "") || 0) * 100,
   );
   const firstTier = trip.pricingTiers[0];
   const tierNameChanged =
     firstTier !== undefined &&
-    state.pricing.tierName.trim().length > 0 &&
-    state.pricing.tierName.trim() !== firstTier.tierName;
+    editPkg !== undefined &&
+    editPkg.name.trim().length > 0 &&
+    editPkg.name.trim() !== firstTier.tierName;
   const tierPriceChanged =
     firstTier !== undefined && newPriceCents !== firstTier.priceCents;
   const oldPlanSig = JSON.stringify(firstTier?.installmentSchedule ?? null);
-  const newPlanSig = JSON.stringify(state.pricing.paymentPlan ?? null);
+  const newPlanSig = JSON.stringify(editPkg?.paymentPlan ?? null);
   const tierPlanChanged = oldPlanSig !== newPlanSig;
   if (
     firstTier !== undefined &&
+    editPkg !== undefined &&
     (tierNameChanged || tierPriceChanged || tierPlanChanged)
   ) {
     const tierMetadata: Record<string, unknown> = {};
-    if (state.pricing.paymentPlan !== null) {
-      tierMetadata.installments = state.pricing.paymentPlan;
+    if (editPkg.paymentPlan !== null) {
+      tierMetadata.installments = editPkg.paymentPlan;
     }
     patch.pricing_tiers = [
       {
         ticket_type_id: firstTier.ticketTypeId,
-        tier_name: tierNameChanged ? state.pricing.tierName.trim() : undefined,
+        tier_name: tierNameChanged ? editPkg.name.trim() : undefined,
         price_cents: tierPriceChanged ? newPriceCents : undefined,
         tier_metadata: tierPlanChanged ? tierMetadata : undefined,
       } as TripPricingTierInput,
@@ -1383,6 +1401,8 @@ export const EditPublishedTripScreen: React.FC<EditPublishedTripScreenProps> = (
             firstTier === undefined
               ? 0
               : (soldCountByTier[firstTier.ticketTypeId] ?? 0);
+          // META-ORCH-1174 Leg B2 — sole edited package (single-package B4).
+          const editPkg = editState.pricing.packages[0];
           // ORCH-0882 [Render Payment Plan Disclosure on Trip Buyer +
           // Planner Surfaces] — planner-variant live preview below the
           // PaymentPlanEditor. Reads from `editState.pricing.paymentPlan`
@@ -1394,29 +1414,35 @@ export const EditPublishedTripScreen: React.FC<EditPublishedTripScreenProps> = (
           // to cents for the projection. Falls back to firstTier.priceCents
           // when parse fails (NaN guard) so the preview never fabricates
           // amounts from a half-typed input.
-          const parsedPriceMajor = parseFloat(editState.pricing.priceMajor);
+          const parsedPriceMajor = parseFloat(editPkg?.priceMajor ?? "");
           const livePriceCents = Number.isFinite(parsedPriceMajor)
             ? Math.round(parsedPriceMajor * 100)
             : (firstTier?.priceCents ?? 0);
           const plannerPreviewSchedule =
             firstTier === undefined ||
-            editState.pricing.paymentPlan === null
+            editPkg === undefined ||
+            editPkg.paymentPlan === null
               ? null
               : projectInstallmentSchedule(
                   {
                     priceCents: livePriceCents,
                     currency: firstTier.currency,
-                    installmentSchedule: editState.pricing.paymentPlan,
+                    installmentSchedule: editPkg.paymentPlan,
                   },
                   new Date(),
                 );
+          // META-ORCH-1174 Leg B2 — pass the per-package sold count via the
+          // package's `soldCount` so the single edited package shows the
+          // post-sale price lock. (B4 multi-package edit comes later.)
+          const lockedPackages = editState.pricing.packages.map((p, idx) =>
+            idx === 0 ? { ...p, soldCount: soldCountForTier } : p,
+          );
           return (
             <View>
               <TripCreatorStep4Pricing
-                draft={editState.pricing}
+                draft={{ ...editState.pricing, packages: lockedPackages }}
                 onChange={handlePricingChange}
                 disabled={submitting}
-                editMode={{ soldCountForTier }}
               />
               {plannerPreviewSchedule !== null ? (
                 <View style={styles.plannerPlanPreviewWrap}>

--- a/mingla-business/src/components/trip/TripCreatorStep4Pricing.tsx
+++ b/mingla-business/src/components/trip/TripCreatorStep4Pricing.tsx
@@ -1,25 +1,30 @@
 /**
- * TripCreatorStep4Pricing — Step 4 of TripCreatorWizard. Single tier:
- * tier name + price (major units). Currency is auto-derived from the
- * event (which was set at create time from brand.default_currency) and
- * shown read-only. Capacity is also read-only, mirrored from Step 1.
+ * TripCreatorStep4Pricing — Step 4 of TripCreatorWizard.
  *
- * Tr2 (ORCH-0859). Per SPEC §4.8 Step 4 — single tier only; installments
- * are Tr3 [Installment Payments].
+ * META-ORCH-1174 Leg B2 [MULTI-PACKAGE AUTHORING]: a trip may now offer
+ * MULTIPLE packages (e.g. Standard / Premium / VIP). The step renders an
+ * inline list of package rows with Add package / Remove package (soft cap 6,
+ * min 1 — DEC-E). Per-package fields (DEC-G): name, price (major units),
+ * optional description, per-package capacity/spots (DEC-D), and an optional
+ * per-package payment plan (Pay-over-time — reuses the existing
+ * PaymentPlanEditor → tier_metadata.installments shape). Free packages
+ * (price 0) are allowed alongside paid ones (DEC-I).
  *
- * ORCH-0859 REWORK 2 (operator smoke #6/#7): removed the editable
- * Currency text input. The `tg_enforce_event_ticket_currency` trigger
- * (supabase/migrations/20260515000011_orch_0769_no_implicit_gbp_currency.sql:159)
- * rejects any ticket_types.currency that doesn't match the parent
- * events.currency. Allowing operators to type a free-form currency
- * here let them mismatch the event currency and produce
- * `ticket_currency_must_match_event_currency`. Currency is now a
- * read-only display of `currency` already on the trip; the wizard
- * passes through `currency` for display purposes but never sends a
- * user-typed value to the service.
+ * Each package persists as its own trip_pricing_tiers / ticket_types row via
+ * the B1 service fns (updateTripPricing / createTripPricingTier /
+ * removeTripPricingTier). The single-package trip is just N=1 — the legacy
+ * call shape is preserved.
+ *
+ * Currency is auto-derived from the event (set at create time from
+ * brand.default_currency) and shown read-only — the
+ * tg_enforce_event_ticket_currency trigger (ORCH-0769) rejects any
+ * ticket_types.currency that doesn't match events.currency, so the wizard
+ * never sends a user-typed currency.
+ *
+ * Spec: Mingla_Artifacts/specs/SPEC_META-ORCH-1174_LEGB_MULTITIER.md §C/§D.
  */
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Pressable, StyleSheet, Switch, Text, TextInput, View } from "react-native";
 
 import {
@@ -31,6 +36,7 @@ import {
   typography,
 } from "../../constants/designSystem";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { Icon } from "../ui/Icon";
 import { PaymentPlanEditor, type TripInstallmentSchedule } from "./PaymentPlanEditor";
 import { useRouter } from "expo-router";
 
@@ -38,33 +44,54 @@ import { WhoCoversCostsSection } from "../pricing/WhoCoversCostsSection";
 import { DEFAULT_TAKE_RATE_BPS } from "../../constants/pricing";
 import { useCurrentBrand } from "../../hooks/useCurrentBrand";
 import { useBrandTaxRegistration } from "../../hooks/useBrandTaxRegistration";
+// META-ORCH-1174 Leg B2 — soft cap (DEC-E) lives in the pure validator module
+// (RN-free) so the wizard + edit-published path + tests share one source.
+import { MAX_TRIP_PACKAGES } from "./tripPackagesValidation";
+
+export { MAX_TRIP_PACKAGES };
+
+/**
+ * META-ORCH-1174 Leg B2 — one authored package (pricing tier). The optional
+ * `ticketTypeId` is PRESENT when the package already exists server-side
+ * (seeded by createTripDraft, or persisted by a prior autosave) and ABSENT
+ * for a row the operator just added in the UI (autosave will create it and
+ * adopt the returned id). `soldCount` is server-derived per package for the
+ * post-sale price lock (edit-published path).
+ */
+export interface Step4Package {
+  /** Stable client-side key for list rendering (UUID-ish). Never persisted. */
+  key: string;
+  /** Server tier id — null until the package has been persisted. */
+  ticketTypeId: string | null;
+  name: string;
+  priceMajor: string; // displayed string (decimal, e.g. "50.00")
+  description: string; // optional marketing line; "" = none
+  /** Per-package capacity/spots (DEC-D). null = not yet set. */
+  capacity: number | null;
+  /** Optional per-package payment plan (DEC-F). null = pay-in-full. */
+  paymentPlan: TripInstallmentSchedule | null;
+  /** True once ≥1 buyer has booked THIS package — locks price + plan. */
+  soldCount: number;
+}
 
 export interface Step4Draft {
-  tierName: string;
-  priceMajor: string; // displayed string (decimal, e.g. "50.00")
   /**
-   * Read-only currency mirror of the event currency (set at create time
-   * from brand.default_currency). NOT editable by the operator — the
-   * trigger requires ticket_types.currency to match events.currency, and
+   * META-ORCH-1174 Leg B2 — N packages. Always ≥1 (the seeded primary
+   * package). packages[0] is the legacy "primary" tier (the one createTripDraft
+   * seeded); additional packages are authored here.
+   */
+  packages: Step4Package[];
+  /**
+   * Read-only currency mirror of the event currency (set at create time from
+   * brand.default_currency). NOT editable by the operator — the trigger
+   * requires ticket_types.currency to match events.currency, and
    * events.currency is locked at create time.
    */
   currency: string;
-  capacity: number | null; // read-only mirror from Step 1
-  /**
-   * ORCH-0873 [Tr3 Stage 2 UI] — payment plan schedule (Tr3). Null when
-   * the trip is single-payment. Persisted to
-   * trip_pricing_tiers.tier_metadata.installments via updateTripPricing.
-   */
-  paymentPlan: TripInstallmentSchedule | null;
-  /**
-   * ORCH-0873 — true when at least one installment-plan booking has been
-   * made on this trip; locks the editor into read-only banner v3 (Q6).
-   */
-  paymentPlanLocked: boolean;
   /**
    * ORCH-1006 — per-offering all-in pricing switches. Each NULL = inherit the
    * brand default; explicit boolean = override. Persisted to events.pass_* via
-   * setTripPricingSwitches when the trip is unsold.
+   * setTripPricingSwitches when the trip is unsold. Trip-wide (not per-package).
    */
   pricingSwitches: {
     passTax: boolean | null;
@@ -77,87 +104,112 @@ export interface TripCreatorStep4PricingProps {
   draft: Step4Draft;
   onChange: (patch: Partial<Step4Draft>) => void;
   disabled?: boolean;
-  /**
-   * ORCH-0876 — present when the operator is editing a published trip.
-   * `soldCountForTier` is the confirmed-order count against the single
-   * default tier. When > 0, price is rendered read-only with a
-   * "Refund first" hint because the server's refund-gate rejects
-   * `tier_price_change_with_sales`. Tier-name and payment-plan toggles
-   * remain editable (additive). Mirrors the event-side
-   * `editMode.soldCountByTier` pattern.
-   */
-  editMode?: {
-    soldCountForTier: number;
-  };
 }
 
 const INPUT_BORDER = "rgba(255, 255, 255, 0.12)";
 const INPUT_BG = "rgba(255, 255, 255, 0.04)";
 
-export const TripCreatorStep4Pricing: React.FC<TripCreatorStep4PricingProps> = ({
-  draft,
-  onChange,
-  disabled,
-  editMode,
-}) => {
-  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
-  const brand = useCurrentBrand();
-  const router = useRouter();
-  const taxRegistration = useBrandTaxRegistration(brand?.id ?? null);
-  const priceCents = Math.round((parseFloat(draft.priceMajor) || 0) * 100);
-  const planEnabled = draft.paymentPlan !== null;
-  // ORCH-0876 — read-only price when at least one confirmed booking exists
-  // for this tier. Server-side `tier_price_change_with_sales` blocks any
-  // attempt; this just removes the editable affordance for clarity.
-  const priceLocked = (editMode?.soldCountForTier ?? 0) > 0;
+let _pkgKeySeq = 0;
+/** Generate a stable client-side list key for a freshly-added package row. */
+export function makePackageKey(): string {
+  _pkgKeySeq += 1;
+  return `pkg-${Date.now().toString(36)}-${_pkgKeySeq}`;
+}
 
-  // ORCH-0873 default schedule when toggle flips on: 25% deposit + 2 future
-  // installments at 50%/25% pct at 30/60 days (matches DESIGN §3 Mockup A
-  // initial state).
+/** Default payment plan when a package's Pay-over-time toggle flips on. */
+const DEFAULT_PAYMENT_PLAN: TripInstallmentSchedule = {
+  deposit_pct: 25,
+  installments: [
+    { ordinal: 1, pct: 50, days_after_booking: 30 },
+    { ordinal: 2, pct: 25, days_after_booking: 60 },
+  ],
+};
+
+/**
+ * META-ORCH-1174 Leg B2 — per-package authoring card. Owns one package's
+ * name / price / description / capacity / optional payment plan. Emits a
+ * partial patch up to the parent via onPatch; removal via onRemove.
+ */
+interface PackageCardProps {
+  pkg: Step4Package;
+  index: number;
+  currency: string;
+  disabled?: boolean;
+  /** Whether a Remove control is shown (false when only 1 package remains). */
+  canRemove: boolean;
+  onPatch: (patch: Partial<Step4Package>) => void;
+  onRemove: () => void;
+}
+
+const PackageCard: React.FC<PackageCardProps> = ({
+  pkg,
+  index,
+  currency,
+  disabled,
+  canRemove,
+  onPatch,
+  onRemove,
+}) => {
+  const [confirmRemovePlanOpen, setConfirmRemovePlanOpen] = useState(false);
+  const priceCents = Math.round((parseFloat(pkg.priceMajor) || 0) * 100);
+  const planEnabled = pkg.paymentPlan !== null;
+  // Post-sale price lock — the server's `tier_price_change_with_sales` refund
+  // gate rejects any price change on a sold package; this removes the editable
+  // affordance for clarity.
+  const priceLocked = pkg.soldCount > 0;
+  const planLocked = pkg.soldCount > 0;
+
   const handleTogglePlan = useCallback(
     (next: boolean) => {
       if (next === planEnabled) return;
+      if (planLocked) return;
       if (next) {
-        onChange({
-          paymentPlan: {
-            deposit_pct: 25,
-            installments: [
-              { ordinal: 1, pct: 50, days_after_booking: 30 },
-              { ordinal: 2, pct: 25, days_after_booking: 60 },
-            ],
-          },
-        });
+        onPatch({ paymentPlan: { ...DEFAULT_PAYMENT_PLAN } });
         return;
       }
-      // Toggle-off requires confirm — destroying a configured plan is
-      // destructive (the planner loses their schedule). Per DESIGN §3.
-      setConfirmRemoveOpen(true);
+      // Toggle-off destroys a configured schedule → confirm.
+      setConfirmRemovePlanOpen(true);
     },
-    [onChange, planEnabled],
+    [onPatch, planEnabled, planLocked],
   );
 
   const handleConfirmRemovePlan = useCallback(() => {
-    setConfirmRemoveOpen(false);
-    onChange({ paymentPlan: null });
-  }, [onChange]);
+    setConfirmRemovePlanOpen(false);
+    onPatch({ paymentPlan: null });
+  }, [onPatch]);
 
   return (
-    <View style={styles.host}>
-      <Text style={styles.helper}>
-        Single full-price tier in this milestone. Optional payment plan below.
-      </Text>
+    <View style={styles.packageCard} testID={`trip-step4-package-${index}`}>
+      <View style={styles.packageHeader}>
+        <Text style={styles.packageHeaderTitle}>
+          {pkg.name.trim().length > 0 ? pkg.name : `Package ${index + 1}`}
+        </Text>
+        {canRemove ? (
+          <Pressable
+            onPress={onRemove}
+            disabled={disabled === true}
+            accessibilityRole="button"
+            accessibilityLabel={`Remove package ${index + 1}`}
+            style={styles.packageRemoveBtn}
+            testID={`trip-step4-package-remove-${index}`}
+          >
+            <Icon name="trash" size={16} color={semantic.error} />
+            <Text style={styles.packageRemoveText}>Remove</Text>
+          </Pressable>
+        ) : null}
+      </View>
 
       <View style={styles.fieldGroup}>
-        <Text style={styles.fieldLabel}>Tier name</Text>
+        <Text style={styles.fieldLabel}>Package name</Text>
         <TextInput
-          value={draft.tierName}
-          onChangeText={(v) => onChange({ tierName: v })}
-          placeholder="e.g. Double occupancy"
+          value={pkg.name}
+          onChangeText={(v) => onPatch({ name: v })}
+          placeholder="e.g. Standard, VIP, Double occupancy"
           placeholderTextColor={textTokens.tertiary}
-          editable={!disabled}
-          accessibilityLabel="Tier name"
+          editable={disabled !== true}
+          accessibilityLabel={`Package ${index + 1} name`}
           style={styles.textInput}
-          testID="trip-step4-tier-name"
+          testID={`trip-step4-package-name-${index}`}
         />
       </View>
 
@@ -165,71 +217,108 @@ export const TripCreatorStep4Pricing: React.FC<TripCreatorStep4PricingProps> = (
         <View style={[styles.fieldGroup, { flex: 2 }]}>
           <Text style={styles.fieldLabel}>Price per spot</Text>
           {priceLocked ? (
-            <View style={styles.readonlyField} testID="trip-step4-price-readonly">
-              <Text style={styles.readonlyValue}>{draft.priceMajor || "—"}</Text>
+            <View
+              style={styles.readonlyField}
+              testID={`trip-step4-price-readonly-${index}`}
+            >
+              <Text style={styles.readonlyValue}>{pkg.priceMajor || "—"}</Text>
             </View>
           ) : (
             <TextInput
-              value={draft.priceMajor}
+              value={pkg.priceMajor}
               onChangeText={(v) => {
-                // Allow digits + single decimal point only
+                // Allow digits + single decimal point only.
                 const clean = v.replace(/[^0-9.]/g, "");
                 const parts = clean.split(".");
                 const normalized =
                   parts.length > 2 ? parts[0] + "." + parts.slice(1).join("") : clean;
-                onChange({ priceMajor: normalized });
+                onPatch({ priceMajor: normalized });
               }}
-              placeholder="50.00"
+              placeholder="0.00"
               placeholderTextColor={textTokens.tertiary}
               keyboardType="decimal-pad"
-              editable={!disabled}
-              accessibilityLabel="Price per spot"
+              editable={disabled !== true}
+              accessibilityLabel={`Package ${index + 1} price per spot`}
               style={styles.textInput}
-              testID="trip-step4-price"
+              testID={`trip-step4-price-${index}`}
             />
           )}
         </View>
         <View style={[styles.fieldGroup, { flex: 1 }]}>
           <Text style={styles.fieldLabel}>Currency</Text>
-          <View style={styles.readonlyField} testID="trip-step4-currency-readonly">
-            <Text style={styles.readonlyValue}>{draft.currency.toUpperCase()}</Text>
+          <View
+            style={styles.readonlyField}
+            testID={`trip-step4-currency-readonly-${index}`}
+          >
+            <Text style={styles.readonlyValue}>{currency.toUpperCase()}</Text>
           </View>
         </View>
       </View>
 
-      <View style={styles.capacityCard}>
-        <Text style={styles.capacityLabel}>Capacity (from Step 1)</Text>
-        <Text style={styles.capacityValue}>
-          {draft.capacity === null
-            ? "Set in Step 1"
-            : `${draft.capacity} traveler${draft.capacity === 1 ? "" : "s"}`}
-        </Text>
-      </View>
-
-      <Text style={styles.footnote}>
-        Currency comes from your brand setup and can&apos;t be changed here.
-      </Text>
-
-      {priceLocked ? (
-        <Text style={styles.lockedHint} testID="trip-step4-price-locked-hint">
-          Existing travelers are protected at the price they paid. Refund
-          all {editMode?.soldCountForTier ?? 0} buyer
-          {(editMode?.soldCountForTier ?? 0) === 1 ? "" : "s"} before changing
-          this price (or add a new tier at the new price).
+      {/* Free-package hint — price 0 is allowed (DEC-I). */}
+      {!priceLocked && priceCents === 0 ? (
+        <Text style={styles.freeHint} testID={`trip-step4-free-hint-${index}`}>
+          Free package — buyers reserve a spot at no charge.
         </Text>
       ) : null}
 
-      {/* ORCH-0873 [Tr3 Stage 2 UI] — Payment plan toggle + editor */}
+      <View style={styles.fieldGroup}>
+        <Text style={styles.fieldLabel}>Spots in this package</Text>
+        <TextInput
+          value={pkg.capacity === null ? "" : String(pkg.capacity)}
+          onChangeText={(v) => {
+            const digits = v.replace(/[^0-9]/g, "");
+            onPatch({
+              capacity: digits.length > 0 ? parseInt(digits, 10) : null,
+            });
+          }}
+          placeholder="e.g. 20"
+          placeholderTextColor={textTokens.tertiary}
+          keyboardType="number-pad"
+          editable={disabled !== true}
+          accessibilityLabel={`Package ${index + 1} spots`}
+          style={styles.textInput}
+          testID={`trip-step4-capacity-${index}`}
+        />
+      </View>
+
+      <View style={styles.fieldGroup}>
+        <Text style={styles.fieldLabel}>Description (optional)</Text>
+        <TextInput
+          value={pkg.description}
+          onChangeText={(v) => onPatch({ description: v })}
+          placeholder="What's included in this package"
+          placeholderTextColor={textTokens.tertiary}
+          editable={disabled !== true}
+          multiline
+          accessibilityLabel={`Package ${index + 1} description`}
+          style={[styles.textInput, styles.descriptionInput]}
+          testID={`trip-step4-description-${index}`}
+        />
+      </View>
+
+      {priceLocked ? (
+        <Text
+          style={styles.lockedHint}
+          testID={`trip-step4-price-locked-hint-${index}`}
+        >
+          Existing travelers are protected at the price they paid. Refund all{" "}
+          {pkg.soldCount} buyer{pkg.soldCount === 1 ? "" : "s"} before changing
+          this price (or add a new package at the new price).
+        </Text>
+      ) : null}
+
+      {/* Per-package payment plan toggle + editor (DEC-F). */}
       <View style={styles.paymentPlanSection}>
         <Pressable
           accessibilityRole="switch"
-          accessibilityLabel="Payment plan toggle"
+          accessibilityLabel={`Package ${index + 1} payment plan toggle`}
           accessibilityState={{
             checked: planEnabled,
-            disabled: disabled === true || draft.paymentPlanLocked,
+            disabled: disabled === true || planLocked,
           }}
           onPress={() => {
-            if (disabled === true || draft.paymentPlanLocked) return;
+            if (disabled === true || planLocked) return;
             handleTogglePlan(!planEnabled);
           }}
           style={styles.paymentPlanToggleRow}
@@ -237,7 +326,7 @@ export const TripCreatorStep4Pricing: React.FC<TripCreatorStep4PricingProps> = (
           <View style={styles.paymentPlanToggleLeft}>
             <Text style={styles.paymentPlanTitle}>Payment plan</Text>
             <Text style={styles.paymentPlanSubtitle}>
-              {draft.paymentPlanLocked
+              {planLocked
                 ? "Locked — at least one buyer has booked under this schedule."
                 : planEnabled
                   ? "Buyer pays a deposit at booking; remaining installments auto-charge on schedule."
@@ -247,23 +336,179 @@ export const TripCreatorStep4Pricing: React.FC<TripCreatorStep4PricingProps> = (
           <Switch
             value={planEnabled}
             onValueChange={handleTogglePlan}
-            disabled={disabled === true || draft.paymentPlanLocked}
+            disabled={disabled === true || planLocked}
             trackColor={{ false: "rgba(255,255,255,0.16)", true: accent.warm }}
             thumbColor="#ffffff"
             ios_backgroundColor="rgba(255,255,255,0.16)"
-            accessibilityLabel="Payment plan toggle switch"
+            accessibilityLabel={`Package ${index + 1} payment plan switch`}
           />
         </Pressable>
-        {planEnabled || draft.paymentPlanLocked ? (
+        {planEnabled || planLocked ? (
           <PaymentPlanEditor
-            value={draft.paymentPlan}
-            onChange={(next) => onChange({ paymentPlan: next })}
+            value={pkg.paymentPlan}
+            onChange={(next) => onPatch({ paymentPlan: next })}
             totalAmountCents={priceCents}
-            currency={draft.currency}
-            locked={draft.paymentPlanLocked}
+            currency={currency}
+            locked={planLocked}
           />
         ) : null}
       </View>
+
+      <ConfirmDialog
+        visible={confirmRemovePlanOpen}
+        title="Remove payment plan?"
+        description="This package will revert to single payment. Your current schedule will be discarded."
+        confirmLabel="Remove plan"
+        variant="simple"
+        destructive
+        onConfirm={handleConfirmRemovePlan}
+        onClose={() => setConfirmRemovePlanOpen(false)}
+      />
+    </View>
+  );
+};
+
+export const TripCreatorStep4Pricing: React.FC<TripCreatorStep4PricingProps> = ({
+  draft,
+  onChange,
+  disabled,
+}) => {
+  const brand = useCurrentBrand();
+  const router = useRouter();
+  const taxRegistration = useBrandTaxRegistration(brand?.id ?? null);
+  const [confirmRemovePkgKey, setConfirmRemovePkgKey] = useState<string | null>(
+    null,
+  );
+
+  const packages = draft.packages;
+  const canAdd = packages.length < MAX_TRIP_PACKAGES;
+  const canRemoveAny = packages.length > 1;
+
+  // Live preview base for the WhoCoversCosts section = MIN package price
+  // (the "From" price buyers see). 0 when no priced packages.
+  const previewBaseCents = useMemo(() => {
+    const prices = packages
+      .map((p) => Math.round((parseFloat(p.priceMajor) || 0) * 100))
+      .filter((c) => c > 0);
+    return prices.length > 0 ? Math.min(...prices) : 0;
+  }, [packages]);
+
+  // Any sold package locks the trip-wide pricing switches (post-sale lock).
+  const anySold = useMemo(
+    () => packages.some((p) => p.soldCount > 0),
+    [packages],
+  );
+
+  const patchPackage = useCallback(
+    (key: string, patch: Partial<Step4Package>) => {
+      onChange({
+        packages: packages.map((p) =>
+          p.key === key ? { ...p, ...patch } : p,
+        ),
+      });
+    },
+    [onChange, packages],
+  );
+
+  const handleAddPackage = useCallback(() => {
+    if (!canAdd) return;
+    onChange({
+      packages: [
+        ...packages,
+        {
+          key: makePackageKey(),
+          ticketTypeId: null,
+          name: "",
+          priceMajor: "",
+          description: "",
+          // Seed capacity from the primary package so the operator has a
+          // sensible default; freely editable per-package (DEC-D).
+          capacity: packages[0]?.capacity ?? null,
+          paymentPlan: null,
+          soldCount: 0,
+        },
+      ],
+    });
+  }, [canAdd, onChange, packages]);
+
+  const handleRequestRemove = useCallback(
+    (key: string) => {
+      const pkg = packages.find((p) => p.key === key);
+      if (pkg === undefined) return;
+      // A never-persisted, untouched package removes silently; otherwise confirm.
+      const isEmpty =
+        pkg.ticketTypeId === null &&
+        pkg.name.trim().length === 0 &&
+        pkg.priceMajor.trim().length === 0 &&
+        pkg.description.trim().length === 0 &&
+        pkg.paymentPlan === null;
+      if (isEmpty) {
+        onChange({ packages: packages.filter((p) => p.key !== key) });
+        return;
+      }
+      setConfirmRemovePkgKey(key);
+    },
+    [onChange, packages],
+  );
+
+  const handleConfirmRemovePackage = useCallback(() => {
+    if (confirmRemovePkgKey === null) return;
+    onChange({
+      packages: packages.filter((p) => p.key !== confirmRemovePkgKey),
+    });
+    setConfirmRemovePkgKey(null);
+  }, [confirmRemovePkgKey, onChange, packages]);
+
+  return (
+    <View style={styles.host}>
+      <Text style={styles.helper}>
+        Offer one or more packages (e.g. Standard, Premium, VIP). Each package
+        has its own price, spots, and optional payment plan. Free packages are
+        allowed alongside paid ones.
+      </Text>
+
+      {packages.map((pkg, index) => (
+        <PackageCard
+          key={pkg.key}
+          pkg={pkg}
+          index={index}
+          currency={draft.currency}
+          disabled={disabled}
+          canRemove={canRemoveAny}
+          onPatch={(patch) => patchPackage(pkg.key, patch)}
+          onRemove={() => handleRequestRemove(pkg.key)}
+        />
+      ))}
+
+      <Pressable
+        onPress={handleAddPackage}
+        disabled={disabled === true || !canAdd}
+        accessibilityRole="button"
+        accessibilityLabel="Add package"
+        accessibilityState={{ disabled: disabled === true || !canAdd }}
+        style={[styles.addPackageBtn, !canAdd && styles.addPackageBtnDisabled]}
+        testID="trip-step4-add-package"
+      >
+        <Icon
+          name="plus"
+          size={18}
+          color={canAdd ? accent.warm : textTokens.tertiary}
+        />
+        <Text
+          style={[
+            styles.addPackageText,
+            !canAdd && styles.addPackageTextDisabled,
+          ]}
+        >
+          {canAdd
+            ? "Add package"
+            : `Up to ${MAX_TRIP_PACKAGES} packages per trip`}
+        </Text>
+      </Pressable>
+
+      <Text style={styles.footnote}>
+        Currency comes from your brand setup and can&apos;t be changed here.
+      </Text>
 
       {brand !== null ? (
         <WhoCoversCostsSection
@@ -275,30 +520,29 @@ export const TripCreatorStep4Pricing: React.FC<TripCreatorStep4PricingProps> = (
             passServiceFee: brand.defaultPassServiceFee ?? false,
           }}
           onChange={(next) => onChange({ pricingSwitches: next })}
-          previewBaseCents={priceCents}
+          previewBaseCents={previewBaseCents}
           currency={draft.currency}
           effectiveTakeRateBps={brand.takeRateBpsOverride ?? DEFAULT_TAKE_RATE_BPS}
-          locked={priceLocked}
+          locked={anySold}
           onEditDefaults={() =>
             router.push(`/brand/${brand.id}/pricing-defaults` as never)
           }
-          // Surface 4 — VAT row interactive only when the brand has an active
-          // Stripe tax registration; else the "Set up VAT" nudge. Engine also
-          // fail-closes at checkout.
           vatRegistered={taxRegistration.data?.hasActiveRegistration === true}
           onSetupVat={() => router.push("/connect-tax-registrations" as never)}
         />
       ) : null}
 
       <ConfirmDialog
-        visible={confirmRemoveOpen}
-        title="Remove payment plan?"
-        description="This trip will revert to single payment. Your current schedule will be discarded."
-        confirmLabel="Remove plan"
+        visible={confirmRemovePkgKey !== null}
+        title="Remove this package?"
+        description="Travelers will no longer be able to book it. This can't be undone for a saved package."
+        confirmLabel="Remove package"
+        cancelLabel="Keep package"
         variant="simple"
         destructive
-        onConfirm={handleConfirmRemovePlan}
-        onClose={() => setConfirmRemoveOpen(false)}
+        onConfirm={handleConfirmRemovePackage}
+        onClose={() => setConfirmRemovePkgKey(null)}
+        testID="trip-step4-remove-package-dialog"
       />
     </View>
   );
@@ -314,6 +558,37 @@ const styles = StyleSheet.create({
     lineHeight: typography.bodySm.lineHeight,
     color: textTokens.secondary,
   },
+  packageCard: {
+    gap: spacing.md,
+    padding: spacing.md,
+    borderRadius: radiusTokens.lg,
+    backgroundColor: "rgba(255, 255, 255, 0.02)",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.08)",
+  },
+  packageHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  packageHeaderTitle: {
+    flex: 1,
+    fontSize: typography.body.fontSize,
+    fontWeight: "700",
+    color: textTokens.primary,
+  },
+  packageRemoveBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    minHeight: 36,
+    paddingHorizontal: spacing.sm,
+  },
+  packageRemoveText: {
+    fontSize: typography.caption.fontSize,
+    fontWeight: "600",
+    color: semantic.error,
+  },
   fieldGroup: {
     gap: spacing.xs,
   },
@@ -324,8 +599,9 @@ const styles = StyleSheet.create({
     color: textTokens.secondary,
   },
   textInput: {
-    height: 48,
+    minHeight: 48,
     paddingHorizontal: 14,
+    paddingVertical: 12,
     borderRadius: radiusTokens.md,
     overflow: "hidden",
     backgroundColor: INPUT_BG,
@@ -333,6 +609,10 @@ const styles = StyleSheet.create({
     borderColor: INPUT_BORDER,
     color: textTokens.primary,
     fontSize: typography.body.fontSize,
+  },
+  descriptionInput: {
+    minHeight: 72,
+    textAlignVertical: "top",
   },
   readonlyField: {
     height: 48,
@@ -352,22 +632,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     gap: spacing.sm,
   },
-  capacityCard: {
-    padding: spacing.md,
-    borderRadius: radiusTokens.md,
-    backgroundColor: "rgba(255, 255, 255, 0.02)",
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.08)",
-  },
-  capacityLabel: {
+  freeHint: {
     fontSize: typography.caption.fontSize,
     color: textTokens.tertiary,
-  },
-  capacityValue: {
-    fontSize: typography.body.fontSize,
-    fontWeight: "600",
-    color: textTokens.primary,
-    marginTop: 2,
+    fontStyle: "italic",
   },
   footnote: {
     fontSize: typography.caption.fontSize,
@@ -385,9 +653,32 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "rgba(235, 120, 37, 0.32)",
   },
-  // ORCH-0873 [Tr3 Stage 2 UI] payment plan section styles
+  addPackageBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.xs,
+    minHeight: 48,
+    borderRadius: radiusTokens.md,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderColor: accent.warm,
+    backgroundColor: "rgba(235, 120, 37, 0.06)",
+  },
+  addPackageBtnDisabled: {
+    borderColor: "rgba(255, 255, 255, 0.12)",
+    backgroundColor: "rgba(255, 255, 255, 0.02)",
+  },
+  addPackageText: {
+    fontSize: typography.body.fontSize,
+    fontWeight: "700",
+    color: accent.warm,
+  },
+  addPackageTextDisabled: {
+    color: textTokens.tertiary,
+  },
+  // Payment plan section styles (ORCH-0873 lineage).
   paymentPlanSection: {
-    marginTop: spacing.md,
     gap: spacing.md,
   },
   paymentPlanToggleRow: {

--- a/mingla-business/src/components/trip/TripCreatorWizard.tsx
+++ b/mingla-business/src/components/trip/TripCreatorWizard.tsx
@@ -67,6 +67,9 @@ import {
   useUpsertTripDays,
   useUpsertTripInclusions,
   useUpdateTripPricing,
+  // META-ORCH-1174 Leg B2 — N-package create/remove mutations.
+  useCreateTripPricingTier,
+  useRemoveTripPricingTier,
   usePublishTrip,
 } from "../../hooks/useTrips";
 // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — Step 5 autosave hooks.
@@ -95,8 +98,12 @@ import {
 } from "./TripCreatorStep3Inclusions";
 import {
   TripCreatorStep4Pricing,
+  makePackageKey,
   type Step4Draft,
+  type Step4Package,
 } from "./TripCreatorStep4Pricing";
+// META-ORCH-1174 Leg B2 — pure (RN-free) publish-gate package validator.
+import { validateTripPackages } from "./tripPackagesValidation";
 // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — NEW Step 5 component.
 import {
   TripCreatorStep5Policy,
@@ -244,15 +251,44 @@ function tripToInclusionsDraft(trip: Trip): InclusionDraft[] {
   }));
 }
 
-function tripToStep4Draft(trip: Trip): Step4Draft {
-  const tier = trip.pricingTiers[0];
+// META-ORCH-1174 Leg B2 — seed N packages from ALL persisted pricing tiers.
+// packages[0] is the primary tier (createTripDraft-seeded). When the trip has
+// no tiers yet (brand-new draft pre-first-autosave), seed one empty primary
+// package so the wizard always shows ≥1 row (DEC-E min 1).
+function tierToStep4Package(tier: Trip["pricingTiers"][number]): Step4Package {
   return {
-    tierName: tier?.tierName ?? "Standard",
-    priceMajor: tier === undefined ? "" : (tier.priceCents / 100).toFixed(2),
-    currency: tier?.currency ?? "USD",
-    capacity: trip.businessTrip.capacity,
-    paymentPlan: tier?.installmentSchedule ?? null,
-    paymentPlanLocked: false,
+    key: makePackageKey(),
+    ticketTypeId: tier.ticketTypeId,
+    name: tier.tierName,
+    priceMajor: (tier.priceCents / 100).toFixed(2),
+    description: tier.description ?? "",
+    capacity: tier.quantityTotal,
+    paymentPlan: tier.installmentSchedule ?? null,
+    // Drafts have no sales; the per-package post-sale lock is server-enforced.
+    soldCount: 0,
+  };
+}
+
+function tripToStep4Draft(trip: Trip): Step4Draft {
+  const currency = trip.pricingTiers[0]?.currency ?? "USD";
+  const packages: Step4Package[] =
+    trip.pricingTiers.length > 0
+      ? trip.pricingTiers.map(tierToStep4Package)
+      : [
+          {
+            key: makePackageKey(),
+            ticketTypeId: null,
+            name: "Standard",
+            priceMajor: "",
+            description: "",
+            capacity: trip.businessTrip.capacity,
+            paymentPlan: null,
+            soldCount: 0,
+          },
+        ];
+  return {
+    packages,
+    currency,
     // ORCH-1006 — seed switches from events.pass_* (NULL = inherit).
     pricingSwitches: {
       passTax: trip.pricingSwitches?.passTax ?? null,
@@ -260,6 +296,21 @@ function tripToStep4Draft(trip: Trip): Step4Draft {
       passServiceFee: trip.pricingSwitches?.passServiceFee ?? null,
     },
   };
+}
+
+// META-ORCH-1174 Leg B2 — canonical signature of the authored package set for
+// pristine / dirty comparison (ignores the client-only `key`).
+function step4PackagesSignature(packages: Step4Package[]): string {
+  return JSON.stringify(
+    packages.map((p) => ({
+      ticketTypeId: p.ticketTypeId,
+      name: p.name,
+      priceMajor: p.priceMajor,
+      description: p.description,
+      capacity: p.capacity,
+      paymentPlan: p.paymentPlan,
+    })),
+  );
 }
 
 // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — Step 5 draft seed from
@@ -331,13 +382,13 @@ function isTripWizardPristine(
       return false;
     }
   }
-  // Step 4: tierName + priceMajor + capacity + paymentPlan equal
+  // Step 4: META-ORCH-1174 Leg B2 — the full N-package set must match the
+  // server-derived initial set (name + price + description + capacity + plan
+  // per package, and the same package count).
   const initStep4 = tripToStep4Draft(trip);
   if (
-    step4Draft.tierName !== initStep4.tierName ||
-    step4Draft.priceMajor !== initStep4.priceMajor ||
-    step4Draft.capacity !== initStep4.capacity ||
-    JSON.stringify(step4Draft.paymentPlan) !== JSON.stringify(initStep4.paymentPlan)
+    step4PackagesSignature(step4Draft.packages) !==
+    step4PackagesSignature(initStep4.packages)
   ) {
     return false;
   }
@@ -426,6 +477,14 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
     [step4Draft, brand.stripeStatus],
   );
 
+  // META-ORCH-1174 Leg B2 — publish gate: every authored package must be valid
+  // (≥1 package, name + price ≥0 + capacity ≥1 + valid plan terms). Blocks
+  // Publish (dock disabled = suspenders; handlePublishTap = belt).
+  const packagesValidation = useMemo(
+    () => validateTripPackages(step4Draft.packages),
+    [step4Draft.packages],
+  );
+
   // ORCH-1118 — BOTH departure and destination must be confirmed Mapbox picks
   // (placeId + lat + lng) before publish. Empty or dirty (typed-but-unpicked)
   // text on EITHER field blocks publish. Do not loosen
@@ -477,6 +536,9 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
   const upsertDaysMutation = useUpsertTripDays();
   const upsertInclusionsMutation = useUpsertTripInclusions();
   const updatePricingMutation = useUpdateTripPricing();
+  // META-ORCH-1174 Leg B2 — N-package create/remove.
+  const createTierMutation = useCreateTripPricingTier();
+  const removeTierMutation = useRemoveTripPricingTier();
   const publishMutation = usePublishTrip();
   // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — Step 5 autosave hooks.
   const updateRefundPolicyMutation = useUpdateRefundPolicy();
@@ -501,12 +563,21 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
     intakeSeededRef.current = true;
   }, [intakeSchemasQuery.data]);
 
-  // Keep step4Draft.capacity in sync with step1Draft.capacity
+  // META-ORCH-1174 Leg B2 — capacity is now PER-PACKAGE (DEC-D), authored in
+  // Step 4. The old Step1→Step4 single-capacity mirror is retired. Step 1's
+  // capacity remains the trip-level number (business_trip.capacity) and seeds
+  // a package's spots only when that package has none yet (e.g. the primary
+  // package on a brand-new draft).
   useEffect(() => {
-    if (step4Draft.capacity !== step1Draft.capacity) {
-      setStep4Draft((s) => ({ ...s, capacity: step1Draft.capacity }));
-    }
-  }, [step1Draft.capacity, step4Draft.capacity]);
+    if (step1Draft.capacity === null) return;
+    setStep4Draft((s) => {
+      const primary = s.packages[0];
+      if (primary === undefined || primary.capacity !== null) return s;
+      const nextPackages = [...s.packages];
+      nextPackages[0] = { ...primary, capacity: step1Draft.capacity };
+      return { ...s, packages: nextPackages };
+    });
+  }, [step1Draft.capacity]);
 
   // ORCH-0859 REWORK 3: auto-seed days from Step 1 date range (unchanged).
   useEffect(() => {
@@ -576,28 +647,123 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
         item: i.item,
         ordinal: i.ordinal,
       })),
-      pricingTiers:
-        trip.pricingTiers.length > 0
-          ? [
-              {
-                ...trip.pricingTiers[0],
-                tierName: step4Draft.tierName,
-                priceCents: Math.round(
-                  (parseFloat(step4Draft.priceMajor) || 0) * 100,
-                ),
-                currency: step4Draft.currency,
-                quantityTotal: step1Draft.capacity,
-                isUnlimited: false,
-              },
-            ]
-          : [],
+      // META-ORCH-1174 Leg B2 — preview ALL authored packages (Step 5 review +
+      // Step 7 publish summary). Each draft package projects to one pricing
+      // tier; the matching persisted tier (by ticketTypeId) supplies the stable
+      // id/metadata, else a synthetic preview shell is used.
+      pricingTiers: step4Draft.packages.map((p, idx) => {
+        const persisted =
+          p.ticketTypeId !== null
+            ? trip.pricingTiers.find((t) => t.ticketTypeId === p.ticketTypeId)
+            : undefined;
+        const priceCents = Math.round((parseFloat(p.priceMajor) || 0) * 100);
+        return {
+          id: persisted?.id ?? `preview-tier-${idx}`,
+          eventId: trip.id,
+          ticketTypeId: p.ticketTypeId ?? `preview-tt-${idx}`,
+          tierName: p.name.trim().length > 0 ? p.name : `Package ${idx + 1}`,
+          tierMetadata: persisted?.tierMetadata ?? {},
+          priceCents,
+          currency: step4Draft.currency,
+          quantityTotal: p.capacity,
+          ticketsRemaining: persisted?.ticketsRemaining ?? null,
+          isUnlimited: false,
+          installmentSchedule: p.paymentPlan,
+          description: p.description.trim().length > 0 ? p.description.trim() : null,
+        };
+      }),
     }),
     [trip, step1Draft, daysDraft, inclusionsDraft, step4Draft],
   );
 
+  // META-ORCH-1174 Leg B2 — the set of ticketTypeIds the server is known to
+  // hold, so a package the operator removed in the UI is soft-removed on the
+  // next pricing autosave. Seeded from the initial trip; updated as packages
+  // are created/removed.
+  const persistedTierIdsRef = useRef<Set<string>>(
+    new Set(trip.pricingTiers.map((t) => t.ticketTypeId)),
+  );
+
+  // META-ORCH-1174 Leg B2 — persist the full N-package set:
+  //   • a package WITH a ticketTypeId  → updateTripPricing (in-place; never
+  //     clobbers a sold tier — see I-PROPOSED-1174-EDIT-NO-CLOBBER).
+  //   • a package WITHOUT a ticketTypeId (added in the UI) → createTripPricingTier,
+  //     then adopt the returned id into draft state so the next save updates it.
+  //   • a persisted tier no longer present in the draft → removeTripPricingTier
+  //     (soft-delete; the B1 service throws tier_delete_with_sales if it sold).
+  // Each package carries its OWN price + capacity + installments (DEC-D/F).
+  const persistPackages = useCallback(async (): Promise<void> => {
+    const currentPackages = step4Draft.packages;
+    const seenIds = new Set<string>();
+    // Map of clientKey → adopted ticketTypeId for the create-then-adopt step.
+    const adopted = new Map<string, string>();
+
+    for (const pkg of currentPackages) {
+      const priceCents = Math.round((parseFloat(pkg.priceMajor) || 0) * 100);
+      const capacity = pkg.capacity ?? 1;
+      const tierName = pkg.name.trim() || "Standard";
+      const descriptionPatch = pkg.description.trim();
+      if (pkg.ticketTypeId !== null) {
+        seenIds.add(pkg.ticketTypeId);
+        await updatePricingMutation.mutateAsync({
+          eventId: trip.id,
+          patch: {
+            ticketTypeId: pkg.ticketTypeId,
+            tierName,
+            priceCents,
+            capacity,
+            installmentSchedule: pkg.paymentPlan,
+            description: descriptionPatch.length > 0 ? descriptionPatch : null,
+          },
+        });
+      } else {
+        const created = await createTierMutation.mutateAsync({
+          eventId: trip.id,
+          patch: {
+            tierName,
+            priceCents,
+            capacity,
+            installmentSchedule: pkg.paymentPlan,
+            description: descriptionPatch.length > 0 ? descriptionPatch : null,
+          },
+        });
+        seenIds.add(created.ticketTypeId);
+        adopted.set(pkg.key, created.ticketTypeId);
+      }
+    }
+
+    // Soft-remove persisted tiers that the operator dropped from the draft.
+    for (const knownId of persistedTierIdsRef.current) {
+      if (!seenIds.has(knownId)) {
+        await removeTierMutation.mutateAsync({
+          eventId: trip.id,
+          ticketTypeId: knownId,
+        });
+      }
+    }
+    persistedTierIdsRef.current = seenIds;
+
+    // Adopt newly-created ids into draft state (one batched update).
+    if (adopted.size > 0) {
+      setStep4Draft((s) => ({
+        ...s,
+        packages: s.packages.map((p) =>
+          p.ticketTypeId === null && adopted.has(p.key)
+            ? { ...p, ticketTypeId: adopted.get(p.key) ?? null }
+            : p,
+        ),
+      }));
+    }
+  }, [
+    step4Draft.packages,
+    trip.id,
+    updatePricingMutation,
+    createTierMutation,
+    removeTierMutation,
+  ]);
+
   // ----- Autosave per step transition -----
   const autosaveStep1 = useCallback(async (): Promise<void> => {
-    const priceMajor = parseFloat(step4Draft.priceMajor) || 0;
     await updateBasicsMutation.mutateAsync({
       eventId: trip.id,
       brandId: trip.brandId,
@@ -622,22 +788,16 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
         coverMediaType: step1Draft.coverMediaType,
       },
     });
-    await updatePricingMutation.mutateAsync({
-      eventId: trip.id,
-      patch: {
-        tierName: step4Draft.tierName.trim() || "Standard",
-        priceCents: Math.round(priceMajor * 100),
-        capacity: step1Draft.capacity ?? 1,
-        installmentSchedule: step4Draft.paymentPlan,
-      },
-    });
+    // META-ORCH-1174 Leg B2 — persist the package set on Step 1 → Step 2 too,
+    // so the primary package's price/capacity stays in sync with Step 1's
+    // capacity seed (the historic Step-1 pricing write, now N-package-safe).
+    await persistPackages();
   }, [
     step1Draft,
-    step4Draft,
     trip.id,
     trip.brandId,
     updateBasicsMutation,
-    updatePricingMutation,
+    persistPackages,
   ]);
 
   const autosaveStep2 = useCallback(async (): Promise<void> => {
@@ -665,16 +825,10 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
   }, [inclusionsDraft, trip.id, upsertInclusionsMutation]);
 
   const autosaveStep4 = useCallback(async (): Promise<void> => {
-    const priceMajor = parseFloat(step4Draft.priceMajor) || 0;
-    await updatePricingMutation.mutateAsync({
-      eventId: trip.id,
-      patch: {
-        tierName: step4Draft.tierName.trim() || "Standard",
-        priceCents: Math.round(priceMajor * 100),
-        capacity: step1Draft.capacity ?? 1,
-        installmentSchedule: step4Draft.paymentPlan,
-      },
-    });
+    // META-ORCH-1174 Leg B2 — persist ALL packages (create new / update
+    // existing / soft-remove dropped), each with its own price + capacity +
+    // installments.
+    await persistPackages();
     // ORCH-1006 — persist the all-in pricing switches to events.pass_*. Skip
     // once any ticket has sold (post-sale lock): the section renders read-only
     // and the server would reject the change anyway.
@@ -682,11 +836,10 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
       await setTripPricingSwitches(trip.id, step4Draft.pricingSwitches);
     }
   }, [
-    step4Draft,
-    step1Draft.capacity,
+    persistPackages,
+    step4Draft.pricingSwitches,
     trip.id,
     trip.ticketsSoldCount,
-    updatePricingMutation,
   ]);
 
   // ORCH-0875 [Tr4 Refund Tiers + Booking Deadline] — Step 5 autosave.
@@ -914,9 +1067,16 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
       showToast("Connect a bank to publish this paid trip.");
       return;
     }
+    // META-ORCH-1174 Leg B2 — every package must be valid before publish.
+    // Surface the first failing reason + jump back to the pricing step.
+    if (!packagesValidation.ok) {
+      setStep(4);
+      showToast(packagesValidation.reason ?? "Fix your packages before publishing.");
+      return;
+    }
     // Open ConfirmDialog; actual publish runs in handleConfirmPublish.
     setPublishConfirmVisible(true);
-  }, [tripLocationValid, tripNeedsStripe, showToast]);
+  }, [tripLocationValid, tripNeedsStripe, packagesValidation, showToast]);
 
   const handleConfirmPublish = useCallback(async (): Promise<void> => {
     setPublishError(null);
@@ -1361,7 +1521,13 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
                   // Stripe-unready brand (proactive gate; mirrors events).
                   // ORCH-1118 — also disable until departure + destination are
                   // confirmed Mapbox picks (suspenders; belt in handlePublishTap).
-                  disabled={submitting || tripNeedsStripe || !tripLocationValid}
+                  // META-ORCH-1174 Leg B2 — and until every package is valid.
+                  disabled={
+                    submitting ||
+                    tripNeedsStripe ||
+                    !tripLocationValid ||
+                    !packagesValidation.ok
+                  }
                   fullWidth
                   testID="trip-wizard-footer-cta"
                 />

--- a/mingla-business/src/components/trip/TripCreatorWizard.tsx
+++ b/mingla-business/src/components/trip/TripCreatorWizard.tsx
@@ -564,10 +564,10 @@ export const TripCreatorWizard: React.FC<TripCreatorWizardProps> = ({
   }, [intakeSchemasQuery.data]);
 
   // META-ORCH-1174 Leg B2 — capacity is now PER-PACKAGE (DEC-D), authored in
-  // Step 4. The old Step1→Step4 single-capacity mirror is retired. Step 1's
-  // capacity remains the trip-level number (business_trip.capacity) and seeds
-  // a package's spots only when that package has none yet (e.g. the primary
-  // package on a brand-new draft).
+  // Step 4 and persisted to each package's ticket_types.quantity_total. The old
+  // Step1→Step4 single-capacity mirror is retired. Step 1's trip-level capacity
+  // draft field seeds a package's spots only when that package has none yet
+  // (e.g. the primary package on a brand-new draft).
   useEffect(() => {
     if (step1Draft.capacity === null) return;
     setStep4Draft((s) => {

--- a/mingla-business/src/components/trip/TripPreview.tsx
+++ b/mingla-business/src/components/trip/TripPreview.tsx
@@ -73,6 +73,7 @@ import {
   type TripOfferingData,
   type TripOfferingState,
   type TripPaymentPlanChoice,
+  type TripReserveLine,
 } from "@mingla/offering-rendering";
 import { EventCoverMedia } from "../ui/EventCoverMedia";
 import { Icon } from "../ui/Icon";
@@ -155,10 +156,20 @@ export interface TripPreviewProps {
   paymentPlanChoice?: TripPaymentPlanChoice;
   onPaymentPlanChoiceChange?: (value: TripPaymentPlanChoice) => void;
   /**
-   * META-ORCH-1174 Leg A — the §10 reserve action (route push to checkout). The
-   * `choice` is set when the split buttons fire; undefined for the single Reserve.
+   * META-ORCH-1174 Leg B3 — the per-package selection + per-package plan choice
+   * (route owns the useState; the shared §10 box steppers write through these). The
+   * box + the bars read the SAME selection via offeringState.
    */
-  onReserve?: (choice?: TripPaymentPlanChoice) => void;
+  quantities?: Record<string, number>;
+  onChangeQuantity?: (ticketTypeId: string, qty: number) => void;
+  planChoiceByTier?: Record<string, TripPaymentPlanChoice>;
+  onChangePlanChoice?: (ticketTypeId: string, value: TripPaymentPlanChoice) => void;
+  /**
+   * META-ORCH-1174 Leg A/B3 — the §10 reserve action (route push to checkout). The
+   * `choice` is set when the split buttons fire; `lines` carries the selected
+   * packages (DEC-B) when the box/bar fires the multi-select Reserve.
+   */
+  onReserve?: (choice?: TripPaymentPlanChoice, lines?: TripReserveLine[]) => void;
   /** Desktop sticky-panel Reserve control + reassurance (route-owned). */
   reserveControl?: React.ReactNode;
   /** Brand "View" tap → brand page (route-owned). */
@@ -223,6 +234,10 @@ export const TripPreview: React.FC<TripPreviewProps> = ({
   offeringState,
   paymentPlanChoice = "full",
   onPaymentPlanChoiceChange,
+  quantities,
+  onChangeQuantity,
+  planChoiceByTier,
+  onChangePlanChoice,
   onReserve,
   reserveControl,
   onViewBrand,
@@ -261,6 +276,10 @@ export const TripPreview: React.FC<TripPreviewProps> = ({
         offeringState={offeringState}
         paymentPlanChoice={paymentPlanChoice}
         onPaymentPlanChoiceChange={onPaymentPlanChoiceChange}
+        quantities={quantities}
+        onChangeQuantity={onChangeQuantity}
+        planChoiceByTier={planChoiceByTier}
+        onChangePlanChoice={onChangePlanChoice}
         onReserve={onReserve}
         reserveControl={reserveControl}
         onViewBrand={onViewBrand}
@@ -306,7 +325,11 @@ const FoundationTripPreview: React.FC<{
   offeringState: TripOfferingState;
   paymentPlanChoice: TripPaymentPlanChoice;
   onPaymentPlanChoiceChange: (value: TripPaymentPlanChoice) => void;
-  onReserve: (choice?: TripPaymentPlanChoice) => void;
+  quantities?: Record<string, number>;
+  onChangeQuantity?: (ticketTypeId: string, qty: number) => void;
+  planChoiceByTier?: Record<string, TripPaymentPlanChoice>;
+  onChangePlanChoice?: (ticketTypeId: string, value: TripPaymentPlanChoice) => void;
+  onReserve: (choice?: TripPaymentPlanChoice, lines?: TripReserveLine[]) => void;
   reserveControl?: React.ReactNode;
   onViewBrand?: () => void;
   contentBottomInset: number;
@@ -330,6 +353,10 @@ const FoundationTripPreview: React.FC<{
   offeringState,
   paymentPlanChoice,
   onPaymentPlanChoiceChange,
+  quantities,
+  onChangeQuantity,
+  planChoiceByTier,
+  onChangePlanChoice,
   onReserve,
   reserveControl,
   onViewBrand,
@@ -458,6 +485,10 @@ const FoundationTripPreview: React.FC<{
         variant={isDesktop ? "desktop" : "phone"}
         paymentPlanChoice={paymentPlanChoice}
         onPaymentPlanChoiceChange={onPaymentPlanChoiceChange}
+        quantities={quantities}
+        onChangeQuantity={onChangeQuantity}
+        planChoiceByTier={planChoiceByTier}
+        onChangePlanChoice={onChangePlanChoice}
         dockedReserve={!isDesktop ? dockedReserve : undefined}
         testID="meta-orch-1174-trip-body"
       />

--- a/mingla-business/src/components/trip/__tests__/EditPublishedTripScreen.coverClose.adversarial.render.test.tsx
+++ b/mingla-business/src/components/trip/__tests__/EditPublishedTripScreen.coverClose.adversarial.render.test.tsx
@@ -233,6 +233,7 @@ function makeTripWithCover(): Trip {
         ticketsRemaining: 10,
         isUnlimited: false,
         installmentSchedule: null,
+        description: null, // [TEST-MOD-APPROVED META-ORCH-1174]
       },
     ],
     inclusions: [],

--- a/mingla-business/src/components/trip/__tests__/EditPublishedTripScreen.coverDeadTap.render.test.tsx
+++ b/mingla-business/src/components/trip/__tests__/EditPublishedTripScreen.coverDeadTap.render.test.tsx
@@ -220,6 +220,7 @@ function makeTrip(): Trip {
         ticketsRemaining: 10,
         isUnlimited: false,
         installmentSchedule: null,
+        description: null, // [TEST-MOD-APPROVED META-ORCH-1174]
       },
     ],
     inclusions: [],

--- a/mingla-business/src/components/trip/__tests__/EditPublishedTripScreen.render.test.tsx
+++ b/mingla-business/src/components/trip/__tests__/EditPublishedTripScreen.render.test.tsx
@@ -211,6 +211,7 @@ function makeTrip(overrides: Partial<Trip["businessTrip"]> = {}): Trip {
         ticketsRemaining: 10,
         isUnlimited: false,
         installmentSchedule: null,
+        description: null, // [TEST-MOD-APPROVED META-ORCH-1174]
       },
     ],
     inclusions: [],

--- a/mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts
+++ b/mingla-business/src/components/trip/__tests__/ORCH-0876.adversarial.test.ts
@@ -126,6 +126,9 @@ const trip = (patch: Partial<Trip> = {}): Trip => ({
       ticketsRemaining: null,
       isUnlimited: false,
       installmentSchedule: null,
+      // [TEST-MOD-APPROVED META-ORCH-1174] — TripPricingTier gained an optional
+      // per-package description field (Leg B2).
+      description: null,
     },
   ],
   inclusions: [],

--- a/mingla-business/src/components/trip/__tests__/metaOrch1174_multiPackageAuthoring.test.ts
+++ b/mingla-business/src/components/trip/__tests__/metaOrch1174_multiPackageAuthoring.test.ts
@@ -1,0 +1,406 @@
+/**
+ * META-ORCH-1174 Leg B2 [MULTI-PACKAGE AUTHORING] — adversarial + behavioral
+ * tests for the trip creator wizard's multi-package pricing step.
+ *
+ * Covers (per dispatch §4 VERIFY):
+ *   1. validateTripPackages: ≥1 package, valid price (≥0, free allowed),
+ *      capacity ≥1, soft cap 6, per-package installment terms, free+paid mix.
+ *   2. Per-package description persists through createTripPricingTier +
+ *      updateTripPricing (tier_metadata.description) and round-trips via
+ *      mapTripPricingTier (listTripPricingTiers).
+ *   3. Source-level wiring: Step4 renders an inline add/remove package list;
+ *      the wizard persists N packages via the B1 service fns
+ *      (updateTripPricing / createTripPricingTier / removeTripPricingTier) and
+ *      gates publish on validateTripPackages.
+ *   4. Single-package (N=1) still works — the validator + persistence accept it.
+ *
+ * Fails-on-revert: each assertion pins a specific Leg-B2 commitment.
+ */
+/* eslint-disable import/first */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+import {
+  MAX_TRIP_PACKAGES,
+  validateTripPackages,
+  type ValidatedPackage,
+} from "../tripPackagesValidation";
+
+// ----- supabase mock (capture insert/update payloads) -----
+
+interface CapturedCall {
+  table: string;
+  op: "insert" | "update" | "select";
+  payload?: Record<string, unknown>;
+}
+const calls: CapturedCall[] = [];
+
+function makeBuilder(table: string) {
+  // Each terminal (.single()/.maybeSingle()) resolves a row the tests pre-seed.
+  const builder: Record<string, unknown> = {};
+  const chain = (): typeof builder => builder;
+  builder.select = jest.fn(() => {
+    calls.push({ table, op: "select" });
+    return builder;
+  });
+  builder.insert = jest.fn((payload: Record<string, unknown>) => {
+    calls.push({ table, op: "insert", payload });
+    return builder;
+  });
+  builder.update = jest.fn((payload: Record<string, unknown>) => {
+    calls.push({ table, op: "update", payload });
+    return builder;
+  });
+  builder.eq = jest.fn(chain);
+  builder.in = jest.fn(chain);
+  builder.is = jest.fn(chain);
+  builder.order = jest.fn(chain);
+  // .limit(1) on the tier lookup is AWAITED directly (no .single()) — resolve a
+  // LIST result so updateTripPricing finds the addressed tier (N-tier-safe path
+  // that replaced the lifted .maybeSingle()-throws-on->1 choke).
+  builder.limit = jest.fn(async () => ({
+    data: [nextRowFor(table).data],
+    error: null,
+  }));
+  builder.single = jest.fn(async () => nextRowFor(table));
+  builder.maybeSingle = jest.fn(async () => nextRowFor(table));
+  return builder;
+}
+
+// Per-table seeded rows the terminal resolvers return.
+let seededTicketRow: Record<string, unknown> = {};
+let seededTierRow: Record<string, unknown> = {};
+let seededEventRow: Record<string, unknown> = { currency: "USD" };
+
+function nextRowFor(table: string): { data: unknown; error: null } {
+  if (table === "events") return { data: seededEventRow, error: null };
+  if (table === "ticket_types") return { data: seededTicketRow, error: null };
+  if (table === "trip_pricing_tiers") return { data: seededTierRow, error: null };
+  return { data: null, error: null };
+}
+
+jest.mock("../../../services/supabase", () => ({
+  supabase: {
+    from: (table: string) => makeBuilder(table),
+    rpc: jest.fn(async () => ({ data: {}, error: null })),
+  },
+}));
+
+import {
+  createTripPricingTier,
+  updateTripPricing,
+} from "../../../services/tripsService";
+
+beforeEach(() => {
+  calls.length = 0;
+  seededEventRow = { currency: "USD" };
+  seededTicketRow = {
+    id: "tt-new",
+    event_id: "evt-1",
+    price_cents: 5000,
+    currency: "USD",
+    quantity_total: 20,
+    is_unlimited: false,
+  };
+  seededTierRow = {
+    id: "tier-new",
+    event_id: "evt-1",
+    ticket_type_id: "tt-new",
+    tier_name: "VIP",
+    tier_metadata: { description: "Spa + transfer" },
+  };
+});
+
+const pkg = (over: Partial<ValidatedPackage> = {}): ValidatedPackage => ({
+  name: "Standard",
+  priceMajor: "50",
+  capacity: 20,
+  paymentPlan: null,
+  ...over,
+});
+
+// ============================================================================
+// 1. validateTripPackages
+// ============================================================================
+
+describe("META-ORCH-1174 B2 — validateTripPackages", () => {
+  test("single package (N=1) valid → ok (legacy single-package still works)", () => {
+    expect(validateTripPackages([pkg()]).ok).toBe(true);
+  });
+
+  test("zero packages → rejected (min 1)", () => {
+    const r = validateTripPackages([]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/at least one package/i);
+  });
+
+  test("multiple packages all valid → ok (Standard + VIP)", () => {
+    expect(
+      validateTripPackages([
+        pkg({ name: "Standard", priceMajor: "50", capacity: 20 }),
+        pkg({ name: "VIP", priceMajor: "150", capacity: 5 }),
+      ]).ok,
+    ).toBe(true);
+  });
+
+  test("free + paid mix allowed (DEC-I)", () => {
+    const r = validateTripPackages([
+      pkg({ name: "Free RSVP", priceMajor: "0", capacity: 100 }),
+      pkg({ name: "VIP", priceMajor: "150", capacity: 5 }),
+    ]);
+    expect(r.ok).toBe(true);
+  });
+
+  test("price 0 / empty string is a valid free package (price floor 0)", () => {
+    expect(validateTripPackages([pkg({ priceMajor: "0" })]).ok).toBe(true);
+    expect(validateTripPackages([pkg({ priceMajor: "" })]).ok).toBe(true);
+  });
+
+  test("negative price → rejected", () => {
+    const r = validateTripPackages([pkg({ priceMajor: "-5" })]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/valid price/i);
+  });
+
+  test("blank name → rejected", () => {
+    const r = validateTripPackages([pkg({ name: "   " })]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/name/i);
+  });
+
+  test("capacity < 1 / null / non-integer → rejected (per-package, DEC-D)", () => {
+    expect(validateTripPackages([pkg({ capacity: 0 })]).ok).toBe(false);
+    expect(validateTripPackages([pkg({ capacity: null })]).ok).toBe(false);
+    expect(validateTripPackages([pkg({ capacity: 2.5 })]).ok).toBe(false);
+    expect(validateTripPackages([pkg({ capacity: 1 })]).ok).toBe(true);
+  });
+
+  test("soft cap: exactly 6 ok, 7 rejected (DEC-E)", () => {
+    const six = Array.from({ length: 6 }, (_, i) =>
+      pkg({ name: `P${i}`, capacity: 5 }),
+    );
+    expect(validateTripPackages(six).ok).toBe(true);
+    expect(MAX_TRIP_PACKAGES).toBe(6);
+    const seven = [...six, pkg({ name: "P7", capacity: 5 })];
+    const r = validateTripPackages(seven);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/at most 6/i);
+  });
+
+  test("enabled payment plan must sum to 100% (per-package, DEC-F)", () => {
+    const bad = validateTripPackages([
+      pkg({
+        paymentPlan: {
+          deposit_pct: 25,
+          installments: [{ pct: 25, days_after_booking: 30 }], // 50% total
+        },
+      }),
+    ]);
+    expect(bad.ok).toBe(false);
+    expect(bad.reason).toMatch(/100%/);
+
+    const good = validateTripPackages([
+      pkg({
+        paymentPlan: {
+          deposit_pct: 50,
+          installments: [{ pct: 50, days_after_booking: 30 }],
+        },
+      }),
+    ]);
+    expect(good.ok).toBe(true);
+  });
+
+  test("payment-plan installment without a due date → rejected", () => {
+    const r = validateTripPackages([
+      pkg({
+        paymentPlan: {
+          deposit_pct: 50,
+          installments: [{ pct: 50 }], // no days_after_booking / fixed_date
+        },
+      }),
+    ]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/due date/i);
+  });
+});
+
+// ============================================================================
+// 2. Per-package description persistence (service)
+// ============================================================================
+
+describe("META-ORCH-1174 B2 — per-package description persists", () => {
+  test("createTripPricingTier writes tier_metadata.description", async () => {
+    await createTripPricingTier("evt-1", {
+      tierName: "VIP",
+      priceCents: 15000,
+      capacity: 5,
+      description: "Spa + private transfer",
+    });
+    const tierInsert = calls.find(
+      (c) => c.table === "trip_pricing_tiers" && c.op === "insert",
+    );
+    expect(tierInsert).toBeDefined();
+    expect(
+      (tierInsert?.payload?.tier_metadata as Record<string, unknown>)
+        ?.description,
+    ).toBe("Spa + private transfer");
+    // Each package is its OWN ticket_types row carrying its own price + capacity.
+    const ttInsert = calls.find(
+      (c) => c.table === "ticket_types" && c.op === "insert",
+    );
+    expect(ttInsert?.payload?.price_cents).toBe(15000);
+    expect(ttInsert?.payload?.quantity_total).toBe(5);
+  });
+
+  test("createTripPricingTier with blank description omits the key", async () => {
+    await createTripPricingTier("evt-1", {
+      tierName: "Standard",
+      priceCents: 5000,
+      capacity: 20,
+      description: "   ",
+    });
+    const tierInsert = calls.find(
+      (c) => c.table === "trip_pricing_tiers" && c.op === "insert",
+    );
+    expect(
+      "description" in
+        ((tierInsert?.payload?.tier_metadata as Record<string, unknown>) ?? {}),
+    ).toBe(false);
+  });
+
+  test("updateTripPricing merges description into tier_metadata (present-key)", async () => {
+    // Existing metadata carries an installments key that must be preserved.
+    seededTierRow = {
+      id: "tier-1",
+      event_id: "evt-1",
+      ticket_type_id: "tt-1",
+      tier_name: "VIP",
+      tier_metadata: { installments: { deposit_pct: 25, installments: [] } },
+    };
+    await updateTripPricing("evt-1", {
+      ticketTypeId: "tt-1",
+      tierName: "VIP",
+      priceCents: 15000,
+      capacity: 5,
+      description: "Updated blurb",
+    });
+    const tierUpdate = calls.find(
+      (c) => c.table === "trip_pricing_tiers" && c.op === "update",
+    );
+    const meta = tierUpdate?.payload?.tier_metadata as Record<string, unknown>;
+    expect(meta.description).toBe("Updated blurb");
+    // installments key preserved (not clobbered by the description merge).
+    expect(meta.installments).toBeDefined();
+  });
+
+  test("updateTripPricing targets the package by ticketTypeId (N-tier safe)", async () => {
+    await updateTripPricing("evt-1", {
+      ticketTypeId: "tt-vip",
+      tierName: "VIP",
+      priceCents: 15000,
+      capacity: 5,
+    });
+    // The tier lookup must be scoped to the addressed ticket_type_id, never a
+    // bare .maybeSingle() that throws on >1 (the lifted single-tier choke).
+    const tierSelect = calls.find(
+      (c) => c.table === "trip_pricing_tiers" && c.op === "select",
+    );
+    expect(tierSelect).toBeDefined();
+  });
+});
+
+// ============================================================================
+// 3. Source-level wiring (Step4 list + wizard persistence + publish gate)
+// ============================================================================
+
+const ROOT = join(__dirname, "..", "..", "..", "..");
+const STEP4_SRC = readFileSync(
+  join(ROOT, "src", "components", "trip", "TripCreatorStep4Pricing.tsx"),
+  "utf8",
+);
+const WIZARD_SRC = readFileSync(
+  join(ROOT, "src", "components", "trip", "TripCreatorWizard.tsx"),
+  "utf8",
+);
+const SERVICE_SRC = readFileSync(
+  join(ROOT, "src", "services", "tripsService.ts"),
+  "utf8",
+);
+
+describe("META-ORCH-1174 B2 — Step4 multi-package authoring UI", () => {
+  test("renders an inline add-package control + per-package remove", () => {
+    expect(STEP4_SRC).toMatch(/testID="trip-step4-add-package"/);
+    expect(STEP4_SRC).toMatch(/trip-step4-package-remove-\$\{index\}/);
+  });
+
+  test("per-package fields: name, price, description, capacity (DEC-G)", () => {
+    expect(STEP4_SRC).toMatch(/trip-step4-package-name-\$\{index\}/);
+    expect(STEP4_SRC).toMatch(/trip-step4-price-\$\{index\}/);
+    expect(STEP4_SRC).toMatch(/trip-step4-description-\$\{index\}/);
+    expect(STEP4_SRC).toMatch(/trip-step4-capacity-\$\{index\}/);
+  });
+
+  test("draft is a packages array (multi-package), not a single tier", () => {
+    expect(STEP4_SRC).toMatch(/packages:\s*Step4Package\[\]/);
+    // The legacy single-tier `tierName`/`priceMajor` top-level draft fields are
+    // gone (now per-package).
+    expect(STEP4_SRC).not.toMatch(/export interface Step4Draft \{[^}]*tierName:/);
+  });
+
+  test("per-package payment plan toggle wired to PaymentPlanEditor (DEC-F)", () => {
+    expect(STEP4_SRC).toMatch(/PaymentPlanEditor/);
+    expect(STEP4_SRC).toMatch(/payment plan toggle/i);
+  });
+});
+
+describe("META-ORCH-1174 B2 — wizard persists N packages via B1 service fns", () => {
+  test("imports the B1 create/remove tier mutations", () => {
+    expect(WIZARD_SRC).toMatch(/useCreateTripPricingTier/);
+    expect(WIZARD_SRC).toMatch(/useRemoveTripPricingTier/);
+  });
+
+  test("persistPackages: update existing / create new / remove dropped", () => {
+    const block = WIZARD_SRC.match(/const persistPackages[^]*?\}, \[/);
+    expect(block).not.toBeNull();
+    const body = block?.[0] ?? "";
+    // existing package (has ticketTypeId) → updateTripPricing
+    expect(body).toMatch(/updatePricingMutation\.mutateAsync/);
+    // new package (no ticketTypeId) → createTripPricingTier
+    expect(body).toMatch(/createTierMutation\.mutateAsync/);
+    // dropped persisted tier → removeTripPricingTier
+    expect(body).toMatch(/removeTierMutation\.mutateAsync/);
+    // each package carries its own price + capacity + installments
+    expect(body).toMatch(/priceCents/);
+    expect(body).toMatch(/capacity/);
+    expect(body).toMatch(/installmentSchedule:\s*pkg\.paymentPlan/);
+  });
+
+  test("publish is gated on validateTripPackages (belt + suspenders)", () => {
+    expect(WIZARD_SRC).toMatch(/validateTripPackages\(step4Draft\.packages\)/);
+    // dock Publish disabled when packages invalid
+    expect(WIZARD_SRC).toMatch(/!packagesValidation\.ok/);
+    // belt: handlePublishTap blocks + jumps to the pricing step (4)
+    expect(WIZARD_SRC).toMatch(/packagesValidation\.ok[\s\S]*?setStep\(4\)/);
+  });
+});
+
+describe("META-ORCH-1174 B2 — B1 service layer is N-tier safe", () => {
+  test("updateTripPricing does NOT use .maybeSingle()-throws-on->1", () => {
+    const block = SERVICE_SRC.match(
+      /export async function updateTripPricing[^]*?\n\}/,
+    );
+    expect(block).not.toBeNull();
+    // The lifted choke: tier lookup orders + limits instead of maybeSingle().
+    expect(block?.[0]).toMatch(/\.order\("created_at"/);
+    expect(block?.[0]).toMatch(/\.limit\(1\)/);
+  });
+
+  test("createTripPricingTier + removeTripPricingTier exist (B1)", () => {
+    expect(SERVICE_SRC).toMatch(/export async function createTripPricingTier/);
+    expect(SERVICE_SRC).toMatch(/export async function removeTripPricingTier/);
+    // removal refuses a sold package (refund-gate parity).
+    expect(SERVICE_SRC).toMatch(/tier_delete_with_sales/);
+  });
+});

--- a/mingla-business/src/components/trip/__tests__/tr2RewordPolish.test.ts
+++ b/mingla-business/src/components/trip/__tests__/tr2RewordPolish.test.ts
@@ -42,20 +42,31 @@ const BUSINESS_EVENTS_SOURCE = readFileSync(
 describe("ORCH-0859 REWORK 2 — item 1 + 7 (pricing currency + stale-banner)", () => {
   test("Step 4 pricing component has NO editable currency TextInput", () => {
     // Currency input was a free-form TextInput pre-fix. Now read-only View.
-    // The mapper "trip-step4-currency" testID belonged to a TextInput;
-    // after rework it must be replaced by "trip-step4-currency-readonly".
+    // [TEST-MOD-APPROVED META-ORCH-1174] — Step 4 is now MULTI-PACKAGE (Leg B2),
+    // so the read-only currency View renders PER PACKAGE with an indexed testID
+    // `trip-step4-currency-readonly-${index}` (template literal). The ORCH-0859
+    // invariant — currency is NEVER an editable input — is fully preserved.
     expect(STEP4_SOURCE).not.toMatch(/testID="trip-step4-currency"/);
-    expect(STEP4_SOURCE).toMatch(/testID="trip-step4-currency-readonly"/);
-    // No TextInput element bound to currency — pin via the onChange handler
-    // pattern that used to write currency to draft.
+    expect(STEP4_SOURCE).toMatch(
+      /testID=\{`trip-step4-currency-readonly-\$\{index\}`\}/,
+    );
+    // No onChange/onPatch handler writes currency to draft/package state.
     expect(STEP4_SOURCE).not.toMatch(/onChange\(\s*\{\s*currency:/);
+    expect(STEP4_SOURCE).not.toMatch(/onPatch\(\s*\{\s*currency:/);
   });
 
-  test("wizard autosaveStep4 does NOT send currency in the pricing patch", () => {
-    // The autosaveStep4 callback must not include a `currency:` key in the
-    // patch payload — currency is server-derived per ORCH-0859 REWORK 2.
+  test("wizard pricing persistence does NOT send currency in the patch", () => {
+    // [TEST-MOD-APPROVED META-ORCH-1174] — autosaveStep4 now delegates to the
+    // N-package `persistPackages` callback. Currency stays server-derived per
+    // ORCH-0859 REWORK 2: neither persistPackages nor autosaveStep4 may include
+    // a `currency:` key in any updateTripPricing/createTripPricingTier patch.
+    const persistBlock = WIZARD_SOURCE.match(
+      /const persistPackages[^]*?\}, \[\s*step4Draft\.packages[^]*?\]\);/,
+    );
+    expect(persistBlock).not.toBeNull();
+    expect(persistBlock?.[0]).not.toMatch(/currency:\s/);
     const autosaveStep4Block = WIZARD_SOURCE.match(
-      /const autosaveStep4[^]*?\}, \[step4Draft[^]*?\]\);/,
+      /const autosaveStep4[^]*?\}, \[\s*persistPackages[^]*?\]\);/,
     );
     expect(autosaveStep4Block).not.toBeNull();
     expect(autosaveStep4Block?.[0]).not.toMatch(/currency:\s/);

--- a/mingla-business/src/components/trip/__tests__/tripReserveSplitButtons.orch1138.test.ts
+++ b/mingla-business/src/components/trip/__tests__/tripReserveSplitButtons.orch1138.test.ts
@@ -140,8 +140,11 @@ describe("ORCH-1138 — trip Reserve UNIFIED seam-split CTA (business/web)", () 
   });
 
   test("SP6 the shared state machine gates the split on a bookable plan trip (rule 9)", () => {
+    // [TEST-MOD-APPROVED META-ORCH-1174] Leg B3 — the split-CTA fast path is now the
+    // SINGLE-package plan case ONLY (multi-package rows own their own per-row toggle).
+    // The gate became `hasSingleTierPlan && !multiTier && cta.tappable`.
     expect(hookSrc).toMatch(
-      /const splitCtas:\s*ReserveSplitCtas \| undefined =\s*\n?\s*hasPlan && cta\.tappable/,
+      /const splitCtas:\s*ReserveSplitCtas \| undefined =\s*\n?\s*hasSingleTierPlan && !multiTier && cta\.tappable/,
     );
   });
 
@@ -152,8 +155,13 @@ describe("ORCH-1138 — trip Reserve UNIFIED seam-split CTA (business/web)", () 
 
   test("SP8 each segment routes STRAIGHT to checkout with its OWN plan choice (byte-identical)", () => {
     // The route's reserve handler threads the choice into the plan route param…
+    // [TEST-MOD-APPROVED META-ORCH-1174] Leg B3 — the handler signature grew a
+    // `lines?: TripReserveLine[]` arg (DEC-B multi-package selection rides the
+    // checkout as a JSON param). The plan-param threading is unchanged.
     expect(routeSrc).toMatch(/handleTripReserve = useCallback\(/);
-    expect(routeSrc).toMatch(/\(choice\?:\s*TripPaymentPlanChoice\):\s*void/);
+    expect(routeSrc).toMatch(
+      /\(choice\?:\s*TripPaymentPlanChoice,\s*lines\?:\s*TripReserveLine\[\]\):\s*void/,
+    );
     expect(routeSrc).toMatch(/plan:\s*choice \?\? paymentPlanChoice/);
     // …and the shared state wires each segment to its OWN choice.
     expect(hookSrc).toMatch(/onPress:\s*\(\)\s*=>\s*onReserve\("full"\)/);

--- a/mingla-business/src/components/trip/tripOfferingAdapter.ts
+++ b/mingla-business/src/components/trip/tripOfferingAdapter.ts
@@ -51,6 +51,11 @@ function coerceRefundPolicy(raw: unknown): TripRefundPolicyShape | null {
 export function buildTripOfferingData(
   trip: Trip,
   bookable: boolean,
+  // META-ORCH-1174 Leg B3 — the SERVER all-in per ticket_type (cents), resolved by
+  // the route via fetchTierAllInCents (pg_public_event_tier_allin). The §10 box +
+  // bar DISPLAY + SUM this (WYSIWYP) instead of the bare base. Absent → the body
+  // falls back to priceCents (free tiers / RPC miss). NEVER recompute fees here.
+  allInByTicketType?: Map<string, number> | null,
 ): TripOfferingData {
   const bt = trip.businessTrip;
   const tier = trip.pricingTiers[0];
@@ -100,17 +105,29 @@ export function buildTripOfferingData(
       item: i.item,
     })),
     refundPolicy: coerceRefundPolicy(trip.refundPolicy),
-    tiers: trip.pricingTiers.map((t) => ({
-      id: t.id,
-      ticketTypeId: t.ticketTypeId,
-      tierName: t.tierName,
-      priceCents: t.priceCents,
-      currency: t.currency,
-      isFree: t.priceCents === 0,
-      isUnlimited: t.isUnlimited,
-      ticketsRemaining: t.ticketsRemaining,
-      installmentSchedule: t.installmentSchedule ?? null,
-    })),
+    tiers: trip.pricingTiers.map((t) => {
+      const allInCents = allInByTicketType?.get(t.ticketTypeId);
+      return {
+        id: t.id,
+        ticketTypeId: t.ticketTypeId,
+        tierName: t.tierName,
+        priceCents: t.priceCents,
+        // META-ORCH-1174 Leg B3 — server all-in (WYSIWYP). Free tier → null (the
+        // body shows "Free"); RPC miss → null → fall back to priceCents.
+        priceAllInCents:
+          t.priceCents === 0
+            ? null
+            : typeof allInCents === "number"
+              ? allInCents
+              : null,
+        description: t.description ?? null,
+        currency: t.currency,
+        isFree: t.priceCents === 0,
+        isUnlimited: t.isUnlimited,
+        ticketsRemaining: t.ticketsRemaining,
+        installmentSchedule: t.installmentSchedule ?? null,
+      };
+    }),
     currency: tier?.currency ?? "USD",
     destinationLat: bt.destinationLat,
     destinationLng: bt.destinationLng,

--- a/mingla-business/src/components/trip/tripPackagesValidation.ts
+++ b/mingla-business/src/components/trip/tripPackagesValidation.ts
@@ -1,0 +1,124 @@
+/**
+ * META-ORCH-1174 Leg B2 — pure (RN-free) publish-gate validation for the
+ * authored trip package set. Extracted from TripCreatorWizard so it can be
+ * unit-tested without pulling React Native into the jest environment, and so
+ * the wizard + edit-published path share ONE validator.
+ *
+ * DEC-E (soft cap 6 / min 1), DEC-G (per-package name/price/capacity/plan),
+ * DEC-I (free + paid mix allowed). The price floor is 0 (free packages OK);
+ * capacity must be a finite integer ≥ 1 (per-package, DEC-D); an enabled
+ * payment plan must sum to 100% with each installment ≥ 1% and a due date —
+ * mirroring PaymentPlanEditor's own validation.
+ *
+ * Spec: Mingla_Artifacts/specs/SPEC_META-ORCH-1174_LEGB_MULTITIER.md §C/§D.
+ */
+
+/**
+ * META-ORCH-1174 Leg B2 — soft cap on packages per trip (DEC-E). The data
+ * layer + checkout engine support N; this is a UX/density guard only.
+ */
+export const MAX_TRIP_PACKAGES = 6;
+
+/** Minimal per-installment shape the validator inspects. */
+export interface ValidatedInstallment {
+  pct: number;
+  days_after_booking?: number;
+  fixed_date?: string;
+}
+
+/** Minimal per-package shape the validator inspects (a subset of Step4Package). */
+export interface ValidatedPackage {
+  name: string;
+  priceMajor: string;
+  capacity: number | null;
+  paymentPlan: {
+    deposit_pct: number;
+    installments: ValidatedInstallment[];
+  } | null;
+}
+
+export interface TripPackagesValidationResult {
+  ok: boolean;
+  reason: string | null;
+}
+
+/**
+ * Validate the authored package set for publish (see module doc). Returns the
+ * first failing reason (or null when valid) so callers can surface it + jump
+ * to the pricing step.
+ */
+export function validateTripPackages(
+  packages: ValidatedPackage[],
+): TripPackagesValidationResult {
+  if (packages.length < 1) {
+    return { ok: false, reason: "Add at least one package." };
+  }
+  if (packages.length > MAX_TRIP_PACKAGES) {
+    return {
+      ok: false,
+      reason: `Trips can have at most ${MAX_TRIP_PACKAGES} packages.`,
+    };
+  }
+  for (let i = 0; i < packages.length; i += 1) {
+    const p = packages[i];
+    const label =
+      p.name.trim().length > 0 ? `"${p.name.trim()}"` : `Package ${i + 1}`;
+    if (p.name.trim().length === 0) {
+      return { ok: false, reason: `Give ${label} a name.` };
+    }
+    const price = parseFloat(p.priceMajor);
+    // Empty string → treated as free (0), valid. Any parsed value must be ≥ 0.
+    if (
+      p.priceMajor.trim().length > 0 &&
+      (!Number.isFinite(price) || price < 0)
+    ) {
+      return { ok: false, reason: `${label} needs a valid price (0 or more).` };
+    }
+    if (
+      p.capacity === null ||
+      !Number.isFinite(p.capacity) ||
+      p.capacity < 1 ||
+      !Number.isInteger(p.capacity)
+    ) {
+      return { ok: false, reason: `${label} needs at least 1 spot.` };
+    }
+    if (p.paymentPlan !== null) {
+      const plan = p.paymentPlan;
+      const sum =
+        plan.deposit_pct +
+        plan.installments.reduce((acc, inst) => acc + inst.pct, 0);
+      if (Math.abs(sum - 100) > 0.01) {
+        return {
+          ok: false,
+          reason: `${label}'s payment plan must add up to 100%.`,
+        };
+      }
+      if (plan.installments.length === 0) {
+        return {
+          ok: false,
+          reason: `${label}'s payment plan needs at least one installment.`,
+        };
+      }
+      for (const inst of plan.installments) {
+        if (inst.pct < 1) {
+          return {
+            ok: false,
+            reason: `${label}'s installments must each be at least 1%.`,
+          };
+        }
+        const hasDays =
+          inst.days_after_booking !== undefined &&
+          inst.days_after_booking !== null;
+        const hasDate =
+          inst.fixed_date !== undefined && inst.fixed_date !== null;
+        if (!hasDays && !hasDate) {
+          return {
+            ok: false,
+            reason: `${label}'s installments each need a due date.`,
+          };
+        }
+      }
+    }
+  }
+  return { ok: true, reason: null };
+}

--- a/mingla-business/src/hooks/usePublicTripBySlug.ts
+++ b/mingla-business/src/hooks/usePublicTripBySlug.ts
@@ -335,6 +335,12 @@ export const usePublicTripBySlug = (
             ticketsRemaining: t.isUnlimited ? null : (t.ticketsRemaining ?? null),
             isUnlimited: t.isUnlimited === true,
             installmentSchedule: asInstallmentSchedule(t.installments),
+            // META-ORCH-1174 Leg B2 — per-package description from tier_metadata.
+            description:
+              typeof (t.tierMetadata as Record<string, unknown> | null)?.description ===
+              "string"
+                ? ((t.tierMetadata as Record<string, unknown>).description as string)
+                : null,
           }),
         ),
         inclusions: (p.inclusions ?? []).map(

--- a/mingla-business/src/hooks/useTripTierAllIn.ts
+++ b/mingla-business/src/hooks/useTripTierAllIn.ts
@@ -1,0 +1,34 @@
+/**
+ * useTripTierAllIn — META-ORCH-1174 Leg B3 [trip-page multi-tier selector].
+ *
+ * Resolves the SERVER all-in (tax/fee-inclusive) cents per ticket_type for a trip's
+ * event, via the single-owner `fetchTierAllInCents` (pg_public_event_tier_allin) the
+ * cart + event public page already use (ORCH-1147). Trips ride the SAME engine — the
+ * §10 multi-package box DISPLAYS + SUMS this all-in (WYSIWYP, I-PROPOSED-1174-ALLIN-
+ * SERVER-SOURCED) instead of the bare base price (which is all trip pages showed
+ * pre-Leg-B). Anon-safe: the RPC is a SECURITY DEFINER public read; this page is an
+ * anon buyer route, so no auth is required.
+ *
+ * Returns a Map<ticket_type_id, all_in_cents>; the route threads it into the trip
+ * offering adapter so the body never touches a service (I-MOR-0827 isolation).
+ */
+
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { fetchTierAllInCents } from "../services/publicEventsService";
+
+export function useTripTierAllIn(
+  eventId: string | null,
+): UseQueryResult<Map<string, number>> {
+  return useQuery({
+    queryKey: ["tripTierAllIn", eventId],
+    enabled: eventId !== null && eventId.length > 0,
+    // The all-in is stable for the page session (fee/tax config rarely changes mid
+    // browse); refetch on remount keeps it fresh enough without spamming the RPC.
+    staleTime: 60_000,
+    queryFn: async (): Promise<Map<string, number>> => {
+      if (eventId === null || eventId.length === 0) return new Map();
+      return fetchTierAllInCents(eventId);
+    },
+  });
+}

--- a/mingla-business/src/hooks/useTrips.ts
+++ b/mingla-business/src/hooks/useTrips.ts
@@ -37,6 +37,9 @@ import {
   upsertTripDays,
   upsertTripInclusions,
   updateTripPricing,
+  // META-ORCH-1174 Leg B2 — N-package data layer (B1 service fns).
+  createTripPricingTier,
+  removeTripPricingTier,
   publishTrip,
   softDeleteTrip,
   type Trip,
@@ -265,6 +268,70 @@ export const useUpdateTripPricing = (): UseMutationResult<
     },
     onError: (error, { eventId }) => {
       console.error("[useUpdateTripPricing] failed", {
+        message: error.message,
+        eventId,
+      });
+    },
+  });
+};
+
+// ---------------------- META-ORCH-1174 Leg B2: N-package tier mutations ----------------------
+
+export interface CreateTripPricingTierInput {
+  eventId: string;
+  patch: Omit<TripPricingPatch, "ticketTypeId">;
+}
+
+/**
+ * META-ORCH-1174 Leg B2 — create an ADDITIONAL pricing package on a trip.
+ * Returns the new tier (incl. its `ticketTypeId`) so the wizard can adopt the
+ * id for subsequent in-place updates. Invalidates the trip detail cache.
+ */
+export const useCreateTripPricingTier = (): UseMutationResult<
+  TripPricingTier,
+  Error,
+  CreateTripPricingTierInput
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<TripPricingTier, Error, CreateTripPricingTierInput>({
+    mutationFn: async ({ eventId, patch }) =>
+      createTripPricingTier(eventId, patch),
+    onSuccess: (_, { eventId }) => {
+      queryClient.invalidateQueries({ queryKey: tripKeys.detail(eventId) });
+    },
+    onError: (error, { eventId }) => {
+      console.error("[useCreateTripPricingTier] failed", {
+        message: error.message,
+        eventId,
+      });
+    },
+  });
+};
+
+export interface RemoveTripPricingTierInput {
+  eventId: string;
+  ticketTypeId: string;
+}
+
+/**
+ * META-ORCH-1174 Leg B2 — soft-remove a pricing package (refuses if it has
+ * sales — the B1 service throws `tier_delete_with_sales`). Invalidates the
+ * trip detail cache.
+ */
+export const useRemoveTripPricingTier = (): UseMutationResult<
+  void,
+  Error,
+  RemoveTripPricingTierInput
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, RemoveTripPricingTierInput>({
+    mutationFn: async ({ eventId, ticketTypeId }) =>
+      removeTripPricingTier(eventId, ticketTypeId),
+    onSuccess: (_, { eventId }) => {
+      queryClient.invalidateQueries({ queryKey: tripKeys.detail(eventId) });
+    },
+    onError: (error, { eventId }) => {
+      console.error("[useRemoveTripPricingTier] failed", {
         message: error.message,
         eventId,
       });

--- a/mingla-business/src/services/__tests__/orch_0946_sold_out_gate.test.ts
+++ b/mingla-business/src/services/__tests__/orch_0946_sold_out_gate.test.ts
@@ -44,6 +44,8 @@ const tier = (patch: Partial<TripPricingTier> = {}): TripPricingTier => ({
   ticketsRemaining: null,
   isUnlimited: false,
   installmentSchedule: null,
+  // [TEST-MOD-APPROVED META-ORCH-1174] — TripPricingTier gained `description`.
+  description: null,
   ...patch,
 });
 

--- a/mingla-business/src/services/publicEventsService.ts
+++ b/mingla-business/src/services/publicEventsService.ts
@@ -1613,6 +1613,11 @@ export const getPublicTripById = async (
         ticketsRemaining,
         isUnlimited,
         installmentSchedule,
+        // META-ORCH-1174 Leg B2 — per-package description from tier_metadata.
+        description:
+          typeof t.tier_metadata?.description === "string"
+            ? (t.tier_metadata.description as string)
+            : null,
         // ORCH-1147 — server fee-grossed per-tier all-in (MAJOR units). Free
         // tier / RPC miss → null; the cart seed owns the single base fallback
         // (mirrors the event path). NEVER recompute fees in TS.

--- a/mingla-business/src/services/tripsService.ts
+++ b/mingla-business/src/services/tripsService.ts
@@ -233,6 +233,16 @@ export interface TripInclusionInput {
 }
 
 export interface TripPricingPatch {
+  /**
+   * META-ORCH-1174 Leg B1 — when a trip has MULTIPLE pricing tiers (packages),
+   * the caller MUST identify which tier this patch targets by its
+   * `ticketTypeId`. When omitted, `updateTripPricing` falls back to the trip's
+   * sole tier (deterministically the earliest-created one if, defensively, more
+   * than one exists) — preserving the single-package wizard's call shape with
+   * zero change. Lifting the historical `.maybeSingle()`-throws-on->1 choke is
+   * what makes N packages possible at the data layer (DEC-1174-B).
+   */
+  ticketTypeId?: string;
   tierName: string;
   priceCents: number;
   capacity: number;
@@ -1042,16 +1052,30 @@ export async function updateTripPricing(
   }
   const eventCurrency = (eventCurrencyResp.data.currency as string | null) ?? "USD";
 
-  // Look up the existing pricing tier + its ticket_type
-  const { data: tierRow, error: tierError } = await supabase
+  // META-ORCH-1174 Leg B1 — lift the single-tier `.maybeSingle()` choke. A trip
+  // may now carry N pricing tiers (packages). Target the tier addressed by
+  // `patch.ticketTypeId` when provided; otherwise fall back to the trip's sole
+  // tier (deterministically the earliest-created row if, defensively, >1 exists
+  // — NEVER throw on >1 as the old `.maybeSingle()` did, which was the hard
+  // single-package barrier). The per-tier validation below is unchanged.
+  let tierQuery = supabase
     .from("trip_pricing_tiers")
     .select("*")
-    .eq("event_id", eventId)
-    .maybeSingle();
+    .eq("event_id", eventId);
+  if (patch.ticketTypeId !== undefined) {
+    tierQuery = tierQuery.eq("ticket_type_id", patch.ticketTypeId);
+  }
+  const { data: tierRows, error: tierError } = await tierQuery
+    .order("created_at", { ascending: true })
+    .limit(1);
   if (tierError) throw tierError;
+  const tierRow = (tierRows ?? [])[0] ?? null;
   if (tierRow === null) {
     throw new Error(
-      "updateTripPricing: no pricing tier found for event_id=" + eventId,
+      "updateTripPricing: no pricing tier found for event_id=" + eventId +
+        (patch.ticketTypeId !== undefined
+          ? " ticketTypeId=" + patch.ticketTypeId
+          : ""),
     );
   }
 
@@ -1110,6 +1134,168 @@ export async function updateTripPricing(
     tierUpdated as TripPricingTierRow,
     ticketRow as TicketTypeRow,
   );
+}
+
+// ---------------------- META-ORCH-1174 Leg B1: N-tier data layer ----------------------
+//
+// The DB schema, checkout engine, per-tier remaining RPC, and public read RPC
+// ALREADY support N pricing tiers per trip (only the service `.maybeSingle()`
+// + the wizard UI enforced one). These functions let the data layer create,
+// list, and soft-remove additional packages WITHOUT building the wizard (B2).
+//
+// Soft-remove = set ticket_types.deleted_at. The public read RPC
+// (pg_public_trip_by_slug) and the remaining RPC (pg_public_ticket_types_remaining)
+// already filter `tt.deleted_at IS NULL`, so a soft-removed package vanishes from
+// every buyer surface while historical orders/tickets (FK → ticket_types.id) stay
+// coherent. Callers MUST gate removal on zero sales (mirrors the published-edit
+// `tier_delete_with_sales` refund-gate; enforced here for draft tiers too).
+
+/**
+ * List ALL non-deleted pricing tiers for a trip, joined to their ticket_types
+ * (price / capacity / currency / installment template). Replaces any
+ * `pricingTiers[0]` single-tier assumption in callers that need the full set.
+ */
+export async function listTripPricingTiers(
+  eventId: string,
+): Promise<TripPricingTier[]> {
+  const { data: tierRows, error: tierError } = await supabase
+    .from("trip_pricing_tiers")
+    .select("*")
+    .eq("event_id", eventId)
+    .order("created_at", { ascending: true });
+  if (tierError) throw tierError;
+  const rows = (tierRows ?? []) as TripPricingTierRow[];
+  if (rows.length === 0) return [];
+
+  const ticketTypeIds = rows.map((r) => r.ticket_type_id);
+  const { data: ttRows, error: ttError } = await supabase
+    .from("ticket_types")
+    .select("id, event_id, price_cents, currency, quantity_total, is_unlimited")
+    .in("id", ticketTypeIds)
+    .is("deleted_at", null);
+  if (ttError) throw ttError;
+  const ttById = new Map(
+    ((ttRows ?? []) as TicketTypeRow[]).map((tt) => [tt.id, tt]),
+  );
+
+  // Drop tiers whose ticket_type was soft-deleted (vanished package).
+  return rows
+    .filter((r) => ttById.has(r.ticket_type_id))
+    .map((r) => mapTripPricingTier(r, ttById.get(r.ticket_type_id)));
+}
+
+/**
+ * Create an ADDITIONAL pricing tier (package) on a trip: inserts a ticket_types
+ * row (currency derived from the event, NEVER caller-supplied — the
+ * tg_enforce_event_ticket_currency trigger rejects mismatch) + the joined
+ * trip_pricing_tiers row. Returns the new tier. Mirrors the createTripDraft
+ * placeholder insert but is additive (the trip keeps its existing tiers).
+ */
+export async function createTripPricingTier(
+  eventId: string,
+  patch: Omit<TripPricingPatch, "ticketTypeId">,
+): Promise<TripPricingTier> {
+  const eventResp = await supabase
+    .from("events")
+    .select("currency")
+    .eq("id", eventId)
+    .eq("event_type", "trip")
+    .maybeSingle();
+  if (eventResp.error) throw eventResp.error;
+  if (eventResp.data === null) {
+    throw new Error("createTripPricingTier: event not found for id=" + eventId);
+  }
+  const eventCurrency = (eventResp.data.currency as string | null) ?? "USD";
+
+  // Place the new package after the existing ones.
+  const { data: existing, error: existingErr } = await supabase
+    .from("trip_pricing_tiers")
+    .select("ticket_type_id")
+    .eq("event_id", eventId);
+  if (existingErr) throw existingErr;
+  const displayOrder = (existing ?? []).length;
+
+  const { data: ticketRow, error: ticketError } = await supabase
+    .from("ticket_types")
+    .insert({
+      event_id: eventId,
+      name: patch.tierName,
+      price_cents: patch.priceCents,
+      currency: eventCurrency,
+      quantity_total: patch.capacity,
+      is_unlimited: false,
+      is_free: patch.priceCents === 0,
+      min_purchase_qty: 1,
+      available_online: true,
+      available_in_person: false,
+      display_order: displayOrder,
+    })
+    .select()
+    .single();
+  if (ticketError) throw ticketError;
+  if (ticketRow === null) {
+    throw new Error("createTripPricingTier: ticket_types insert returned null");
+  }
+
+  // Build tier_metadata.installments from the optional per-package plan.
+  const tierMetadata: Record<string, unknown> = {};
+  if (
+    patch.installmentSchedule !== null &&
+    patch.installmentSchedule !== undefined
+  ) {
+    tierMetadata.installments = patch.installmentSchedule;
+  }
+
+  const { data: tierRow, error: tierError } = await supabase
+    .from("trip_pricing_tiers")
+    .insert({
+      event_id: eventId,
+      ticket_type_id: (ticketRow as TicketTypeRow).id,
+      tier_name: patch.tierName,
+      tier_metadata: tierMetadata,
+    })
+    .select()
+    .single();
+  if (tierError) throw tierError;
+  if (tierRow === null) {
+    throw new Error("createTripPricingTier: tier insert returned null");
+  }
+
+  return mapTripPricingTier(
+    tierRow as TripPricingTierRow,
+    ticketRow as TicketTypeRow,
+  );
+}
+
+/**
+ * Soft-remove a pricing tier (package) by its ticketTypeId. Refuses to remove a
+ * package that has sold tickets (mirrors the published-edit `tier_delete_with_sales`
+ * refund-gate — applies to draft tiers too so historical inventory is never
+ * orphaned). Sets ticket_types.deleted_at; the read + remaining RPCs filter it
+ * out, so the package disappears from every buyer surface.
+ */
+export async function removeTripPricingTier(
+  eventId: string,
+  ticketTypeId: string,
+): Promise<void> {
+  const soldByTier = await readTripSoldCountsByTier(eventId);
+  if ((soldByTier.get(ticketTypeId) ?? 0) > 0) {
+    throw new Error("tier_delete_with_sales");
+  }
+
+  // I-PROPOSED-I (MUTATION-ROWCOUNT-VERIFIED): chain .select() so a 0-row write
+  // surfaces as an error rather than a silent no-op.
+  const { data, error } = await supabase
+    .from("ticket_types")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", ticketTypeId)
+    .eq("event_id", eventId)
+    .is("deleted_at", null)
+    .select("id");
+  if (error) throw error;
+  if (data === null || data.length === 0) {
+    throw new Error("removeTripPricingTier: no rows updated (already removed?)");
+  }
 }
 
 export async function readTripSoldCountsByTier(

--- a/mingla-business/src/services/tripsService.ts
+++ b/mingla-business/src/services/tripsService.ts
@@ -96,6 +96,16 @@ export interface TripPricingTier {
    */
   installmentSchedule: TripInstallmentScheduleData | null;
   /**
+   * META-ORCH-1174 Leg B2 — optional per-package marketing description
+   * (e.g. "Includes spa + private transfer"). Persisted to
+   * trip_pricing_tiers.tier_metadata.description (free-form jsonb — NO
+   * migration; the column already holds installments under the same object).
+   * Null when the package has no description. Surfaced by the wizard's
+   * per-package authoring rows; the public selector (B3) renders it under the
+   * package name.
+   */
+  description: string | null;
+  /**
    * ORCH-1147 — server fee-grossed per-tier all-in in MAJOR units
    * (`pg_public_event_tier_allin` → /100). Null = free tier or RPC miss;
    * the cart seed falls back to `priceCents`/base. NEVER recompute fees in TS.
@@ -268,6 +278,13 @@ export interface TripPricingPatch {
    * 1b finalize key off the JSONB presence/shape.
    */
   installmentSchedule?: TripInstallmentScheduleData | null;
+  /**
+   * META-ORCH-1174 Leg B2 — optional per-package description. When the key is
+   * PRESENT, the tier_metadata.description value is replaced (null/blank →
+   * REMOVE the key). When ABSENT from the patch, the existing description is
+   * preserved (mirrors the installmentSchedule "present vs absent" semantics).
+   */
+  description?: string | null;
 }
 
 export class SlugCollisionError extends Error {
@@ -404,7 +421,22 @@ function mapTripPricingTier(
     ticketsRemaining: null,
     isUnlimited: ticketType?.is_unlimited ?? false,
     installmentSchedule: extractInstallmentSchedule(metadata),
+    // META-ORCH-1174 Leg B2 — per-package description from tier_metadata.
+    description: extractTierDescription(metadata),
   };
+}
+
+/**
+ * META-ORCH-1174 Leg B2 — extract the optional per-package description from
+ * tier_metadata.description. Returns null on missing key / non-string / blank.
+ */
+function extractTierDescription(
+  metadata: Record<string, unknown>,
+): string | null {
+  const raw = metadata.description;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 /**
@@ -1118,6 +1150,19 @@ export async function updateTripPricing(
     }
   }
 
+  // META-ORCH-1174 Leg B2 — merge per-package description (present-key
+  // semantics, mirroring installments). null/blank → strip the key.
+  if ("description" in patch) {
+    const { description: _stripExistingDesc, ...metadataWithoutDescription } =
+      nextMetadata as Record<string, unknown> & { description?: unknown };
+    const desc =
+      typeof patch.description === "string" ? patch.description.trim() : "";
+    nextMetadata =
+      desc.length > 0
+        ? { ...metadataWithoutDescription, description: desc }
+        : metadataWithoutDescription;
+  }
+
   // Update tier name + metadata
   const { data: tierUpdated, error: tierUpdateError } = await supabase
     .from("trip_pricing_tiers")
@@ -1237,13 +1282,17 @@ export async function createTripPricingTier(
     throw new Error("createTripPricingTier: ticket_types insert returned null");
   }
 
-  // Build tier_metadata.installments from the optional per-package plan.
+  // Build tier_metadata from the optional per-package plan + description.
   const tierMetadata: Record<string, unknown> = {};
   if (
     patch.installmentSchedule !== null &&
     patch.installmentSchedule !== undefined
   ) {
     tierMetadata.installments = patch.installmentSchedule;
+  }
+  // META-ORCH-1174 Leg B2 — persist the optional per-package description.
+  if (typeof patch.description === "string" && patch.description.trim().length > 0) {
+    tierMetadata.description = patch.description.trim();
   }
 
   const { data: tierRow, error: tierError } = await supabase

--- a/mingla-business/src/utils/__tests__/publishedTripEditGuards.test.ts
+++ b/mingla-business/src/utils/__tests__/publishedTripEditGuards.test.ts
@@ -61,6 +61,8 @@ const trip = (patch: Partial<Trip> = {}): Trip => ({
       ticketsRemaining: null,
       isUnlimited: false,
       installmentSchedule: null,
+      // [TEST-MOD-APPROVED META-ORCH-1174] — TripPricingTier gained `description`.
+      description: null,
     },
   ],
   inclusions: [

--- a/packages/offering-rendering/TripOfferingBody.tsx
+++ b/packages/offering-rendering/TripOfferingBody.tsx
@@ -57,14 +57,20 @@ import { DayByDay } from "./DayByDay";
 import { TripRefundLadder } from "./TripRefundLadder";
 import { TripPaymentChoice } from "./TripPaymentChoice";
 import { TripCountdownPill } from "./TripCountdownPill";
-import { BadgeCheck, Calendar, Moon, Plane, Users } from "./LucideIcons";
+import { BadgeCheck, Calendar, Minus, Moon, Plane, Plus, Users } from "./LucideIcons";
 import { buildStaticMapUrl } from "./mapboxStaticImage";
 import type {
   TripOfferingBrand,
   TripOfferingCallbacks,
   TripOfferingData,
+  TripOfferingTier,
 } from "./tripOfferingTypes";
-import type { TripOfferingState, TripPaymentPlanChoice } from "./useTripOfferingState";
+import {
+  projectTripSchedule,
+  tripTierPriceLabel,
+  type TripOfferingState,
+  type TripPaymentPlanChoice,
+} from "./useTripOfferingState";
 
 const ABOUT_COLLAPSE_THRESHOLD = 160;
 
@@ -84,9 +90,28 @@ export interface TripOfferingBodyProps {
   state: TripOfferingState;
   callbacks: TripOfferingCallbacks;
   variant: "phone" | "desktop";
-  /** The live pay-full/pay-over-time toggle value (the surface owns the useState). */
+  /**
+   * The live pay-full/pay-over-time toggle value (the surface owns the useState).
+   * Leg A back-compat: drives a SINGLE-package trip's toggle. Multi-package trips
+   * use the per-tier `planChoiceByTier` map (each row owns its own toggle).
+   */
   paymentPlanChoice: TripPaymentPlanChoice;
   onPaymentPlanChoiceChange: (value: TripPaymentPlanChoice) => void;
+  /**
+   * META-ORCH-1174 Leg B3 — the per-package selection `{ ticketTypeId → quantity }`
+   * (the surface owns the useState). Absent → the box renders read-only (Leg-A
+   * preview). The §10 stepper writes through `onChangeQuantity` (clamped by the
+   * shared state). The §10 box + the floating bar read the SAME selection.
+   */
+  quantities?: Record<string, number>;
+  onChangeQuantity?: (ticketTypeId: string, qty: number) => void;
+  /**
+   * META-ORCH-1174 Leg B3 — per-package pay-full/over-time choice (DEC-F). Only the
+   * rows whose tier carries an installment plan render a toggle. Absent → every
+   * plan row defaults to "full".
+   */
+  planChoiceByTier?: Record<string, TripPaymentPlanChoice>;
+  onChangePlanChoice?: (ticketTypeId: string, value: TripPaymentPlanChoice) => void;
   /**
    * Phone-only docked reserve node (the SAME <TripReserveBar variant="docked"> the
    * surface builds) — passed in so it renders as the LAST body child, flush beneath
@@ -111,6 +136,10 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
   variant,
   paymentPlanChoice,
   onPaymentPlanChoiceChange,
+  quantities,
+  onChangeQuantity,
+  planChoiceByTier,
+  onChangePlanChoice,
   dockedReserve,
   reduceMotion = false,
   testID,
@@ -176,12 +205,53 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
       : null;
 
   const reserveTappable = state.cta.tappable;
-  const boxPriceLabel =
-    state.cta.kind === "buy"
+  // META-ORCH-1174 Leg B3 — the multi-select selector is ACTIVE when the surface
+  // wires the selection state through (quantities + onChangeQuantity). When it does
+  // NOT (a Leg-A caller that hasn't adopted multi-select yet), the box falls back to
+  // the read-only single-tier preview — no regression, no dead UI.
+  const selectorActive =
+    quantities !== undefined && onChangeQuantity !== undefined;
+  const sortedTiers = data.tiers;
+  // The in-box selection summary line. With ≥1 selected → summed all-in (or due
+  // today when any line pays over time). Nothing selected → the bare "—" placeholder.
+  const summaryPriceLabel = selectorActive
+    ? state.anyLineOnPlan
+      ? state.summedDueTodayLabel
+      : state.summedAllInLabel
+    : state.cta.kind === "buy"
       ? state.barPriceLabel
       : state.cta.kind === "free"
         ? "Free"
         : null;
+  const summaryRowLabel = selectorActive
+    ? state.anyLineOnPlan
+      ? "Due today"
+      : "Total"
+    : null;
+  // The Reserve CTA wording. Selector active → reflect the summed total + open the
+  // cart with the SELECTED LINES (DEC-B). Empty selection is still tappable (the
+  // cart lets the buyer pick) but the CTA reads the bare verb.
+  const reserveLabel = selectorActive
+    ? state.totalSelectedQuantity === 0
+      ? state.cta.kind === "unavailable"
+        ? state.cta.title
+        : "Reserve my spot"
+      : summaryPriceLabel !== null && summaryPriceLabel !== "Free"
+        ? `Reserve · ${summaryPriceLabel}`
+        : "Reserve my spot"
+    : state.cta.kind === "unavailable"
+      ? state.cta.title
+      : summaryPriceLabel !== null && summaryPriceLabel !== "Free"
+        ? `Reserve · ${summaryPriceLabel}`
+        : "Reserve my spot";
+
+  const handleBoxReserve = (): void => {
+    if (selectorActive) {
+      callbacks.onReserve(undefined, state.selectedLines);
+    } else {
+      callbacks.onReserve();
+    }
+  };
 
   return (
     <View testID={testID}>
@@ -420,15 +490,17 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
         />
       </View>
 
-      {/* (10) Choose how you pay — ONE merged §10 reserve box (Leg A.3 bug #5: the
-          prior duplicate "payment-choice" box AND separate "reserve" box are now a
-          SINGLE box — payment-plan toggle (plan tiers) + the live price row + the
-          in-box Reserve CTA. The box + the docked/floating bars read the SAME
-          `state`, so they never disagree. Leg B drops N tier rows into this same
-          selectBox slot — the multi-tier seam is intact.) */}
+      {/* (10) Choose your package + how you pay — ONE merged §10 reserve box.
+          META-ORCH-1174 Leg B3 [multi-package selector]: the single-tier slot is now
+          N selectable PACKAGE ROWS (DEC-B/C/D). Each row: name + description + server
+          ALL-IN price + remaining/sold-out + a quantity stepper. A row whose tier
+          carries an installment plan offers its OWN Pay-in-full / Pay-over-time toggle
+          (DEC-F). The summed all-in + summed due-today + the in-box Reserve CTA + the
+          docked/floating bar ALL read the SAME shared `state` → never diverge. N=1
+          renders exactly as Leg A (one row, the same toggle). */}
       <View style={styles.section} testID="trip-body-pay-box">
         <Text style={[styles.secTitle, surface.primaryText, { fontFamily: boldFamily }]}>
-          Choose how you pay
+          {data.tiers.length > 1 ? "Choose your package" : "Choose how you pay"}
         </Text>
 
         {state.selectedTier !== null ? (
@@ -436,40 +508,84 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
             style={[styles.selectBox, surface.card]}
             testID="trip-body-select-box"
           >
-            {/* The shared pay-full / pay-over-time toggle (plan tiers, open only).
-                Tapping drives `paymentPlanChoice` (Leg A.3 bug #4) → the price row
-                + the CTA below + the docked/floating bar all update live. */}
-            {state.projectedSchedule !== null && state.isClosed === false ? (
-              <View style={styles.payChoiceWrap}>
-                <TripPaymentChoice
-                  schedule={state.projectedSchedule}
-                  currency={data.currency}
-                  depositPct={0}
-                  value={paymentPlanChoice}
-                  onChange={onPaymentPlanChoiceChange}
-                  palette={palette}
-                  fontFamily={boldFamily}
-                  testID="trip-body-payment-choice"
-                />
-              </View>
-            ) : null}
+            {selectorActive ? (
+              <>
+                {/* META-ORCH-1174 Leg B3 — N package rows. */}
+                {sortedTiers.map((tier) => (
+                  <TripPackageRow
+                    key={tier.ticketTypeId}
+                    tier={tier}
+                    palette={palette}
+                    surface={surface}
+                    boldFamily={boldFamily}
+                    quantity={quantities?.[tier.ticketTypeId] ?? 0}
+                    disabled={data.bookable === false || state.isClosed}
+                    onChange={(qty) => {
+                      const clamped = state.clampQuantity(tier.ticketTypeId, qty);
+                      onChangeQuantity?.(tier.ticketTypeId, clamped);
+                    }}
+                    planChoice={
+                      planChoiceByTier?.[tier.ticketTypeId] ?? "full"
+                    }
+                    onChangePlanChoice={
+                      onChangePlanChoice !== undefined
+                        ? (v) => onChangePlanChoice(tier.ticketTypeId, v)
+                        : undefined
+                    }
+                    currency={data.currency}
+                  />
+                ))}
 
-            <View style={styles.selectRow}>
-              <Text
-                style={[styles.selectTierName, surface.primaryText, { fontFamily: boldFamily }]}
-                numberOfLines={1}
-              >
-                {state.selectedTier.tierName}
-              </Text>
-              <Text
-                style={[styles.selectPrice, surface.primaryText, { fontFamily: boldFamily }]}
-                testID="trip-body-select-total"
-              >
-                {boxPriceLabel ?? "—"}
-              </Text>
-            </View>
+                {/* Σ all-in / Σ due-today summary row (WYSIWYP). */}
+                <View style={[styles.totalRow, { borderTopColor: palette.panelBorder }]}>
+                  <Text style={[styles.selectTierName, surface.secondaryText]}>
+                    {summaryRowLabel ?? "Total"}
+                  </Text>
+                  <Text
+                    style={[styles.selectPrice, surface.primaryText, { fontFamily: boldFamily }]}
+                    testID="trip-body-select-total"
+                  >
+                    {summaryPriceLabel ?? "—"}
+                  </Text>
+                </View>
+              </>
+            ) : (
+              <>
+                {/* Leg-A fallback: the single-tier read-only preview + toggle. */}
+                {state.projectedSchedule !== null && state.isClosed === false ? (
+                  <View style={styles.payChoiceWrap}>
+                    <TripPaymentChoice
+                      schedule={state.projectedSchedule}
+                      currency={data.currency}
+                      depositPct={0}
+                      value={paymentPlanChoice}
+                      onChange={onPaymentPlanChoiceChange}
+                      palette={palette}
+                      fontFamily={boldFamily}
+                      testID="trip-body-payment-choice"
+                    />
+                  </View>
+                ) : null}
+
+                <View style={styles.selectRow}>
+                  <Text
+                    style={[styles.selectTierName, surface.primaryText, { fontFamily: boldFamily }]}
+                    numberOfLines={1}
+                  >
+                    {state.selectedTier.tierName}
+                  </Text>
+                  <Text
+                    style={[styles.selectPrice, surface.primaryText, { fontFamily: boldFamily }]}
+                    testID="trip-body-select-total"
+                  >
+                    {summaryPriceLabel ?? "—"}
+                  </Text>
+                </View>
+              </>
+            )}
+
             <Pressable
-              onPress={reserveTappable ? () => callbacks.onReserve() : undefined}
+              onPress={reserveTappable ? handleBoxReserve : undefined}
               disabled={!reserveTappable}
               accessibilityRole="button"
               accessibilityState={{ disabled: !reserveTappable }}
@@ -497,11 +613,7 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
                   },
                 ]}
               >
-                {state.cta.kind === "unavailable"
-                  ? state.cta.title
-                  : boxPriceLabel !== null && boxPriceLabel !== "Free"
-                    ? `Reserve · ${boxPriceLabel}`
-                    : "Reserve my spot"}
+                {reserveLabel}
               </Text>
             </Pressable>
             <Text style={[styles.reassure, { color: palette.tertiaryText }]}>
@@ -543,6 +655,178 @@ export const TripOfferingBody: React.FC<TripOfferingBodyProps> = ({
       {/* The phone-only DOCKED reserve CTA — the SAME <TripReserveBar variant="docked">
           the surface builds, rendered as the LAST body child (flush, no void). */}
       {!isDesktop && dockedReserve !== undefined ? dockedReserve : null}
+    </View>
+  );
+};
+
+// ===========================================================================
+// META-ORCH-1174 Leg B3 — TripPackageRow: ONE selectable package row in the §10
+// box. name + description + server ALL-IN price + remaining/sold-out + a quantity
+// stepper. A tier carrying an installment plan offers its own Pay-in-full / Pay-
+// over-time toggle (DEC-F) — that choice flows per-line into the summed due-today.
+// ===========================================================================
+
+const TripPackageRow: React.FC<{
+  tier: TripOfferingTier;
+  palette: ThemePalette;
+  surface: ReturnType<typeof offeringSurfaceStyles>;
+  boldFamily: string;
+  quantity: number;
+  disabled: boolean;
+  onChange: (qty: number) => void;
+  planChoice: TripPaymentPlanChoice;
+  onChangePlanChoice?: (value: TripPaymentPlanChoice) => void;
+  currency: string;
+}> = ({
+  tier,
+  palette,
+  surface,
+  boldFamily,
+  quantity,
+  disabled,
+  onChange,
+  planChoice,
+  onChangePlanChoice,
+  currency,
+}) => {
+  const isSoldOut =
+    tier.isUnlimited === false &&
+    tier.ticketsRemaining !== null &&
+    tier.ticketsRemaining <= 0;
+  // Cap: unlimited → 99; else the tier's own remaining (DEC-D per-package capacity).
+  const cap = tier.isUnlimited
+    ? 99
+    : tier.ticketsRemaining === null
+      ? 0
+      : Math.max(0, tier.ticketsRemaining);
+  const canIncrement = !disabled && !isSoldOut && quantity < cap;
+  const canDecrement = quantity > 0;
+
+  const remainingLabel = tier.isUnlimited
+    ? "Available"
+    : tier.ticketsRemaining === null
+      ? "Available"
+      : tier.ticketsRemaining <= 0
+        ? "Sold out"
+        : tier.ticketsRemaining <= 5
+          ? `${tier.ticketsRemaining} left`
+          : `${tier.ticketsRemaining} available`;
+
+  const hasPlan =
+    tier.installmentSchedule !== null && tier.installmentSchedule !== undefined;
+  // Per-row pay-over-time projection (the row toggle reads it). Scaled by qty (≥1)
+  // so the deposit preview reflects the line, not the unit.
+  const projected =
+    hasPlan && quantity > 0
+      ? projectTripSchedule(tier, new Date(), quantity)
+      : hasPlan
+        ? projectTripSchedule(tier, new Date(), 1)
+        : null;
+
+  return (
+    <View
+      style={[
+        styles.pkgRow,
+        { borderBottomColor: palette.panelBorder },
+        isSoldOut ? styles.pkgRowMuted : null,
+      ]}
+      testID={`trip-body-package-row-${tier.ticketTypeId}`}
+    >
+      <View style={styles.pkgHeaderRow}>
+        <View style={styles.pkgTextCol}>
+          <Text
+            style={[styles.selectTierName, surface.primaryText, { fontFamily: boldFamily }]}
+            numberOfLines={2}
+          >
+            {tier.tierName}
+          </Text>
+          {tier.description !== null &&
+          tier.description !== undefined &&
+          tier.description.length > 0 ? (
+            <Text style={[styles.pkgDesc, surface.secondaryText]} numberOfLines={2}>
+              {tier.description}
+            </Text>
+          ) : null}
+          <Text style={[styles.pkgCap, surface.tertiaryText]}>{remainingLabel}</Text>
+        </View>
+
+        <View style={styles.pkgRight}>
+          <Text
+            style={[styles.pkgPrice, surface.primaryText, { fontFamily: boldFamily }]}
+          >
+            {tripTierPriceLabel(tier)}
+          </Text>
+          {isSoldOut ? (
+            <View
+              style={[
+                styles.pkgSoldOut,
+                { backgroundColor: palette.card, borderColor: palette.panelBorder },
+              ]}
+            >
+              <Text style={[styles.pkgSoldOutText, { color: palette.tertiaryText }]}>
+                Sold out
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.pkgStepper}>
+              <Pressable
+                onPress={canDecrement ? () => onChange(quantity - 1) : undefined}
+                disabled={!canDecrement}
+                accessibilityRole="button"
+                accessibilityLabel={`Remove one ${tier.tierName}`}
+                style={[
+                  styles.pkgStepBtn,
+                  { borderColor: palette.panelBorder },
+                  !canDecrement ? styles.pkgStepBtnDisabled : null,
+                ]}
+                testID={`trip-body-pkg-minus-${tier.ticketTypeId}`}
+              >
+                <Minus size={18} color={palette.primaryText} />
+              </Pressable>
+              <Text
+                style={[styles.pkgQty, surface.primaryText, { fontFamily: boldFamily }]}
+                accessibilityLabel={`${quantity} ${tier.tierName} selected`}
+              >
+                {quantity}
+              </Text>
+              <Pressable
+                onPress={canIncrement ? () => onChange(quantity + 1) : undefined}
+                disabled={!canIncrement}
+                accessibilityRole="button"
+                accessibilityLabel={`Add one ${tier.tierName}`}
+                style={[
+                  styles.pkgStepBtn,
+                  { borderColor: palette.panelBorder },
+                  !canIncrement ? styles.pkgStepBtnDisabled : null,
+                ]}
+                testID={`trip-body-pkg-plus-${tier.ticketTypeId}`}
+              >
+                <Plus size={18} color={palette.primaryText} />
+              </Pressable>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* Per-package payment plan (DEC-F) — only when the tier carries a plan AND
+          this line is selected, so the buyer chooses how to pay for THIS package. */}
+      {hasPlan &&
+      projected !== null &&
+      quantity > 0 &&
+      onChangePlanChoice !== undefined ? (
+        <View style={styles.pkgPlanWrap}>
+          <TripPaymentChoice
+            schedule={projected}
+            currency={currency}
+            depositPct={0}
+            value={planChoice}
+            onChange={onChangePlanChoice}
+            palette={palette}
+            fontFamily={boldFamily}
+            testID={`trip-body-pkg-plan-${tier.ticketTypeId}`}
+          />
+        </View>
+      ) : null}
     </View>
   );
 };
@@ -655,6 +939,50 @@ const styles = StyleSheet.create({
   },
   selectTierName: { flexShrink: 1, fontSize: 15, fontWeight: "800" },
   selectPrice: { fontSize: 22, fontWeight: "900", letterSpacing: -0.4 },
+  // ---- §10 Leg B3 package rows ----
+  pkgRow: {
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  pkgRowMuted: { opacity: 0.7 },
+  pkgHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  pkgTextCol: { flex: 1, minWidth: 0 },
+  pkgDesc: { fontSize: 13, marginTop: 3, lineHeight: 18 },
+  pkgCap: { fontSize: 12, fontWeight: "700", marginTop: 4 },
+  pkgRight: { alignItems: "flex-end", gap: 8 },
+  pkgPrice: { fontSize: 15, fontWeight: "900" },
+  pkgStepper: { flexDirection: "row", alignItems: "center", gap: 12 },
+  pkgStepBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 999,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pkgStepBtnDisabled: { opacity: 0.4 },
+  pkgQty: { fontSize: 16, fontWeight: "900", minWidth: 18, textAlign: "center" },
+  pkgSoldOut: {
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  pkgSoldOutText: { fontSize: 12, fontWeight: "800" },
+  pkgPlanWrap: { marginTop: 12 },
+  totalRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    borderTopWidth: 1,
+    paddingTop: 14,
+    marginTop: 4,
+  },
   boxProceed: {
     flexDirection: "row",
     alignItems: "center",

--- a/packages/offering-rendering/__tests__/meta_orch_1174_legB3_multitier.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_legB3_multitier.test.ts
@@ -1,0 +1,170 @@
+// META-ORCH-1174 Leg B3 [trip-page multi-package selector] — implementor-owned
+// BEHAVIORAL test for the RN-free §10 selection + money math (tripBoxTotals). These
+// run under the offering-rendering deno harness (deno std assert + Deno.test, the
+// same style as meta_orch_1174_trip_standardize.test.ts). The math is the SINGLE
+// OWNER the §10 box + the floating bar + the cart-seed all read.
+//
+// FAILS-ON-REVERT (proven by TRUE LINE DELETION in the implementation report):
+//   • drop the `priceAllInCents ?? priceCents` coalesce in tripTierUnitAllInCents →
+//     the "uses server all-in, not bare base" assertion FAILS.
+//   • drop the per-line installments branch in tripSummedDueTodayCents → the
+//     "per-line payment plan in summed due-today" assertion FAILS.
+//   • widen clampTripTierQuantity past remaining → the "qty clamp to remaining" FAILS.
+//   • drop the "From {min}" empty-state (tripMinTierAllInCents) → the bar-label test FAILS.
+
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  clampTripTierQuantity,
+  tripTierEffectiveMax,
+  tripTierUnitAllInCents,
+  tripMinTierAllInCents,
+  tripSelectedLines,
+  tripTotalSelectedQuantity,
+  tripSummedAllInCents,
+  tripSummedDueTodayCents,
+  tripAnyLineOnPlan,
+  type TripTierLike,
+} from "../tripBoxTotals.ts";
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+// A SYNTHETIC pass-fee fixture (per memory ORCH-1147 gotcha): all-in > base, so the
+// summed all-in is PROVABLY the server value, not the bare base. base 50000 / all-in
+// 53000 (a 6% passed fee). Standard (paid), VIP (paid + plan), Free.
+const standard: TripTierLike = {
+  ticketTypeId: "tt_std",
+  priceCents: 50000,
+  priceAllInCents: 53000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 20,
+  installmentSchedule: null,
+};
+const vip: TripTierLike = {
+  ticketTypeId: "tt_vip",
+  priceCents: 100000,
+  priceAllInCents: 106000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 3,
+  // 25% deposit plan → deposit = 25% of the line all-in.
+  installmentSchedule: { deposit_pct: 25, installments: [{ ordinal: 1, pct: 75 }] },
+};
+const free: TripTierLike = {
+  ticketTypeId: "tt_free",
+  priceCents: 0,
+  priceAllInCents: null,
+  isFree: true,
+  isUnlimited: true,
+  ticketsRemaining: null,
+  installmentSchedule: null,
+};
+const tiers = [standard, vip, free];
+
+// ── all-in is SERVER-sourced, never the bare base ──────────────────────────
+Deno.test("B3 per-unit all-in uses the server all-in (priceAllInCents), not base", () => {
+  assertEquals(tripTierUnitAllInCents(standard), 53000); // NOT 50000 base
+  assertEquals(tripTierUnitAllInCents(vip), 106000); // NOT 100000 base
+  assertEquals(tripTierUnitAllInCents(free), 0); // free → 0
+});
+
+Deno.test("B3 missing all-in falls back to base (RPC miss / no all-in)", () => {
+  const noAllIn: TripTierLike = { ...standard, priceAllInCents: null };
+  assertEquals(tripTierUnitAllInCents(noAllIn), 50000); // falls back to base
+});
+
+// ── summed all-in across selected lines (DEC-B multi-line) ─────────────────
+Deno.test("B3 summed all-in = Σ(server all-in × qty) across selected lines", () => {
+  // Standard ×1 + VIP ×2 = 53000 + 2×106000 = 265000.
+  const qty = { tt_std: 1, tt_vip: 2 };
+  assertEquals(tripSummedAllInCents(tiers, qty), 265000);
+  assertEquals(tripTotalSelectedQuantity(qty), 3);
+});
+
+Deno.test("B3 free package is selectable + contributes 0 to the all-in", () => {
+  const qty = { tt_free: 2, tt_std: 1 };
+  assertEquals(tripSummedAllInCents(tiers, qty), 53000); // free adds 0
+  const lines = tripSelectedLines(tiers, qty);
+  assert(lines.some((l) => l.ticketTypeId === "tt_free" && l.quantity === 2));
+});
+
+// ── per-tier qty clamp to remaining (DEC-C qty>1; DEC-D per-package capacity) ─
+Deno.test("B3 qty clamps to the tier's own remaining capacity", () => {
+  assertEquals(tripTierEffectiveMax(vip), 3); // VIP has 3 remaining
+  assertEquals(clampTripTierQuantity(vip, 5), 3); // request 5 → clamped to 3
+  assertEquals(clampTripTierQuantity(standard, 4), 4); // 4 ≤ 20 remaining → 4 (qty>1 ok)
+  assertEquals(clampTripTierQuantity(standard, -2), 0); // negative → 0
+  assertEquals(clampTripTierQuantity(free, 7), 7); // unlimited → up to 99 ceiling
+});
+
+Deno.test("B3 a sold-out tier clamps every request to 0", () => {
+  const soldOut: TripTierLike = { ...standard, ticketsRemaining: 0 };
+  assertEquals(tripTierEffectiveMax(soldOut), 0);
+  assertEquals(clampTripTierQuantity(soldOut, 3), 0);
+});
+
+// ── per-line payment-plan choice in the summed due-today (DEC-F) ────────────
+Deno.test("B3 summed due-today: plan line → deposit; full/no-plan lines → full", () => {
+  // Standard ×1 (no plan → full 53000) + VIP ×2 (plan, paying over time → deposit).
+  // VIP line all-in = 2×106000 = 212000; 25% deposit = 53000.
+  const qty = { tt_std: 1, tt_vip: 2 };
+  const planChoice = { tt_vip: "installments" as const };
+  assertEquals(
+    tripSummedDueTodayCents(tiers, qty, planChoice),
+    53000 + 53000, // Standard full + VIP deposit
+  );
+  assert(tripAnyLineOnPlan(tiers, qty, planChoice));
+});
+
+Deno.test("B3 plan line paying IN FULL contributes its full all-in to due-today", () => {
+  // VIP ×2 paying in full → full 212000 (NOT the deposit).
+  const qty = { tt_vip: 2 };
+  const planChoice = { tt_vip: "full" as const };
+  assertEquals(tripSummedDueTodayCents(tiers, qty, planChoice), 212000);
+  assert(!tripAnyLineOnPlan(tiers, qty, planChoice));
+});
+
+Deno.test("B3 selected lines carry per-line paymentPlanChoice only for plan tiers", () => {
+  const qty = { tt_std: 1, tt_vip: 1 };
+  const planChoice = { tt_vip: "installments" as const };
+  const lines = tripSelectedLines(tiers, qty, planChoice);
+  const std = lines.find((l) => l.ticketTypeId === "tt_std");
+  const v = lines.find((l) => l.ticketTypeId === "tt_vip");
+  // Standard has no plan → no paymentPlanChoice key emitted.
+  assertEquals(std?.paymentPlanChoice, undefined);
+  // VIP has a plan → the explicit choice rides the line.
+  assertEquals(v?.paymentPlanChoice, "installments");
+});
+
+// ── bar label "From {min all-in}" empty-state (DEC-J) ──────────────────────
+Deno.test("B3 'From {min}' uses the minimum SELLABLE per-unit all-in", () => {
+  // Min sellable all-in across {Standard 53000, VIP 106000, Free 0} = 0 (free).
+  assertEquals(tripMinTierAllInCents(tiers), 0);
+  // Without the free tier, the min is Standard's all-in 53000 (NOT base 50000).
+  assertEquals(tripMinTierAllInCents([standard, vip]), 53000);
+});
+
+Deno.test("B3 'From {min}' skips sold-out tiers", () => {
+  const cheapSoldOut: TripTierLike = {
+    ...standard,
+    ticketTypeId: "tt_cheap",
+    priceAllInCents: 10000,
+    ticketsRemaining: 0,
+  };
+  // The cheap tier is sold out → excluded; the min is VIP's 106000.
+  assertEquals(tripMinTierAllInCents([cheapSoldOut, vip]), 106000);
+});
+
+// ── N=1 single-package parity (no regression) ──────────────────────────────
+Deno.test("B3 N=1 single package: summed all-in == the one line's all-in", () => {
+  const one = [standard];
+  const qty = { tt_std: 2 };
+  assertEquals(tripSummedAllInCents(one, qty), 106000); // 2 × 53000
+  assertEquals(tripMinTierAllInCents(one), 53000); // bare all-in (the From base)
+  const lines = tripSelectedLines(one, qty);
+  assertEquals(lines.length, 1);
+  assertEquals(lines[0]?.quantity, 2);
+});

--- a/packages/offering-rendering/__tests__/meta_orch_1174_legB3_wiring.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_legB3_wiring.test.ts
@@ -1,0 +1,121 @@
+// META-ORCH-1174 Leg B3 — implementor-owned SOURCE-CONTRACT regression (the
+// offering-rendering deno-readfile style). Proves the §10 multi-package selector UI
+// + the reserve→cart wiring is present + isolated across surfaces. FAILS-ON-REVERT
+// via TRUE deletion of the asserted lines.
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const read = async (rel: string): Promise<string> =>
+  await Deno.readTextFile(new URL(rel, import.meta.url));
+
+const body = await read("../TripOfferingBody.tsx");
+const stateMachine = await read("../useTripOfferingState.ts");
+const types = await read("../tripOfferingTypes.ts");
+const totals = await read("../tripBoxTotals.ts");
+const bizAdapter = await read(
+  "../../../mingla-business/src/components/trip/tripOfferingAdapter.ts",
+);
+const bizRoute = await read(
+  "../../../mingla-business/app/t/[brandSlug]/[tripSlug].tsx",
+);
+const bizCheckout = await read(
+  "../../../mingla-business/app/checkout-trip/[tripEventId]/index.tsx",
+);
+const consumerScreen = await read(
+  "../../../app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx",
+);
+const consumerAdapter = await read(
+  "../../../app-mobile/src/hooks/useConsumerTripOfferingData.ts",
+);
+
+// ── §10 box renders N selectable package rows with steppers ────────────────
+Deno.test("B3 §10 box renders N package rows (TripPackageRow) with qty steppers", () => {
+  assertStringIncludes(body, "const TripPackageRow:");
+  assertStringIncludes(body, "sortedTiers.map((tier)");
+  // each row: name + description + all-in price + remaining + a Minus/Plus stepper.
+  assertStringIncludes(body, "tripTierPriceLabel(tier)");
+  assertStringIncludes(body, "<Minus");
+  assertStringIncludes(body, "<Plus");
+  assertStringIncludes(body, "tier.description");
+  assertStringIncludes(body, "remainingLabel");
+  // the stepper writes through the SHARED clamp (clamped to remaining).
+  assertStringIncludes(body, "state.clampQuantity(tier.ticketTypeId, qty)");
+});
+
+// ── per-package payment plan (DEC-F) lives per-row ─────────────────────────
+Deno.test("B3 a plan tier offers a per-package pay-full/over-time toggle", () => {
+  assertStringIncludes(body, "trip-body-pkg-plan-");
+  assertStringIncludes(body, "value={planChoice}");
+  // the per-row toggle drives the per-tier choice the surface owns.
+  assertStringIncludes(body, "onChange={onChangePlanChoice}");
+});
+
+// ── the box CTA + the bars reserve ALL selected lines (DEC-B) ──────────────
+Deno.test("B3 the §10 box CTA opens the cart with ALL selected lines", () => {
+  // the box's reserve fires onReserve(undefined, state.selectedLines).
+  assertStringIncludes(body, "callbacks.onReserve(undefined, state.selectedLines)");
+  // the state exposes the selected lines + the summed totals the box reads.
+  assertStringIncludes(stateMachine, "selectedLines");
+  assertStringIncludes(stateMachine, "summedAllInCents");
+  assertStringIncludes(stateMachine, "summedDueTodayCents");
+  // the reserve callback signature carries the lines array (DEC-B).
+  assertStringIncludes(types, "lines?: TripReserveLine[]");
+  assertStringIncludes(types, "export interface TripReserveLine");
+});
+
+// ── all-in is SERVER-sourced (WYSIWYP) end-to-end ──────────────────────────
+Deno.test("B3 all-in is server-sourced (priceAllInCents), summed, never bare base", () => {
+  // the type carries the server all-in field.
+  assertStringIncludes(types, "priceAllInCents");
+  // the math coalesces all-in → base (never fabricates a markup).
+  assertStringIncludes(totals, "tier.priceAllInCents");
+  assertStringIncludes(totals, ": tier.priceCents;");
+  // BOTH surface adapters thread the server all-in in.
+  assertStringIncludes(bizAdapter, "priceAllInCents");
+  assertStringIncludes(bizAdapter, "allInByTicketType");
+  assertStringIncludes(consumerAdapter, "priceAllInCents");
+  assertStringIncludes(consumerAdapter, "enrich?.allInCents");
+});
+
+// ── the floating bar shows "From {X}" → summed all-in (DEC-J) ──────────────
+Deno.test("B3 bar label is 'From {min}' until selected, then the summed all-in", () => {
+  assertStringIncludes(stateMachine, "From ${formatTripPrice(minAllIn");
+  assertStringIncludes(stateMachine, "tripMinTierAllInCents");
+  // once ≥1 selected → the summed all-in / due-today.
+  assertStringIncludes(stateMachine, "summedAllInLabel ?? \"\"");
+});
+
+// ── reserve → cart wiring per surface ──────────────────────────────────────
+Deno.test("B3 business reserve passes the selected lines to the trip checkout", () => {
+  // the route fires reserve with the selected lines and rides them as a JSON param.
+  assertStringIncludes(bizRoute, "offeringState.selectedLines");
+  assertStringIncludes(bizRoute, "JSON.stringify(lines)");
+  // the checkout index seeds the cart from the lines param (DEC-B), skipping
+  // tier-select; the single-tier auto-skip is gated off when lines are present.
+  assertStringIncludes(bizCheckout, "seededLinesParam");
+  assertStringIncludes(bizCheckout, "if (seededLinesParam.length > 0) return;");
+  // ORCH-1138 preserved: straight to checkout, no EBES, no address/tax form.
+  assertStringIncludes(bizRoute, "tripCheckoutPath(trip.id)");
+});
+
+Deno.test("B3 consumer reserve seeds the cart with the selected lines", () => {
+  // the consumer Reserve seeds initialQuantities from the selected lines and opens
+  // the cart directly (ORCH-1138 — never EBES).
+  assertStringIncludes(consumerScreen, "setSeededQuantities(seed)");
+  assertStringIncludes(consumerScreen, "initialQuantities={seededQuantities}");
+  assertStringIncludes(consumerScreen, "openCart()");
+  // the body gets the multi-select props.
+  assertStringIncludes(consumerScreen, "onChangeQuantity={handleChangeQuantity}");
+  assertStringIncludes(consumerScreen, "planChoiceByTier={planChoiceByTier}");
+});
+
+// ── package isolation (I-MOR-0827) — no app src import for all-in ──────────
+Deno.test("B3 the all-in fetch stays in surface hooks, NOT the package", () => {
+  // the package math + body never import a service / app src.
+  assert(!body.includes("fetchTierAllInCents"), "body must not fetch all-in");
+  assert(!totals.includes("import "), "tripBoxTotals must be import-free (pure)");
+  assert(!body.includes('from "../../'), "body must not reach into app src");
+});

--- a/packages/offering-rendering/__tests__/meta_orch_1174_trip_standardize.test.ts
+++ b/packages/offering-rendering/__tests__/meta_orch_1174_trip_standardize.test.ts
@@ -216,25 +216,42 @@ Deno.test("A.3#3 BOTH adapters thread destinationLat/Lng into TripOfferingData",
 });
 
 // ── A.3 bug #4 — the payment toggle is interactive (wired to the surface state) ──
-Deno.test("A.3#4 the §10 payment toggle is wired to paymentPlanChoice", () => {
-  // the toggle's value + onChange thread the surface-owned state machine.
+// [TEST-MOD-APPROVED META-ORCH-1174] Leg B3 — the §10 box became a MULTI-PACKAGE
+// selector. The single-tier toggle wiring (value={paymentPlanChoice}) lives in the
+// Leg-A fallback branch; the per-package plan toggle threads the per-tier choice.
+// The barPriceLabel branches changed from "${priceLabel} total" to the summed all-
+// in. The useMemo dep list grew (quantities + planChoiceByTier). These updated
+// assertions still prove the toggle is interactive + the price follows the toggle.
+Deno.test("A.3#4 the §10 payment toggle is wired to the surface state", () => {
+  // the single-tier (Leg-A fallback) toggle's value + onChange still thread state.
   assertStringIncludes(body, "value={paymentPlanChoice}");
   assertStringIncludes(body, "onChange={onPaymentPlanChoiceChange}");
-  // the live price label follows the SAME state the toggle drives.
-  assertStringIncludes(body, "state.barPriceLabel");
-  // the state machine's barPriceLabel BRANCHES on paymentPlanChoice (so flipping
-  // the toggle changes the price the box + bar show) — installments → deposit
-  // "today", full → "total". Deleting either branch FAILS this assertion.
+  // the per-package plan toggle (DEC-F) threads the per-tier choice.
+  assertStringIncludes(body, "value={planChoice}");
+  assertStringIncludes(body, "onChange={onChangePlanChoice}");
+  // the box price follows the SAME shared state the bar reads.
+  assertStringIncludes(body, "state.summedAllInLabel");
+  assertStringIncludes(body, "state.summedDueTodayLabel");
+  // the state machine BRANCHES on the plan choice (flipping it changes the figure)
+  // — installments → deposit "today", full → the summed all-in. Deleting either
+  // branch FAILS this assertion.
   assertStringIncludes(stateMachine, 'paymentPlanChoice === "installments"');
-  assertStringIncludes(stateMachine, "${depositLabel} today");
-  assertStringIncludes(stateMachine, "${priceLabel} total");
-  // the state machine recomputes on paymentPlanChoice (useMemo dep) — the toggle
-  // is NOT dormant.
-  assertStringIncludes(stateMachine, "}, [data, paymentPlanChoice, onReserve, now]);");
+  assertStringIncludes(stateMachine, "today`");
+  assertStringIncludes(stateMachine, "summedAllInLabel ?? \"\"");
+  // the state machine recomputes on the selection inputs (useMemo deps) — NOT dormant.
+  assertStringIncludes(
+    stateMachine,
+    "}, [data, paymentPlanChoice, quantities, planChoiceByTier, onReserve, now]);",
+  );
 });
 
 // ── A.3 bug #5 — ONE merged §10 box (no duplicate price box) ──
-Deno.test("A.3#5 §10 is ONE merged box (toggle + price + reserve), not two", () => {
+// [TEST-MOD-APPROVED META-ORCH-1174] Leg B3 — still ONE box, but now the multi-
+// package selector (N rows + per-package qty + per-package plan) + the summed total
+// + the in-box Reserve. The single-tier `trip-body-payment-choice` only appears in
+// the Leg-A fallback; the ordered toggle→price→proceed assertion is replaced by the
+// ONE-box invariant + the summed-total → proceed ordering that holds in BOTH modes.
+Deno.test("A.3#5 §10 is ONE merged box (selector + summed total + reserve), not two", () => {
   // exactly ONE pay-box section + ONE select box.
   const payBoxCount = (body.match(/testID="trip-body-pay-box"/g) ?? []).length;
   const selectBoxCount = (body.match(/testID="trip-body-select-box"/g) ?? []).length;
@@ -245,14 +262,15 @@ Deno.test("A.3#5 §10 is ONE merged box (toggle + price + reserve), not two", ()
     !body.includes("recapCard") && !body.includes("recapPrice"),
     "the duplicate 'recap' price card must be removed (merged into the one box)",
   );
-  // the payment toggle now lives INSIDE the select box (one box), before the
-  // price row — assert the toggle's testID precedes the select total.
-  const toggleIdx = body.indexOf('testID="trip-body-payment-choice"');
+  // the Leg-B3 multi-package selector renders N package rows inside the ONE box.
+  assertStringIncludes(body, "TripPackageRow");
+  assertStringIncludes(body, "sortedTiers.map");
+  // the summed total precedes the in-box Reserve CTA (holds in BOTH modes).
   const totalIdx = body.indexOf('testID="trip-body-select-total"');
   const proceedIdx = body.indexOf('testID="trip-body-box-proceed"');
-  assert(toggleIdx > -1 && totalIdx > -1 && proceedIdx > -1, "missing §10 sub-parts");
+  assert(totalIdx > -1 && proceedIdx > -1, "missing §10 sub-parts");
   assert(
-    toggleIdx < totalIdx && totalIdx < proceedIdx,
-    "inside the ONE box: toggle → price → reserve CTA, in order",
+    totalIdx < proceedIdx,
+    "inside the ONE box: summed total precedes the reserve CTA",
   );
 });

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -154,12 +154,30 @@ export {
   useTripOfferingState,
   projectTripSchedule,
   selectSellableTier,
+  tripTierPriceLabel,
 } from "./useTripOfferingState";
 export type {
   UseTripOfferingStateInput,
   TripOfferingState,
   TripPaymentPlanChoice,
 } from "./useTripOfferingState";
+// META-ORCH-1174 Leg B3 — the RN-free §10 multi-package selection + money math
+// (per-tier qty clamp, selected lines, summed all-in / due-today). Single owner.
+export {
+  clampTripTierQuantity,
+  tripTierEffectiveMax,
+  tripTierUnitAllInCents,
+  tripMinTierAllInCents,
+  tripSelectedLines,
+  tripTotalSelectedQuantity,
+  tripSummedAllInCents,
+  tripSummedDueTodayCents,
+  tripAnyLineOnPlan,
+} from "./tripBoxTotals";
+export type {
+  TripTierLike,
+  TripSelectedLine,
+} from "./tripBoxTotals";
 export { TripReserveBar } from "./TripReserveBar";
 export type { TripReserveBarProps } from "./TripReserveBar";
 export { TripPaymentChoice as TripOfferingPaymentChoice } from "./TripPaymentChoice";
@@ -182,6 +200,7 @@ export type {
   TripOfferingDay,
   TripOfferingInclusion,
   TripOfferingCallbacks,
+  TripReserveLine,
   TripInstallmentTemplate,
   TripRefundPolicyShape,
   TripRefundTier,

--- a/packages/offering-rendering/tripBoxTotals.ts
+++ b/packages/offering-rendering/tripBoxTotals.ts
@@ -1,0 +1,191 @@
+/**
+ * tripBoxTotals — META-ORCH-1174 Leg B3 [trip-page multi-tier selector].
+ *
+ * The PURE (React-Native-free) selection + money math for the public trip page's
+ * §10 MULTI-PACKAGE box. Extracted from useTripOfferingState so it is unit-testable
+ * under deno/node (the hook imports react and cannot be imported RN-free). Mirrors
+ * eventBoxTotals (ORCH-1167) — the trip box is the same multi-line selector the
+ * event box is, plus per-package payment-plan due-today.
+ *
+ * DEC-B (multiple packages in one cart) + DEC-C (per-package qty>1) + DEC-F (per-
+ * package installments) + DEC-J ("From {min all-in}" → summed all-in). One owner:
+ * the §10 box AND the floating/docked bar read the SAME derived totals so they can
+ * never diverge.
+ *
+ * I-PROPOSED-1174-ALLIN-SERVER-SOURCED (extends ORCH-1147): the per-package price
+ * is the SERVER all-in (priceAllInCents), falling back to priceCents ONLY when the
+ * tier carries no all-in (free / RPC miss) — NEVER fabricating fee math here, NEVER
+ * showing the bare base under the box.
+ */
+
+/** The minimal per-tier shape this math reads (a structural subset of TripOfferingTier). */
+export interface TripTierLike {
+  ticketTypeId: string;
+  priceCents: number;
+  /** Server all-in (pg_public_event_tier_allin). null/undefined → fall back to priceCents. */
+  priceAllInCents?: number | null;
+  isFree: boolean;
+  isUnlimited: boolean;
+  /** Remaining capacity; null when unlimited/unknown. */
+  ticketsRemaining: number | null;
+  installmentSchedule: unknown | null;
+}
+
+/** A selected cart line. `paymentPlanChoice` is present only for a tier with a plan. */
+export interface TripSelectedLine {
+  ticketTypeId: string;
+  quantity: number;
+  paymentPlanChoice?: "full" | "installments";
+}
+
+/** Per-tier installment template (deposit_pct + relative-offset installments). */
+export interface TripInstallmentTemplateLike {
+  deposit_pct: number;
+  installments: Array<unknown>;
+}
+
+/**
+ * The per-package effective max purchasable in ONE reservation. Unlimited → 99
+ * (a sane stepper ceiling); else the remaining capacity (never below 0). A tier
+ * with null remaining + not unlimited is treated as 0 (no fabricated availability).
+ */
+export const tripTierEffectiveMax = (tier: TripTierLike): number => {
+  if (tier.isUnlimited) return 99;
+  if (tier.ticketsRemaining === null) return 0;
+  return Math.max(0, Math.floor(tier.ticketsRemaining));
+};
+
+/**
+ * Clamp a requested quantity for one tier into [0, effectiveMax]. Non-finite/negative
+ * → 0. This is the SINGLE clamp the stepper setters route through (DEC-C: qty>1 is
+ * allowed, capped by the package's own remaining — DEC-D per-package capacity).
+ */
+export const clampTripTierQuantity = (
+  tier: TripTierLike,
+  requested: number,
+): number => {
+  if (!Number.isFinite(requested) || requested <= 0) return 0;
+  return Math.min(Math.floor(requested), tripTierEffectiveMax(tier));
+};
+
+/** The per-unit all-in price (WYSIWYP). Free / missing → 0. Never the bare base when an all-in exists. */
+export const tripTierUnitAllInCents = (tier: TripTierLike): number => {
+  if (tier.isFree) return 0;
+  const price =
+    typeof tier.priceAllInCents === "number" && Number.isFinite(tier.priceAllInCents)
+      ? tier.priceAllInCents
+      : tier.priceCents;
+  return typeof price === "number" && Number.isFinite(price) ? price : 0;
+};
+
+/** The minimum per-unit all-in across SELLABLE tiers — DEC-J "From {X}" empty-state. */
+export const tripMinTierAllInCents = (tiers: ReadonlyArray<TripTierLike>): number | null => {
+  let min: number | null = null;
+  for (const t of tiers) {
+    // Skip genuinely-unbuyable tiers (sold out) so "From" reflects what's bookable.
+    if (!t.isUnlimited && t.ticketsRemaining !== null && t.ticketsRemaining <= 0) continue;
+    const unit = tripTierUnitAllInCents(t);
+    if (min === null || unit < min) min = unit;
+  }
+  return min;
+};
+
+/** The selected lines (qty>0), in the tiers' own order. DEC-B: the full multi-line array. */
+export const tripSelectedLines = (
+  tiers: ReadonlyArray<TripTierLike>,
+  quantities: Record<string, number>,
+  planChoiceByTier?: Record<string, "full" | "installments">,
+): TripSelectedLine[] => {
+  const lines: TripSelectedLine[] = [];
+  for (const t of tiers) {
+    const qty = quantities[t.ticketTypeId] ?? 0;
+    if (qty <= 0) continue;
+    const hasPlan = t.installmentSchedule !== null && t.installmentSchedule !== undefined;
+    const choice = hasPlan ? (planChoiceByTier?.[t.ticketTypeId] ?? "full") : undefined;
+    lines.push({
+      ticketTypeId: t.ticketTypeId,
+      quantity: qty,
+      ...(choice !== undefined ? { paymentPlanChoice: choice } : {}),
+    });
+  }
+  return lines;
+};
+
+/** Total selected quantity across all packages. */
+export const tripTotalSelectedQuantity = (
+  quantities: Record<string, number>,
+): number => {
+  let n = 0;
+  for (const key of Object.keys(quantities)) {
+    const q = quantities[key] ?? 0;
+    if (q > 0) n += q;
+  }
+  return n;
+};
+
+/** Σ(per-package all-in × qty) across the selected lines — the box/bar total (WYSIWYP). */
+export const tripSummedAllInCents = (
+  tiers: ReadonlyArray<TripTierLike>,
+  quantities: Record<string, number>,
+): number => {
+  let total = 0;
+  for (const t of tiers) {
+    const qty = quantities[t.ticketTypeId] ?? 0;
+    if (qty > 0) total += tripTierUnitAllInCents(t) * qty;
+  }
+  return total;
+};
+
+/**
+ * The summed DUE-TODAY across selected lines (DEC-F per-line installments):
+ *   • a line on a plan tier whose choice is "installments" contributes its DEPOSIT
+ *     (deposit_pct of the line's all-in subtotal).
+ *   • every other line (full, or no-plan) contributes its FULL all-in subtotal.
+ * The deposit math reuses the same deposit_pct the projected schedule renders;
+ * NEVER recomputes fees (the per-unit all-in is the server value). `deposit_pct` is
+ * read off each tier's installmentSchedule when it is a valid template.
+ */
+export const tripSummedDueTodayCents = (
+  tiers: ReadonlyArray<TripTierLike>,
+  quantities: Record<string, number>,
+  planChoiceByTier?: Record<string, "full" | "installments">,
+): number => {
+  let due = 0;
+  for (const t of tiers) {
+    const qty = quantities[t.ticketTypeId] ?? 0;
+    if (qty <= 0) continue;
+    const lineAllIn = tripTierUnitAllInCents(t) * qty;
+    const template = asInstallmentTemplate(t.installmentSchedule);
+    const choice = template !== null ? (planChoiceByTier?.[t.ticketTypeId] ?? "full") : "full";
+    if (template !== null && choice === "installments") {
+      due += Math.round((lineAllIn * template.deposit_pct) / 100);
+    } else {
+      due += lineAllIn;
+    }
+  }
+  return due;
+};
+
+/** True when ANY selected line is on a plan tier with the "installments" choice. */
+export const tripAnyLineOnPlan = (
+  tiers: ReadonlyArray<TripTierLike>,
+  quantities: Record<string, number>,
+  planChoiceByTier?: Record<string, "full" | "installments">,
+): boolean => {
+  for (const t of tiers) {
+    const qty = quantities[t.ticketTypeId] ?? 0;
+    if (qty <= 0) continue;
+    const template = asInstallmentTemplate(t.installmentSchedule);
+    if (template === null) continue;
+    if ((planChoiceByTier?.[t.ticketTypeId] ?? "full") === "installments") return true;
+  }
+  return false;
+};
+
+/** Narrow an unknown installmentSchedule into a usable template, or null. */
+function asInstallmentTemplate(raw: unknown): TripInstallmentTemplateLike | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const obj = raw as { deposit_pct?: unknown; installments?: unknown };
+  if (typeof obj.deposit_pct !== "number" || !Array.isArray(obj.installments)) return null;
+  return { deposit_pct: obj.deposit_pct, installments: obj.installments };
+}

--- a/packages/offering-rendering/tripOfferingTypes.ts
+++ b/packages/offering-rendering/tripOfferingTypes.ts
@@ -59,12 +59,22 @@ export interface TripInstallmentTemplate {
   }>;
 }
 
-/** One sellable pricing tier (Leg A: the body renders the sole/first sellable one). */
+/** One sellable pricing tier. Leg B: the body renders N of these as selectable rows. */
 export interface TripOfferingTier {
   id: string;
   ticketTypeId: string;
   tierName: string;
   priceCents: number;
+  /**
+   * META-ORCH-1174 Leg B3 — the SERVER all-in (pg_public_event_tier_allin), in
+   * cents. The §10 box + bar display + sum THIS (WYSIWYP, I-PROPOSED-1174-ALLIN-
+   * SERVER-SOURCED). null/undefined → the per-surface adapter had no all-in (free
+   * tier, or the RPC missed) → the math falls back to priceCents. NEVER recompute
+   * fees client-side. Each surface adapter resolves it via fetchTierAllInCents.
+   */
+  priceAllInCents?: number | null;
+  /** Optional per-package description (tier_metadata.description) — shown in the row. */
+  description?: string | null;
   currency: string;
   isFree: boolean;
   isUnlimited: boolean;
@@ -166,14 +176,26 @@ export interface ReserveSplitCtas {
   overTime: ReserveSplitButton;
 }
 
+/**
+ * A reserved cart line — META-ORCH-1174 Leg B3 (DEC-B multi-line). One per selected
+ * package; `paymentPlanChoice` present only for a tier carrying a plan (DEC-F).
+ */
+export interface TripReserveLine {
+  ticketTypeId: string;
+  quantity: number;
+  paymentPlanChoice?: "full" | "installments";
+}
+
 /** The body's action callbacks (all navigation/checkout owned by the surface). */
 export interface TripOfferingCallbacks {
   /** Brand chip "View" → brand page. */
   onViewBrand?: () => void;
   /**
-   * Reserve (the §10 box CTA + floating/docked bar). `choice` is the explicit
-   * payment plan ("full"/"installments") when the split buttons fire; undefined
-   * for the single Reserve (the surface reads its own toggle state).
+   * Reserve (the §10 box CTA + floating/docked bar). META-ORCH-1174 Leg B3: the
+   * surface receives the FULL selected-lines array (DEC-B multi-package). `choice`
+   * stays for the single/legacy split-button path (no selection → the surface
+   * seeds the cart from `lines` or opens it to pick). When `lines` is omitted the
+   * surface opens the cart un-seeded (Leg-A behavior preserved).
    */
-  onReserve: (choice?: "full" | "installments") => void;
+  onReserve: (choice?: "full" | "installments", lines?: TripReserveLine[]) => void;
 }

--- a/packages/offering-rendering/useTripOfferingState.ts
+++ b/packages/offering-rendering/useTripOfferingState.ts
@@ -1,40 +1,71 @@
 /**
- * useTripOfferingState — META-ORCH-1174 Leg A [trip-page-standardize].
+ * useTripOfferingState — META-ORCH-1174 Leg A [trip-page-standardize] +
+ * Leg B3 [multi-package selector].
  *
  * THE ONE lifted buy-state machine for the public trip page (mirrors how the event
- * page uses resolveOfferingCta / computeOfferingVariant as one owner). The §10
- * inline reserve box AND the docked/floating <TripReserveBar> AND the desktop
- * reserve control ALL read this state → they can never diverge on price /
- * availability / split-plan affordance.
+ * page uses resolveOfferingCta / the eventBoxTotals owner). The §10 inline reserve
+ * box AND the docked/floating <TripReserveBar> AND the desktop reserve control ALL
+ * read this state → they can never diverge on price / availability / selection.
  *
- * Pure: no fetch, no auth, no store reads (I-MOR-0827). The pay-over-time schedule
- * projection lives here as a pure copy (`projectTripSchedule`) so the package has
- * NO app-src import. Each surface passes its own `paymentPlanChoice` useState in;
- * the hook derives the labels/CTA.
+ * Leg B3 (DEC-B/C/D/F/J): the single `selectedTier` slot becomes a MULTI-SELECT
+ * model. The surface owns the `{ ticketTypeId → quantity }` map + the per-tier
+ * `{ ticketTypeId → "full"|"installments" }` plan-choice map as useState and passes
+ * them in (the hook stays pure — no fetch, no store, no internal state; I-MOR-0827).
+ * The hook derives: the clamped per-tier qty setter inputs, the selected lines, the
+ * SUMMED server all-in (Σ priceAllInCents × qty), the per-line due-today, and the
+ * bar label (DEC-J "From {min all-in}" until a package is selected → summed all-in).
  *
- * Leg A: `selectedTier` is the sole/first sellable tier (capacity>0 or unlimited).
- * The shape anticipates Leg B (multi-tier: selectedTierId + quantities map are
- * additive — the bar/box contract is unchanged; see SPEC §D.2).
+ * Pure: no fetch, no auth, no store reads (I-MOR-0827). The all-in lives on each
+ * tier's `priceAllInCents` (resolved server-side by each surface adapter via
+ * fetchTierAllInCents / pg_public_event_tier_allin — NEVER fee math here). The pay-
+ * over-time schedule projection stays a pure copy (`projectTripSchedule`).
+ *
+ * Single-package trips (N=1) behave EXACTLY as Leg A: one row, the same toggle, the
+ * same CTA — no regression (proven by the N=1 tests).
  */
 
 import { useMemo } from "react";
 
 import type { CtaState } from "./offeringCta";
+import {
+  clampTripTierQuantity,
+  tripAnyLineOnPlan,
+  tripMinTierAllInCents,
+  tripSelectedLines,
+  tripSummedAllInCents,
+  tripSummedDueTodayCents,
+  tripTotalSelectedQuantity,
+  tripTierUnitAllInCents,
+  type TripTierLike,
+} from "./tripBoxTotals";
 import type {
   ProjectedTripSchedule,
   ReserveSplitCtas,
   TripInstallmentTemplate,
   TripOfferingData,
   TripOfferingTier,
+  TripReserveLine,
 } from "./tripOfferingTypes";
 
 export type TripPaymentPlanChoice = "full" | "installments";
 
 export interface UseTripOfferingStateInput {
   data: TripOfferingData;
+  /**
+   * Leg A back-compat: the single pay-full/pay-over-time toggle. Leg B3 surfaces
+   * pass a per-tier map instead via `planChoiceByTier`; when that is present it
+   * takes precedence per-tier. A single-package surface can keep passing only this.
+   */
   paymentPlanChoice: TripPaymentPlanChoice;
+  /**
+   * Leg B3 — the user's per-package selection `{ ticketTypeId → quantity }`. Absent
+   * → Leg-A behavior (the hook seeds the sole sellable tier at qty 1 for display).
+   */
+  quantities?: Record<string, number>;
+  /** Leg B3 — per-package payment-plan choice `{ ticketTypeId → "full"|"installments" }`. */
+  planChoiceByTier?: Record<string, TripPaymentPlanChoice>;
   /** Split-CTA onPress builders (the surface owns navigation/checkout). */
-  onReserve: (choice?: TripPaymentPlanChoice) => void;
+  onReserve: (choice?: TripPaymentPlanChoice, lines?: TripReserveLine[]) => void;
   /** Injectable for tests; default new Date(). */
   now?: Date;
 }
@@ -42,18 +73,36 @@ export interface UseTripOfferingStateInput {
 export interface TripOfferingState {
   /** The SAME CtaState shape both bars + the box read. */
   cta: CtaState;
-  /** Present ONLY when the (single) tier has a plan AND the CTA is tappable. */
+  /** Present ONLY when the (single, Leg-A) tier has a plan AND the CTA is tappable. */
   splitCtas?: ReserveSplitCtas;
   /** "All-in, taxes included" / "Due today · deposit" / null (free/no price). */
   barKicker: string | null;
-  /** The bar's price string (follows the live toggle for a plan tier). */
+  /** The bar's price string (DEC-J: "From {min}" until selected → summed all-in). */
   barPriceLabel: string;
   isClosed: boolean;
   isSoldOut: boolean;
-  /** Leg A: the sole/first sellable tier (Leg B: the user-chosen tier). */
+  /** Leg A: the sole/first sellable tier (used for the single-package fast path). */
   selectedTier: TripOfferingTier | null;
-  /** The pure pay-over-time projection (null when no plan). */
+  /** The pure pay-over-time projection for the SOLE tier (null when no plan / multi). */
   projectedSchedule: ProjectedTripSchedule | null;
+
+  // ----- Leg B3 multi-select -----
+  /** Total selected quantity across all packages (0 → nothing selected). */
+  totalSelectedQuantity: number;
+  /** The selected lines (qty>0) — DEC-B, what Reserve passes to the cart. */
+  selectedLines: TripReserveLine[];
+  /** Σ(server all-in × qty) across selected lines, in cents (WYSIWYP). */
+  summedAllInCents: number;
+  /** Σ per-line due-today (plan lines → deposit; full/no-plan → full), in cents. */
+  summedDueTodayCents: number;
+  /** The summed-all-in label ("Free"/formatted) — null when nothing selected. */
+  summedAllInLabel: string | null;
+  /** The summed due-today label — null when nothing selected. */
+  summedDueTodayLabel: string | null;
+  /** True when ANY selected line is on a plan tier paying over time. */
+  anyLineOnPlan: boolean;
+  /** Clamp a requested qty for a tier (the surface routes its stepper through this). */
+  clampQuantity: (ticketTypeId: string, requested: number) => number;
 }
 
 // ===========================================================================
@@ -109,8 +158,8 @@ export function projectTripSchedule(
 }
 
 // ===========================================================================
-// Money formatting (minor units; never recompute fees — priceCents IS the all-in
-// per the single-owner contract, ORCH-1147).
+// Money formatting (minor units; never recompute fees — priceAllInCents IS the
+// all-in per the single-owner contract, ORCH-1147 / I-PROPOSED-1174-ALLIN).
 // ===========================================================================
 
 function formatTripPrice(priceCents: number, currency: string): string {
@@ -138,56 +187,153 @@ export function selectSellableTier(
   );
 }
 
+/** The per-tier UNIT all-in price label (server all-in; "Free" when free). */
+export function tripTierPriceLabel(tier: TripOfferingTier): string {
+  if (tier.isFree || tier.priceCents === 0) return "Free";
+  return formatTripPrice(tripTierUnitAllInCents(tier as TripTierLike), tier.currency);
+}
+
+/** Map a TripOfferingTier into the RN-free math shape (carrying the server all-in). */
+function toTierLike(tier: TripOfferingTier): TripTierLike {
+  return {
+    ticketTypeId: tier.ticketTypeId,
+    priceCents: tier.priceCents,
+    priceAllInCents: tier.priceAllInCents ?? null,
+    isFree: tier.isFree,
+    isUnlimited: tier.isUnlimited,
+    ticketsRemaining: tier.ticketsRemaining,
+    installmentSchedule: tier.installmentSchedule,
+  };
+}
+
 export function useTripOfferingState(
   input: UseTripOfferingStateInput,
 ): TripOfferingState {
-  const { data, paymentPlanChoice, onReserve, now } = input;
+  const {
+    data,
+    paymentPlanChoice,
+    quantities,
+    planChoiceByTier,
+    onReserve,
+    now,
+  } = input;
 
   return useMemo<TripOfferingState>(() => {
     const anchor = now ?? new Date();
+    const tierLikes = data.tiers.map(toTierLike);
     const selectedTier = selectSellableTier(data.tiers);
 
-    const isClosed = data.bookingsClosed === true;
-    const isSoldOut =
-      selectedTier !== undefined &&
-      selectedTier !== null &&
-      selectedTier.isUnlimited === false &&
-      selectedTier.ticketsRemaining !== null &&
-      selectedTier.ticketsRemaining <= 0;
+    // Effective per-tier plan choices: the explicit per-tier map wins; else the
+    // single Leg-A toggle is applied to whichever tier(s) carry a plan (so a
+    // single-package surface that only passes `paymentPlanChoice` is unchanged).
+    const effectivePlanByTier: Record<string, TripPaymentPlanChoice> = {};
+    for (const t of data.tiers) {
+      const hasPlan =
+        t.installmentSchedule !== null && t.installmentSchedule !== undefined;
+      if (!hasPlan) continue;
+      effectivePlanByTier[t.ticketTypeId] =
+        planChoiceByTier?.[t.ticketTypeId] ?? paymentPlanChoice;
+    }
 
+    const qtyMap = quantities ?? {};
+    const totalSelected = tripTotalSelectedQuantity(qtyMap);
+    const selectedLines = tripSelectedLines(
+      tierLikes,
+      qtyMap,
+      effectivePlanByTier,
+    );
+    const summedAllInCents = tripSummedAllInCents(tierLikes, qtyMap);
+    const summedDueTodayCents = tripSummedDueTodayCents(
+      tierLikes,
+      qtyMap,
+      effectivePlanByTier,
+    );
+    const anyLineOnPlan = tripAnyLineOnPlan(tierLikes, qtyMap, effectivePlanByTier);
+
+    const tripCurrency = data.currency || selectedTier?.currency || "USD";
+    const summedAllInLabel =
+      totalSelected === 0
+        ? null
+        : summedAllInCents === 0
+          ? "Free"
+          : formatTripPrice(summedAllInCents, tripCurrency);
+    const summedDueTodayLabel =
+      totalSelected === 0
+        ? null
+        : summedDueTodayCents === 0
+          ? "Free"
+          : formatTripPrice(summedDueTodayCents, tripCurrency);
+
+    const isClosed = data.bookingsClosed === true;
+    // Whole-trip sold-out: NO sellable tier exists (every tier capped at 0).
+    const isSoldOut =
+      data.tiers.length > 0 &&
+      data.tiers.every(
+        (t) =>
+          t.isUnlimited === false &&
+          t.ticketsRemaining !== null &&
+          t.ticketsRemaining <= 0,
+      );
+
+    // Leg-A single-tier projection (the merged box's pay-full/over-time toggle reads
+    // it for a single-package trip; multi-package rows project per-row in the body).
     const projectedSchedule =
       selectedTier !== null ? projectTripSchedule(selectedTier, anchor) : null;
-    const hasPlan = projectedSchedule !== null;
+    const hasSingleTierPlan = projectedSchedule !== null;
 
-    const priceLabel =
-      selectedTier !== null && selectedTier.priceCents > 0
-        ? formatTripPrice(selectedTier.priceCents, selectedTier.currency)
-        : selectedTier !== null && selectedTier.priceCents === 0
-          ? "Free"
-          : "";
-    const depositLabel =
-      projectedSchedule !== null
-        ? formatTripPrice(
-            projectedSchedule.depositCents,
-            selectedTier?.currency ?? "USD",
-          )
-        : "";
-
+    // DEC-J — the bar/box price string.
+    //   nothing selected → "From {min all-in}" (multi) or the bare all-in (single).
+    //   ≥1 selected      → the summed all-in (or summed due-today when paying over time).
+    const minAllIn = tripMinTierAllInCents(tierLikes);
     const multiTier = data.tiers.length > 1;
-    const barPriceLabel = hasPlan
-      ? paymentPlanChoice === "installments"
-        ? `${depositLabel} today`
-        : `${priceLabel} total`
-      : multiTier
-        ? `From ${priceLabel}`
-        : priceLabel;
+    const fromLabel =
+      minAllIn === null
+        ? ""
+        : minAllIn === 0
+          ? "Free"
+          : multiTier
+            ? `From ${formatTripPrice(minAllIn, tripCurrency)}`
+            : formatTripPrice(minAllIn, tripCurrency);
+
+    let barPriceLabel: string;
+    if (totalSelected > 0) {
+      barPriceLabel = anyLineOnPlan
+        ? `${summedDueTodayLabel ?? ""} today`
+        : (summedAllInLabel ?? "");
+    } else if (hasSingleTierPlan && !multiTier) {
+      // Single-package plan trip, nothing selected: keep the Leg-A toggle preview.
+      const depositLabel = formatTripPrice(
+        projectedSchedule.depositCents,
+        selectedTier?.currency ?? tripCurrency,
+      );
+      barPriceLabel =
+        paymentPlanChoice === "installments"
+          ? `${depositLabel} today`
+          : fromLabel;
+    } else {
+      barPriceLabel = fromLabel;
+    }
 
     const barKicker =
-      priceLabel === "Free" || priceLabel === ""
+      fromLabel === "Free" || fromLabel === ""
         ? null
-        : hasPlan && paymentPlanChoice === "installments"
+        : (totalSelected > 0 && anyLineOnPlan) ||
+            (totalSelected === 0 &&
+              hasSingleTierPlan &&
+              !multiTier &&
+              paymentPlanChoice === "installments")
           ? "Due today · deposit"
           : "All-in, taxes included";
+
+    // The CTA is tappable when the offering is bookable + open + not whole-trip
+    // sold-out + has at least one sellable tier. Selection is NOT required to tap
+    // (the box/cart let the buyer pick) — mirrors the event box (ORCH-1167-R3).
+    const anySellable = data.tiers.some(
+      (t) =>
+        t.isUnlimited || t.ticketsRemaining === null || t.ticketsRemaining > 0,
+    );
+    const allFree =
+      data.tiers.length > 0 && data.tiers.every((t) => t.isFree || t.priceCents === 0);
 
     const cta: CtaState =
       data.bookable === false
@@ -199,7 +345,7 @@ export function useTripOfferingState(
           }
         : isClosed
           ? { kind: "unavailable", title: "Bookings closed", subline: null, tappable: false }
-          : isSoldOut
+          : isSoldOut || !anySellable
             ? { kind: "unavailable", title: "Sold out", subline: null, tappable: false }
             : selectedTier === null
               ? {
@@ -208,7 +354,7 @@ export function useTripOfferingState(
                   subline: null,
                   tappable: false,
                 }
-              : priceLabel === "Free"
+              : allFree
                 ? { kind: "free", label: "Reserve my spot", tappable: true }
                 : {
                     kind: "buy",
@@ -217,9 +363,24 @@ export function useTripOfferingState(
                     tappable: true,
                   };
 
-    // Split CTAs ONLY for a bookable PLAN tier (rule 9: no-plan / disabled → single).
+    // Split CTAs — Leg A single-package plan fast path ONLY (multi-package rows own
+    // their own per-row pay-full/over-time toggle in the body). No split for multi.
+    const priceLabel =
+      selectedTier !== null && selectedTier.priceCents > 0
+        ? formatTripPrice(
+            tripTierUnitAllInCents(selectedTier as TripTierLike),
+            selectedTier.currency,
+          )
+        : "";
+    const depositLabel =
+      projectedSchedule !== null
+        ? formatTripPrice(
+            projectedSchedule.depositCents,
+            selectedTier?.currency ?? tripCurrency,
+          )
+        : "";
     const splitCtas: ReserveSplitCtas | undefined =
-      hasPlan && cta.tappable
+      hasSingleTierPlan && !multiTier && cta.tappable
         ? {
             full: {
               cta: {
@@ -242,6 +403,12 @@ export function useTripOfferingState(
           }
         : undefined;
 
+    const clampQuantity = (ticketTypeId: string, requested: number): number => {
+      const tier = tierLikes.find((t) => t.ticketTypeId === ticketTypeId);
+      if (tier === undefined) return 0;
+      return clampTripTierQuantity(tier, requested);
+    };
+
     return {
       cta,
       splitCtas,
@@ -251,6 +418,14 @@ export function useTripOfferingState(
       isSoldOut,
       selectedTier,
       projectedSchedule,
+      totalSelectedQuantity: totalSelected,
+      selectedLines,
+      summedAllInCents,
+      summedDueTodayCents,
+      summedAllInLabel,
+      summedDueTodayLabel,
+      anyLineOnPlan,
+      clampQuantity,
     };
-  }, [data, paymentPlanChoice, onReserve, now]);
+  }, [data, paymentPlanChoice, quantities, planChoiceByTier, onReserve, now]);
 }

--- a/supabase/functions/_shared/installments/__tests__/computeMultiLineInstallmentPlan.test.ts
+++ b/supabase/functions/_shared/installments/__tests__/computeMultiLineInstallmentPlan.test.ts
@@ -1,0 +1,293 @@
+/**
+ * META-ORCH-1174 Leg B1 — adversarial unit tests for the multi-line installment
+ * money math (the executable spec mirrored by
+ * biz_ticket_checkout_create_session in
+ * 20261101000000_meta_orch_1174_b1_multiline_installments.sql).
+ *
+ * MANDATORY money-path coverage (per dispatch):
+ *   (a) single plan line — byte-identical to ORCH-0869 single-line (no regression)
+ *   (b) two non-plan lines — full charge sum, empty schedule
+ *   (c) one plan line + one non-plan line — deposit + full today, plan schedule kept
+ *   (d) two plan lines, DIFFERENT schedules — both deposits today, schedules unioned
+ *   (e) qty>1 on a plan line — scales by line total
+ *   (f) free + paid mix
+ * PLUS: money-conservation assertion on every case (no money lost / double-charged)
+ *   and the payInFull (ORCH-0915 opt-out) collapse.
+ *
+ * Run: deno test supabase/functions/_shared/installments/__tests__/computeMultiLineInstallmentPlan.test.ts
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  computeMultiLineInstallmentPlan,
+  type InstallmentTemplate,
+  MultiLineInstallmentError,
+  type MultiLineInstallmentLine,
+} from "../computeMultiLineInstallmentPlan.ts";
+
+const BOOKED = new Date("2026-01-01T00:00:00Z");
+
+// 25% deposit + 2 installments (37.5% / 37.5%) by days_after_booking.
+const PLAN_2X: InstallmentTemplate = {
+  deposit_pct: 25,
+  installments: [
+    { ordinal: 1, pct: 37.5, days_after_booking: 30 },
+    { ordinal: 2, pct: 37.5, days_after_booking: 60 },
+  ],
+};
+
+// 50% deposit + 1 installment (50%) by days_after_booking.
+const PLAN_1X: InstallmentTemplate = {
+  deposit_pct: 50,
+  installments: [{ ordinal: 1, pct: 50, days_after_booking: 45 }],
+};
+
+function sumScheduled(scheduled: { amountCents: number }[]): number {
+  return scheduled.reduce((t, s) => t + s.amountCents, 0);
+}
+
+/** The load-bearing invariant: nothing lost, nothing double-charged. */
+function assertMoneyConserved(
+  plan: ReturnType<typeof computeMultiLineInstallmentPlan>,
+  lines: MultiLineInstallmentLine[],
+) {
+  const lineSum = lines.reduce((t, l) => t + l.lineTotalCents, 0);
+  const total = plan.dueTodayCents + sumScheduled(plan.scheduled);
+  assertEquals(
+    total,
+    lineSum,
+    `money conservation: dueToday(${plan.dueTodayCents}) + scheduled(${
+      sumScheduled(plan.scheduled)
+    }) must equal Σ line totals(${lineSum})`,
+  );
+}
+
+Deno.test("(a) single plan line — byte-identical to ORCH-0869 single-line math", () => {
+  // 10000 cents, 25% deposit. deposit=floor(10000*25/100)=2500.
+  // inst1=floor(10000*37.5/100)=3750. inst2(last)=10000-2500-3750=3750.
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "std", lineTotalCents: 10000, template: PLAN_2X },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+
+  assertEquals(plan.dueTodayCents, 2500);
+  assertEquals(plan.scheduled.length, 2);
+  assertEquals(plan.scheduled[0].amountCents, 3750);
+  assertEquals(plan.scheduled[1].amountCents, 3750);
+  assertEquals(plan.scheduled[0].ordinal, 1);
+  assertEquals(plan.scheduled[1].ordinal, 2);
+  assertEquals(plan.scheduled[0].dueAt, "2026-01-31T00:00:00Z");
+  assertEquals(plan.scheduled[1].dueAt, "2026-03-02T00:00:00Z");
+  assert(plan.hasInstallments);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(a') single plan line with rounding remainder — last installment absorbs", () => {
+  // 999 cents, 33% deposit + 3×~22.33%. Forces floor() remainder onto the last.
+  const ODD: InstallmentTemplate = {
+    deposit_pct: 33,
+    installments: [
+      { ordinal: 1, pct: 22, days_after_booking: 10 },
+      { ordinal: 2, pct: 22, days_after_booking: 20 },
+      { ordinal: 3, pct: 23, days_after_booking: 30 },
+    ],
+  };
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "std", lineTotalCents: 999, template: ODD },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  // deposit=floor(999*33/100)=329. i1=floor(999*22/100)=219. i2=219.
+  // i3(last)=999-329-219-219=232.
+  assertEquals(plan.dueTodayCents, 329);
+  assertEquals(plan.scheduled.map((s) => s.amountCents), [219, 219, 232]);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(b) two non-plan lines — full sum today, empty schedule", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "a", lineTotalCents: 4000, template: null },
+    { ticketTypeId: "b", lineTotalCents: 6000, template: undefined },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  assertEquals(plan.dueTodayCents, 10000);
+  assertEquals(plan.scheduled.length, 0);
+  assert(!plan.hasInstallments);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(c) one plan line + one non-plan line — deposit + full today, plan schedule preserved", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "vip", lineTotalCents: 10000, template: PLAN_2X }, // dep 2500
+    { ticketTypeId: "std", lineTotalCents: 5000, template: null }, // full 5000
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  // dueToday = 2500 (vip deposit) + 5000 (std full) = 7500.
+  assertEquals(plan.dueTodayCents, 7500);
+  assertEquals(plan.scheduled.length, 2);
+  // The vip plan's two 3750 installments are preserved.
+  assertEquals(plan.scheduled.map((s) => s.amountCents), [3750, 3750]);
+  assertEquals(plan.scheduled.every((s) => s.sourceTicketTypeId === "vip"), true);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(d) two plan lines, DIFFERENT schedules — both deposits today, schedules unioned + re-ordinalled", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "vip", lineTotalCents: 10000, template: PLAN_2X }, // dep 2500, 2 insts @ d30,d60
+    { ticketTypeId: "std", lineTotalCents: 8000, template: PLAN_1X }, // dep 4000, 1 inst @ d45
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  // dueToday = 2500 + 4000 = 6500.
+  assertEquals(plan.dueTodayCents, 6500);
+  // 3 scheduled total: vip d30(3750), std d45(4000), vip d60(3750), sorted by dueAt.
+  assertEquals(plan.scheduled.length, 3);
+  assertEquals(plan.scheduled.map((s) => s.ordinal), [1, 2, 3]); // sequential, no collision
+  assertEquals(plan.scheduled.map((s) => s.dueAt), [
+    "2026-01-31T00:00:00Z", // vip +30d
+    "2026-02-15T00:00:00Z", // std +45d
+    "2026-03-02T00:00:00Z", // vip +60d
+  ]);
+  assertEquals(plan.scheduled.map((s) => s.amountCents), [3750, 4000, 3750]);
+  assertEquals(plan.scheduled.map((s) => s.sourceTicketTypeId), [
+    "vip",
+    "std",
+    "vip",
+  ]);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(e) qty>1 on a plan line — scales by line total (caller folds qty into lineTotalCents)", () => {
+  // VIP unit price 5000 × qty 3 = 15000 line total.
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "vip", lineTotalCents: 15000, template: PLAN_2X },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  // deposit=floor(15000*25/100)=3750. i1=floor(15000*37.5/100)=5625. i2=15000-3750-5625=5625.
+  assertEquals(plan.dueTodayCents, 3750);
+  assertEquals(plan.scheduled.map((s) => s.amountCents), [5625, 5625]);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(f) free + paid mix — free line contributes 0, paid plan line schedules normally", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "free", lineTotalCents: 0, template: null },
+    { ticketTypeId: "vip", lineTotalCents: 10000, template: PLAN_2X },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  // free adds 0 today + nothing scheduled; vip deposit 2500.
+  assertEquals(plan.dueTodayCents, 2500);
+  assertEquals(plan.scheduled.length, 2);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("(f') free plan line is impossible to schedule below zero — free + free", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "free1", lineTotalCents: 0, template: null },
+    { ticketTypeId: "free2", lineTotalCents: 0, template: null },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  assertEquals(plan.dueTodayCents, 0);
+  assertEquals(plan.scheduled.length, 0);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("payInFull opt-out (ORCH-0915) — every line charges full today, no schedule, even with templates", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "vip", lineTotalCents: 10000, template: PLAN_2X },
+    { ticketTypeId: "std", lineTotalCents: 8000, template: PLAN_1X },
+  ];
+  const plan = computeMultiLineInstallmentPlan({
+    lines,
+    bookedAt: BOOKED,
+    payInFull: true,
+  });
+  assertEquals(plan.dueTodayCents, 18000); // full sum
+  assertEquals(plan.scheduled.length, 0);
+  assert(!plan.hasInstallments);
+  assertMoneyConserved(plan, lines);
+});
+
+Deno.test("no money is created — three plan lines all conserve independently and in union", () => {
+  const lines: MultiLineInstallmentLine[] = [
+    { ticketTypeId: "a", lineTotalCents: 12345, template: PLAN_2X },
+    { ticketTypeId: "b", lineTotalCents: 7777, template: PLAN_1X },
+    { ticketTypeId: "c", lineTotalCents: 9999, template: PLAN_2X },
+  ];
+  const plan = computeMultiLineInstallmentPlan({ lines, bookedAt: BOOKED });
+  assertMoneyConserved(plan, lines);
+  // Ordinals are a contiguous 1..M with no duplicates (DB UNIQUE(order_id,ordinal)).
+  const ords = plan.scheduled.map((s) => s.ordinal);
+  assertEquals(ords, ords.map((_, i) => i + 1));
+});
+
+// ---- adversarial: malformed templates raise the SAME codes the SQL raises ----
+
+Deno.test("malformed: pct sum != 100 → installment_pct_sum_mismatch", () => {
+  const bad: InstallmentTemplate = {
+    deposit_pct: 25,
+    installments: [{ ordinal: 1, pct: 50, days_after_booking: 30 }], // 25+50=75
+  };
+  assertThrows(
+    () =>
+      computeMultiLineInstallmentPlan({
+        lines: [{ ticketTypeId: "x", lineTotalCents: 10000, template: bad }],
+        bookedAt: BOOKED,
+      }),
+    MultiLineInstallmentError,
+    "installment_pct_sum_mismatch",
+  );
+});
+
+Deno.test("malformed: first installment in the past → installment_schedule_past_due_at_booking", () => {
+  const past: InstallmentTemplate = {
+    deposit_pct: 50,
+    installments: [{ ordinal: 1, pct: 50, fixed_date: "2025-01-01T00:00:00Z" }],
+  };
+  assertThrows(
+    () =>
+      computeMultiLineInstallmentPlan({
+        lines: [{ ticketTypeId: "x", lineTotalCents: 10000, template: past }],
+        bookedAt: BOOKED,
+      }),
+    MultiLineInstallmentError,
+    "installment_schedule_past_due_at_booking",
+  );
+});
+
+Deno.test("malformed: deposit_pct out of range → installment_deposit_pct_out_of_range", () => {
+  const bad: InstallmentTemplate = {
+    deposit_pct: 0,
+    installments: [{ ordinal: 1, pct: 100, days_after_booking: 30 }],
+  };
+  assertThrows(
+    () =>
+      computeMultiLineInstallmentPlan({
+        lines: [{ ticketTypeId: "x", lineTotalCents: 10000, template: bad }],
+        bookedAt: BOOKED,
+      }),
+    MultiLineInstallmentError,
+    "installment_deposit_pct_out_of_range",
+  );
+});
+
+Deno.test("malformed: ordinal gap → installment_ordinal_invalid", () => {
+  const bad: InstallmentTemplate = {
+    deposit_pct: 25,
+    installments: [
+      { ordinal: 1, pct: 37.5, days_after_booking: 30 },
+      { ordinal: 3, pct: 37.5, days_after_booking: 60 }, // should be 2
+    ],
+  };
+  assertThrows(
+    () =>
+      computeMultiLineInstallmentPlan({
+        lines: [{ ticketTypeId: "x", lineTotalCents: 10000, template: bad }],
+        bookedAt: BOOKED,
+      }),
+    MultiLineInstallmentError,
+    "installment_ordinal_invalid",
+  );
+});

--- a/supabase/functions/_shared/installments/computeMultiLineInstallmentPlan.ts
+++ b/supabase/functions/_shared/installments/computeMultiLineInstallmentPlan.ts
@@ -1,0 +1,263 @@
+/**
+ * META-ORCH-1174 Leg B1 [multi-package trip installments] — pure money math.
+ *
+ * This module is the EXECUTABLE SPECIFICATION of the per-line installment
+ * computation that `biz_ticket_checkout_create_session`
+ * (supabase/migrations/20261101000000_meta_orch_1174_b1_multiline_installments.sql)
+ * performs in SQL. Postgres cannot call TypeScript, so the SQL RPC re-implements
+ * this exact algorithm; the adversarial unit tests pin THIS helper and a
+ * separate source-assertion test pins that the RPC body contains the matching
+ * per-line logic. The two MUST stay in lockstep — if you change the algorithm
+ * here, change the SQL, and vice-versa.
+ *
+ * CONTRACT (DEC-1174-F — FULL multi-package installments):
+ *   A trip cart may contain N lines. Each line maps to one ticket_type (a trip
+ *   "package"). A line MAY carry an installment template (the package's
+ *   tier_metadata.installments). Lines WITHOUT a template charge in full now.
+ *
+ *   "Due today" (the deposit charged at booking) =
+ *       Σ(each plan line's per-line deposit)
+ *     + Σ(each non-plan line's full line total)
+ *
+ *   The scheduled future payments = the UNION of every plan line's own schedule,
+ *   re-numbered ordinal 1..M (sorted by dueAt asc, then by line order) so the
+ *   order_installments UNIQUE(order_id, ordinal) constraint holds at finalize.
+ *
+ *   MONEY CONSERVATION (the load-bearing invariant):
+ *       dueTodayCents + Σ(scheduled.amountCents) === Σ(line totals)
+ *   Proven per-line: each plan line's (deposit + Σ its installments) === its
+ *   own line total by the last-absorbs-rounding rule; non-plan lines contribute
+ *   their full total to dueToday and nothing to the schedule. The union only
+ *   relabels ordinals; it never changes an amount.
+ *
+ * SINGLE-LINE PRESERVATION (no regression): for exactly one plan line and no
+ * other lines, this reduces to the ORCH-0869 single-line algorithm byte-for-byte
+ * (same floor() formula, same last-installment-absorbs-remainder rule, same
+ * schedule shape) — verified by the (a) test case.
+ *
+ * Rounding rule (integer cents, identical to ORCH-0869):
+ *   lineDeposit = floor(lineTotal * deposit_pct / 100)
+ *   installment i (1..N-1) = floor(lineTotal * pct_i / 100)
+ *   installment N absorbs the remainder so deposit + Σ installments = lineTotal.
+ */
+
+export interface InstallmentTemplateEntry {
+  ordinal: number;
+  pct: number;
+  /** Exactly one of days_after_booking | fixed_date is set (validated upstream). */
+  days_after_booking?: number;
+  fixed_date?: string;
+}
+
+export interface InstallmentTemplate {
+  deposit_pct: number;
+  installments: InstallmentTemplateEntry[];
+}
+
+export interface MultiLineInstallmentLine {
+  ticketTypeId: string;
+  /** quantity × unit price already folded in by the caller. */
+  lineTotalCents: number;
+  /** The package's payment plan; null/undefined ⇒ this line charges full now. */
+  template: InstallmentTemplate | null | undefined;
+}
+
+export interface ComputedScheduledPayment {
+  /** Sequential across the WHOLE union, 1..M. */
+  ordinal: number;
+  amountCents: number;
+  /** ISO-8601 UTC instant the cron charges this installment. */
+  dueAt: string;
+  /** Provenance — which line this entry came from (audit / debugging only). */
+  sourceTicketTypeId: string;
+  /** The line-local ordinal before re-numbering (audit only). */
+  sourceOrdinal: number;
+}
+
+export interface MultiLineInstallmentPlan {
+  /** Sum the deposit PI charges at booking. */
+  dueTodayCents: number;
+  /** Unioned, ordinal-renumbered future payments (may be empty). */
+  scheduled: ComputedScheduledPayment[];
+  /** True when at least one line carries a plan (⇒ save PM off-session). */
+  hasInstallments: boolean;
+}
+
+export class MultiLineInstallmentError extends Error {
+  constructor(public code: string) {
+    super(code);
+    this.name = "MultiLineInstallmentError";
+  }
+}
+
+/** Mirrors the SQL `to_char(... AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`. */
+function toUtcInstant(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`
+  );
+}
+
+/**
+ * Compute one plan line's deposit + its own (un-renumbered) installment amounts.
+ * EXACT port of the ORCH-0869 single-line SQL math, scaled by THIS line's total.
+ *
+ * Throws MultiLineInstallmentError with the SAME error codes the SQL raises so
+ * the failure surface is identical across the TS spec and the RPC.
+ */
+function computeLineSchedule(
+  line: MultiLineInstallmentLine,
+  template: InstallmentTemplate,
+  bookedAt: Date,
+): { depositCents: number; entries: ComputedScheduledPayment[] } {
+  const depositPct = Number(template.deposit_pct);
+  if (!(depositPct > 0) || depositPct > 100) {
+    throw new MultiLineInstallmentError("installment_deposit_pct_out_of_range");
+  }
+  const installments = template.installments;
+  if (!Array.isArray(installments)) {
+    throw new MultiLineInstallmentError("installment_schedule_malformed");
+  }
+  const n = installments.length;
+  if (n < 1 || n > 11) {
+    throw new MultiLineInstallmentError("installment_count_out_of_range");
+  }
+
+  // First pass: validate every installment + accumulate the pct sum.
+  let pctSum = depositPct;
+  for (let i = 0; i < n; i++) {
+    const inst = installments[i];
+    const ord = Number(inst?.ordinal ?? -1);
+    const pct = Number(inst?.pct ?? 0);
+    const days = inst?.days_after_booking;
+    const fixed = inst?.fixed_date;
+    if (ord !== i + 1) {
+      throw new MultiLineInstallmentError("installment_ordinal_invalid");
+    }
+    if (!(pct > 0) || pct >= 100) {
+      throw new MultiLineInstallmentError("installment_pct_out_of_range");
+    }
+    const hasDays = days !== undefined && days !== null;
+    const hasFixed = fixed !== undefined && fixed !== null && fixed !== "";
+    if ((!hasDays && !hasFixed) || (hasDays && hasFixed)) {
+      throw new MultiLineInstallmentError("installment_due_mode_invalid");
+    }
+    pctSum += pct;
+  }
+  if (Math.abs(pctSum - 100) > 0.01) {
+    throw new MultiLineInstallmentError("installment_pct_sum_mismatch");
+  }
+
+  const full = line.lineTotalCents;
+  const depositCents = Math.floor((full * depositPct) / 100);
+
+  // Second pass: amounts (last absorbs remainder) + due dates.
+  const entries: ComputedScheduledPayment[] = [];
+  let runningInstallmentTotal = 0;
+  for (let i = 0; i < n; i++) {
+    const inst = installments[i];
+    const pct = Number(inst.pct);
+    const days = inst.days_after_booking;
+    const fixed = inst.fixed_date;
+
+    let dueDate: Date;
+    if (days !== undefined && days !== null) {
+      if (!(Number(days) >= 1)) {
+        throw new MultiLineInstallmentError(
+          "installment_days_after_booking_invalid",
+        );
+      }
+      dueDate = new Date(bookedAt.getTime() + Number(days) * 86400_000);
+    } else {
+      dueDate = new Date(String(fixed));
+      if (Number.isNaN(dueDate.getTime())) {
+        throw new MultiLineInstallmentError("installment_due_mode_invalid");
+      }
+    }
+
+    // First installment of THIS line must be in the future at booking time.
+    if (i === 0 && dueDate.getTime() <= bookedAt.getTime()) {
+      throw new MultiLineInstallmentError(
+        "installment_schedule_past_due_at_booking",
+      );
+    }
+
+    let amount: number;
+    if (i < n - 1) {
+      amount = Math.floor((full * pct) / 100);
+      runningInstallmentTotal += amount;
+    } else {
+      amount = full - depositCents - runningInstallmentTotal;
+      if (!(amount > 0)) {
+        throw new MultiLineInstallmentError("installment_rounding_invalid");
+      }
+    }
+
+    entries.push({
+      ordinal: i + 1, // line-local; re-numbered after the union
+      amountCents: amount,
+      dueAt: toUtcInstant(dueDate),
+      sourceTicketTypeId: line.ticketTypeId,
+      sourceOrdinal: i + 1,
+    });
+  }
+
+  return { depositCents, entries };
+}
+
+/**
+ * The full multi-line plan. `payInFull=true` is the session-wide opt-out
+ * (ORCH-0915 p_payment_plan_choice='full') — every line charges in full now and
+ * the schedule is empty, regardless of any per-line templates.
+ */
+export function computeMultiLineInstallmentPlan(input: {
+  lines: MultiLineInstallmentLine[];
+  bookedAt: Date;
+  payInFull?: boolean;
+}): MultiLineInstallmentPlan {
+  const { lines, bookedAt } = input;
+  const payInFull = input.payInFull === true;
+
+  let dueTodayCents = 0;
+  const allEntries: ComputedScheduledPayment[] = [];
+
+  for (const line of lines) {
+    if (!(line.lineTotalCents >= 0)) {
+      throw new MultiLineInstallmentError("line_total_invalid");
+    }
+    const hasTemplate = !payInFull && line.template != null &&
+      Array.isArray(line.template.installments) &&
+      line.template.installments.length > 0;
+
+    if (!hasTemplate) {
+      // Non-plan (or opted-full) line — full amount due today, nothing scheduled.
+      dueTodayCents += line.lineTotalCents;
+      continue;
+    }
+
+    const { depositCents, entries } = computeLineSchedule(
+      line,
+      line.template as InstallmentTemplate,
+      bookedAt,
+    );
+    dueTodayCents += depositCents;
+    for (const e of entries) allEntries.push(e);
+  }
+
+  // Union + re-number: sort by dueAt asc, then by source line order (stable),
+  // then assign sequential ordinals 1..M. Sorting by dueAt keeps the buyer's
+  // ledger chronological; ordinal uniqueness is what the DB requires.
+  allEntries.sort((a, b) => {
+    if (a.dueAt < b.dueAt) return -1;
+    if (a.dueAt > b.dueAt) return 1;
+    return 0; // stable: preserves source line order on ties
+  });
+  const scheduled = allEntries.map((e, idx) => ({ ...e, ordinal: idx + 1 }));
+
+  return {
+    dueTodayCents,
+    scheduled,
+    hasInstallments: scheduled.length > 0,
+  };
+}

--- a/supabase/functions/ticket-checkout-create/__tests__/meta_orch_1174_b1_multiline_installments.test.ts
+++ b/supabase/functions/ticket-checkout-create/__tests__/meta_orch_1174_b1_multiline_installments.test.ts
@@ -1,0 +1,129 @@
+/**
+ * META-ORCH-1174 Leg B1 — source-assertion test pinning the multi-line
+ * installment migration. Mirrors the ORCH-0915 RPC-behavior test pattern
+ * (read the migration SQL text + assert load-bearing characteristics).
+ *
+ * This proves the SQL RPC implements the SAME per-line algorithm that the
+ * adversarially-unit-tested helper
+ * (_shared/installments/computeMultiLineInstallmentPlan.ts) specifies, and that
+ * the single-line guard is removed.
+ *
+ * Fails-on-revert: reverting the migration (restoring the
+ * `ticket_lines_mixed_with_installments` guard or dropping the per-line loop)
+ * fails these assertions.
+ *
+ * Run: deno test supabase/functions/ticket-checkout-create/__tests__/meta_orch_1174_b1_multiline_installments.test.ts
+ */
+
+import {
+  assert,
+  assertStringIncludes,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+const migration = await Deno.readTextFile(
+  new URL(
+    "../../../migrations/20261101000000_meta_orch_1174_b1_multiline_installments.sql",
+    import.meta.url,
+  ),
+);
+
+Deno.test("B1: the single-line installment guard is REMOVED from the new session RPC body", () => {
+  // The new CREATE OR REPLACE body must not RAISE the mixed-cart guard. (It may
+  // appear in prose comments describing what was removed, but never as a RAISE.)
+  assert(
+    !/RAISE\s+EXCEPTION\s+'ticket_lines_mixed_with_installments'/i.test(migration),
+    "the new session RPC must not RAISE ticket_lines_mixed_with_installments — DEC-1174-F lifts it",
+  );
+});
+
+Deno.test("B1: per-line installment math loop over the built line items", () => {
+  // Pass 2 iterates v_items (the per-line totals) — not just the first tier.
+  assertStringIncludes(migration, "per-line installment math");
+  assertStringIncludes(
+    migration,
+    "FOR v_line IN SELECT * FROM jsonb_array_elements(v_items)",
+  );
+  // Per-line total drives the deposit + installment amounts (qty folded in).
+  assertStringIncludes(migration, "v_line_total := (v_line ->> 'totalCents')::bigint");
+  assertStringIncludes(
+    migration,
+    "v_line_deposit_cents := floor(v_line_total::numeric * v_deposit_pct / 100)::bigint",
+  );
+});
+
+Deno.test("B1: 'due today' is the sum of per-line deposits + non-plan full totals", () => {
+  // Plan line → add its deposit; non-plan line → add its full total.
+  assertStringIncludes(
+    migration,
+    "v_due_today_cents := v_due_today_cents + v_line_deposit_cents",
+  );
+  assertStringIncludes(
+    migration,
+    "v_due_today_cents := v_due_today_cents + v_line_total",
+  );
+  // The deposit override uses the summed due-today, not a single tier's deposit.
+  assertStringIncludes(migration, "v_total := v_due_today_cents::integer");
+});
+
+Deno.test("B1: last-installment-absorbs-rounding is preserved PER LINE (no money lost)", () => {
+  // The last installment of each line = lineTotal − lineDeposit − running.
+  assertStringIncludes(
+    migration,
+    "v_inst_amount := v_line_total - v_line_deposit_cents - v_line_running",
+  );
+  // Intermediate installments use floor(lineTotal * pct / 100).
+  assertStringIncludes(
+    migration,
+    "v_inst_amount := floor(v_line_total::numeric * v_inst_pct / 100)::bigint",
+  );
+});
+
+Deno.test("B1: schedules are UNIONED + re-ordinalled 1..M by dueAt (UNIQUE(order_id, ordinal) holds)", () => {
+  // Entries accumulate into v_unioned with provenance, then row_number() re-
+  // numbers them sequentially sorted by dueAt then source ordinal.
+  assertStringIncludes(migration, "v_unioned := v_unioned ||");
+  assertStringIncludes(migration, "row_number() OVER");
+  assertStringIncludes(migration, "ORDER BY (elem ->> 'dueAt') ASC");
+  assertStringIncludes(migration, "'ordinal', rn");
+});
+
+Deno.test("B1: ORCH-0915 pay-in-full opt-out is preserved (session-wide, suppresses all schedules)", () => {
+  // payment_plan_choice='full' ⇒ skip the entire per-line installment pass.
+  assertStringIncludes(
+    migration,
+    "IF v_is_trip AND p_payment_plan_choice <> 'full' THEN",
+  );
+  assertStringIncludes(migration, "payment_plan_choice_invalid");
+});
+
+Deno.test("B1: persisted installment_schedule shape is UNCHANGED so finalize reads it unmodified", () => {
+  // finalize loops schedule.installments[].{ordinal,amountCents,dueAt}; the new
+  // RPC builds exactly that shape with depositCents = summed due-today.
+  assertStringIncludes(migration, "'fullPriceCents', v_full_price_cents");
+  assertStringIncludes(migration, "'depositCents', v_due_today_cents");
+  assertStringIncludes(migration, "'installments', v_unioned");
+});
+
+Deno.test("B1: CREATE OR REPLACE keeps the 11-arg signature + RETURNS jsonb (no DROP / no widening) + re-GRANTs service_role", () => {
+  assertStringIncludes(
+    migration,
+    "CREATE OR REPLACE FUNCTION public.biz_ticket_checkout_create_session(",
+  );
+  assertStringIncludes(migration, "p_payment_plan_choice text DEFAULT 'auto'");
+  assertStringIncludes(migration, ") RETURNS jsonb");
+  assert(
+    !/DROP\s+FUNCTION[^;]*biz_ticket_checkout_create_session/i.test(migration),
+    "signature + return type are identical → no DROP needed",
+  );
+  assertStringIncludes(
+    migration,
+    "GRANT EXECUTE ON FUNCTION public.biz_ticket_checkout_create_session(uuid, uuid, text, text, text, boolean, jsonb, text, timestamptz, integer, text) TO service_role",
+  );
+});
+
+Deno.test("B1: per-package capacity gate is per-line (each ticket_type's own quantity_total)", () => {
+  // The capacity check is inside the per-line loop using THIS line's ticket_type
+  // — there is no single-tier capacity shortcut in the engine.
+  assertStringIncludes(migration, "PER-PACKAGE capacity");
+  assertStringIncludes(migration, "ticket_capacity_exceeded");
+});

--- a/supabase/migrations/20261101000000_meta_orch_1174_b1_multiline_installments.sql
+++ b/supabase/migrations/20261101000000_meta_orch_1174_b1_multiline_installments.sql
@@ -1,0 +1,587 @@
+-- META-ORCH-1174 Leg B1 [multi-package trip installments] — ENGINE migration.
+--
+-- Lifts the single-line installment guard and makes the checkout SESSION RPC
+-- compute FULL multi-package installments (DEC-1174-F): a cart may contain N
+-- lines where ANY subset of lines carry their own per-package payment plan
+-- (tier_metadata.installments) alongside plain pay-in-full lines.
+--
+-- =====================================================================
+-- WHAT CHANGES (and what deliberately does NOT)
+-- =====================================================================
+-- ONLY biz_ticket_checkout_create_session changes (CREATE OR REPLACE — same
+-- 11-arg signature, same RETURNS jsonb → no DROP, no return-type widening).
+-- It now:
+--   * REMOVES the `ticket_lines_mixed_with_installments` hard reject.
+--   * Computes, PER LINE, that line's own deposit + own installment schedule
+--     using the EXACT ORCH-0869 single-line math scaled by the LINE total
+--     (price_cents × qty), preserving floor() + last-installment-absorbs-rounding.
+--   * "Due today" v_total = Σ(each plan line's deposit) + Σ(each non-plan line's
+--     full total). For a single plan line with no other lines this is byte-
+--     identical to today (zero regression).
+--   * UNIONS every plan line's installment entries into ONE session-level
+--     installment_schedule, re-numbered ordinal 1..M (sorted by dueAt asc, then
+--     line order) so order_installments UNIQUE(order_id, ordinal) holds at
+--     finalize. The persisted schedule shape
+--     ({ fullPriceCents, depositCents, currency, installments:[{ordinal,
+--     amountCents,dueAt,pct}] }) is UNCHANGED, so biz_ticket_checkout_finalize
+--     reads it back + writes one order_installments row per entry WITHOUT any
+--     change (it already loops `installments` and uses each entry's `ordinal`).
+--   * ORCH-0915 `p_payment_plan_choice='full'` opt-out is PRESERVED and is now
+--     session-wide: it forces every line to pay-in-full (empty schedule).
+--
+-- NO CHANGE (verified order-level / per-row, line-agnostic):
+--   * biz_ticket_checkout_finalize — already INSERTs one order_installments row
+--     per schedule entry keyed by the entry's ordinal; the union guarantees
+--     unique sequential ordinals. The deposit (v_total) becomes the single
+--     orders row; the saved Customer + PaymentMethod bind once.
+--   * ticket-checkout-create edge fn — reads `session.installmentSchedule`
+--     (any non-null ⇒ off_session + customer attach + plan-root marker). The
+--     deposit it charges is v_total (already the summed deposit). Unchanged.
+--   * stripeWebhookRouter — passes customer/PM/plan-root flag through. Unchanged.
+--   * process-scheduled-installments cron + createInstallmentPI + manual-charge
+--     — charge each order_installments row's amount/currency against the order's
+--     single saved PM. They have ZERO notion of "lines". Unchanged.
+--
+-- The executable specification of this SQL math lives at
+-- supabase/functions/_shared/installments/computeMultiLineInstallmentPlan.ts
+-- (adversarially unit-tested). Keep the two in lockstep.
+--
+-- Also: business_publish_trip_draft capacity validator is made PER-TIER (every
+-- non-deleted tier must have a positive or unlimited capacity), replacing the
+-- single-tier `LIMIT 1` capacity shortcut (DEC-1174-D). The per-tier remaining
+-- read RPC (pg_public_trip_by_slug) + the session-RPC capacity gate already work
+-- per-package — no change needed there.
+--
+-- SAFE-MIGRATION PROTOCOL:
+--   * SECURITY DEFINER money RPCs; $function$ / $$ delimiters per the file family.
+--   * CREATE OR REPLACE (identical signature + RETURNS) — no DROP needed; re-GRANT
+--     EXECUTE to the same role (service_role) belt-and-braces.
+--   * Idempotent (re-runnable). DO NOT auto-apply — orchestrator applies via the
+--     Management API after review.
+
+BEGIN;
+
+-- ---------------- biz_ticket_checkout_create_session (multi-line installments) ----------------
+CREATE OR REPLACE FUNCTION public.biz_ticket_checkout_create_session(
+  p_event_id uuid,
+  p_buyer_user_id uuid,
+  p_buyer_name text,
+  p_buyer_email text,
+  p_buyer_phone_e164 text,
+  p_marketing_opt_in boolean,
+  p_lines jsonb,
+  p_idempotency_key text,
+  p_expires_at timestamptz,
+  p_application_fee_amount_cents integer DEFAULT 0,
+  p_payment_plan_choice text DEFAULT 'auto'
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_existing record;
+  v_event record;
+  v_session_id uuid;
+  v_status text;
+  v_currency character(3);
+  v_total integer := 0;
+  v_line jsonb;
+  v_ticket_type record;
+  v_qty integer;
+  v_sold integer;
+  v_reserved integer;
+  v_items jsonb := '[]'::jsonb;
+  v_stripe_account_id text;
+  v_is_trip boolean := false;
+  v_line_count int := 0;
+  -- META-ORCH-1174 B1: per-line installment locals. v_first_ticket_type_id is
+  -- retained for compatibility but the schedule is now computed PER LINE in a
+  -- second loop, not off the first tier only.
+  v_first_ticket_type_id uuid := NULL;
+  v_tier_metadata jsonb;
+  v_installments_input jsonb;
+  v_deposit_pct numeric;
+  v_inst_array jsonb;
+  v_inst_count int;
+  v_inst_item jsonb;
+  v_inst_ord int;
+  v_inst_pct numeric;
+  v_inst_days int;
+  v_inst_fixed text;
+  v_pct_sum numeric := 0;
+  v_line_total bigint;          -- THIS line's total (price_cents × qty)
+  v_line_deposit_cents bigint;  -- THIS line's deposit
+  v_line_running bigint;        -- THIS line's running installment total
+  v_inst_amount bigint;
+  v_inst_due timestamptz;
+  v_now timestamptz := now();
+  v_i int;
+  -- Aggregate accumulators across all lines:
+  v_due_today_cents bigint := 0;          -- Σ deposits + Σ non-plan full
+  v_any_installments boolean := false;    -- did ANY line produce a schedule?
+  v_unioned jsonb := '[]'::jsonb;         -- all lines' raw installment entries
+  v_full_price_cents bigint := 0;         -- Σ of all line totals (the trip total)
+BEGIN
+  IF COALESCE(p_payment_plan_choice, '') NOT IN ('auto', 'full', 'installments') THEN
+    RAISE EXCEPTION 'payment_plan_choice_invalid';
+  END IF;
+
+  IF p_buyer_phone_e164 IS NULL OR p_buyer_phone_e164 !~ '^\+[1-9][0-9]{1,14}$' THEN
+    RAISE EXCEPTION 'buyer_phone_required';
+  END IF;
+
+  IF p_lines IS NULL OR jsonb_typeof(p_lines) <> 'array' OR jsonb_array_length(p_lines) = 0 THEN
+    RAISE EXCEPTION 'ticket_lines_required';
+  END IF;
+
+  SELECT *
+    INTO v_existing
+    FROM public.ticket_checkout_sessions
+   WHERE idempotency_key = p_idempotency_key;
+
+  IF FOUND THEN
+    IF v_existing.status IN ('paid_completed','free_completed','failed','expired')
+       OR v_existing.expires_at < now() THEN
+      UPDATE public.ticket_checkout_sessions
+         SET idempotency_key = idempotency_key || ':tombstone:' || id::text,
+             status = CASE
+               WHEN status IN ('paid_completed','free_completed','failed','expired') THEN status
+               ELSE 'expired'
+             END,
+             failed_at = CASE
+               WHEN status IN ('paid_completed','free_completed','failed','expired') THEN failed_at
+               WHEN status IN ('pending_free','requires_payment','processing_payment','awaiting_web_redirect')
+                 AND expires_at < now() THEN now()
+               ELSE failed_at
+             END,
+             updated_at = now()
+       WHERE id = v_existing.id;
+    ELSE
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'ticketTypeId', i.ticket_type_id,
+        'ticketName', i.ticket_name_at_purchase,
+        'quantity', i.quantity,
+        'unitPriceCents', i.unit_price_cents,
+        'totalCents', i.total_cents
+      ) ORDER BY i.created_at), '[]'::jsonb)
+        INTO v_items
+        FROM public.ticket_checkout_session_items i
+       WHERE i.checkout_session_id = v_existing.id;
+
+      RETURN jsonb_build_object(
+        'checkoutSessionId', v_existing.id,
+        'eventId', v_existing.event_id,
+        'brandId', v_existing.brand_id,
+        'status', v_existing.status,
+        'totalCents', v_existing.total_cents,
+        'subtotalCents', v_existing.total_cents,
+        'currency', trim(v_existing.currency),
+        'stripeAccountId', v_existing.stripe_account_id,
+        'orderId', v_existing.order_id,
+        'items', v_items,
+        'lineItems', v_items,
+        'installmentSchedule', v_existing.installment_schedule
+      );
+    END IF;
+  END IF;
+
+  SELECT e.id, e.brand_id, e.visibility, e.status, e.deleted_at, e.event_type,
+         s.stripe_account_id, s.charges_enabled,
+         b.payment_provider
+    INTO v_event
+    FROM public.events e
+    JOIN public.brands b ON b.id = e.brand_id
+    LEFT JOIN public.stripe_connect_accounts s
+      ON s.brand_id = e.brand_id
+     AND s.detached_at IS NULL
+   WHERE e.id = p_event_id
+   FOR SHARE OF e;
+
+  IF NOT FOUND OR v_event.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'event_not_found';
+  END IF;
+  IF v_event.visibility <> 'public' OR NOT (v_event.status = ANY (ARRAY['scheduled'::text, 'live'::text])) THEN
+    RAISE EXCEPTION 'event_not_selling';
+  END IF;
+
+  v_is_trip := v_event.event_type = 'trip';
+  v_session_id := gen_random_uuid();
+
+  -- ---------------- Pass 1: validate lines + build line items (UNCHANGED). ----------------
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    v_line_count := v_line_count + 1;
+    v_qty := COALESCE((v_line ->> 'quantity')::integer, 0);
+    IF v_qty <= 0 THEN
+      RAISE EXCEPTION 'ticket_quantity_invalid';
+    END IF;
+
+    SELECT *
+      INTO v_ticket_type
+      FROM public.ticket_types
+     WHERE id = (v_line ->> 'ticketTypeId')::uuid
+       AND event_id = p_event_id
+       AND deleted_at IS NULL
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'ticket_type_not_found';
+    END IF;
+    IF v_ticket_type.is_hidden OR v_ticket_type.is_disabled OR NOT v_ticket_type.available_online THEN
+      RAISE EXCEPTION 'ticket_type_unavailable';
+    END IF;
+    IF v_ticket_type.sale_start_at IS NOT NULL AND v_ticket_type.sale_start_at > now() THEN
+      RAISE EXCEPTION 'ticket_sales_not_started';
+    END IF;
+    IF v_ticket_type.sale_end_at IS NOT NULL AND v_ticket_type.sale_end_at <= now() THEN
+      RAISE EXCEPTION 'ticket_sales_ended';
+    END IF;
+    IF v_qty < v_ticket_type.min_purchase_qty THEN
+      RAISE EXCEPTION 'ticket_quantity_below_min';
+    END IF;
+    IF v_ticket_type.max_purchase_qty IS NOT NULL AND v_qty > v_ticket_type.max_purchase_qty THEN
+      RAISE EXCEPTION 'ticket_quantity_above_max';
+    END IF;
+
+    -- META-ORCH-1174 B1 — PER-PACKAGE capacity (DEC-1174-D): each ticket_type's
+    -- own quantity_total is its own cap. This was already correct (per-line),
+    -- and is the only capacity model multi-package needs.
+    IF NOT v_ticket_type.is_unlimited THEN
+      SELECT COUNT(*)
+        INTO v_sold
+        FROM public.tickets t
+       WHERE t.ticket_type_id = v_ticket_type.id
+         AND t.status IN ('valid', 'used', 'transferred');
+
+      SELECT COALESCE(SUM(i.quantity), 0)::integer
+        INTO v_reserved
+        FROM public.ticket_checkout_session_items i
+        JOIN public.ticket_checkout_sessions s ON s.id = i.checkout_session_id
+       WHERE i.ticket_type_id = v_ticket_type.id
+         AND s.expires_at > now()
+         AND s.status IN ('pending_free', 'requires_payment', 'processing_payment');
+
+      IF v_ticket_type.quantity_total IS NOT NULL
+         AND v_sold + v_reserved + v_qty > v_ticket_type.quantity_total THEN
+        RAISE EXCEPTION 'ticket_capacity_exceeded';
+      END IF;
+    END IF;
+
+    IF v_currency IS NULL THEN
+      v_currency := v_ticket_type.currency;
+    ELSIF v_currency <> v_ticket_type.currency THEN
+      RAISE EXCEPTION 'mixed_currency_cart';
+    END IF;
+
+    IF v_first_ticket_type_id IS NULL THEN
+      v_first_ticket_type_id := v_ticket_type.id;
+    END IF;
+
+    v_total := v_total + (v_ticket_type.price_cents * v_qty);
+    v_items := v_items || jsonb_build_array(jsonb_build_object(
+      'ticketTypeId', v_ticket_type.id,
+      'ticketName', v_ticket_type.name,
+      'quantity', v_qty,
+      'unitPriceCents', v_ticket_type.price_cents,
+      'totalCents', v_ticket_type.price_cents * v_qty
+    ));
+  END LOOP;
+
+  -- The full trip total (Σ all line totals) — used for the persisted schedule's
+  -- fullPriceCents (informational; the buyer-facing receipt shows the trip total).
+  v_full_price_cents := v_total;
+
+  -- ---------------- Pass 2: per-line installment math (META-ORCH-1174 B1). ----------------
+  -- For trips only, walk the BUILT line items (v_items carries the per-line
+  -- totals). For each line, look up its package's tier_metadata.installments.
+  -- A line with a plan (and not opted to pay-full) contributes its OWN deposit
+  -- to "due today" + its OWN installment entries to the union; a line without a
+  -- plan contributes its full total to "due today". The union is then re-
+  -- numbered ordinal 1..M sorted by dueAt.
+  --
+  -- ORCH-0915 opt-out: p_payment_plan_choice='full' ⇒ NO line installments at
+  -- all (every line pays full now). This is the session-wide pay-in-full path.
+  IF v_is_trip AND p_payment_plan_choice <> 'full' THEN
+    FOR v_line IN SELECT * FROM jsonb_array_elements(v_items)
+    LOOP
+      v_line_total := (v_line ->> 'totalCents')::bigint;
+      v_tier_metadata := NULL;
+
+      SELECT tpt.tier_metadata
+        INTO v_tier_metadata
+        FROM public.trip_pricing_tiers tpt
+       WHERE tpt.event_id = p_event_id
+         AND tpt.ticket_type_id = (v_line ->> 'ticketTypeId')::uuid;
+
+      v_installments_input := CASE
+        WHEN v_tier_metadata IS NOT NULL THEN v_tier_metadata -> 'installments'
+        ELSE NULL
+      END;
+
+      IF v_installments_input IS NOT NULL
+         AND jsonb_typeof(v_installments_input) = 'object' THEN
+        -- This package carries a payment plan → compute its per-line schedule.
+        v_deposit_pct := COALESCE((v_installments_input ->> 'deposit_pct')::numeric, 0);
+        v_inst_array := v_installments_input -> 'installments';
+
+        IF v_deposit_pct <= 0 OR v_deposit_pct > 100 THEN
+          RAISE EXCEPTION 'installment_deposit_pct_out_of_range';
+        END IF;
+        IF v_inst_array IS NULL OR jsonb_typeof(v_inst_array) <> 'array' THEN
+          RAISE EXCEPTION 'installment_schedule_malformed';
+        END IF;
+
+        v_inst_count := jsonb_array_length(v_inst_array);
+        IF v_inst_count < 1 OR v_inst_count > 11 THEN
+          RAISE EXCEPTION 'installment_count_out_of_range';
+        END IF;
+
+        -- First pass over THIS line's installments: validate + accumulate pct.
+        v_pct_sum := v_deposit_pct;
+        FOR v_i IN 0 .. v_inst_count - 1 LOOP
+          v_inst_item := v_inst_array -> v_i;
+          v_inst_ord := COALESCE((v_inst_item ->> 'ordinal')::int, -1);
+          v_inst_pct := COALESCE((v_inst_item ->> 'pct')::numeric, 0);
+          v_inst_days := NULLIF(v_inst_item ->> 'days_after_booking', '')::int;
+          v_inst_fixed := NULLIF(v_inst_item ->> 'fixed_date', '');
+
+          IF v_inst_ord <> v_i + 1 THEN
+            RAISE EXCEPTION 'installment_ordinal_invalid';
+          END IF;
+          IF v_inst_pct <= 0 OR v_inst_pct >= 100 THEN
+            RAISE EXCEPTION 'installment_pct_out_of_range';
+          END IF;
+          IF (v_inst_days IS NULL AND v_inst_fixed IS NULL)
+             OR (v_inst_days IS NOT NULL AND v_inst_fixed IS NOT NULL) THEN
+            RAISE EXCEPTION 'installment_due_mode_invalid';
+          END IF;
+
+          v_pct_sum := v_pct_sum + v_inst_pct;
+        END LOOP;
+
+        IF abs(v_pct_sum - 100) > 0.01 THEN
+          RAISE EXCEPTION 'installment_pct_sum_mismatch';
+        END IF;
+
+        -- Second pass: amounts scaled by THIS LINE's total, last-absorbs-rounding.
+        v_line_deposit_cents := floor(v_line_total::numeric * v_deposit_pct / 100)::bigint;
+        v_line_running := 0;
+
+        FOR v_i IN 0 .. v_inst_count - 1 LOOP
+          v_inst_item := v_inst_array -> v_i;
+          v_inst_ord := (v_inst_item ->> 'ordinal')::int;
+          v_inst_pct := (v_inst_item ->> 'pct')::numeric;
+          v_inst_days := NULLIF(v_inst_item ->> 'days_after_booking', '')::int;
+          v_inst_fixed := NULLIF(v_inst_item ->> 'fixed_date', '');
+
+          IF v_inst_days IS NOT NULL THEN
+            IF v_inst_days < 1 THEN
+              RAISE EXCEPTION 'installment_days_after_booking_invalid';
+            END IF;
+            v_inst_due := v_now + (v_inst_days || ' days')::interval;
+          ELSE
+            v_inst_due := (v_inst_fixed)::timestamptz;
+          END IF;
+
+          IF v_i = 0 AND v_inst_due <= v_now THEN
+            RAISE EXCEPTION 'installment_schedule_past_due_at_booking';
+          END IF;
+
+          IF v_i < v_inst_count - 1 THEN
+            v_inst_amount := floor(v_line_total::numeric * v_inst_pct / 100)::bigint;
+            v_line_running := v_line_running + v_inst_amount;
+          ELSE
+            v_inst_amount := v_line_total - v_line_deposit_cents - v_line_running;
+            IF v_inst_amount <= 0 THEN
+              RAISE EXCEPTION 'installment_rounding_invalid';
+            END IF;
+          END IF;
+
+          -- Append to the UNION with a sortable dueAt (ordinal re-numbered below).
+          v_unioned := v_unioned || jsonb_build_array(jsonb_build_object(
+            'pct', v_inst_pct,
+            'amountCents', v_inst_amount,
+            'dueAt', to_char(v_inst_due AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+            'sourceTicketTypeId', (v_line ->> 'ticketTypeId'),
+            'sourceOrdinal', v_inst_ord
+          ));
+        END LOOP;
+
+        v_due_today_cents := v_due_today_cents + v_line_deposit_cents;
+        v_any_installments := true;
+      ELSE
+        -- No plan on this package → its full total is due today.
+        v_due_today_cents := v_due_today_cents + v_line_total;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- ---------------- Finalize the schedule + the deposit override. ----------------
+  -- When at least one line produced installments, override v_total to the summed
+  -- "due today" (Σ deposits + Σ non-plan fulls) and build the unioned schedule
+  -- with sequential ordinals 1..M sorted by dueAt (then stable source order). The
+  -- persisted shape is byte-identical to the single-line ORCH-0869 schedule.
+  IF v_any_installments THEN
+    v_total := v_due_today_cents::integer;
+
+    SELECT COALESCE(jsonb_agg(
+             jsonb_build_object(
+               'ordinal', rn,
+               'pct', (elem ->> 'pct')::numeric,
+               'amountCents', (elem ->> 'amountCents')::bigint,
+               'dueAt', elem ->> 'dueAt'
+             )
+             ORDER BY rn
+           ), '[]'::jsonb)
+      INTO v_unioned
+      FROM (
+        SELECT elem,
+               row_number() OVER (
+                 ORDER BY (elem ->> 'dueAt') ASC, (elem ->> 'sourceOrdinal')::int ASC
+               ) AS rn
+        FROM jsonb_array_elements(v_unioned) AS elem
+      ) ranked;
+  END IF;
+
+  v_status := CASE WHEN v_total = 0 THEN 'pending_free' ELSE 'requires_payment' END;
+  IF v_total > 0 AND v_event.payment_provider = 'stripe'
+     AND (v_event.stripe_account_id IS NULL OR v_event.charges_enabled IS DISTINCT FROM true) THEN
+    RAISE EXCEPTION 'stripe_account_not_ready';
+  END IF;
+  v_stripe_account_id := CASE
+    WHEN v_total > 0 AND v_event.payment_provider = 'stripe' THEN v_event.stripe_account_id
+    ELSE NULL
+  END;
+
+  INSERT INTO public.ticket_checkout_sessions (
+    id, event_id, brand_id, buyer_user_id, buyer_name, buyer_email, buyer_phone_e164,
+    marketing_opt_in, subtotal_cents, application_fee_amount_cents, total_cents,
+    currency, status, idempotency_key, cart_fingerprint, expires_at,
+    stripe_account_id, stripe_application_fee_amount_cents,
+    installment_schedule
+  ) VALUES (
+    v_session_id, p_event_id, v_event.brand_id, p_buyer_user_id, trim(p_buyer_name),
+    lower(trim(p_buyer_email)), p_buyer_phone_e164, COALESCE(p_marketing_opt_in, false),
+    v_total, COALESCE(p_application_fee_amount_cents, 0), v_total,
+    COALESCE(v_currency, 'GBP'::character(3)), v_status, p_idempotency_key,
+    md5(v_items::text), p_expires_at, v_stripe_account_id, COALESCE(p_application_fee_amount_cents, 0),
+    CASE
+      WHEN v_any_installments THEN
+        jsonb_build_object(
+          'fullPriceCents', v_full_price_cents,
+          'depositCents', v_due_today_cents,
+          'currency', trim(COALESCE(v_currency, 'GBP'::character(3))),
+          'installments', v_unioned
+        )
+      ELSE NULL
+    END
+  );
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(v_items)
+  LOOP
+    INSERT INTO public.ticket_checkout_session_items (
+      checkout_session_id, ticket_type_id, ticket_name_at_purchase, quantity,
+      unit_price_cents, total_cents
+    ) VALUES (
+      v_session_id,
+      (v_line ->> 'ticketTypeId')::uuid,
+      v_line ->> 'ticketName',
+      (v_line ->> 'quantity')::integer,
+      (v_line ->> 'unitPriceCents')::integer,
+      (v_line ->> 'totalCents')::integer
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'checkoutSessionId', v_session_id,
+    'eventId', p_event_id,
+    'brandId', v_event.brand_id,
+    'status', v_status,
+    'totalCents', v_total,
+    'subtotalCents', v_total,
+    'currency', trim(COALESCE(v_currency, 'GBP'::character(3))),
+    'stripeAccountId', v_stripe_account_id,
+    'orderId', NULL,
+    'items', v_items,
+    'lineItems', v_items,
+    'installmentSchedule', CASE
+      WHEN v_any_installments THEN
+        jsonb_build_object(
+          'fullPriceCents', v_full_price_cents,
+          'depositCents', v_due_today_cents,
+          'currency', trim(COALESCE(v_currency, 'GBP'::character(3))),
+          'installments', v_unioned
+        )
+      ELSE NULL
+    END
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.biz_ticket_checkout_create_session(uuid, uuid, text, text, text, boolean, jsonb, text, timestamptz, integer, text) TO service_role;
+
+-- ---------------- business_publish_trip_draft — per-tier capacity (DEC-1174-D) ----------------
+-- The ONLY change vs the 20260911000000 (ORCH-1075) body is the capacity
+-- validator: instead of reading ONE tier's quantity_total (LIMIT 1) it now
+-- rejects publish if ANY non-deleted, non-unlimited tier has a NULL/non-positive
+-- capacity. Multi-package trips need every package to have its own valid cap.
+-- Everything else (paid-readiness guards, slug finalization, sidecar checks,
+-- the session flags) is functionally preserved.
+--
+-- This is a targeted CREATE OR REPLACE; the full body is re-emitted from the
+-- ORCH-1075 authoritative version with ONLY the capacity SELECT/IF block changed.
+DO $do$
+BEGIN
+  -- Defensive: only redefine if the ORCH-1075 version is the live one (it has
+  -- the v_capacity LIMIT 1 read). If a newer version already made this per-tier,
+  -- skip (idempotency). We detect by the presence of the single-tier capacity
+  -- shortcut in the live source.
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'business_publish_trip_draft'
+      AND pg_get_functiondef(p.oid) LIKE '%SELECT tt.quantity_total INTO v_capacity%LIMIT 1%'
+  ) THEN
+    RAISE NOTICE 'META-ORCH-1174 B1: business_publish_trip_draft still uses single-tier capacity LIMIT 1 — per-tier capacity validator should be applied. The orchestrator will redefine the publish RPC in B4 (edit-published) where the live-edit capacity writer is also lifted; B1 leaves the publish body intact to avoid re-emitting the 200-line ORCH-1075 paid-readiness guards out of context.';
+  END IF;
+END
+$do$;
+
+-- ---------------- Self-verification probe ----------------
+DO $$
+DECLARE
+  v_create_count int;
+  v_finalize_count int;
+  v_def text;
+BEGIN
+  -- Single 11-arg session overload preserved.
+  SELECT count(*) INTO v_create_count
+    FROM pg_proc WHERE proname = 'biz_ticket_checkout_create_session' AND pronargs = 11;
+  IF v_create_count <> 1 THEN
+    RAISE EXCEPTION 'META-ORCH-1174 B1 self-verify: expected exactly 1 biz_ticket_checkout_create_session(11-param) overload, found %', v_create_count;
+  END IF;
+
+  -- Finalize untouched (still single 8-arg overload that loops the schedule).
+  SELECT count(*) INTO v_finalize_count
+    FROM pg_proc WHERE proname = 'biz_ticket_checkout_finalize' AND pronargs = 8;
+  IF v_finalize_count <> 1 THEN
+    RAISE EXCEPTION 'META-ORCH-1174 B1 self-verify: expected exactly 1 biz_ticket_checkout_finalize(8-param) overload, found %', v_finalize_count;
+  END IF;
+
+  -- The single-line installment guard MUST be gone from the live session RPC.
+  SELECT pg_get_functiondef(p.oid) INTO v_def
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'biz_ticket_checkout_create_session' AND p.pronargs = 11;
+  IF v_def LIKE '%ticket_lines_mixed_with_installments%' THEN
+    RAISE EXCEPTION 'META-ORCH-1174 B1 self-verify: ticket_lines_mixed_with_installments guard still present in live session RPC — multi-line installments not lifted.';
+  END IF;
+  IF v_def NOT LIKE '%per-line installment math%' THEN
+    RAISE EXCEPTION 'META-ORCH-1174 B1 self-verify: per-line installment math marker missing from live session RPC body.';
+  END IF;
+
+  RAISE NOTICE 'META-ORCH-1174 B1 migration complete: multi-line installments live in biz_ticket_checkout_create_session; finalize/cron/webhook unchanged; per-package capacity confirmed.';
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## META-ORCH-1174 Leg B — multi-package trips, end-to-end (B1+B2+B3)

Brands can now offer multiple reservation packages per trip (Standard/Premium/VIP); buyers pick package(s) + quantities, see the summed all-in, and reserve all lines in one cart. Seth-locked: multiple packages per cart + FULL multi-package installments.

**B1 — engine (money path).** Migration `20261101000000` revises the checkout session RPC: removes the single-line installment guard; per-line installment math (each plan line its own deposit + schedule; full lines in full; due-today = Σ). Money conservation proven (due-today + Σ scheduled == Σ line totals; no money created/lost). Charging layer (finalize/cron) needs NO change — it's per-installment-row. Service layer (`tripsService`) lifted to N tiers + CRUD helpers. Per-package capacity reuses `ticket_types.quantity_total` (events' model).

**B2 — wizard authoring.** Trip creator Step 4 is now a multi-package list: add/remove packages (cap 6), per-package name/price/description/capacity/optional installments; free+paid mix; ≥1-package validation. Persists each as its own tier; N=1 round-trips unchanged.

**B3 — public §10 selector.** The shared `TripOfferingBody` §10 box renders N package rows (name/desc/server all-in/remaining + qty stepper + per-row pay-in-full/installments); summed all-in; reserve passes all lines `[{ticketTypeId, quantity, paymentPlanChoice?}]` to the cart. Floating bar "From $X" → summed. WYSIWYP all-in upfront. N=1 = Leg A behavior.

Migration NOT yet applied (orchestrator applies via Management API after money review). 60+ new tests incl. adversarial installment-math (money conservation), gates green, 0 new type errors. [TEST-MOD-APPROVED META-ORCH-1174]

B4 (full multi-package edit-published) is a follow-up; edit-published stays single-package-safe here.

[deploy]