### PR TITLE
META-ORCH-1175: trip floating-price + checkout cart step + wizard discard (1175/1176/1177)

### DIFF
--- a/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1176_funnel_wiring.test.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1176_funnel_wiring.test.ts
@@ -1,0 +1,53 @@
+/**
+ * ORCH-1176 [trip-multipkg-checkout-wizard] — source-contract wiring proof. The
+ * pure gate logic is exercised in orch_1176_multitier_cart_step.test.ts; this
+ * proves the THREE checkout files actually consume it:
+ *   - index.tsx multi-seed effect gates the /buyer auto-advance on
+ *     bookableTierCount(...) > 1 (stay on index for multi-package).
+ *   - buyer.tsx + payment.tsx DERIVE totalSteps from bookableTierCount instead of
+ *     the old hardcoded `totalSteps={2}`.
+ *
+ * Fails-on-revert via TRUE line deletion (restore the unconditional
+ * router.replace / the literal totalSteps={2} → these assertions fail).
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+const DIR = join(__dirname, "..");
+const read = (f: string): string => readFileSync(join(DIR, f), "utf8");
+// Strip comments so prose mentioning a token never satisfies an assertion.
+const strip = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+describe("ORCH-1176 — funnel wiring consumes bookableTierCount", () => {
+  test("index.tsx gates the multi-seed auto-advance on bookable tier count > 1", () => {
+    const src = strip(read("index.tsx"));
+    expect(src).toContain('import { bookableTierCount } from "./bookableTierCount"');
+    // The seed effect computes the bookable count from the real tiers ...
+    expect(src).toMatch(/bookableTierCount\(\s*trip\.pricingTiers\.map\(tierToTicketStub\)/);
+    // ... and stays on index (returns WITHOUT router.replace) when > 1.
+    expect(src).toMatch(/if \(bookableCount > 1\) \{[\s\S]*?return;/);
+  });
+
+  test("buyer.tsx derives totalSteps from bookableTierCount (no hardcoded 2)", () => {
+    const src = strip(read("buyer.tsx"));
+    expect(src).toContain('import { bookableTierCount } from "./bookableTierCount"');
+    expect(src).toMatch(/const totalSteps: 2 \| 3 =[\s\S]*?bookableTierCount\(/);
+    expect(src).toMatch(/\? 3\s*\n?\s*: 2/);
+    // The header reads the derived value, not a literal.
+    expect(src).toContain("totalSteps={totalSteps}");
+    // No surviving hardcoded totalSteps={2} on a CheckoutHeader.
+    expect(src).not.toMatch(/totalSteps=\{2\}/);
+  });
+
+  test("payment.tsx derives totalSteps from bookableTierCount (no hardcoded 2)", () => {
+    const src = strip(read("payment.tsx"));
+    expect(src).toContain('import { bookableTierCount } from "./bookableTierCount"');
+    expect(src).toMatch(/const totalSteps: 2 \| 3 =[\s\S]*?bookableTierCount\(/);
+    expect(src).toContain("totalSteps={totalSteps}");
+    expect(src).not.toMatch(/totalSteps=\{2\}/);
+  });
+});

--- a/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1176_multitier_cart_step.test.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1176_multitier_cart_step.test.ts
@@ -1,0 +1,104 @@
+/**
+ * ORCH-1176 [trip-multipkg-checkout-wizard] — the trip checkout must keep the
+ * cart/quantity step for a genuine multi-PACKAGE trip, and only auto-skip it
+ * (straight to /buyer) when the trip is effectively single-tier.
+ *
+ * Root cause (INVESTIGATE_ORCH-1176): the multi-seed effect in index.tsx
+ * unconditionally `router.replace`'d to /buyer after seeding the cart — even for
+ * a 2+-package trip — so the buyer never saw the cart/quantity review step. The
+ * fix gates the auto-advance on `bookableTierCount(...) <= 1`; a multi-package
+ * trip stays on index (totalSteps 3, "1 OF 3"), a single-tier trip auto-skips
+ * (totalSteps 2). The count keys off BOOKABLE tiers (unlimited OR remaining > 0),
+ * NOT the raw tier count, so a 3-tier trip with 2 sold out still streamlines —
+ * no regression to the ORCH-1130 single-tier auto-skip.
+ *
+ * These tests drive the SAME pure helper both the index auto-advance gate and the
+ * buyer/payment totalSteps derivation read, plus the buyer's totalSteps mapping.
+ *
+ * Fails-on-revert: widen `isTierBookable` to count sold-out tiers (drop the
+ * `(capacity ?? 0) > 0` clause) → the "all-but-one sold out → single-tier" test
+ * sees count 3 and the auto-advance / totalSteps assertions flip.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  bookableTierCount,
+  isTierBookable,
+  type BookableTierLike,
+} from "../bookableTierCount";
+
+// Mirror the buyer/payment derivation: totalSteps = bookable > 1 ? 3 : 2.
+function deriveTotalSteps(tiers: BookableTierLike[]): 2 | 3 {
+  return bookableTierCount(tiers) > 1 ? 3 : 2;
+}
+
+// Mirror the index auto-advance gate: stay on index (no /buyer replace) when the
+// trip has > 1 bookable tier; otherwise auto-advance.
+function shouldAutoAdvanceToBuyer(tiers: BookableTierLike[]): boolean {
+  return bookableTierCount(tiers) <= 1;
+}
+
+describe("ORCH-1176 — multi-package trips keep the cart/quantity step", () => {
+  // ── HAPPY — a genuine 2-package trip stays on index and reads 3 steps ──
+  test("multi-package trip: stays on index (no auto-advance) + buyer reads 3 steps", () => {
+    const tiers: BookableTierLike[] = [
+      { isUnlimited: false, capacity: 20 }, // Standard, bookable
+      { isUnlimited: false, capacity: 5 }, // VIP, bookable
+    ];
+    expect(bookableTierCount(tiers)).toBe(2);
+    // The seed effect must NOT auto-advance to /buyer (buyer reviews quantities).
+    expect(shouldAutoAdvanceToBuyer(tiers)).toBe(false);
+    // The funnel reads "1 OF 3" / "2 OF 3".
+    expect(deriveTotalSteps(tiers)).toBe(3);
+  });
+
+  test("an unlimited package counts as bookable (no capacity cap)", () => {
+    const tiers: BookableTierLike[] = [
+      { isUnlimited: true, capacity: null },
+      { isUnlimited: false, capacity: 3 },
+    ];
+    expect(bookableTierCount(tiers)).toBe(2);
+    expect(shouldAutoAdvanceToBuyer(tiers)).toBe(false);
+    expect(deriveTotalSteps(tiers)).toBe(3);
+  });
+
+  // ── ADVERSARIAL — single bookable tier OR multi-tier-all-but-one-sold-out
+  //    STILL auto-advances + reads 2 steps (keys off BOOKABLE count) ──
+  test("single bookable tier: STILL auto-advances to /buyer + reads 2 steps", () => {
+    const tiers: BookableTierLike[] = [{ isUnlimited: false, capacity: 10 }];
+    expect(bookableTierCount(tiers)).toBe(1);
+    expect(shouldAutoAdvanceToBuyer(tiers)).toBe(true);
+    expect(deriveTotalSteps(tiers)).toBe(2);
+  });
+
+  test("3 tiers, 2 sold out → effectively single-tier: auto-advances + 2 steps", () => {
+    const tiers: BookableTierLike[] = [
+      { isUnlimited: false, capacity: 0 }, // sold out — NOT bookable
+      { isUnlimited: false, capacity: 8 }, // the only bookable tier
+      { isUnlimited: false, capacity: 0 }, // sold out — NOT bookable
+    ];
+    // The gate keys off BOOKABLE count (1), NOT the raw tier count (3).
+    expect(bookableTierCount(tiers)).toBe(1);
+    expect(shouldAutoAdvanceToBuyer(tiers)).toBe(true);
+    expect(deriveTotalSteps(tiers)).toBe(2);
+  });
+
+  test("ALL tiers sold out → 0 bookable: auto-advance gate is true, 2 steps", () => {
+    // (The bookability EmptyState fires upstream; the count is 0 ≤ 1.)
+    const tiers: BookableTierLike[] = [
+      { isUnlimited: false, capacity: 0 },
+      { isUnlimited: false, capacity: 0 },
+    ];
+    expect(bookableTierCount(tiers)).toBe(0);
+    expect(deriveTotalSteps(tiers)).toBe(2);
+  });
+
+  test("isTierBookable: unlimited OR remaining>0; sold-out / null-cap-non-unlimited excluded", () => {
+    expect(isTierBookable({ isUnlimited: true, capacity: null })).toBe(true);
+    expect(isTierBookable({ isUnlimited: false, capacity: 1 })).toBe(true);
+    expect(isTierBookable({ isUnlimited: false, capacity: 0 })).toBe(false);
+    // A non-unlimited tier with a null capacity coalesces to 0 → NOT bookable.
+    expect(isTierBookable({ isUnlimited: false, capacity: null })).toBe(false);
+  });
+});

--- a/mingla-business/app/checkout-trip/[tripEventId]/bookableTierCount.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/bookableTierCount.ts
@@ -1,0 +1,42 @@
+/**
+ * ORCH-1176 [trip-multipkg-checkout-wizard] — pure helper counting a trip's
+ * BOOKABLE pricing tiers, extracted so the multi-tier gate is unit-testable
+ * without rendering the expo-router screens.
+ *
+ * Background (INVESTIGATE_ORCH-1176): the trip checkout index unconditionally
+ * `router.replace`'d to /buyer after seeding the cart — even for genuine
+ * multi-package trips — skipping the cart/quantity review step. The auto-skip
+ * is only correct when the trip is effectively SINGLE-tier; a multi-package
+ * trip must stay on index so the buyer can review/edit quantities.
+ *
+ * "Bookable" mirrors the capacity logic already used across the checkout files:
+ * a tier is bookable when it is unlimited OR has remaining capacity > 0. A
+ * sold-out tier (capacity 0) does NOT count — so a 3-tier trip with 2 tiers
+ * sold out is effectively single-tier and STILL streamlines (no regression to
+ * the ORCH-1130 single-tier auto-skip). The count keys off BOOKABLE tiers, not
+ * the raw tier count.
+ */
+
+export interface BookableTierLike {
+  /** True when the tier sells without a capacity cap. */
+  isUnlimited: boolean;
+  /**
+   * Remaining bookable capacity. Null → unlimited/unknown (treated as bookable,
+   * mirroring `tierToTicketStub` / the QuantityRow "+" cap logic).
+   */
+  capacity: number | null;
+}
+
+/** Is this tier still bookable (unlimited or has remaining capacity)? */
+export function isTierBookable(tier: BookableTierLike): boolean {
+  return tier.isUnlimited || (tier.capacity ?? 0) > 0;
+}
+
+/**
+ * Count the trip's bookable tiers. The checkout wizard shows the cart/quantity
+ * step (totalSteps 3, stay on index) when this is > 1, and auto-skips straight
+ * to /buyer (totalSteps 2) when it is <= 1.
+ */
+export function bookableTierCount(tiers: ReadonlyArray<BookableTierLike>): number {
+  return tiers.reduce((n, t) => (isTierBookable(t) ? n + 1 : n), 0);
+}

