### PR TITLE
ORCH-1180: trip checkout cart is installment-aware

### DIFF
--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -50,6 +50,10 @@ import { EmptyState } from "../../../src/components/ui/EmptyState";
 import { EventCoverMedia } from "../../../src/components/ui/EventCoverMedia";
 import { decideAutoSkip } from "./autoSkipDecision";
 import { tripFunnelTotalSteps } from "./tripFunnelSteps";
+import {
+  parseSeededTripLines,
+  resolveSeededCartPlanChoice,
+} from "../../../src/components/trip/tripCartPlanChoice";
 
 import {
   useCart,
@@ -143,34 +147,15 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
   // present we seed the cart with ALL selected packages (skipping tier-select),
   // mirroring ORCH-1138 "Reserve opens the cart directly". Parsed once (stable
   // string); malformed → empty (the auto-skip / tier-select path takes over).
-  const seededLinesParam = React.useMemo<
-    Array<{ ticketTypeId: string; quantity: number }>
-  >(() => {
-    if (typeof params.lines !== "string" || params.lines.length === 0) return [];
-    try {
-      const parsed: unknown = JSON.parse(params.lines);
-      if (!Array.isArray(parsed)) return [];
-      return parsed.flatMap((row) => {
-        if (
-          row !== null &&
-          typeof row === "object" &&
-          typeof (row as { ticketTypeId?: unknown }).ticketTypeId === "string" &&
-          typeof (row as { quantity?: unknown }).quantity === "number" &&
-          (row as { quantity: number }).quantity > 0
-        ) {
-          return [
-            {
-              ticketTypeId: (row as { ticketTypeId: string }).ticketTypeId,
-              quantity: Math.floor((row as { quantity: number }).quantity),
-            },
-          ];
-        }
-        return [];
-      });
-    } catch {
-      return [];
-    }
-  }, [params.lines]);
+  // ORCH-1180 — each row may also carry the per-package `paymentPlanChoice`
+  // ("full" | "installments"). It is the AUTHORITATIVE pay-over-time signal (the
+  // scalar `plan` param can lag the §10 box toggle); the seed effect below uses it
+  // to set the cart-level choice so the cart is installment-aware. Absent/unknown
+  // values are dropped (the line stays a plain full-price line).
+  const seededLinesParam = React.useMemo(
+    () => parseSeededTripLines(params.lines),
+    [params.lines],
+  );
 
   const publicTripQuery = usePublicTripById(tripEventId);
   const trip = publicTripQuery.data?.trip ?? null;
@@ -254,9 +239,16 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
     dueTodayCents === null;
 
   // ORCH-1130 — seed the cart's payment-plan choice from the public-page param.
+  // ORCH-1180 — the `lines` JSON is the AUTHORITATIVE pay-over-time source: if ANY
+  // seeded package carries paymentPlanChoice="installments", the whole cart leads
+  // with the deposit (mirrors the consumer session-wide choice + Fix A's collapse),
+  // overriding a possibly-stale scalar `plan` param. No installments line → honor
+  // the scalar param (default "full"), so the pay-in-full opt-out is preserved.
   useEffect(() => {
-    setPaymentPlanChoice(planParam);
-    // Run once per mount with the inbound param; the Review step is the
+    setPaymentPlanChoice(
+      resolveSeededCartPlanChoice(seededLinesParam, planParam),
+    );
+    // Run once per mount with the inbound params; the Review step is the
     // last-chance editor thereafter.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
+++ b/mingla-business/app/t/[brandSlug]/[tripSlug].tsx
@@ -64,6 +64,7 @@ import {
   buildTripOfferingBrand,
   buildTripOfferingData,
 } from "../../../src/components/trip/tripOfferingAdapter";
+import { collapseTripPlanChoice } from "../../../src/components/trip/tripCartPlanChoice";
 
 export default function PublicTripRoute(): React.ReactElement {
   const router = useRouter();
@@ -407,8 +408,16 @@ const ResolvedTripPage: React.FC<{
   // META-ORCH-1174 Leg B3 — the bars + desktop control fire Reserve with the SAME
   // selected lines the §10 box reads (DEC-B). Empty selection → no lines → the cart
   // opens to pick (never a dead tap; the CTA itself is gated by reserveTappable).
-  const reserveSelected = (): void =>
-    handleTripReserve(undefined, offeringState.selectedLines);
+  // ORCH-1180 — collapse the per-package plan choice into the cart-level choice
+  // (mirrors the consumer ConsumerTripDetailScreen). If ANY selected line pays over
+  // time, the whole cart leads with the deposit; else "full" (NOT "auto", so no
+  // installment rows are minted when no package is on a plan — pay-in-full opt-out).
+  const reserveSelected = (): void => {
+    handleTripReserve(
+      collapseTripPlanChoice(offeringState.selectedLines),
+      offeringState.selectedLines,
+    );
+  };
   const reserveControl = (
     <View>
       <Pressable

--- a/mingla-business/src/components/trip/__tests__/tripCartInstallmentAware_orch_1180_adversarial.test.ts
+++ b/mingla-business/src/components/trip/__tests__/tripCartInstallmentAware_orch_1180_adversarial.test.ts
@@ -1,0 +1,152 @@
+/**
+ * ORCH-1180 [trip-cart-installment-aware] — adversarial suite (implementor-owned,
+ * different angle from the happy regression).
+ *
+ * Attacks the collapse + seed-resolve logic at the edges that protect the existing
+ * gates:
+ *   (a) ALL lines "full" → choice "full" (NOT "auto") so NO installment rows are
+ *       minted — i-proposed-pay-in-full-opt-out-no-installment-rows.
+ *   (b) MIXED (one line installments, one full) → the whole cart goes
+ *       "installments" (the documented session-wide-choice behavior).
+ *   (c) a `lines` JSON that carries paymentPlanChoice but a STALE scalar plan=full
+ *       → Fix B still sets the cart to "installments" (lines JSON is the source of
+ *       truth — this is the literal ORCH-1180 root cause).
+ * Plus malformed-input hardening so a bad param can never force a plan / crash.
+ *
+ * Synthetic fixtures only (0/8 live brands set plans).
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import {
+  collapseTripPlanChoice,
+  parseSeededTripLines,
+  resolveSeededCartPlanChoice,
+  type SeededTripLine,
+} from "../tripCartPlanChoice";
+
+describe("ORCH-1180 adversarial (a) — pay-in-full opt-out: no plan rows", () => {
+  test("ALL lines 'full' → collapse yields exactly 'full', never 'auto'", () => {
+    const lines = [
+      { ticketTypeId: "a", quantity: 1, paymentPlanChoice: "full" as const },
+      { ticketTypeId: "b", quantity: 2, paymentPlanChoice: "full" as const },
+    ];
+    const choice = collapseTripPlanChoice(lines);
+    expect(choice).toBe("full");
+    expect(choice).not.toBe("auto");
+  });
+
+  test("lines with NO plan field (plain full-price) → 'full'", () => {
+    const lines: SeededTripLine[] = [
+      { ticketTypeId: "a", quantity: 1 },
+      { ticketTypeId: "b", quantity: 1 },
+    ];
+    expect(collapseTripPlanChoice(lines)).toBe("full");
+  });
+
+  test("empty selection → 'full' (never 'auto', never a plan)", () => {
+    expect(collapseTripPlanChoice([])).toBe("full");
+  });
+
+  test("seed resolve with no installments line honors a 'full' scalar param", () => {
+    const seeded = parseSeededTripLines(
+      JSON.stringify([{ ticketTypeId: "a", quantity: 1, paymentPlanChoice: "full" }]),
+    );
+    expect(resolveSeededCartPlanChoice(seeded, "full")).toBe("full");
+  });
+});
+
+describe("ORCH-1180 adversarial (b) — mixed selection → whole cart goes plan", () => {
+  test("one line installments + one line full → collapse yields 'installments'", () => {
+    const lines = [
+      { ticketTypeId: "a", quantity: 1, paymentPlanChoice: "full" as const },
+      { ticketTypeId: "b", quantity: 1, paymentPlanChoice: "installments" as const },
+    ];
+    expect(collapseTripPlanChoice(lines)).toBe("installments");
+  });
+
+  test("seed resolve: a mixed lines JSON → cart-level 'installments'", () => {
+    const seeded = parseSeededTripLines(
+      JSON.stringify([
+        { ticketTypeId: "a", quantity: 1, paymentPlanChoice: "full" },
+        { ticketTypeId: "b", quantity: 1, paymentPlanChoice: "installments" },
+      ]),
+    );
+    expect(resolveSeededCartPlanChoice(seeded, "full")).toBe("installments");
+  });
+});
+
+describe("ORCH-1180 adversarial (c) — lines JSON overrides a STALE scalar param", () => {
+  test("plan=full scalar BUT a line is installments → cart is 'installments'", () => {
+    // The literal ORCH-1180 root cause: the box toggle never updated the scalar
+    // route plan, so plan=full arrived stale. The lines JSON must win.
+    const seeded = parseSeededTripLines(
+      JSON.stringify([
+        { ticketTypeId: "vip", quantity: 1, paymentPlanChoice: "installments" },
+      ]),
+    );
+    expect(resolveSeededCartPlanChoice(seeded, "full")).toBe("installments");
+  });
+
+  test("no lines carry a choice → the scalar param is honored unchanged", () => {
+    const seeded = parseSeededTripLines(
+      JSON.stringify([{ ticketTypeId: "a", quantity: 1 }]),
+    );
+    // a route that DID set plan=installments (e.g. single-tier split CTA) still works.
+    expect(resolveSeededCartPlanChoice(seeded, "installments")).toBe("installments");
+    expect(resolveSeededCartPlanChoice(seeded, "full")).toBe("full");
+  });
+});
+
+describe("ORCH-1180 parse hardening — malformed input can't force a plan / crash", () => {
+  test("undefined / empty string → []", () => {
+    expect(parseSeededTripLines(undefined)).toEqual([]);
+    expect(parseSeededTripLines("")).toEqual([]);
+  });
+
+  test("non-JSON → [] (no throw)", () => {
+    expect(parseSeededTripLines("{not json")).toEqual([]);
+  });
+
+  test("non-array JSON → []", () => {
+    expect(parseSeededTripLines(JSON.stringify({ ticketTypeId: "a", quantity: 1 }))).toEqual(
+      [],
+    );
+  });
+
+  test("rows with bad/zero quantity or missing id are dropped", () => {
+    const parsed = parseSeededTripLines(
+      JSON.stringify([
+        { ticketTypeId: "a", quantity: 0 },
+        { ticketTypeId: "b", quantity: -3, paymentPlanChoice: "installments" },
+        { quantity: 1, paymentPlanChoice: "installments" },
+        { ticketTypeId: "ok", quantity: 2 },
+      ]),
+    );
+    expect(parsed).toEqual([{ ticketTypeId: "ok", quantity: 2 }]);
+  });
+
+  test("an UNKNOWN paymentPlanChoice value is dropped (line stays plain full)", () => {
+    const parsed = parseSeededTripLines(
+      JSON.stringify([
+        { ticketTypeId: "a", quantity: 1, paymentPlanChoice: "auto" },
+        { ticketTypeId: "b", quantity: 1, paymentPlanChoice: 42 },
+      ]),
+    );
+    expect(parsed).toEqual([
+      { ticketTypeId: "a", quantity: 1 },
+      { ticketTypeId: "b", quantity: 1 },
+    ]);
+    // a garbage choice must NOT collapse the cart into a plan.
+    expect(resolveSeededCartPlanChoice(parsed, "full")).toBe("full");
+  });
+
+  test("quantity is floored (no fractional seeded qty)", () => {
+    const parsed = parseSeededTripLines(
+      JSON.stringify([{ ticketTypeId: "a", quantity: 2.9, paymentPlanChoice: "installments" }]),
+    );
+    expect(parsed).toEqual([
+      { ticketTypeId: "a", quantity: 2, paymentPlanChoice: "installments" },
+    ]);
+  });
+});

--- a/mingla-business/src/components/trip/__tests__/tripCartInstallmentAware_orch_1180_regression.test.ts
+++ b/mingla-business/src/components/trip/__tests__/tripCartInstallmentAware_orch_1180_regression.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ORCH-1180 [trip-cart-installment-aware] — happy-path regression
+ * (implementor-owned).
+ *
+ * Proves the per-package "pay over time" choice the §10 box selects now reaches
+ * the cart-level CartContext.paymentPlanChoice the whole checkout reads, across
+ * BOTH drop points that were broken:
+ *   FIX A — the public page Reserve collapses the selected lines into the cart
+ *           choice (was passing `undefined` → fell back to a stale route param).
+ *   FIX B — the checkout cart seed parses each line's paymentPlanChoice and lets
+ *           the lines JSON override a stale scalar `plan` param.
+ *
+ * mingla-business Jest runs node-env / ts-jest (no RN renderer), so this proves
+ * the redesign two ways that BOTH bite on revert:
+ *   (1) REAL-logic: the extracted pure helpers (collapse + parse + resolve).
+ *   (2) Source-characterization: the public page + checkout index actually CALL
+ *       the helpers (so the wiring can't silently revert to `undefined`/drop).
+ *
+ * The tester writes a SEPARATE adversarial suite on a different angle.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { readFileSync } from "fs";
+import path from "path";
+
+import {
+  collapseTripPlanChoice,
+  parseSeededTripLines,
+  resolveSeededCartPlanChoice,
+} from "../tripCartPlanChoice";
+
+const read = (rel: string): string =>
+  readFileSync(path.join(process.cwd(), rel), "utf8");
+
+const slugSrc = (): string => read("app/t/[brandSlug]/[tripSlug].tsx");
+const checkoutIndexSrc = (): string =>
+  read("app/checkout-trip/[tripEventId]/index.tsx");
+
+describe("ORCH-1180 FIX A — public page Reserve collapses the plan choice", () => {
+  test("a selected line on a plan → the cart-level choice is 'installments'", () => {
+    const lines = [
+      { ticketTypeId: "vip", quantity: 1, paymentPlanChoice: "installments" as const },
+    ];
+    expect(collapseTripPlanChoice(lines)).toBe("installments");
+  });
+
+  test("the public page Reserve calls collapseTripPlanChoice (not undefined)", () => {
+    const src = slugSrc();
+    expect(src).toContain("collapseTripPlanChoice(offeringState.selectedLines)");
+    // and forwards the SAME selected lines as the JSON `lines` param.
+    expect(src).toContain("offeringState.selectedLines,");
+  });
+});
+
+describe("ORCH-1180 FIX B — checkout cart seed reads the per-line choice", () => {
+  test("parse reads an optional paymentPlanChoice per row", () => {
+    const json = JSON.stringify([
+      { ticketTypeId: "a", quantity: 2, paymentPlanChoice: "installments" },
+    ]);
+    const parsed = parseSeededTripLines(json);
+    expect(parsed).toEqual([
+      { ticketTypeId: "a", quantity: 2, paymentPlanChoice: "installments" },
+    ]);
+  });
+
+  test("a seeded line carrying 'installments' → the cart choice is 'installments'", () => {
+    const seeded = parseSeededTripLines(
+      JSON.stringify([{ ticketTypeId: "a", quantity: 1, paymentPlanChoice: "installments" }]),
+    );
+    // even if the scalar plan param defaulted to "full", the lines JSON wins.
+    expect(resolveSeededCartPlanChoice(seeded, "full")).toBe("installments");
+  });
+
+  test("the checkout index calls the parse + resolve helpers + sets the cart choice", () => {
+    const src = checkoutIndexSrc();
+    expect(src).toContain("parseSeededTripLines(params.lines)");
+    expect(src).toContain(
+      "resolveSeededCartPlanChoice(seededLinesParam, planParam)",
+    );
+    // the resolved choice is what seeds CartContext.paymentPlanChoice.
+    expect(src).toContain("setPaymentPlanChoice(");
+  });
+});
+
+describe("ORCH-1180 the cart is then AWARE — deposit branch fires on 'installments'", () => {
+  // The checkout index's dueTodayCents memo (the "cart is aware" proof) is gated
+  // on paymentPlanChoice === "installments". Once Fix A/B set that, the existing
+  // projectInstallmentSchedule deposit branch + schedule + Pay-button deposit
+  // label all fire. Characterize that gate so it can't silently drop.
+  test("dueTodayCents is non-null ONLY under the installments cart choice", () => {
+    const src = checkoutIndexSrc();
+    expect(src).toContain('if (paymentPlanChoice !== "installments"');
+    expect(src).toContain("projectInstallmentSchedule(");
+    expect(src).toContain("projected.depositCents");
+  });
+});

--- a/mingla-business/src/components/trip/tripCartPlanChoice.ts
+++ b/mingla-business/src/components/trip/tripCartPlanChoice.ts
@@ -1,0 +1,109 @@
+/**
+ * tripCartPlanChoice — ORCH-1180 [trip-cart-installment-aware].
+ *
+ * Two tiny pure helpers that carry the buyer's per-package "pay over time" choice
+ * from the public trip page §10 box all the way into the cart-level
+ * CartContext.paymentPlanChoice the whole checkout reads. Before this, the
+ * per-package choice (selectedLine.paymentPlanChoice) was dropped twice — the
+ * public page reserved with `undefined` and the checkout cart seed parsed only
+ * {ticketTypeId, quantity} — so the cart never learned the buyer wanted a plan and
+ * charged the full price with no deposit/schedule.
+ *
+ * Both helpers COLLAPSE per-line choices into the single session-wide cart choice
+ * (mirrors the consumer ConsumerTripDetailScreen): if ANY selected/seeded line pays
+ * over time, the whole cart leads with the deposit; otherwise "full" (NEVER "auto",
+ * so no installment rows are minted when no package is on a plan — the pay-in-full
+ * opt-out, i-proposed-pay-in-full-opt-out-no-installment-rows). No money is computed
+ * here — the cart's existing projectInstallmentSchedule branch owns deposit/schedule.
+ */
+
+import type { TripPaymentPlanChoice } from "@mingla/offering-rendering";
+
+/**
+ * Minimal line shape both the reserve collapse + the seed resolve read. Only
+ * `paymentPlanChoice` is consulted; the real selected/seeded lines carry more
+ * fields, which is why the helpers take a structural-supertype generic below.
+ */
+export interface TripCartLineChoice {
+  paymentPlanChoice?: TripPaymentPlanChoice;
+}
+
+/**
+ * FIX A — collapse the per-package plan choice of the selected lines into the
+ * cart-level choice for the public-page Reserve. Any line on a plan → the whole
+ * cart goes "installments"; else "full". Generic over the line shape so the real
+ * selected/seeded lines (with ticketTypeId/quantity) pass without widening.
+ */
+export const collapseTripPlanChoice = (
+  lines: ReadonlyArray<TripCartLineChoice>,
+): TripPaymentPlanChoice =>
+  lines.some((l) => l.paymentPlanChoice === "installments")
+    ? "installments"
+    : "full";
+
+/** A seeded checkout line parsed from the `lines` route param JSON. */
+export interface SeededTripLine {
+  ticketTypeId: string;
+  quantity: number;
+  paymentPlanChoice?: TripPaymentPlanChoice;
+}
+
+/**
+ * FIX B — parse the checkout `lines` route param into seeded cart lines, reading
+ * each row's OPTIONAL paymentPlanChoice ("full" | "installments"). Malformed input
+ * → []. Unknown/absent choice → the line is a plain full-price line (no choice).
+ * This is the AUTHORITATIVE pay-over-time source: a stale scalar `plan` param can
+ * disagree, but the lines JSON is what the §10 box actually selected.
+ */
+export const parseSeededTripLines = (
+  raw: string | undefined,
+): SeededTripLine[] => {
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.flatMap((row) => {
+    if (
+      row !== null &&
+      typeof row === "object" &&
+      typeof (row as { ticketTypeId?: unknown }).ticketTypeId === "string" &&
+      typeof (row as { quantity?: unknown }).quantity === "number" &&
+      (row as { quantity: number }).quantity > 0
+    ) {
+      const rawChoice = (row as { paymentPlanChoice?: unknown })
+        .paymentPlanChoice;
+      const choice: TripPaymentPlanChoice | undefined =
+        rawChoice === "installments"
+          ? "installments"
+          : rawChoice === "full"
+            ? "full"
+            : undefined;
+      return [
+        {
+          ticketTypeId: (row as { ticketTypeId: string }).ticketTypeId,
+          quantity: Math.floor((row as { quantity: number }).quantity),
+          ...(choice !== undefined ? { paymentPlanChoice: choice } : {}),
+        },
+      ];
+    }
+    return [];
+  });
+};
+
+/**
+ * FIX B — given the seeded lines parsed above and the inbound scalar `plan` param,
+ * resolve the cart-level choice the seed effect should set. The lines JSON wins: if
+ * any seeded line is "installments" the cart leads with the deposit, overriding a
+ * possibly-stale scalar param; otherwise honor the scalar param (default "full").
+ */
+export const resolveSeededCartPlanChoice = (
+  seededLines: ReadonlyArray<TripCartLineChoice>,
+  scalarPlanParam: TripPaymentPlanChoice,
+): TripPaymentPlanChoice =>
+  seededLines.some((l) => l.paymentPlanChoice === "installments")
+    ? "installments"
+    : scalarPlanParam;


### PR DESCRIPTION
The trip checkout cart ignored the buyer's "pay over time" choice — it showed/charged the full price instead of the deposit due today + schedule. The per-package plan choice (`planChoiceByTier` / each `selectedLine.paymentPlanChoice`) never reached the cart-level `CartContext.paymentPlanChoice` the whole checkout reads.

Two drops, both fixed (UI/wiring only — backend already supports the deposit+schedule charge; consumer app already did this):
- **Fix A** — `reserveSelected` (public page) collapses the selected lines into the cart choice (`collapseTripPlanChoice`): any line on a plan → "installments", else "full" (never "auto").
- **Fix B** — checkout `index.tsx` parses each `lines`-JSON row's `paymentPlanChoice` and the seed effect sets the cart choice from it (authoritative source, overrides a stale scalar `plan` param). This is what makes the §10 box's own CTA path correct.

New pure helper `tripCartPlanChoice.ts` (collapse + parse + resolve). Once the cart flag is set, the existing machinery shows "Due today"/deposit + schedule + forwards `payment_plan_choice` to the checkout session — buyer.tsx/payment.tsx unchanged.

Gates green: orch-1147-cart-total-is-allin, orch-1147r2-selection-shows-allin, i-proposed-pay-in-full-opt-out-no-installment-rows. New happy + adversarial suites 20/20. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)