### PR TITLE
ORCH-1181: per-package installment note on the checkout/cart ticket tile (business + web + consumer)

### DIFF
--- a/app-mobile/src/components/expandedCard/TicketCartSheet.tsx
+++ b/app-mobile/src/components/expandedCard/TicketCartSheet.tsx
@@ -241,6 +241,15 @@ export interface TicketCartSheetProps {
    * byte-identical to today.
    */
   dueTodayCents?: number;
+  /**
+   * ORCH-1181 — per-package installment sub-line copy keyed by ticketTypeId
+   * (ready-formatted, e.g. "From $125.00 today · pay over time"). The trip detail
+   * screen computes these from the SAME projected per-tier deposit it already
+   * derives, ONLY for plan packages when pay-over-time is the active cart choice.
+   * Absent / empty → no tile carries a note (events / no-plan / pay-in-full),
+   * byte-identical to today. The cart sheet never computes the deposit itself.
+   */
+  installmentNoteByTicketId?: Record<string, string>;
   onCancel: () => void;
   onCheckout: (payload: TicketCartCheckoutPayload) => void;
 }
@@ -260,6 +269,7 @@ export const TicketCartSheet: React.FC<TicketCartSheetProps> = ({
   isSubmitting,
   clearFloatingNav = true,
   dueTodayCents,
+  installmentNoteByTicketId,
   onCancel,
   onCheckout,
 }) => {
@@ -686,6 +696,7 @@ export const TicketCartSheet: React.FC<TicketCartSheetProps> = ({
               formatCurrency={formatMajorCurrency}
               theme={CONSUMER_TICKET_CART_THEME}
               fallbackCurrency={fallbackCurrency}
+              installmentNote={installmentNoteByTicketId?.[ticket.id] ?? null}
             />
           );
         })}

--- a/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
+++ b/app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx
@@ -79,6 +79,11 @@ import {
   TripOfferingBody,
   TripReserveBar,
   useTripOfferingState,
+  // ORCH-1181 — per-package deposit-due-today + the shared installment sub-line
+  // copy (identical to business + web). Reuses the same all-in deposit math the
+  // cart-level "Due today" reads — never recomputes fees.
+  tripTierDepositTodayCents,
+  formatTripTierInstallmentNote,
   type TripOfferingData,
   type TripPaymentPlanChoice,
   type TripReserveLine,
@@ -511,6 +516,60 @@ export default function ConsumerTripDetailScreen({
     onReserve: onReserveFromBody,
   });
 
+  // ORCH-1181 — the per-package installment sub-line shown on each cart tile
+  // (parity with the business/web checkout tile). For each PLAN tier whose
+  // effective choice is pay-over-time, compute the deposit-due-today off the
+  // SAME all-in deposit math the cart-level "Due today" uses
+  // (tripTierDepositTodayCents), and format via the SHARED copy formatter. We
+  // scale by the buyer's selected quantity (default 1 so the affordance shows on
+  // a plan tier even before a row is bumped). Gated on detail.hasPlan so events /
+  // experiences / no-plan trips contribute nothing (the map is empty → no notes).
+  const installmentNoteByTicketId = useMemo<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    if (detail === null || !detail.hasPlan) return map;
+    for (const tier of offeringData.tiers) {
+      const hasPlan =
+        tier.installmentSchedule !== null &&
+        tier.installmentSchedule !== undefined;
+      if (!hasPlan) continue;
+      // Effective per-tier choice: explicit per-tier map wins, else the cart-level
+      // toggle (mirrors useTripOfferingState's effectivePlanByTier).
+      const choice =
+        planChoiceByTier[tier.ticketTypeId] ?? paymentPlanChoice;
+      if (choice !== "installments") continue;
+      const qty = Math.max(1, quantities[tier.ticketTypeId] ?? 1);
+      const deposit = tripTierDepositTodayCents(
+        {
+          ticketTypeId: tier.ticketTypeId,
+          priceCents: tier.priceCents,
+          priceAllInCents: tier.priceAllInCents ?? null,
+          isFree: tier.isFree,
+          isUnlimited: tier.isUnlimited,
+          ticketsRemaining: tier.ticketsRemaining,
+          installmentSchedule: tier.installmentSchedule,
+        },
+        qty,
+      );
+      const note = formatTripTierInstallmentNote(
+        deposit,
+        tier.currency || detail.currency || "USD",
+        (value, currency) =>
+          (() => {
+            try {
+              return new Intl.NumberFormat(undefined, {
+                style: "currency",
+                currency: currency || "USD",
+              }).format(value);
+            } catch {
+              return `${value.toFixed(2)} ${currency}`;
+            }
+          })(),
+      );
+      if (note !== null) map[tier.ticketTypeId] = note;
+    }
+    return map;
+  }, [detail, offeringData.tiers, planChoiceByTier, paymentPlanChoice, quantities]);
+
   // ORCH-1138 — handleBuy ported VERBATIM (behavior) from EBES handleBuy
   // (ExpandedBusinessEventSheet.tsx:313-432), scoped to the trip. Same buyer
   // derivation, same guards, same byte-identical runNativeCheckout request (NO