--- a/mingla-business/app/checkout-trip/[tripEventId]/buyer.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/buyer.tsx
@@ -73,6 +73,7 @@ import {
   useCartTotals,
 } from "../../../src/components/checkout/CartContext";
 import { CheckoutHeader } from "../../../src/components/checkout/CheckoutHeader";
+import { bookableTierCount } from "./bookableTierCount";
 
 import {
   PhoneInput,
@@ -175,6 +176,21 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
   const trip = publicTripQuery.data?.trip ?? null;
   const { lines, buyer, setBuyer, recordResult, paymentPlanChoice } = useCart();
   const totals = useCartTotals();
+
+  // ORCH-1176 — derive the funnel length from the trip's BOOKABLE tier count.
+  // A multi-package trip keeps the cart/quantity step (3 steps); an effectively
+  // single-tier trip auto-skips it (2 steps), matching index.tsx's auto-advance
+  // gate. Bookable = unlimited OR remaining capacity > 0 (mirrors tierToTicketStub).
+  const totalSteps: 2 | 3 =
+    trip !== null &&
+    bookableTierCount(
+      trip.pricingTiers.map((t) => ({
+        isUnlimited: t.isUnlimited,
+        capacity: t.ticketsRemaining ?? t.quantityTotal,
+      })),
+    ) > 1
+      ? 3
+      : 2;
 
   // ORCH-1130 Fix #1 — "Total due today" (deposit) line for the order-summary
   // box. When pay-over-time is selected AND the cart holds a plan-active tier,
@@ -430,7 +446,7 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={0}
-          totalSteps={2}
+          totalSteps={totalSteps}
           title="Your details"
           onBack={handleBack}
         />
@@ -442,7 +458,7 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
     <View style={styles.host}>
       <CheckoutHeader
         stepIndex={0}
-        totalSteps={2}
+        totalSteps={totalSteps}
         title="Your details"
         onBack={handleBack}
       />

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -48,6 +48,7 @@ import { Button } from "../../../src/components/ui/Button";
 import { EmptyState } from "../../../src/components/ui/EmptyState";
 import { EventCoverMedia } from "../../../src/components/ui/EventCoverMedia";
 import { decideAutoSkip } from "./autoSkipDecision";
+import { bookableTierCount } from "./bookableTierCount";
 
 import {
   useCart,
@@ -327,6 +328,19 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
           quantity: qty,
         });
       }
