### PR TITLE
META-ORCH-1178/1179: trip checkout always shows cart step + consumer installment parity

### DIFF
--- a/app-mobile/src/hooks/__tests__/orch_1179_consumer_installment_parity.test.ts
+++ b/app-mobile/src/hooks/__tests__/orch_1179_consumer_installment_parity.test.ts
@@ -1,0 +1,182 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1179 [consumer-trip-installment-parity] — the consumer trip page must
+// surface the §10 pay-in-full / pay-over-time toggle, the reserve-bar split CTAs,
+// and the cart deposit-lead for plan tiers, at parity with the business twin.
+//
+// ROOT CAUSE (verified): `pg_public_trip_by_slug` emits BOTH
+//   - t.installments  → ALREADY unwrapped (`tier_metadata -> 'installments'`, the
+//                       inner {deposit_pct, installments:[...]} template), AND
+//   - t.tierMetadata  → the FULL tier_metadata jsonb.
+// The consumer's `extractTripInstallmentSchedule(metadata)` expects the FULL
+// metadata — its first line does `metadata.installments` (unwraps ONCE). The bug
+// fed it `t.installments` (already inner) → it unwrapped AGAIN → read `deposit_pct`
+// off the installments ARRAY → null for every plan tier. So hasSingleTierPlan /
+// splitCtas / projectedSchedule were all false on consumer → toggle + CTAs + cart
+// deposit-lead all silently vanished. The business twin reads `t.installments` with
+// a DIRECT reader (`asInstallmentSchedule`) and works.
+//
+// FIX: the consumer tier mapper passes `t.tierMetadata` (the full metadata the
+// extractor was written for), NOT `t.installments`.
+//
+// Harness note (no jest/RTL in app-mobile; the hook's top-level supabase import
+// can't resolve under bare node): per repo convention this combines a VERBATIM
+// behavioral replica of `extractTripInstallmentSchedule` (executed against a
+// synthetic RPC-shaped fixture — 0/8 live brands set plans, so prod data proves
+// nothing) with a source-assertion on the actual mapper line (fails-on-revert on a
+// true line edit, never on a comment-out).
+//
+// Run:  node --experimental-strip-types --test \
+//         app-mobile/src/hooks/__tests__/orch_1179_consumer_installment_parity.test.ts
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const hookSrc = readFileSync(
+  join(__dirname, "../useConsumerTripDetail.ts"),
+  "utf8",
+);
+// Strip block + line comments so prose mentioning a token never satisfies an
+// assertion (the doc-comment cites both `t.installments` and `t.tierMetadata`).
+const hookCode = hookSrc
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/^[ \t]*\/\/.*$/gm, "")
+  .replace(/[ \t]\/\/[^\n]*$/gm, "");
+
+// ── VERBATIM replica of extractTripInstallmentSchedule (the extractor under test;
+//    do NOT "fix" it — ORCH-1179 leaves the function untouched and changes the
+//    CALLER's argument). Mirrors useConsumerTripDetail.ts exactly. ──────────────
+function extractTripInstallmentScheduleReplica(metadata) {
+  if (metadata === null || typeof metadata !== "object") return null;
+  const raw = metadata.installments;
+  if (raw === null || raw === undefined || typeof raw !== "object") return null;
+  const obj = raw;
+  const depositPct = obj.deposit_pct;
+  const installments = obj.installments;
+  if (typeof depositPct !== "number" || !Array.isArray(installments)) {
+    return null;
+  }
+  const clean = installments
+    .map((inst, i) => {
+      if (typeof inst !== "object" || inst === null) return null;
+      const r = inst;
+      const ordinal = typeof r.ordinal === "number" ? r.ordinal : i + 1;
+      const pct = typeof r.pct === "number" ? r.pct : 0;
+      const days =
+        typeof r.days_after_booking === "number"
+          ? r.days_after_booking
+          : undefined;
+      const fixed = typeof r.fixed_date === "string" ? r.fixed_date : undefined;
+      if (days === undefined && fixed === undefined) return null;
+      return {
+        ordinal,
+        pct,
+        ...(days !== undefined ? { days_after_booking: days } : {}),
+        ...(fixed !== undefined ? { fixed_date: fixed } : {}),
+      };
+    })
+    .filter((x) => x !== null);
+  if (clean.length === 0) return null;
+  return { deposit_pct: depositPct, installments: clean };
+}
+
+// ── A synthetic plan tier, shaped EXACTLY like a `pg_public_trip_by_slug` tier
+//    row: `installments` is the ALREADY-unwrapped inner template; `tierMetadata`
+//    is the FULL metadata that wraps it. ─────────────────────────────────────────
+const INNER_TEMPLATE = {
+  deposit_pct: 25,
+  installments: [
+    { ordinal: 1, pct: 25, days_after_booking: 30 },
+    { ordinal: 2, pct: 25, days_after_booking: 60 },
+    { ordinal: 3, pct: 25, days_after_booking: 90 },
+  ],
+};
+const PLAN_TIER = {
+  ticketTypeId: "tier-plan",
+  tierName: "Standard",
+  // RPC emits the inner template here (tier_metadata -> 'installments') ...
+  installments: INNER_TEMPLATE,
+  // ... and the FULL metadata here.
+  tierMetadata: { installments: INNER_TEMPLATE, description: "A trip tier" },
+};
+
+// ───────────────────────── HAPPY ─────────────────────────
+test("ORCH-1179 happy: tierMetadata (full) → non-null schedule, deposit_pct 25 + parsed installments", () => {
+  const schedule = extractTripInstallmentScheduleReplica(PLAN_TIER.tierMetadata);
+  assert.notEqual(schedule, null, "the FULL metadata must yield a real schedule");
+  assert.equal(schedule.deposit_pct, 25);
+  assert.equal(schedule.installments.length, 3);
+  assert.deepEqual(
+    schedule.installments.map((i) => i.ordinal),
+    [1, 2, 3],
+  );
+  assert.equal(schedule.installments[0].days_after_booking, 30);
+});
+
+test("ORCH-1179 happy: the mapper reads t.tierMetadata (the fix), threaded to extractTripInstallmentSchedule", () => {
+  // Fails-on-revert: a TRUE edit back to `extractTripInstallmentSchedule(t.installments)`
+  // trips this (comments are stripped, so the doc-comment citation can't satisfy it).
+  assert.match(
+    hookCode,
+    /installmentSchedule:\s*extractTripInstallmentSchedule\(\s*t\.tierMetadata\s*\)/,
+    "the consumer tier mapper must pass t.tierMetadata (full metadata)",
+  );
+  assert.doesNotMatch(
+    hookCode,
+    /installmentSchedule:\s*extractTripInstallmentSchedule\(\s*t\.installments\s*\)/,
+    "the OLD double-unwrapping arg (t.installments) must be gone from code",
+  );
+});
+
+// ─────────────────────── ADVERSARIAL ───────────────────────
+test("ORCH-1179 adversarial (fails-on-revert): the OLD arg t.installments yields null (proves the bug + fix)", () => {
+  // Feeding the already-inner template double-unwraps: metadata.installments is
+  // the installments ARRAY, whose typeof is 'object' but has no numeric
+  // deposit_pct → the guard returns null. This is the exact silent-vanish bug.
+  const wrong = extractTripInstallmentScheduleReplica(PLAN_TIER.installments);
+  assert.equal(
+    wrong,
+    null,
+    "the pre-fix arg (t.installments) must extract to null — the regression we fixed",
+  );
+  // And the fixed arg recovers a real schedule on the SAME tier.
+  const right = extractTripInstallmentScheduleReplica(PLAN_TIER.tierMetadata);
+  assert.notEqual(right, null);
+});
+
+test("ORCH-1179 adversarial: a no-plan tier (tierMetadata without installments) → null (byte-identical no-plan)", () => {
+  const noPlanTier = {
+    ticketTypeId: "tier-noplan",
+    tierName: "Basic",
+    installments: null, // RPC emits null when tier_metadata has no installments
+    tierMetadata: { description: "no plan here" },
+  };
+  assert.equal(
+    extractTripInstallmentScheduleReplica(noPlanTier.tierMetadata),
+    null,
+    "no-plan tiers must stay null (no fabricated schedule)",
+  );
+  // empty/null metadata is also null-safe.
+  assert.equal(extractTripInstallmentScheduleReplica(null), null);
+  assert.equal(extractTripInstallmentScheduleReplica({}), null);
+});
+
+test("ORCH-1179 adversarial: malformed inner (deposit_pct missing / installments not array) → null", () => {
+  assert.equal(
+    extractTripInstallmentScheduleReplica({ installments: { installments: [] } }),
+    null,
+    "missing deposit_pct → null",
+  );
+  assert.equal(
+    extractTripInstallmentScheduleReplica({
+      installments: { deposit_pct: 25, installments: "nope" },
+    }),
+    null,
+    "non-array installments → null",
+  );
+});

