### PR TITLE
ORCH-1171: Consumer keyboard Done bar + zero field occlusion (#556)

### DIFF
--- a/app-mobile/app.config.ts
+++ b/app-mobile/app.config.ts
@@ -6,6 +6,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   slug: config.slug ?? "mingla",
   plugins: [
     ...(config.plugins ?? []),
+    "./plugins/withGooglePodsModularHeaders",
     [
       "@react-native-google-signin/google-signin",
       {

--- a/app-mobile/app/_layout.tsx
+++ b/app-mobile/app/_layout.tsx
@@ -35,6 +35,9 @@ import { queryClient, asyncStoragePersister } from "../src/config/queryClient";
 import { shouldDehydrateMinglaQuery } from "../src/utils/queryPersistence";
 import { useAppStore } from "../src/store/appStore";
 import AnimatedSplashScreen from "../src/components/AnimatedSplashScreen";
+// ORCH-1171: Done-only keyboard accessory bar + native keyboard frame provider.
+import { KeyboardRoot } from "../src/wrappers/KeyboardRoot";
+import { KeyboardToolbarRoot } from "../src/wrappers/KeyboardToolbarRoot";
 
 // ORCH-0679 Wave 2B-2: SINGLE source of truth for Sentry init.
 // I-SENTRY-SINGLE-INIT — duplicate Sentry.init in app/index.tsx was deleted as
@@ -164,23 +167,27 @@ export default Sentry.wrap(function RootLayout() {
             resolves before the provider mounts. Exactly ONE provider app-wide —
             do NOT re-add one in any route file (index.tsx). */}
         {cacheReady && (
-          <PersistQueryClientProvider
-            client={queryClient}
-            persistOptions={{
-              persister: asyncStoragePersister,
-              maxAge: 24 * 60 * 60 * 1000, // 24 hours
+          <KeyboardRoot>
+            <PersistQueryClientProvider
+              client={queryClient}
+              persistOptions={{
+                persister: asyncStoragePersister,
+                maxAge: 24 * 60 * 60 * 1000, // 24 hours
 
-              dehydrateOptions: {
-                // Exclude large/transient queries from persistence to prevent
-                // Android CursorWindow overflow (2MB SQLite row limit)
-                shouldDehydrateQuery: (query) => {
-                  return shouldDehydrateMinglaQuery(query, useAppStore.getState().user?.id ?? null);
+                dehydrateOptions: {
+                  // Exclude large/transient queries from persistence to prevent
+                  // Android CursorWindow overflow (2MB SQLite row limit)
+                  shouldDehydrateQuery: (query) => {
+                    return shouldDehydrateMinglaQuery(query, useAppStore.getState().user?.id ?? null);
+                  },
                 },
-              },
-            }}
-          >
-            <Stack screenOptions={{ headerShown: false }} />
-          </PersistQueryClientProvider>
+              }}
+            >
+              <Stack screenOptions={{ headerShown: false }} />
+            </PersistQueryClientProvider>
+            {/* Sibling so the toolbar stays visually above the keyboard. */}
+            <KeyboardToolbarRoot />
+          </KeyboardRoot>
         )}
         {/* ORCH-1125: AnimatedSplashScreen renders immediately (independent of
             cacheReady) so its own useEffect fires as soon as it's painted — that's

--- a/app-mobile/package-lock.json
+++ b/app-mobile/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "mingla",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo-google-fonts/anton": "^0.4.2",
         "@expo-google-fonts/bebas-neue": "^0.4.1",
@@ -81,6 +82,7 @@
         "react-native-appsflyer": "^6.17.8",
         "react-native-compressor": "^1.18.2",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-keyboard-controller": "^1.18.5",
         "react-native-onesignal": "^5.3.3",
         "react-native-purchases": "^9.12.0",
         "react-native-purchases-ui": "^9.12.0",
@@ -4113,7 +4115,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.17",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5821,7 +5823,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -11588,6 +11590,20 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.5.tgz",
+      "integrity": "sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
+      }
+    },
     "node_modules/react-native-onesignal": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/react-native-onesignal/-/react-native-onesignal-5.3.3.tgz",
@@ -13255,7 +13271,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/app-mobile/package.json
+++ b/app-mobile/package.json
@@ -81,7 +81,8 @@
     "test:orch-1163-going-confirm": "node ./scripts/ci/orch-1163-rsvp-going-confirm-check.mjs",
     "test:orch-1163-plus-one-per-guest": "node ./scripts/ci/orch-1163-rsvp-plus-one-per-guest-check.mjs",
     "test:orch-1163-going-calendar-qr": "node ./scripts/ci/orch-1163-rsvp-going-calendar-qr-check.mjs",
-    "test:orch-1163-guest-notify-match": "node ./scripts/ci/orch-1163-rsvp-guest-notify-match-check.mjs"
+    "test:orch-1163-guest-notify-match": "node ./scripts/ci/orch-1163-rsvp-guest-notify-match-check.mjs",
+    "test:orch-1171": "node ./scripts/ci/orch-1171-keyboard-done-bar-check.mjs && node --test src/wrappers/__tests__/orch_1171_keyboard_toolbar_mount_coverage.test.mjs"
   },
   "dependencies": {
     "@expo-google-fonts/anton": "^0.4.2",
@@ -157,6 +158,7 @@
     "react-native-appsflyer": "^6.17.8",
     "react-native-compressor": "^1.18.2",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-keyboard-controller": "^1.18.5",
     "react-native-onesignal": "^5.3.3",
     "react-native-purchases": "^9.12.0",
     "react-native-purchases-ui": "^9.12.0",

--- a/app-mobile/plugins/withGooglePodsModularHeaders.js
+++ b/app-mobile/plugins/withGooglePodsModularHeaders.js
@@ -1,0 +1,58 @@
+const { withDangerousMod } = require("@expo/config-plugins");
+const fs = require("fs");
+const path = require("path");
+
+// Copyright Mingla. ORCH-1129 / ORCH-1171 (ported from mingla-business).
+//
+// The Google Sign-In pod chain needs modular headers for AppCheckCore's ObjC deps.
+// Without this, fresh EAS iOS builds fail at pod install (COMMS-0031).
+
+const MARKER = "ORCH-1129 modular headers";
+const MODULAR_PODS = ["GoogleUtilities", "RecaptchaInterop", "AppCheckCore"];
+
+const BLOCK =
+  `  # ${MARKER}: GoogleSignIn 9.x → AppCheckCore (Swift) needs module maps for\n` +
+  `  # these non-modular deps under static libraries. Injected by\n` +
+  `  # plugins/withGooglePodsModularHeaders.js.\n` +
+  MODULAR_PODS.map((p) => `  pod '${p}', :modular_headers => true`).join("\n") +
+  "\n";
+
+const withGooglePodsModularHeaders = (config) =>
+  withDangerousMod(config, [
+    "ios",
+    (cfg) => {
+      const podfilePath = path.join(
+        cfg.modRequest.platformProjectRoot,
+        "Podfile",
+      );
+      if (!fs.existsSync(podfilePath)) {
+        return cfg;
+      }
+      let contents = fs.readFileSync(podfilePath, "utf8");
+
+      if (contents.includes(MARKER)) {
+        return cfg;
+      }
+
+      const expoAnchor = "use_expo_modules!";
+      const expoIdx = contents.indexOf(expoAnchor);
+      if (expoIdx !== -1) {
+        const lineStart = contents.lastIndexOf("\n", expoIdx) + 1;
+        contents =
+          contents.slice(0, lineStart) + BLOCK + contents.slice(lineStart);
+      } else {
+        const m = contents.match(/^target ['"][^'"]+['"] do[^\n]*\n/m);
+        if (!m) {
+          return cfg;
+        }
+        const insertAt = m.index + m[0].length;
+        contents =
+          contents.slice(0, insertAt) + BLOCK + contents.slice(insertAt);
+      }
+
+      fs.writeFileSync(podfilePath, contents);
+      return cfg;
+    },
+  ]);
+
+module.exports = withGooglePodsModularHeaders;

--- a/app-mobile/scripts/ci/orch-1171-keyboard-done-bar-check.mjs
+++ b/app-mobile/scripts/ci/orch-1171-keyboard-done-bar-check.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * ORCH-1171 — consumer keyboard Done bar CI gate.
+ * Fails if root/modal keyboard hosts or clearance constants regress.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+
+const checks = [
+  {
+    name: "app/_layout KeyboardRoot + KeyboardToolbarRoot",
+    pass: () => {
+      const s = read("app/_layout.tsx");
+      return (
+        /KeyboardRoot/.test(s) &&
+        /KeyboardToolbarRoot/.test(s) &&
+        /react-native-keyboard-controller/.test(read("package.json"))
+      );
+    },
+  },
+  {
+    name: "BaseBottomSheet per-modal KeyboardRoot",
+    pass: () => {
+      const s = read("src/components/ui/BaseBottomSheet.tsx");
+      return /<KeyboardRoot>/.test(s) && /wrapInRNModal/.test(s);
+    },
+  },
+  {
+    name: "keyboardConstants KEYBOARD_TOOLBAR_HEIGHT = 42",
+    pass: () => {
+      const s = read("src/wrappers/keyboardConstants.ts");
+      return /KEYBOARD_TOOLBAR_HEIGHT = 42/.test(s);
+    },
+  },
+  {
+    name: "withGooglePodsModularHeaders plugin registered",
+    pass: () =>
+      read("app.config.ts").includes('"./plugins/withGooglePodsModularHeaders"') &&
+      fs.existsSync(path.join(ROOT, "plugins/withGooglePodsModularHeaders.js")),
+  },
+  {
+    name: "CountryPickerModal per-window KeyboardProvider",
+    pass: () => {
+      const s = read("../packages/phone-input/CountryPickerModal.tsx");
+      return /<KeyboardProvider>/.test(s) && /<KeyboardToolbar/.test(s);
+    },
+  },
+];
+
+let failed = 0;
+for (const c of checks) {
+  if (c.pass()) {
+    console.log(`OK   ${c.name}`);
+  } else {
+    console.error(`FAIL ${c.name}`);
+    failed += 1;
+  }
+}
+
+if (failed > 0) {
+  process.exit(1);
+}
+
+console.log(`ORCH-1171 keyboard gate: ${checks.length}/${checks.length} passed`);

--- a/app-mobile/src/components/MessageInterface.tsx
+++ b/app-mobile/src/components/MessageInterface.tsx
@@ -60,6 +60,7 @@ import { useBoardSession } from "../hooks/useBoardSession";
 import { useConversationParticipants } from "../hooks/useConversationParticipants";
 import { useChatCardTagSource } from "../hooks/useChatCardTagSource";
 import { useChatInputController } from "../hooks/useChatInputController";
+import { KEYBOARD_TOOLBAR_HEIGHT } from "../wrappers/keyboardConstants";
 import ExpandedCardModal from "./ExpandedCardModal";  // ORCH-0667
 import { BaseBottomSheet } from "./ui/BaseBottomSheet";
 // ORCH-1138 Leg 3 — chat purchased-banner repointed off ExpandedBusinessEventSheet
@@ -1175,9 +1176,13 @@ export default function MessageInterface({
   // the actual visible keyboard, we need to account for it.
   const androidManualLift =
     Platform.OS === 'android' && keyboardVisible
-      ? Math.max(0, keyboardHeight + safeInsets.bottom - windowShrinkAmount)
+      ? Math.max(0, keyboardHeight + safeInsets.bottom - windowShrinkAmount) +
+        KEYBOARD_TOOLBAR_HEIGHT
       : 0;
-  const iosKeyboardLift = Platform.OS === 'ios' && keyboardVisible ? keyboardHeight : 0;
+  const iosKeyboardLift =
+    Platform.OS === 'ios' && keyboardVisible
+      ? keyboardHeight + KEYBOARD_TOOLBAR_HEIGHT
+      : 0;
 
   // When the keyboard is open, the floating bottom nav is hidden behind the
   // keyboard — the composer only needs a small breathing gap above the keyboard

--- a/app-mobile/src/components/activity/CalendarTab.tsx
+++ b/app-mobile/src/components/activity/CalendarTab.tsx
@@ -35,6 +35,7 @@ import { formatCurrency } from "../utils/formatters";
 import { useFeatureGate } from "../../hooks/useFeatureGate";
 import { CustomPaywallScreen } from "../CustomPaywallScreen";
 import { useKeyboard } from "../../hooks/useKeyboard";
+import { KEYBOARD_TOOLBAR_HEIGHT } from "../../wrappers/keyboardConstants";
 import { useTranslation } from 'react-i18next';
 // ORCH-1019 F-1: curated reschedule validation routes through the canonical
 // shared validator (extractWeekdayText + isPlaceOpenAt), same as SavedTab.
@@ -217,6 +218,8 @@ const CalendarTab = ({
   const { t } = useTranslation(['activity', 'common']);
   const { canAccess } = useFeatureGate();
   const { keyboardHeight } = useKeyboard({ disableLayoutAnimation: true });
+  const keyboardSpacerHeight =
+    keyboardHeight > 0 ? keyboardHeight + KEYBOARD_TOOLBAR_HEIGHT : 0;
   const [showLockedPaywall, setShowLockedPaywall] = useState(false);
   const [expandedCard, setExpandedCard] = useState<string | null>(null);
   const [currentImageIndex, setCurrentImageIndex] = useState<{
@@ -2766,7 +2769,9 @@ const CalendarTab = ({
                 })}
           </View>
         )}
-        {keyboardHeight > 0 && <View style={{ height: keyboardHeight }} />}
+        {keyboardSpacerHeight > 0 && (
+          <View style={{ height: keyboardSpacerHeight }} />
+        )}
       </ScrollView>
 
       {/* Propose Date & Time Modal */}

--- a/app-mobile/src/components/ui/BaseBottomSheet.tsx
+++ b/app-mobile/src/components/ui/BaseBottomSheet.tsx
@@ -70,6 +70,10 @@ import {
   pushHideBottomNav,
   popHideBottomNav,
 } from '../../store/bottomNavStore';
+// ORCH-1171: per-RN-Modal-window keyboard provider + Done bar. The app-root
+// KeyboardRoot in _layout.tsx does NOT reach into wrapInRNModal windows.
+import { KeyboardRoot } from '../../wrappers/KeyboardRoot';
+import { KeyboardToolbarRoot } from '../../wrappers/KeyboardToolbarRoot';
 
 // META-ORCH-0991 Wave B — keyboard-aware text input re-export. Form sheets
 // (ReportUserModal, CustomHolidayModal, …) need gorhom's BottomSheetTextInput
@@ -818,9 +822,12 @@ function BaseBottomSheetComponent(props: BaseBottomSheetProps): React.ReactEleme
         statusBarTranslucent
         navigationBarTranslucent
       >
-        <GestureHandlerRootView style={styles.flexContainer}>
-          {sheet}
-        </GestureHandlerRootView>
+        <KeyboardRoot>
+          <GestureHandlerRootView style={styles.flexContainer}>
+            {sheet}
+          </GestureHandlerRootView>
+          <KeyboardToolbarRoot />
+        </KeyboardRoot>
       </RNModal>
     );
   }

--- a/app-mobile/src/components/ui/KeyboardAwareScrollView.tsx
+++ b/app-mobile/src/components/ui/KeyboardAwareScrollView.tsx
@@ -46,14 +46,20 @@ function measureInWindow(
   // Neither path available — silently skip
 }
 import { useKeyboard } from "../../hooks/useKeyboard";
+import {
+  KEYBOARD_CLEARANCE_ABOVE_TOOLBAR,
+  KEYBOARD_TOOLBAR_HEIGHT,
+} from "../../wrappers/keyboardConstants";
 
 const SCREEN_HEIGHT = Dimensions.get("window").height;
 
 /**
  * Breathing room between the bottom of the focused input and the top of
- * the keyboard. Feels premium — not cramped, not wasteful.
+ * the keyboard toolbar (which sits on the keyboard). ORCH-1171: includes
+ * KEYBOARD_TOOLBAR_HEIGHT so fields stay above the Done bar.
  */
-const KEYBOARD_PADDING = 40;
+const KEYBOARD_PADDING =
+  KEYBOARD_CLEARANCE_ABOVE_TOOLBAR + KEYBOARD_TOOLBAR_HEIGHT;
 
 interface KeyboardAwareScrollViewProps extends ScrollViewProps {
   /**

--- a/app-mobile/src/components/ui/KeyboardAwareView.tsx
+++ b/app-mobile/src/components/ui/KeyboardAwareView.tsx
@@ -9,6 +9,7 @@ import {
   StyleProp,
 } from "react-native";
 import { useKeyboard } from "../../hooks/useKeyboard";
+import { KEYBOARD_TOOLBAR_HEIGHT } from "../../wrappers/keyboardConstants";
 
 interface KeyboardAwareViewProps {
   /**
@@ -70,9 +71,9 @@ export const KeyboardAwareView: React.FC<
 }) => {
   const { isVisible, keyboardHeight, dismiss } = useKeyboard();
 
-  // Effective padding: keyboard height minus any persistent bottom chrome
+  // Effective padding: keyboard height + Done toolbar minus persistent bottom chrome
   const effectivePadding = isVisible
-    ? Math.max(keyboardHeight - bottomOffset, 0)
+    ? Math.max(keyboardHeight + KEYBOARD_TOOLBAR_HEIGHT - bottomOffset, 0)
     : 0;
 
   const content = (

--- a/app-mobile/src/wrappers/KeyboardRoot.native.tsx
+++ b/app-mobile/src/wrappers/KeyboardRoot.native.tsx
@@ -1,0 +1,10 @@
+// ORCH-1171: KeyboardRoot — native variant. Wraps the app (or a per-Modal
+// window) in KeyboardProvider so KeyboardToolbar + KeyboardAwareScrollView
+// receive native keyboard frame events.
+
+import React from "react";
+import { KeyboardProvider } from "react-native-keyboard-controller";
+
+export const KeyboardRoot: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <KeyboardProvider>{children}</KeyboardProvider>;

--- a/app-mobile/src/wrappers/KeyboardRoot.tsx
+++ b/app-mobile/src/wrappers/KeyboardRoot.tsx
@@ -1,0 +1,8 @@
+// ORCH-1171: KeyboardRoot — web passthrough. react-native-keyboard-controller
+// has no web entry point; browsers handle keyboard avoidance natively.
+
+import React from "react";
+
+export const KeyboardRoot: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <>{children}</>;

--- a/app-mobile/src/wrappers/KeyboardToolbarRoot.native.tsx
+++ b/app-mobile/src/wrappers/KeyboardToolbarRoot.native.tsx
@@ -1,0 +1,30 @@
+// ORCH-1171: Done-only keyboard accessory bar for every consumer TextInput.
+
+import React from "react";
+import {
+  KeyboardToolbar,
+  type KeyboardToolbarProps,
+} from "react-native-keyboard-controller";
+
+import { colors } from "../constants/colors";
+
+type KeyboardToolbarTheme = NonNullable<KeyboardToolbarProps["theme"]>;
+
+export const MINGLA_KEYBOARD_TOOLBAR_THEME: KeyboardToolbarTheme = {
+  light: {
+    primary: colors.primary,
+    disabled: "#B0BEC5",
+    background: "#f3f3f4",
+    ripple: "#bcbcbcbc",
+  },
+  dark: {
+    primary: colors.primary,
+    disabled: "#707070",
+    background: "#2C2C2E",
+    ripple: "#F8F8F888",
+  },
+};
+
+export const KeyboardToolbarRoot: React.FC = () => (
+  <KeyboardToolbar showArrows={false} theme={MINGLA_KEYBOARD_TOOLBAR_THEME} />
+);

--- a/app-mobile/src/wrappers/KeyboardToolbarRoot.tsx
+++ b/app-mobile/src/wrappers/KeyboardToolbarRoot.tsx
@@ -1,0 +1,5 @@
+// ORCH-1171: KeyboardToolbarRoot — web passthrough (no on-screen keyboard bar).
+
+import React from "react";
+
+export const KeyboardToolbarRoot: React.FC = () => null;

--- a/app-mobile/src/wrappers/__tests__/orch_1171_keyboard_toolbar_mount_coverage.test.mjs
+++ b/app-mobile/src/wrappers/__tests__/orch_1171_keyboard_toolbar_mount_coverage.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * ORCH-1171 — consumer keyboard Done-bar mount-coverage regression test.
+ *
+ * Run: node src/wrappers/__tests__/orch_1171_keyboard_toolbar_mount_coverage.test.mjs
+ */
+
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const MOBILE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
+
+const read = (relativePath) =>
+  fs.readFileSync(path.join(MOBILE_ROOT, relativePath), "utf8");
+
+describe("ORCH-1171 Done-bar mount coverage (consumer)", () => {
+  const HOSTS = [
+    { label: "app root", rel: "app/_layout.tsx" },
+    {
+      label: "BaseBottomSheet wrapInRNModal host",
+      rel: "src/components/ui/BaseBottomSheet.tsx",
+    },
+  ];
+
+  for (const { label, rel } of HOSTS) {
+    it(`${label} imports AND renders KeyboardToolbarRoot`, () => {
+      const src = read(rel);
+      assert.match(
+        src,
+        /import\s*\{\s*KeyboardToolbarRoot\s*\}\s*from\s*["'][^"']*KeyboardToolbarRoot["']/,
+      );
+      const withoutImports = src
+        .split("\n")
+        .filter((l) => !/^\s*import\b/.test(l))
+        .join("\n");
+      assert.match(withoutImports, /<KeyboardToolbarRoot\s*\/?>/);
+    });
+  }
+
+  it("app root nests KeyboardToolbarRoot inside KeyboardRoot", () => {
+    const src = read("app/_layout.tsx");
+    assert.match(
+      src,
+      /import\s*\{\s*KeyboardRoot\s*\}\s*from\s*["'][^"']*KeyboardRoot["']/,
+    );
+    const withoutImports = src
+      .split("\n")
+      .filter((l) => !/^\s*import\b/.test(l))
+      .join("\n");
+    assert.match(withoutImports, /<KeyboardRoot\b[^>]*>/);
+    assert.match(withoutImports, /<KeyboardToolbarRoot\s*\/?>/);
+  });
+
+  it("BaseBottomSheet wrapInRNModal nests toolbar inside per-window KeyboardRoot", () => {
+    const src = read("src/components/ui/BaseBottomSheet.tsx");
+    assert.match(
+      src,
+      /import\s*\{\s*KeyboardRoot\s*\}\s*from\s*["'][^"']*KeyboardRoot["']/,
+    );
+    const modalBlock = src.slice(src.indexOf("if (wrapInRNModal)"));
+    assert.match(modalBlock, /<KeyboardRoot\b[^>]*>/);
+    assert.match(modalBlock, /<KeyboardToolbarRoot\s*\/?>/);
+  });
+
+  it("KeyboardAwareScrollView clearance includes toolbar height constants", () => {
+    const kas = read("src/components/ui/KeyboardAwareScrollView.tsx");
+    assert.match(kas, /KEYBOARD_TOOLBAR_HEIGHT/);
+    assert.match(kas, /KEYBOARD_CLEARANCE_ABOVE_TOOLBAR/);
+  });
+
+  it("MessageInterface lifts composer by KEYBOARD_TOOLBAR_HEIGHT when keyboard open", () => {
+    const chat = read("src/components/MessageInterface.tsx");
+    assert.match(chat, /keyboardHeight\s*\+\s*KEYBOARD_TOOLBAR_HEIGHT/);
+  });
+
+  it("KeyboardToolbarRoot native uses showArrows={false} and brand primary color", () => {
+    const toolbar = read("src/wrappers/KeyboardToolbarRoot.native.tsx");
+    assert.match(toolbar, /showArrows=\{false\}/);
+    assert.match(toolbar, /colors\.primary/);
+  });
+
+  it("app.config registers withGooglePodsModularHeaders plugin", () => {
+    const cfg = read("app.config.ts");
+    assert.match(cfg, /"\.\/plugins\/withGooglePodsModularHeaders"/);
+  });
+
+  it("package.json declares react-native-keyboard-controller", () => {
+    const pkg = read("package.json");
+    assert.match(pkg, /"react-native-keyboard-controller"/);
+  });
+});

--- a/app-mobile/src/wrappers/keyboardConstants.ts
+++ b/app-mobile/src/wrappers/keyboardConstants.ts
@@ -1,0 +1,13 @@
+// ORCH-1171: shared keyboard-toolbar geometry for the consumer app.
+// The Done-only accessory bar adds KEYBOARD_TOOLBAR_HEIGHT on top of the OS
+// keyboard; scroll/composer clearance must account for it (mirror ORCH-1170).
+
+/** Height of react-native-keyboard-controller's Done-only KeyboardToolbar. */
+export const KEYBOARD_TOOLBAR_HEIGHT = 42;
+
+/** Visible breathing room between a focused field and the toolbar top. */
+export const KEYBOARD_CLEARANCE_ABOVE_TOOLBAR = 12;
+
+/** Default bottomOffset for library KeyboardAwareScrollView wrappers. */
+export const KEYBOARD_SCROLL_BOTTOM_OFFSET =
+  KEYBOARD_CLEARANCE_ABOVE_TOOLBAR + KEYBOARD_TOOLBAR_HEIGHT;

--- a/packages/phone-input/CountryPickerModal.tsx
+++ b/packages/phone-input/CountryPickerModal.tsx
@@ -19,6 +19,11 @@
 
 import React, { useState, useCallback, useMemo, useRef } from "react";
 import {
+  KeyboardProvider,
+  KeyboardToolbar,
+  type KeyboardToolbarProps,
+} from "react-native-keyboard-controller";
+import {
   View,
   Text,
   TextInput,
@@ -74,6 +79,26 @@ interface CountryPickerModalProps extends CountryPickerContentProps {
 
 const ROW_HEIGHT = 48;
 
+/** ORCH-1171: Done-only toolbar height (matches app-mobile keyboardConstants). */
+const KEYBOARD_TOOLBAR_HEIGHT = 42;
+
+const MINGLA_KEYBOARD_TOOLBAR_THEME: NonNullable<
+  KeyboardToolbarProps["theme"]
+> = {
+  light: {
+    primary: "#eb7825",
+    disabled: "#B0BEC5",
+    background: "#f3f3f4",
+    ripple: "#bcbcbcbc",
+  },
+  dark: {
+    primary: "#eb7825",
+    disabled: "#707070",
+    background: "#2C2C2E",
+    ripple: "#F8F8F888",
+  },
+};
+
 const CountryPickerContent: React.FC<CountryPickerContentProps> = ({
   selectedCode,
   onSelect,
@@ -92,7 +117,10 @@ const CountryPickerContent: React.FC<CountryPickerContentProps> = ({
   );
 
   const { keyboardHeight } = useKeyboard({ disableLayoutAnimation: true });
-  const bottomSpacer = keyboardHeight > 0 ? keyboardHeight : insets.bottom;
+  const bottomSpacer =
+    keyboardHeight > 0
+      ? keyboardHeight + KEYBOARD_TOOLBAR_HEIGHT
+      : insets.bottom;
 
   const filteredCountries = useMemo(() => {
     if (!search.trim()) return COUNTRIES;
@@ -266,16 +294,22 @@ export const CountryPickerModal: React.FC<CountryPickerModalProps> = ({
       presentationStyle="fullScreen"
       statusBarTranslucent
     >
-      <SafeAreaProvider>
-        <CountryPickerContent
-          selectedCode={selectedCode}
-          onSelect={onSelect}
-          onClose={onClose}
-          iconRenderer={iconRenderer}
-          labels={labels}
-          theme={theme}
+      <KeyboardProvider>
+        <SafeAreaProvider>
+          <CountryPickerContent
+            selectedCode={selectedCode}
+            onSelect={onSelect}
+            onClose={onClose}
+            iconRenderer={iconRenderer}
+            labels={labels}
+            theme={theme}
+          />
+        </SafeAreaProvider>
+        <KeyboardToolbar
+          showArrows={false}
+          theme={MINGLA_KEYBOARD_TOOLBAR_THEME}
         />
-      </SafeAreaProvider>
+      </KeyboardProvider>
     </Modal>
   );
 };

--- a/packages/phone-input/package.json
+++ b/packages/phone-input/package.json
@@ -11,6 +11,7 @@
     "expo-haptics": "*",
     "react": "*",
     "react-native": "*",
+    "react-native-keyboard-controller": "*",
     "react-native-safe-area-context": "*"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `react-native-keyboard-controller` to the consumer app with a Done-only brand-orange `KeyboardToolbar` at the root and inside every `wrapInRNModal` `BaseBottomSheet` window (per-window `KeyboardProvider`, mirroring business ORCH-1170 PR #555).
- Bumps keyboard clearance on shared scroll/composer paths (+42pt toolbar height): `KeyboardAwareScrollView`, `KeyboardAwareView`, `MessageInterface` chat composer, `CalendarTab` spacer, and `@mingla/phone-input` `CountryPickerModal`.
- Ports the ORCH-1129 Google-pods modular-headers config plugin into `app-mobile` so iOS native builds can succeed after adding the new native module.
- Adds `test:orch-1171` CI gate + mount-coverage regression tests.

Closes #556.

## Test plan
- [ ] `cd app-mobile && npm run test:orch-1171` (gate + mount-coverage tests)
- [ ] Cut a **native** EAS build (iOS + Android) — this is NOT OTA-deliverable
- [ ] iOS sim: focus fields on onboarding, chat composer, a `wrapInRNModal` sheet (e.g. Add Friend, Report User) — Done bar visible, field not occluded
- [ ] Physical Samsung: same surfaces + real-finger keyboard open on chat composer and at least one sheet input
- [ ] Country picker search (phone onboarding): Done bar + search field visible above keyboard