@@ -930,6 +989,9 @@ export default function ConsumerTripDetailScreen({
             ? offeringState.projectedSchedule.depositCents
             : undefined
         }
+        // ORCH-1181 — per-package installment sub-line on each cart tile (parity
+        // with business/web). Empty for events / no-plan / pay-in-full.
+        installmentNoteByTicketId={installmentNoteByTicketId}
         onCancel={handleCartCancel}
         onCheckout={handleCartCheckout}
       />

--- a/app-mobile/src/screens/Trip/__tests__/orch_1181_consumer_installment_note.test.ts
+++ b/app-mobile/src/screens/Trip/__tests__/orch_1181_consumer_installment_note.test.ts
@@ -1,0 +1,200 @@
+// @ts-nocheck
+/* eslint-disable @typescript-eslint/no-require-imports */
+//
+// ORCH-1181 [trip-tile-installment] — the CONSUMER cart tile shows the per-package
+// installment sub-line "From {deposit} today · pay over time" (parity with the
+// business app + buyer web), ONLY for a trip package on a payment plan when
+// pay-over-time is the active cart choice. Events / experiences / no-plan / pay-
+// in-full → no note.
+//
+// app-mobile has no jest/RTL runner; the repo convention is node:assert
+// source-assertions + executed pure logic. Every wiring assertion FAILS on a TRUE
+// line-deletion of the code it protects (fails-on-revert). The deposit math + the
+// exact copy are owned by the shared package and proven by its deno suite
+// (packages/offering-rendering/__tests__/orch_1181_installment_note.test.ts); here
+// we (a) source-grep the consumer wiring and (b) replay the per-tier MAP GATE the
+// trip detail screen builds, proving plan+installments → note, no-plan/full → none.
+//
+// Run with:
+//   node --test --experimental-strip-types \
+//     app-mobile/src/screens/Trip/__tests__/orch_1181_consumer_installment_note.test.ts
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "../../../../..");
+const read = (rel: string): string =>
+  fs.readFileSync(path.join(ROOT, rel), "utf8");
+const stripComments = (src: string): string =>
+  src
+    .replace(/(^|[^:])\/\/.*$/gm, "$1")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+
+// ── replay of the shared deposit math + formatter (deposit_pct-of-all-in, the
+// same single owner the cart-level "Due today" reads). Proven in the package
+// deno suite; replicated here so the consumer MAP-gate is provable under node. ──
+const depositTodayCents = (tier, quantity: number): number | null => {
+  if (!Number.isFinite(quantity) || quantity <= 0) return null;
+  const sched = tier.installmentSchedule;
+  if (
+    sched === null ||
+    typeof sched !== "object" ||
+    typeof sched.deposit_pct !== "number" ||
+    !Array.isArray(sched.installments)
+  ) {
+    return null;
+  }
+  const unitAllIn =
+    typeof tier.priceAllInCents === "number"
+      ? tier.priceAllInCents
+      : tier.priceCents;
+  const lineAllIn = (tier.isFree ? 0 : unitAllIn) * Math.floor(quantity);
+  if (lineAllIn <= 0) return null;
+  const deposit = Math.round((lineAllIn * sched.deposit_pct) / 100);
+  return deposit > 0 ? deposit : null;
+};
+const fmtNote = (cents: number | null): string | null => {
+  if (cents === null || !Number.isFinite(cents) || cents <= 0) return null;
+  const money = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100);
+  return `From ${money} today · pay over time`;
+};
+
+// The EXACT consumer MAP-gate from ConsumerTripDetailScreen.installmentNoteByTicketId.
+const buildNoteMap = (
+  detail,
+  tiers,
+  planChoiceByTier,
+  paymentPlanChoice: "full" | "installments",
+  quantities,
+): Record<string, string> => {
+  const map: Record<string, string> = {};
+  if (detail === null || !detail.hasPlan) return map;
+  for (const tier of tiers) {
+    const hasPlan =
+      tier.installmentSchedule !== null && tier.installmentSchedule !== undefined;
+    if (!hasPlan) continue;
+    const choice = planChoiceByTier[tier.ticketTypeId] ?? paymentPlanChoice;
+    if (choice !== "installments") continue;
+    const qty = Math.max(1, quantities[tier.ticketTypeId] ?? 1);
+    const note = fmtNote(depositTodayCents(tier, qty));
+    if (note !== null) map[tier.ticketTypeId] = note;
+  }
+  return map;
+};
+
+// ── synthetic fixtures (memory ORCH-1147: 0/8 live brands set plans) ──
+const planTier = {
+  ticketTypeId: "tt_plan",
+  priceCents: 50000,
+  priceAllInCents: 53000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 20,
+  installmentSchedule: {
+    deposit_pct: 25,
+    installments: [{ ordinal: 1, pct: 75, days_after_booking: 30 }],
+  },
+};
+const noPlanTier = {
+  ticketTypeId: "tt_std",
+  priceCents: 40000,
+  priceAllInCents: 42000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 20,
+  installmentSchedule: null,
+};
+const planDetail = { hasPlan: true, currency: "USD" };
+const eventLikeDetail = { hasPlan: false, currency: "USD" };
+
+// ───────────────────────── MAP-gate (happy) ─────────────────────────
+test("plan tier + cart 'installments' → tile carries the deposit note (deposit_pct of all-in)", () => {
+  const map = buildNoteMap(planDetail, [planTier], {}, "installments", {
+    tt_plan: 1,
+  });
+  // 25% of all-in 53000 = 13250 = $132.50.
+  assert.strictEqual(map.tt_plan, "From $132.50 today · pay over time");
+});
+
+test("deposit scales with the selected quantity", () => {
+  const map = buildNoteMap(planDetail, [planTier], {}, "installments", {
+    tt_plan: 2,
+  });
+  // 25% of (53000 × 2) = 26500 = $265.00.
+  assert.strictEqual(map.tt_plan, "From $265.00 today · pay over time");
+});
+
+// ───────────────────────── MAP-gate (adversarial — empty) ─────────────────────────
+test("cart 'full' (pay-in-full) → no note on a plan tier", () => {
+  const map = buildNoteMap(planDetail, [planTier], {}, "full", { tt_plan: 1 });
+  assert.deepStrictEqual(map, {});
+});
+
+test("no-plan tier → no note", () => {
+  const map = buildNoteMap(
+    planDetail,
+    [noPlanTier],
+    {},
+    "installments",
+    { tt_std: 2 },
+  );
+  assert.deepStrictEqual(map, {});
+});
+
+test("event-like detail (hasPlan=false) → empty map (events untouched)", () => {
+  const map = buildNoteMap(
+    eventLikeDetail,
+    [planTier],
+    {},
+    "installments",
+    { tt_plan: 1 },
+  );
+  assert.deepStrictEqual(map, {});
+});
+
+test("per-tier override beats the cart-level toggle (one tier full, one over-time)", () => {
+  const planTierB = { ...planTier, ticketTypeId: "tt_plan2" };
+  const map = buildNoteMap(
+    planDetail,
+    [planTier, planTierB],
+    { tt_plan2: "full" },
+    "installments",
+    { tt_plan: 1, tt_plan2: 1 },
+  );
+  assert.ok(map.tt_plan); // cart-level "installments" applies
+  assert.strictEqual(map.tt_plan2, undefined); // per-tier "full" suppresses
+});
+
+// ───────────────────────── source-contract wiring (fails-on-revert) ─────────────────────────
+test("ConsumerTripDetailScreen imports the shared deposit + formatter and builds installmentNoteByTicketId", () => {
+  const src = stripComments(
+    read("app-mobile/src/screens/Trip/ConsumerTripDetailScreen.tsx"),
+  );
+  assert.ok(src.includes("tripTierDepositTodayCents"));
+  assert.ok(src.includes("formatTripTierInstallmentNote"));
+  assert.ok(/installmentNoteByTicketId/.test(src));
+  // gated on the trip having a plan + the per-tier/cart installments choice
+  assert.ok(/detail\.hasPlan/.test(src));
+  assert.ok(/!==\s*"installments"|===\s*"installments"/.test(src));
+  // passed to the cart sheet
+  assert.ok(
+    /installmentNoteByTicketId=\{installmentNoteByTicketId\}/.test(src),
+  );
+});
+
+test("TicketCartSheet accepts installmentNoteByTicketId and forwards installmentNote per row", () => {
+  const src = stripComments(
+    read("app-mobile/src/components/expandedCard/TicketCartSheet.tsx"),
+  );
+  assert.ok(/installmentNoteByTicketId\??:/.test(src)); // prop declared
+  assert.ok(
+    /installmentNote=\{installmentNoteByTicketId\?\.\[ticket\.id\]\s*\?\?\s*null\}/.test(
+      src,
+    ),
+  ); // forwarded to QuantityRow
+});