--- a/app-mobile/src/hooks/useConsumerTripDetail.ts
+++ b/app-mobile/src/hooks/useConsumerTripDetail.ts
@@ -383,7 +383,15 @@ async function fetchTripDetail(
     // META-ORCH-1174 — real per-tier remaining (null when unlimited; no
     // fabricated sold-out — rule 9). Previously always null on consumer.
     ticketsRemaining: t.isUnlimited ? null : (t.ticketsRemaining ?? null),
-    installmentSchedule: extractTripInstallmentSchedule(t.installments),
+    // ORCH-1179 — extractTripInstallmentSchedule expects the FULL tier_metadata
+    // (its first line unwraps `.installments`). The RPC ALSO emits `t.installments`
+    // ALREADY unwrapped (tier_metadata -> 'installments'), so passing that here
+    // double-unwrapped → null for every plan tier → the §10 pay-over-time toggle,
+    // reserve split CTAs, and cart deposit-lead all silently vanished on consumer.
+    // Read `t.tierMetadata` (the full metadata the extractor was written for) to
+    // restore parity with the business twin (which reads t.installments via a
+    // DIRECT reader). I-1179: consumer installment parity.
+    installmentSchedule: extractTripInstallmentSchedule(t.tierMetadata),
   }));
 
   // Aggregate availability derived from the per-tier rows (the prior consumer