+      return;
+    }
+    // ORCH-1176 — only auto-advance to /buyer for an effectively SINGLE-tier trip
+    // (≤1 bookable tier). For a genuine MULTI-PACKAGE trip (>1 bookable tier) the
+    // cart is seeded but we STAY on index ("1 OF 3") so the buyer reviews/edits the
+    // package quantities before handleContinue routes them to /buyer. Bookable =
+    // unlimited OR remaining capacity > 0 (mirrors tierToTicketStub's capacity).
+    const bookableCount = bookableTierCount(
+      trip.pricingTiers.map(tierToTicketStub),
+    );
+    if (bookableCount > 1) {
+      // Latch so we don't keep re-seeding; the buyer drives the funnel from here.
+      multiSeedNavigatedRef.current = true;
       return;
     }
     // All seeded lines have landed → /buyer reads a populated cart.

--- a/mingla-business/app/checkout-trip/[tripEventId]/payment.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/payment.tsx
@@ -75,6 +75,7 @@ import {
   writeCheckoutResumePayload,
 } from "../../../src/components/checkout/checkoutPersistence";
 import { CheckoutHeader } from "../../../src/components/checkout/CheckoutHeader";
+import { bookableTierCount } from "./bookableTierCount";
 import { supabase } from "../../../src/services/supabase";
 
 const NativeCheckoutPaymentBoundary = React.lazy(
@@ -589,6 +590,20 @@ function CheckoutTripPaymentScreenContent({
   const showFeesTaxLine = feesTaxLineCents > 0;
   const displayAllIn = formatCurrency(headlineCents, totals.currency, true);
 
+  // ORCH-1176 — derive the funnel length from the trip's BOOKABLE tier count so
+  // the "Review & pay" step reads "2 OF 3" on a multi-package trip and "2 OF 2"
+  // on the single-tier auto-skip path (consistent with index.tsx + buyer.tsx).
+  const totalSteps: 2 | 3 =
+    trip !== null &&
+    bookableTierCount(
+      trip.pricingTiers.map((t) => ({
+        isUnlimited: t.isUnlimited,
+        capacity: t.ticketsRemaining ?? t.quantityTotal,
+      })),
+    ) > 1
+      ? 3
+      : 2;
+
   // Defensive shell while guards redirect.
   if (
     tripEventId === null ||
@@ -601,7 +616,7 @@ function CheckoutTripPaymentScreenContent({
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={1}
-          totalSteps={2}
+          totalSteps={totalSteps}
           title="Review & pay"
           onBack={handleBack}
         />
@@ -613,7 +628,7 @@ function CheckoutTripPaymentScreenContent({
     <View style={styles.host}>
       <CheckoutHeader
         stepIndex={1}
-        totalSteps={2}
+        totalSteps={totalSteps}
         title="Review & pay"
         onBack={handleBack}
       />

--- a/mingla-business/app/trip/[id]/edit.tsx
+++ b/mingla-business/app/trip/[id]/edit.tsx
@@ -40,6 +40,7 @@ import {
 import { TripCreatorWizard } from "../../../src/components/trip/TripCreatorWizard";
 import { EditPublishedTripScreen } from "../../../src/components/trip/EditPublishedTripScreen";
 import { Button } from "../../../src/components/ui/Button";
+import { TRIP_DRAFT_PLACEHOLDER_TITLE } from "../../../src/services/tripsService";
 
 export default function TripEditRoute(): React.ReactElement {
   const router = useRouter();
@@ -186,9 +187,16 @@ export default function TripEditRoute(): React.ReactElement {
   // ORCH-0874: derive isCreateMode — true for freshly-created draft trips
   // that haven't been edited yet (no title, no days, no inclusions). Drives
   // wizard chrome X discard semantics per SPEC §3.3.5/§3.3.6.
+  // ORCH-1177 — `createTripDraft` seeds the title with TRIP_DRAFT_PLACEHOLDER_TITLE
+  // ("Untitled trip"), NOT an empty string, so a fresh never-edited draft failed
+  // the `title.length === 0` clause and was misclassified as edit-mode → Close X /
+  // Android back silently autosaved + bounced to Home with no "Discard this trip?"
+  // confirm. Treat the placeholder title as still-pristine so a fresh draft routes
+  // through the proper create-mode discard path (pristine → discard orphan + exit;
+  // dirty → confirm). The shared const keeps the seed + this guard from drifting.
   const isCreateMode =
     trip.status === "draft" &&
-    trip.title.length === 0 &&
+    (trip.title.length === 0 || trip.title === TRIP_DRAFT_PLACEHOLDER_TITLE) &&
     trip.days.length === 0 &&
     trip.inclusions.length === 0;
 

--- a/mingla-business/app/trip/__tests__/orch_1177_create_mode_placeholder.test.ts
+++ b/mingla-business/app/trip/__tests__/orch_1177_create_mode_placeholder.test.ts
@@ -1,0 +1,149 @@
+/**
+ * ORCH-1177 [trip-wizard-discard-prompt] — a fresh trip-create draft must route
+ * Close X / Android back through the create-mode DISCARD path (pristine → discard
+ * orphan + exit; dirty → "Discard this trip?" confirm), NOT the silent edit-mode
+ * autosave + bounce-to-Home.
+ *
+ * Root cause (INVESTIGATE_ORCH-1177): `createTripDraft` seeds the title with the
+ * placeholder "Untitled trip" (NOT an empty string), but `isCreateMode` required
+ * `trip.title.length === 0`. So a never-edited draft was misclassified as
+ * edit-mode → Close silently autosaved + router.back()'d to Home with no confirm.
+ *
+ * The fix: export the placeholder title as a shared const
+ * (TRIP_DRAFT_PLACEHOLDER_TITLE) used by BOTH the seed and the isCreateMode guard,
+ * and treat that placeholder title as still-pristine in the guard.
+ *
+ * This file proves: (1) the create-mode PREDICATE (replicated from edit.tsx)
+ * classifies a fresh placeholder-title draft as create-mode; (2) a real edited
+ * trip stays edit-mode; (3) a SOURCE-GUARD that the seed + the guard reference the
+ * SAME exported const (fails-on-revert if the literal drifts).
+ */
+
+/* eslint-disable import/first */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, jest, test } from "@jest/globals";
+
+// tripsService.ts imports the real Supabase client (expo-constants ESM), which
+// the node/ts-jest env can't transpile. We only need the exported const, so stub
+// the supabase module (mirrors src/services/__tests__/tripsService.test.ts). The
+// path resolves to the SAME module tripsService imports as `./supabase`.
+jest.mock("../../../src/services/supabase", () => ({
+  supabase: {
+    from: () => ({}),
+    rpc: () => ({}),
+    auth: { getUser: () => ({ data: { user: null } }) },
+  },
+}));
+
+import { TRIP_DRAFT_PLACEHOLDER_TITLE } from "../../../src/services/tripsService";
+
+// Replicate the exact isCreateMode predicate from app/trip/[id]/edit.tsx so the
+// classification can be unit-tested without rendering the expo-router screen.
+function isCreateMode(trip: {
+  status: string;
+  title: string;
+  days: unknown[];
+  inclusions: unknown[];
+}): boolean {
+  return (
+    trip.status === "draft" &&
+    (trip.title.length === 0 || trip.title === TRIP_DRAFT_PLACEHOLDER_TITLE) &&
+    trip.days.length === 0 &&
+    trip.inclusions.length === 0
+  );
+}
+
+describe("ORCH-1177 — fresh placeholder-title draft is create-mode", () => {
+  // ── HAPPY — a fresh draft (seeded placeholder title, no days/inclusions) ──
+  test("a fresh draft with the placeholder title is create-mode (→ discard path)", () => {
+    const fresh = {
+      status: "draft",
+      title: TRIP_DRAFT_PLACEHOLDER_TITLE, // "Untitled trip" — what createTripDraft seeds
+      days: [],
+      inclusions: [],
+    };
+    expect(isCreateMode(fresh)).toBe(true);
+  });
+
+  test("an empty-string-title draft is still create-mode (back-compat)", () => {
+    expect(
+      isCreateMode({ status: "draft", title: "", days: [], inclusions: [] }),
+    ).toBe(true);
+  });
+
+  // ── ADVERSARIAL — a real edited / published trip stays EDIT-mode ──
+  test("a draft with a real (non-placeholder) title is NOT create-mode", () => {
+    expect(
+      isCreateMode({
+        status: "draft",
+        title: "Tuscany Wine Tour",
+        days: [],
+        inclusions: [],
+      }),
+    ).toBe(false);
+  });
+
+  test("a placeholder-title draft that already has days is NOT create-mode (edited)", () => {
+    expect(
+      isCreateMode({
+        status: "draft",
+        title: TRIP_DRAFT_PLACEHOLDER_TITLE,
+        days: [{ ordinal: 1 }],
+        inclusions: [],
+      }),
+    ).toBe(false);
+  });
+
+  test("a non-draft (published) trip is never create-mode regardless of title", () => {
+    expect(
+      isCreateMode({
+        status: "live",
+        title: TRIP_DRAFT_PLACEHOLDER_TITLE,
+        days: [],
+        inclusions: [],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("ORCH-1177 — source guard: seed + guard share ONE const (no drift)", () => {
+  const SERVICE = readFileSync(
+    join(__dirname, "..", "..", "..", "src", "services", "tripsService.ts"),
+    "utf8",
+  );
+  const EDIT = readFileSync(
+    join(__dirname, "..", "..", "..", "app", "trip", "[id]", "edit.tsx"),
+    "utf8",
+  );
+  const strip = (s: string): string =>
+    s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+  test("the const value is exactly the historical placeholder literal", () => {
+    // If someone changes the displayed placeholder, BOTH sites move together via
+    // this const; this pins the value the create-mode guard keys off.
+    expect(TRIP_DRAFT_PLACEHOLDER_TITLE).toBe("Untitled trip");
+  });
+
+  test("tripsService exports the const AND seeds the draft title FROM it", () => {
+    const src = strip(SERVICE);
+    expect(src).toMatch(
+      /export const TRIP_DRAFT_PLACEHOLDER_TITLE = "Untitled trip";/,
+    );
+    // The seed uses the const, NOT a bare duplicated literal.
+    expect(src).toMatch(
+      /const tempTitle = input\.initialTitle\?\.trim\(\) \|\| TRIP_DRAFT_PLACEHOLDER_TITLE;/,
+    );
+  });
+
+  test("edit.tsx imports the const AND the isCreateMode guard references it", () => {
+    const src = strip(EDIT);
+    expect(src).toContain(
+      'import { TRIP_DRAFT_PLACEHOLDER_TITLE } from "../../../src/services/tripsService"',
+    );
+    expect(src).toMatch(
+      /trip\.title\.length === 0 \|\| trip\.title === TRIP_DRAFT_PLACEHOLDER_TITLE/,
+    );
+  });
+});

--- a/mingla-business/src/services/tripsService.ts
+++ b/mingla-business/src/services/tripsService.ts
@@ -618,6 +618,16 @@ export async function setTripPricingSwitches(
 // ---------------------- createTripDraft ----------------------
 
 /**
+ * ORCH-1177 — the placeholder title `createTripDraft` seeds a fresh draft with.
+ * Exported so the create-mode guard (`/trip/[id]/edit.tsx` isCreateMode) can
+ * recognise a never-edited draft by this exact title and route Close/back
+ * through the discard-confirm path instead of silently autosaving + bouncing to
+ * Home. The seed (below) and the guard MUST reference this one const so they
+ * can never drift.
+ */
+export const TRIP_DRAFT_PLACEHOLDER_TITLE = "Untitled trip";
+
+/**
  * Creates a draft event_type='trip' row + placeholder ticket_types row +
  * placeholder trip_pricing_tiers row joining the two. Returns the Trip with
  * empty days/inclusions arrays + single placeholder pricing tier.
@@ -631,7 +641,7 @@ export async function createTripDraft(
 ): Promise<Trip> {
   // I-BRAND-UNIVERSAL-AUTHORING (META-ORCH-0972) — no kind gate.
 
-  const tempTitle = input.initialTitle?.trim() || "Untitled trip";
+  const tempTitle = input.initialTitle?.trim() || TRIP_DRAFT_PLACEHOLDER_TITLE;
   const tempSlug = `draft-${Date.now().toString(36)}`;
 
   // 1. Look up brand default_currency + slug BEFORE creating the event.

--- a/packages/offering-rendering/TripReserveBar.tsx
+++ b/packages/offering-rendering/TripReserveBar.tsx
@@ -20,8 +20,10 @@
  *     child (flush, no black void). May carry its bg at rest; pads its own bottom
  *     safe-area; `onDockLayout` reports its position so the surface hides the pill.
  *   • variant="floating" — JUST the button: a compact self-width pill (NO kicker,
- *     NO price block, NO bar bg), absolute-positioned + lifted above the home
- *     indicator + the sheet overshoot. Shown while the docked button is off-screen.
+ *     NO bar bg), absolute-positioned + lifted above the home indicator + the
+ *     sheet overshoot. Shown while the docked button is off-screen. ORCH-1175:
+ *     the pill DOES carry the live `cta.price` segment ("$130 · Reserve my spot →")
+ *     so it tracks the §10 selected total — the docked + floating bars never diverge.
  *
  * Split-plan (Seth, 2026-06-15): when `splitCtas` is set, BOTH variants render the
  * unified seam-split "Treatment B" two-tone control (accent "Pay in full" half +
@@ -314,6 +316,19 @@ export const TripReserveBar: React.FC<TripReserveBarProps> = ({
       ]}
       testID={testID !== undefined ? `${testID}-action` : undefined}
     >
+      {/* ORCH-1175 — the floating pill ALSO shows the live selected price (the
+          same `cta.price` the docked bar + §10 box read) so it never lags the
+          box. Truncates first (flexShrink) so a long price can't shove the
+          label + arrow off-edge (F-4 arrow-bleed guard parity). */}
+      {price.length > 0 ? (
+        <Text
+          style={[styles.floatPrice, { color: palette.accentText }, fontStyle]}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
+          {price} ·{" "}
+        </Text>
+      ) : null}
       <Text style={[styles.floatCta, { color: palette.accentText }, fontStyle]}>
         {cta.label} →
       </Text>
@@ -401,6 +416,9 @@ const styles = StyleSheet.create({
       },
     }),
   },
+  // ORCH-1175 — the live price segment inside the floating pill. Yields space
+  // first (flexShrink:1) so the label + arrow stay intact on a long price.
+  floatPrice: { fontSize: 16, fontWeight: "900", flexShrink: 1, minWidth: 0 },
   floatCta: { fontSize: 16, fontWeight: "900", flexShrink: 0 },
   floatButtonDisabled: {
     alignSelf: "center",

--- a/packages/offering-rendering/__tests__/orch_1175_reserve_pill_live_price.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1175_reserve_pill_live_price.test.ts
@@ -1,0 +1,135 @@
+// ORCH-1175 [reserve-pill-live-price] — implementor-owned. The floating reserve
+// pill + the SPLIT control prices must reflect the LIVE qty-scaled selected total
+// (the same value the §10 box + the docked bar show), never a per-unit figure.
+//
+// Two halves, both fails-on-revert via TRUE line deletion:
+//   (A) BEHAVIORAL (pure math, deno) — the summed all-in / due-today the hook's
+//       split labels now read scale with quantity and use the SERVER all-in (not
+//       bare base). A synthetic pass-fee fixture (all-in > base) proves the summed
+//       value is provably > qty×base, per the ORCH-1147 "0/8 brands pass a fee"
+//       gotcha (equal-fee fixtures prove nothing).
+//   (B) SOURCE-CONTRACT (deno readfile) — TripReserveBar's floating pill renders
+//       the live `cta.price`, and useTripOfferingState wires the split full/over-time
+//       prices to the SUMMED labels when ≥1 selected (falling back to unit at 0).
+
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  tripSummedAllInCents,
+  tripSummedDueTodayCents,
+  tripTierUnitAllInCents,
+  type TripTierLike,
+} from "../tripBoxTotals.ts";
+
+const read = async (rel: string): Promise<string> =>
+  await Deno.readTextFile(new URL(rel, import.meta.url));
+const strip = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+// ── synthetic PASS-FEE fixture: all-in > base, so the summed all-in is PROVABLY
+//    the server value (not the bare base). base 50000 / all-in 53000 (6% passed). ──
+const standard: TripTierLike = {
+  ticketTypeId: "tt_std",
+  priceCents: 50000,
+  priceAllInCents: 53000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 20,
+  installmentSchedule: null,
+};
+// A PLAN tier (25% deposit) for the over-time split-label adversarial.
+const plan: TripTierLike = {
+  ticketTypeId: "tt_plan",
+  priceCents: 100000,
+  priceAllInCents: 106000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 10,
+  installmentSchedule: { deposit_pct: 25, installments: [{ ordinal: 1, pct: 75 }] },
+};
+
+// ── (A) HAPPY — qty 2 on a 2-tier fixture: the summed all-in the split "Pay in
+//    full" label reads is qty-scaled AND provably > 1× unit (and > qty×base). ──
+Deno.test("ORCH-1175 happy — split full price uses the qty-scaled SUMMED all-in (> 1× unit, > qty×base)", () => {
+  const tiers = [standard, plan];
+  const unit = tripTierUnitAllInCents(standard); // 53000 (server all-in, not 50000 base)
+  assertEquals(unit, 53000);
+  // Select qty 2 of standard → the summed all-in the split label reads.
+  const summed = tripSummedAllInCents(tiers, { tt_std: 2 });
+  assertEquals(summed, 106000); // 2 × 53000
+  // It scales with qty (NOT the flat unit) ...
+  assert(summed > unit, "summed all-in must exceed the per-unit value (qty-scaled)");
+  // ... and is provably the SERVER all-in, not qty × bare base (2×50000 = 100000).
+  assert(
+    summed > standard.priceCents * 2,
+    "summed all-in must exceed qty × bare base (proves the server fee-grossed all-in)",
+  );
+});
+
+// ── (A) ADVERSARIAL — single PLAN tier, qty 2, paying over time: the split
+//    "Pay over time" deposit the label reads is the qty-scaled summed due-today
+//    (NOT the unit deposit). "Pay in full" reads the qty-scaled summed all-in. ──
+Deno.test("ORCH-1175 adversarial — over-time split deposit is the qty-scaled summed due-today (not unit)", () => {
+  const tiers = [plan];
+  const qty = { tt_plan: 2 };
+  const installments = { tt_plan: "installments" as const };
+  // Full all-in for qty 2 = 2 × 106000 = 212000 (what "Pay in full" reads).
+  assertEquals(tripSummedAllInCents(tiers, qty), 212000);
+  // Due-today (deposit) for qty 2 = 25% of 212000 = 53000 (what "Pay over time"
+  // reads) — NOT the UNIT deposit (25% of 106000 = 26500).
+  const summedDueToday = tripSummedDueTodayCents(tiers, qty, installments);
+  assertEquals(summedDueToday, 53000);
+  const unitDeposit = Math.round((tripTierUnitAllInCents(plan) * 25) / 100); // 26500
+  assert(
+    summedDueToday > unitDeposit,
+    "the over-time deposit must be the qty-scaled summed deposit, not the unit deposit",
+  );
+  assertEquals(summedDueToday, unitDeposit * 2);
+});
+
+// ── (B) SOURCE — the FLOATING pill renders the live price (Fix 1a) ──
+Deno.test("ORCH-1175 §1a — the floating reserve pill renders the live cta.price", async () => {
+  const bar = strip(await read("../TripReserveBar.tsx"));
+  // A `floatPrice` style exists next to floatCta.
+  assertStringIncludes(bar, "floatPrice:");
+  // The floating button (floatBody) gates a price Text on `price.length > 0` and
+  // renders {price} — the SAME live value the docked bar reads.
+  assert(
+    /floatBody[\s\S]*?price\.length > 0 \?[\s\S]*?styles\.floatPrice[\s\S]*?\{price\}/.test(
+      bar,
+    ),
+    "the floating pill must render a floatPrice Text with {price} when price.length > 0",
+  );
+  // The label still renders after it (the pill reads "$X · Reserve my spot →").
+  assert(
+    /styles\.floatPrice[\s\S]*?\{cta\.label\} →/.test(bar),
+    "the floating pill must still render the {cta.label} → after the price",
+  );
+});
+
+// ── (B) SOURCE — the split labels read the SUMMED qty-scaled values (Fix 1b) ──
+Deno.test("ORCH-1175 §1b — split full/over-time prices use the summed labels when ≥1 selected", async () => {
+  const sm = strip(await read("../useTripOfferingState.ts"));
+  // priceLabel (full) → summedAllInLabel when totalSelected > 0, else unit.
+  assert(
+    /priceLabel\s*=\s*\n?\s*totalSelected > 0 \? \(summedAllInLabel \?\? unitPriceLabel\) : unitPriceLabel/.test(
+      sm,
+    ),
+    "priceLabel must be summedAllInLabel when totalSelected>0, unitPriceLabel otherwise",
+  );
+  // depositLabel (over-time) → summedDueTodayLabel when totalSelected > 0, else unit.
+  assert(
+    /depositLabel\s*=\s*\n?\s*totalSelected > 0 \? \(summedDueTodayLabel \?\? unitDepositLabel\) : unitDepositLabel/.test(
+      sm,
+    ),
+    "depositLabel must be summedDueTodayLabel when totalSelected>0, unitDepositLabel otherwise",
+  );
+  // The non-split bar + §10 box keep reading barPriceLabel/summedAllInLabel directly
+  // (unaffected by the split change).
+  assertStringIncludes(sm, "barPriceLabel");
+  assertStringIncludes(sm, "summedAllInLabel");
+});

--- a/packages/offering-rendering/useTripOfferingState.ts
+++ b/packages/offering-rendering/useTripOfferingState.ts
@@ -365,20 +365,31 @@ export function useTripOfferingState(
 
     // Split CTAs — Leg A single-package plan fast path ONLY (multi-package rows own
     // their own per-row pay-full/over-time toggle in the body). No split for multi.
-    const priceLabel =
+    //
+    // ORCH-1175 — the split "Pay in full" / "Pay over time" prices must reflect the
+    // QTY-SCALED selected total, not the bare per-unit values, so they match the §10
+    // box and the non-split bar. Once the buyer has selected quantity (totalSelected
+    // > 0) read the already-summed labels (summedAllInLabel / summedDueTodayLabel);
+    // fall back to the per-unit all-in + unit deposit for the DEC-J empty state
+    // (nothing selected → the Leg-A "From {unit}" preview).
+    const unitPriceLabel =
       selectedTier !== null && selectedTier.priceCents > 0
         ? formatTripPrice(
             tripTierUnitAllInCents(selectedTier as TripTierLike),
             selectedTier.currency,
           )
         : "";
-    const depositLabel =
+    const unitDepositLabel =
       projectedSchedule !== null
         ? formatTripPrice(
             projectedSchedule.depositCents,
             selectedTier?.currency ?? tripCurrency,
           )
         : "";
+    const priceLabel =
+      totalSelected > 0 ? (summedAllInLabel ?? unitPriceLabel) : unitPriceLabel;
+    const depositLabel =
+      totalSelected > 0 ? (summedDueTodayLabel ?? unitDepositLabel) : unitDepositLabel;
     const splitCtas: ReserveSplitCtas | undefined =
       hasSingleTierPlan && !multiTier && cta.tappable
         ? {


### PR DESCRIPTION
Three trip-flow follow-on fixes from Leg B (META-ORCH-1174), all client-side (no migrations).

## ORCH-1175 — floating Reserve pill now reflects the live selected total
On the public trip page, the docked (in-box) total updated on quantity change but the **floating** pill did not. Root cause: both bars receive the same live `cta`, but the floating render path dropped the price — the plain pill was label-only, and the split (plan) pill showed the **per-unit** price, never qty-scaled.
- `TripReserveBar.tsx`: floating pill now shows `{price} · {label} →` (same `cta.price` the docked bar reads).
- `useTripOfferingState.ts`: split "Pay in full" / "Pay over time" labels read the qty-scaled summed totals when a quantity is selected (unit fallback for the empty/"From {min}" state).

## ORCH-1176 — trip checkout keeps the cart/quantity step for multi-package trips (business app + buyer web)
After reserving a multi-package trip, the buyer was dropped past the cart step (counter read "1 OF 2", no way to edit quantity). Root cause: the checkout index multi-seed effect auto-`router.replace`'d to `/buyer` for **any** seeded selection, even multi-tier.
- New pure `bookableTierCount.ts` (unlimited OR remaining capacity > 0; sold-out excluded).
- `index.tsx`: auto-advance to `/buyer` only when ≤1 bookable tier; multi-package seeds the cart but stays on index ("1 OF 3") so quantities are reviewable/editable. Single-tier auto-skip unchanged.
- `buyer.tsx` / `payment.tsx`: step counter derived (3 for multi-tier, 2 for single-tier streamline).
- Consumer app already shows an editable `TicketCartSheet` — unchanged.

## ORCH-1177 — trip-create wizard shows the Discard prompt instead of silently bouncing to Home
A fresh trip draft is seeded with title `"Untitled trip"`, but create-mode detection required an **empty** title, so a never-edited draft was misclassified as edit-mode → tapping Close/back silently autosaved and `router.back()`'d to Home with no "Discard this trip?" confirmation.
- `tripsService.ts`: hoisted `TRIP_DRAFT_PLACEHOLDER_TITLE` (seed + guard share one const, can't drift).
- `edit.tsx`: `isCreateMode` recognizes the placeholder title → Close/back routes through the proper discard path.

## Tests
New happy + adversarial regression suites per ORCH (offering-rendering deno + checkout-trip/trip jest), all passing. No existing tests modified (no append-only token needed). Pre-existing unrelated failures fail identically on baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)