--- a/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1181_installment_note.test.ts
+++ b/mingla-business/app/checkout-trip/[tripEventId]/__tests__/orch_1181_installment_note.test.ts
@@ -1,0 +1,179 @@
+/**
+ * ORCH-1181 [trip-tile-installment] — the per-package installment sub-line on the
+ * checkout/cart ticket tile.
+ *
+ * GOAL (Seth): each trip PACKAGE tile on the "1 OF 3" cart step shows
+ * "From {deposit} today · pay over time" under its price — ONLY when that package
+ * is on a payment plan AND pay-over-time is the active cart choice. Events have no
+ * plan → no note. The deposit comes from the SAME projectInstallmentSchedule the
+ * cart-level "Due today" bottom bar reads (index.tsx lines 195-215) — never
+ * recomputed/fabricated.
+ *
+ * Harness: no @testing-library/react-native in this repo. This combines:
+ *  (1) the SHARED RN-free formatter (executed) — exact copy + null contract.
+ *  (2) the EXACT index.tsx per-tier gate replayed against synthetic fixtures
+ *      (the real projectInstallmentSchedule), proving plan+installments → a
+ *      non-null note, and cart "full" / no-plan / event-ticket → null.
+ *  (3) source-contract assertions on index.tsx + the two QuantityRow wrappers
+ *      (fails-on-revert on a true line edit, never on a comment-out).
+ *
+ * Memory ORCH-1147 gotcha: 0/8 live brands set plans → all fixtures are synthetic.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { describe, expect, test } from "@jest/globals";
+
+import { projectInstallmentSchedule } from "../../../../src/utils/installmentScheduleProjection";
+import { formatCurrency } from "../../../../src/utils/currency";
+import type { TripPricingTier } from "../../../../src/services/tripsService";
+
+// The shared formatter lives in @mingla/offering-rendering, which this jest config
+// does not module-map (only the apps' bundler/metro resolve it). Its exact copy +
+// null contract are proven by the package's deno suite
+// (packages/offering-rendering/__tests__/orch_1181_installment_note.test.ts).
+// Here we replay the IDENTICAL pure logic so this surface's gate is proven
+// end-to-end without depending on jest package resolution. (If the package copy
+// ever forks, the source-contract grep below + the deno test catch it.)
+const formatTripTierInstallmentNote = (
+  dueTodayCents: number | null,
+  currency: string,
+  fmt: (value: number, currency: string) => string,
+): string | null => {
+  if (
+    dueTodayCents === null ||
+    !Number.isFinite(dueTodayCents) ||
+    dueTodayCents <= 0
+  ) {
+    return null;
+  }
+  return `From ${fmt(dueTodayCents / 100, currency || "USD")} today · pay over time`;
+};
+
+const DIR = join(__dirname, "..");
+const read = (f: string): string => readFileSync(join(DIR, f), "utf8");
+const strip = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+// ── synthetic fixtures (no live brand has a plan) ───────────────────────────
+const PLAN_TIER = {
+  ticketTypeId: "tier-plan",
+  priceCents: 50000,
+  currency: "USD",
+  installmentSchedule: {
+    deposit_pct: 25,
+    installments: [{ ordinal: 1, pct: 75, days_after_booking: 30 }],
+  },
+} as unknown as TripPricingTier;
+
+const NO_PLAN_TIER = {
+  ticketTypeId: "tier-noplan",
+  priceCents: 40000,
+  currency: "USD",
+  installmentSchedule: null,
+} as unknown as TripPricingTier;
+
+/**
+ * Replays the EXACT index.tsx per-tier gate (the `.map` block added by ORCH-1181):
+ *   plan-choice "installments" + tier has a schedule + qty>=1 → deposit from
+ *   projectInstallmentSchedule(tier, now, qty).depositCents → formatted note;
+ *   else null.
+ */
+function noteForTier(
+  tier: TripPricingTier,
+  qty: number,
+  paymentPlanChoice: "full" | "installments",
+): string | null {
+  const sourceTier =
+    paymentPlanChoice === "installments" ? tier : undefined;
+  const tierDeposit =
+    sourceTier !== undefined &&
+    sourceTier.installmentSchedule !== null &&
+    qty >= 1
+      ? (projectInstallmentSchedule(sourceTier, new Date(), qty)?.depositCents ??
+        null)
+      : null;
+  return formatTripTierInstallmentNote(tierDeposit, tier.currency, (v, c) =>
+    formatCurrency(v, c),
+  );
+}
+
+// ───────────────────────── shared formatter ─────────────────────────
+describe("ORCH-1181 shared formatter", () => {
+  test('formats "From {deposit} today · pay over time"', () => {
+    expect(formatTripTierInstallmentNote(12500, "USD", formatCurrency)).toBe(
+      "From $125.00 today · pay over time",
+    );
+  });
+
+  test("null / 0 deposit → null (no sub-line)", () => {
+    expect(formatTripTierInstallmentNote(null, "USD", formatCurrency)).toBeNull();
+    expect(formatTripTierInstallmentNote(0, "USD", formatCurrency)).toBeNull();
+  });
+});
+
+// ───────────────────────── index.tsx gate (happy) ─────────────────────────
+describe("ORCH-1181 happy — plan tier + pay-over-time shows the note", () => {
+  test("plan tier, cart 'installments', qty 1 → non-null note (matches the deposit)", () => {
+    const note = noteForTier(PLAN_TIER, 1, "installments");
+    // 25% of base 50000 = 12500 = $125.00 (same projection the bottom bar reads).
+    expect(note).toBe("From $125.00 today · pay over time");
+  });
+
+  test("deposit scales with quantity (qty 2 → 25% of 100000 = $250.00)", () => {
+    expect(noteForTier(PLAN_TIER, 2, "installments")).toBe(
+      "From $250.00 today · pay over time",
+    );
+  });
+});
+
+// ───────────────────────── adversarial — null paths ─────────────────────────
+describe("ORCH-1181 adversarial — no note", () => {
+  test("cart 'full' (pay-in-full) → null even on a plan tier", () => {
+    expect(noteForTier(PLAN_TIER, 1, "full")).toBeNull();
+  });
+
+  test("no-plan tier → null (events/experiences untouched)", () => {
+    expect(noteForTier(NO_PLAN_TIER, 1, "installments")).toBeNull();
+    expect(noteForTier(NO_PLAN_TIER, 3, "full")).toBeNull();
+  });
+
+  test("qty 0 (unselected) → null", () => {
+    expect(noteForTier(PLAN_TIER, 0, "installments")).toBeNull();
+  });
+});
+
+// ───────────────────────── source-contract wiring ─────────────────────────
+describe("ORCH-1181 wiring (fails-on-revert)", () => {
+  test("index.tsx computes the note from projectInstallmentSchedule + the shared formatter and passes it to QuantityRow", () => {
+    const idx = strip(read("index.tsx"));
+    expect(idx).toContain("formatTripTierInstallmentNote");
+    expect(idx).toMatch(/projectInstallmentSchedule\(/);
+    // gated on the cart-level installments choice
+    expect(idx).toMatch(/paymentPlanChoice === "installments"/);
+    // forwarded to the tile
+    expect(idx).toMatch(/installmentNote=\{installmentNote\}/);
+  });
+
+  test("the business QuantityRow wrapper forwards installmentNote into the shared row", () => {
+    const wrapper = strip(
+      readFileSync(
+        join(DIR, "../../../src/components/checkout/QuantityRow.tsx"),
+        "utf8",
+      ),
+    );
+    expect(wrapper).toMatch(/installmentNote\??:/); // prop declared
+    expect(wrapper).toMatch(/installmentNote=\{installmentNote\}/); // forwarded
+  });
+
+  test("the event checkout tile passes NO installmentNote (events untouched)", () => {
+    const evt = strip(
+      readFileSync(
+        join(DIR, "../../checkout/[eventId]/index.tsx"),
+        "utf8",
+      ),
+    );
+    expect(evt).not.toContain("installmentNote");
+  });
+});

--- a/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
+++ b/mingla-business/app/checkout-trip/[tripEventId]/index.tsx
@@ -38,6 +38,10 @@ import { usePublicTripById } from "../../../src/hooks/usePublicTripById";
 import { useTripIntakeSchemasByEvent } from "../../../src/hooks/useIntakeSchema";
 import { formatCurrency } from "../../../src/utils/currency";
 import { projectInstallmentSchedule } from "../../../src/utils/installmentScheduleProjection";
+// ORCH-1181 — the shared per-package installment sub-line copy (business + web +
+// consumer identical). The deposit-due-today still comes from the existing
+// projectInstallmentSchedule; this only formats the already-computed cents.
+import { formatTripTierInstallmentNote } from "@mingla/offering-rendering";
 import type { TripPricingTier } from "../../../src/services/tripsService";
 import type {
   TicketAvailableAt,
@@ -587,11 +591,34 @@ export default function CheckoutTripTicketsScreen(): React.ReactElement {
         {tickets.map((ticket) => {
           const line = lines.find((l) => l.ticketTypeId === ticket.id);
           const qty = line?.quantity ?? 0;
+          // ORCH-1181 — per-package installment sub-line on the tile. Shown ONLY
+          // when pay-over-time is the active cart choice AND this tier is on a
+          // plan AND it has ≥1 selected. The deposit comes from the SAME
+          // projectInstallmentSchedule the cart-level "Due today" reads (lines
+          // 195-215) — never recomputed/fabricated. No-plan / pay-in-full / cart
+          // "full" → null (events untouched: trip-only tiers carry a schedule).
+          const sourceTier =
+            paymentPlanChoice === "installments"
+              ? trip.pricingTiers.find((t) => t.ticketTypeId === ticket.id)
+              : undefined;
+          const tierDeposit =
+            sourceTier !== undefined &&
+            sourceTier.installmentSchedule !== null &&
+            qty >= 1
+              ? (projectInstallmentSchedule(sourceTier, new Date(), qty)
+                  ?.depositCents ?? null)
+              : null;
+          const installmentNote = formatTripTierInstallmentNote(
+            tierDeposit,
+            ticket.currency ?? trip.pricingTiers[0]?.currency ?? "USD",
+            (value, currency) => formatCurrency(value, currency),
+          );
           return (
             <View key={ticket.id} style={styles.tierWrap}>
               <QuantityRow
                 ticket={ticket}
                 quantity={qty}
+                installmentNote={installmentNote}
                 onQuantityChange={(next): void =>
                   setLineQuantity({
                     ticketTypeId: ticket.id,

--- a/mingla-business/src/components/checkout/QuantityRow.tsx
+++ b/mingla-business/src/components/checkout/QuantityRow.tsx
@@ -38,6 +38,14 @@ export interface QuantityRowProps {
   /** Caller dispatches; this component is fully controlled. */
   onQuantityChange: (next: number) => void;
   onJoinWaitlist?: (ticketId: string) => void;
+  /**
+   * ORCH-1181 — a ready-formatted per-package installment sub-line (e.g.
+   * "From $125.00 today · pay over time"). Forwarded verbatim to the shared
+   * QuantityRow. The checkout screen passes it ONLY for a trip tier on a payment
+   * plan when pay-over-time is the active cart choice (null otherwise → events /
+   * no-plan / pay-in-full render nothing).
+   */
+  installmentNote?: string | null;
 }
 
 const MINGLA_BUSINESS_THEME: QuantityRowTheme = {
@@ -75,6 +83,7 @@ export const QuantityRow: React.FC<QuantityRowProps> = ({
   quantity,
   onQuantityChange,
   onJoinWaitlist,
+  installmentNote,
 }) => {
   const renderPlusIcon = useCallback(
     (iconProps: { size: number; color: string }) => (
@@ -119,6 +128,7 @@ export const QuantityRow: React.FC<QuantityRowProps> = ({
       theme={MINGLA_BUSINESS_THEME}
       fallbackCurrency="GBP"
       onJoinWaitlist={onJoinWaitlist}
+      installmentNote={installmentNote}
     />
   );
 };

--- a/packages/offering-rendering/QuantityRow.tsx
+++ b/packages/offering-rendering/QuantityRow.tsx
@@ -141,6 +141,15 @@ export interface QuantityRowProps {
   fallbackCurrency?: string;
   /** Called when a sold-out waitlist-enabled row is tapped. */
   onJoinWaitlist?: (ticketId: string) => void;
+  /**
+   * ORCH-1181 — an optional, READY-FORMATTED installment sub-line shown directly
+   * under the price block (e.g. "From $125.00 today · pay over time"). The caller
+   * passes it ONLY for a trip package on a payment plan when pay-over-time is the
+   * active cart choice (via the shared `formatTripTierInstallmentNote`). Null /
+   * undefined → nothing renders (byte-identical for events & no-plan tiers). This
+   * component stays pure-presentational: it never computes the deposit (I-MOR-0827).
+   */
+  installmentNote?: string | null;
 }
 
 export const QuantityRow: React.FC<QuantityRowProps> = ({
@@ -153,6 +162,7 @@ export const QuantityRow: React.FC<QuantityRowProps> = ({
   theme,
   fallbackCurrency = "GBP",
   onJoinWaitlist,
+  installmentNote,
 }) => {
   const t: Required<QuantityRowTheme> = useMemo(
     () => ({ ...DEFAULT_THEME, ...(theme ?? {}) }),
@@ -270,6 +280,14 @@ export const QuantityRow: React.FC<QuantityRowProps> = ({
     ...styles.inclusiveText,
     color: t.textTertiary,
   };
+  // ORCH-1181 — secondary installment sub-line under the price block. Only
+  // rendered when the caller passes a non-empty note (trip plan + pay-over-time).
+  const installmentTextStyle: TextStyle = {
+    ...styles.installmentText,
+    color: t.textSecondary,
+  };
+  const showInstallmentNote =
+    typeof installmentNote === "string" && installmentNote.trim().length > 0;
   const descriptionStyle: TextStyle = {
     ...styles.description,
     color: t.textTertiary,
@@ -390,6 +408,9 @@ export const QuantityRow: React.FC<QuantityRowProps> = ({
       {showInclusive ? (
         <Text style={inclusiveTextStyle}>incl. VAT &amp; fees</Text>
       ) : null}
+      {showInstallmentNote ? (
+        <Text style={installmentTextStyle}>{installmentNote}</Text>
+      ) : null}
 
       {ticket.description && ticket.description.trim().length > 0 ? (
         <Text style={descriptionStyle} numberOfLines={2}>
@@ -487,6 +508,13 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: "400",
     marginTop: 2,
+  },
+  // ORCH-1181 — installment sub-line; slightly stronger than the VAT caption
+  // (secondary, not tertiary) since it carries an actionable money figure.
+  installmentText: {
+    fontSize: 12,
+    fontWeight: "500",
+    marginTop: 3,
   },
   description: {
     marginTop: 4,

--- a/packages/offering-rendering/__tests__/orch_1181_installment_note.test.ts
+++ b/packages/offering-rendering/__tests__/orch_1181_installment_note.test.ts
@@ -1,0 +1,123 @@
+// ORCH-1181 [trip-tile-installment] — implementor-owned BEHAVIORAL test for the
+// RN-free per-package deposit-due-today helper + the shared installment sub-line
+// copy formatter. Runs under the offering-rendering deno harness (deno std
+// assert + Deno.test), same style as meta_orch_1174_legB3_multitier.test.ts.
+//
+// These two pure functions are the SINGLE OWNER of the cart-tile installment note
+// that the business app, buyer web, AND the consumer app all render — the copy
+// can never fork because all three import THIS formatter.
+//
+// FAILS-ON-REVERT:
+//   • drop the deposit_pct-of-all-in math in tripTierDepositTodayCents → the
+//     "deposit is deposit_pct of the all-in subtotal" assertion FAILS.
+//   • return a non-null note for null/0 deposit → the "no note when nothing due"
+//     assertion FAILS.
+//   • change the "From {x} today · pay over time" copy → the exact-string FAILS.
+
+import {
+  assertEquals,
+  assert,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import {
+  tripTierDepositTodayCents,
+  formatTripTierInstallmentNote,
+  type TripTierLike,
+} from "../tripBoxTotals.ts";
+
+// A test currency formatter (major units → string), shaped like each surface's
+// host formatCurrency. Fixed locale so the assertion is deterministic.
+const fmt = (value: number, currency: string): string =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency }).format(value);
+
+// SYNTHETIC pass-fee plan fixture (memory ORCH-1147: 0/8 live brands set plans).
+// base 50000 / all-in 53000 (6% passed fee); 25% deposit plan.
+const planTier: TripTierLike = {
+  ticketTypeId: "tt_plan",
+  priceCents: 50000,
+  priceAllInCents: 53000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 20,
+  installmentSchedule: {
+    deposit_pct: 25,
+    installments: [{ ordinal: 1, pct: 75, days_after_booking: 30 }],
+  },
+};
+
+const noPlanTier: TripTierLike = {
+  ticketTypeId: "tt_std",
+  priceCents: 40000,
+  priceAllInCents: 42000,
+  isFree: false,
+  isUnlimited: false,
+  ticketsRemaining: 20,
+  installmentSchedule: null,
+};
+
+const freePlanTier: TripTierLike = {
+  ticketTypeId: "tt_free",
+  priceCents: 0,
+  priceAllInCents: null,
+  isFree: true,
+  isUnlimited: true,
+  ticketsRemaining: null,
+  installmentSchedule: {
+    deposit_pct: 25,
+    installments: [{ ordinal: 1, pct: 75, days_after_booking: 30 }],
+  },
+};
+
+// ── formatter copy ──────────────────────────────────────────────────────────
+
+Deno.test("formatTripTierInstallmentNote — exact copy on a real deposit", () => {
+  // 12500 cents = $125.00.
+  assertEquals(
+    formatTripTierInstallmentNote(12500, "USD", fmt),
+    "From $125.00 today · pay over time",
+  );
+});
+
+Deno.test("formatTripTierInstallmentNote — null/0 deposit → null (no note)", () => {
+  assertEquals(formatTripTierInstallmentNote(null, "USD", fmt), null);
+  assertEquals(formatTripTierInstallmentNote(0, "USD", fmt), null);
+  assertEquals(formatTripTierInstallmentNote(-100, "USD", fmt), null);
+  assertEquals(formatTripTierInstallmentNote(Number.NaN, "USD", fmt), null);
+});
+
+// ── per-package deposit-due-today ────────────────────────────────────────────
+
+Deno.test("tripTierDepositTodayCents — deposit is deposit_pct of the all-in subtotal (qty 1)", () => {
+  // 25% of 53000 (the all-in, NOT the 50000 base) = 13250.
+  assertEquals(tripTierDepositTodayCents(planTier, 1), 13250);
+});
+
+Deno.test("tripTierDepositTodayCents — scales by quantity", () => {
+  // 25% of (53000 × 2 = 106000) = 26500.
+  assertEquals(tripTierDepositTodayCents(planTier, 2), 26500);
+});
+
+Deno.test("tripTierDepositTodayCents — no plan / qty 0 / free → null", () => {
+  assertEquals(tripTierDepositTodayCents(noPlanTier, 1), null);
+  assertEquals(tripTierDepositTodayCents(planTier, 0), null);
+  assertEquals(tripTierDepositTodayCents(freePlanTier, 1), null);
+});
+
+// ── end-to-end: helper → formatter (what each surface does) ──────────────────
+
+Deno.test("plan tier → note; no-plan tier → null (events untouched)", () => {
+  const planNote = formatTripTierInstallmentNote(
+    tripTierDepositTodayCents(planTier, 1),
+    "USD",
+    fmt,
+  );
+  assert(planNote !== null);
+  assertEquals(planNote, "From $132.50 today · pay over time");
+
+  const noPlanNote = formatTripTierInstallmentNote(
+    tripTierDepositTodayCents(noPlanTier, 3),
+    "USD",
+    fmt,
+  );
+  assertEquals(noPlanNote, null);
+});

--- a/packages/offering-rendering/index.ts
+++ b/packages/offering-rendering/index.ts
@@ -173,6 +173,10 @@ export {
   tripSummedAllInCents,
   tripSummedDueTodayCents,
   tripAnyLineOnPlan,
+  // ORCH-1181 — per-package deposit-due-today + the shared installment sub-line
+  // copy for the checkout/cart ticket tile (business + web + consumer identical).
+  tripTierDepositTodayCents,
+  formatTripTierInstallmentNote,
 } from "./tripBoxTotals";
 export type {
   TripTierLike,

--- a/packages/offering-rendering/tripBoxTotals.ts
+++ b/packages/offering-rendering/tripBoxTotals.ts
@@ -182,6 +182,52 @@ export const tripAnyLineOnPlan = (
   return false;
 };
 
+/**
+ * ORCH-1181 — the SINGLE per-package deposit-due-today, in cents, for one trip
+ * tier paying over time. Reuses the SAME deposit_pct-of-all-in math as
+ * tripSummedDueTodayCents (one owner), so the per-package tile note and the
+ * cart-level "Due today" never diverge. Returns null when the tier has no plan,
+ * is free, or the qty/all-in resolves to 0 — the caller renders no note.
+ */
+export const tripTierDepositTodayCents = (
+  tier: TripTierLike,
+  quantity: number,
+): number | null => {
+  if (!Number.isFinite(quantity) || quantity <= 0) return null;
+  const template = asInstallmentTemplate(tier.installmentSchedule);
+  if (template === null) return null;
+  const lineAllIn = tripTierUnitAllInCents(tier) * Math.floor(quantity);
+  if (lineAllIn <= 0) return null;
+  const deposit = Math.round((lineAllIn * template.deposit_pct) / 100);
+  return deposit > 0 ? deposit : null;
+};
+
+/**
+ * ORCH-1181 — the SHARED, surface-identical per-package installment sub-line for
+ * the checkout/cart ticket tile. Business app + buyer web + consumer app all
+ * import THIS formatter so the copy never forks. Returns null (→ no sub-line)
+ * when there is no deposit due today (no plan / pay-in-full / free / 0).
+ *
+ * `formatCurrency` is the host's locale-aware MAJOR-unit money formatter (the
+ * same one each surface already passes to QuantityRow); we hand it the deposit
+ * in major units. Pure: no fee math, no RN import (I-MOR-0827).
+ */
+export const formatTripTierInstallmentNote = (
+  dueTodayCents: number | null,
+  currency: string,
+  formatCurrency: (value: number, currency: string) => string,
+): string | null => {
+  if (
+    dueTodayCents === null ||
+    !Number.isFinite(dueTodayCents) ||
+    dueTodayCents <= 0
+  ) {
+    return null;
+  }
+  const formatted = formatCurrency(dueTodayCents / 100, currency || "USD");
+  return `From ${formatted} today · pay over time`;
+};
+
 /** Narrow an unknown installmentSchedule into a usable template, or null. */
 function asInstallmentTemplate(raw: unknown): TripInstallmentTemplateLike | null {
   if (raw === null || typeof raw !== "object") return null;


### PR DESCRIPTION
Seth: on the trip checkout cart step ("1 OF 3") and the consumer cart, each ticket/package TILE should show the installment, not just the bottom button.

Adds a per-package sub-line under each tile's price — "From {deposit} today · pay over time" — shown only when that package is on a payment plan and pay-over-time is the active cart choice. Business app + buyer web + consumer app. Events/experiences untouched (no plan → null → byte-identical).

- `packages/offering-rendering/QuantityRow.tsx` (the ONE shared tile all surfaces render): optional `installmentNote?: string | null`, rendered as a secondary sub-line under the price; pure-presentational.
- `packages/offering-rendering/tripBoxTotals.ts`: shared `tripTierDepositTodayCents` (reuses the cart-level due-today math, one owner) + `formatTripTierInstallmentNote` (single source of the copy so it never forks).
- Business `checkout/QuantityRow.tsx` + `checkout-trip/[tripEventId]/index.tsx`: pass the per-tier note when cart is "installments" (deposit via the existing `projectInstallmentSchedule`, matching the business bottom-bar figure).
- Consumer `TicketCartSheet.tsx` + `ConsumerTripDetailScreen.tsx`: build a per-ticket note map gated on `hasPlan`, via the shared formatter.

Gates green (package-isolation/MOR-isolation, orch-1147 cart-total-is-allin, experience byte-identical). New tests: deno 6/6 + jest 10/10 + node 8/8. No migrations.

Note: business deposit basis = base price, consumer = all-in — each matches its own existing cart-level "Due today"; the cross-surface basis difference is pre-existing (ORCH-1147 family), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)