--- a/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1176_funnel_wiring.test.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1176_funnel_wiring.test.ts
@@ -1,14 +1,25 @@
 /**
- * ORCH-1176 [trip-multipkg-checkout-wizard] — source-contract wiring proof. The
- * pure gate logic is exercised in orch_1176_multitier_cart_step.test.ts; this
- * proves the THREE checkout files actually consume it:
- *   - index.tsx multi-seed effect gates the /buyer auto-advance on
- *     bookableTierCount(...) > 1 (stay on index for multi-package).
- *   - buyer.tsx + payment.tsx DERIVE totalSteps from bookableTierCount instead of
- *     the old hardcoded `totalSteps={2}`.
+ * ORCH-1176 → SUPERSEDED BY ORCH-1178 [trip-checkout-always-cart-step].
  *
- * Fails-on-revert via TRUE line deletion (restore the unconditional
- * router.replace / the literal totalSteps={2} → these assertions fail).
+ * ORCH-1176 made the cart/quantity step conditional: multi-package trips kept it
+ * (3 steps) while an effectively single-tier trip auto-skipped it (2 steps, via
+ * `bookableTierCount(...) > 1 ? 3 : 2`). ORCH-1178 reverses that — the
+ * cart/quantity step ALWAYS shows and STAYS for EVERY trip (single AND multi
+ * tier), because a single-tier buyer was briefly shown the cart then yanked to
+ * /buyer with no chance to edit quantity. So the `bookableTierCount`-derived
+ * `totalSteps` is gone; the funnel is now index → buyer → [intake] → payment =
+ * 3 steps (no intake) or 4 (intake), derived via `tripFunnelTotalSteps`.
+ *
+ * This suite is retargeted to the ORCH-1178 contract (the THREE checkout files):
+ *   - index.tsx no longer auto-`router.replace`s to /buyer (both seed effects
+ *     just latch + stay on the cart step).
+ *   - buyer.tsx + payment.tsx derive totalSteps from `tripFunnelTotalSteps(...)`,
+ *     NOT from `bookableTierCount`, and NOT a literal 2.
+ *
+ * Fails-on-revert via TRUE line deletion (restoring the router.replace / the
+ * bookableTierCount derivation → these assertions fail).
+ *
+ * [TEST-MOD-APPROVED ORCH-1178]
  */
 
 import { readFileSync } from "fs";
@@ -22,32 +33,40 @@ const read = (f: string): string => readFileSync(join(DIR, f), "utf8");
 const strip = (s: string): string =>
   s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
 
-describe("ORCH-1176 — funnel wiring consumes bookableTierCount", () => {
-  test("index.tsx gates the multi-seed auto-advance on bookable tier count > 1", () => {
+describe("ORCH-1178 — trip checkout always shows the cart step (supersedes ORCH-1176 wiring)", () => {
+  test("index.tsx no longer auto-navigates to /buyer (both seed effects stay on the cart step)", () => {
     const src = strip(read("index.tsx"));
-    expect(src).toContain('import { bookableTierCount } from "./bookableTierCount"');
-    // The seed effect computes the bookable count from the real tiers ...
-    expect(src).toMatch(/bookableTierCount\(\s*trip\.pricingTiers\.map\(tierToTicketStub\)/);
-    // ... and stays on index (returns WITHOUT router.replace) when > 1.
-    expect(src).toMatch(/if \(bookableCount > 1\) \{[\s\S]*?return;/);
+    // The auto-skip + multi-seed effects must NOT router.replace to /buyer.
+    expect(src).not.toMatch(/router\.replace\(\s*`\/checkout-trip\/\$\{tripEventId\}\/buyer`/);
+    // The bookableTierCount import + gate are gone (the multi-seed branch deleted).
+    expect(src).not.toContain('from "./bookableTierCount"');
+    expect(src).not.toMatch(/if \(bookableCount > 1\)/);
+    // The cart step derives its total from the intake-aware helper.
+    expect(src).toContain('import { tripFunnelTotalSteps } from "./tripFunnelSteps"');
+    expect(src).toMatch(/totalSteps\s*=\s*tripFunnelTotalSteps\(/);
   });
 
-  test("buyer.tsx derives totalSteps from bookableTierCount (no hardcoded 2)", () => {
+  test("buyer.tsx derives totalSteps from tripFunnelTotalSteps (no bookableTierCount, no literal 2)", () => {
     const src = strip(read("buyer.tsx"));
-    expect(src).toContain('import { bookableTierCount } from "./bookableTierCount"');
-    expect(src).toMatch(/const totalSteps: 2 \| 3 =[\s\S]*?bookableTierCount\(/);
-    expect(src).toMatch(/\? 3\s*\n?\s*: 2/);
-    // The header reads the derived value, not a literal.
+    expect(src).not.toContain('from "./bookableTierCount"');
+    expect(src).toContain('import { tripFunnelTotalSteps } from "./tripFunnelSteps"');
+    expect(src).toMatch(/totalSteps\s*=\s*tripFunnelTotalSteps\(/);
     expect(src).toContain("totalSteps={totalSteps}");
-    // No surviving hardcoded totalSteps={2} on a CheckoutHeader.
+    // buyer is step 2 of N → stepIndex 1 (the latent "1 OF" bug fixed).
+    expect(src).toContain("stepIndex={1}");
     expect(src).not.toMatch(/totalSteps=\{2\}/);
   });
 
-  test("payment.tsx derives totalSteps from bookableTierCount (no hardcoded 2)", () => {
+  test("payment.tsx derives totalSteps + last-step index from tripFunnelSteps (no bookableTierCount, no literal 2)", () => {
     const src = strip(read("payment.tsx"));
-    expect(src).toContain('import { bookableTierCount } from "./bookableTierCount"');
-    expect(src).toMatch(/const totalSteps: 2 \| 3 =[\s\S]*?bookableTierCount\(/);
+    expect(src).not.toContain('from "./bookableTierCount"');
+    expect(src).toMatch(/tripFunnelTotalSteps,\s*tripPaymentStepIndex,/);
+    expect(src).toMatch(/totalSteps\s*=\s*tripFunnelTotalSteps\(/);
+    expect(src).toMatch(/paymentStepIndex\s*=\s*tripPaymentStepIndex\(/);
     expect(src).toContain("totalSteps={totalSteps}");
+    // payment is the LAST step → stepIndex is the derived N-1 (was the latent
+    // "2 OF" bug: hardcoded stepIndex 1).
+    expect(src).toContain("stepIndex={paymentStepIndex}");
     expect(src).not.toMatch(/totalSteps=\{2\}/);
   });
 });

--- a/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1178_always_cart_step.test.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1178_always_cart_step.test.ts
@@ -1,0 +1,182 @@
+/**
+ * ORCH-1178 [trip-checkout-always-cart-step] — the cart/quantity step ALWAYS
+ * shows and STAYS for every trip (single AND multi tier).
+ *
+ * Bug (INVESTIGATE_ORCH-1178): a single-tier trip still auto-skipped the cart
+ * step — the buyer briefly saw "Reserve your spot" then it auto-`router.replace`d
+ * to /buyer, with no chance to edit quantity. TWO auto-navigate paths existed in
+ * index.tsx (the multi-SEED effect and the `decideAutoSkip` effect); ORCH-1176
+ * only gated path 1. ORCH-1178 removes BOTH navigations: the sole tier is still
+ * PRE-SEEDED (qty 1, editable), but the buyer stays on the cart step and taps
+ * Continue to advance.
+ *
+ * `decideAutoSkip` (the pure fn) is intentionally LEFT UNCHANGED — the behavior
+ * change is in the COMPONENT (it no longer navigates on the "navigate" outcome).
+ * The visible sequence is index(1) → buyer(2) → [intake(3)] → payment(N), so
+ * totalSteps = 3 without an intake form, 4 with one.
+ *
+ * Harness: no @testing-library/react-native in this repo. This combines:
+ *  (1) the pure `tripFunnelTotalSteps`/`tripPaymentStepIndex` helpers (executed),
+ *  (2) a simulation of the component's NEW per-commit behavior (latch-without-
+ *      navigate), proving the sole tier is seeded but /buyer is NEVER pushed, and
+ *  (3) source-contract assertions on the three checkout files (fails-on-revert on
+ *      a true line edit, never on a comment-out).
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  tripFunnelTotalSteps,
+  tripPaymentStepIndex,
+} from "../tripFunnelSteps";
+import {
+  decideAutoSkip,
+  type AutoSkipCartLine,
+} from "../autoSkipDecision";
+
+const DIR = join(__dirname, "..");
+const read = (f: string): string => readFileSync(join(DIR, f), "utf8");
+const strip = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+const SOLE_TIER = { id: "tier-1", isUnlimited: false, capacity: 10 };
+
+/**
+ * Simulate the ORCH-1178 component behavior of the `decideAutoSkip` effect: on
+ * "addLine" seed the sole tier (lands next commit); on "navigate" JUST LATCH —
+ * the component no longer router.replace's. Returns whether the cart was seeded
+ * and whether any navigation occurred.
+ */
+function simulateAlwaysStay(maxCommits = 8): {
+  navigations: number;
+  soleSeeded: boolean;
+} {
+  let alreadyNavigated = false;
+  let lines: AutoSkipCartLine[] = [];
+  let navigations = 0;
+
+  for (let commit = 0; commit < maxCommits; commit += 1) {
+    const outcome = decideAutoSkip({
+      alreadyNavigated,
+      tripPresent: true,
+      bookingsClosed: false,
+      isPast: false,
+      tiers: [SOLE_TIER],
+      lines,
+    });
+    if (outcome === "addLine") {
+      lines = [{ ticketTypeId: SOLE_TIER.id, quantity: 1 }];
+    } else if (outcome === "navigate") {
+      // ORCH-1178: component LATCHES but does NOT navigate (stay on cart step).
+      alreadyNavigated = true;
+      // navigations intentionally NOT incremented — the fix removed the replace.
+    }
+  }
+  const soleSeeded = lines.some(
+    (l) => l.ticketTypeId === SOLE_TIER.id && l.quantity === 1,
+  );
+  return { navigations, soleSeeded };
+}
+
+// ───────────────────────── HAPPY ─────────────────────────
+describe("ORCH-1178 happy — single-tier trip stays on the cart step", () => {
+  test("the sole tier is pre-seeded (qty 1, editable) and NO navigation to /buyer fires", () => {
+    const { navigations, soleSeeded } = simulateAlwaysStay();
+    expect(soleSeeded).toBe(true);
+    expect(navigations).toBe(0);
+  });
+
+  test('index.tsx never router.replace()s to /buyer (both seed effects latch + stay)', () => {
+    const src = strip(read("index.tsx"));
+    expect(src).not.toMatch(
+      /router\.replace\(\s*`\/checkout-trip\/\$\{tripEventId\}\/buyer`/,
+    );
+    // The "addLine" seeding is kept (the sole tier is still pre-added qty 1).
+    expect(src).toMatch(/outcome === "addLine"/);
+    // Both effects latch.
+    expect(src).toContain("autoSkipNavigatedRef.current = true");
+    expect(src).toContain("multiSeedNavigatedRef.current = true");
+  });
+
+  test("counter: a no-intake trip reads 1 OF 3 / 2 OF 3 / 3 OF 3 (index/buyer/payment)", () => {
+    expect(tripFunnelTotalSteps(false)).toBe(3);
+    // index stepIndex 0 → "1 OF 3"; buyer stepIndex 1 → "2 OF 3".
+    expect(tripPaymentStepIndex(false)).toBe(2); // payment "3 OF 3".
+    // index.tsx renders the cart step at "1 OF N".
+    const idx = strip(read("index.tsx"));
+    expect(idx).toContain("stepIndex={0}");
+    expect(idx).toContain("totalSteps={totalSteps}");
+  });
+});
+
+// ─────────────────────── ADVERSARIAL ───────────────────────
+describe("ORCH-1178 adversarial", () => {
+  test("(a) multi-tier still shows the cart + stays (no navigation; decideAutoSkip noops on >1 tier)", () => {
+    // >1 bookable tier → decideAutoSkip returns noop (tiers.length !== 1), so the
+    // sole-tier seeding never runs and nothing navigates. The buyer drives it.
+    const outcome = decideAutoSkip({
+      alreadyNavigated: false,
+      tripPresent: true,
+      bookingsClosed: false,
+      isPast: false,
+      tiers: [SOLE_TIER, { id: "tier-2", isUnlimited: false, capacity: 5 }],
+      lines: [],
+    });
+    expect(outcome).toBe("noop");
+    // And the multi-SEED effect, once all seeded lines land, just latches:
+    const idx = strip(read("index.tsx"));
+    expect(idx).toMatch(/multiSeedNavigatedRef\.current = true;\s*$/m);
+    // No bookableCount > 1 navigation branch survives.
+    expect(idx).not.toMatch(/if \(bookableCount > 1\)/);
+  });
+
+  test("(b) public-page `lines` param seeds qty + stays on index (does NOT auto-advance)", () => {
+    const idx = strip(read("index.tsx"));
+    // The multi-seed effect dispatches setLineQuantity for the parsed lines ...
+    expect(idx).toMatch(/seededLinesParam/);
+    expect(idx).toContain("setLineQuantity");
+    // ... and after landing it ONLY latches — no router.replace in the effect.
+    const seedEffect = idx.slice(
+      idx.indexOf("const multiSeedNavigatedRef"),
+      idx.indexOf("const autoSkipNavigatedRef"),
+    );
+    expect(seedEffect.length).toBeGreaterThan(0);
+    expect(seedEffect).not.toContain("router.replace");
+    expect(seedEffect).toContain("multiSeedNavigatedRef.current = true");
+  });
+
+  test("(c) buyer.tsx keeps the empty-cart guard that bounces back to the cart step (index)", () => {
+    const buyer = strip(read("buyer.tsx"));
+    // hasNoLines → router.replace back to /checkout-trip/{id} (the index/cart step).
+    expect(buyer).toMatch(/hasNoLines/);
+    expect(buyer).toMatch(
+      /router\.replace\(\s*`\/checkout-trip\/\$\{tripEventId\}`\s*as never\)/,
+    );
+  });
+
+  test("(d) intake-required trip reads N=4 across the funnel (index/buyer 1..2, intake 3, payment 4)", () => {
+    expect(tripFunnelTotalSteps(true)).toBe(4);
+    // payment is the LAST step → stepIndex 3 ("4 OF 4").
+    expect(tripPaymentStepIndex(true)).toBe(3);
+    // The intake page renders its own inline "3 OF {free?3:4}" header.
+    const intake = strip(read("intake.tsx"));
+    expect(intake).toMatch(/3 OF \{totals\.isFree \? 3 : 4\}/);
+    // index + buyer + payment derive totalSteps from the intake-aware helper.
+    for (const f of ["index.tsx", "buyer.tsx", "payment.tsx"]) {
+      expect(strip(read(f))).toMatch(/tripFunnelTotalSteps\(/);
+    }
+  });
+
+  test("the pure helpers are total + correct for both branches", () => {
+    expect(tripFunnelTotalSteps(false)).toBe(3);
+    expect(tripFunnelTotalSteps(true)).toBe(4);
+    expect(tripPaymentStepIndex(false)).toBe(2);
+    expect(tripPaymentStepIndex(true)).toBe(3);
+    // last-step index is always total - 1.
+    expect(tripPaymentStepIndex(false)).toBe(tripFunnelTotalSteps(false) - 1);
+    expect(tripPaymentStepIndex(true)).toBe(tripFunnelTotalSteps(true) - 1);
+  });
+});

--- a/mingla-business/app/checkout-trip/[tripEventId]/buyer.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/buyer.tsx
@@ -73,7 +73,7 @@ import {
   useCartTotals,
 } from "../../../src/components/checkout/CartContext";
 import { CheckoutHeader } from "../../../src/components/checkout/CheckoutHeader";
-import { bookableTierCount } from "./bookableTierCount";
+import { tripFunnelTotalSteps } from "./tripFunnelSteps";
 
 import {
   PhoneInput,
@@ -177,21 +177,6 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
   const { lines, buyer, setBuyer, recordResult, paymentPlanChoice } = useCart();
   const totals = useCartTotals();
 
-  // ORCH-1176 — derive the funnel length from the trip's BOOKABLE tier count.
-  // A multi-package trip keeps the cart/quantity step (3 steps); an effectively
-  // single-tier trip auto-skips it (2 steps), matching index.tsx's auto-advance
-  // gate. Bookable = unlimited OR remaining capacity > 0 (mirrors tierToTicketStub).
-  const totalSteps: 2 | 3 =
-    trip !== null &&
-    bookableTierCount(
-      trip.pricingTiers.map((t) => ({
-        isUnlimited: t.isUnlimited,
-        capacity: t.ticketsRemaining ?? t.quantityTotal,
-      })),
-    ) > 1
-      ? 3
-      : 2;
-
   // ORCH-1130 Fix #1 — "Total due today" (deposit) line for the order-summary
   // box. When pay-over-time is selected AND the cart holds a plan-active tier,
   // surface the DEPOSIT DUE TODAY alongside the full Total. Read from the SAME
@@ -236,6 +221,14 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
     }
     return false;
   }, [intakeSchemasQuery.data, lines]);
+
+  // ORCH-1178 — the cart step ALWAYS shows now, so the funnel is index → buyer
+  // → [intake] → payment: 3 steps without an intake form, 4 with. (Supersedes
+  // the ORCH-1176 bookableTierCount-derived 2|3, which collapsed the single-tier
+  // trip to 2 — that collapse is gone.) Reuse the SAME intake-presence predicate
+  // that decides whether Continue routes to /intake, so the counter and the
+  // routing can never disagree.
+  const totalSteps = tripFunnelTotalSteps(hasAnyIntakeSchema);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -445,7 +438,7 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
     return (
       <View style={styles.host}>
         <CheckoutHeader
-          stepIndex={0}
+          stepIndex={1}
           totalSteps={totalSteps}
           title="Your details"
           onBack={handleBack}
@@ -457,7 +450,7 @@ export default function CheckoutTripBuyerScreen(): React.ReactElement {
   return (
     <View style={styles.host}>
       <CheckoutHeader
-        stepIndex={0}
+        stepIndex={1}
         totalSteps={totalSteps}
         title="Your details"
         onBack={handleBack}

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -35,6 +35,7 @@ import {
 } from "../../../src/constants/designSystem";
 import { tripPublicPath } from "../../../src/constants/publicUrls";
 import { usePublicTripById } from "../../../src/hooks/usePublicTripById";
+import { useTripIntakeSchemasByEvent } from "../../../src/hooks/useIntakeSchema";
 import { formatCurrency } from "../../../src/utils/currency";
 import { projectInstallmentSchedule } from "../../../src/utils/installmentScheduleProjection";
 import type { TripPricingTier } from "../../../src/services/tripsService";
@@ -48,7 +49,7 @@ import { Button } from "../../../src/components/ui/Button";
 import { EmptyState } from "../../../src/components/ui/EmptyState";
 import { EventCoverMedia } from "../../../src/components/ui/EventCoverMedia";
 import { decideAutoSkip } from "./autoSkipDecision";
-import { bookableTierCount } from "./bookableTierCount";
+import { tripFunnelTotalSteps } from "./tripFunnelSteps";
 
 import {
   useCart,
@@ -178,6 +179,26 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
   const { lines, paymentPlanChoice, setLineQuantity, setPaymentPlanChoice } =
     useCart();
   const totals = useCartTotals();
+
+  // ORCH-1178 — the cart step always shows, so the trip funnel is index → buyer
+  // → [intake] → payment. Derive the visible total (3 without intake, 4 with) so
+  // the "1 OF N" pill reads correctly. The cart is empty on first mount (the
+  // buyer hasn't picked a tier yet), so the intake-presence probe keys off ANY
+  // of the trip's tiers having a schema with ≥1 question — a stable answer that
+  // matches what buyer/payment derive once a selection is committed. Same
+  // anon-tolerant by-event query the buyer step uses.
+  const intakeSchemasQuery = useTripIntakeSchemasByEvent(tripEventId ?? "", {
+    enabled: tripEventId !== null,
+  });
+  const hasAnyIntakeSchema = React.useMemo<boolean>(() => {
+    if (intakeSchemasQuery.data === undefined || trip === null) return false;
+    for (const tier of trip.pricingTiers) {
+      const schema = intakeSchemasQuery.data.get(tier.ticketTypeId);
+      if (schema !== undefined && schema.questions.length > 0) return true;
+    }
+    return false;
+  }, [intakeSchemasQuery.data, trip]);
+  const totalSteps = tripFunnelTotalSteps(hasAnyIntakeSchema);
 
   // ORCH-1130 ADDENDUM (Seth-BINDING) — the price shown beside the Continue CTA
   // (the Subtotal) follows the current pay-full vs pay-over-time selection
@@ -330,24 +351,15 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       }
       return;
     }
-    // ORCH-1176 — only auto-advance to /buyer for an effectively SINGLE-tier trip
-    // (≤1 bookable tier). For a genuine MULTI-PACKAGE trip (>1 bookable tier) the
-    // cart is seeded but we STAY on index ("1 OF 3") so the buyer reviews/edits the
-    // package quantities before handleContinue routes them to /buyer. Bookable =
-    // unlimited OR remaining capacity > 0 (mirrors tierToTicketStub's capacity).
-    const bookableCount = bookableTierCount(
-      trip.pricingTiers.map(tierToTicketStub),
-    );
-    if (bookableCount > 1) {
-      // Latch so we don't keep re-seeding; the buyer drives the funnel from here.
-      multiSeedNavigatedRef.current = true;
-      return;
-    }
-    // All seeded lines have landed → /buyer reads a populated cart.
+    // ORCH-1178 — the cart/quantity step ALWAYS shows and STAYS for every trip
+    // (single AND multi tier). The public-page `lines` selection pre-seeds the
+    // cart so the buyer sees their picks, but we NO LONGER auto-advance to /buyer
+    // (the old single-tier `router.replace` is removed — it briefly showed the
+    // cart then yanked the buyer to "Your details" with no chance to edit qty).
+    // Just latch so we stop re-seeding; the buyer taps Continue to advance.
     multiSeedNavigatedRef.current = true;
-    router.replace(`/checkout-trip/${tripEventId}/buyer` as never);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tripEventId, trip, seededLinesParam, lines, router]);
+  }, [tripEventId, trip, seededLinesParam, lines]);
 
   const autoSkipNavigatedRef = useRef(false);
   useEffect(() => {
@@ -392,13 +404,16 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       });
       return;
     }
-    // outcome === "navigate": the sole tier's line is present (qty>=1) → /buyer
-    // reads a populated cart and its empty-cart guard will not bounce us back.
-    // Latch so this navigation fires EXACTLY ONCE per mount (kills the ping-pong).
+    // ORCH-1178 — outcome === "navigate": the sole tier's line is present
+    // (qty>=1). We PRE-SEED the sole tier (the "addLine" branch above) so it's
+    // editable at qty 1, but we NO LONGER auto-`router.replace` to /buyer — the
+    // cart/quantity step ALWAYS stays so the buyer can edit quantity and tap
+    // Continue. Just latch so the effect goes quiet (the sole tier is seeded,
+    // no ping-pong). This supersedes the ORCH-1130 single-tier auto-skip
+    // behaviorally (decideAutoSkip the pure fn is intentionally unchanged).
     autoSkipNavigatedRef.current = true;
-    router.replace(`/checkout-trip/${tripEventId}/buyer` as never);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tripEventId, trip, lines, router]);
+  }, [tripEventId, trip, lines]);
 
   // ----- Trip-not-found / past / closed empty states -----
   if (publicTripQuery.isLoading || publicTripQuery.isFetching) {
@@ -406,7 +421,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={0}
-          totalSteps={3}
+          totalSteps={totalSteps}
           title="Reserve your spot"
           onBack={handleBack}
         />
@@ -422,7 +437,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={0}
-          totalSteps={3}
+          totalSteps={totalSteps}
           title="Reserve your spot"
           onBack={handleBack}
         />
@@ -443,7 +458,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={0}
-          totalSteps={3}
+          totalSteps={totalSteps}
           title="Reserve your spot"
           onBack={handleBack}
         />
@@ -467,7 +482,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={0}
-          totalSteps={3}
+          totalSteps={totalSteps}
           title="Reserve your spot"
           onBack={handleBack}
         />
@@ -495,7 +510,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
       <View style={styles.host}>
         <CheckoutHeader
           stepIndex={0}
-          totalSteps={3}
+          totalSteps={totalSteps}
           title="Reserve your spot"
           onBack={handleBack}
         />
@@ -533,7 +548,7 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
     <View style={styles.host}>
       <CheckoutHeader
         stepIndex={0}
-        totalSteps={3}
+        totalSteps={totalSteps}
         title="Reserve your spot"
         onBack={handleBack}
       />

--- a/mingla-business/app/checkout-trip/[tripEventId]/payment.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/payment.tsx
@@ -50,6 +50,7 @@ import {
   text as textTokens,
 } from "../../../src/constants/designSystem";
 import { usePublicTripById } from "../../../src/hooks/usePublicTripById";
+import { useTripIntakeSchemasByEvent } from "../../../src/hooks/useIntakeSchema";
 import { formatCurrency } from "../../../src/utils/currency";
 import { isRequiredPhoneValid } from "../../../src/utils/phone";
 import { tripPublicPath } from "../../../src/constants/publicUrls";
@@ -75,7 +76,10 @@ import {
   writeCheckoutResumePayload,
 } from "../../../src/components/checkout/checkoutPersistence";
 import { CheckoutHeader } from "../../../src/components/checkout/CheckoutHeader";
-import { bookableTierCount } from "./bookableTierCount";
+import {
+  tripFunnelTotalSteps,
+  tripPaymentStepIndex,
+} from "./tripFunnelSteps";
 import { supabase } from "../../../src/services/supabase";
 
 const NativeCheckoutPaymentBoundary = React.lazy(
@@ -110,6 +114,12 @@ function CheckoutTripPaymentScreenContent({
 
   const publicTripQuery = usePublicTripById(tripEventId);
   const trip = publicTripQuery.data?.trip ?? null;
+  // ORCH-1178 — anon-tolerant per-tier intake schemas, used ONLY to derive the
+  // funnel length (whether /intake sits between /buyer and /payment). Mirrors
+  // buyer.tsx's by-event query.
+  const intakeSchemasQuery = useTripIntakeSchemasByEvent(tripEventId ?? "", {
+    enabled: tripEventId !== null,
+  });
   const {
     lines,
     buyer,
@@ -590,19 +600,22 @@ function CheckoutTripPaymentScreenContent({
   const showFeesTaxLine = feesTaxLineCents > 0;
   const displayAllIn = formatCurrency(headlineCents, totals.currency, true);
 
-  // ORCH-1176 — derive the funnel length from the trip's BOOKABLE tier count so
-  // the "Review & pay" step reads "2 OF 3" on a multi-package trip and "2 OF 2"
-  // on the single-tier auto-skip path (consistent with index.tsx + buyer.tsx).
-  const totalSteps: 2 | 3 =
-    trip !== null &&
-    bookableTierCount(
-      trip.pricingTiers.map((t) => ({
-        isUnlimited: t.isUnlimited,
-        capacity: t.ticketsRemaining ?? t.quantityTotal,
-      })),
-    ) > 1
-      ? 3
-      : 2;
+  // ORCH-1178 — the cart step ALWAYS shows now, so the "Review & pay" step is
+  // the LAST step of the index → buyer → [intake] → payment funnel: "3 OF 3"
+  // without an intake form, "4 OF 4" with one. (Supersedes the ORCH-1176
+  // bookableTierCount-derived 2|3.) Reuse the SAME per-cart-line intake-presence
+  // predicate buyer.tsx uses to route Continue → /intake, so the payment counter
+  // and the funnel can never disagree.
+  const hasAnyIntakeSchema = React.useMemo<boolean>(() => {
+    if (intakeSchemasQuery.data === undefined) return false;
+    for (const line of lines) {
+      const schema = intakeSchemasQuery.data.get(line.ticketTypeId);
+      if (schema !== undefined && schema.questions.length > 0) return true;
+    }
+    return false;
+  }, [intakeSchemasQuery.data, lines]);
+  const totalSteps = tripFunnelTotalSteps(hasAnyIntakeSchema);
+  const paymentStepIndex = tripPaymentStepIndex(hasAnyIntakeSchema);
 
   // Defensive shell while guards redirect.
   if (
@@ -615,7 +628,7 @@ function CheckoutTripPaymentScreenContent({
     return (
       <View style={styles.host}>
         <CheckoutHeader
-          stepIndex={1}
+          stepIndex={paymentStepIndex}
           totalSteps={totalSteps}
           title="Review & pay"
           onBack={handleBack}
@@ -627,7 +640,7 @@ function CheckoutTripPaymentScreenContent({
   return (
     <View style={styles.host}>
       <CheckoutHeader
-        stepIndex={1}
+        stepIndex={paymentStepIndex}
         totalSteps={totalSteps}
         title="Review & pay"
         onBack={handleBack}

--- a/mingla-business/app/checkout-trip/[tripEventId]/tripFunnelSteps.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/tripFunnelSteps.ts
@@ -1,0 +1,30 @@
+/**
+ * ORCH-1178 [trip-checkout-always-cart-step] — pure helper for the trip
+ * checkout funnel length, extracted so the step-counter wiring is unit-testable
+ * without rendering the expo-router screens.
+ *
+ * Background (INVESTIGATE_ORCH-1178): the trip checkout ALWAYS shows the
+ * cart/quantity step now (single AND multi tier — the ORCH-1130/1176 single-tier
+ * auto-skip is removed). The visible sequence is therefore:
+ *
+ *   index (cart) → buyer (details) → [intake, only if the trip requires it] → payment
+ *
+ * so the funnel is 4 steps when an intake form is present, else 3. The intake
+ * step itself renders its own inline "3 OF N" header; index/buyer/payment use
+ * CheckoutHeader and derive their `totalSteps` from this helper (NEVER a literal
+ * 2 — that was the ORCH-1176 collapse the always-cart-step supersedes).
+ *
+ * `stepIndex` is the 0-indexed position in that sequence:
+ *   index = 0 ("1 OF N"), buyer = 1 ("2 OF N"),
+ *   payment = N-1 (last; "3 OF 3" no-intake / "4 OF 4" with intake).
+ */
+
+/** Total visible steps: 4 with an intake form, 3 without. */
+export function tripFunnelTotalSteps(hasIntake: boolean): 3 | 4 {
+  return hasIntake ? 4 : 3;
+}
+
+/** 0-indexed payment step (the last step): N-1. */
+export function tripPaymentStepIndex(hasIntake: boolean): 2 | 3 {
+  return hasIntake ? 3 : 2;
+}

--- a/mingla-business/src/components/checkout/CheckoutHeader.tsx
+++ b/mingla-business/src/components/checkout/CheckoutHeader.tsx
@@ -21,14 +21,20 @@ import { IconChrome } from "../ui/IconChrome";
 import { Pill } from "../ui/Pill";
 
 export interface CheckoutHeaderProps {
-  /** 0-indexed step (0=Tickets, 1=Buyer, 2=Payment). */
-  stepIndex: 0 | 1 | 2;
   /**
-   * Total visible steps. The event-side funnel is 3; the ORCH-1130 trip funnel
-   * collapses single-tier trips to 2 ("Your details" → "Review & pay"). The
-   * multi-tier trip fallback + all event checkouts keep 3.
+   * 0-indexed step. Event-side: 0=Tickets, 1=Buyer, 2=Payment. ORCH-1178 trip
+   * funnel ALWAYS shows the cart step (index=0) so the trip sequence is
+   * index(0) → buyer(1) → [intake] → payment(2 without intake, 3 with intake);
+   * the intake step itself renders its own inline "3 OF N" header.
    */
-  totalSteps: 2 | 3;
+  stepIndex: 0 | 1 | 2 | 3;
+  /**
+   * Total visible steps. Event checkouts are 3. ORCH-1178 trips ALWAYS keep the
+   * cart/quantity step, so the trip funnel is 3 (no intake) or 4 (intake
+   * present). (Legacy 2 retained for source-compat; the trip funnel no longer
+   * collapses to 2 — ORCH-1178 supersedes the ORCH-1130 single-tier auto-skip.)
+   */
+  totalSteps: 2 | 3 | 4;
   title: string;
   onBack: () => void;
 }


### PR DESCRIPTION
Two trip-flow fixes from Seth device testing. Client-side only, no migrations.

## ORCH-1178 — trip checkout ALWAYS shows the cart/quantity step (business app + buyer web)
A single-tier trip still auto-skipped the cart step: the buyer briefly saw "Reserve your spot" then it auto-`router.replace`'d to "your details" (counter "1 OF 2"), and couldn't edit quantity. The prior ORCH-1176 fix only gated the multi-seed path; the `decideAutoSkip` path still navigated for single-tier.
- `index.tsx`: both auto-navigate paths now SEED the cart but never `router.replace` — the cart/quantity step always stays; the buyer edits quantity and taps Continue. `decideAutoSkip` (pure fn) + its unit test left byte-identical.
- Step counters: new `tripFunnelSteps.ts` derives total (3, or 4 when an intake step is present); `buyer.tsx`/`payment.tsx` use it and the latent stepIndex bug is fixed → sequence reads 1/2/[3]/N OF N. `CheckoutHeader` widened to 4-step.
- Supersedes the ORCH-1130 single-tier auto-skip behaviorally (no gate/test touched).

## ORCH-1179 — consumer trip page installment (payment-plan) parity
The consumer trip page showed no pay-in-full/pay-over-time toggle, no split CTAs, no cart deposit-lead. Root cause: a one-line double-unwrap in the consumer read hook — `extractTripInstallmentSchedule(t.installments)` was fed the already-inner template, so it unwrapped `.installments` again → null schedule for every tier. The business twin reads it correctly.
- `useConsumerTripDetail.ts`: feed `t.tierMetadata` (the full metadata the extractor expects). Restores split CTAs + §10 toggle + deposit lead. Consumer already renders the shared `TripOfferingBody` (no fork); this one arg was the only break. Full section-by-section audit found no other gaps.

## Tests
New happy + adversarial suites per ORCH (checkout-trip jest + consumer hook node:test), all passing; `orch_1130_auto_skip_latch` unchanged + green. One existing test (`orch_1176_funnel_wiring.test.ts`) retargeted to the 1178 contract under `[TEST-MOD-APPROVED ORCH-1178]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)